### PR TITLE
Use add exe wrapper for solc, soltest, lllc

### DIFF
--- a/lllc/CMakeLists.txt
+++ b/lllc/CMakeLists.txt
@@ -4,7 +4,7 @@ set(EXECUTABLE lllc)
 
 file(GLOB HEADERS "*.h")
 include_directories(BEFORE ..)
-add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
+eth_simple_add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Solidity::lll Dev::buildinfo Solidity::evmasm)
 

--- a/solc/CMakeLists.txt
+++ b/solc/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(BEFORE ..)
 set(EXECUTABLE solc)
 
 file(GLOB HEADERS "*.h")
-add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
+eth_simple_add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Solidity::solidity)
 target_link_libraries(${EXECUTABLE} ${Boost_PROGRAM_OPTIONS_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,7 +42,7 @@ endforeach(file)
 
 file(GLOB HEADERS "*.h")
 set(EXECUTABLE soltest)
-add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
+eth_simple_add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 eth_use(${EXECUTABLE} REQUIRED Solidity::solidity Eth::ethereum Eth::ethcore)
 


### PR DESCRIPTION
Allows access to static linking logic. See ethereum/webthree-umbrella#495
