### PR TITLE
AST printer: do not output invalid UTF8 sequences

### DIFF
--- a/libdevcore/UTF8.cpp
+++ b/libdevcore/UTF8.cpp
@@ -27,9 +27,6 @@
 namespace dev
 {
 
-namespace utf8
-{
-
 
 bool validate(std::string const& _input, size_t& _invalidPosition)
 {
@@ -80,7 +77,5 @@ bool validate(std::string const& _input, size_t& _invalidPosition)
 	return false;
 }
 
-
-}
 
 }

--- a/libdevcore/UTF8.cpp
+++ b/libdevcore/UTF8.cpp
@@ -1,0 +1,86 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file UTF8.cpp
+ * @author Alex Beregszaszi
+ * @date 2016
+ *
+ * UTF-8 related helpers
+ */
+
+#include "UTF8.h"
+
+
+namespace dev
+{
+
+namespace utf8
+{
+
+
+bool validate(std::string input, int &invalidPosition)
+{
+	const int length = input.length();
+	bool valid = true;
+	int i = 0;
+
+	for (; i < length; i++)
+	{
+		if ((unsigned char)input[i] < 0x80)
+			continue;
+
+		int count = 0;
+		switch(input[i] & 0xe0) {
+			case 0xc0: count = 1; break;
+			case 0xe0: count = 2; break;
+			case 0xf0: count = 3; break;
+			default: break;
+		}
+
+		if (count == 0)
+		{
+			valid = false;
+			break;
+		}
+
+		if ((i + count) >= length)
+		{
+			valid = false;
+			break;
+		}
+
+		for (int j = 0; j < count; j++)
+		{
+			i++;
+			if ((input[i] & 0xc0) != 0x80)
+			{
+				valid = false;
+				break;
+			}
+		}
+	}
+
+	if (valid)
+		return true;
+
+	invalidPosition = i;
+	return false;
+}
+
+
+}
+
+}

--- a/libdevcore/UTF8.cpp
+++ b/libdevcore/UTF8.cpp
@@ -31,19 +31,19 @@ namespace utf8
 {
 
 
-bool validate(std::string input, int &invalidPosition)
+bool validate(std::string const& _input, int& _invalidPosition)
 {
-	const int length = input.length();
+	const int length = _input.length();
 	bool valid = true;
 	int i = 0;
 
 	for (; i < length; i++)
 	{
-		if ((unsigned char)input[i] < 0x80)
+		if ((unsigned char)_input[i] < 0x80)
 			continue;
 
 		int count = 0;
-		switch(input[i] & 0xe0) {
+		switch(_input[i] & 0xe0) {
 			case 0xc0: count = 1; break;
 			case 0xe0: count = 2; break;
 			case 0xf0: count = 3; break;
@@ -65,7 +65,7 @@ bool validate(std::string input, int &invalidPosition)
 		for (int j = 0; j < count; j++)
 		{
 			i++;
-			if ((input[i] & 0xc0) != 0x80)
+			if ((_input[i] & 0xc0) != 0x80)
 			{
 				valid = false;
 				break;
@@ -76,7 +76,7 @@ bool validate(std::string input, int &invalidPosition)
 	if (valid)
 		return true;
 
-	invalidPosition = i;
+	_invalidPosition = i;
 	return false;
 }
 

--- a/libdevcore/UTF8.cpp
+++ b/libdevcore/UTF8.cpp
@@ -31,18 +31,18 @@ namespace utf8
 {
 
 
-bool validate(std::string const& _input, int& _invalidPosition)
+bool validate(std::string const& _input, size_t& _invalidPosition)
 {
-	const int length = _input.length();
+	const size_t length = _input.length();
 	bool valid = true;
-	int i = 0;
+	size_t i = 0;
 
 	for (; i < length; i++)
 	{
 		if ((unsigned char)_input[i] < 0x80)
 			continue;
 
-		int count = 0;
+		size_t count = 0;
 		switch(_input[i] & 0xe0) {
 			case 0xc0: count = 1; break;
 			case 0xe0: count = 2; break;
@@ -62,7 +62,7 @@ bool validate(std::string const& _input, int& _invalidPosition)
 			break;
 		}
 
-		for (int j = 0; j < count; j++)
+		for (size_t j = 0; j < count; j++)
 		{
 			i++;
 			if ((_input[i] & 0xc0) != 0x80)

--- a/libdevcore/UTF8.h
+++ b/libdevcore/UTF8.h
@@ -28,13 +28,8 @@
 namespace dev
 {
 
-namespace utf8
-{
-
 /// Validate an input for UTF8 encoding
 /// @returns true if it is invalid and the first invalid position in invalidPosition
 bool validate(std::string const& _input, size_t& _invalidPosition);
-
-}
 
 }

--- a/libdevcore/UTF8.h
+++ b/libdevcore/UTF8.h
@@ -33,7 +33,7 @@ namespace utf8
 
 /// Validate an input for UTF8 encoding
 /// @returns true if it is invalid and the first invalid position in invalidPosition
-bool validate(std::string const& _input, int& _invalidPosition);
+bool validate(std::string const& _input, size_t& _invalidPosition);
 
 }
 

--- a/libdevcore/UTF8.h
+++ b/libdevcore/UTF8.h
@@ -33,7 +33,7 @@ namespace utf8
 
 /// Validate an input for UTF8 encoding
 /// @returns true if it is invalid and the first invalid position in invalidPosition
-bool validate(std::string input, int &invalidPosition);
+bool validate(std::string const& _input, int& _invalidPosition);
 
 }
 

--- a/libdevcore/UTF8.h
+++ b/libdevcore/UTF8.h
@@ -1,0 +1,40 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file UTF8.h
+ * @author Alex Beregszaszi
+ * @date 2016
+ *
+ * UTF-8 related helpers
+ */
+
+#pragma once
+
+#include <string>
+
+namespace dev
+{
+
+namespace utf8
+{
+
+/// Validate an input for UTF8 encoding
+/// @returns true if it is invalid and the first invalid position in invalidPosition
+bool validate(std::string input, int &invalidPosition);
+
+}
+
+}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -852,6 +852,11 @@ bool StringLiteralType::operator==(const Type& _other) const
 	return m_value == dynamic_cast<StringLiteralType const&>(_other).m_value;
 }
 
+std::string StringLiteralType::toString(bool) const
+{
+	return "literal_string \"" + m_value + "\"";
+}
+
 TypePointer StringLiteralType::mobileType() const
 {
 	return make_shared<ArrayType>(DataLocation::Memory, true);

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -26,6 +26,7 @@
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/CommonData.h>
 #include <libdevcore/SHA3.h>
+#include <libdevcore/UTF8.h>
 #include <libsolidity/interface/Utils.h>
 #include <libsolidity/ast/AST.h>
 
@@ -854,6 +855,11 @@ bool StringLiteralType::operator==(const Type& _other) const
 
 std::string StringLiteralType::toString(bool) const
 {
+	int invalidSequence;
+
+	if (!dev::utf8::validate(m_value, invalidSequence))
+		return "literal_string (contains invalid UTF-8 sequence at position " + dev::toString(invalidSequence) + ")";
+
 	return "literal_string \"" + m_value + "\"";
 }
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -855,7 +855,7 @@ bool StringLiteralType::operator==(const Type& _other) const
 
 std::string StringLiteralType::toString(bool) const
 {
-	int invalidSequence;
+	size_t invalidSequence;
 
 	if (!dev::utf8::validate(m_value, invalidSequence))
 		return "literal_string (contains invalid UTF-8 sequence at position " + dev::toString(invalidSequence) + ")";

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -857,7 +857,7 @@ std::string StringLiteralType::toString(bool) const
 {
 	size_t invalidSequence;
 
-	if (!dev::utf8::validate(m_value, invalidSequence))
+	if (!dev::validate(m_value, invalidSequence))
 		return "literal_string (contains invalid UTF-8 sequence at position " + dev::toString(invalidSequence) + ")";
 
 	return "literal_string \"" + m_value + "\"";

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -419,7 +419,7 @@ public:
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override { return 0; }
 
-	virtual std::string toString(bool) const override { return "literal_string \"" + m_value + "\""; }
+	virtual std::string toString(bool) const override;
 	virtual TypePointer mobileType() const override;
 
 	std::string const& value() const { return m_value; }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/603. _Finally, phew._

This doesn't affect code generation, only the output provided by `solc --ast` (as well as soljson's JSON).
