### PR TITLE
Support shift operators for variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.7 (unreleased)
 
 Features:
+ * Support shifting variables. This is implemented via ``EXP`` and ``MUL`` / ``(S)DIV``.
  * Optimizer: Some dead code elimination.
 
 Bugfixes:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -345,7 +345,9 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 		return TypePointer();
 
 	// All integer types can be compared
-	if (Token::isCompareOp(_operator) || Token::isShiftOp(_operator))
+	if (Token::isCompareOp(_operator))
+		return commonType;
+	if (Token::isShiftOp(_operator) && !isAddress()) // && !_other->isAddress())
 		return commonType;
 	if (Token::isBooleanOp(_operator))
 		return TypePointer();

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -345,7 +345,7 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 		return TypePointer();
 
 	// All integer types can be compared
-	if (Token::isCompareOp(_operator))
+	if (Token::isCompareOp(_operator) || Token::isShiftOp(_operator))
 		return commonType;
 	if (Token::isBooleanOp(_operator))
 		return TypePointer();

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -347,6 +347,9 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 	// All integer types can be compared
 	if (Token::isCompareOp(_operator))
 		return commonType;
+	// Disable >>> here.
+	if (_operator == Token::SHR)
+		return TypePointer();
 	if (Token::isShiftOp(_operator) && !isAddress()) // && !_other->isAddress())
 		return shared_from_this();
 	if (Token::isBooleanOp(_operator))

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -348,7 +348,7 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 	if (Token::isCompareOp(_operator))
 		return commonType;
 	if (Token::isShiftOp(_operator) && !isAddress()) // && !_other->isAddress())
-		return commonType;
+		return shared_from_this();
 	if (Token::isBooleanOp(_operator))
 		return TypePointer();
 	if (auto intType = dynamic_pointer_cast<IntegerType const>(commonType))

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -223,7 +223,8 @@ bool ExpressionCompiler::visit(Assignment const& _assignment)
 		}
 		m_currentLValue->retrieveValue(_assignment.location(), true);
 		if (Token::isShiftOp(target_op))
-			appendShiftOperatorCode(target_op, *_assignment.annotation().type, *_assignment.annotation().type);
+			// shift only cares about the signedness of both sides
+			appendShiftOperatorCode(target_op, *_assignment.leftHandSide().annotation().type, *_assignment.rightHandSide().annotation().type);
 		else
 			appendOrdinaryBinaryOperatorCode(target_op, *_assignment.annotation().type);
 		if (lvalueSize > 0)
@@ -391,7 +392,8 @@ bool ExpressionCompiler::visit(BinaryOperation const& _binaryOperation)
 			utils().convertType(*leftExpression.annotation().type, commonType, cleanupNeeded);
 		}
 		if (Token::isShiftOp(c_op))
-			appendShiftOperatorCode(c_op, commonType, commonType);
+			// shift only cares about the signedness of both sides
+			appendShiftOperatorCode(c_op, *leftExpression.annotation().type, *rightExpression.annotation().type);
 		else if (Token::isCompareOp(c_op))
 			appendCompareOperatorCode(c_op, commonType);
 		else

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1406,8 +1406,7 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::SWAP1 << (c_isSigned ? Instruction::SDIV : Instruction::DIV);
 		break;
 	case Token::SHR:
-		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::DIV;
-		break;
+		// This is the >>> operator, which we disable here.
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown shift operator."));
 	}

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1419,7 +1419,7 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 	// shift with negative rvalue throws exception
 	if (c_rightSigned)
 	{
-		m_context << Instruction::DUP2 << (u256(1) << 255) << Instruction::AND << Instruction::ISZERO << Instruction::ISZERO;
+		m_context << u256(0) << Instruction::DUP3 << Instruction::SLT;
 		m_context.appendConditionalJumpTo(m_context.errorTag());
 	}
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -361,7 +361,7 @@ bool ExpressionCompiler::visit(BinaryOperation const& _binaryOperation)
 	else
 	{
 		bool cleanupNeeded = false;
-		if (Token::isCompareOp(c_op))
+		if (Token::isCompareOp(c_op) || Token::isShiftOp(c_op))
 			cleanupNeeded = true;
 		if (commonType.category() == Type::Category::Integer && (c_op == Token::Div || c_op == Token::Mod))
 			cleanupNeeded = true;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1405,16 +1405,10 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 
 	// The RValue can be a RationalNumberType too.
 	bool c_rightSigned = false;
-	if (_rightType.category() == Type::Category::RationalNumber)
-	{
-		RationalNumberType const& rightType = dynamic_cast<RationalNumberType const&>(_rightType);
-		c_rightSigned = rightType.integerType()->isSigned();
-	}
-	else
-	{
-		IntegerType const& rightType = dynamic_cast<IntegerType const&>(_rightType);
-		c_rightSigned = rightType.isSigned();
-	}
+	if (auto rightType = dynamic_cast<RationalNumberType const*>(&_rightType))
+		c_rightSigned = rightType->integerType()->isSigned();
+	else if (auto rightType = dynamic_cast<IntegerType const*>(&_rightType))
+		c_rightSigned = rightType->isSigned();
 
 	// shift with negative rvalue throws exception
 	if (c_rightSigned)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1397,6 +1397,11 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 	bool const c_isSigned = type.isSigned();
 
+	// shift with negative rvalue throws exception
+	// FIXME: include this only for signed rvalues
+	m_context << Instruction::DUP2 << (u256(1) << 255) << Instruction::AND << Instruction::ISZERO << Instruction::ISZERO;
+	m_context.appendConditionalJumpTo(m_context.errorTag());
+
 	switch (_operator)
 	{
 	case Token::SHL:

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1327,7 +1327,7 @@ void ExpressionCompiler::appendOrdinaryBinaryOperatorCode(Token::Value _operator
 	else if (Token::isBitOp(_operator))
 		appendBitOperatorCode(_operator);
 	else if (Token::isShiftOp(_operator))
-		appendShiftOperatorCode(_operator);
+		appendShiftOperatorCode(_operator, _type);
 	else
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown binary operator."));
 }
@@ -1390,9 +1390,12 @@ void ExpressionCompiler::appendBitOperatorCode(Token::Value _operator)
 	}
 }
 
-void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
+void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type const& _type)
 {
 	// stack: rvalue lvalue
+
+	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
+	bool const c_isSigned = type.isSigned();
 
 	switch (_operator)
 	{
@@ -1400,7 +1403,7 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
 		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::MUL;
 		break;
 	case Token::SAR:
-		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::SWAP1 << Instruction::DIV;
+		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::SWAP1 << (c_isSigned ? Instruction::SDIV : Instruction::DIV);
 		break;
 	case Token::SHR:
 		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::DIV;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1402,8 +1402,19 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 
 	IntegerType const& leftType = dynamic_cast<IntegerType const&>(_leftType);
 	bool const c_leftSigned = leftType.isSigned();
-	IntegerType const& rightType = dynamic_cast<IntegerType const&>(_rightType);
-	bool const c_rightSigned = rightType.isSigned();
+
+	// The RValue can be a RationalNumberType too.
+	bool c_rightSigned = false;
+	if (_rightType.category() == Type::Category::RationalNumber)
+	{
+		RationalNumberType const& rightType = dynamic_cast<RationalNumberType const&>(_rightType);
+		c_rightSigned = rightType.integerType()->isSigned();
+	}
+	else
+	{
+		IntegerType const& rightType = dynamic_cast<IntegerType const&>(_rightType);
+		c_rightSigned = rightType.isSigned();
+	}
 
 	// shift with negative rvalue throws exception
 	if (c_rightSigned)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1406,9 +1406,14 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 	// The RValue can be a RationalNumberType too.
 	bool c_rightSigned = false;
 	if (auto rightType = dynamic_cast<RationalNumberType const*>(&_rightType))
+	{
+		solAssert(rightType->integerType(), "integerType() called for fractional number.");
 		c_rightSigned = rightType->integerType()->isSigned();
+	}
 	else if (auto rightType = dynamic_cast<IntegerType const*>(&_rightType))
 		c_rightSigned = rightType->isSigned();
+	else
+		solUnimplemented("Not implemented yet - FixedPointType.");
 
 	// shift with negative rvalue throws exception
 	if (c_rightSigned)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1392,14 +1392,18 @@ void ExpressionCompiler::appendBitOperatorCode(Token::Value _operator)
 
 void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
 {
-	solUnimplemented("Shift operators not yet implemented.");
+	// stack: rvalue lvalue
+
 	switch (_operator)
 	{
 	case Token::SHL:
+		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::MUL;
 		break;
 	case Token::SAR:
+		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::SWAP1 << Instruction::DIV;
 		break;
 	case Token::SHR:
+		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::DIV;
 		break;
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown shift operator."));

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1400,8 +1400,11 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 {
 	// stack: rvalue lvalue
 
-	IntegerType const& leftType = dynamic_cast<IntegerType const&>(_leftType);
-	bool const c_leftSigned = leftType.isSigned();
+	bool c_leftSigned = false;
+	if (auto leftType = dynamic_cast<IntegerType const*>(&_leftType))
+		c_leftSigned = leftType->isSigned();
+	else
+		solUnimplemented("Only IntegerType can be shifted.");
 
 	// The RValue can be a RationalNumberType too.
 	bool c_rightSigned = false;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1434,7 +1434,6 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator, Type co
 		m_context << Instruction::SWAP1 << u256(2) << Instruction::EXP << Instruction::SWAP1 << (c_leftSigned ? Instruction::SDIV : Instruction::DIV);
 		break;
 	case Token::SHR:
-		// This is the >>> operator, which we disable here.
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown shift operator."));
 	}

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -91,7 +91,7 @@ private:
 
 	void appendArithmeticOperatorCode(Token::Value _operator, Type const& _type);
 	void appendBitOperatorCode(Token::Value _operator);
-	void appendShiftOperatorCode(Token::Value _operator);
+	void appendShiftOperatorCode(Token::Value _operator, Type const& _type);
 	/// @}
 
 	/// Appends code to call a function of the given type with the given arguments.

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -91,7 +91,7 @@ private:
 
 	void appendArithmeticOperatorCode(Token::Value _operator, Type const& _type);
 	void appendBitOperatorCode(Token::Value _operator);
-	void appendShiftOperatorCode(Token::Value _operator, Type const& _type);
+	void appendShiftOperatorCode(Token::Value _operator, Type const& _leftType, Type const& _rightType);
 	/// @}
 
 	/// Appends code to call a function of the given type with the given arguments.

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8403,6 +8403,23 @@ BOOST_AUTO_TEST_CASE(shift_right)
 	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(17)) == encodeArgs(u256(0)));
 }
 
+BOOST_AUTO_TEST_CASE(shift_right_garbled)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint8 a, uint8 b) returns (uint) {
+				assembly {
+					a := 0xffffffff
+				}
+				// Higher bits should be cleared before the shift
+				return a >> b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x0), u256(4)) == encodeArgs(u256(0xf)));
+}
+
 BOOST_AUTO_TEST_CASE(shift_right_uint32)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8596,9 +8596,7 @@ BOOST_AUTO_TEST_CASE(shift_overflow)
 	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 1) == encodeArgs(u256(254)));
 	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 0) == encodeArgs(u256(255)));
 
-	// should throw
-	BOOST_CHECK(callContractFunction("leftS(int8,int8)", 1, 7) == encodeArgs());
-	// should return
+	BOOST_CHECK(callContractFunction("leftS(int8,int8)", 1, 7) == encodeArgs(u256(128)));
 	BOOST_CHECK(callContractFunction("leftS(int8,int8)", 1, 6) == encodeArgs(u256(64)));
 }
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8547,6 +8547,22 @@ BOOST_AUTO_TEST_CASE(shift_constant_right_assignment)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(0x42)));
 }
 
+BOOST_AUTO_TEST_CASE(shift_cleanup)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (uint x) {
+				uint16 x = 0xffff;
+				x += 32;
+				x <<= 8
+				x >>= 16;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(0x0)));
+}
+
 BOOST_AUTO_TEST_CASE(inline_assembly_in_modifiers)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8592,11 +8592,8 @@ BOOST_AUTO_TEST_CASE(shift_overflow)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
-	// should throw
-	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 8) == encodeArgs());
-	// should throw
-	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 1) == encodeArgs());
-	// should return
+	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 8) == encodeArgs(u256(0)));
+	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 1) == encodeArgs(u256(254)));
 	BOOST_CHECK(callContractFunction("leftU(uint8,uint8)", 255, 0) == encodeArgs(u256(255)));
 
 	// should throw

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8319,6 +8319,234 @@ BOOST_AUTO_TEST_CASE(shift_negative_constant_right)
 	BOOST_CHECK(callContractFunction("a()") == encodeArgs(u256(-0x42)));
 }
 
+BOOST_AUTO_TEST_CASE(shift_left)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint a, uint b) returns (uint) {
+				return a << b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(0)) == encodeArgs(u256(0x4266)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(8)) == encodeArgs(u256(0x426600)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(16)) == encodeArgs(u256(0x42660000)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(17)) == encodeArgs(u256(0x84cc0000)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(240)) == fromHex("4266000000000000000000000000000000000000000000000000000000000000"));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(256)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_left_uint32)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint32 a, uint32 b) returns (uint) {
+				return a << b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(0)) == encodeArgs(u256(0x4266)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(8)) == encodeArgs(u256(0x426600)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(16)) == encodeArgs(u256(0x42660000)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(17)) == encodeArgs(u256(0x84cc0000)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(32)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_left_uint8)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint8 a, uint8 b) returns (uint) {
+				return a << b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint8,uint8)", u256(0x66), u256(0)) == encodeArgs(u256(0x66)));
+	BOOST_CHECK(callContractFunction("f(uint8,uint8)", u256(0x66), u256(8)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_left_assignment)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint a, uint b) returns (uint) {
+				a <<= b;
+				return a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(0)) == encodeArgs(u256(0x4266)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(8)) == encodeArgs(u256(0x426600)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(16)) == encodeArgs(u256(0x42660000)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(17)) == encodeArgs(u256(0x84cc0000)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(240)) == fromHex("4266000000000000000000000000000000000000000000000000000000000000"));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(256)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint a, uint b) returns (uint) {
+				return a >> b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(0)) == encodeArgs(u256(0x4266)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(8)) == encodeArgs(u256(0x42)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(16)) == encodeArgs(u256(0)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(17)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right_uint32)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint32 a, uint32 b) returns (uint) {
+				return a >> b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(0)) == encodeArgs(u256(0x4266)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(8)) == encodeArgs(u256(0x42)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(16)) == encodeArgs(u256(0)));
+	BOOST_CHECK(callContractFunction("f(uint32,uint32)", u256(0x4266), u256(17)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right_uint8)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint8 a, uint8 b) returns (uint) {
+				return a >> b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint8,uint8)", u256(0x66), u256(0)) == encodeArgs(u256(0x66)));
+	BOOST_CHECK(callContractFunction("f(uint8,uint8)", u256(0x66), u256(8)) == encodeArgs(u256(0x0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right_assignment)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint a, uint b) returns (uint) {
+				a >>= b;
+				return a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(0)) == encodeArgs(u256(0x4266)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(8)) == encodeArgs(u256(0x42)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(16)) == encodeArgs(u256(0)));
+	BOOST_CHECK(callContractFunction("f(uint256,uint256)", u256(0x4266), u256(17)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right_negative_lvalue)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(int a, int b) returns (int) {
+				return a >> b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(0)) == encodeArgs(u256(-4266)));
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(8)) == encodeArgs(u256(-16)));
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(16)) == encodeArgs(u256(0)));
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(17)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right_negative_lvalue_assignment)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(int a, int b) returns (int) {
+				a >>= b;
+				return a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(0)) == encodeArgs(u256(-4266)));
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(8)) == encodeArgs(u256(-16)));
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(16)) == encodeArgs(u256(0)));
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(-4266), u256(17)) == encodeArgs(u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_negative_rvalue)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(int a, int b) returns (int) {
+				return a << b;
+			}
+			function g(int a, int b) returns (int) {
+				return a >> b;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(1), u256(-1)) == encodeArgs());
+	BOOST_CHECK(callContractFunction("g(int256,int256)", u256(1), u256(-1)) == encodeArgs());
+}
+
+BOOST_AUTO_TEST_CASE(shift_negative_rvalue_assignment)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(int a, int b) returns (int) {
+				a <<= b;
+				return a;
+			}
+			function g(int a, int b) returns (int) {
+				a >>= b;
+				return a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(int256,int256)", u256(1), u256(-1)) == encodeArgs());
+	BOOST_CHECK(callContractFunction("g(int256,int256)", u256(1), u256(-1)) == encodeArgs());
+}
+
+BOOST_AUTO_TEST_CASE(shift_constant_left_assignment)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (uint a) {
+				a = 0x42;
+				a <<= 8;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(0x4200)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_constant_right_assignment)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (uint a) {
+				a = 0x4200;
+				a >>= 8;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(0x42)));
+}
+
 BOOST_AUTO_TEST_CASE(inline_assembly_in_modifiers)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Add tests for:
- [x]    shifting constants
- [x]    smaller types
- [ ]    checks that high order bit cleanup is performed correctly
- [x]    right shift of negative left hand sides
- [x]    shifts by negative amounts (both for signed and unsigned right hand sides)
- [ ]    more complex usage of shifts in some actually useful snippet
- [x]    shift assignment (a <<= 2)

---

Do not merge yet - I would like to get feedback before finishing this work. Also some commits should be squashed later.

First two commits could be merged as those are only trivial fixes.

Regarding this rest:
- SHL seems solid
- SAR/SHR needs further testing (and not failing tests) and validation
- the tests need to be extended and perhaps it shouldn't be in the end-to-end test

(Fixes https://github.com/ethereum/solidity/issues/33.)
