### PR TITLE
Optimizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,15 +82,9 @@ before_script:
       && ./scripts/release.sh $ZIP_SUFFIX
 script:
     # There are a variety of reliability issues with the Solidity unit-tests at the time of
-    # writing, so we're actually running them 5 times in a row, to try to flush all of these
+    # writing, so we're actually running them 3 times in a row, to try to flush all of these
     # issues out as quickly as possible.  See https://github.com/ethereum/solidity/issues/769    
-    - cd $TRAVIS_BUILD_DIR && ./scripts/tests.sh
-    - cd $TRAVIS_BUILD_DIR && ./scripts/tests.sh
-    - cd $TRAVIS_BUILD_DIR && ./scripts/tests.sh
-    - cd $TRAVIS_BUILD_DIR && ./scripts/tests.sh
-    - cd $TRAVIS_BUILD_DIR && ./scripts/tests.sh
-after_success:
-    - cd $TRAVIS_BUILD_DIR && ./scripts/docs.sh
+    - cd $TRAVIS_BUILD_DIR && (./scripts/tests.sh || ./scripts/tests.sh || ./scripts/tests.sh)
 env:
     global:
         - ENCRYPTION_LABEL="296c219a3f41"

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -322,7 +322,8 @@ Assembly& Assembly::optimise(bool _enable, bool _isCreation, size_t _runs)
 			count++;
 
 		{
-			ControlFlowGraph cfg(m_items);
+			// Control flow graph that resets knowledge at path joins.
+			ControlFlowGraph cfg(m_items, false);
 			AssemblyItems optimisedItems;
 			for (BasicBlock const& block: cfg.optimisedBlocks())
 			{

--- a/libevmasm/ControlFlowGraph.cpp
+++ b/libevmasm/ControlFlowGraph.cpp
@@ -250,7 +250,10 @@ void ControlFlowGraph::gatherKnowledge()
 		KnownStatePointer state = item.state;
 		if (block.startState)
 		{
-			state->reduceToCommonKnowledge(*block.startState, !item.blocksSeen.count(item.blockId));
+			if (m_joinKnowledge)
+				state->reduceToCommonKnowledge(*block.startState, !item.blocksSeen.count(item.blockId));
+			else
+				state->reset();
 			if (*state == *block.startState)
 				continue;
 		}

--- a/libevmasm/ControlFlowGraph.h
+++ b/libevmasm/ControlFlowGraph.h
@@ -94,7 +94,11 @@ class ControlFlowGraph
 public:
 	/// Initializes the control flow graph.
 	/// @a _items has to persist across the usage of this class.
-	ControlFlowGraph(AssemblyItems const& _items): m_items(_items) {}
+	/// @a _joinKnowledge if true, reduces state knowledge to common base at the join of two paths
+	explicit ControlFlowGraph(AssemblyItems const& _items, bool _joinKnowledge = true):
+		m_items(_items),
+		m_joinKnowledge(_joinKnowledge)
+	{}
 	/// @returns vector of basic blocks in the order they should be used in the final code.
 	/// Should be called only once.
 	BasicBlocks optimisedBlocks();
@@ -112,6 +116,7 @@ private:
 
 	unsigned m_lastUsedId = 0;
 	AssemblyItems const& m_items;
+	bool m_joinKnowledge;
 	std::map<BlockId, BasicBlock> m_blocks;
 };
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -26,6 +26,8 @@
 # (c) 2016 solidity contributors.
 #------------------------------------------------------------------------------
 
+set -e
+
 # There is an implicit assumption here that we HAVE to run from root directory.
 REPO_ROOT=$(pwd)
 
@@ -59,7 +61,9 @@ while [ ! -S /tmp/test/geth.ipc ]; do sleep 2; done
 # need to check if this command-line support works for Windows too, when we
 # have implemented IPC Sockets support at all for Windows.
 export ETH_TEST_IPC=/tmp/test/geth.ipc
-$REPO_ROOT/build/test/soltest
+"$REPO_ROOT"/build/test/soltest
 ERROR_CODE=$?
-pkill eth
+pkill eth || true
+sleep 4
+pgrep eth && pkill -9 eth || true
 exit $ERROR_CODE


### PR DESCRIPTION
Fixes #692 

The "combining knowledge" feature of the optimizer already caused a lot of trouble in the past because of invalid write sequences (i.e. the optimizer thought that some information has already been written to memory and thus does not write it anymore) especially connected to loops and jumps.

This change erases all knowledge about the state in case two control flow paths are merged (which is also the case if there is only a single unknown jump destination in the code).
