### PR TITLE
Bugfix in calldata unpacker.

### DIFF
--- a/libsolidity/Compiler.h
+++ b/libsolidity/Compiler.h
@@ -85,12 +85,8 @@ private:
 	void appendFunctionSelector(ContractDefinition const& _contract);
 	/// Creates code that unpacks the arguments for the given function represented by a vector of TypePointers.
 	/// From memory if @a _fromMemory is true, otherwise from call data.
-	/// Expects source offset on the stack.
-	void appendCalldataUnpacker(
-		TypePointers const& _typeParameters,
-		bool _fromMemory = false,
-		u256 _startOffset = u256(-1)
-	);
+	/// Expects source offset on the stack, which is removed.
+	void appendCalldataUnpacker(TypePointers const& _typeParameters, bool _fromMemory = false);
 	void appendReturnValuePacker(TypePointers const& _typeParameters);
 
 	void registerStateVariables(ContractDefinition const& _contract);

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(location_test)
 	AssemblyItems items = compileContract(sourceCode);
 	vector<SourceLocation> locations =
 		vector<SourceLocation>(17, SourceLocation(2, 75, n)) +
-		vector<SourceLocation>(26, SourceLocation(20, 72, n)) +
+		vector<SourceLocation>(28, SourceLocation(20, 72, n)) +
 		vector<SourceLocation>{SourceLocation(42, 51, n), SourceLocation(65, 67, n)} +
 		vector<SourceLocation>(4, SourceLocation(58, 67, n)) +
 		vector<SourceLocation>(3, SourceLocation(20, 72, n));

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5354,6 +5354,25 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_as_return_type)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(calldata_offset)
+{
+	// This tests a specific bug that was caused by not using the correct memory offset in the
+	// calldata unpacker.
+	char const* sourceCode = R"(
+			contract CB
+			{
+				address[] _arr;
+				string public last = "nd";
+				function CB(address[] guardians)
+				{
+					_arr = guardians;
+				}
+			}
+			)";
+	compileAndRun(sourceCode, 0, "CB", encodeArgs(u256(0x20)));
+	BOOST_CHECK(callContractFunction("last()", encodeArgs()) == encodeDyn(string("nd")));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
The offset was not specified correctly if memory activity preceded the
unpacker.

Fixes #104
