### PR TITLE
Fix wrong msg.gas definition

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -57,7 +57,7 @@ Block and Transaction Properties
 - ``block.number`` (``uint``): current block number
 - ``block.timestamp`` (``uint``): current block timestamp
 - ``msg.data`` (``bytes``): complete calldata
-- ``msg.gas`` (``uint``): remaining gas
+- ``msg.gas`` (``uint``): estimated gas by sender
 - ``msg.sender`` (``address``): sender of the message (current call)
 - ``msg.sig`` (``bytes4``): first four bytes of the calldata (i.e. function identifier)
 - ``msg.value`` (``uint``): number of wei sent with the message


### PR DESCRIPTION
msg.gas  (uint): remaining gas
It isn't remaining gas, it is estimated gas by sender.
