### PR TITLE
Why3 translation: Fix problems with statement blocks.

### DIFF
--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -818,6 +818,8 @@ public:
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
+	std::vector<ASTPointer<Statement>> const& statements() const { return m_statements; }
+
 private:
 	std::vector<ASTPointer<Statement>> m_statements;
 };

--- a/libsolidity/formal/Why3Translator.h
+++ b/libsolidity/formal/Why3Translator.h
@@ -64,7 +64,7 @@ private:
 	/// if the type is not supported.
 	std::string toFormalType(Type const& _type) const;
 
-	void indent() { m_indentation++; }
+	void indent() { newLine(); m_indentation++; }
 	void unindent();
 	void addLine(std::string const& _line);
 	void add(std::string const& _str);
@@ -74,13 +74,11 @@ private:
 	virtual bool visit(ContractDefinition const& _contract) override;
 	virtual bool visit(FunctionDefinition const& _function) override;
 	virtual bool visit(Block const&) override;
-	virtual void endVisit(Block const&) override { unindent(); addLine("end;"); }
 	virtual bool visit(IfStatement const& _node) override;
 	virtual bool visit(WhileStatement const& _node) override;
 	virtual bool visit(Return const& _node) override;
 	virtual bool visit(VariableDeclarationStatement const& _node) override;
 	virtual bool visit(ExpressionStatement const&) override;
-	virtual void endVisit(ExpressionStatement const&) override { add(";"); newLine(); }
 	virtual bool visit(Assignment const& _node) override;
 	virtual bool visit(TupleExpression const& _node) override;
 	virtual void endVisit(TupleExpression const&) override { add(")"); }
@@ -98,8 +96,13 @@ private:
 		return false;
 	}
 
+	/// Visits the givin statement and indents it unless it is a block
+	/// (which does its own indentation).
+	void visitIndentedUnlessBlock(Statement const& _statement);
+
 	void addSourceFromDocStrings(DocumentedAnnotation const& _annotation);
 
+	size_t m_indentationAtLineStart = 0;
 	size_t m_indentation = 0;
 	std::string m_currentLine;
 	/// True if we have already seen a contract. For now, only a single contract


### PR DESCRIPTION
Previously, semicolons were appended to all statements instead of only between statements.
