### PR TITLE
Small refactor of Structure of a Contract page

### DIFF
--- a/_docs/structure-of-a-contract.md
+++ b/_docs/structure-of-a-contract.md
@@ -5,8 +5,12 @@ permalink: /docs/structure-of-a-contract/
 ---
 
 In Solidity, contracts are what classes are in object-oriented languages.
-They can contain so-called state variables, which are permanently stored
-in storage together with the contract and functions, the entry pointers
-into operating on these state variables. Apart from state variables, there are
-also local variables declared inside functions, whose content is cleared
-as soon as control flow returns from the function.
+They can contain **state variables**, **functions**, and **events**.
+
+* State variables are values which are permanently stored in contract storage.
+* Functions are are the executable units of code within a contract.
+* Events are convenience interfaces with the EVM logging facilities.
+
+Functions can also declare local variables which are defined inside of a
+function and whos content is cleared as soon as control flow returns from the
+function.

--- a/_docs/structure-of-a-contract.md
+++ b/_docs/structure-of-a-contract.md
@@ -5,12 +5,9 @@ permalink: /docs/structure-of-a-contract/
 ---
 
 In Solidity, contracts are what classes are in object-oriented languages.
-They can contain **state variables**, **functions**, and **events**.
+They can contain **state variables**, **functions**, **structs**, and **events**.
 
 * State variables are values which are permanently stored in contract storage.
 * Functions are are the executable units of code within a contract.
+* Structs are custom defined types.
 * Events are convenience interfaces with the EVM logging facilities.
-
-Functions can also declare local variables which are defined inside of a
-function and whos content is cleared as soon as control flow returns from the
-function.


### PR DESCRIPTION
I thought that there were some minor improvements that could be made to the "Structure of a Contract" page in the new documentation.
#### Cute animal picture

![animals-pumpkins-14](https://cloud.githubusercontent.com/assets/824194/10621143/27c2844c-773c-11e5-9eb8-6acba2640c4b.jpg)
