### PR TITLE
Removing "easy" language

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Solidity
 
 Solidity is a high-level language whose syntax is similar to that of JavaScript
 and it is designed to compile to code for the Ethereum Virtual Machine.
-As you will see, it is quite easy to create contracts for voting,
+As you will see, it is possible to create contracts for voting,
 crowdfunding, blind auctions, multi-signature wallets and more.
 
 .. note::


### PR DESCRIPTION
I'm trying to steer us away from language that over-simplifies the complexity of writing secure smart contracts.
