### PR TITLE
Fix JSON AST structure

### DIFF
--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -379,10 +379,12 @@ void ASTJsonConverter::endVisit(UserDefinedTypeName const&)
 
 void ASTJsonConverter::endVisit(Mapping const&)
 {
+	goUp();
 }
 
 void ASTJsonConverter::endVisit(InlineAssembly const&)
 {
+	goUp();
 }
 
 void ASTJsonConverter::endVisit(Block const&)

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -362,6 +362,7 @@ void ASTJsonConverter::endVisit(FunctionDefinition const&)
 
 void ASTJsonConverter::endVisit(VariableDeclaration const&)
 {
+	goUp();
 }
 
 void ASTJsonConverter::endVisit(TypeName const&)


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/853

Solc with `--combined-json` key prints incorrect AST.

For example, AST for this contract:

``` js
contract Contract {
  uint i;
  function a() {}
}
```

is

``` json
{
    "children": [{
        "attributes": {
            "name": "Contract"
        },
        "children": [{
            "attributes": {
                "name": "i"
            },
            "children": [{
                "attributes": {
                    "name": "uint"
                },
                "name": "ElementaryTypeName"
            }, {
                "attributes": {
                    "const": false,
                    "name": "a",
                    "public": true
                },
                "children": [{
                    "children": [],
                    "name": "ParameterList"
                }, {
                    "children": [],
                    "name": "ParameterList"
                }, {
                    "children": [],
                    "name": "Block"
                }],
                "name": "Function"
            }],
            "name": "VariableDeclaration"
        }],
        "name": "Contract"
    }],
    "name": "root"
}
```

Here `function a()` is a child of `uint i`.

This PR won't work without the fix #794.
