### PR TITLE
Fix a "Solidity::solidity" dependency edge in the CMake file for soltest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,7 @@ file(GLOB HEADERS "*.h")
 set(EXECUTABLE soltest)
 add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
-eth_use(${EXECUTABLE} REQUIRED Solidity Eth::ethereum)
+eth_use(${EXECUTABLE} REQUIRED Solidity::solidity Eth::ethereum)
 
 include_directories(BEFORE ..)
 target_link_libraries(${EXECUTABLE} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES})


### PR DESCRIPTION
Fix a "Solidity::solidity" dependency edge in the CMake file for soltest which got missed in the previous PR.

This change resolves an inconsistency which was discovered in the automated dependency graph generation.
softest was being declared as dependent on the Solidity module, not on just libsolidity, as it should be.
