### PR TITLE
BREAKING: Throw if contract creation fails.

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -106,6 +106,43 @@ of unused parameters (especially return parameters) can be omitted.
         }
     }
 
+.. index:: ! new, contracts;creating
+
+.. _creating-contracts:
+
+Creating Contracts via new
+==========================
+
+A contract can create a new contract using the ``new`` keyword. The full
+code of the contract to be created has to be known and thus recursive
+creation-dependencies are now possible.
+
+::
+
+    contract D {
+        uint x;
+        function D(uint a) {
+            x = a;
+        }
+    }
+    contract C {
+        D d = new D(4); // will be executed as part of C's constructor
+
+        function createD(uint arg) {
+            D newD = new D(arg);
+        }
+
+        function createAndEndowD(uint arg, uint amount) {
+            // Send ether along with the creation
+            D newD = (new D).value(amount)(arg);
+        }
+    }
+
+As seen in the example, it is possible to forward Ether to the creation,
+but it is not possible to limit the amount of gas. If the creation fails
+(due to out-of-stack, not enough balance or other problems), an exception
+is thrown.
+
 Order of Evaluation of Expressions
 ==================================
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -533,6 +533,9 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			else
 				m_context << u256(0);
 			m_context << Instruction::CREATE;
+			// Check if zero (out of stack or not enough balance).
+			m_context << Instruction::DUP1 << Instruction::ISZERO;
+			m_context.appendConditionalJumpTo(m_context.errorTag());
 			if (function.valueSet())
 				m_context << swapInstruction(1) << Instruction::POP;
 			break;


### PR DESCRIPTION
This is a breaking change that throws an exception if the creation of a contract fails.
Despite of that, I would say it is fine to add even without incrementing the minor version number.
