### PR TITLE
fix example solidity contract code by adding argument to constructor

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -44,7 +44,7 @@ API, this is done as follows::
     var MyContract = web3.eth.contract(abiArray);
     // deploy new contract
     var contractInstance = MyContract.new(
-      10,
+      10, 11,
       {from: myAccount, gas: 1000000}
     );
 


### PR DESCRIPTION
In reading the documentation for how to work with Solidity smart contracts I found this contract example and did not understand how the MyContract.new() call could work, given the contract's constructor required two uint256 arguments, but it looked like only one was being given.

I brought this question to the #solidity gitter channel where @VoR0220 confirmed it needs to be changed,  and @tymat suggested this code change. So here it is!
