### PR TITLE
Use paths instead of simple identifiers wherever possible.

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -264,7 +264,7 @@ void NameAndTypeResolver::linearizeBaseContracts(ContractDefinition& _contract)
 	list<list<ContractDefinition const*>> input(1, {});
 	for (ASTPointer<InheritanceSpecifier> const& baseSpecifier: _contract.baseContracts())
 	{
-		Identifier const& baseName = baseSpecifier->name();
+		UserDefinedTypeName const& baseName = baseSpecifier->name();
 		auto base = dynamic_cast<ContractDefinition const*>(baseName.annotation().referencedDeclaration);
 		if (!base)
 			reportFatalTypeError(baseName.createTypeError("Contract expected."));

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -340,7 +340,7 @@ class InheritanceSpecifier: public ASTNode
 public:
 	InheritanceSpecifier(
 		SourceLocation const& _location,
-		ASTPointer<Identifier> const& _baseName,
+		ASTPointer<UserDefinedTypeName> const& _baseName,
 		std::vector<ASTPointer<Expression>> _arguments
 	):
 		ASTNode(_location), m_baseName(_baseName), m_arguments(_arguments) {}
@@ -348,11 +348,11 @@ public:
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	Identifier const& name() const { return *m_baseName; }
+	UserDefinedTypeName const& name() const { return *m_baseName; }
 	std::vector<ASTPointer<Expression>> const& arguments() const { return m_arguments; }
 
 private:
-	ASTPointer<Identifier> m_baseName;
+	ASTPointer<UserDefinedTypeName> m_baseName;
 	std::vector<ASTPointer<Expression>> m_arguments;
 };
 
@@ -366,7 +366,7 @@ class UsingForDirective: public ASTNode
 public:
 	UsingForDirective(
 		SourceLocation const& _location,
-		ASTPointer<Identifier> const& _libraryName,
+		ASTPointer<UserDefinedTypeName> const& _libraryName,
 		ASTPointer<TypeName> const& _typeName
 	):
 		ASTNode(_location), m_libraryName(_libraryName), m_typeName(_typeName) {}
@@ -374,12 +374,12 @@ public:
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	Identifier const& libraryName() const { return *m_libraryName; }
+	UserDefinedTypeName const& libraryName() const { return *m_libraryName; }
 	/// @returns the type name the library is attached to, null for `*`.
 	TypeName const* typeName() const { return m_typeName.get(); }
 
 private:
-	ASTPointer<Identifier> m_libraryName;
+	ASTPointer<UserDefinedTypeName> m_libraryName;
 	ASTPointer<TypeName> m_typeName;
 };
 

--- a/libsolidity/ast/ASTPrinter.cpp
+++ b/libsolidity/ast/ASTPrinter.cpp
@@ -63,7 +63,7 @@ bool ASTPrinter::visit(ContractDefinition const& _node)
 
 bool ASTPrinter::visit(InheritanceSpecifier const& _node)
 {
-	writeLine("InheritanceSpecifier \"" + _node.name().name() + "\"");
+	writeLine("InheritanceSpecifier");
 	printSourcePart(_node);
 	return goDeeper();
 }

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -77,6 +77,7 @@ private:
 	ASTPointer<UsingForDirective> parseUsingDirective();
 	ASTPointer<ModifierInvocation> parseModifierInvocation();
 	ASTPointer<Identifier> parseIdentifier();
+	ASTPointer<UserDefinedTypeName> parseUserDefinedTypeName();
 	ASTPointer<TypeName> parseTypeName(bool _allowVar);
 	ASTPointer<Mapping> parseMapping();
 	ASTPointer<ParameterList> parseParameterList(

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(simple_alias)
 {
 	CompilerStack c;
 	c.addSource("a", "contract A {}");
-	c.addSource("dir/a/b/c", "import \"../../.././a\" as x; contract B { function() { x.A r = x.A(20); } }");
+	c.addSource("dir/a/b/c", "import \"../../.././a\" as x; contract B is x.A { function() { x.A r = x.A(20); } }");
 	BOOST_CHECK(c.compile());
 }
 


### PR DESCRIPTION
Fixes #310
