### PR TITLE
Contract docs generator

### DIFF
--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -170,6 +170,11 @@ string const& ContractDefinition::userDocumentation() const
 	return m_userDocumentation;
 }
 
+string const& ContractDefinition::fullDocumentation() const
+{
+	return m_fullDocumentation;
+}
+
 void ContractDefinition::setDevDocumentation(string const& _devDocumentation)
 {
 	m_devDocumentation = _devDocumentation;
@@ -180,6 +185,10 @@ void ContractDefinition::setUserDocumentation(string const& _userDocumentation)
 	m_userDocumentation = _userDocumentation;
 }
 
+void ContractDefinition::setFullDocumentation(string const& _fullDocumentation)
+{
+	m_fullDocumentation = _fullDocumentation;
+}
 
 vector<Declaration const*> const& ContractDefinition::inheritableMembers() const
 {

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -321,6 +321,9 @@ public:
 	std::string const& devDocumentation() const;
 	void setDevDocumentation(std::string const& _devDocumentation);
 
+	std::string const& fullDocumentation() const;
+	void setFullDocumentation(std::string const& _fullDocumentation);
+
 	virtual TypePointer type() const override;
 
 	virtual ContractDefinitionAnnotation& annotation() const override;
@@ -333,6 +336,7 @@ private:
 	// parsed Natspec documentation of the contract.
 	std::string m_userDocumentation;
 	std::string m_devDocumentation;
+	std::string m_fullDocumentation;
 
 	std::vector<ContractDefinition const*> m_linearizedBaseContracts;
 	mutable std::unique_ptr<std::vector<std::pair<FixedHash<4>, FunctionTypePointer>>> m_interfaceFunctionList;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1730,6 +1730,30 @@ string FunctionType::externalSignature() const
 	return ret + ")";
 }
 
+string FunctionType::fullSignature() const
+{
+	solAssert(m_declaration != nullptr, "Full signature of function needs declaration");
+
+	const bool _addDataLocation = false;
+
+	// Function name
+	string ret = m_declaration->name() + "(";
+	// Params types with names
+	const vector<string> params = parameterNames();
+	const vector<string> paramTypes = parameterTypeNames(_addDataLocation);
+	solAssert(params.size() == paramTypes.size(), "Inconsistent function params");
+	for (unsigned short i = 0; i < params.size(); ++i)
+		ret += paramTypes[i] + " " + params[i] + (i == params.size() - 1 ? "" : ", ");
+
+	ret += ") returns (";
+	// Return types
+	const vector<string> returns = returnParameterTypeNames(_addDataLocation);
+	for (vector<string>::const_iterator it = returns.cbegin(); it != returns.cend(); ++it)
+		ret += *it + (it + 1 == returns.cend() ? "" : ", ");
+
+	return ret + ")";
+}
+
 u256 FunctionType::externalIdentifier() const
 {
 	return FixedHash<4>::Arith(FixedHash<4>(dev::sha3(externalSignature())));

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -844,6 +844,8 @@ public:
 	Location const& location() const { return m_location; }
 	/// @returns the external signature of this function type given the function name
 	std::string externalSignature() const;
+	/// @returns the full signature of this function: name, parameter types and names, etc.
+	std::string fullSignature() const;
 	/// @returns the external identifier of this function (the hash of the signature).
 	u256 externalIdentifier() const;
 	Declaration const& declaration() const

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -179,6 +179,7 @@ bool CompilerStack::parse()
 				{
 					contract->setDevDocumentation(InterfaceHandler::devDocumentation(*contract));
 					contract->setUserDocumentation(InterfaceHandler::userDocumentation(*contract));
+					contract->setFullDocumentation(InterfaceHandler::fullDocumentation(*contract));
 				}
 				else
 					noErrors = false;
@@ -327,6 +328,9 @@ string const& CompilerStack::metadata(string const& _contractName, Documentation
 		break;
 	case DocumentationType::ABISolidityInterface:
 		doc = &currentContract.solidityInterface;
+		break;
+	case DocumentationType::FullDocumentation:
+		doc = &currentContract.fullDocumentation;
 		break;
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Illegal documentation type."));

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -64,7 +64,8 @@ enum class DocumentationType: uint8_t
 	NatspecUser = 1,
 	NatspecDev,
 	ABIInterface,
-	ABISolidityInterface
+	ABISolidityInterface,
+	FullDocumentation
 };
 
 /**
@@ -203,6 +204,7 @@ private:
 		mutable std::unique_ptr<std::string const> solidityInterface;
 		mutable std::unique_ptr<std::string const> userDocumentation;
 		mutable std::unique_ptr<std::string const> devDocumentation;
+		mutable std::unique_ptr<std::string const> fullDocumentation;
 	};
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback

--- a/libsolidity/interface/InterfaceHandler.h
+++ b/libsolidity/interface/InterfaceHandler.h
@@ -83,6 +83,11 @@ public:
 	/// @return             A string with the json representation
 	///                     of the contract's developer documentation
 	static std::string devDocumentation(ContractDefinition const& _contractDef);
+	/// Genereates the full API documentation of the contract
+	/// @param _contractDef The contract definition
+	/// @return             A string with the json representation
+	///                     of the contract's API documentation
+	static std::string fullDocumentation(ContractDefinition const& _contractDef);
 
 private:
 	/// @returns concatenation of all content under the given tag name.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -71,6 +71,7 @@ static string const g_argCloneBinaryStr = "clone-bin";
 static string const g_argOpcodesStr = "opcodes";
 static string const g_argNatspecDevStr = "devdoc";
 static string const g_argNatspecUserStr = "userdoc";
+static string const g_argFullDocStr = "fulldoc";
 static string const g_argAddStandard = "add-std";
 static string const g_stdinFileName = "<stdin>";
 
@@ -85,7 +86,8 @@ static set<string> const g_combinedJsonArgs{
 	"asm",
 	"ast",
 	"userdoc",
-	"devdoc"
+	"devdoc",
+	"fulldoc"
 };
 
 static void version()
@@ -112,6 +114,7 @@ static bool needsHumanTargetedStdout(po::variables_map const& _args)
 		g_argNatspecUserStr,
 		g_argAstJson,
 		g_argNatspecDevStr,
+        g_argFullDocStr,
 		g_argAsmStr,
 		g_argAsmJsonStr,
 		g_argOpcodesStr,
@@ -236,6 +239,18 @@ void CommandLineInterface::handleMeta(DocumentationType _type, string const& _co
 			cout << m_compiler->metadata(_contract, _type) << endl;
 		}
 
+	}
+}
+
+void CommandLineInterface::handleDocumentation(std::string const& _contract)
+{
+	if (m_args.count(g_argFullDocStr))
+	{
+		auto _type = DocumentationType::FullDocumentation;
+		if (m_args.count("output-dir"))
+			createFile(_contract + ".doc", m_compiler->metadata(_contract, _type));
+		else
+			cout << m_compiler->metadata(_contract, _type) << endl;
 	}
 }
 
@@ -455,6 +470,7 @@ Allowed options)",
 		(g_argSignatureHashes.c_str(), "Function signature hashes of the contracts.")
 		(g_argNatspecUserStr.c_str(), "Natspec user documentation of all contracts.")
 		(g_argNatspecDevStr.c_str(), "Natspec developer documentation of all contracts.")
+		(g_argFullDocStr.c_str(), "Render to Markdown full documentation of all contracts.")
 		("formal", "Translated source suitable for formal analysis.");
 	desc.add(outputComponents);
 
@@ -904,6 +920,7 @@ void CommandLineInterface::outputCompilationResults()
 		handleMeta(DocumentationType::ABISolidityInterface, contract);
 		handleMeta(DocumentationType::NatspecDev, contract);
 		handleMeta(DocumentationType::NatspecUser, contract);
+		handleDocumentation(contract);
 	} // end of contracts iteration
 
 	handleFormal();

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -66,6 +66,7 @@ private:
 	void handleMeta(DocumentationType _type, std::string const& _contract);
 	void handleGasEstimation(std::string const& _contract);
 	void handleFormal();
+	void handleDocumentation(std::string const& _contract);
 
 	/// Fills @a m_sourceCodes initially and @a m_redirects.
 	void readInputFilesAndConfigureRemappings();

--- a/solc/docgen/doc.template
+++ b/solc/docgen/doc.template
@@ -1,0 +1,22 @@
+## {{ contract }}
+
+{% if title | length > 0 %}{{ title }}{% endif %}
+{% if author | length > 0 %}`(c) {{ author }}`{% endif %}
+
+{% for method_name, method in methods.iteritems() %}
+
+#### ```{{ method_name }}```
+
+    {% if method["params"] | length > 0 %}
+        {% for param_name, param_desc in method["params"].iteritems() %}
+* **{{ param_name }}**: {{ param_desc }}
+        {% endfor %}
+    {% endif %}
+
+{% if method["return"] | length > 0 %} **Return**: {{ method["return"] }} {% endif %}
+
+{{ method["details"] }}
+
+{% if method["notice"] | length > 0 %}**Notice:** `{{ method["notice"] }}`{% endif %}
+
+{% endfor %}

--- a/solc/docgen/docsol.py
+++ b/solc/docgen/docsol.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+from pexpect import spawn
+from json import loads
+from jinja2 import Environment, PackageLoader
+import sys
+
+class ContractDoc:
+    def render(self, output):
+        env = Environment(loader=PackageLoader('docsol', '.'))
+        template = env.get_template('doc.template')
+        output.write(template.render(contract=self._name, title=self._title, author=self._author, methods=self._methods))
+
+    def __init__(self, contract_name, description_string):
+        self._name = contract_name
+        description = loads(description_string) 
+        self._methods = description['methods']
+        if 'author' in description:
+            self._author = description['author']
+        else:
+            self._author = ''
+        if 'title' in description:
+            self._title = description['title']
+        else:
+            self._title = ''
+
+class DocParser:
+    # Tags
+    name_tag   = '======='
+
+    @staticmethod
+    def parse(input_file): 
+        readjson = False
+        jsonbuff = []
+        docname = ''
+        docs = []
+        for line in input_file:
+            if not readjson:
+                if line[0:7] == DocParser.name_tag:
+                    docname = line.replace(DocParser.name_tag, "")[1:-1]
+                    readjson = True
+                    jsonbuff = []
+            else:
+                if line != '\n':
+                    jsonbuff.append(line)
+                else:
+                    docs.append(ContractDoc(docname, ''.join(jsonbuff)))
+                    readjson = False
+        return docs
+
+if __name__ == '__main__':
+    docs = DocParser.parse(sys.stdin)
+    for d in docs:
+        d.render(sys.stdout)


### PR DESCRIPTION
In this PR added:
- `--fulldoc` key
- `docsol.py` tool

Example of usage:

https://github.com/akru/core/tree/develop

``` make
all: doc/Core-API.md doc/Market-API.md

doc/Core-API.md: core.sol 
    solc --fulldoc $^ | docsol.py > $@

doc/Market-API.md: market.sol 
    solc --fulldoc $^ | docsol.py > $@
```

`docsol.py` generates the _Markdown_ doc based on template:

``````
## {{ contract }}

{% if title | length > 0 %}{{ title }}{% endif %}
{% if author | length > 0 %}`(c) {{ author }}`{% endif %}

{% for method_name, method in methods.iteritems() %}

#### ```{{ method_name }}```

    {% if method["params"] | length > 0 %}
        {% for param_name, param_desc in method["params"].iteritems() %}
* **{{ param_name }}**: {{ param_desc }}
        {% endfor %}
    {% endif %}

{% if method["return"] | length > 0 %} **Return**: {{ method["return"] }} {% endif %}

{{ method["details"] }}

{% if method["notice"] | length > 0 %}**Notice:** `{{ method["notice"] }}`{% endif %}

{% endfor %}
``````

Finally doc files looks like https://github.com/airalab/core/wiki/Core-API
