### PR TITLE
Trivial shift parser fixes

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1360,6 +1360,8 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
 		break;
 	case Token::SAR:
 		break;
+	case Token::SHR:
+		break;
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown shift operator."));
 	}

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -275,7 +275,7 @@ public:
 		return Value(op + (BitOr - AssignBitOr));
 	}
 
-	static bool isBitOp(Value op) { return (BitOr <= op && op <= SHR) || op == BitNot; }
+	static bool isBitOp(Value op) { return (BitOr <= op && op <= BitAnd) || op == BitNot; }
 	static bool isBooleanOp(Value op) { return (Or <= op && op <= And) || op == Not; }
 	static bool isUnaryOp(Value op) { return (Not <= op && op <= Delete) || op == Add || op == Sub || op == After; }
 	static bool isCountOp(Value op) { return op == Inc || op == Dec; }


### PR DESCRIPTION
This picks the two trivial _fixes_ from #527.
