### PR TITLE
Typo correction in solidity-by-example.rst

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -76,7 +76,7 @@ of votes.
             // to the end of the array.
             for (uint i = 0; i < proposalNames.length; i++) {
                 // `Proposal({...})` creates a temporary
-                // Proposal object and `proposal.push(...)`
+                // Proposal object and `proposals.push(...)`
                 // appends it to the end of `proposals`.
                 proposals.push(Proposal({
                     name: proposalNames[i],


### PR DESCRIPTION
Just correcting a simple typo in the comments of the code .. It's a one letter change but still.
