### PR TITLE
Fixed mix-up of variable names in Sent event

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -136,12 +136,12 @@ single account.
 
 .. index:: event
 
-The line ``event Sent(address from, address to, uint value);`` declares
+The line ``event Sent(address from, address to, uint amount);`` declares
 a so-called "event" which is fired in the last line of the function
 ``send``. User interfaces (as well as server appliances of course) can
 listen for those events being fired on the blockchain without much
 cost. As soon as it is fired, the listener will also receive the
-arguments ``from``, ``to`` and ``value``, which makes it easy to track
+arguments ``from``, ``to`` and ``amount``, which makes it easy to track
 transactions. In order to listen for this event, you would use ::
 
     Coin.Sent().watch({}, '', function(error, result) {


### PR DESCRIPTION
event Sent(address from, address to, uint amount) defines "amount" variable but it is two times referred to as "value", which can be a bit confusing for the reader.
