### PR TITLE
Clean higher order bits before array index access.

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1069,6 +1069,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.indexExpression(), "Index expression expected.");
 
 		_indexAccess.indexExpression()->accept(*this);
+		utils().convertType(*_indexAccess.indexExpression()->annotation().type, IntegerType(256), true);
 		// stack layout: <base_ref> [<length>] <index>
 		ArrayUtils(m_context).accessIndex(arrayType);
 		switch (arrayType.location())
@@ -1104,6 +1105,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.indexExpression(), "Index expression expected.");
 
 		_indexAccess.indexExpression()->accept(*this);
+		utils().convertType(*_indexAccess.indexExpression()->annotation().type, IntegerType(256), true);
 		// stack layout: <value> <index>
 		// check out-of-bounds access
 		m_context << u256(fixedBytesType.numBytes());

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -6575,6 +6575,22 @@ BOOST_AUTO_TEST_CASE(inline_assembly_jumps)
 	BOOST_CHECK(callContractFunction("f()", u256(7)) == encodeArgs(u256(34)));
 }
 
+BOOST_AUTO_TEST_CASE(index_access_with_type_conversion)
+{
+	// Test for a bug where higher order bits cleanup was not done for array index access.
+	char const* sourceCode = R"(
+			contract C {
+				function f(uint x) returns (uint[256] r){
+					r[uint8(x)] = 2;
+				}
+			}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	// neither of the two should throw due to out-of-bounds access
+	BOOST_CHECK(callContractFunction("f(uint256)", u256(0x01)).size() == 256 * 32);
+	BOOST_CHECK(callContractFunction("f(uint256)", u256(0x101)).size() == 256 * 32);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixes #446 

Without the explicit type conversion, we do not really zero-out the higher order bits because that is done in a lazy fashion.
