### PR TITLE
Documentation Typos

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -161,7 +161,7 @@ Unfortunately, there are some subtleties the compiler does not yet warn you abou
   2. Sending Ether can fail due to the call depth going above 1024. Since the caller is in total control of the call
      depth, they can force the transfer to fail, so make sure to always check the return value of ``send``. Better yet,
      write your contract using a pattern where the recipient can withdraw Ether instead.
-  3. Sending Ether can also fail because the recipient goes out of gas (either explicitly by using ``throw`` or
+  3. Sending Ether can also fail because the recipient runs out of gas (either explicitly by using ``throw`` or
      because the operation is just too expensive). If the return value of ``send`` is checked, this might provide a
      means for the recipient to block progress in the sending contract. Again, the best practise here is to use
      a "withdraw" pattern instead of a "send" pattern.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -10,7 +10,7 @@ Solidity is a statically typed language, which means that the type of each
 variable (state and local) needs to be specified (or at least known -
 see :ref:`type-deduction` below) at
 compile-time. Solidity provides several elementary types which can be combined
-to complex types.
+to form complex types.
 
 .. index:: ! value type, ! type;value
 


### PR DESCRIPTION
Just found these while reading the docs, thanks for putting these together!
