### PR TITLE
Do not clutter importee when importing.

### DIFF
--- a/libsolidity/analysis/DeclarationContainer.h
+++ b/libsolidity/analysis/DeclarationContainer.h
@@ -41,23 +41,24 @@ class DeclarationContainer
 {
 public:
 	explicit DeclarationContainer(
-		Declaration const* _enclosingDeclaration = nullptr,
+		ASTNode const* _enclosingNode = nullptr,
 		DeclarationContainer const* _enclosingContainer = nullptr
 	):
-		m_enclosingDeclaration(_enclosingDeclaration), m_enclosingContainer(_enclosingContainer) {}
+		m_enclosingNode(_enclosingNode), m_enclosingContainer(_enclosingContainer) {}
 	/// Registers the declaration in the scope unless its name is already declared or the name is empty.
+	/// @param _name the name to register, if nullptr the intrinsic name of @a _declaration is used.
 	/// @param _invisible if true, registers the declaration, reports name clashes but does not return it in @a resolveName
 	/// @param _update if true, replaces a potential declaration that is already present
 	/// @returns false if the name was already declared.
-	bool registerDeclaration(Declaration const& _declaration, bool _invisible = false, bool _update = false);
+	bool registerDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr, bool _invisible = false, bool _update = false);
 	std::vector<Declaration const*> resolveName(ASTString const& _name, bool _recursive = false) const;
-	Declaration const* enclosingDeclaration() const { return m_enclosingDeclaration; }
+	ASTNode const* enclosingNode() const { return m_enclosingNode; }
 	std::map<ASTString, std::vector<Declaration const*>> const& declarations() const { return m_declarations; }
 	/// @returns whether declaration is valid, and if not also returns previous declaration.
-	Declaration const* conflictingDeclaration(Declaration const& _declaration) const;
+	Declaration const* conflictingDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr) const;
 
 private:
-	Declaration const* m_enclosingDeclaration;
+	ASTNode const* m_enclosingNode;
 	DeclarationContainer const* m_enclosingContainer;
 	std::map<ASTString, std::vector<Declaration const*>> m_declarations;
 	std::map<ASTString, std::vector<Declaration const*>> m_invisibleDeclarations;

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -113,7 +113,7 @@ bool NameAndTypeResolver::resolveNamesAndTypes(ContractDefinition& _contract)
 		if (success)
 		{
 			linearizeBaseContracts(_contract);
-			std::vector<ContractDefinition const*> properBases(
+			vector<ContractDefinition const*> properBases(
 				++_contract.annotation().linearizedBaseContracts.begin(),
 				_contract.annotation().linearizedBaseContracts.end()
 			);
@@ -380,7 +380,7 @@ void NameAndTypeResolver::reportFatalTypeError(Error const& _e)
 }
 
 DeclarationRegistrationHelper::DeclarationRegistrationHelper(
-	map<ASTNode const*, std::unique_ptr<DeclarationContainer>>& _scopes,
+	map<ASTNode const*, unique_ptr<DeclarationContainer>>& _scopes,
 	ASTNode& _astRoot,
 	ErrorList& _errors
 ):
@@ -489,9 +489,9 @@ void DeclarationRegistrationHelper::endVisit(EventDefinition&)
 
 void DeclarationRegistrationHelper::enterNewSubScope(Declaration const& _declaration)
 {
-	map<ASTNode const*, std::unique_ptr<DeclarationContainer>>::iterator iter;
+	map<ASTNode const*, unique_ptr<DeclarationContainer>>::iterator iter;
 	bool newlyAdded;
-	std::unique_ptr<DeclarationContainer> container(new DeclarationContainer(m_currentScope, m_scopes[m_currentScope].get()));
+	unique_ptr<DeclarationContainer> container(new DeclarationContainer(m_currentScope, m_scopes[m_currentScope].get()));
 	tie(iter, newlyAdded) = m_scopes.emplace(&_declaration, move(container));
 	solAssert(newlyAdded, "Unable to add new scope.");
 	m_currentScope = &_declaration;

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -71,19 +71,25 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 	for (auto const& node: _sourceUnit.nodes())
 		if (auto imp = dynamic_cast<ImportDirective const*>(node.get()))
 		{
-			if (!_sourceUnits.count(imp->identifier()))
+			string const& path = imp->annotation().absolutePath;
+			if (!_sourceUnits.count(path))
 			{
-				reportDeclarationError(node->location(), "Import \"" + imp->identifier() + "\" not found.");
+				reportDeclarationError( node->location(),
+					"Import \"" +
+					path +
+					"\" (referenced as \"" +
+					imp->identifier() +
+					"\") not found."
+				);
 				error = true;
 			}
 			else
 			{
-				auto scope = m_scopes.find(_sourceUnits.at(imp->identifier()));
+				auto scope = m_scopes.find(_sourceUnits.at(path));
 				solAssert(scope != end(m_scopes), "");
 				for (auto const& nameAndDeclaration: scope->second->declarations())
 					for (auto const& declaration: nameAndDeclaration.second)
 						target.registerDeclaration(*declaration, &nameAndDeclaration.first);
-
 			}
 		}
 	return !error;

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -91,7 +91,7 @@ private:
 	/// Maps nodes declaring a scope to scopes, i.e. ContractDefinition and FunctionDeclaration,
 	/// where nullptr denotes the global scope. Note that structs are not scope since they do
 	/// not contain code.
-	std::map<ASTNode const*, DeclarationContainer> m_scopes;
+	std::map<ASTNode const*, std::unique_ptr<DeclarationContainer>> m_scopes;
 
 	// creates the Declaration error and adds it in the errors list
 	void reportDeclarationError(
@@ -121,7 +121,11 @@ private:
 class DeclarationRegistrationHelper: private ASTVisitor
 {
 public:
-	DeclarationRegistrationHelper(std::map<ASTNode const*, DeclarationContainer>& _scopes, ASTNode& _astRoot, ErrorList& _errors);
+	DeclarationRegistrationHelper(
+		std::map<ASTNode const*, std::unique_ptr<DeclarationContainer>>& _scopes,
+		ASTNode& _astRoot,
+		ErrorList& _errors
+	);
 
 private:
 	bool visit(ContractDefinition& _contract) override;
@@ -159,7 +163,7 @@ private:
 	// creates the Declaration error and adds it in the errors list and throws FatalError
 	void fatalDeclarationError(SourceLocation _sourceLocation, std::string const& _description);
 
-	std::map<ASTNode const*, DeclarationContainer>& m_scopes;
+	std::map<ASTNode const*, std::unique_ptr<DeclarationContainer>>& m_scopes;
 	Declaration const* m_currentScope = nullptr;
 	VariableScope* m_currentFunction = nullptr;
 	ErrorList& m_errors;

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -139,7 +139,9 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 			bool isPointer = true;
 			if (_variable.isExternalCallableParameter())
 			{
-				auto const& contract = dynamic_cast<ContractDefinition const&>(*_variable.scope()->scope());
+				auto const& contract = dynamic_cast<ContractDefinition const&>(
+					*dynamic_cast<Declaration const&>(*_variable.scope()).scope()
+				);
 				if (contract.isLibrary())
 				{
 					if (varLoc == Location::Memory)
@@ -162,9 +164,11 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 				else
 					typeLoc = varLoc == Location::Memory ? DataLocation::Memory : DataLocation::Storage;
 			}
-			else if (_variable.isCallableParameter() && _variable.scope()->isPublic())
+			else if (_variable.isCallableParameter() && dynamic_cast<Declaration const&>(*_variable.scope()).isPublic())
 			{
-				auto const& contract = dynamic_cast<ContractDefinition const&>(*_variable.scope()->scope());
+				auto const& contract = dynamic_cast<ContractDefinition const&>(
+					*dynamic_cast<Declaration const&>(*_variable.scope()).scope()
+				);
 				// force locations of public or external function (return) parameters to memory
 				if (varLoc == Location::Storage && !contract.isLibrary())
 					fatalTypeError(_variable.location(),

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -56,6 +56,13 @@ Error ASTNode::createTypeError(string const& _description) const
 	return Error(Error::Type::TypeError) << errinfo_sourceLocation(location()) << errinfo_comment(_description);
 }
 
+ImportAnnotation& ImportDirective::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = new ImportAnnotation();
+	return static_cast<ImportAnnotation&>(*m_annotation);
+}
+
 map<FixedHash<4>, FunctionTypePointer> ContractDefinition::interfaceFunctions() const
 {
 	auto exportedFunctionList = interfaceFunctionList();

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -142,6 +142,7 @@ public:
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
 	ASTString const& identifier() const { return *m_identifier; }
+	virtual ImportAnnotation& annotation() const override;
 
 private:
 	ASTPointer<ASTString> m_identifier;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -172,8 +172,8 @@ public:
 
 	/// @returns the scope this declaration resides in. Can be nullptr if it is the global scope.
 	/// Available only after name and type resolution step.
-	Declaration const* scope() const { return m_scope; }
-	void setScope(Declaration const* _scope) { m_scope = _scope; }
+	ASTNode const* scope() const { return m_scope; }
+	void setScope(ASTNode const* _scope) { m_scope = _scope; }
 
 	virtual bool isLValue() const { return false; }
 	virtual bool isPartOfExternalInterface() const { return false; }
@@ -190,7 +190,7 @@ protected:
 private:
 	ASTPointer<ASTString> m_name;
 	Visibility m_visibility;
-	Declaration const* m_scope;
+	ASTNode const* m_scope;
 };
 
 /**

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -54,6 +54,12 @@ struct DocumentedAnnotation
 	std::multimap<std::string, DocTag> docTags;
 };
 
+struct ImportAnnotation: ASTAnnotation
+{
+	/// The absolute path of the source unit to import.
+	std::string absolutePath;
+};
+
 struct TypeDeclarationAnnotation: ASTAnnotation
 {
 	/// The name of this type, prefixed by proper namespaces if globally accessible.

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/parsing/Scanner.h>
 #include <libsolidity/parsing/Parser.h>
@@ -367,7 +368,7 @@ void CompilerStack::resolveImports()
 	vector<Source const*> sourceOrder;
 	set<Source const*> sourcesSeen;
 
-	function<void(Source const*)> toposort = [&](Source const* _source)
+	function<void(string const&, Source const*)> toposort = [&](string const& _sourceName, Source const* _source)
 	{
 		if (sourcesSeen.count(_source))
 			return;
@@ -375,24 +376,42 @@ void CompilerStack::resolveImports()
 		for (ASTPointer<ASTNode> const& node: _source->ast->nodes())
 			if (ImportDirective const* import = dynamic_cast<ImportDirective*>(node.get()))
 			{
-				string const& id = import->identifier();
-				if (!m_sources.count(id))
+				string path = absolutePath(import->identifier(), _sourceName);
+				import->annotation().absolutePath = path;
+				if (!m_sources.count(path))
 					BOOST_THROW_EXCEPTION(
 						Error(Error::Type::ParserError)
 							<< errinfo_sourceLocation(import->location())
 							<< errinfo_comment("Source not found.")
 					);
 
-				toposort(&m_sources[id]);
+				toposort(path, &m_sources[path]);
 			}
 		sourceOrder.push_back(_source);
 	};
 
 	for (auto const& sourcePair: m_sources)
 		if (!sourcePair.second.isLibrary)
-			toposort(&sourcePair.second);
+			toposort(sourcePair.first, &sourcePair.second);
 
 	swap(m_sourceOrder, sourceOrder);
+}
+
+string CompilerStack::absolutePath(string const& _path, string const& _reference) const
+{
+	// Anything that does not start with `.` is an absolute path.
+	if (_path.empty() || _path.front() != '.')
+		return _path;
+	using path = boost::filesystem::path;
+	path p(_path);
+	path result(_reference);
+	result.remove_filename();
+	for (path::iterator it = p.begin(); it != p.end(); ++it)
+		if (*it == "..")
+			result = result.parent_path();
+		else if (*it != ".")
+			result /= *it;
+	return result.string();
 }
 
 void CompilerStack::compileContract(

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -199,6 +199,8 @@ private:
 	};
 
 	void resolveImports();
+	/// @returns the absolute path corresponding to @a _path relative to @a _reference.
+	std::string absolutePath(std::string const& _path, std::string const& _reference) const;
 	/// Compile a single contract and put the result in @a _compiledContracts.
 	void compileContract(
 		bool _optimize,

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -76,6 +76,23 @@ BOOST_AUTO_TEST_CASE(circular_import)
 	BOOST_CHECK(c.compile());
 }
 
+BOOST_AUTO_TEST_CASE(relative_import)
+{
+	CompilerStack c;
+	c.addSource("a", "import \"./dir/b\"; contract A is B {}");
+	c.addSource("dir/b", "contract B {}");
+	c.addSource("dir/c", "import \"../a\"; contract C is A {}");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(relative_import_multiplex)
+{
+	CompilerStack c;
+	c.addSource("a", "contract A {}");
+	c.addSource("dir/a/b/c", "import \"../../.././a\"; contract B is A {}");
+	BOOST_CHECK(c.compile());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -1,0 +1,83 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <c@ethdev.com>
+ * @date 2015
+ * Tests for high level features like import.
+ */
+
+#include <string>
+#include <boost/test/unit_test.hpp>
+#include <libsolidity/interface/Exceptions.h>
+#include <libsolidity/interface/CompilerStack.h>
+
+using namespace std;
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+BOOST_AUTO_TEST_SUITE(SolidityImports)
+
+BOOST_AUTO_TEST_CASE(smoke_test)
+{
+	CompilerStack c;
+	c.addSource("a", "contract C {}");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(regular_import)
+{
+	CompilerStack c;
+	c.addSource("a", "contract C {}");
+	c.addSource("b", "import \"a\"; contract D is C {}");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(import_does_not_clutter_importee)
+{
+	CompilerStack c;
+	c.addSource("a", "contract C { D d; }");
+	c.addSource("b", "import \"a\"; contract D is C {}");
+	BOOST_CHECK(!c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(import_is_transitive)
+{
+	CompilerStack c;
+	c.addSource("a", "contract C { }");
+	c.addSource("b", "import \"a\";");
+	c.addSource("c", "import \"b\"; contract D is C {}");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(circular_import)
+{
+	CompilerStack c;
+	c.addSource("a", "import \"b\"; contract C { D d; }");
+	c.addSource("b", "import \"a\"; contract D { C c; }");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+} // end namespaces


### PR DESCRIPTION
This is actually a breaking change, but hopefully, no-one relied on the changed functionality.

The change is that we do no longer have a single global namespace, i.e. the namespace of modules ("source units") is not modified when they are imported.
