### PR TITLE
Reserved keywords update

### DIFF
--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -214,6 +214,7 @@ namespace solidity
 	T(Identifier, NULL, 0)                                             \
 	\
 	/* Keywords reserved for future use. */                            \
+	K(Abstract, "abstract", 0)                                         \
 	K(After, "after", 0)                                               \
 	K(As, "as", 0)                                                     \
 	K(Case, "case", 0)                                                 \
@@ -221,9 +222,11 @@ namespace solidity
 	K(Final, "final", 0)                                               \
 	K(In, "in", 0)                                                     \
 	K(Inline, "inline", 0)                                             \
+	K(Interface, "interface", 0)                                       \
 	K(Let, "let", 0)                                                   \
 	K(Match, "match", 0)                                               \
 	K(Of, "of", 0)                                                     \
+	K(Payable, "payable", 0)                                           \
 	K(Relocatable, "relocatable", 0)                                   \
 	K(Switch, "switch", 0)                                             \
 	K(Try, "try", 0)                                                   \

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -229,6 +229,7 @@ namespace solidity
 	K(Of, "of", 0)                                                     \
 	K(Payable, "payable", 0)                                           \
 	K(Relocatable, "relocatable", 0)                                   \
+	K(Static, "static", 0)                                             \
 	K(Switch, "switch", 0)                                             \
 	K(Try, "try", 0)                                                   \
 	K(Type, "type", 0)                                                 \

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -141,6 +141,7 @@ namespace solidity
 	\
 	/* Keywords */                                                     \
 	K(Anonymous, "anonymous", 0)                                       \
+	K(As, "as", 0)                                                     \
 	K(Assembly, "assembly", 0)                                         \
 	K(Break, "break", 0)                                               \
 	K(Const, "constant", 0)                                            \
@@ -171,6 +172,7 @@ namespace solidity
 	K(Storage, "storage", 0)                                           \
 	K(Struct, "struct", 0)                                             \
 	K(Throw, "throw", 0)                                               \
+	K(Using, "using", 0)                                               \
 	K(Var, "var", 0)                                                   \
 	K(While, "while", 0)                                               \
 	\
@@ -216,7 +218,6 @@ namespace solidity
 	/* Keywords reserved for future use. */                            \
 	K(Abstract, "abstract", 0)                                         \
 	K(After, "after", 0)                                               \
-	K(As, "as", 0)                                                     \
 	K(Case, "case", 0)                                                 \
 	K(Catch, "catch", 0)                                               \
 	K(Final, "final", 0)                                               \
@@ -232,7 +233,6 @@ namespace solidity
 	K(Try, "try", 0)                                                   \
 	K(Type, "type", 0)                                                 \
 	K(TypeOf, "typeof", 0)                                             \
-	K(Using, "using", 0)                                               \
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \
 	\


### PR DESCRIPTION
Add `abstract` and `interface` to the list of reserved keywords. Also add `payable`.

Move `as` and `using` from the reserved list as they're already used.
