### PR TITLE
Restore OS X Mavericks builds in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,10 @@ matrix:
         # OS X Mavericks (10.9)
         # https://en.wikipedia.org/wiki/OS_X_Mavericks
         #
-#        - os: osx
-#          osx_image: beta-xcode6.2
-#          env:
-#              - ZIP_SUFFIX=osx-mavericks
+        - os: osx
+          osx_image: beta-xcode6.2
+          env:
+              - ZIP_SUFFIX=osx-mavericks
 
         # OS X Yosemite (10.10)
         # https://en.wikipedia.org/wiki/OS_X_Yosemite


### PR DESCRIPTION
Their stability issues have apparently been resolved, and the backlog is caught up.
We will just add one Mac SKU for now, and take it from there.
