### PR TITLE
Update installing-solidity.rst

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -58,6 +58,8 @@ Set up Homebrew:
 .. code-block:: bash
 
     brew update
+    brew upgrade
+    
     brew install boost --c++11             # this takes a while
     brew install cmake cryptopp miniupnpc leveldb gmp libmicrohttpd libjson-rpc-cpp 
     # For Mix IDE and Alethzero only


### PR DESCRIPTION
The brew install boost --c++11 command failed for me due to an outdated version of Node.js.

`brew upgrade` fixed this. I think it should be in the documentation to reduce the number of errors on install
