### PR TITLE
Require "payable" modifier if function wants to receive ether.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -270,6 +270,7 @@ void TypeChecker::checkContractIllegalOverrides(ContractDefinition const& _contr
 				if (
 					overriding->visibility() != function->visibility() ||
 					overriding->isDeclaredConst() != function->isDeclaredConst() ||
+					overriding->isPayable() != function->isPayable() ||
 					overridingType != functionType
 				)
 					typeError(overriding->location(), "Override changes extended function signature.");
@@ -414,6 +415,13 @@ bool TypeChecker::visit(StructDefinition const& _struct)
 bool TypeChecker::visit(FunctionDefinition const& _function)
 {
 	bool isLibraryFunction = dynamic_cast<ContractDefinition const&>(*_function.scope()).isLibrary();
+	if (_function.isPayable())
+	{
+		if (isLibraryFunction)
+			typeError(_function.location(), "Library functions cannot be payable.");
+		if (!_function.isConstructor() && !_function.name().empty() && !_function.isPartOfExternalInterface())
+			typeError(_function.location(), "Internal functions cannot be payable.");
+	}
 	for (ASTPointer<VariableDeclaration> const& var: _function.parameters() + _function.returnParameters())
 	{
 		if (!type(*var)->canLiveOutsideStorage())
@@ -1326,14 +1334,16 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 		fatalTypeError(
 			_memberAccess.location(),
 			"Member \"" + memberName + "\" not found or not visible "
-			"after argument-dependent lookup in " + exprType->toString()
+			"after argument-dependent lookup in " + exprType->toString() +
+			(memberName == "value" ? " - did you forget the \"payable\" modifier?" : "")
 		);
 	}
 	else if (possibleMembers.size() > 1)
 		fatalTypeError(
 			_memberAccess.location(),
 			"Member \"" + memberName + "\" not unique "
-			"after argument-dependent lookup in " + exprType->toString()
+			"after argument-dependent lookup in " + exprType->toString() +
+			(memberName == "value" ? " - did you forget the \"payable\" modifier?" : "")
 		);
 
 	auto& annotation = _memberAccess.annotation();

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -512,6 +512,7 @@ public:
 		bool _isDeclaredConst,
 		std::vector<ASTPointer<ModifierInvocation>> const& _modifiers,
 		ASTPointer<ParameterList> const& _returnParameters,
+		bool _isPayable,
 		ASTPointer<Block> const& _body
 	):
 		CallableDeclaration(_location, _name, _visibility, _parameters, _returnParameters),
@@ -519,6 +520,7 @@ public:
 		ImplementationOptional(_body != nullptr),
 		m_isConstructor(_isConstructor),
 		m_isDeclaredConst(_isDeclaredConst),
+		m_isPayable(_isPayable),
 		m_functionModifiers(_modifiers),
 		m_body(_body)
 	{}
@@ -528,6 +530,7 @@ public:
 
 	bool isConstructor() const { return m_isConstructor; }
 	bool isDeclaredConst() const { return m_isDeclaredConst; }
+	bool isPayable() const { return m_isPayable; }
 	std::vector<ASTPointer<ModifierInvocation>> const& modifiers() const { return m_functionModifiers; }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameters() const { return m_returnParameters->parameters(); }
 	Block const& body() const { return *m_body; }
@@ -550,6 +553,7 @@ public:
 private:
 	bool m_isConstructor;
 	bool m_isDeclaredConst;
+	bool m_isPayable;
 	std::vector<ASTPointer<ModifierInvocation>> m_functionModifiers;
 	ASTPointer<Block> m_body;
 };

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -905,6 +905,7 @@ public:
 	}
 	bool hasDeclaration() const { return !!m_declaration; }
 	bool isConstant() const { return m_isConstant; }
+	bool isPayable() const { return m_isPayable; }
 	/// @return A shared pointer of an ASTString.
 	/// Can contain a nullptr in which case indicates absence of documentation
 	ASTPointer<ASTString> documentation() const;
@@ -942,6 +943,7 @@ private:
 	bool const m_valueSet = false; ///< true iff the value to be sent is on the stack
 	bool const m_bound = false; ///< true iff the function is called as arg1.fun(arg2, ..., argn)
 	bool m_isConstant = false;
+	bool m_isPayable = false;
 	Declaration const* m_declaration = nullptr;
 };
 

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -258,7 +258,15 @@ void ContractCompiler::appendFunctionSelector(ContractDefinition const& _contrac
 		FunctionTypePointer const& functionType = it.second;
 		solAssert(functionType->hasDeclaration(), "");
 		CompilerContext::LocationSetter locationSetter(m_context, functionType->declaration());
+
 		m_context << callDataUnpackerEntryPoints.at(it.first);
+		if (!functionType->isPayable())
+		{
+			// Throw if function is not payable but call contained ether.
+			m_context << Instruction::CALLVALUE;
+			m_context.appendConditionalJumpTo(m_context.errorTag());
+		}
+
 		eth::AssemblyItem returnTag = m_context.pushNewTag();
 		m_context << CompilerUtils::dataStartOffset;
 		appendCalldataUnpacker(functionType->parameterTypes());

--- a/libsolidity/interface/InterfaceHandler.cpp
+++ b/libsolidity/interface/InterfaceHandler.cpp
@@ -52,6 +52,7 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 		method["type"] = "function";
 		method["name"] = it.second->declaration().name();
 		method["constant"] = it.second->isConstant();
+		method["payable"] = it.second->isPayable();
 		method["inputs"] = populateParameters(
 			externalFunctionType->parameterNames(),
 			externalFunctionType->parameterTypeNames(_contractDef.isLibrary())

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -272,6 +272,7 @@ ASTPointer<FunctionDefinition> Parser::parseFunctionDefinition(ASTString const* 
 	options.allowLocationSpecifier = true;
 	ASTPointer<ParameterList> parameters(parseParameterList(options));
 	bool isDeclaredConst = false;
+	bool isPayable = false;
 	Declaration::Visibility visibility(Declaration::Visibility::Default);
 	vector<ASTPointer<ModifierInvocation>> modifiers;
 	while (true)
@@ -280,6 +281,11 @@ ASTPointer<FunctionDefinition> Parser::parseFunctionDefinition(ASTString const* 
 		if (token == Token::Const)
 		{
 			isDeclaredConst = true;
+			m_scanner->next();
+		}
+		else if (m_scanner->currentToken() == Token::Payable)
+		{
+			isPayable = true;
 			m_scanner->next();
 		}
 		else if (token == Token::Identifier)
@@ -321,6 +327,7 @@ ASTPointer<FunctionDefinition> Parser::parseFunctionDefinition(ASTString const* 
 		isDeclaredConst,
 		modifiers,
 		returnParameters,
+		isPayable,
 		block
 	);
 }

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -166,6 +166,7 @@ namespace solidity
 	K(Memory, "memory", 0)                                             \
 	K(Modifier, "modifier", 0)                                         \
 	K(New, "new", 0)                                                   \
+	K(Payable, "payable", 0)                                           \
 	K(Public, "public", 0)                                             \
 	K(Private, "private", 0)                                           \
 	K(Return, "return", 0)                                             \
@@ -228,7 +229,6 @@ namespace solidity
 	K(Let, "let", 0)                                                   \
 	K(Match, "match", 0)                                               \
 	K(Of, "of", 0)                                                     \
-	K(Payable, "payable", 0)                                           \
 	K(Relocatable, "relocatable", 0)                                   \
 	K(Static, "static", 0)                                             \
 	K(Switch, "switch", 0)                                             \

--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -115,11 +115,6 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		// TODO: Populate with hall-of-fame.
 	}
 
-	function() {
-		// prevent people from just sending funds to the registrar
-		throw;
-	}
-
 	function onAuctionEnd(string _name) internal {
 		var auction = m_auctions[_name];
 		var record = m_toRecord[_name];
@@ -138,7 +133,7 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		}
 	}
 
-	function reserve(string _name) external {
+	function reserve(string _name) external payable {
 		if (bytes(_name).length == 0)
 			throw;
 		bool needAuction = requiresAuction(_name);

--- a/test/contracts/FixedFeeRegistrar.cpp
+++ b/test/contracts/FixedFeeRegistrar.cpp
@@ -71,7 +71,7 @@ contract FixedFeeRegistrar is Registrar {
 
 	modifier onlyrecordowner(string _name) { if (m_record(_name).owner == msg.sender) _ }
 
-	function reserve(string _name) {
+	function reserve(string _name) payable {
 		Record rec = m_record(_name);
 		if (rec.owner == 0 && msg.value >= c_fee) {
 			rec.owner = msg.sender;

--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -375,7 +375,7 @@ contract Wallet is multisig, multiowned, daylimit {
 	}
 
 	// gets called when no other function matches
-	function() {
+	function() payable {
 		// just being sent some cash?
 		if (msg.value > 0)
 			Deposit(msg.sender, msg.value);

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -68,6 +68,7 @@ BOOST_AUTO_TEST_CASE(basic_test)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -107,6 +108,7 @@ BOOST_AUTO_TEST_CASE(multiple_methods)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -124,6 +126,7 @@ BOOST_AUTO_TEST_CASE(multiple_methods)
 	{
 		"name": "g",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -153,6 +156,7 @@ BOOST_AUTO_TEST_CASE(multiple_params)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -188,6 +192,7 @@ BOOST_AUTO_TEST_CASE(multiple_methods_order)
 	{
 		"name": "c",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -205,6 +210,7 @@ BOOST_AUTO_TEST_CASE(multiple_methods_order)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -235,6 +241,7 @@ BOOST_AUTO_TEST_CASE(const_function)
 	{
 		"name": "foo",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -256,6 +263,7 @@ BOOST_AUTO_TEST_CASE(const_function)
 	{
 		"name": "boo",
 		"constant": true,
+		"payable" : false,
 		"type": "function",
 		"inputs": [{
 			"name": "a",
@@ -293,6 +301,7 @@ BOOST_AUTO_TEST_CASE(events)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -370,6 +379,7 @@ BOOST_AUTO_TEST_CASE(inherited)
 	{
 		"name": "baseFunction",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs":
 		[{
@@ -385,6 +395,7 @@ BOOST_AUTO_TEST_CASE(inherited)
 	{
 		"name": "derivedFunction",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs":
 		[{
@@ -438,6 +449,7 @@ BOOST_AUTO_TEST_CASE(empty_name_input_parameter_with_named_one)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -478,6 +490,7 @@ BOOST_AUTO_TEST_CASE(empty_name_return_parameter)
 	{
 		"name": "f",
 		"constant": false,
+		"payable" : false,
 		"type": "function",
 		"inputs": [
 		{
@@ -545,6 +558,7 @@ BOOST_AUTO_TEST_CASE(return_param_in_abi)
 	[
 		{
 			"constant" : false,
+			"payable" : false,
 			"inputs" : [],
 			"name" : "ret",
 			"outputs" : [
@@ -582,6 +596,7 @@ BOOST_AUTO_TEST_CASE(strings_and_arrays)
 	[
 		{
 			"constant" : false,
+			"payable" : false,
 			"name": "f",
 			"inputs": [
 				{ "name": "a", "type": "string" },
@@ -609,6 +624,7 @@ BOOST_AUTO_TEST_CASE(library_function)
 	[
 		{
 			"constant" : false,
+			"payable" : false,
 			"name": "f",
 			"inputs": [
 				{ "name": "b", "type": "test.StructType storage" },
@@ -625,6 +641,39 @@ BOOST_AUTO_TEST_CASE(library_function)
 	)";
 	checkInterface(sourceCode, interface);
 }
+
+BOOST_AUTO_TEST_CASE(payable_function)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f() {}
+			function g() payable {}
+		}
+	)";
+
+	char const* interface = R"(
+	[
+		{
+			"constant" : false,
+			"payable": false,
+			"inputs": [],
+			"name": "f",
+			"outputs": [],
+			"type" : "function"
+		},
+		{
+			"constant" : false,
+			"payable": true,
+			"inputs": [],
+			"name": "g",
+			"outputs": [],
+			"type" : "function"
+		}
+	]
+	)";
+	checkInterface(sourceCode, interface);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -3840,7 +3840,69 @@ BOOST_AUTO_TEST_CASE(modifier_without_underscore)
 			modifier m() {}
 		}
 	)";
-	BOOST_CHECK(expectError(text, true) == Error::Type::SyntaxError);
+	BOOST_CHECK(expectError(text) == Error::Type::SyntaxError);
+}
+
+BOOST_AUTO_TEST_CASE(payable_in_library)
+{
+	char const* text = R"(
+		library test {
+			function f() payable {}
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(payable_internal)
+{
+	char const* text = R"(
+		contract test {
+			function f() payable internal {}
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(illegal_override_payable)
+{
+	char const* text = R"(
+		contract B { function f() payable {} }
+		contract C is B { function f() {} }
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(illegal_override_payable_nonpayable)
+{
+	char const* text = R"(
+		contract B { function f() {} }
+		contract C is B { function f() payable {} }
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(calling_payable)
+{
+	char const* text = R"(
+		contract receiver { function pay() payable {} }
+		contract test {
+			funciton f() { (new receiver()).pay.value(10)(); }
+			recevier r = new receiver();
+			function g() { r.pay.value(10)(); }
+		}
+	)";
+	BOOST_CHECK(success(text));
+}
+
+BOOST_AUTO_TEST_CASE(calling_nonpayable)
+{
+	char const* text = R"(
+		contract receiver { function nopay() {} }
+		contract test {
+			function_argument_mem_to_storage f() { (new receiver()).nopay.value(10)(); }
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1223,6 +1223,16 @@ BOOST_AUTO_TEST_CASE(invalid_fixed_conversion_leading_zeroes_check)
 	BOOST_CHECK(!successParse(text));
 }
 
+BOOST_AUTO_TEST_CASE(payable_accessor)
+{
+	char const* text = R"(
+		contract test {
+			uint payable x;
+		}
+	)";
+	BOOST_CHECK(!successParse(text));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Work in progress

Replaces https://github.com/ethereum/solidity/pull/665

Partially implements #500 and #563. Comments welcome.

Fixes #602.

todo:
- [ ] library function should not be payable
- [ ] `contract is payable` should create payable fallback function (and error if there already is one)
- [ ] calling a non-payable function with value set should report an error
- [ ] accessor functions should not be able to receive ether (-> callvalue check should probably move to dispatcher)
- [ ] internal functions should not allow payable modifier
- [ ] overwriting a base contract function should not change payable
