### PR TITLE
Updated the function withdraw() in the SimpleAuction and BlindAuction…

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -278,14 +278,21 @@ activate themselves.
         }
 
         /// Withdraw a bid that was overbid.
-        function withdraw() {
+        function withdraw() returns (bool) {
             var amount = pendingReturns[msg.sender];
-            // It is important to set this to zero because the recipient
-            // can call this function again as part of the receiving call
-            // before `send` returns.
-            pendingReturns[msg.sender] = 0;
-            if (!msg.sender.send(amount))
-                throw; // If anything fails, this will revert the changes above
+            if (amount > 0) {
+                // It is important to set this to zero because the recipient
+                // can call this function again as part of the receiving call
+                // before `send` returns.
+                pendingReturns[msg.sender] = 0;
+
+                if (!msg.sender.send(amount)) { 
+                    // No need to call throw here, just reset the amount owing
+                    pendingReturns[msg.sender] = amount;
+                    return false;
+                }
+            }
+            return true;
         }
 
         /// End the auction and send the highest bid
@@ -489,15 +496,22 @@ high or low invalid bids.
         }
 
         /// Withdraw a bid that was overbid.
-        function withdraw() {
+        function withdraw() returns (bool) {
             var amount = pendingReturns[msg.sender];
-            // It is important to set this to zero because the recipient
-            // can call this function again as part of the receiving call
-            // before `send` returns (see the remark above about
-            // conditions -> effects -> interaction).
-            pendingReturns[msg.sender] = 0;
-            if (!msg.sender.send(amount))
-                throw; // If anything fails, this will revert the changes above
+            if (amount > 0) {
+                // It is important to set this to zero because the recipient
+                // can call this function again as part of the receiving call
+                // before `send` returns (see the remark above about
+                // conditions -> effects -> interaction).
+                pendingReturns[msg.sender] = 0;
+
+                if (!msg.sender.send(amount)){
+                    // No need to call throw here, just reset the amount owing
+                    pendingReturns[msg.sender] = amount;
+                    return false;
+                }
+            }
+            return true;
         }
 
         /// End the auction and send the highest bid


### PR DESCRIPTION
… contracts to not use a 'throw' if a address send() fails.

Replaces https://github.com/ethereum/solidity/pull/660
