### PR TITLE
Shift constants (<< and >>)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
  * Inline assembly: support both ``suicide`` and ``selfdestruct`` opcodes
    (note: ``suicide`` is deprecated).
  * Include ``keccak256()`` as an alias to ``sha3()``.
+ * Support shifting constant numbers.
 
 Bugfixes:
  * Disallow unknown options in ``solc``.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -718,7 +718,9 @@ TypePointer RationalNumberType::binaryOperatorResult(Token::Value _operator, Typ
 			value = m_value.numerator() * pow(bigint(2), exponent);
 			break;
 		}
-		case Token::SHR:
+		// NOTE: we're using >> (SAR) to denote right shifting. The type of the LValue
+		//       determines the resulting type and the type of shift (SAR or SHR).
+		case Token::SAR:
 		{
 			using boost::multiprecision::pow;
 			if (fractional)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -705,6 +705,28 @@ TypePointer RationalNumberType::binaryOperatorResult(Token::Value _operator, Typ
 				value = rational(denominator, numerator);
 			break;
 		}
+		case Token::SHL:
+		{
+			using boost::multiprecision::pow;
+			if (fractional)
+				return TypePointer();
+			else if (abs(other.m_value) > numeric_limits<uint32_t>::max())
+				return TypePointer();
+			uint32_t exponent = abs(other.m_value).numerator().convert_to<uint32_t>();
+			value = m_value.numerator() * pow(bigint(2), exponent);
+			break;
+		}
+		case Token::SHR:
+		{
+			using boost::multiprecision::pow;
+			if (fractional)
+				return TypePointer();
+			else if (abs(other.m_value) > numeric_limits<uint32_t>::max())
+				return TypePointer();
+			uint32_t exponent = abs(other.m_value).numerator().convert_to<uint32_t>();
+			value = rational(m_value.numerator() / pow(bigint(2), exponent), 1);
+			break;
+		}
 		default:
 			return TypePointer();
 		}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -710,9 +710,11 @@ TypePointer RationalNumberType::binaryOperatorResult(Token::Value _operator, Typ
 			using boost::multiprecision::pow;
 			if (fractional)
 				return TypePointer();
-			else if (abs(other.m_value) > numeric_limits<uint32_t>::max())
+			else if (other.m_value < 0)
 				return TypePointer();
-			uint32_t exponent = abs(other.m_value).numerator().convert_to<uint32_t>();
+			else if (other.m_value > numeric_limits<uint32_t>::max())
+				return TypePointer();
+			uint32_t exponent = other.m_value.numerator().convert_to<uint32_t>();
 			value = m_value.numerator() * pow(bigint(2), exponent);
 			break;
 		}
@@ -721,9 +723,11 @@ TypePointer RationalNumberType::binaryOperatorResult(Token::Value _operator, Typ
 			using boost::multiprecision::pow;
 			if (fractional)
 				return TypePointer();
-			else if (abs(other.m_value) > numeric_limits<uint32_t>::max())
+			else if (other.m_value < 0)
 				return TypePointer();
-			uint32_t exponent = abs(other.m_value).numerator().convert_to<uint32_t>();
+			else if (other.m_value > numeric_limits<uint32_t>::max())
+				return TypePointer();
+			uint32_t exponent = other.m_value.numerator().convert_to<uint32_t>();
 			value = rational(m_value.numerator() / pow(bigint(2), exponent), 1);
 			break;
 		}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7260,6 +7260,50 @@ BOOST_AUTO_TEST_CASE(mem_resize_is_not_paid_at_call)
 	BOOST_CHECK(callContractFunction("f(address)", cAddrOpt) == encodeArgs(u256(7)));
 }
 
+BOOST_AUTO_TEST_CASE(shift_constant_left)
+{
+	char const* sourceCode = R"(
+		contract C {
+			uint public a = 0x42 << 8;
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("a()") == encodeArgs(u256(0x4200)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_negative_constant_left)
+{
+	char const* sourceCode = R"(
+		contract C {
+			int public a = -0x42 << 8;
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("a()") == encodeArgs(u256(-0x4200)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_constant_right)
+{
+	char const* sourceCode = R"(
+		contract C {
+			uint public a = 0x4200 >> 8;
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("a()") == encodeArgs(u256(0x42)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_negative_constant_right)
+{
+	char const* sourceCode = R"(
+		contract C {
+			int public a = -0x4200 >> 8;
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("a()") == encodeArgs(u256(-0x42)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4039,6 +4039,46 @@ BOOST_AUTO_TEST_CASE(using_directive_for_missing_selftype)
 	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(shift_constant_left_negative_rvalue)
+{
+	char const* text = R"(
+		contract C {
+			uint public a = 0x42 << -8;
+		}
+	)";
+	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(shift_constant_right_negative_rvalue)
+{
+	char const* text = R"(
+		contract C {
+			uint public a = 0x42 >> -8;
+		}
+	)";
+	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(shift_constant_left_excessive_rvalue)
+{
+	char const* text = R"(
+		contract C {
+			uint public a = 0x42 << 0x100000000;
+		}
+	)";
+	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(shift_constant_right_excessive_rvalue)
+{
+	char const* text = R"(
+		contract C {
+			uint public a = 0x42 >> 0x100000000;
+		}
+	)";
+	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Split out of #527, this only handles constants, e.g.

```
contract A {
  uint a = 1 << 128;
}
```
