### PR TITLE
fix CompilerStack::absolutePath

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,6 @@ test_script:
     - cd %APPVEYOR_BUILD_FOLDER%\build\test\%CONFIGURATION%
     - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvc*.dll" .
     - soltest.exe -- --ipcpath \\.\pipe\geth.ipc
-    - ps: Stop-Process -Id $ethProc.Id
 
 artifacts:
     - path: solidity-windows.zip

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -555,7 +555,7 @@ string CompilerStack::absolutePath(string const& _path, string const& _reference
 			result = result.parent_path();
 		else if (*it != ".")
 			result /= *it;
-	return result.string();
+	return result.generic_string();
 }
 
 void CompilerStack::compileContract(


### PR DESCRIPTION
fixing relative_import test on windows 
