### PR TITLE
Guard encoding crashes with assertions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@ Bugfixes:
  * JSON AST: nodes were added at wrong parent
  * Why3 translator: crash fix for exponentiation
  * Type Checker: Fallback function cannot return data anymore.
+ * Code Generator: Fix crash when sha3() was used on unsupported types.
 
 Lots of changes to the documentation mainly by voluntary external contributors.
 

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -160,7 +160,15 @@ void CompilerUtils::encodeToMemory(
 	TypePointers targetTypes = _targetTypes.empty() ? _givenTypes : _targetTypes;
 	solAssert(targetTypes.size() == _givenTypes.size(), "");
 	for (TypePointer& t: targetTypes)
+	{
+		solAssert(
+			t->mobileType() &&
+			t->mobileType()->interfaceType(_encodeAsLibraryTypes) &&
+			t->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType(),
+			"Encoding type " + t->toString() + " not yet implemented."
+		);
 		t = t->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType();
+	}
 
 	// Stack during operation:
 	// <v1> <v2> ... <vn> <mem_start> <dyn_head_1> ... <dyn_head_r> <end_of_mem>

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -165,7 +165,7 @@ void CompilerUtils::encodeToMemory(
 			t->mobileType() &&
 			t->mobileType()->interfaceType(_encodeAsLibraryTypes) &&
 			t->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType(),
-			"Encoding type " + t->toString() + " not yet implemented."
+			"Encoding type \"" + t->toString() + "\" not yet implemented."
 		);
 		t = t->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType();
 	}


### PR DESCRIPTION
This only fixes the crash for now, implementing the missing functionality is https://github.com/ethereum/solidity/issues/980

Fixes https://github.com/ethereum/solidity/issues/981
Fixes https://github.com/ethereum/solidity/issues/332
Fixes https://github.com/ethereum/solidity/issues/978
