### PR TITLE
Clarify the encoding logic for

### DIFF
--- a/_docs/types.md
+++ b/_docs/types.md
@@ -167,7 +167,7 @@ if (x.balance < 10 && myAddress.balance >= 10) x.send(10);
 Beware that if `x` is a contract address, its code (more specifically: its fallback function, if present) will be executed together with the `send` call (this is a limitation of the EVM and cannot be prevented). If that execution runs out of gas or fails in any way, the Ether transfer will be reverted. In this case, `send` returns `false`.
 
 Furthermore, to interface with contracts that do not adhere to the ABI (like the classic NameReg contract),
-the function `call` is provided which takes an arbitrary number of arguments of any type. These arguments are ABI-serialized (i.e. also padded to 32 bytes). One exception is the case where the first argument is encoded to exactly four bytes. In this case, it is not padded to allow the use of function signatures here.
+the function `call` is provided which takes an arbitrary number of arguments of any type. These arguments are padded to 32 bytes and concatenated. One exception is the case where the first argument is encoded to exactly four bytes. In this case, it is not padded to allow the use of function signatures here.
 
 {% highlight javascript %}
 address nameReg = 0x72ba7d8e73fe8eb666ea66babc8116a41bfb10e2;


### PR DESCRIPTION
### What was wrong

The wording around how values passed into `call` are handled was written such that it could be interpreted that the values would be properly ABI serialized as if they were being passed into a function with a matching function signature.  This is not the case, as they are merely padded to 32 bytes and concatenated.
### How was it fixed

Reworded the statement to be more precise about the behavior.
#### Cute animal picture.

![baby-tiger-hunter-and-puppy-chelsea](https://cloud.githubusercontent.com/assets/824194/10985721/c2f4066a-83e0-11e5-978a-fff93e86aedf.jpg)
