### PR TITLE
Move reusable parser components into base class.

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -96,21 +96,6 @@ ASTPointer<SourceUnit> Parser::parse(shared_ptr<Scanner> const& _scanner)
 	}
 }
 
-std::shared_ptr<const string> const& Parser::sourceName() const
-{
-	return m_scanner->sourceName();
-}
-
-int Parser::position() const
-{
-	return m_scanner->currentLocation().start;
-}
-
-int Parser::endPosition() const
-{
-	return m_scanner->currentLocation().end;
-}
-
 ASTPointer<ImportDirective> Parser::parseImportDirective()
 {
 	// import "abc" [as x];
@@ -1286,71 +1271,11 @@ ASTPointer<Expression> Parser::expressionFromIndexAccessStructure(
 	return expression;
 }
 
-void Parser::expectToken(Token::Value _value)
-{
-	if (m_scanner->currentToken() != _value)
-		fatalParserError(
-			string("Expected token ") +
-			string(Token::name(_value)) +
-			string(" got '") +
-			string(Token::name(m_scanner->currentToken())) +
-			string("'")
-		);
-	m_scanner->next();
-}
-
-Token::Value Parser::expectAssignmentOperator()
-{
-	Token::Value op = m_scanner->currentToken();
-	if (!Token::isAssignmentOp(op))
-		fatalParserError(
-			string("Expected assignment operator,  got '") +
-			string(Token::name(m_scanner->currentToken())) +
-			string("'")
-		);
-	m_scanner->next();
-	return op;
-}
-
-ASTPointer<ASTString> Parser::expectIdentifierToken()
-{
-	if (m_scanner->currentToken() != Token::Identifier)
-		fatalParserError(
-			string("Expected identifier, got '") +
-			string(Token::name(m_scanner->currentToken())) +
-			string("'")
-		);
-	return getLiteralAndAdvance();
-}
-
-ASTPointer<ASTString> Parser::getLiteralAndAdvance()
-{
-	ASTPointer<ASTString> identifier = make_shared<ASTString>(m_scanner->currentLiteral());
-	m_scanner->next();
-	return identifier;
-}
-
 ASTPointer<ParameterList> Parser::createEmptyParameterList()
 {
 	ASTNodeFactory nodeFactory(*this);
 	nodeFactory.setLocationEmpty();
 	return nodeFactory.createNode<ParameterList>(vector<ASTPointer<VariableDeclaration>>());
-}
-
-void Parser::parserError(string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::ParserError);
-	*err <<
-		errinfo_sourceLocation(SourceLocation(position(), position(), sourceName())) <<
-		errinfo_comment(_description);
-
-	m_errors.push_back(err);
-}
-
-void Parser::fatalParserError(string const& _description)
-{
-	parserError(_description);
-	BOOST_THROW_EXCEPTION(FatalError());
 }
 
 }

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -22,7 +22,8 @@
 
 #pragma once
 
-#include "libsolidity/ast/AST.h"
+#include <libsolidity/ast/AST.h>
+#include <libsolidity/parsing/ParserBase.h>
 
 namespace dev
 {
@@ -31,21 +32,15 @@ namespace solidity
 
 class Scanner;
 
-class Parser
+class Parser: public ParserBase
 {
 public:
-	Parser(ErrorList& errors): m_errors(errors){};
+	Parser(ErrorList& _errors): ParserBase(_errors) {}
 
 	ASTPointer<SourceUnit> parse(std::shared_ptr<Scanner> const& _scanner);
-	std::shared_ptr<std::string const> const& sourceName() const;
 
 private:
 	class ASTNodeFactory;
-
-	/// Start position of the current token
-	int position() const;
-	/// End position of the current token
-	int endPosition() const;
 
 	struct VarDeclParserOptions
 	{
@@ -139,29 +134,13 @@ private:
 		std::vector<ASTPointer<PrimaryExpression>> const& _path,
 		std::vector<std::pair<ASTPointer<Expression>, SourceLocation>> const& _indices
 	);
-	/// If current token value is not _value, throw exception otherwise advance token.
-	void expectToken(Token::Value _value);
-	Token::Value expectAssignmentOperator();
-	ASTPointer<ASTString> expectIdentifierToken();
-	ASTPointer<ASTString> getLiteralAndAdvance();
 	///@}
 
 	/// Creates an empty ParameterList at the current location (used if parameters can be omitted).
 	ASTPointer<ParameterList> createEmptyParameterList();
 
-	/// Creates a @ref ParserError and annotates it with the current position and the
-	/// given @a _description.
-	void parserError(std::string const& _description);
-
-	/// Creates a @ref ParserError and annotates it with the current position and the
-	/// given @a _description. Throws the FatalError.
-	void fatalParserError(std::string const& _description);
-
-	std::shared_ptr<Scanner> m_scanner;
 	/// Flag that signifies whether '_' is parsed as a PlaceholderStatement or a regular identifier.
 	bool m_insideModifier = false;
-	/// The reference to the list of errors and warning to add errors/warnings during parsing
-	ErrorList& m_errors;
 };
 
 }

--- a/libsolidity/parsing/ParserBase.cpp
+++ b/libsolidity/parsing/ParserBase.cpp
@@ -1,0 +1,103 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <c@ethdev.com>
+ * @date 2016
+ * Solidity parser shared functionality.
+ */
+
+#include <libsolidity/parsing/ParserBase.h>
+#include <libsolidity/parsing/Scanner.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+std::shared_ptr<string const> const& ParserBase::sourceName() const
+{
+	return m_scanner->sourceName();
+}
+
+int ParserBase::position() const
+{
+	return m_scanner->currentLocation().start;
+}
+
+int ParserBase::endPosition() const
+{
+	return m_scanner->currentLocation().end;
+}
+
+void ParserBase::expectToken(Token::Value _value)
+{
+	if (m_scanner->currentToken() != _value)
+		fatalParserError(
+			string("Expected token ") +
+			string(Token::name(_value)) +
+			string(" got '") +
+			string(Token::name(m_scanner->currentToken())) +
+			string("'")
+		);
+	m_scanner->next();
+}
+
+Token::Value ParserBase::expectAssignmentOperator()
+{
+	Token::Value op = m_scanner->currentToken();
+	if (!Token::isAssignmentOp(op))
+		fatalParserError(
+			string("Expected assignment operator,  got '") +
+			string(Token::name(m_scanner->currentToken())) +
+			string("'")
+		);
+	m_scanner->next();
+	return op;
+}
+
+ASTPointer<ASTString> ParserBase::expectIdentifierToken()
+{
+	if (m_scanner->currentToken() != Token::Identifier)
+		fatalParserError(
+			string("Expected identifier, got '") +
+			string(Token::name(m_scanner->currentToken())) +
+			string("'")
+		);
+	return getLiteralAndAdvance();
+}
+
+ASTPointer<ASTString> ParserBase::getLiteralAndAdvance()
+{
+	ASTPointer<ASTString> identifier = make_shared<ASTString>(m_scanner->currentLiteral());
+	m_scanner->next();
+	return identifier;
+}
+
+void ParserBase::parserError(string const& _description)
+{
+	auto err = make_shared<Error>(Error::Type::ParserError);
+	*err <<
+		errinfo_sourceLocation(SourceLocation(position(), position(), sourceName())) <<
+		errinfo_comment(_description);
+
+	m_errors.push_back(err);
+}
+
+void ParserBase::fatalParserError(string const& _description)
+{
+	parserError(_description);
+	BOOST_THROW_EXCEPTION(FatalError());
+}

--- a/libsolidity/parsing/ParserBase.h
+++ b/libsolidity/parsing/ParserBase.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/parsing/Token.h>
+#include <libsolidity/ast/ASTForward.h>
 
 namespace dev
 {
@@ -32,9 +33,6 @@ namespace solidity
 {
 
 class Scanner;
-template <class T>
-using ASTPointer = std::shared_ptr<T>;
-using ASTString = std::string; // might be changed to a reference to the source
 
 class ParserBase
 {

--- a/libsolidity/parsing/ParserBase.h
+++ b/libsolidity/parsing/ParserBase.h
@@ -1,0 +1,76 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <c@ethdev.com>
+ * @date 2016
+ * Solidity parser shared functionality.
+ */
+
+#pragma once
+
+#include <memory>
+#include <libsolidity/interface/Exceptions.h>
+#include <libsolidity/parsing/Token.h>
+
+namespace dev
+{
+namespace solidity
+{
+
+class Scanner;
+template <class T>
+using ASTPointer = std::shared_ptr<T>;
+using ASTString = std::string; // might be changed to a reference to the source
+
+class ParserBase
+{
+public:
+	ParserBase(ErrorList& errors): m_errors(errors) {}
+
+	std::shared_ptr<std::string const> const& sourceName() const;
+
+protected:
+	/// Start position of the current token
+	int position() const;
+	/// End position of the current token
+	int endPosition() const;
+
+
+	///@{
+	///@name Helper functions
+	/// If current token value is not _value, throw exception otherwise advance token.
+	void expectToken(Token::Value _value);
+	Token::Value expectAssignmentOperator();
+	ASTPointer<ASTString> expectIdentifierToken();
+	ASTPointer<ASTString> getLiteralAndAdvance();
+	///@}
+
+	/// Creates a @ref ParserError and annotates it with the current position and the
+	/// given @a _description.
+	void parserError(std::string const& _description);
+
+	/// Creates a @ref ParserError and annotates it with the current position and the
+	/// given @a _description. Throws the FatalError.
+	void fatalParserError(std::string const& _description);
+
+	std::shared_ptr<Scanner> m_scanner;
+	/// The reference to the list of errors and warning to add errors/warnings during parsing
+	ErrorList& m_errors;
+};
+
+}
+}


### PR DESCRIPTION
This is in preparation for inline assembly.
