### PR TITLE
Work around bug in MSVC/Boost for u256->unsigned conversion.

### DIFF
--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -359,6 +359,16 @@ BOOST_AUTO_TEST_CASE(store_tags_as_unions)
 //	BOOST_CHECK_EQUAL(2, numSHA3s);
 }
 
+BOOST_AUTO_TEST_CASE(successor_not_found_bug)
+{
+	// This bug was caused because MSVC chose to use the u256->bool conversion
+	// instead of u256->unsigned
+	char const* sourceCode = R"(
+		contract greeter { function greeter() {} }
+	)";
+	compileBothVersions(sourceCode);
+}
+
 BOOST_AUTO_TEST_CASE(cse_intermediate_swap)
 {
 	eth::KnownState state;


### PR DESCRIPTION
The actual fix is in https://github.com/ethereum/libethereum/pull/90 - this is only the test.
Fixes #82.
