### PR TITLE
Internal types for library

### DIFF
--- a/libsolidity/AST.cpp
+++ b/libsolidity/AST.cpp
@@ -135,7 +135,7 @@ vector<pair<FixedHash<4>, FunctionTypePointer>> const& ContractDefinition::inter
 					FunctionType ftype(*v);
 					solAssert(!!v->annotation().type.get(), "");
 					functionsSeen.insert(v->name());
-					FixedHash<4> hash(dev::sha3(ftype.externalSignature(v->name())));
+					FixedHash<4> hash(dev::sha3(ftype.externalSignature()));
 					m_interfaceFunctionList->push_back(make_pair(hash, make_shared<FunctionType>(*v)));
 				}
 		}
@@ -215,6 +215,13 @@ TypePointer StructDefinition::type(ContractDefinition const*) const
 	return make_shared<TypeType>(make_shared<StructType>(*this));
 }
 
+TypeDeclarationAnnotation& StructDefinition::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = new TypeDeclarationAnnotation();
+	return static_cast<TypeDeclarationAnnotation&>(*m_annotation);
+}
+
 TypePointer EnumValue::type(ContractDefinition const*) const
 {
 	auto parentDef = dynamic_cast<EnumDefinition const*>(scope());
@@ -227,6 +234,13 @@ TypePointer EnumDefinition::type(ContractDefinition const*) const
 	return make_shared<TypeType>(make_shared<EnumType>(*this));
 }
 
+TypeDeclarationAnnotation& EnumDefinition::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = new TypeDeclarationAnnotation();
+	return static_cast<TypeDeclarationAnnotation&>(*m_annotation);
+}
+
 TypePointer FunctionDefinition::type(ContractDefinition const*) const
 {
 	return make_shared<FunctionType>(*this);
@@ -234,7 +248,7 @@ TypePointer FunctionDefinition::type(ContractDefinition const*) const
 
 string FunctionDefinition::externalSignature() const
 {
-	return FunctionType(*this).externalSignature(name());
+	return FunctionType(*this).externalSignature();
 }
 
 TypePointer ModifierDefinition::type(ContractDefinition const*) const

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -352,6 +352,8 @@ public:
 
 	virtual TypePointer type(ContractDefinition const* m_currentContract) const override;
 
+	virtual TypeDeclarationAnnotation& annotation() const override;
+
 private:
 	std::vector<ASTPointer<VariableDeclaration>> m_members;
 };
@@ -371,6 +373,8 @@ public:
 	std::vector<ASTPointer<EnumValue>> const& members() const { return m_members; }
 
 	virtual TypePointer type(ContractDefinition const* m_currentContract) const override;
+
+	virtual TypeDeclarationAnnotation& annotation() const override;
 
 private:
 	std::vector<ASTPointer<EnumValue>> m_members;

--- a/libsolidity/AST.h
+++ b/libsolidity/AST.h
@@ -712,17 +712,17 @@ private:
 class UserDefinedTypeName: public TypeName
 {
 public:
-	UserDefinedTypeName(SourceLocation const& _location, ASTPointer<ASTString> const& _name):
-		TypeName(_location), m_name(_name) {}
+	UserDefinedTypeName(SourceLocation const& _location, std::vector<ASTString> const& _namePath):
+		TypeName(_location), m_namePath(_namePath) {}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	ASTString const& name() const { return *m_name; }
+	std::vector<ASTString> const& namePath() const { return m_namePath; }
 
 	virtual UserDefinedTypeNameAnnotation& annotation() const override;
 
 private:
-	ASTPointer<ASTString> m_name;
+	std::vector<ASTString> m_namePath;
 };
 
 /**

--- a/libsolidity/ASTAnnotations.h
+++ b/libsolidity/ASTAnnotations.h
@@ -40,7 +40,13 @@ struct ASTAnnotation
 	virtual ~ASTAnnotation() {}
 };
 
-struct ContractDefinitionAnnotation: ASTAnnotation
+struct TypeDeclarationAnnotation: ASTAnnotation
+{
+	/// The name of this type, prefixed by proper namespaces if globally accessible.
+	std::string canonicalName;
+};
+
+struct ContractDefinitionAnnotation: TypeDeclarationAnnotation
 {
 	/// Whether all functions are implemented.
 	bool isFullyImplemented = true;

--- a/libsolidity/ASTJsonConverter.cpp
+++ b/libsolidity/ASTJsonConverter.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <libsolidity/ASTJsonConverter.h>
+#include <boost/algorithm/string/join.hpp>
 #include <libsolidity/AST.h>
 
 using namespace std;
@@ -144,7 +145,9 @@ bool ASTJsonConverter::visit(ElementaryTypeName const& _node)
 
 bool ASTJsonConverter::visit(UserDefinedTypeName const& _node)
 {
-	addJsonNode("UserDefinedTypeName", { make_pair("name", _node.name()) });
+	addJsonNode("UserDefinedTypeName", {
+		make_pair("name", boost::algorithm::join(_node.namePath(), "."))
+	});
 	return true;
 }
 

--- a/libsolidity/ASTPrinter.cpp
+++ b/libsolidity/ASTPrinter.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <libsolidity/ASTPrinter.h>
+#include <boost/algorithm/string/join.hpp>
 #include <libsolidity/AST.h>
 
 using namespace std;
@@ -151,7 +152,7 @@ bool ASTPrinter::visit(ElementaryTypeName const& _node)
 
 bool ASTPrinter::visit(UserDefinedTypeName const& _node)
 {
-	writeLine("UserDefinedTypeName \"" + _node.name() + "\"");
+	writeLine("UserDefinedTypeName \"" + boost::algorithm::join(_node.namePath(), ".") + "\"");
 	printSourcePart(_node);
 	return goDeeper();
 }

--- a/libsolidity/Compiler.cpp
+++ b/libsolidity/Compiler.cpp
@@ -280,15 +280,13 @@ void Compiler::appendCalldataUnpacker(TypePointers const& _typeParameters, bool 
 
 	// Retain the offset pointer as base_offset, the point from which the data offsets are computed.
 	m_context << eth::Instruction::DUP1;
-	for (TypePointer const& type: _typeParameters)
+	for (TypePointer const& parameterType: _typeParameters)
 	{
 		// stack: v1 v2 ... v(k-1) base_offset current_offset
-		switch (type->category())
-		{
-		case Type::Category::Array:
+		TypePointer type = parameterType->encodingType();
+		if (type->category() == Type::Category::Array)
 		{
 			auto const& arrayType = dynamic_cast<ArrayType const&>(*type);
-			solAssert(arrayType.location() != DataLocation::Storage, "");
 			solAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
 			if (_fromMemory)
 			{
@@ -344,7 +342,8 @@ void Compiler::appendCalldataUnpacker(TypePointers const& _typeParameters, bool 
 			}
 			break;
 		}
-		default:
+		else
+		{
 			solAssert(!type->isDynamicallySized(), "Unknown dynamically sized type: " + type->toString());
 			CompilerUtils(m_context).loadFromMemoryDynamic(*type, !_fromMemory, true);
 			CompilerUtils(m_context).moveToStackTop(1 + type->sizeOnStack());

--- a/libsolidity/Compiler.cpp
+++ b/libsolidity/Compiler.cpp
@@ -68,6 +68,12 @@ void Compiler::compileContract(
 	packIntoContractCreator(_contract, m_runtimeContext);
 	if (m_optimize)
 		m_context.optimise(m_optimizeRuns);
+
+	if (_contract.isLibrary())
+	{
+		solAssert(m_runtimeSub != size_t(-1), "");
+		m_context.injectVersionStampIntoSub(m_runtimeSub);
+	}
 }
 
 void Compiler::compileClone(

--- a/libsolidity/Compiler.h
+++ b/libsolidity/Compiler.h
@@ -87,7 +87,7 @@ private:
 	/// From memory if @a _fromMemory is true, otherwise from call data.
 	/// Expects source offset on the stack, which is removed.
 	void appendCalldataUnpacker(TypePointers const& _typeParameters, bool _fromMemory = false);
-	void appendReturnValuePacker(TypePointers const& _typeParameters);
+	void appendReturnValuePacker(TypePointers const& _typeParameters, bool _isLibrary);
 
 	void registerStateVariables(ContractDefinition const& _contract);
 	void initializeStateVariables(ContractDefinition const& _contract);

--- a/libsolidity/CompilerContext.cpp
+++ b/libsolidity/CompilerContext.cpp
@@ -20,10 +20,12 @@
  * Utilities for the solidity compiler.
  */
 
+#include <libsolidity/CompilerContext.h>
 #include <utility>
 #include <numeric>
 #include <libsolidity/AST.h>
 #include <libsolidity/Compiler.h>
+#include <libsolidity/Version.h>
 
 using namespace std;
 
@@ -175,6 +177,13 @@ void CompilerContext::resetVisitedNodes(ASTNode const* _node)
 	newStack.push(_node);
 	std::swap(m_visitedNodes, newStack);
 	updateSourceLocation();
+}
+
+void CompilerContext::injectVersionStampIntoSub(size_t _subIndex)
+{
+	eth::Assembly& sub = m_asm.sub(_subIndex);
+	sub.injectStart(eth::Instruction::POP);
+	sub.injectStart(fromBigEndian<u256>(binaryVersion()));
 }
 
 eth::AssemblyItem CompilerContext::virtualFunctionEntryLabel(

--- a/libsolidity/CompilerContext.h
+++ b/libsolidity/CompilerContext.h
@@ -128,6 +128,9 @@ public:
 	CompilerContext& operator<<(u256 const& _value) { m_asm.append(_value); return *this; }
 	CompilerContext& operator<<(bytes const& _data) { m_asm.append(_data); return *this; }
 
+	/// Prepends "PUSH <compiler version number> POP"
+	void injectVersionStampIntoSub(size_t _subIndex);
+
 	void optimise(unsigned _runs = 200) { m_asm.optimise(true, true, _runs); }
 
 	eth::Assembly const& assembly() const { return m_asm; }

--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -130,12 +130,15 @@ bool CompilerStack::parse()
 				m_globalContext->setCurrentContract(*contract);
 				resolver.updateDeclaration(*m_globalContext->currentThis());
 				TypeChecker typeChecker;
-				if (!typeChecker.checkTypeRequirements(*contract))
+				if (typeChecker.checkTypeRequirements(*contract))
+				{
+					contract->setDevDocumentation(interfaceHandler.devDocumentation(*contract));
+					contract->setUserDocumentation(interfaceHandler.userDocumentation(*contract));
+				}
+				else
 					typesFine = false;
-				m_errors += typeChecker.errors();
-				contract->setDevDocumentation(interfaceHandler.devDocumentation(*contract));
-				contract->setUserDocumentation(interfaceHandler.userDocumentation(*contract));
 				m_contracts[contract->name()].contract = contract;
+				m_errors += typeChecker.errors();
 			}
 	m_parseSuccessful = typesFine;
 	return m_parseSuccessful;

--- a/libsolidity/CompilerUtils.cpp
+++ b/libsolidity/CompilerUtils.cpp
@@ -160,7 +160,7 @@ void CompilerUtils::encodeToMemory(
 	TypePointers targetTypes = _targetTypes.empty() ? _givenTypes : _targetTypes;
 	solAssert(targetTypes.size() == _givenTypes.size(), "");
 	for (TypePointer& t: targetTypes)
-		t = t->mobileType()->externalType();
+		t = t->mobileType()->encodingType();
 
 	// Stack during operation:
 	// <v1> <v2> ... <vn> <mem_start> <dyn_head_1> ... <dyn_head_r> <end_of_mem>

--- a/libsolidity/CompilerUtils.cpp
+++ b/libsolidity/CompilerUtils.cpp
@@ -153,14 +153,15 @@ void CompilerUtils::encodeToMemory(
 	TypePointers const& _givenTypes,
 	TypePointers const& _targetTypes,
 	bool _padToWordBoundaries,
-	bool _copyDynamicDataInPlace
+	bool _copyDynamicDataInPlace,
+	bool _encodeAsLibraryTypes
 )
 {
 	// stack: <v1> <v2> ... <vn> <mem>
 	TypePointers targetTypes = _targetTypes.empty() ? _givenTypes : _targetTypes;
 	solAssert(targetTypes.size() == _givenTypes.size(), "");
 	for (TypePointer& t: targetTypes)
-		t = t->mobileType()->encodingType();
+		t = t->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType();
 
 	// Stack during operation:
 	// <v1> <v2> ... <vn> <mem_start> <dyn_head_1> ... <dyn_head_r> <end_of_mem>

--- a/libsolidity/CompilerUtils.cpp
+++ b/libsolidity/CompilerUtils.cpp
@@ -189,7 +189,14 @@ void CompilerUtils::encodeToMemory(
 			copyToStackTop(argSize - stackPos + dynPointers + 2, _givenTypes[i]->sizeOnStack());
 			solAssert(!!targetType, "Externalable type expected.");
 			TypePointer type = targetType;
-			if (
+			if (_givenTypes[i]->dataStoredIn(DataLocation::Storage) && targetType->isValueType())
+			{
+				// special case: convert storage reference type to value type - this is only
+				// possible for library calls where we just forward the storage reference
+				solAssert(_encodeAsLibraryTypes, "");
+				solAssert(_givenTypes[i]->sizeOnStack() == 1, "");
+			}
+			else if (
 				_givenTypes[i]->dataStoredIn(DataLocation::Storage) ||
 				_givenTypes[i]->dataStoredIn(DataLocation::CallData) ||
 				_givenTypes[i]->category() == Type::Category::StringLiteral

--- a/libsolidity/CompilerUtils.h
+++ b/libsolidity/CompilerUtils.h
@@ -91,13 +91,16 @@ public:
 	/// @param _padToWordBoundaries if false, all values are concatenated without padding.
 	/// @param _copyDynamicDataInPlace if true, dynamic types is stored (without length)
 	/// together with fixed-length data.
+	/// @param _encodeAsLibraryTypes if true, encodes for a library function, e.g. does not
+	/// convert storage pointer types to memory types.
 	/// @note the locations of target reference types are ignored, because it will always be
 	/// memory.
 	void encodeToMemory(
 		TypePointers const& _givenTypes = {},
 		TypePointers const& _targetTypes = {},
 		bool _padToWordBoundaries = true,
-		bool _copyDynamicDataInPlace = false
+		bool _copyDynamicDataInPlace = false,
+		bool _encodeAsLibraryTypes = false
 	);
 
 	/// Uses a CALL to the identity contract to perform a memory-to-memory copy.

--- a/libsolidity/DeclarationContainer.h
+++ b/libsolidity/DeclarationContainer.h
@@ -40,8 +40,10 @@ namespace solidity
 class DeclarationContainer
 {
 public:
-	explicit DeclarationContainer(Declaration const* _enclosingDeclaration = nullptr,
-								  DeclarationContainer const* _enclosingContainer = nullptr):
+	explicit DeclarationContainer(
+		Declaration const* _enclosingDeclaration = nullptr,
+		DeclarationContainer const* _enclosingContainer = nullptr
+	):
 		m_enclosingDeclaration(_enclosingDeclaration), m_enclosingContainer(_enclosingContainer) {}
 	/// Registers the declaration in the scope unless its name is already declared or the name is empty.
 	/// @param _invisible if true, registers the declaration, reports name clashes but does not return it in @a resolveName

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -1179,7 +1179,8 @@ void ExpressionCompiler::appendExternalFunctionCall(
 		argumentTypes,
 		_functionType.parameterTypes(),
 		_functionType.padArguments(),
-		_functionType.takesArbitraryParameters()
+		_functionType.takesArbitraryParameters(),
+		isCallCode
 	);
 
 	// Stack now:

--- a/libsolidity/ExpressionCompiler.cpp
+++ b/libsolidity/ExpressionCompiler.cpp
@@ -585,7 +585,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				}
 			if (!event.isAnonymous())
 			{
-				m_context << u256(h256::Arith(dev::sha3(function.externalSignature(event.name()))));
+				m_context << u256(h256::Arith(dev::sha3(function.externalSignature())));
 				++numIndexed;
 			}
 			solAssert(numIndexed <= 4, "Too many indexed arguments.");

--- a/libsolidity/InterfaceHandler.cpp
+++ b/libsolidity/InterfaceHandler.cpp
@@ -64,11 +64,11 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 		method["constant"] = it.second->isConstant();
 		method["inputs"] = populateParameters(
 			externalFunctionType->parameterNames(),
-			externalFunctionType->parameterTypeNames()
+			externalFunctionType->parameterTypeNames(_contractDef.isLibrary())
 		);
 		method["outputs"] = populateParameters(
 			externalFunctionType->returnParameterNames(),
-			externalFunctionType->returnParameterTypeNames()
+			externalFunctionType->returnParameterTypeNames(_contractDef.isLibrary())
 		);
 		abi.append(method);
 	}
@@ -80,7 +80,7 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 		solAssert(!!externalFunction, "");
 		method["inputs"] = populateParameters(
 			externalFunction->parameterNames(),
-			externalFunction->parameterTypeNames()
+			externalFunction->parameterTypeNames(_contractDef.isLibrary())
 		);
 		abi.append(method);
 	}
@@ -96,7 +96,7 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 		{
 			Json::Value input;
 			input["name"] = p->name();
-			input["type"] = p->annotation().type->toString(true);
+			input["type"] = p->annotation().type->canonicalName(false);
 			input["indexed"] = p->isIndexed();
 			params.append(input);
 		}
@@ -125,16 +125,24 @@ string InterfaceHandler::ABISolidityInterface(ContractDefinition const& _contrac
 		ret +=
 			"function " +
 			_contractDef.name() +
-			populateParameters(externalFunction->parameterNames(), externalFunction->parameterTypeNames()) +
+			populateParameters(
+				externalFunction->parameterNames(),
+				externalFunction->parameterTypeNames(_contractDef.isLibrary())
+			) +
 			";";
 	}
 	for (auto const& it: _contractDef.interfaceFunctions())
 	{
 		ret += "function " + it.second->declaration().name() +
-			populateParameters(it.second->parameterNames(), it.second->parameterTypeNames()) +
-			(it.second->isConstant() ? "constant " : "");
+			populateParameters(
+				it.second->parameterNames(),
+				it.second->parameterTypeNames(_contractDef.isLibrary())
+			) + (it.second->isConstant() ? "constant " : "");
 		if (it.second->returnParameterTypes().size())
-			ret += "returns" + populateParameters(it.second->returnParameterNames(), it.second->returnParameterTypeNames());
+			ret += "returns" + populateParameters(
+				it.second->returnParameterNames(),
+				it.second->returnParameterTypeNames(_contractDef.isLibrary())
+			);
 		else if (ret.back() == ' ')
 			ret.pop_back();
 		ret += ";";

--- a/libsolidity/InterfaceHandler.cpp
+++ b/libsolidity/InterfaceHandler.cpp
@@ -57,7 +57,7 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 
 	for (auto it: _contractDef.interfaceFunctions())
 	{
-		auto externalFunctionType = it.second->externalFunctionType();
+		auto externalFunctionType = it.second->interfaceFunctionType();
 		Json::Value method;
 		method["type"] = "function";
 		method["name"] = it.second->declaration().name();
@@ -76,7 +76,7 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 	{
 		Json::Value method;
 		method["type"] = "constructor";
-		auto externalFunction = FunctionType(*_contractDef.constructor()).externalFunctionType();
+		auto externalFunction = FunctionType(*_contractDef.constructor()).interfaceFunctionType();
 		solAssert(!!externalFunction, "");
 		method["inputs"] = populateParameters(
 			externalFunction->parameterNames(),
@@ -120,7 +120,7 @@ string InterfaceHandler::ABISolidityInterface(ContractDefinition const& _contrac
 	};
 	if (_contractDef.constructor())
 	{
-		auto externalFunction = FunctionType(*_contractDef.constructor()).externalFunctionType();
+		auto externalFunction = FunctionType(*_contractDef.constructor()).interfaceFunctionType();
 		solAssert(!!externalFunction, "");
 		ret +=
 			"function " +

--- a/libsolidity/NameAndTypeResolver.cpp
+++ b/libsolidity/NameAndTypeResolver.cpp
@@ -130,6 +130,22 @@ vector<Declaration const*> NameAndTypeResolver::nameFromCurrentScope(ASTString c
 	return m_currentScope->resolveName(_name, _recursive);
 }
 
+Declaration const* NameAndTypeResolver::pathFromCurrentScope(vector<ASTString> const& _path, bool _recursive)
+{
+	solAssert(!_path.empty(), "");
+	vector<Declaration const*> candidates = m_currentScope->resolveName(_path.front(), _recursive);
+	for (size_t i = 1; i < _path.size() && candidates.size() == 1; i++)
+	{
+		if (!m_scopes.count(candidates.front()))
+			return nullptr;
+		candidates = m_scopes.at(candidates.front()).resolveName(_path[i], false);
+	}
+	if (candidates.size() == 1)
+		return candidates.front();
+	else
+		return nullptr;
+}
+
 vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 		Identifier const& _identifier,
 		vector<Declaration const*> const& _declarations

--- a/libsolidity/NameAndTypeResolver.cpp
+++ b/libsolidity/NameAndTypeResolver.cpp
@@ -263,6 +263,7 @@ DeclarationRegistrationHelper::DeclarationRegistrationHelper(map<ASTNode const*,
 bool DeclarationRegistrationHelper::visit(ContractDefinition& _contract)
 {
 	registerDeclaration(_contract, true);
+	_contract.annotation().canonicalName = currentCanonicalName();
 	return true;
 }
 
@@ -274,6 +275,7 @@ void DeclarationRegistrationHelper::endVisit(ContractDefinition&)
 bool DeclarationRegistrationHelper::visit(StructDefinition& _struct)
 {
 	registerDeclaration(_struct, true);
+	_struct.annotation().canonicalName = currentCanonicalName();
 	return true;
 }
 
@@ -285,6 +287,7 @@ void DeclarationRegistrationHelper::endVisit(StructDefinition&)
 bool DeclarationRegistrationHelper::visit(EnumDefinition& _enum)
 {
 	registerDeclaration(_enum, true);
+	_enum.annotation().canonicalName = currentCanonicalName();
 	return true;
 }
 
@@ -398,6 +401,22 @@ void DeclarationRegistrationHelper::registerDeclaration(Declaration& _declaratio
 	_declaration.setScope(m_currentScope);
 	if (_opensScope)
 		enterNewSubScope(_declaration);
+}
+
+string DeclarationRegistrationHelper::currentCanonicalName() const
+{
+	string ret;
+	for (
+		Declaration const* scope = m_currentScope;
+		scope != nullptr;
+		scope = m_scopes[scope].enclosingDeclaration()
+	)
+	{
+		if (!ret.empty())
+			ret = "." + ret;
+		ret = scope->name() + ret;
+	}
+	return ret;
 }
 
 }

--- a/libsolidity/NameAndTypeResolver.cpp
+++ b/libsolidity/NameAndTypeResolver.cpp
@@ -125,12 +125,12 @@ vector<Declaration const*> NameAndTypeResolver::resolveName(ASTString const& _na
 	return iterator->second.resolveName(_name, false);
 }
 
-vector<Declaration const*> NameAndTypeResolver::nameFromCurrentScope(ASTString const& _name, bool _recursive)
+vector<Declaration const*> NameAndTypeResolver::nameFromCurrentScope(ASTString const& _name, bool _recursive) const
 {
 	return m_currentScope->resolveName(_name, _recursive);
 }
 
-Declaration const* NameAndTypeResolver::pathFromCurrentScope(vector<ASTString> const& _path, bool _recursive)
+Declaration const* NameAndTypeResolver::pathFromCurrentScope(vector<ASTString> const& _path, bool _recursive) const
 {
 	solAssert(!_path.empty(), "");
 	vector<Declaration const*> candidates = m_currentScope->resolveName(_path.front(), _recursive);

--- a/libsolidity/NameAndTypeResolver.h
+++ b/libsolidity/NameAndTypeResolver.h
@@ -58,12 +58,12 @@ public:
 
 	/// Resolves a name in the "current" scope. Should only be called during the initial
 	/// resolving phase.
-	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name, bool _recursive = true);
+	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name, bool _recursive = true) const;
 
 	/// Resolves a path starting from the "current" scope. Should only be called during the initial
 	/// resolving phase.
 	/// @note Returns a null pointer if any component in the path was not unique or not found.
-	Declaration const* pathFromCurrentScope(std::vector<ASTString> const& _path, bool _recursive = true);
+	Declaration const* pathFromCurrentScope(std::vector<ASTString> const& _path, bool _recursive = true) const;
 
 	/// returns the vector of declarations without repetitions
 	static std::vector<Declaration const*> cleanedDeclarations(

--- a/libsolidity/NameAndTypeResolver.h
+++ b/libsolidity/NameAndTypeResolver.h
@@ -36,9 +36,8 @@ namespace solidity
 {
 
 /**
- * Resolves name references, types and checks types of all expressions.
- * Specifically, it checks that all operations are valid for the inferred types.
- * An exception is throw on the first error.
+ * Resolves name references, typenames and sets the (explicitly given) types for all variable
+ * declarations.
  */
 class NameAndTypeResolver: private boost::noncopyable
 {
@@ -60,6 +59,11 @@ public:
 	/// Resolves a name in the "current" scope. Should only be called during the initial
 	/// resolving phase.
 	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name, bool _recursive = true);
+
+	/// Resolves a path starting from the "current" scope. Should only be called during the initial
+	/// resolving phase.
+	/// @note Returns a null pointer if any component in the path was not unique or not found.
+	Declaration const* pathFromCurrentScope(std::vector<ASTString> const& _path, bool _recursive = true);
 
 	/// returns the vector of declarations without repetitions
 	static std::vector<Declaration const*> cleanedDeclarations(

--- a/libsolidity/NameAndTypeResolver.h
+++ b/libsolidity/NameAndTypeResolver.h
@@ -119,6 +119,9 @@ private:
 	void closeCurrentScope();
 	void registerDeclaration(Declaration& _declaration, bool _opensScope);
 
+	/// @returns the canonical name of the current scope.
+	std::string currentCanonicalName() const;
+
 	std::map<ASTNode const*, DeclarationContainer>& m_scopes;
 	Declaration const* m_currentScope;
 	VariableScope* m_currentFunction;

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -522,7 +522,14 @@ ASTPointer<TypeName> Parser::parseTypeName(bool _allowVar)
 	{
 		ASTNodeFactory nodeFactory(*this);
 		nodeFactory.markEndPosition();
-		type = nodeFactory.createNode<UserDefinedTypeName>(expectIdentifierToken());
+		vector<ASTString> identifierPath{*expectIdentifierToken()};
+		while (m_scanner->currentToken() == Token::Period)
+		{
+			m_scanner->next();
+			nodeFactory.markEndPosition();
+			identifierPath.push_back(*expectIdentifierToken());
+		}
+		type = nodeFactory.createNode<UserDefinedTypeName>(identifierPath);
 	}
 	else
 		BOOST_THROW_EXCEPTION(createParserError("Expected type name"));
@@ -1036,7 +1043,7 @@ ASTPointer<TypeName> Parser::typeNameIndexAccessStructure(
 	ASTNodeFactory nodeFactory(*this, _primary);
 	ASTPointer<TypeName> type;
 	if (auto identifier = dynamic_cast<Identifier const*>(_primary.get()))
-		type = nodeFactory.createNode<UserDefinedTypeName>(make_shared<ASTString>(identifier->name()));
+		type = nodeFactory.createNode<UserDefinedTypeName>(vector<ASTString>{identifier->name()});
 	else if (auto typeName = dynamic_cast<ElementaryTypeNameExpression const*>(_primary.get()))
 		type = nodeFactory.createNode<ElementaryTypeName>(typeName->typeToken());
 	else

--- a/libsolidity/ReferencesResolver.cpp
+++ b/libsolidity/ReferencesResolver.cpp
@@ -106,27 +106,45 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 		// References are forced to calldata for external function parameters (not return)
 		// and memory for parameters (also return) of publicly visible functions.
 		// They default to memory for function parameters and storage for local variables.
+		// As an exception, "storage" is allowed for library functions.
 		if (auto ref = dynamic_cast<ReferenceType const*>(type.get()))
 		{
-			if (_variable.isExternalCallableParameter())
+			if (_variable.isCallableParameter())
 			{
-				// force location of external function parameters (not return) to calldata
-				if (loc != Location::Default)
-					BOOST_THROW_EXCEPTION(_variable.createTypeError(
-						"Location has to be calldata for external functions "
-						"(remove the \"memory\" or \"storage\" keyword)."
-					));
-				type = ref->copyForLocation(DataLocation::CallData, true);
-			}
-			else if (_variable.isCallableParameter() && _variable.scope()->isPublic())
-			{
-				// force locations of public or external function (return) parameters to memory
-				if (loc == VariableDeclaration::Location::Storage)
-					BOOST_THROW_EXCEPTION(_variable.createTypeError(
-						"Location has to be memory for publicly visible functions "
-						"(remove the \"storage\" keyword)."
-					));
-				type = ref->copyForLocation(DataLocation::Memory, true);
+				auto const& contract = dynamic_cast<ContractDefinition const&>(*_variable.scope()->scope());
+				if (_variable.isExternalCallableParameter())
+				{
+					if (contract.isLibrary())
+					{
+						if (loc == Location::Memory)
+							BOOST_THROW_EXCEPTION(_variable.createTypeError(
+								"Location has to be calldata or storage for external "
+								"library functions (remove the \"memory\" keyword)."
+							));
+					}
+					else
+					{
+						// force location of external function parameters (not return) to calldata
+						if (loc != Location::Default)
+							BOOST_THROW_EXCEPTION(_variable.createTypeError(
+								"Location has to be calldata for external functions "
+								"(remove the \"memory\" or \"storage\" keyword)."
+							));
+					}
+					if (loc == Location::Default)
+						type = ref->copyForLocation(DataLocation::CallData, true);
+				}
+				else if (_variable.isCallableParameter() && _variable.scope()->isPublic())
+				{
+					// force locations of public or external function (return) parameters to memory
+					if (loc == Location::Storage && !contract.isLibrary())
+						BOOST_THROW_EXCEPTION(_variable.createTypeError(
+							"Location has to be memory for publicly visible functions "
+							"(remove the \"storage\" keyword)."
+						));
+					if (loc == Location::Default)
+						type = ref->copyForLocation(DataLocation::Memory, true);
+				}
 			}
 			else
 			{

--- a/libsolidity/ReferencesResolver.cpp
+++ b/libsolidity/ReferencesResolver.cpp
@@ -54,20 +54,13 @@ bool ReferencesResolver::visit(Return const& _return)
 
 bool ReferencesResolver::visit(UserDefinedTypeName const& _typeName)
 {
-	auto declarations = m_resolver.nameFromCurrentScope(_typeName.name());
-	if (declarations.empty())
+	Declaration const* declaration = m_resolver.pathFromCurrentScope(_typeName.namePath());
+	if (!declaration)
 		BOOST_THROW_EXCEPTION(
 			DeclarationError() <<
 			errinfo_sourceLocation(_typeName.location()) <<
-			errinfo_comment("Undeclared identifier.")
+			errinfo_comment("Identifier not found or not unique.")
 		);
-	else if (declarations.size() > 1)
-		BOOST_THROW_EXCEPTION(
-			DeclarationError() <<
-			errinfo_sourceLocation(_typeName.location()) <<
-			errinfo_comment("Duplicate identifier.")
-		);
-	Declaration const* declaration = *declarations.begin();
 	_typeName.annotation().referencedDeclaration = declaration;
 	return true;
 }

--- a/libsolidity/TypeChecker.cpp
+++ b/libsolidity/TypeChecker.cpp
@@ -299,7 +299,7 @@ void TypeChecker::checkContractExternalTypeClashes(ContractDefinition const& _co
 			if (f->isPartOfExternalInterface())
 			{
 				auto functionType = make_shared<FunctionType>(*f);
-				externalDeclarations[functionType->externalSignature(f->name())].push_back(
+				externalDeclarations[functionType->externalSignature()].push_back(
 					make_pair(f.get(), functionType)
 				);
 			}
@@ -307,7 +307,7 @@ void TypeChecker::checkContractExternalTypeClashes(ContractDefinition const& _co
 			if (v->isPartOfExternalInterface())
 			{
 				auto functionType = make_shared<FunctionType>(*v);
-				externalDeclarations[functionType->externalSignature(v->name())].push_back(
+				externalDeclarations[functionType->externalSignature()].push_back(
 					make_pair(v.get(), functionType)
 				);
 			}
@@ -403,7 +403,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		if (!type(*var)->canLiveOutsideStorage())
 			typeError(*var, "Type is required to live outside storage.");
 		if (_function.visibility() >= FunctionDefinition::Visibility::Public && !(type(*var)->interfaceType(isLibraryFunction)))
-			typeError(*var, "Internal type is not allowed for public and external functions.");
+			fatalTypeError(*var, "Internal type is not allowed for public or external functions.");
 	}
 	for (ASTPointer<ModifierInvocation> const& modifier: _function.modifiers())
 		visitManually(

--- a/libsolidity/Types.cpp
+++ b/libsolidity/Types.cpp
@@ -847,6 +847,14 @@ TypePointer ArrayType::encodingType() const
 		return this->copyForLocation(DataLocation::Memory, true);
 }
 
+TypePointer ArrayType::decodingType() const
+{
+	if (location() == DataLocation::Storage)
+		return make_shared<IntegerType>(256);
+	else
+		return shared_from_this();
+}
+
 TypePointer ArrayType::interfaceType(bool _inLibrary) const
 {
 	if (_inLibrary && location() == DataLocation::Storage)

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -218,6 +218,9 @@ public:
 
 	virtual std::string toString(bool _short) const = 0;
 	std::string toString() const { return toString(false); }
+	/// @returns the canonical name of this type for use in function signatures.
+	/// @param _addDataLocation if true, includes data location for reference types if it is "storage".
+	virtual std::string canonicalName(bool /*_addDataLocation*/) const { return toString(true); }
 	virtual u256 literalValue(Literal const*) const
 	{
 		BOOST_THROW_EXCEPTION(
@@ -501,6 +504,7 @@ public:
 	virtual bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
 	virtual unsigned sizeOnStack() const override;
 	virtual std::string toString(bool _short) const override;
+	virtual std::string canonicalName(bool _addDataLocation) const override;
 	virtual MemberList const& members() const override
 	{
 		return isString() ? EmptyMemberList : s_arrayTypeMemberList;
@@ -554,6 +558,7 @@ public:
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual bool isValueType() const override { return true; }
 	virtual std::string toString(bool _short) const override;
+	virtual std::string canonicalName(bool _addDataLocation) const override;
 
 	virtual MemberList const& members() const override;
 	virtual TypePointer encodingType() const override
@@ -617,6 +622,8 @@ public:
 
 	TypePointer copyForLocation(DataLocation _location, bool _isPointer) const override;
 
+	virtual std::string canonicalName(bool _addDataLocation) const override;
+
 	/// @returns a function that peforms the type conversion between a list of struct members
 	/// and a memory struct of this type.
 	FunctionTypePointer constructorType() const;
@@ -652,6 +659,7 @@ public:
 	virtual unsigned storageBytes() const override;
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual std::string toString(bool _short) const override;
+	virtual std::string canonicalName(bool _addDataLocation) const override;
 	virtual bool isValueType() const override { return true; }
 
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
@@ -756,10 +764,10 @@ public:
 
 	TypePointers const& parameterTypes() const { return m_parameterTypes; }
 	std::vector<std::string> const& parameterNames() const { return m_parameterNames; }
-	std::vector<std::string> const parameterTypeNames() const;
+	std::vector<std::string> const parameterTypeNames(bool _addDataLocation) const;
 	TypePointers const& returnParameterTypes() const { return m_returnParameterTypes; }
 	std::vector<std::string> const& returnParameterNames() const { return m_returnParameterNames; }
-	std::vector<std::string> const returnParameterTypeNames() const;
+	std::vector<std::string> const returnParameterTypeNames(bool _addDataLocation) const;
 
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
@@ -786,9 +794,7 @@ public:
 	bool isBareCall() const;
 	Location const& location() const { return m_location; }
 	/// @returns the external signature of this function type given the function name
-	/// If @a _name is not provided (empty string) then the @c m_declaration member of the
-	/// function type is used
-	std::string externalSignature(std::string const& _name = "") const;
+	std::string externalSignature() const;
 	/// @returns the external identifier of this function (the hash of the signature).
 	u256 externalIdentifier() const;
 	Declaration const& declaration() const
@@ -849,6 +855,7 @@ public:
 
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
+	virtual std::string canonicalName(bool _addDataLocation) const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual TypePointer encodingType() const override
 	{

--- a/libsolidity/Types.h
+++ b/libsolidity/Types.h
@@ -230,6 +230,8 @@ public:
 	/// This for example returns address for contract types.
 	/// If there is no such type, returns an empty shared pointer.
 	virtual TypePointer encodingType() const { return TypePointer(); }
+	/// @returns a (simpler) type that is used when decoding this type in calldata.
+	virtual TypePointer decodingType() const { return encodingType(); }
 	/// @returns a type that will be used outside of Solidity for e.g. function signatures.
 	/// This for example returns address for contract types.
 	/// If there is no such type, returns an empty shared pointer.
@@ -504,6 +506,7 @@ public:
 		return isString() ? EmptyMemberList : s_arrayTypeMemberList;
 	}
 	virtual TypePointer encodingType() const override;
+	virtual TypePointer decodingType() const override;
 	virtual TypePointer interfaceType(bool _inLibrary) const override;
 
 	/// @returns true if this is a byte array or a string

--- a/libsolidity/Utils.h
+++ b/libsolidity/Utils.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <libdevcore/Assertions.h>
+#include <libsolidity/Exceptions.h>
 
 /// Assertion that throws an InternalCompilerError containing the given description if it is not met.
 #define solAssert(CONDITION, DESCRIPTION) \

--- a/libsolidity/Version.cpp
+++ b/libsolidity/Version.cpp
@@ -22,20 +22,52 @@
 
 #include <libsolidity/Version.h>
 #include <string>
-#include <libevmasm/Version.h>
-#include <solidity/BuildInfo.h>
+#include <libdevcore/CommonData.h>
 #include <libdevcore/Common.h>
+#include <libevmasm/Version.h>
+#include <libsolidity/Utils.h>
+#include <solidity/BuildInfo.h>
 
 using namespace dev;
 using namespace dev::solidity;
 using namespace std;
 
 char const* dev::solidity::VersionNumber = ETH_PROJECT_VERSION;
-extern string const dev::solidity::VersionString =
+
+string const dev::solidity::VersionString =
 	string(dev::solidity::VersionNumber) +
 	"-" +
 	string(DEV_QUOTED(ETH_COMMIT_HASH)).substr(0, 8) +
 	(ETH_CLEAN_REPO ? "" : "*") +
 	"/" DEV_QUOTED(ETH_BUILD_TYPE) "-" DEV_QUOTED(ETH_BUILD_PLATFORM)
 	" linked to libethereum-" + eth::VersionStringLibEvmAsm;
+
+
+bytes dev::solidity::binaryVersion()
+{
+	bytes ret{0};
+	size_t i = 0;
+	auto parseDecimal = [&]()
+	{
+		size_t ret = 0;
+		solAssert('0' <= VersionString[i] && VersionString[i] <= '9', "");
+		for (; i < VersionString.size() && '0' <= VersionString[i] && VersionString[i] <= '9'; ++i)
+			ret = ret * 10 + (VersionString[i] - '0');
+		return ret;
+	};
+	ret.push_back(byte(parseDecimal()));
+	solAssert(i < VersionString.size() && VersionString[i] == '.', "");
+	++i;
+	ret.push_back(byte(parseDecimal()));
+	solAssert(i < VersionString.size() && VersionString[i] == '.', "");
+	++i;
+	ret.push_back(byte(parseDecimal()));
+	solAssert(i < VersionString.size() && VersionString[i] == '-', "");
+	++i;
+	solAssert(i + 7 < VersionString.size(), "");
+	ret += fromHex(VersionString.substr(i, 8));
+	solAssert(ret.size() == 1 + 3 + 4, "");
+
+	return ret;
+}
 

--- a/libsolidity/Version.h
+++ b/libsolidity/Version.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <string>
+#include <libdevcore/Common.h>
 
 namespace dev
 {
@@ -31,6 +32,11 @@ namespace solidity
 
 extern char const* VersionNumber;
 extern std::string const VersionString;
+
+/// @returns a binary form of the version string, where A.B.C-HASH is encoded such that
+/// the first byte is zero, the following three bytes encode A B and C (interpreted as decimals)
+/// and HASH is interpreted as 8 hex digits and encoded into the last four bytes.
+bytes binaryVersion();
 
 }
 }

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -595,6 +595,36 @@ BOOST_AUTO_TEST_CASE(strings_and_arrays)
 	checkInterface(sourceCode, interface);
 }
 
+BOOST_AUTO_TEST_CASE(library_function)
+{
+	char const* sourceCode = R"(
+		library test {
+			struct StructType { uint a; }
+			function f(StructType storage b, uint[] storage c, test d) returns (uint[] e, StructType storage f){}
+		}
+	)";
+
+	char const* interface = R"(
+	[
+		{
+			"constant" : false,
+			"name": "f",
+			"inputs": [
+				{ "name": "b", "type": "test.StructType storage" },
+				{ "name": "c", "type": "uint256[] storage" },
+				{ "name": "d", "type": "test" }
+			],
+			"outputs": [
+				{ "name": "e", "type": "uint256[]" },
+				{ "name": "f", "type": "test.StructType storage" }
+			],
+			"type" : "function"
+		}
+	]
+	)";
+	checkInterface(sourceCode, interface);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5383,6 +5383,33 @@ BOOST_AUTO_TEST_CASE(internal_types_in_library)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(4), u256(17)));
 }
 
+BOOST_AUTO_TEST_CASE(using_library_structs)
+{
+	char const* sourceCode = R"(
+		library Lib {
+			struct Data { uint a; uint[] b; }
+			function set(Data storage _s)
+			{
+				_s.a = 7;
+				_s.b.length = 20;
+				_s.b[19] = 8;
+			}
+		}
+		contract Test {
+			mapping(string => Lib.Data) data;
+			function f() returns (uint a, uint b)
+			{
+				Lib.set(data["abc"]);
+				a = data["abc"].a;
+				b = data["abc"].b[19];
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Lib");
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(7), u256(8)));
+}
+
 BOOST_AUTO_TEST_CASE(short_strings)
 {
 	// This test verifies that the byte array encoding that combines length and data works

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5354,6 +5354,35 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_as_return_type)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(internal_types_in_library)
+{
+	char const* sourceCode = R"(
+		library Lib {
+			function find(uint16[] storage _haystack, uint16 _needle) constant returns (uint)
+			{
+				for (uint i = 0; i < _haystack.length; ++i)
+					if (_haystack[i] == _needle)
+						return i;
+				return uint(-1);
+			}
+		}
+		contract Test {
+			mapping(string => uint16[]) data;
+			function f() returns (uint a, uint b)
+			{
+				data["abc"].length = 20;
+				data["abc"][4] = 9;
+				data["abc"][17] = 3;
+				a = Lib.find(data["abc"], 9);
+				b = Lib.find(data["abc"], 3);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Lib");
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(4), u256(17)));
+}
+
 BOOST_AUTO_TEST_CASE(short_strings)
 {
 	// This test verifies that the byte array encoding that combines length and data works

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5539,6 +5539,17 @@ BOOST_AUTO_TEST_CASE(calldata_offset)
 	BOOST_CHECK(callContractFunction("last()", encodeArgs()) == encodeDyn(string("nd")));
 }
 
+BOOST_AUTO_TEST_CASE(version_stamp_for_libraries)
+{
+	char const* sourceCode = "library lib {}";
+	m_optimize = true;
+	bytes runtimeCode = compileAndRun(sourceCode, 0, "lib");
+	BOOST_CHECK(runtimeCode.size() >= 8);
+	BOOST_CHECK_EQUAL(runtimeCode[0], int(eth::Instruction::PUSH6)); // might change once we switch to 1.x.x
+	BOOST_CHECK_EQUAL(runtimeCode[1], 1); // might change once we switch away from x.1.x
+	BOOST_CHECK_EQUAL(runtimeCode[7], int(eth::Instruction::POP));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5383,32 +5383,6 @@ BOOST_AUTO_TEST_CASE(internal_types_in_library)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(4), u256(17)));
 }
 
-BOOST_AUTO_TEST_CASE(differentiate_storage_and_memory_in_libraries)
-{
-	char const* sourceCode = R"(
-		library Lib {
-			function f(uint[] storage x) returns (uint) { return 1; }
-			function f(uint[] memory x) returns (uint) { return 2; }
-		}
-		contract Test {
-			uint[] data;
-			function f() returns (uint a,)
-			{
-				uint[] memory d = data;
-				Lib.f(d)
-				data["abc"].length = 20;
-				data["abc"][4] = 9;
-				data["abc"][17] = 3;
-				a = Lib.find(data["abc"], 9);
-				b = Lib.find(data["abc"], 3);
-			}
-		}
-	)";
-	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
-	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(4), u256(17)));
-}
-
 BOOST_AUTO_TEST_CASE(short_strings)
 {
 	// This test verifies that the byte array encoding that combines length and data works

--- a/test/libsolidity/SolidityInterface.cpp
+++ b/test/libsolidity/SolidityInterface.cpp
@@ -142,6 +142,21 @@ BOOST_AUTO_TEST_CASE(inheritance)
 												  sourcePart(*contract.definedFunctions().at(1))}));
 }
 
+BOOST_AUTO_TEST_CASE(libraries)
+{
+	char const* sourceCode = R"(
+		library Lib {
+			struct Str { uint a; }
+			enum E { E1, E2 }
+			function f(uint[] x,Str storage y,E z) external;
+		}
+	)";
+	ContractDefinition const& contract = checkInterface(sourceCode);
+	set<string> expectedFunctions({"function f(uint256[] x,Lib.Str y,Lib.E z);"});
+	BOOST_REQUIRE_EQUAL(1, contract.definedFunctions().size());
+	BOOST_CHECK(expectedFunctions == set<string>({sourcePart(*contract.definedFunctions().at(0))}));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityInterface.cpp
+++ b/test/libsolidity/SolidityInterface.cpp
@@ -152,7 +152,8 @@ BOOST_AUTO_TEST_CASE(libraries)
 		}
 	)";
 	ContractDefinition const& contract = checkInterface(sourceCode);
-	set<string> expectedFunctions({"function f(uint256[] x,Lib.Str y,Lib.E z);"});
+	BOOST_CHECK(contract.isLibrary());
+	set<string> expectedFunctions({"function f(uint256[] x,Lib.Str storage y,Lib.E z);"});
 	BOOST_REQUIRE_EQUAL(1, contract.definedFunctions().size());
 	BOOST_CHECK(expectedFunctions == set<string>({sourcePart(*contract.definedFunctions().at(0))}));
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -933,24 +933,24 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 	BOOST_REQUIRE((contract = retrieveContract(source, 0)) != nullptr);
 	FunctionTypePointer function = retrieveFunctionBySignature(contract, "foo()");
 	BOOST_REQUIRE(function && function->hasDeclaration());
-	auto returnParams = function->returnParameterTypeNames();
+	auto returnParams = function->returnParameterTypeNames(false);
 	BOOST_CHECK_EQUAL(returnParams.at(0), "uint256");
 	BOOST_CHECK(function->isConstant());
 
 	function = retrieveFunctionBySignature(contract, "map(uint256)");
 	BOOST_REQUIRE(function && function->hasDeclaration());
-	auto params = function->parameterTypeNames();
+	auto params = function->parameterTypeNames(false);
 	BOOST_CHECK_EQUAL(params.at(0), "uint256");
-	returnParams = function->returnParameterTypeNames();
+	returnParams = function->returnParameterTypeNames(false);
 	BOOST_CHECK_EQUAL(returnParams.at(0), "bytes4");
 	BOOST_CHECK(function->isConstant());
 
 	function = retrieveFunctionBySignature(contract, "multiple_map(uint256,uint256)");
 	BOOST_REQUIRE(function && function->hasDeclaration());
-	params = function->parameterTypeNames();
+	params = function->parameterTypeNames(false);
 	BOOST_CHECK_EQUAL(params.at(0), "uint256");
 	BOOST_CHECK_EQUAL(params.at(1), "uint256");
-	returnParams = function->returnParameterTypeNames();
+	returnParams = function->returnParameterTypeNames(false);
 	BOOST_CHECK_EQUAL(returnParams.at(0), "bytes4");
 	BOOST_CHECK(function->isConstant());
 }


### PR DESCRIPTION
This includes
- allow `storage` types to be passed to library calls
- provide access to internal types of a contract or library (`LibraryName.StructName`)
- add a version stamp to the beginning of library runtime code
