### PR TITLE
solc crashes without 'export LC_ALL=C'

### DIFF
--- a/lllc/main.cpp
+++ b/lllc/main.cpp
@@ -53,9 +53,22 @@ void version()
 	exit(0);
 }
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -67,7 +80,7 @@ enum Mode { Binary, Hex, Assembly, ParseTree, Disassemble };
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 	unsigned optimise = 1;
 	string infile;
 	Mode mode = Hex;

--- a/lllc/main.cpp
+++ b/lllc/main.cpp
@@ -22,6 +22,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <clocale>
 #include <liblll/Compiler.h>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/CommonData.h>
@@ -52,10 +53,20 @@ void version()
 	exit(0);
 }
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 enum Mode { Binary, Hex, Assembly, ParseTree, Disassemble };
 
 int main(int argc, char** argv)
 {
+	setEnv();
 	unsigned optimise = 1;
 	string infile;
 	Mode mode = Hex;

--- a/lllc/main.cpp
+++ b/lllc/main.cpp
@@ -53,10 +53,11 @@ void version()
 	exit(0);
 }
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -98,7 +98,7 @@ case $(uname -s) in
 
         brew update
         brew upgrade
-        
+
         brew install boost
         brew install cmake
         brew install jsoncpp
@@ -127,14 +127,14 @@ case $(uname -s) in
 #------------------------------------------------------------------------------
 # Linux
 #------------------------------------------------------------------------------
-        
+
     Linux)
         case $(detect_linux_distro) in
 
 #------------------------------------------------------------------------------
 # Arch Linux
 #------------------------------------------------------------------------------
-        
+
             Arch)
                 #Arch
                 echo "Installing solidity dependencies on Arch Linux."
@@ -143,7 +143,7 @@ case $(uname -s) in
                 # See https://wiki.archlinux.org/index.php/Official_repositories
                 sudo pacman -Sy \
                     base-devel \
-                    boost \ 
+                    boost \
                     cmake \
                     git \
                 ;;
@@ -158,7 +158,7 @@ case $(uname -s) in
 
                 # All our dependencies can be found in the Alpine Linux official repositories.
                 # See https://pkgs.alpinelinux.org/
-                
+
                 apk update
                 apk add boost-dev build-base cmake jsoncpp-dev
 
@@ -231,7 +231,7 @@ case $(uname -s) in
                 # Install "normal packages"
                 # See https://fedoraproject.org/wiki/Package_management_system.
                 dnf install \
-                    autoconf \ 
+                    autoconf \
                     automake \
                     boost-devel \
                     cmake \
@@ -325,16 +325,6 @@ case $(uname -s) in
                 sudo add-apt-repository -y ppa:ethereum/ethereum-dev
                 sudo apt-get -y update
                 sudo apt-get -y install eth
-
-                # And install the English language package and reconfigure the locales.
-                # We really shouldn't need to do this, and should instead force our locales to "C"
-                # within our application runtimes, because this issue shows up on multiple Linux distros,
-                # and each will need fixing in the install steps, where we should really just fix it once
-                # in the code.
-                #
-                # See https://github.com/ethereum/webthree-umbrella/issues/169
-                sudo apt-get -y install language-pack-en-base
-                sudo dpkg-reconfigure locales
 
                 ;;
             *)

--- a/solc/main.cpp
+++ b/solc/main.cpp
@@ -21,13 +21,24 @@
  */
 
 #include "CommandLineInterface.h"
+#include <clocale>
 #include <iostream>
 #include <boost/exception/all.hpp>
 
 using namespace std;
 
+void setEnv() {
+	std::setlocale(LC_ALL, "C");
+#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+	if (!std::setlocale(LC_ALL, "")) {
+		setenv("LC_ALL", "C", 1);
+	}
+#endif
+}
+
 int main(int argc, char** argv)
 {
+	setEnv();
 	dev::solidity::CommandLineInterface cli;
 	if (!cli.parseArguments(argc, argv))
 		return 1;

--- a/solc/main.cpp
+++ b/solc/main.cpp
@@ -27,10 +27,11 @@
 
 using namespace std;
 
-void setEnv() {
-	std::setlocale(LC_ALL, "C");
+void setEnv()
+{
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	if (!std::setlocale(LC_ALL, "")) {
+	if (!std::setlocale(LC_ALL, ""))
+	{
 		setenv("LC_ALL", "C", 1);
 	}
 #endif

--- a/solc/main.cpp
+++ b/solc/main.cpp
@@ -27,9 +27,22 @@
 
 using namespace std;
 
-void setEnv()
+/*
+The equivalent of setlocale(LC_ALL, “C”) is called before any user code is run.
+If the user has an invalid environment setting then it is possible for the call
+to set locale to fail, so there are only two possible actions, the first is to
+throw a runtime exception and cause the program to quit (default behaviour),
+or the second is to modify the environment to something sensible (least
+surprising behaviour).
+
+The follow code produces the least surprising behaviour. It will use the user
+specified default locale if it is valid, and if not then it will modify the
+environment the process is running in to use a sensible default. This also means
+that users do not need to install language packs for their OS.
+*/
+void setDefaultOrCLocale()
 {
-#if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#if __unix__
 	if (!std::setlocale(LC_ALL, ""))
 	{
 		setenv("LC_ALL", "C", 1);
@@ -39,7 +52,7 @@ void setEnv()
 
 int main(int argc, char** argv)
 {
-	setEnv();
+	setDefaultOrCLocale();
 	dev::solidity::CommandLineInterface cli;
 	if (!cli.parseArguments(argc, argv))
 		return 1;


### PR DESCRIPTION
This pull request fixes #674. The issue is that it is possible for the POSIX system environment to be invalid when the program starts, causing a runtime exception to be thrown. The solution is to call setlocale to test that setting the user defined default succeeds, only if the call fails then adjust the environment setting to a reasonable default (else the only viable course of action for the program would be to exit).
