### PR TITLE
fix typo in costs modifier

### DIFF
--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -166,7 +166,7 @@ function finishes.
     to call nextStage manually from those functions. 
     With version 0.4.0 (unreleased), modifier 
     code will run even if the function explicitly returns.
-    
+
 ::
 
     contract StateMachine {

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -163,7 +163,7 @@ function finishes.
     the code in the transitionNext modifier
     can be skipped if the function itself uses
     return. If you want to do that, make sure
-    to call nextStage manually from those functions. 
+    to call nextStage manually from those functions.
 
 ::
 

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -157,7 +157,7 @@ function finishes.
 .. note::
     As of version 0.3.6, modifier code placed after a function (i.e. after "_") 
     will run even if the function explicitly returns. **In older versions, 
-    modifiers could be skipped because when applied, they simply replaced code 
+    modifiers could get skipped because when applied, they simply replaced code 
     instead of using a function call.**
 ::
 

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -82,7 +82,7 @@ restrictions highly readable.
         // refunded, but only after the function body.
         // This is dangerous, because if the function
         // uses `return` explicitly, this will not be
-        // done! This behavior will be fixed in Version 0.4.0.
+        // done!
         modifier costs(uint _amount) {
             if (msg.value < _amount)
                 throw;

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -155,6 +155,7 @@ to automatically go to the next stage when the
 function finishes.
 
 .. note::
+    **Modifier May be Skipped (OLD)**
     As of version 0.3.6, modifier code placed after a function (i.e. after "_") 
     will run even if the function explicitly returns. **In older versions, a return statement
     in a modified function would cause modifier code after "_" to get skipped.** Modifiers

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -164,8 +164,6 @@ function finishes.
     can be skipped if the function itself uses
     return. If you want to do that, make sure
     to call nextStage manually from those functions. 
-    With version 0.4.0 (unreleased), modifier 
-    code will run even if the function explicitly returns.
 
 ::
 

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -80,13 +80,11 @@ restrictions highly readable.
         // fee being associated with a function call.
         // If the caller sent too much, he or she is
         // refunded, but only after the function body.
-        // This is dangerous, because if the function
-        // uses `return` explicitly, this will not be
-        // done!
         modifier costs(uint _amount) {
             if (msg.value < _amount)
                 throw;
             _
+            // this runs after the function body, even if the function explicitly returns (as of Version 0.3.6)
             if (msg.value > _amount)
                 msg.sender.send(msg.value - _amount);
         }
@@ -157,14 +155,10 @@ to automatically go to the next stage when the
 function finishes.
 
 .. note::
-    **Modifier May be Skipped**.
-    Since modifiers are applied by simply replacing
-    code and not by using a function call,
-    the code in the transitionNext modifier
-    can be skipped if the function itself uses
-    return. If you want to do that, make sure
-    to call nextStage manually from those functions.
-
+    As of version 0.3.6, modifier code placed after a function (i.e. after "_") 
+    will run even if the function explicitly returns. **In older versions, 
+    modifiers could be skipped because when applied, they simply replaced code 
+    instead of using a function call.**
 ::
 
     contract StateMachine {

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -156,9 +156,9 @@ function finishes.
 
 .. note::
     As of version 0.3.6, modifier code placed after a function (i.e. after "_") 
-    will run even if the function explicitly returns. **In older versions, 
-    modifiers could get skipped because when applied, they simply replaced code 
-    instead of using a function call.**
+    will run even if the function explicitly returns. **In older versions, a return statement
+    in a modified function would cause modifier code after "_" to get skipped.** Modifiers
+    used to simply replaced code instead of using a function call.
 ::
 
     contract StateMachine {
@@ -214,9 +214,6 @@ function finishes.
 
         // This modifier goes to the next stage
         // after the function is done.
-        // If you use `return` in the function,
-        // `nextStage` will not be called
-        // automatically.
         modifier transitionNext()
         {
             _

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -166,6 +166,7 @@ function finishes.
     to call nextStage manually from those functions. 
     With version 0.4.0 (unreleased), modifier 
     code will run even if the function explicitly returns.
+    
 ::
 
     contract StateMachine {

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -88,7 +88,7 @@ restrictions highly readable.
                 throw;
             _
             if (msg.value > _amount)
-                msg.sender.send(_amount - msg.value);
+                msg.sender.send(msg.value - _amount);
         }
 
         function forceOwnerChange(address _newOwner)

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -80,6 +80,9 @@ restrictions highly readable.
         // fee being associated with a function call.
         // If the caller sent too much, he or she is
         // refunded, but only after the function body.
+        // This is dangerous, because if the function
+        // uses `return` explicitly, this will not be
+        // done!
         modifier costs(uint _amount) {
             if (msg.value < _amount)
                 throw;

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -158,7 +158,7 @@ function finishes.
     As of version 0.3.6, modifier code placed after a function (i.e. after "_") 
     will run even if the function explicitly returns. **In older versions, a return statement
     in a modified function would cause modifier code after "_" to get skipped.** Modifiers
-    used to simply replaced code instead of using a function call.
+    used to simply replace code instead of using a function call.
 ::
 
     contract StateMachine {

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -82,7 +82,7 @@ restrictions highly readable.
         // refunded, but only after the function body.
         // This is dangerous, because if the function
         // uses `return` explicitly, this will not be
-        // done!
+        // done! This behavior will be fixed in Version 0.4.0.
         modifier costs(uint _amount) {
             if (msg.value < _amount)
                 throw;

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -87,7 +87,6 @@ restrictions highly readable.
             if (msg.value < _amount)
                 throw;
             _
-            // this runs after the function body, even if the function explicitly returns (as of Version 0.3.6)
             if (msg.value > _amount)
                 msg.sender.send(msg.value - _amount);
         }
@@ -158,11 +157,15 @@ to automatically go to the next stage when the
 function finishes.
 
 .. note::
-    **Modifier May be Skipped (OLD)**
-    As of version 0.3.6, modifier code placed after a function (i.e. after "_") 
-    will run even if the function explicitly returns. **In older versions, a return statement
-    in a modified function would cause modifier code after "_" to get skipped.** Modifiers
-    used to simply replace code instead of using a function call.
+    **Modifier May be Skipped**.
+    Since modifiers are applied by simply replacing
+    code and not by using a function call,
+    the code in the transitionNext modifier
+    can be skipped if the function itself uses
+    return. If you want to do that, make sure
+    to call nextStage manually from those functions. 
+    With version 0.4.0 (unreleased), modifier 
+    code will run even if the function explicitly returns.
 ::
 
     contract StateMachine {

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -82,7 +82,7 @@ restrictions highly readable.
         // refunded, but only after the function body.
         // This is dangerous, because if the function
         // uses `return` explicitly, this will not be
-        // done!
+        // done! This behavior will be fixed in Version 0.4.0.
         modifier costs(uint _amount) {
             if (msg.value < _amount)
                 throw;
@@ -163,7 +163,9 @@ function finishes.
     the code in the transitionNext modifier
     can be skipped if the function itself uses
     return. If you want to do that, make sure
-    to call nextStage manually from those functions.
+    to call nextStage manually from those functions. 
+    With version 0.4.0 (unreleased), modifier code 
+    will run even if the function explicitly returns.
 
 ::
 

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -221,6 +221,9 @@ function finishes.
 
         // This modifier goes to the next stage
         // after the function is done.
+        // If you use `return` in the function,
+        // `nextStage` will not be called
+        // automatically.
         modifier transitionNext()
         {
             _


### PR DESCRIPTION
In the documentation of Common Patterns, the cost modifier code snippet contained a typo. 
The Correction:
if (msg.value > _amount) {
    msg.sender.send(msg.value - _amount) // send back the excess ether
}

The original docs had msg.sender.send(_amount - msg.value). We know msg.value > _amount, so _amount - msg.value would be a negative number (or 0 as an unsigned integer), and we would send nothing.
