### PR TITLE
Include assert for selfType on bound functions to avoid crash

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2130,7 +2130,8 @@ vector<string> const FunctionType::returnParameterTypeNames(bool _addDataLocatio
 
 TypePointer FunctionType::selfType() const
 {
-	solAssert(bound(), "");
+	solAssert(bound(), "Function is not bound.");
+	solAssert(m_parameterTypes.size() > 0, "Function has no self type.");
 	return m_parameterTypes.at(0);
 }
 


### PR DESCRIPTION
 #561.

Is there a better fix to this? In the parser?
