### PR TITLE
Do not catch InternalCompilerErrors as part of fatal error handling.

### DIFF
--- a/libsolidity/CompilerStack.cpp
+++ b/libsolidity/CompilerStack.cpp
@@ -104,7 +104,9 @@ bool CompilerStack::parse()
 	for (auto& sourcePair: m_sources)
 	{
 		sourcePair.second.scanner->reset();
-		sourcePair.second.ast = Parser(m_errors).parse(sourcePair.second.scanner); // todo check for errors
+		sourcePair.second.ast = Parser(m_errors).parse(sourcePair.second.scanner);
+		if (!sourcePair.second.ast)
+			solAssert(!Error::containsOnlyWarnings(m_errors), "Parser returned null but did not report error.");
 	}
 	if (!Error::containsOnlyWarnings(m_errors))
 		// errors while parsing. sould stop before type checking

--- a/libsolidity/NameAndTypeResolver.cpp
+++ b/libsolidity/NameAndTypeResolver.cpp
@@ -49,8 +49,10 @@ bool NameAndTypeResolver::registerDeclarations(SourceUnit& _sourceUnit)
 	{
 		DeclarationRegistrationHelper registrar(m_scopes, _sourceUnit, m_errors);
 	}
-	catch (FatalError)
+	catch (FatalError const& _e)
 	{
+		if (m_errors.empty())
+			throw; // Something is weird here, rather throw again.
 		return false;
 	}
 	return true;
@@ -124,6 +126,8 @@ bool NameAndTypeResolver::resolveNamesAndTypes(ContractDefinition& _contract)
 	}
 	catch (FatalError const& _e)
 	{
+		if (m_errors.empty())
+			throw; // Something is weird here, rather throw again.
 		return false;
 	}
 	return true;
@@ -136,8 +140,10 @@ bool NameAndTypeResolver::updateDeclaration(Declaration const& _declaration)
 		m_scopes[nullptr].registerDeclaration(_declaration, false, true);
 		solAssert(_declaration.scope() == nullptr, "Updated declaration outside global scope.");
 	}
-	catch(FatalError const& _error)
+	catch (FatalError const& _error)
 	{
+		if (m_errors.empty())
+			throw; // Something is weird here, rather throw again.
 		return false;
 	}
 	return true;

--- a/libsolidity/Parser.cpp
+++ b/libsolidity/Parser.cpp
@@ -88,12 +88,10 @@ ASTPointer<SourceUnit> Parser::parse(shared_ptr<Scanner> const& _scanner)
 		}
 		return nodeFactory.createNode<SourceUnit>(nodes);
 	}
-	catch(FatalError const& _error)
+	catch (FatalError const& _error)
 	{
-		return nullptr;
-	}
-	catch(Exception const& _e)
-	{
+		if (m_errors.empty())
+			throw; // Something is weird here, rather throw again.
 		return nullptr;
 	}
 }

--- a/libsolidity/TypeChecker.cpp
+++ b/libsolidity/TypeChecker.cpp
@@ -43,7 +43,7 @@ bool TypeChecker::checkTypeRequirements(const ContractDefinition& _contract)
 		if (m_errors.empty())
 			throw; // Something is weird here, rather throw again.
 	}
-	return	Error::containsOnlyWarnings(m_errors);
+	return Error::containsOnlyWarnings(m_errors);
 }
 
 TypePointer const& TypeChecker::type(Expression const& _expression) const


### PR DESCRIPTION
InternalCompilerErrors always have to end the whole compilation process because a serious inconsistency was detected.
