### PR TITLE
add `--statevars` and `--structs` to solc output

### DIFF
--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -180,6 +180,26 @@ void ContractDefinition::setUserDocumentation(string const& _userDocumentation)
 	m_userDocumentation = _userDocumentation;
 }
 
+string const& ContractDefinition::structsDocumentation() const
+{
+	return m_structsDocumentation;
+}
+
+string const& ContractDefinition::stateVariablesDocumentation() const
+{
+	return m_stateVariablesDocumentation;
+}
+
+void ContractDefinition::setStructsDocumentation(string const& _structsDocumentation)
+{
+	m_structsDocumentation = _structsDocumentation;
+}
+
+void ContractDefinition::setStateVariablesDocumentation(string const& _stateVariablesDocumentation)
+{
+	m_stateVariablesDocumentation = _stateVariablesDocumentation;
+}
+
 
 vector<Declaration const*> const& ContractDefinition::inheritableMembers() const
 {

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -321,6 +321,12 @@ public:
 	std::string const& devDocumentation() const;
 	void setDevDocumentation(std::string const& _devDocumentation);
 
+	std::string const& structsDocumentation() const;
+	void setStructsDocumentation(std::string const& _structsDocumentation);
+
+	std::string const& stateVariablesDocumentation() const;
+	void setStateVariablesDocumentation(std::string const& _stateVariablesDocumentation);
+
 	virtual TypePointer type() const override;
 
 	virtual ContractDefinitionAnnotation& annotation() const override;
@@ -333,6 +339,8 @@ private:
 	// parsed Natspec documentation of the contract.
 	std::string m_userDocumentation;
 	std::string m_devDocumentation;
+	std::string m_structsDocumentation;
+	std::string m_stateVariablesDocumentation;
 
 	std::vector<ContractDefinition const*> m_linearizedBaseContracts;
 	mutable std::unique_ptr<std::vector<std::pair<FixedHash<4>, FunctionTypePointer>>> m_interfaceFunctionList;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -195,6 +195,8 @@ bool CompilerStack::parse()
 				TypeChecker typeChecker(m_errors);
 				if (typeChecker.checkTypeRequirements(*contract))
 				{
+					contract->setStructsDocumentation(InterfaceHandler::structsDocumentation(*contract));
+					contract->setStateVariablesDocumentation(InterfaceHandler::stateVariablesDocumentation(*contract));
 					contract->setDevDocumentation(InterfaceHandler::devDocumentation(*contract));
 					contract->setUserDocumentation(InterfaceHandler::userDocumentation(*contract));
 				}
@@ -345,6 +347,12 @@ string const& CompilerStack::metadata(string const& _contractName, Documentation
 		break;
 	case DocumentationType::ABISolidityInterface:
 		doc = &currentContract.solidityInterface;
+		break;
+	case DocumentationType::Structs:
+		doc = &currentContract.structsDocumentation;
+		break;
+	case DocumentationType::StateVariables:
+		doc = &currentContract.stateVariablesDocumentation;
 		break;
 	default:
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Illegal documentation type."));

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -64,7 +64,9 @@ enum class DocumentationType: uint8_t
 	NatspecUser = 1,
 	NatspecDev,
 	ABIInterface,
-	ABISolidityInterface
+	ABISolidityInterface,
+	Structs,
+	StateVariables
 };
 
 /**
@@ -211,6 +213,8 @@ private:
 		mutable std::unique_ptr<std::string const> solidityInterface;
 		mutable std::unique_ptr<std::string const> userDocumentation;
 		mutable std::unique_ptr<std::string const> devDocumentation;
+		mutable std::unique_ptr<std::string const> structsDocumentation;
+		mutable std::unique_ptr<std::string const> stateVariablesDocumentation;
 	};
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback

--- a/libsolidity/interface/InterfaceHandler.cpp
+++ b/libsolidity/interface/InterfaceHandler.cpp
@@ -23,6 +23,10 @@ string InterfaceHandler::documentation(
 		return abiInterface(_contractDef);
 	case DocumentationType::ABISolidityInterface:
 		return ABISolidityInterface(_contractDef);
+	case DocumentationType::Structs:
+		return structsDocumentation(_contractDef);
+	case DocumentationType::StateVariables:
+		return stateVariablesDocumentation(_contractDef);
 	}
 
 	BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown documentation type"));
@@ -236,6 +240,53 @@ string InterfaceHandler::devDocumentation(ContractDefinition const& _contractDef
 	doc["methods"] = methods;
 
 	return Json::StyledWriter().write(doc);
+}
+
+string InterfaceHandler::structsDocumentation(ContractDefinition const& _contractDef)
+{
+	Json::Value structs(Json::arrayValue);
+
+	for (auto const& s: _contractDef.definedStructs())
+	{
+		Json::Value _struct;
+		Json::Value members(Json::arrayValue);
+
+		_struct["type"] = "struct";
+		_struct["name"] = s->name();
+
+		for (auto const& m: s->members())
+		{
+			Json::Value member;
+
+			member["type"] = m->annotation().type->canonicalName(false);
+			member["name"] = m->name();
+
+			members.append(member);
+		}
+
+		_struct["members"] = members;
+
+		structs.append(_struct);
+	}
+
+	return Json::StyledWriter().write(structs);
+}
+
+string InterfaceHandler::stateVariablesDocumentation(ContractDefinition const& _contractDef)
+{
+	Json::Value statevars(Json::arrayValue);
+
+	for (auto const& v: _contractDef.stateVariables())
+	{
+		Json::Value statevar;
+
+		statevar["type"] = v->annotation().type->canonicalName(false);
+		statevar["name"] = v->name();
+
+		statevars.append(statevar);
+	}
+
+	return Json::StyledWriter().write(statevars);
 }
 
 string InterfaceHandler::extractDoc(multimap<string, DocTag> const& _tags, string const& _name)

--- a/libsolidity/interface/InterfaceHandler.h
+++ b/libsolidity/interface/InterfaceHandler.h
@@ -83,6 +83,16 @@ public:
 	/// @return             A string with the json representation
 	///                     of the contract's developer documentation
 	static std::string devDocumentation(ContractDefinition const& _contractDef);
+	/// Genereates the Structs documentation of the contract
+	/// @param _contractDef The contract definition
+	/// @return             A string with the json representation
+	///                     of the contract's structs documentation
+	static std::string structsDocumentation(ContractDefinition const& _contractDef);
+	/// Genereates the State Variables documentation of the contract
+	/// @param _contractDef The contract definition
+	/// @return             A string with the json representation
+	///                     of the contract's structs documentation
+	static std::string stateVariablesDocumentation(ContractDefinition const& _contractDef);
 
 private:
 	/// @returns concatenation of all content under the given tag name.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -78,6 +78,8 @@ static string const g_argCloneBinaryStr = "clone-bin";
 static string const g_argOpcodesStr = "opcodes";
 static string const g_argNatspecDevStr = "devdoc";
 static string const g_argNatspecUserStr = "userdoc";
+static string const g_argStructsStr = "structs";
+static string const g_argStateVariablesStr = "statevars";
 static string const g_argAddStandard = "add-std";
 static string const g_stdinFileName = "<stdin>";
 
@@ -92,7 +94,9 @@ static set<string> const g_combinedJsonArgs{
 	"asm",
 	"ast",
 	"userdoc",
-	"devdoc"
+	"devdoc",
+	"structs",
+	"statevars"
 };
 
 static void version()
@@ -119,6 +123,8 @@ static bool needsHumanTargetedStdout(po::variables_map const& _args)
 		g_argNatspecUserStr,
 		g_argAstJson,
 		g_argNatspecDevStr,
+		g_argStructsStr,
+		g_argStateVariablesStr,
 		g_argAsmStr,
 		g_argAsmJsonStr,
 		g_argOpcodesStr,
@@ -227,6 +233,16 @@ void CommandLineInterface::handleMeta(DocumentationType _type, string const& _co
 		argName = g_argNatspecDevStr;
 		suffix = ".docdev";
 		title = "Developer Documentation";
+		break;
+	case DocumentationType::Structs:
+		argName = g_argStructsStr;
+		suffix = ".structs";
+		title = "Contract Structs";
+		break;
+	case DocumentationType::StateVariables:
+		argName = g_argStateVariablesStr;
+		suffix = ".statevars";
+		title = "Contract State Variables";
 		break;
 	default:
 		// should never happen
@@ -457,6 +473,8 @@ Allowed options)",
 		(g_argSignatureHashes.c_str(), "Function signature hashes of the contracts.")
 		(g_argNatspecUserStr.c_str(), "Natspec user documentation of all contracts.")
 		(g_argNatspecDevStr.c_str(), "Natspec developer documentation of all contracts.")
+		(g_argStructsStr.c_str(), "Structs definitions of all contracts.")
+		(g_argStateVariablesStr.c_str(), "State Variables definitions of of all contracts.")
 		("formal", "Translated source suitable for formal analysis.");
 	desc.add(outputComponents);
 
@@ -662,6 +680,10 @@ void CommandLineInterface::handleCombinedJSON()
 			contractData["devdoc"] = m_compiler->metadata(contractName, DocumentationType::NatspecDev);
 		if (requests.count("userdoc"))
 			contractData["userdoc"] = m_compiler->metadata(contractName, DocumentationType::NatspecUser);
+		if (requests.count("structs"))
+			contractData["structs"] = m_compiler->metadata(contractName, DocumentationType::Structs);
+		if (requests.count("statevars"))
+			contractData["statevars"] = m_compiler->metadata(contractName, DocumentationType::StateVariables);
 		output["contracts"][contractName] = contractData;
 	}
 
@@ -882,6 +904,8 @@ void CommandLineInterface::outputCompilationResults()
 		handleMeta(DocumentationType::ABISolidityInterface, contract);
 		handleMeta(DocumentationType::NatspecDev, contract);
 		handleMeta(DocumentationType::NatspecUser, contract);
+		handleMeta(DocumentationType::Structs, contract);
+		handleMeta(DocumentationType::StateVariables, contract);
 	} // end of contracts iteration
 
 	handleFormal();

--- a/test/libsolidity/SolidityStateVarsJSON.cpp
+++ b/test/libsolidity/SolidityStateVarsJSON.cpp
@@ -1,0 +1,192 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author Ruben de Vries <ruben@rubensayshi.com>
+ * @date 2015
+ * Unit tests for the solidity compiler JSON Interface output.
+ */
+
+#include "../TestHelper.h"
+#include "../../libsolidity/interface/CompilerStack.h"
+#include <string>
+#include <json/json.h>
+#include <libsolidity/interface/CompilerStack.h>
+#include <libsolidity/interface/Exceptions.h>
+#include <libdevcore/Exceptions.h>
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+class StateVarsDocumentationChecker
+{
+public:
+	StateVarsDocumentationChecker(): m_compilerStack(false) {}
+
+	void checkStateVarsDocumentation(
+		std::string const& _code,
+		std::string const& _expectedStateVarsDocumentationString
+	)
+	{
+		std::string generatedStateVarsDocumentationString;
+		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse(_code), "Parsing failed");
+
+		generatedStateVarsDocumentationString = m_compilerStack.metadata("", DocumentationType::StateVariables);
+		Json::Value generatedStateVarsDocumentation;
+		m_reader.parse(generatedStateVarsDocumentationString, generatedStateVarsDocumentation);
+		Json::Value expectedStateVarsDocumentation;
+		m_reader.parse(_expectedStateVarsDocumentationString, expectedStateVarsDocumentation);
+		BOOST_CHECK_MESSAGE(
+				expectedStateVarsDocumentation == generatedStateVarsDocumentation,
+			"Expected " << _expectedStateVarsDocumentationString <<
+			"\n but got:\n" << generatedStateVarsDocumentationString
+		);
+	}
+
+private:
+	CompilerStack m_compilerStack;
+	Json::Reader m_reader;
+};
+
+BOOST_FIXTURE_TEST_SUITE(SolidityStateVarsJSON, StateVarsDocumentationChecker)
+
+BOOST_AUTO_TEST_CASE(statevars_basic_test)
+{
+	char const* sourceCode = "contract test {\n"
+	"  uint a;\n"
+	"  uint8 b;\n"
+	"  uint256 c;\n"
+	"  bytes d;\n"
+	"  bytes32 e;\n"
+	"  string f;\n"
+	"  uint[] g;\n"
+	"  string[] h;\n"
+	"  address i;\n"
+	"}\n";
+
+	char const* statevarsDocumentation = "["
+	"    {"
+	"        \"name\": \"a\","
+	"        \"type\": \"uint256\""
+	"    },"
+	"    {"
+	"        \"name\": \"b\","
+	"        \"type\": \"uint8\""
+	"    },"
+	"    {"
+	"        \"name\": \"c\","
+	"        \"type\": \"uint256\""
+	"    },"
+	"    {"
+	"        \"name\": \"d\","
+	"        \"type\": \"bytes\""
+	"    },"
+	"    {"
+	"        \"name\": \"e\","
+	"        \"type\": \"bytes32\""
+	"    },"
+	"    {"
+	"        \"name\": \"f\","
+	"        \"type\": \"string\""
+	"    },"
+	"    {"
+	"        \"name\": \"g\","
+	"        \"type\": \"uint256[]\""
+	"    },"
+	"    {"
+	"        \"name\": \"h\","
+	"        \"type\": \"string[]\""
+	"    },"
+	"    {"
+	"        \"name\": \"i\","
+	"        \"type\": \"address\""
+	"    }"
+	"]";
+
+	checkStateVarsDocumentation(sourceCode, statevarsDocumentation);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(statevars_structs_test)
+{
+	char const* sourceCode = "contract test {\n"
+	"  struct X {\n"
+	"    uint a;\n"
+	"  }\n"
+	"\n"
+	"  X a;\n"
+	"  X[] b;\n"
+	"}\n";
+
+	char const* statevarsDocumentation = "["
+	"    {"
+	"        \"name\": \"a\","
+	"        \"type\": \"test.X\""
+	"    },"
+	"    {"
+	"        \"name\": \"b\","
+	"        \"type\": \"test.X[]\""
+	"    }"
+	"]";
+
+	checkStateVarsDocumentation(sourceCode, statevarsDocumentation);
+}
+
+BOOST_AUTO_TEST_CASE(statevars_mapping_test)
+{
+	char const* sourceCode = "contract test {\n"
+	"  struct X {\n"
+	"    uint a;\n"
+	"  }\n"
+	"\n"
+	"  mapping(uint => uint) data1;\n"
+	"  mapping(string => string) data2;\n"
+	"  mapping(uint => string) data3;\n"
+	"  mapping(uint => X) data4;\n"
+	"}\n";
+
+	char const* statevarsDocumentation = "["
+	"    {"
+	"        \"name\": \"data1\","
+	"        \"type\": \"mapping(uint256 => uint256)\""
+	"    },"
+	"    {"
+	"        \"name\": \"data2\","
+	"        \"type\": \"mapping(string => string)\""
+	"    },"
+	"    {"
+	"        \"name\": \"data3\","
+	"        \"type\": \"mapping(uint256 => string)\""
+	"    },"
+	"    {"
+	"        \"name\": \"data4\","
+	"        \"type\": \"mapping(uint256 => test.X)\""
+	"    }"
+	"]";
+
+	checkStateVarsDocumentation(sourceCode, statevarsDocumentation);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+}

--- a/test/libsolidity/SolidityStructsJSON.cpp
+++ b/test/libsolidity/SolidityStructsJSON.cpp
@@ -1,0 +1,191 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * @author Ruben de Vries <ruben@rubensayshi.com>
+ * @date 2015
+ * Unit tests for the solidity compiler JSON Interface output.
+ */
+
+#include "../TestHelper.h"
+#include "../../libsolidity/interface/CompilerStack.h"
+#include <string>
+#include <json/json.h>
+#include <libsolidity/interface/CompilerStack.h>
+#include <libsolidity/interface/Exceptions.h>
+#include <libdevcore/Exceptions.h>
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+class StructsDocumentationChecker
+{
+public:
+	StructsDocumentationChecker(): m_compilerStack(false) {}
+
+	void checkStructsDocumentation(
+		std::string const& _code,
+		std::string const& _expectedStructsDocumentationString
+	)
+	{
+		std::string generatedStructsDocumentationString;
+		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse(_code), "Parsing failed");
+
+		generatedStructsDocumentationString = m_compilerStack.metadata("", DocumentationType::Structs);
+		Json::Value generatedStructsDocumentation;
+		m_reader.parse(generatedStructsDocumentationString, generatedStructsDocumentation);
+		Json::Value expectedStructsDocumentation;
+		m_reader.parse(_expectedStructsDocumentationString, expectedStructsDocumentation);
+		BOOST_CHECK_MESSAGE(
+				expectedStructsDocumentation == generatedStructsDocumentation,
+			"Expected " << _expectedStructsDocumentationString <<
+			"\n but got:\n" << generatedStructsDocumentationString
+		);
+	}
+
+private:
+	CompilerStack m_compilerStack;
+	Json::Reader m_reader;
+};
+
+BOOST_FIXTURE_TEST_SUITE(SolidityStructsJSON, StructsDocumentationChecker)
+
+BOOST_AUTO_TEST_CASE(structs_basic_test)
+{
+	char const* sourceCode = "contract test {\n"
+	"  struct X {\n"
+	"    uint a;\n"
+	"    uint8 b;\n"
+	"    uint256 c;\n"
+	"    bytes d;\n"
+	"    bytes32 e;\n"
+	"    string f;\n"
+	"    uint[] g;\n"
+	"    string[] h;\n"
+	"    address i;\n"
+	"  }\n"
+	"}\n";
+
+	char const* structsDocumentation = "["
+	"    {"
+	"        \"members\": ["
+	"            {"
+	"                \"name\": \"a\","
+	"                \"type\": \"uint256\""
+	"            },"
+	"            {"
+	"                \"name\": \"b\","
+	"                \"type\": \"uint8\""
+	"            },"
+	"            {"
+	"                \"name\": \"c\","
+	"                \"type\": \"uint256\""
+	"            },"
+	"            {"
+	"                \"name\": \"d\","
+	"                \"type\": \"bytes\""
+	"            },"
+	"            {"
+	"                \"name\": \"e\","
+	"                \"type\": \"bytes32\""
+	"            },"
+	"            {"
+	"                \"name\": \"f\","
+	"                \"type\": \"string\""
+	"            },"
+	"            {"
+	"                \"name\": \"g\","
+	"                \"type\": \"uint256[]\""
+	"            },"
+	"            {"
+	"                \"name\": \"h\","
+	"                \"type\": \"string[]\""
+	"            },"
+	"            {"
+	"                \"name\": \"i\","
+	"                \"type\": \"address\""
+	"            }"
+	"        ],"
+	"        \"name\": \"X\","
+	"        \"type\": \"struct\""
+	"    }"
+	"]";
+
+	checkStructsDocumentation(sourceCode, structsDocumentation);
+}
+
+
+BOOST_AUTO_TEST_CASE(structs_nested_test)
+{
+	char const* sourceCode = "contract test {\n"
+	"  struct X {\n"
+	"    uint a;\n"
+	"    Y b;\n"
+	"    Y[] c;\n"
+	"  }\n"
+	"  struct Y {\n"
+	"    uint a;\n"
+	"    uint8 b;\n"
+	"  }\n"
+	"}\n";
+
+	char const* structsDocumentation = "["
+	"    {"
+	"        \"members\": ["
+	"            {"
+	"                \"name\": \"a\","
+	"                \"type\": \"uint256\""
+	"            },"
+	"            {"
+	"                \"name\": \"b\","
+	"                \"type\": \"test.Y\""
+	"            },"
+	"            {"
+	"                \"name\": \"c\","
+	"                \"type\": \"test.Y[]\""
+	"            }"
+	"        ],"
+	"        \"name\": \"X\","
+	"        \"type\": \"struct\""
+	"    },"
+	"    {"
+	"        \"members\": ["
+	"            {"
+	"                \"name\": \"a\","
+	"                \"type\": \"uint256\""
+	"            },"
+	"            {"
+	"                \"name\": \"b\","
+	"                \"type\": \"uint8\""
+	"            }"
+	"        ],"
+	"        \"name\": \"Y\","
+	"        \"type\": \"struct\""
+	"    }"
+	"]";
+
+	checkStructsDocumentation(sourceCode, structsDocumentation);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+}


### PR DESCRIPTION
adding `--statevars` and `--structs` to solc output for debugging purposes

``` bash
echo 'contract test {
  struct X {
    uint a;
  }

  uint a;
  string[] b;
  mapping(uint => X) c;
}' | ./build/solc/solc --statevars
```

``` json
[
   {
      "name" : "a",
      "type" : "uint256"
   },
   {
      "name" : "b",
      "type" : "string[]"
   },
   {
      "name" : "c",
      "type" : "mapping(uint256 => test.X)"
   }
]
```

``` bash
echo 'contract test {
  struct X {
    uint a;
    string f;
    Y[] j;
  }

  struct Y {
    uint a;
  }
}' | ./build/solc/solc --structs
```

``` json
[
   {
      "members" : [
         {
            "name" : "a",
            "type" : "uint256"
         },
         {
            "name" : "f",
            "type" : "string"
         },
         {
            "name" : "j",
            "type" : "test.Y[]"
         }
      ],
      "name" : "X",
      "type" : "struct"
   },
   {
      "members" : [
         {
            "name" : "a",
            "type" : "uint256"
         }
      ],
      "name" : "Y",
      "type" : "struct"
   }
]
```
