### PR TITLE
Fix dynamic indexed event arguments - applies sha3.

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -587,11 +587,24 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				{
 					++numIndexed;
 					arguments[arg - 1]->accept(*this);
-					utils().convertType(
-						*arguments[arg - 1]->annotation().type,
-						*function.parameterTypes()[arg - 1],
-						true
-					);
+					if (auto const& arrayType = dynamic_pointer_cast<ArrayType const>(function.parameterTypes()[arg - 1]))
+					{
+						utils().fetchFreeMemoryPointer();
+						utils().encodeToMemory(
+							{arguments[arg - 1]->annotation().type},
+							{arrayType},
+							false,
+							true
+						);
+						utils().toSizeAfterFreeMemoryPointer();
+						m_context << eth::Instruction::SHA3;
+					}
+					else
+						utils().convertType(
+							*arguments[arg - 1]->annotation().type,
+							*function.parameterTypes()[arg - 1],
+							true
+						);
 				}
 			if (!event.isAnonymous())
 			{

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2484,6 +2484,41 @@ BOOST_AUTO_TEST_CASE(event_really_lots_of_data_from_storage)
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::sha3(string("Deposit(uint256,bytes,uint256)")));
 }
 
+BOOST_AUTO_TEST_CASE(event_indexed_string)
+{
+	char const* sourceCode = R"(
+		contract C {
+			string x;
+			uint[4] y;
+			event E(string indexed r, uint[4] indexed t);
+			function deposit() {
+				bytes(x).length = 90;
+				for (uint i = 0; i < 90; i++)
+					bytes(x)[i] = byte(i);
+				y[0] = 4;
+				y[1] = 5;
+				y[2] = 6;
+				y[3] = 7;
+				E(x, y);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("deposit()");
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	string dynx(90, 0);
+	for (size_t i = 0; i < dynx.size(); ++i)
+		dynx[i] = i;
+	BOOST_CHECK(m_logs[0].data == bytes());
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 3);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[1], dev::sha3(dynx));
+	BOOST_CHECK_EQUAL(m_logs[0].topics[2], dev::sha3(
+		encodeArgs(u256(4), u256(5), u256(6), u256(7))
+	));
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::sha3(string("E(string,uint256[4])")));
+}
+
 BOOST_AUTO_TEST_CASE(empty_name_input_parameter_with_named_one)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Fixes #199

As the `LOG` opcodes only allow indexing 32-byte value, we apply sha3 before storing array data in bloom filters via the `LOG` opcode. So if you want to filter for events which have indexed string arguments, you have to apply sha3 to the string before you send it to the filter.
