### PR TITLE
Inaccessible dynamic types

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2037,29 +2037,20 @@ FunctionTypePointer FunctionType::asMemberFunction(bool _inLibrary, bool _bound)
 			location = Location::DelegateCall;
 	}
 
-	TypePointers returnParameterTypes;
-	vector<string> returnParameterNames;
-	if (location == Location::Internal)
+	TypePointers returnParameterTypes = m_returnParameterTypes;
+	if (location != Location::Internal)
 	{
-		returnParameterNames = m_returnParameterNames;
-		returnParameterTypes = m_returnParameterTypes;
-	}
-	else
-	{
-		// Removes dynamic types.
-		for (size_t i = 0; i < m_returnParameterTypes.size(); ++i)
-			if (!m_returnParameterTypes[i]->isDynamicallySized())
-			{
-				returnParameterTypes.push_back(m_returnParameterTypes[i]);
-				returnParameterNames.push_back(m_returnParameterNames[i]);
-			}
+		// Alter dynamic types to be non-accessible.
+		for (auto& param: returnParameterTypes)
+			if (param->isDynamicallySized())
+				param = make_shared<InaccessibleDynamicType>();
 	}
 
 	return make_shared<FunctionType>(
 		parameterTypes,
 		returnParameterTypes,
 		m_parameterNames,
-		returnParameterNames,
+		m_returnParameterNames,
 		location,
 		m_arbitraryParameters,
 		m_declaration,

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -137,7 +137,8 @@ public:
 	{
 		Integer, RationalNumber, StringLiteral, Bool, FixedPoint, Array,
 		FixedBytes, Contract, Struct, Function, Enum, Tuple,
-		Mapping, TypeType, Modifier, Magic, Module
+		Mapping, TypeType, Modifier, Magic, Module,
+		InaccessibleDynamic
 	};
 
 	/// @{
@@ -1079,6 +1080,26 @@ public:
 
 private:
 	Kind m_kind;
+};
+
+/**
+ * Special type that is used for dynamic types in returns from external function calls
+ * (The EVM currently cannot access dynamically-sized return values).
+ */
+class InaccessibleDynamicType: public Type
+{
+public:
+	virtual Category category() const override { return Category::InaccessibleDynamic; }
+
+	virtual bool isImplicitlyConvertibleTo(Type const&) const override { return false; }
+	virtual bool isExplicitlyConvertibleTo(Type const&) const override { return false; }
+	virtual unsigned calldataEncodedSize(bool _padded) const override { (void)_padded; return 32; }
+	virtual bool canBeStored() const override { return false; }
+	virtual bool canLiveOutsideStorage() const override { return false; }
+	virtual bool isValueType() const override { return true; }
+	virtual unsigned sizeOnStack() const override { return 1; }
+	virtual std::string toString(bool) const override { return "inaccessible dynamic type"; }
+	virtual TypePointer decodingType() const override { return std::make_shared<IntegerType>(256); }
 };
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -6812,6 +6812,32 @@ BOOST_AUTO_TEST_CASE(skip_dynamic_types)
 	BOOST_CHECK(callContractFunction("g()") == encodeArgs(u256(7), u256(8)));
 }
 
+BOOST_AUTO_TEST_CASE(skip_dynamic_types_for_structs)
+{
+	// For accessors, the dynamic types are already removed in the external signature itself.
+	char const* sourceCode = R"(
+		contract C {
+			struct S {
+				uint x;
+				string a; // this is present in the accessor
+				uint[] b; // this is not present
+				uint y;
+			}
+			S public s;
+			function g() returns (uint, uint) {
+				s.x = 2;
+				s.a = "abc";
+				s.b = [7, 8, 9];
+				s.y = 6;
+				var (x, a, y) = this.s();
+				return (x, y);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("g()") == encodeArgs(u256(2), u256(6)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2154,6 +2154,8 @@ BOOST_AUTO_TEST_CASE(dynamic_return_types_not_possible)
 			function f(uint) returns (string);
 			function g() {
 				var (x,) = this.f(2);
+				// we can assign to x but it is not usable.
+				bytes(x).length;
 			}
 		}
 	)";


### PR DESCRIPTION
Dynamic types returned function calls are not available inside Solidity due to a limitation of the EVM. Previously, such components in the return type were discarded. This fix replaces them with an "unusable" type so that the order of components is not destroyed.
