### PR TITLE
Check invalid integer constants for functions accepting arbitrary arguments.

### DIFF
--- a/libsolidity/TypeChecker.cpp
+++ b/libsolidity/TypeChecker.cpp
@@ -824,10 +824,15 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 	{
 		// call by positional arguments
 		for (size_t i = 0; i < arguments.size(); ++i)
-			if (
-				!functionType->takesArbitraryParameters() &&
-				!type(*arguments[i])->isImplicitlyConvertibleTo(*parameterTypes[i])
-			)
+		{
+			auto const& argType = type(*arguments[i]);
+			if (functionType->takesArbitraryParameters())
+			{
+				if (auto t = dynamic_cast<IntegerConstantType const*>(argType.get()))
+					if (!t->integerType())
+						typeError(*arguments[i], "Integer constant too large.");
+			}
+			else if (!type(*arguments[i])->isImplicitlyConvertibleTo(*parameterTypes[i]))
 				typeError(
 					*arguments[i],
 					"Invalid type for argument in function call. "
@@ -837,6 +842,7 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 					parameterTypes[i]->toString() +
 					" requested."
 				);
+		}
 	}
 	else
 	{

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -54,9 +54,9 @@ parseAnalyseAndReturnError(string const& _source, bool _reportWarnings = false)
 	try
 	{
 		sourceUnit = parser.parse(std::make_shared<Scanner>(CharStream(_source)));
-		NameAndTypeResolver resolver({});
-		resolver.registerDeclarations(*sourceUnit);
 		std::shared_ptr<GlobalContext> globalContext = make_shared<GlobalContext>();
+		NameAndTypeResolver resolver(globalContext->declarations());
+		resolver.registerDeclarations(*sourceUnit);
 
 		for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 			if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
@@ -2364,6 +2364,17 @@ BOOST_AUTO_TEST_CASE(non_initialized_references)
 		}
 	)";
 	SOLIDITY_CHECK_ERROR_TYPE(parseAndAnalyseReturnError(text, true), Warning);
+}
+
+BOOST_AUTO_TEST_CASE(sha3_with_large_integer_constant)
+{
+	char const* text = R"(
+		contract c
+		{
+			function f() { sha3(2**500); }
+		}
+	)";
+	SOLIDITY_CHECK_ERROR_TYPE(parseAndAnalyseReturnError(text), TypeError);
 }
 
 BOOST_AUTO_TEST_CASE(cyclic_binary_dependency)


### PR DESCRIPTION
Fixes #106
