### PR TITLE
add a way to read from stdin in combination with other input_files args

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -306,9 +306,35 @@ void CommandLineInterface::handleFormal()
 		cout << "Formal version:" << endl << m_compiler->formalTranslation() << endl;
 }
 
-void CommandLineInterface::readInputFilesAndConfigureRemappings()
+void CommandLineInterface::readInputFilesAndConfigureRemappings(bool usestdin, vector<string> inputFiles)
 {
-	if (!m_args.count("input-file"))
+	for (string path: inputFiles)
+	{
+		auto eq = find(path.begin(), path.end(), '=');
+		if (eq != path.end())
+			path = string(eq + 1, path.end());
+		else
+		{
+			auto infile = boost::filesystem::path(path);
+			if (!boost::filesystem::exists(infile))
+			{
+				cerr << "Skipping non existant input file \"" << infile << "\"" << endl;
+				continue;
+			}
+
+			if (!boost::filesystem::is_regular_file(infile))
+			{
+				cerr << "\"" << infile << "\" is not a valid file. Skipping" << endl;
+				continue;
+			}
+
+			m_sourceCodes[infile.string()] = dev::contentsString(infile.string());
+			path = boost::filesystem::canonical(infile).string();
+		}
+		m_allowedDirectories.push_back(boost::filesystem::path(path).remove_filename());
+	}
+
+	if (usestdin)
 	{
 		string s;
 		while (!cin.eof())
@@ -317,32 +343,6 @@ void CommandLineInterface::readInputFilesAndConfigureRemappings()
 			m_sourceCodes[g_stdinFileName].append(s + '\n');
 		}
 	}
-	else
-		for (string path: m_args["input-file"].as<vector<string>>())
-		{
-			auto eq = find(path.begin(), path.end(), '=');
-			if (eq != path.end())
-				path = string(eq + 1, path.end());
-			else
-			{
-				auto infile = boost::filesystem::path(path);
-				if (!boost::filesystem::exists(infile))
-				{
-					cerr << "Skipping non existant input file \"" << infile << "\"" << endl;
-					continue;
-				}
-
-				if (!boost::filesystem::is_regular_file(infile))
-				{
-					cerr << "\"" << infile << "\" is not a valid file. Skipping" << endl;
-					continue;
-				}
-
-				m_sourceCodes[infile.string()] = dev::contentsString(infile.string());
-				path = boost::filesystem::canonical(infile).string();
-			}
-			m_allowedDirectories.push_back(boost::filesystem::path(path).remove_filename());
-		}
 }
 
 bool CommandLineInterface::parseLibraryOption(string const& _input)
@@ -401,6 +401,8 @@ Compiles the given Solidity input files (or the standard input if none given) an
 outputs the components specified in the options at standard output or in files in
 the output directory, if specified.
 Example: solc --bin -o /tmp/solcoutput contract.sol
+
+When - is specified as one of the input files it will add the current directory to the allowed directories and read from standard input
 
 Allowed options)",
 		po::options_description::m_default_line_length,
@@ -509,7 +511,32 @@ Allowed options)",
 
 bool CommandLineInterface::processInput()
 {
-	readInputFilesAndConfigureRemappings();
+	// determine if we should use stdin
+	bool usestdin = false;
+	vector<string> inputFiles;
+
+	if (!m_args.count("input-file")) {
+		inputFiles = vector<string>();
+		usestdin = true;
+	} else {
+		inputFiles = m_args["input-file"].as<vector<string>>();
+
+		if (inputFiles.size() == 0)
+			usestdin = true;
+		else
+			// search for "-" in input files to enable stdin (and filter out the "-")
+			for (unsigned idx = 0; idx < inputFiles.size(); ++idx) {
+				string path = inputFiles[idx];
+				if (path == "-") {
+					inputFiles.erase(inputFiles.begin() + idx);
+					usestdin = true;
+					m_allowedDirectories.push_back(boost::filesystem::current_path());
+					break;
+				}
+			}
+	}
+
+	readInputFilesAndConfigureRemappings(usestdin, inputFiles);
 
 	if (m_args.count("libraries"))
 		for (string const& library: m_args["libraries"].as<vector<string>>())
@@ -564,8 +591,8 @@ bool CommandLineInterface::processInput()
 	auto scannerFromSourceName = [&](string const& _sourceName) -> solidity::Scanner const& { return m_compiler->scanner(_sourceName); };
 	try
 	{
-		if (m_args.count("input-file"))
-			m_compiler->setRemappings(m_args["input-file"].as<vector<string>>());
+		if (inputFiles.size())
+			m_compiler->setRemappings(inputFiles);
 		for (auto const& sourceCode: m_sourceCodes)
 			m_compiler->addSource(sourceCode.first, sourceCode.second);
 		// TODO: Perhaps we should not compile unless requested

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -27,6 +27,7 @@
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/inlineasm/AsmStack.h>
 
+using namespace std;
 namespace dev
 {
 namespace solidity
@@ -68,7 +69,7 @@ private:
 	void handleFormal();
 
 	/// Fills @a m_sourceCodes initially and @a m_redirects.
-	void readInputFilesAndConfigureRemappings();
+	void readInputFilesAndConfigureRemappings(bool usestdin, vector<string> inputFiles);
 	/// Tries to read from the file @a _input or interprets _input literally if that fails.
 	/// It then tries to parse the contents and appends to m_libraries.
 	bool parseLibraryOption(std::string const& _input);


### PR DESCRIPTION
until now it was only possible to either use stdin or a list of paths, with `-` you can combine the 2.  

when you specify `-`:
- it will add `cwd` to allowed directories (so you can import from `cwd`)
- you can add other arguments and still be reading from stdin too, eg; `myimports/=~/mysolimportsdir`

```
echo '
contract mul2 {
    function double(uint v) returns (uint) {
        return v * 2;
    }
}
' > mul2.sol;

echo '
import "mul2.sol";

contract testme {
    function main() returns (uint) {
        mul2 x = new mul2();
        return x.double(5);
    }
}
' > testme.sol

# ./solidity/build/solc/solc --abi < testme.sol # doesn't work: Source "mul2.sol" not found: File outside of allowed directories.
./solidity/build/solc/solc --abi - < testme.sol # does work

rm mul2.sol
rm testme.sol
```
