### PR TITLE
Literal strings to storage pointer

### DIFF
--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -511,7 +511,9 @@ bool StringLiteralType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	if (auto fixedBytes = dynamic_cast<FixedBytesType const*>(&_convertTo))
 		return size_t(fixedBytes->numBytes()) >= m_value.size();
 	else if (auto arrayType = dynamic_cast<ArrayType const*>(&_convertTo))
-		return arrayType->isByteArray();
+		return
+			arrayType->isByteArray() &&
+			!(arrayType->dataStoredIn(DataLocation::Storage) && arrayType->isPointer());
 	else
 		return false;
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2308,6 +2308,16 @@ BOOST_AUTO_TEST_CASE(array_out_of_bound_access)
 	SOLIDITY_CHECK_ERROR_TYPE(parseAndAnalyseReturnError(text), TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(literal_string_to_storage_pointer)
+{
+	char const* text = R"(
+		contract C {
+			function f() { string x = "abc"; }
+		}
+	)";
+	SOLIDITY_CHECK_ERROR_TYPE(parseAndAnalyseReturnError(text), TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Disallow assignment from string literal to storage pointer.

Fixes #90 
