### PR TITLE
Updated Solidity docs for building from source and binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
 #------------------------------------------------------------------------------
 # TravisCI configuration file for solidity.
 #
-# The documentation for solidity is hosted at:
-#
-# http://solidity.readthedocs.org
+# The documentation for solidity is hosted at http://solidity.readthedocs.org
 #
 # ------------------------------------------------------------------------------
-# This file is part of cpp-ethereum.
+# This file is part of solidity.
 #
-# cpp-ethereum is free software: you can redistribute it and/or modify
+# solidity is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cpp-ethereum is distributed in the hope that it will be useful,
+# solidity is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
 #
-# (c) 2016 cpp-ethereum contributors.
+# (c) 2016 solidity contributors.
 #------------------------------------------------------------------------------
 
 language: cpp
@@ -200,11 +198,6 @@ deploy:
     # good bits back out of what it generated.  The gem changes all the
     # whitespace and deletes comments, so cannot be used as-is.  But
     # it does generate an appropriate auth token.
-    #
-    # TODO - I do not know if the api_key below which work correctly
-    # for ethereum/solidity.   I suspect not, for the same reason as
-    # my auth token does not work for Appveyor.  I don't have enough
-    # permissions to enable this myself.  Christian should be able to.
     #
     # See https://docs.travis-ci.com/user/deployment/releases
     # See https://blog.travis-ci.com/2013-01-28-token-token-token/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,28 @@
 #------------------------------------------------------------------------------
 # Appveyor configuration file for solidity.
 #
-# The documentation for solidity is hosted at:
-#
-# http://solidity.readthedocs.org
+# The documentation for solidity is hosted at http://solidity.readthedocs.org
 #
 # TODO - Tests currently disabled, because Tests-over-IPC code is using UNIX
 # sockets unconditionally at the time of writing.
 #
 # ------------------------------------------------------------------------------
-# This file is part of cpp-ethereum.
+# This file is part of solidity.
 #
-# cpp-ethereum is free software: you can redistribute it and/or modify
+# solidity is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# cpp-ethereum is distributed in the hope that it will be useful,
+# solidity is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
 #
-# (c) 2016 cpp-ethereum contributors.
+# (c) 2016 solidity contributors.
 #------------------------------------------------------------------------------
 
 os: Visual Studio 2015
@@ -82,6 +80,8 @@ deploy:
     on:
         branch: release
 
+# Disable slightly annoying AppVeyorBot.  The comments it adds onto Github issues are
+# redundant with the "Checks Passed/Failure" detail which is already on the issues.
 notifications:
     - provider: GitHubPullRequest
       on_build_success: false

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -1,12 +1,12 @@
 #------------------------------------------------------------------------------
 # EthCompilerSettings.cmake
 #
-# CMake file for cpp-ethereum project which specifies our compiler settings
+# CMake file for solidity project which specifies our compiler settings
 # for each supported platform and build configuration.
 #
-# See http://www.ethdocs.org/en/latest/ethereum-clients/cpp-ethereum/.
+# The documentation for solidity is hosted at http://solidity.readthedocs.org
 #
-# Copyright (c) 2014-2016 cpp-ethereum contributors.
+# Copyright (c) 2014-2016 solidity contributors.
 #------------------------------------------------------------------------------
 
 # Clang seeks to be command-line compatible with GCC as much as possible, so

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -29,105 +29,78 @@ To install it, simply use
 Details about the usage of the Node.js package can be found in the
 `solc-js repository <https://github.com/ethereum/solc-js>`_.
 
-Binary Packages
+Binary Releases
 ===============
 
-Binary packages of Solidity together with its IDE Mix are available through
-the `C++ bundle <https://github.com/ethereum/webthree-umbrella/releases>`_ of
-Ethereum.
+The `solidity-v0.3.6 <https://github.com/ethereum/solidity/releases/tag/v0.3.6>`_
+release (10th August 2016) was the first "standalone" version of Solidity.
+All runtime dependencies onto cpp-ethereum have been removed.  This was a pretty
+major refactoring.  We also transitioned from Jenkins to TravisCI and Appveyor.
 
-Building from Source
-====================
+At the time of writing, our Homebrew and ZIP workflows have not yet been
+restored.  They will be back for the pending solidity-v0.4.0 release.
 
-Building Solidity is quite similar on MacOS X, Ubuntu and probably other Unices.
-This guide starts explaining how to install the dependencies for each platform
-and then shows how to build Solidity itself.
+Ubuntu PPAs **are** working, though there are still some clashes with the
+cpp-ethereum PPAs which won't be resolved until the next cpp-ethereum release.
+This is the sequence of commands which should be successful.  We will get the
+PPAs into a state where they can cleanly coexist as soon as we can. ::
 
-MacOS X
--------
-
-
-Requirements:
-
-- OS X Yosemite (10.10.5)
-- Homebrew
-- Xcode
-
-Set up Homebrew:
-
-.. code-block:: bash
-
-    brew update
-    brew upgrade
-
-    brew install boost --c++11             # this takes a while
-    brew install cmake cryptopp gmp jsoncpp
-
-Ubuntu Trusty (14.04)
----------------------
-
-Below are the instructions to install the minimal dependencies required
-to compile Solidity on Ubuntu 14.04 (Trusty Tahr).
-
-.. code-block:: bash
-
-    sudo apt-get -y install build-essential git cmake libgmp-dev libboost-all-dev \
-        libjsoncpp-dev
-    
     sudo add-apt-repository -y ppa:ethereum/ethereum
     sudo add-apt-repository -y ppa:ethereum/ethereum-dev
-    sudo apt-get -y update
-    sudo apt-get -y upgrade # this will update cmake to version 3.x
-    sudo apt-get -y install libcryptopp-dev libjsoncpp-dev
+    apt-get remove libethereum solc cpp-ethereum
+    apt-get install solc
 
-Ubuntu Xenial (16.04)
----------------------
 
-Below are the instructions to install the minimal dependencies required
-to compile Solidity on Ubuntu 16.04 (Xenial Xerus).
+Building from Source (macOS, Debian or Ubuntu)
+==============================================
 
-One of the dependencies (Crypto++ Library, with version >= 5.6.2) can be
-installed either by adding the Ethereum PPA (Option 1) or by backporting
-``libcrypto++`` from Ubuntu Development to Ubuntu Xenial (Option 2).
+As of August 2016 we now support an **install_deps.sh** script which encodes all of the
+distro-specific installation steps for macOS, Debian and Ubuntu, with support for more
+distros being added all the time.
 
-.. code-block:: bash
-
-    sudo apt-get -y install build-essential git cmake libgmp-dev libboost-all-dev \
-        libjsoncpp-dev
-    
-    # (Option 1) For those willing to add the Ethereum PPA:
-    sudo add-apt-repository -y ppa:ethereum/ethereum
-    sudo add-apt-repository -y ppa:ethereum/ethereum-dev
-    sudo apt-get -y update
-    sudo apt-get -y upgrade
-    sudo apt-get -y install libcryptopp-dev
-    
-    ## (Option 2) For those willing to backport libcrypto++:
-    #sudo apt-get -y install ubuntu-dev-tools
-    #sudo pbuilder create
-    #mkdir ubuntu
-    #cd ubuntu
-    #backportpackage --workdir=. --build --dont-sign libcrypto++
-    #sudo dpkg -i buildresult/libcrypto++6_*.deb buildresult/libcrypto++-dev_*.deb
-    #cd ..
-
-Building
---------
-
-Run this if you plan on installing Solidity only:
+So the build process is very trivial for these OSes:
 
 .. code-block:: bash
 
     git clone --recursive https://github.com/ethereum/solidity.git
     cd solidity
+    ./scripts/install_deps.sh
     mkdir build
     cd build
     cmake .. && make
 
-If you want to help developing Solidity,
-you should fork Solidity and add your personal fork as a second remote:
+Building from Source (Windows)
+======================================
+
+Pre-requisites
+--------------------------------------------------------------------------------
+
+You will need to install the following dependencies
+
++------------------------------+-------------------------------------------------------+
+| Software                     | Notes                                                 |
++==============================+=======================================================+
+| `Git for Windows`_           | Command-line tool for retrieving source from Github.  |
++------------------------------+-------------------------------------------------------+
+| `CMake`_                     | Cross-platform build file generator.                  |
++------------------------------+-------------------------------------------------------+
+| `Visual Studio 2015`_        | C++ compiler and dev environment.                     |
++------------------------------+-------------------------------------------------------+
+
+.. _Git for Windows: https://git-scm.com/download/win
+.. _CMake: https://cmake.org/download/
+.. _Visual Studio 2015: https://www.visualstudio.com/products/vs-2015-product-editions
+
+From there, the build process is very similar to macOS and Linux:
 
 .. code-block:: bash
 
+    git clone --recursive https://github.com/ethereum/solidity.git
     cd solidity
-    git remote add personal git@github.com:username/solidity.git
+    scripts\install_deps.bat
+    mkdir build
+    cd build
+    cmake -G "Visual Studio 14 2015 Win64" ..
+
+And then open the generated **cpp-ethereum.sln** file in Visual Studio, where you can
+build and debug it to your hearts content.


### PR DESCRIPTION
They now reflect our current status, and refer to the 'install_deps.sh' script.
