### PR TITLE
Correctly parse ambiguities like `A.B[10] x` and `x.y[10] = 3`.

### DIFF
--- a/libsolidity/Parser.h
+++ b/libsolidity/Parser.h
@@ -125,14 +125,14 @@ private:
 	/// For source code of the form "a[][8]" ("IndexAccessStructure"), this is not possible to
 	/// decide with constant look-ahead.
 	LookAheadInfo peekStatementType() const;
-	/// Returns a typename parsed in look-ahead fashion from something like "a[8][2**70]".
+	/// Returns a typename parsed in look-ahead fashion from something like "a.b[8][2**70]".
 	ASTPointer<TypeName> typeNameIndexAccessStructure(
-		ASTPointer<PrimaryExpression> const& _primary,
+		std::vector<ASTPointer<PrimaryExpression>> const& _path,
 		std::vector<std::pair<ASTPointer<Expression>, SourceLocation>> const& _indices
 	);
-	/// Returns an expression parsed in look-ahead fashion from something like "a[8][2**70]".
+	/// Returns an expression parsed in look-ahead fashion from something like "a.b[8][2**70]".
 	ASTPointer<Expression> expressionFromIndexAccessStructure(
-		ASTPointer<PrimaryExpression> const& _primary,
+		std::vector<ASTPointer<PrimaryExpression>> const& _path,
 		std::vector<std::pair<ASTPointer<Expression>, SourceLocation>> const& _indices
 	);
 	/// If current token value is not _value, throw exception otherwise advance token.

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2505,6 +2505,27 @@ BOOST_AUTO_TEST_CASE(multi_variable_declaration_wildcards_fail_6)
 	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(member_access_parser_ambiguity)
+{
+	char const* text = R"(
+		contract C {
+			struct R { uint[10][10] y; }
+			struct S { uint a; uint b; uint[20][20][20] c; R d; }
+			S data;
+			function f() {
+				C.S x = data;
+				C.S memory y;
+				C.S[10] memory z;
+				C.S[10];
+				y.a = 2;
+				x.c[1][2][3] = 9;
+				x.d.y[2][2] = 3;
+			}
+		}
+	)";
+	BOOST_CHECK(success(text));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1015,6 +1015,24 @@ BOOST_AUTO_TEST_CASE(tuples)
 	BOOST_CHECK(successParse(text));
 }
 
+BOOST_AUTO_TEST_CASE(member_access_parser_ambiguity)
+{
+	char const* text = R"(
+		contract C {
+			struct S { uint a; uint b; uint[][][] c; }
+			function f() {
+				C.S x;
+				C.S memory y;
+				C.S[10] memory z;
+				C.S[10](x);
+				x.a = 2;
+				x.c[1][2][3] = 9;
+			}
+		}
+	)";
+	BOOST_CHECK(successParse(text));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixes #138 
