### PR TITLE
support the syntax "(x) = 3"

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -792,7 +792,10 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 			}
 			else
 				types.push_back(TypePointer());
-		_tuple.annotation().type = make_shared<TupleType>(types);
+		if (components.size() == 1)
+			_tuple.annotation().type = type(*components[0]);
+		else
+			_tuple.annotation().type = make_shared<TupleType>(types);
 		// If some of the components are not LValues, the error is reported above.
 		_tuple.annotation().isLValue = true;
 	}

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -233,7 +233,12 @@ bool ExpressionCompiler::visit(TupleExpression const& _tuple)
 		else if (_tuple.annotation().lValueRequested)
 			lvalues.push_back(unique_ptr<LValue>());
 	if (_tuple.annotation().lValueRequested)
-		m_currentLValue.reset(new TupleObject(m_context, move(lvalues)));
+	{
+		if (_tuple.components().size() == 1)
+			m_currentLValue = move(lvalues[0]);
+		else
+			m_currentLValue.reset(new TupleObject(m_context, move(lvalues)));
+	}
 	return false;
 }
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5785,6 +5785,21 @@ BOOST_AUTO_TEST_CASE(string_tuples)
 	BOOST_CHECK(callContractFunction("g()") == encodeArgs(u256(0x40), u256(0x80), u256(3), string("abc"), u256(3), string("def")));
 }
 
+BOOST_AUTO_TEST_CASE(decayed_tuple)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (uint) {
+				uint x = 1;
+				(x) = 2;
+				return x;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(2)));
+}
+
 BOOST_AUTO_TEST_CASE(destructuring_assignment)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1008,6 +1008,7 @@ BOOST_AUTO_TEST_CASE(tuples)
 				var (b,) = (1,);
 				var (c,d) = (1, 2 + a);
 				var (e,) = (1, 2, b);
+				(a) = 3;
 			}
 		}
 	)";


### PR DESCRIPTION
The tuple expression is decayed, it only has one component, it's slightly different with "(x,) = (3,)"'s syntax.

We have to support this because conditional expression "(true ? x : y) = 3" would use this syntax.
