### PR TITLE
BREAKING: Remove after

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -228,7 +228,7 @@ The following is the order of precedence for operators, listed in order of evalu
 +            +-------------------------------------+--------------------------------------------+
 |            | Unary plus and minus                | ``+``, ``-``                               |
 +            +-------------------------------------+--------------------------------------------+
-|            | Unary operations                    | ``after``, ``delete``                      |
+|            | Unary operations                    | ``delete``                                 |
 +            +-------------------------------------+--------------------------------------------+
 |            | Logical NOT                         | ``!``                                      |
 +            +-------------------------------------+--------------------------------------------+
@@ -321,4 +321,3 @@ Modifiers
 - ``constant`` for functions: Disallows modification of state - this is not enforced yet.
 - ``anonymous`` for events: Does not store event signature as topic.
 - ``indexed`` for event parameters: Stores the parameter as topic.
-

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -306,7 +306,7 @@ TypePointer IntegerType::unaryOperatorResult(Token::Value _operator) const
 	// for non-address integers, we allow +, -, ++ and --
 	else if (_operator == Token::Add || _operator == Token::Sub ||
 			_operator == Token::Inc || _operator == Token::Dec ||
-			_operator == Token::After || _operator == Token::BitNot)
+			_operator == Token::BitNot)
 		return shared_from_this();
 	else
 		return TypePointer();
@@ -416,8 +416,7 @@ TypePointer FixedPointType::unaryOperatorResult(Token::Value _operator) const
 		_operator == Token::Add || 
 		_operator == Token::Sub ||
 		_operator == Token::Inc || 
-		_operator == Token::Dec ||
-		_operator == Token::After
+		_operator == Token::Dec
 	)
 		return shared_from_this();
 	else

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -297,9 +297,6 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 	case Token::BitNot: // ~
 		m_context << Instruction::NOT;
 		break;
-	case Token::After: // after
-		m_context << Instruction::TIMESTAMP << Instruction::ADD;
-		break;
 	case Token::Delete: // delete
 		solAssert(!!m_currentLValue, "LValue not retrieved.");
 		m_currentLValue->setToZero(_unaryOperation.location());

--- a/libsolidity/grammar.txt
+++ b/libsolidity/grammar.txt
@@ -56,7 +56,7 @@ VariableDefinition = VariableDeclaration ( '=' Expression )?
 // Precedence by order (see github.com/ethereum/solidity/pull/732)
 Expression =
   ( Expression ('++' | '--') | FunctionCall | IndexAccess | MemberAccess | '(' Expression ')' )
-  | ('!' | '~' | 'after' | 'delete' | '++' | '--' | '+' | '-') Expression
+  | ('!' | '~' | 'delete' | '++' | '--' | '+' | '-') Expression
   | Expression '**' Expression
   | Expression ('*' | '/' | '%') Expression
   | Expression ('+' | '-') Expression

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -214,6 +214,7 @@ namespace solidity
 	T(Identifier, NULL, 0)                                             \
 	\
 	/* Keywords reserved for future use. */                            \
+	K(After, "after", 0)                                               \
 	K(As, "as", 0)                                                     \
 	K(Case, "case", 0)                                                 \
 	K(Catch, "catch", 0)                                               \
@@ -229,10 +230,6 @@ namespace solidity
 	K(Type, "type", 0)                                                 \
 	K(TypeOf, "typeof", 0)                                             \
 	K(Using, "using", 0)                                               \
-	\
-	/* Deprecated tokens. */                                           \
-	K(After, "after", 0)                                               \
-	\
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \
 	\
@@ -288,7 +285,6 @@ public:
 	static bool isLocationSpecifier(Value op) { return op == Memory || op == Storage; }
 	static bool isEtherSubdenomination(Value op) { return op == SubWei || op == SubSzabo || op == SubFinney || op == SubEther; }
 	static bool isTimeSubdenomination(Value op) { return op == SubSecond || op == SubMinute || op == SubHour || op == SubDay || op == SubWeek || op == SubYear; }
-	static bool isDeprecated(Value op) { return op == After; }
 
 	// @returns a string corresponding to the JS token string
 	// (.e., "<" for the token LT) or NULL if the token doesn't

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -214,7 +214,6 @@ namespace solidity
 	T(Identifier, NULL, 0)                                             \
 	\
 	/* Keywords reserved for future use. */                            \
-	K(After, "after", 0)                                               \
 	K(As, "as", 0)                                                     \
 	K(Case, "case", 0)                                                 \
 	K(Catch, "catch", 0)                                               \
@@ -230,6 +229,10 @@ namespace solidity
 	K(Type, "type", 0)                                                 \
 	K(TypeOf, "typeof", 0)                                             \
 	K(Using, "using", 0)                                               \
+	\
+	/* Deprecated tokens. */                                           \
+	K(After, "after", 0)                                               \
+	\
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \
 	\
@@ -285,6 +288,7 @@ public:
 	static bool isLocationSpecifier(Value op) { return op == Memory || op == Storage; }
 	static bool isEtherSubdenomination(Value op) { return op == SubWei || op == SubSzabo || op == SubFinney || op == SubEther; }
 	static bool isTimeSubdenomination(Value op) { return op == SubSecond || op == SubMinute || op == SubHour || op == SubDay || op == SubWeek || op == SubYear; }
+	static bool isDeprecated(Value op) { return op == After; }
 
 	// @returns a string corresponding to the JS token string
 	// (.e., "<" for the token LT) or NULL if the token doesn't

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -185,7 +185,6 @@ namespace solidity
 	K(SubDay, "days", 0)                                               \
 	K(SubWeek, "weeks", 0)                                             \
 	K(SubYear, "years", 0)                                             \
-	K(After, "after", 0)                                               \
 	/* type keywords*/                                                 \
 	K(Int, "int", 0)                                                   \
 	K(UInt, "uint", 0)                                                 \
@@ -215,6 +214,7 @@ namespace solidity
 	T(Identifier, NULL, 0)                                             \
 	\
 	/* Keywords reserved for future use. */                            \
+	K(After, "after", 0)                                               \
 	K(As, "as", 0)                                                     \
 	K(Case, "case", 0)                                                 \
 	K(Catch, "catch", 0)                                               \
@@ -277,7 +277,7 @@ public:
 
 	static bool isBitOp(Value op) { return (BitOr <= op && op <= BitAnd) || op == BitNot; }
 	static bool isBooleanOp(Value op) { return (Or <= op && op <= And) || op == Not; }
-	static bool isUnaryOp(Value op) { return (Not <= op && op <= Delete) || op == Add || op == Sub || op == After; }
+	static bool isUnaryOp(Value op) { return (Not <= op && op <= Delete) || op == Add || op == Sub; }
 	static bool isCountOp(Value op) { return op == Inc || op == Dec; }
 	static bool isShiftOp(Value op) { return (SHL <= op) && (op <= SHR); }
 	static bool isVisibilitySpecifier(Value op) { return isVariableVisibilitySpecifier(op) || op == External; }

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -275,12 +275,6 @@ BOOST_AUTO_TEST_CASE(time_subdenominations)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::SubYear);
 }
 
-BOOST_AUTO_TEST_CASE(time_after)
-{
-	Scanner scanner(CharStream("after 1"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::After);
-}
-
 BOOST_AUTO_TEST_CASE(empty_comment)
 {
 	Scanner scanner(CharStream("//\ncontract{}"));


### PR DESCRIPTION
I would like to issue a compiler error stating that `after` is deprecated if someone attempts to use it but I'm not quite sure which file I should put that in. @chriseth, could I have a little bit of help?

Resolve #815 
