### PR TITLE
Updated example Auction withdraw functions to not use 'throw'. 

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -280,12 +280,17 @@ activate themselves.
         /// Withdraw a bid that was overbid.
         function withdraw() {
             var amount = pendingReturns[msg.sender];
-            // It is important to set this to zero because the recipient
-            // can call this function again as part of the receiving call
-            // before `send` returns.
-            pendingReturns[msg.sender] = 0;
-            if (!msg.sender.send(amount))
-                throw; // If anything fails, this will revert the changes above
+            if (amount > 0) {
+                // It is important to set this to zero because the recipient
+                // can call this function again as part of the receiving call
+                // before `send` returns.
+                pendingReturns[msg.sender] = 0;
+				
+                if (!msg.sender.send(amount)) { 
+                    // No need to call throw here, just reset the amount owing
+                    pendingReturns[msg.sender] = amount;     
+                }
+            }
         }
 
         /// End the auction and send the highest bid
@@ -474,12 +479,17 @@ high or low invalid bids.
         /// Withdraw a bid that was overbid.
         function withdraw() {
             var amount = pendingReturns[msg.sender];
-            // It is important to set this to zero because the recipient
-            // can call this function again as part of the receiving call
-            // before `send` returns.
-            pendingReturns[msg.sender] = 0;
-            if (!msg.sender.send(amount))
-                throw; // If anything fails, this will revert the changes above
+            if (amount > 0) {
+                // It is important to set this to zero because the recipient
+                // can call this function again as part of the receiving call
+                // before `send` returns.
+                pendingReturns[msg.sender] = 0;
+				
+                if (!msg.sender.send(amount)){
+                    // No need to call throw here, just reset the amount owing
+                    pendingReturns[msg.sender] = amount;   
+                }
+            }
         }
 
         /// End the auction and send the highest bid


### PR DESCRIPTION
Updated the function withdraw() in the SimpleAuction and BlindAuction contracts to not use a 'throw' if a address send() fails.
# Documentation #Examples
