### PR TITLE
Docs: Refund actual deposit, and not bid value.

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -396,7 +396,7 @@ high or low invalid bids.
                     // Bid was not actually revealed.
                     // Do not refund deposit.
                     continue;
-                refund += value;
+                refund += bid.deposit;
                 if (!fake && bid.deposit >= value)
                     if (placeBid(msg.sender, value))
                         refund -= value;


### PR DESCRIPTION
Thanks to @jonasnick for finding this.
Fixes #349
