### PR TITLE
Reject constant modifier on the fallback function

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -94,6 +94,8 @@ bool TypeChecker::visit(ContractDefinition const& _contract)
 				fallbackFunction = function;
 				if (_contract.isLibrary())
 					typeError(fallbackFunction->location(), "Libraries cannot have fallback functions.");
+				if (fallbackFunction->isDeclaredConst())
+					typeError(fallbackFunction->location(), "Fallback function cannot be declared constant.");
 				if (!fallbackFunction->parameters().empty())
 					typeError(fallbackFunction->parameterList().location(), "Fallback function cannot take parameters.");
 				if (!fallbackFunction->returnParameters().empty())

--- a/libsolidity/interface/InterfaceHandler.cpp
+++ b/libsolidity/interface/InterfaceHandler.cpp
@@ -81,7 +81,6 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 		solAssert(!!externalFunctionType, "");
 		Json::Value method;
 		method["type"] = "fallback";
-		method["constant"] = externalFunctionType->isConstant();
 		method["payable"] = externalFunctionType->isPayable();
 		abi.append(method);
 	}

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -644,7 +644,6 @@ BOOST_AUTO_TEST_CASE(include_fallback_function)
 	char const* interface = R"(
 	[
 		{
-			"constant" : false,
 			"payable": false,
 			"type" : "fallback"
 		}
@@ -696,7 +695,6 @@ BOOST_AUTO_TEST_CASE(payable_fallback_unction)
 	char const* interface = R"(
 	[
 		{
-			"constant" : false,
 			"payable": true,
 			"type" : "fallback"
 		}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1124,6 +1124,17 @@ BOOST_AUTO_TEST_CASE(fallback_function_with_return_parameters)
 	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(fallback_function_with_constant_modifier)
+{
+	char const* text = R"(
+		contract C {
+			uint x;
+			function() constant { x = 2; }
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_CASE(fallback_function_twice)
 {
 	char const* text = R"(


### PR DESCRIPTION
Same as #963, but Github won't allow to reopen it due to the push.

@chriseth see my reasoning in #963. Close if still not convinced.
