### PR TITLE
Parent directory import

### DIFF
--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -53,7 +53,8 @@ with `.` are treated as absolute paths.
 
 To import a file `x` from the same directory as the current file, use `import "./x" as x;`.
 If you use `import "x" as x;` instead, a different file could be referenced
-(in a global "include directory").
+(in a global "include directory"). If you are importing from a parent directory, you
+can use either `../x` or `.././x`.
 
 It depends on the compiler (see below) how to actually resolve the paths.
 In general, the directory hierarchy does not need to strictly map onto your local

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -106,6 +106,7 @@ bool CompilerStack::parse()
 	for (auto const& s: m_sources)
 		sourcesToParse.push_back(s.first);
 	map<string, SourceUnit const*> sourceUnitsByName;
+	m_searchAbsolutePath = (sourcesToParse.size() == 1);
 	for (size_t i = 0; i < sourcesToParse.size(); ++i)
 	{
 		string const& path = sourcesToParse[i];
@@ -484,6 +485,8 @@ string CompilerStack::absolutePath(string const& _path, string const& _reference
 	using path = boost::filesystem::path;
 	path p(_path);
 	path result(_reference);
+	if (!result.has_parent_path() && m_searchAbsolutePath)
+		result = path(boost::filesystem::current_path() /= _reference);
 	result.remove_filename();
 	for (path::iterator it = p.begin(); it != p.end(); ++it)
 		if (*it == "..")

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -178,7 +178,7 @@ public:
 
 	/// @returns the list of errors that occured during parsing and type checking.
 	ErrorList const& errors() const { return m_errors; }
-
+	bool searchAbsolutePath() const { return m_searchAbsolutePath; }
 private:
 	/**
 	 * Information pertaining to one source unit, filled gradually during parsing and compilation.
@@ -228,6 +228,7 @@ private:
 
 	ReadFileCallback m_readFile;
 	bool m_parseSuccessful;
+	bool m_searchAbsolutePath = false;
 	std::map<std::string const, Source> m_sources;
 	std::shared_ptr<GlobalContext> m_globalContext;
 	std::vector<Source const*> m_sourceOrder;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -196,9 +196,9 @@ void CommandLineInterface::handleSignatureHashes(string const& _contract)
 
 void CommandLineInterface::handleMeta(DocumentationType _type, string const& _contract)
 {
-	std::string argName;
-	std::string suffix;
-	std::string title;
+	string argName;
+	string suffix;
+	string title;
 	switch(_type)
 	{
 	case DocumentationType::ABIInterface:
@@ -540,7 +540,7 @@ bool CommandLineInterface::processInput()
 			auto const& virt = redir.first;
 			if (longestPrefix > 0 && virt.length() <= longestPrefix)
 				continue;
-			if (virt.length() > _path.length() || !std::equal(virt.begin(), virt.end(), _path.begin()))
+			if (virt.length() > _path.length() || !equal(virt.begin(), virt.end(), _path.begin()))
 				continue;
 			string path = redir.second;
 			path.append(_path.begin() + virt.length(), _path.end());
@@ -551,13 +551,13 @@ bool CommandLineInterface::processInput()
 				continue;
 			}
 			boostPath = boost::filesystem::canonical(boostPath);
-			bool isAllowed = false;
+			bool isAllowed = m_compiler->searchAbsolutePath();
 			for (auto const& dir: m_allowedDirectories)
 			{
 				// If dir is a prefix of boostPath, we are fine.
 				if (
 					std::distance(dir.begin(), dir.end()) <= std::distance(boostPath.begin(), boostPath.end()) &&
-					std::equal(dir.begin(), dir.end(), boostPath.begin())
+ 					std::equal(dir.begin(), dir.end(), boostPath.begin())
 				)
 				{
 					isAllowed = true;


### PR DESCRIPTION
fixes #553 . Fixed all issues. I have made this so that you can link from a single file in the compiler arguments, or multiple as has been the traditional approach. I think this is a much more dynamic import scheme and should be merged immediately. 
