### PR TITLE
Dynamically create memory arrays.

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -49,7 +49,7 @@ bool NameAndTypeResolver::registerDeclarations(SourceUnit& _sourceUnit)
 	{
 		DeclarationRegistrationHelper registrar(m_scopes, _sourceUnit, m_errors);
 	}
-	catch (FatalError const& _e)
+	catch (FatalError const&)
 	{
 		if (m_errors.empty())
 			throw; // Something is weird here, rather throw again.
@@ -146,7 +146,7 @@ bool NameAndTypeResolver::resolveNamesAndTypes(ContractDefinition& _contract)
 		if (!success)
 			return false;
 	}
-	catch (FatalError const& _e)
+	catch (FatalError const&)
 	{
 		if (m_errors.empty())
 			throw; // Something is weird here, rather throw again.
@@ -162,7 +162,7 @@ bool NameAndTypeResolver::updateDeclaration(Declaration const& _declaration)
 		m_scopes[nullptr].registerDeclaration(_declaration, false, true);
 		solAssert(_declaration.scope() == nullptr, "Updated declaration outside global scope.");
 	}
-	catch (FatalError const& _error)
+	catch (FatalError const&)
 	{
 		if (m_errors.empty())
 			throw; // Something is weird here, rather throw again.

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -44,6 +44,7 @@ bool ReferencesResolver::visit(UserDefinedTypeName const& _typeName)
 		fatalDeclarationError(_typeName.location(), "Identifier not found or not unique.");
 
 	_typeName.annotation().referencedDeclaration = declaration;
+	_typeName.annotation().contractScope = m_currentContract;
 	return true;
 }
 

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -49,6 +49,7 @@ bool ReferencesResolver::visit(UserDefinedTypeName const& _typeName)
 		fatalDeclarationError(_typeName.location(), "Identifier not found or not unique.");
 
 	_typeName.annotation().referencedDeclaration = declaration;
+
 	_typeName.annotation().contractScope = m_currentContract;
 	return true;
 }
@@ -59,7 +60,7 @@ bool ReferencesResolver::resolve(ASTNode& _root)
 	{
 		_root.accept(*this);
 	}
-	catch (FatalError const& e)
+	catch (FatalError const&)
 	{
 		solAssert(m_errorOccurred, "");
 	}

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -37,6 +37,11 @@ bool ReferencesResolver::visit(Return const& _return)
 	return true;
 }
 
+void ReferencesResolver::endVisit(NewExpression const& _new)
+{
+	typeFor(_new.typeName());
+}
+
 bool ReferencesResolver::visit(UserDefinedTypeName const& _typeName)
 {
 	Declaration const* declaration = m_resolver.pathFromCurrentScope(_typeName.namePath());

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -64,6 +64,7 @@ private:
 	virtual bool visit(Identifier const& _identifier) override;
 	virtual bool visit(UserDefinedTypeName const& _typeName) override;
 	virtual bool visit(Return const& _return) override;
+	virtual void endVisit(NewExpression const& _new) override;
 	virtual void endVisit(VariableDeclaration const& _variable) override;
 
 	TypePointer typeFor(TypeName const& _typeName);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1311,13 +1311,13 @@ bool TypeChecker::contractDependenciesAreCyclic(
 	return false;
 }
 
-Declaration const& TypeChecker::dereference(Identifier const& _identifier)
+Declaration const& TypeChecker::dereference(Identifier const& _identifier) const
 {
 	solAssert(!!_identifier.annotation().referencedDeclaration, "Declaration not stored.");
 	return *_identifier.annotation().referencedDeclaration;
 }
 
-Declaration const& TypeChecker::dereference(UserDefinedTypeName const& _typeName)
+Declaration const& TypeChecker::dereference(UserDefinedTypeName const& _typeName) const
 {
 	solAssert(!!_typeName.annotation().referencedDeclaration, "Declaration not stored.");
 	return *_typeName.annotation().referencedDeclaration;

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -107,9 +107,9 @@ private:
 	) const;
 
 	/// @returns the referenced declaration and throws on error.
-	Declaration const& dereference(Identifier const& _identifier);
+	Declaration const& dereference(Identifier const& _identifier) const;
 	/// @returns the referenced declaration and throws on error.
-	Declaration const& dereference(UserDefinedTypeName const& _typeName);
+	Declaration const& dereference(UserDefinedTypeName const& _typeName) const;
 
 	/// Runs type checks on @a _expression to infer its type and then checks that it is implicitly
 	/// convertible to @a _expectedType.

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -108,6 +108,8 @@ private:
 
 	/// @returns the referenced declaration and throws on error.
 	Declaration const& dereference(Identifier const& _identifier);
+	/// @returns the referenced declaration and throws on error.
+	Declaration const& dereference(UserDefinedTypeName const& _typeName);
 
 	/// Runs type checks on @a _expression to infer its type and then checks that it is implicitly
 	/// convertible to @a _expectedType.

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1216,23 +1216,24 @@ private:
 };
 
 /**
- * Expression that creates a new contract, e.g. the "new SomeContract" part in "new SomeContract(1, 2)".
+ * Expression that creates a new contract or memory-array,
+ * e.g. the "new SomeContract" part in "new SomeContract(1, 2)".
  */
 class NewExpression: public Expression
 {
 public:
 	NewExpression(
 		SourceLocation const& _location,
-		ASTPointer<Identifier> const& _contractName
+		ASTPointer<TypeName> const& _typeName
 	):
-		Expression(_location), m_contractName(_contractName) {}
+		Expression(_location), m_typeName(_typeName) {}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	Identifier const& contractName() const { return *m_contractName; }
+	TypeName const& typeName() const { return *m_typeName; }
 
 private:
-	ASTPointer<Identifier> m_contractName;
+	ASTPointer<TypeName> m_typeName;
 };
 
 /**

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -111,6 +111,9 @@ struct UserDefinedTypeNameAnnotation: TypeNameAnnotation
 {
 	/// Referenced declaration, set during reference resolution stage.
 	Declaration const* referencedDeclaration = nullptr;
+	/// Stores a reference to the current contract.
+	/// This is needed because types of base contracts change depending on the context.
+	ContractDefinition const* contractScope = nullptr;
 };
 
 struct VariableDeclarationStatementAnnotation: StatementAnnotation

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -634,14 +634,14 @@ void FunctionCall::accept(ASTConstVisitor& _visitor) const
 void NewExpression::accept(ASTVisitor& _visitor)
 {
 	if (_visitor.visit(*this))
-		m_contractName->accept(_visitor);
+		m_typeName->accept(_visitor);
 	_visitor.endVisit(*this);
 }
 
 void NewExpression::accept(ASTConstVisitor& _visitor) const
 {
 	if (_visitor.visit(*this))
-		m_contractName->accept(_visitor);
+		m_typeName->accept(_visitor);
 	_visitor.endVisit(*this);
 }
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -141,9 +141,6 @@ public:
 	/// Factory functions that convert an AST @ref TypeName to a Type.
 	static TypePointer fromElementaryTypeName(Token::Value _typeToken);
 	static TypePointer fromElementaryTypeName(std::string const& _name);
-	static TypePointer fromUserDefinedTypeName(UserDefinedTypeName const& _typeName);
-	static TypePointer fromMapping(ElementaryTypeName& _keyType, TypeName& _valueType);
-	static TypePointer fromArrayTypeName(TypeName& _baseTypeName, Expression* _length);
 	/// @}
 
 	/// Auto-detect the proper type for a literal. @returns an empty pointer if the literal does
@@ -751,7 +748,8 @@ public:
 		AddMod, ///< ADDMOD
 		MulMod, ///< MULMOD
 		ArrayPush, ///< .push() to a dynamically sized array in storage
-		ByteArrayPush ///< .push() to a dynamically sized byte array in storage
+		ByteArrayPush, ///< .push() to a dynamically sized byte array in storage
+		ObjectCreation ///< array creation using new
 	};
 
 	virtual Category category() const override { return Category::Function; }

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -103,6 +103,11 @@ public:
 		bool _encodeAsLibraryTypes = false
 	);
 
+	/// Zero-initialises (the data part of) an already allocated memory array.
+	/// Stack pre: <length> <memptr>
+	/// Stack post: <updated_memptr>
+	void zeroInitialiseMemoryArray(ArrayType const& _type);
+
 	/// Uses a CALL to the identity contract to perform a memory-to-memory copy.
 	/// Stack pre: <size> <target> <source>
 	/// Stack post:

--- a/libsolidity/formal/Why3Translator.h
+++ b/libsolidity/formal/Why3Translator.h
@@ -43,7 +43,7 @@ class SourceUnit;
 class Why3Translator: private ASTConstVisitor
 {
 public:
-	Why3Translator(ErrorList& _errors): m_lines{{std::string(), 0}}, m_errors(_errors) {}
+	Why3Translator(ErrorList& _errors): m_lines(std::vector<Line>{{std::string(), 0}}), m_errors(_errors) {}
 
 	/// Appends formalisation of the given source unit to the output.
 	/// @returns false on error.

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -88,7 +88,7 @@ ASTPointer<SourceUnit> Parser::parse(shared_ptr<Scanner> const& _scanner)
 		}
 		return nodeFactory.createNode<SourceUnit>(nodes);
 	}
-	catch (FatalError const& _error)
+	catch (FatalError const&)
 	{
 		if (m_errors.empty())
 			throw; // Something is weird here, rather throw again.

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -939,7 +939,7 @@ ASTPointer<Expression> Parser::parseLeftHandSideExpression(
 	else if (m_scanner->currentToken() == Token::New)
 	{
 		expectToken(Token::New);
-		ASTPointer<Identifier> contractName(parseIdentifier());
+		ASTPointer<TypeName> contractName(parseTypeName(false));
 		nodeFactory.setEndPositionFromNode(contractName);
 		expression = nodeFactory.createNode<NewExpression>(contractName);
 	}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -1955,7 +1955,7 @@ BOOST_AUTO_TEST_CASE(value_for_constructor)
 		contract Main {
 			Helper h;
 			function Main() {
-				h = new Helper.value(10)("abc", true);
+				h = (new Helper).value(10)("abc", true);
 			}
 			function getFlag() returns (bool ret) { return h.getFlag(); }
 			function getName() returns (bytes3 ret) { return h.getName(); }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2538,13 +2538,49 @@ BOOST_AUTO_TEST_CASE(create_memory_arrays)
 		}
 		contract C {
 			function f(uint size) {
-				L.S[][] x = new L.S[][](10);
+				L.S[][] memory x = new L.S[][](10);
 				var y = new uint[](20);
 				var z = new bytes(size);
 			}
 		}
 	)";
 	BOOST_CHECK(success(text));
+}
+
+BOOST_AUTO_TEST_CASE(mapping_in_memory_array)
+{
+	char const* text = R"(
+		contract C {
+			function f(uint size) {
+				var x = new mapping(uint => uint)[](4);
+			}
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(new_for_non_array)
+{
+	char const* text = R"(
+		contract C {
+			function f(uint size) {
+				var x = new uint(7);
+			}
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_args_creating_memory_array)
+{
+	char const* text = R"(
+		contract C {
+			function f(uint size) {
+				var x = new uint[]();
+			}
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2529,6 +2529,24 @@ BOOST_AUTO_TEST_CASE(member_access_parser_ambiguity)
 	BOOST_CHECK(success(text));
 }
 
+BOOST_AUTO_TEST_CASE(create_memory_arrays)
+{
+	char const* text = R"(
+		library L {
+			struct R { uint[10][10] y; }
+			struct S { uint a; uint b; uint[20][20][20] c; R d; }
+		}
+		contract C {
+			function f(uint size) {
+				L.S[][] x = new L.S[][](10);
+				var y = new uint[](20);
+				var z = new bytes(size);
+			}
+		}
+	)";
+	BOOST_CHECK(success(text));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Use `new uint[](7)`, `new bytes(200)` or similiar to allocate a new zero-initialised memory array.

This is a breaking change.
