### PR TITLE
Report the usage of reserved keywords more nicely

### DIFF
--- a/libsolidity/parsing/ParserBase.cpp
+++ b/libsolidity/parsing/ParserBase.cpp
@@ -47,7 +47,17 @@ void ParserBase::expectToken(Token::Value _value)
 	Token::Value tok = m_scanner->currentToken();
 	if (tok != _value)
 	{
-		if (Token::isElementaryTypeName(tok)) //for the sake of accuracy in reporting
+		if (Token::isReservedKeyword(tok))
+		{
+			fatalParserError(
+				string("Expected token ") +
+				string(Token::name(_value)) +
+				string(" got reserved keyword '") +
+				string(Token::name(tok)) +
+				string("'")
+			);
+		}
+		else if (Token::isElementaryTypeName(tok)) //for the sake of accuracy in reporting
 		{
 			ElementaryTypeNameToken elemTypeName = m_scanner->currentElementaryTypeNameToken();
 			fatalParserError(

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -291,6 +291,7 @@ public:
 	static bool isLocationSpecifier(Value op) { return op == Memory || op == Storage; }
 	static bool isEtherSubdenomination(Value op) { return op == SubWei || op == SubSzabo || op == SubFinney || op == SubEther; }
 	static bool isTimeSubdenomination(Value op) { return op == SubSecond || op == SubMinute || op == SubHour || op == SubDay || op == SubWeek || op == SubYear; }
+	static bool isReservedKeyword(Value op) { return (Abstract <= op && op <= TypeOf); }
 
 	// @returns a string corresponding to the JS token string
 	// (.e., "<" for the token LT) or NULL if the token doesn't


### PR DESCRIPTION
Before:

```
reserved.sol:7:12: Error: Expected token Semicolon got 'Final'
    string final;
           ^
```

After:

```
reserved.sol:7:12: Error: Token Final is reserved
    string final;
```
