### PR TITLE
correct true/false literal's source

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1004,6 +1004,7 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 	{
 	case Token::TrueLiteral:
 	case Token::FalseLiteral:
+		nodeFactory.markEndPosition();
 		expression = nodeFactory.createNode<Literal>(token, getLiteralAndAdvance());
 		break;
 	case Token::Number:


### PR DESCRIPTION
Before:
        Literal, token: true value: true
           Type: bool
           Source: "true;"

After:
        Literal, token: true value: true
           Type: bool
           Source: "true"

Extra token is removed.
