### PR TITLE
fix: error: call of overloaded ‘list(int, <brace-enclosed initializer…

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -296,7 +296,7 @@ void NameAndTypeResolver::linearizeBaseContracts(ContractDefinition& _contract)
 {
 	// order in the lists is from derived to base
 	// list of lists to linearize, the last element is the list of direct bases
-	list<list<ContractDefinition const*>> input(1, {});
+	list<list<ContractDefinition const*>> input(1, list<ContractDefinition const*>{});
 	for (ASTPointer<InheritanceSpecifier> const& baseSpecifier: _contract.baseContracts())
 	{
 		UserDefinedTypeName const& baseName = baseSpecifier->name();


### PR DESCRIPTION
… list>)’

Issue: https://github.com/ethereum/solidity/issues/574

Compilation of webthree-umbrella on Arch with gcc 6.1 results in the following
error:

```
/home/mwo/webthree-umbrella/solidity/libsolidity/analysis/NameAndTypeResolver.cpp:299:51: error: call of overloaded ‘list(int, <brace-enclosed initializer list>)’ is ambiguous
  list<list<ContractDefinition const*>> input(1, {});
```

A proposed fix is to change the problematic line into:

```
  list<list<ContractDefinition const*>> input(1, list<ContractDefinition const*>{})
```
