### PR TITLE
Flesh out naming convention in the Style Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 
 # Build directory
 build/
+docs/_build
 
 # vim stuff
 *.swp

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -559,14 +559,10 @@ naming styles.
 * ``UPPERCASE``
 * ``UPPER_CASE_WITH_UNDERSCORES``
 * ``CapitalizedWords`` (or CapWords)
-
-.. note:: When using abbreviations in CapWords, capitalize all the letters of the abbreviation. Thus HTTPServerError is better than HttpServerError.
-
-
-The following naming conventions are discouraged.
-
 * ``mixedCase`` (differs from CapitalizedWords by initial lowercase character!)
 * ``Capitalized_Words_With_Underscores``
+
+.. note:: When using abbreviations in CapWords, capitalize all the letters of the abbreviation. Thus HTTPServerError is better than HttpServerError.
 
 
 Names to Avoid
@@ -595,7 +591,7 @@ Events should be named using the CapWords style.
 Function Names
 ==============
 
-Functions should be lowercase with words separated by underscores.
+Functions should use mixedCase.
 
 
 Function Arguments
@@ -608,8 +604,7 @@ should be the first argument and should always be named ``self``.
 Contract and Local Variables
 ============================
 
-Use lowercase words separated by underscores.  Use trailing underscores to
-avoid collisions with reserved names.
+Use mixedCase.
 
 
 Constants

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -529,10 +529,110 @@ No::
     x = y+z;
     x +=1;
 
+
+******************
 Naming Conventions
+******************
+
+Naming conventions are powerful when adopted and used broadly.  The use of
+different conventions can convey significant *meta* information that would
+otherwise not be immediately available.
+
+The naming recomendations given here are intended to improve the readability,
+and thus they are not rules, but rather guidelines to try and help convey the
+most information through the names of things.
+
+Lastly, consistency within a codebase should always supercede any conventions
+outlined in this document.
+
+
+Naming Styles
+=============
+
+To avoid confusion, the following names will be used to refer to different
+naming styles.
+
+* ``b`` (single lowercase letter)
+* ``B`` (single uppercase letter)
+* ``lowercase``
+* ``lower_case_with_underscores``
+* ``UPPERCASE``
+* ``UPPER_CASE_WITH_UNDERSCORES``
+* ``CapitalizedWords`` (or CapWords)
+
+.. note:: When using abbreviations in CapWords, capitalize all the letters of the abbreviation. Thus HTTPServerError is better than HttpServerError.
+
+
+The following naming conventions are discouraged.
+
+* ``mixedCase`` (differs from CapitalizedWords by initial lowercase character!)
+* ``Capitalized_Words_With_Underscores``
+
+
+Names to Avoid
+==============
+
+* ``l`` - Lowercase letter el
+* ``O`` - Uppercase letter oh
+* ``I`` - Uppercase letter eye
+
+Never use any of these for single letter variable names.  They are often
+indistinguishable from the numerals one and zero.
+
+
+Contract and Library Names
+==========================
+
+Contracts should be named using the CapWords style.
+
+
+Events
+======
+
+Events should be named using the CapWords style.
+
+
+Function Names
+==============
+
+Functions should be lowercase with words separated by underscores.
+
+
+Function Arguments
 ==================
 
-TODO
+When writing library functions that operate on a custom struct, the struct
+should be the first argument and should always be named ``self``.
+
+
+Contract and Local Variables
+============================
+
+Use lowercase words separated by underscores.  Use trailing underscores to
+avoid collisions with reserved names.
+
+
+Constants
+=========
+
+Constants should be named with all capital letters with underscores separating
+words.  (for example:``MAX_BLOCKS``)
+
+
+Modifiers
+=========
+
+Function modifiers should use lowercase words separated by underscores.
+
+
+Avoiding Collisions
+===================
+
+* ``single_trailing_underscore_``
+
+This convention is suggested when the desired name collides with that of a
+built-in or otherwise reserved name.
+
 
 General Recommendations
 =======================

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -538,7 +538,7 @@ Naming conventions are powerful when adopted and used broadly.  The use of
 different conventions can convey significant *meta* information that would
 otherwise not be immediately available.
 
-The naming recomendations given here are intended to improve the readability,
+The naming recommendations given here are intended to improve the readability,
 and thus they are not rules, but rather guidelines to try and help convey the
 most information through the names of things.
 
@@ -601,8 +601,8 @@ When writing library functions that operate on a custom struct, the struct
 should be the first argument and should always be named ``self``.
 
 
-Contract and Local Variables
-============================
+Local and State Variables
+=========================
 
 Use mixedCase.
 


### PR DESCRIPTION
### What does this do?

This fills out the naming convention section in the [style guide](http://solidity.readthedocs.org/en/latest/style-guide.html) section of the documentation.
### How did I come up with these conventions?

This part of the document is largely transcribed from [it's counterpart in pep8](https://www.python.org/dev/peps/pep-0008/#naming-conventions).
### The `modifier` naming convention

I would specifically like to point out the naming convention for function modifiers because I chose a different convention than has been used in all code examples, documentation, etc.  Instead of suggesting the use of `onlyowner` the style guide instead would have it named `only_owner`.

I have trouble coming up with exactly why this seemed appropriate.  My general thought was that it should be easier to read and would prevent confusion when the words being used easily run together and it isn't immediately clear where the word break should be.  I've not been able to think of a good example of this but I know it's out there.
#### Cute animal picture

![i-have-one-excited-puppy-1346639405](https://cloud.githubusercontent.com/assets/824194/11857039/46991a5e-a412-11e5-8640-234dc8479f12.JPG)
