### PR TITLE
Simple aliasing during import

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -78,7 +78,7 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 					"Import \"" +
 					path +
 					"\" (referenced as \"" +
-					imp->identifier() +
+					imp->path() +
 					"\") not found."
 				);
 				error = true;

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -56,11 +56,24 @@ Error ASTNode::createTypeError(string const& _description) const
 	return Error(Error::Type::TypeError) << errinfo_sourceLocation(location()) << errinfo_comment(_description);
 }
 
+SourceUnitAnnotation& SourceUnit::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = new SourceUnitAnnotation();
+	return static_cast<SourceUnitAnnotation&>(*m_annotation);
+}
+
 ImportAnnotation& ImportDirective::annotation() const
 {
 	if (!m_annotation)
 		m_annotation = new ImportAnnotation();
 	return static_cast<ImportAnnotation&>(*m_annotation);
+}
+
+TypePointer ImportDirective::type() const
+{
+	solAssert(!!annotation().sourceUnit, "");
+	return make_shared<ModuleType>(*annotation().sourceUnit);
 }
 
 map<FixedHash<4>, FunctionTypePointer> ContractDefinition::interfaceFunctions() const

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -129,23 +129,39 @@ private:
 
 /**
  * Import directive for referencing other files / source objects.
- * Example: import "abc.sol"
+ * Example: import "abc.sol" // imports all symbols of "abc.sol" into current scope
  * Source objects are identified by a string which can be a file name but does not have to be.
+ * Other ways to use it:
+ * import "abc" as x; // creates symbol "x" that contains all symbols in "abc"
+ * import * as x from "abc"; // same as above
+ * import {a as b, c} from "abc"; // creates new symbols "b" and "c" referencing "a" and "c" in "abc", respectively.
  */
 class ImportDirective: public ASTNode
 {
 public:
-	ImportDirective(SourceLocation const& _location, ASTPointer<ASTString> const& _identifier):
-		ASTNode(_location), m_identifier(_identifier) {}
+	ImportDirective(
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _path,
+			ASTPointer<ASTString> const& _unitAlias,
+			std::vector<std::pair<ASTPointer<Identifier>, ASTPointer<ASTString>>>&& _symbolAliases
+		):
+		ASTNode(_location), m_path(_path), m_unitAlias(_unitAlias), m_symbolAliases(_symbolAliases) {}
 
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	ASTString const& identifier() const { return *m_identifier; }
+	ASTString const& path() const { return *m_path; }
 	virtual ImportAnnotation& annotation() const override;
 
 private:
-	ASTPointer<ASTString> m_identifier;
+	ASTPointer<ASTString> m_path;
+	/// The alias for the module itself. If present, import the whole unit under that name and
+	/// ignore m_symbolAlias.
+	ASTPointer<ASTString> m_unitAlias;
+	/// The aliases for the specific symbols to import. If non-empty import the specific symbols.
+	/// If the second component is empty, import the identifier unchanged.
+	/// If both m_unitAlias and m_symbolAlias are empty, import all symbols into the current scope.
+	std::vector<std::pair<ASTPointer<Identifier>, ASTPointer<ASTString>>> m_symbolAliases;
 };
 
 /**

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -54,10 +54,20 @@ struct DocumentedAnnotation
 	std::multimap<std::string, DocTag> docTags;
 };
 
+struct SourceUnitAnnotation: ASTAnnotation
+{
+	/// The "absolute" (in the compiler sense) path of this source unit.
+	std::string path;
+	/// The exported symbols (all global symbols).
+	std::map<ASTString, std::vector<Declaration const*>> exportedSymbols;
+};
+
 struct ImportAnnotation: ASTAnnotation
 {
 	/// The absolute path of the source unit to import.
 	std::string absolutePath;
+	/// The actual source unit.
+	SourceUnit const* sourceUnit = nullptr;
 };
 
 struct TypeDeclarationAnnotation: ASTAnnotation

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -91,7 +91,7 @@ Json::Value const& ASTJsonConverter::json()
 
 bool ASTJsonConverter::visit(ImportDirective const& _node)
 {
-	addJsonNode("Import", { make_pair("file", _node.identifier())});
+	addJsonNode("Import", { make_pair("file", _node.path())});
 	return true;
 }
 

--- a/libsolidity/ast/ASTPrinter.cpp
+++ b/libsolidity/ast/ASTPrinter.cpp
@@ -49,7 +49,7 @@ void ASTPrinter::print(ostream& _stream)
 
 bool ASTPrinter::visit(ImportDirective const& _node)
 {
-	writeLine("ImportDirective \"" + _node.identifier() + "\"");
+	writeLine("ImportDirective \"" + _node.path() + "\"");
 	printSourcePart(_node);
 	return goDeeper();
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1925,9 +1925,25 @@ string ModifierType::toString(bool _short) const
 	return name + ")";
 }
 
-MagicType::MagicType(MagicType::Kind _kind):
-	m_kind(_kind)
+bool ModuleType::operator==(Type const& _other) const
 {
+	if (_other.category() != category())
+		return false;
+	return &m_sourceUnit == &dynamic_cast<ModuleType const&>(_other).m_sourceUnit;
+}
+
+MemberList::MemberMap ModuleType::nativeMembers(ContractDefinition const*) const
+{
+	MemberList::MemberMap symbols;
+	for (auto const& symbolName: m_sourceUnit.annotation().exportedSymbols)
+		for (Declaration const* symbol: symbolName.second)
+			symbols.push_back(MemberList::Member(symbolName.first, symbol->type(), symbol));
+	return symbols;
+}
+
+string ModuleType::toString(bool) const
+{
+	return string("module \"") + m_sourceUnit.annotation().path + string("\"");
 }
 
 bool MagicType::operator==(Type const& _other) const

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -134,7 +134,7 @@ public:
 	{
 		Integer, IntegerConstant, StringLiteral, Bool, Real, Array,
 		FixedBytes, Contract, Struct, Function, Enum, Tuple,
-		Mapping, TypeType, Modifier, Magic
+		Mapping, TypeType, Modifier, Magic, Module
 	};
 
 	/// @{
@@ -969,6 +969,34 @@ private:
 };
 
 
+
+/**
+ * Special type for imported modules. These mainly give access to their scope via members.
+ */
+class ModuleType: public Type
+{
+public:
+	virtual Category category() const override { return Category::Module; }
+
+	explicit ModuleType(SourceUnit const& _source): m_sourceUnit(_source) {}
+
+	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override
+	{
+		return TypePointer();
+	}
+
+	virtual bool operator==(Type const& _other) const override;
+	virtual bool canBeStored() const override { return false; }
+	virtual bool canLiveOutsideStorage() const override { return true; }
+	virtual unsigned sizeOnStack() const override { return 0; }
+	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
+
+	virtual std::string toString(bool _short) const override;
+
+private:
+	SourceUnit const& m_sourceUnit;
+};
+
 /**
  * Special type for magic variables (block, msg, tx), similar to a struct but without any reference
  * (it always references a global singleton by name).
@@ -979,7 +1007,7 @@ public:
 	enum class Kind { Block, Message, Transaction };
 	virtual Category category() const override { return Category::Magic; }
 
-	explicit MagicType(Kind _kind);
+	explicit MagicType(Kind _kind): m_kind(_kind) {}
 
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override
 	{

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -111,6 +111,8 @@ bool CompilerStack::parse()
 		sourcePair.second.ast = Parser(m_errors).parse(sourcePair.second.scanner);
 		if (!sourcePair.second.ast)
 			solAssert(!Error::containsOnlyWarnings(m_errors), "Parser returned null but did not report error.");
+		else
+			sourcePair.second.ast->annotation().path = sourcePair.first;
 		sourceUnitsByName[sourcePair.first] = sourcePair.second.ast.get();
 	}
 	if (!Error::containsOnlyWarnings(m_errors))
@@ -384,6 +386,7 @@ void CompilerStack::resolveImports()
 							<< errinfo_sourceLocation(import->location())
 							<< errinfo_comment("Source not found.")
 					);
+				import->annotation().sourceUnit = m_sources.at(path).ast.get();
 
 				toposort(path, &m_sources[path]);
 			}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -376,7 +376,7 @@ void CompilerStack::resolveImports()
 		for (ASTPointer<ASTNode> const& node: _source->ast->nodes())
 			if (ImportDirective const* import = dynamic_cast<ImportDirective*>(node.get()))
 			{
-				string path = absolutePath(import->identifier(), _sourceName);
+				string path = absolutePath(import->path(), _sourceName);
 				import->annotation().absolutePath = path;
 				if (!m_sources.count(path))
 					BOOST_THROW_EXCEPTION(

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -119,7 +119,7 @@ ASTPointer<ImportDirective> Parser::parseImportDirective()
 	ASTNodeFactory nodeFactory(*this);
 	expectToken(Token::Import);
 	ASTPointer<ASTString> path;
-	ASTPointer<ASTString> unitAlias;
+	ASTPointer<ASTString> unitAlias = make_shared<string>();
 	vector<pair<ASTPointer<Identifier>, ASTPointer<ASTString>>> symbolAliases;
 
 	if (m_scanner->currentToken() == Token::StringLiteral)

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -93,6 +93,14 @@ BOOST_AUTO_TEST_CASE(relative_import_multiplex)
 	BOOST_CHECK(c.compile());
 }
 
+BOOST_AUTO_TEST_CASE(simple_alias)
+{
+	CompilerStack c;
+	c.addSource("a", "contract A {}");
+	c.addSource("dir/a/b/c", "import \"../../.././a\" as x; contract B { function() { x.A r = x.A(20); } }");
+	BOOST_CHECK(c.compile());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1047,6 +1047,27 @@ BOOST_AUTO_TEST_CASE(using_for)
 	BOOST_CHECK(successParse(text));
 }
 
+BOOST_AUTO_TEST_CASE(complex_import)
+{
+	char const* text = R"(
+		import "abc" as x;
+		import * as x from "abc";
+		import {a as b, c as d, f} from "def";
+		contract x {}
+	)";
+	BOOST_CHECK(successParse(text));
+}
+
+BOOST_AUTO_TEST_CASE(from_is_not_keyword)
+{
+	// "from" is not a keyword although it is used as a keyword in import directives.
+	char const* text = R"(
+		contract from {
+		}
+	)";
+	BOOST_CHECK(successParse(text));
+}
+
 BOOST_AUTO_TEST_CASE(inline_array_declaration)
 {
 	char const* text = R"(


### PR DESCRIPTION
Provides support for

```
import "controller.sol" as cont;

contract C {
  function f(cont.Controller owner) { ... }
}
```
