### PR TITLE
Confirmed that ZIPs work for Solidity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -217,5 +217,5 @@ deploy:
       skip_cleanup: true
       on:
           repo: ethereum/solidity
-          branch: develop
+          branch: release
           condition: $TRAVIS_RELEASE == On

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ deploy:
         secure: HPjiugbDSCsEFTphj/qwHuSw80/BV1xWoSvj95CPmtb16Ukh2VQbLVB7iFtZSans
     artifact: solidity-windows-zip
     on:
-        branch: develop
+        branch: release
 
 notifications:
     - provider: GitHubPullRequest


### PR DESCRIPTION
Switching whitelisting back to 'release' branch for TravisCI and Appveyor.
