### PR TITLE
Introduce hex literals

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -218,6 +218,15 @@ String literals are written with either double or single-quotes (``"foo"`` or ``
 
 String literals support escape characters, such as ``\n``, ``\xNN`` and ``\uNNNN``. ``\xNN`` takes a hex value and inserts the appropriate byte, while ``\uNNNN`` takes a Unicode codepoint and inserts an UTF-8 sequence.
 
+.. index:: literal, bytes
+
+Hexadecimal Literals
+--------------------
+
+Hexademical Literals are prefixed with the keyword ``hex`` and are enclosed in double or single-quotes (``hex"001122FF"``). Their content must be a hexadecimal string and their value will be the binary representation of those values.
+
+Hexademical Literals behave like String Literals and have the same convertibility restrictions.
+
 .. index:: enum
 
 .. _enums:

--- a/libsolidity/parsing/Scanner.h
+++ b/libsolidity/parsing/Scanner.h
@@ -203,6 +203,7 @@ private:
 	std::tuple<Token::Value, unsigned, unsigned> scanIdentifierOrKeyword();
 
 	Token::Value scanString();
+	Token::Value scanHexString();
 	Token::Value scanSingleLineDocComment();
 	Token::Value scanMultiLineDocComment();
 	/// Scans a slash '/' and depending on the characters returns the appropriate token

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -154,6 +154,7 @@ namespace solidity
 	K(External, "external", 0)                                         \
 	K(For, "for", 0)                                                   \
 	K(Function, "function", 0)                                         \
+	K(Hex, "hex", 0)                                                   \
 	K(If, "if", 0)                                                     \
 	K(Indexed, "indexed", 0)                                           \
 	K(Internal, "internal", 0)                                         \

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -324,6 +324,42 @@ BOOST_AUTO_TEST_CASE(invalid_short_unicode_string_escape)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 }
 
+BOOST_AUTO_TEST_CASE(valid_hex_literal)
+{
+	Scanner scanner(CharStream("{ hex\"00112233FF\""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("\x00\x11\x22\x33\xFF", 5));
+}
+
+BOOST_AUTO_TEST_CASE(invalid_short_hex_literal)
+{
+	Scanner scanner(CharStream("{ hex\"00112233F\""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_hex_literal_with_space)
+{
+	Scanner scanner(CharStream("{ hex\"00112233FF \""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_hex_literal_with_wrong_quotes)
+{
+	Scanner scanner(CharStream("{ hex\"00112233FF'"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_hex_literal_nonhex_string)
+{
+	Scanner scanner(CharStream("{ hex\"hello\""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Fixes #479.

Supports both quotes:

```
bytes memory a = hex"00112233ff";
bytes memory a = hex'00112233ff';
```
