### PR TITLE
[WIP] Replace the constant keyword with pure and view for functions

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -25,7 +25,7 @@ ModifierDefinition = 'modifier' Identifier ParameterList? Block
 ModifierInvocation = Identifier ( '(' ExpressionList? ')' )?
 
 FunctionDefinition = 'function' Identifier? ParameterList
-                     ( ModifierInvocation | 'constant' | 'payable' | 'external' | 'public' | 'internal' | 'private' )*
+                     ( ModifierInvocation | 'constant' | 'view' | 'pure' | 'payable' | 'external' | 'public' | 'internal' | 'private' )*
                      ( 'returns' ParameterList )? ( ';' | Block )
 EventDefinition = 'event' Identifier IndexedParameterList 'anonymous'? ';'
 
@@ -50,7 +50,7 @@ UserDefinedTypeName = Identifier ( '.' Identifier )*
 
 Mapping = 'mapping' '(' ElementaryTypeName '=>' TypeName ')'
 ArrayTypeName = TypeName '[' Expression? ']'
-FunctionTypeName = 'function' TypeNameList ( 'internal' | 'external' | 'constant' | 'payable' )*
+FunctionTypeName = 'function' TypeNameList ( 'internal' | 'external' | 'constant' | 'view' | 'pure' | 'payable' )*
                    ( 'returns' TypeNameList )?
 StorageLocation = 'memory' | 'storage'
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -333,7 +333,7 @@ be passed via and returned from external function calls.
 
 Function types are notated as follows::
 
-    function (<parameter types>) {internal|external} [constant] [payable] [returns (<return types>)]
+    function (<parameter types>) {internal|external} [constant] [view] [pure] [payable] [returns (<return types>)]
 
 In contrast to the parameter types, the return types cannot be empty - if the
 function type should not return anything, the whole ``returns (<return types>)``

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -609,6 +609,7 @@ public:
 	bool isConstructor() const { return m_isConstructor; }
 	bool isFallback() const { return name().empty(); }
 	bool isDeclaredConst() const { return m_stateMutability == StateMutability::View; }
+	bool isPure() const { return m_stateMutability == StateMutability::Pure; }
 	bool isPayable() const { return m_stateMutability == StateMutability::Payable; }
 	std::vector<ASTPointer<ModifierInvocation>> const& modifiers() const { return m_functionModifiers; }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameters() const { return m_returnParameters->parameters(); }
@@ -914,6 +915,7 @@ public:
 	}
 	StateMutability stateMutability() const { return m_stateMutability; }
 	bool isDeclaredConst() const { return m_stateMutability == StateMutability::View; }
+	bool isPure() const { return m_stateMutability == StateMutability::Pure; }
 	bool isPayable() const { return m_stateMutability == StateMutability::Payable; }
 
 private:

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -323,7 +323,10 @@ bool ASTJsonConverter::visit(FunctionDefinition const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("name", _node.name()),
-		make_pair(m_legacy ? "constant" : "isDeclaredConst", _node.isDeclaredConst()),
+		// FIXME: remove with next breaking release
+		make_pair(m_legacy ? "constant" : "isDeclaredConst", _node.isDeclaredConst)),
+		make_pair("view", _node.isDeclaredConst()),
+		make_pair("pure", _node.isPure()),
 		make_pair("payable", _node.isPayable()),
 		make_pair("visibility", Declaration::visibilityToString(_node.visibility())),
 		make_pair("parameters", toJson(_node.parameterList())),
@@ -420,6 +423,8 @@ bool ASTJsonConverter::visit(FunctionTypeName const& _node)
 		make_pair("payable", _node.isPayable()),
 		make_pair("visibility", Declaration::visibilityToString(_node.visibility())),
 		make_pair(m_legacy ? "constant" : "isDeclaredConst", _node.isDeclaredConst()),
+		make_pair("view", _node.isDeclaredConst()),
+		make_pair("pure", _node.isPure()),
 		make_pair("parameterTypes", toJson(*_node.parameterTypeList())),
 		make_pair("returnParameterTypes", toJson(*_node.returnParameterTypeList())),
 		make_pair("typeDescriptions", typePointerToJson(_node.annotation().type))

--- a/libsolidity/ast/ASTPrinter.cpp
+++ b/libsolidity/ast/ASTPrinter.cpp
@@ -105,7 +105,8 @@ bool ASTPrinter::visit(FunctionDefinition const& _node)
 {
 	writeLine("FunctionDefinition \"" + _node.name() + "\"" +
 			  (_node.isPublic() ? " - public" : "") +
-			  (_node.isDeclaredConst() ? " - const" : ""));
+			  (_node.isView() ? " - view" : "") +
+			  (_node.isPure() ? " - pure" : ""));
 	printSourcePart(_node);
 	return goDeeper();
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2217,6 +2217,8 @@ string FunctionType::identifier() const
 	}
 	if (isConstant())
 		id += "_constant";
+	if (isPure())
+		id += "_pure";
 	if (isPayable())
 		id += "_payable";
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
@@ -2238,6 +2240,7 @@ bool FunctionType::operator==(Type const& _other) const
 	if (
 		m_kind != other.m_kind ||
 		isConstant() != other.isConstant() ||
+		isPure() != other.isPure() ||
 		isPayable() != other.isPayable() ||
 		m_parameterTypes.size() != other.m_parameterTypes.size() ||
 		m_returnParameterTypes.size() != other.m_returnParameterTypes.size()
@@ -2302,6 +2305,8 @@ string FunctionType::toString(bool _short) const
 	name += ")";
 	if (isConstant())
 		name += " constant";
+	if (isPure())
+		name += " pure";
 	if (isPayable())
 		name += " payable";
 	if (m_kind == Kind::External)
@@ -2569,6 +2574,7 @@ u256 FunctionType::externalIdentifier() const
 bool FunctionType::isPure() const
 {
 	return
+		m_isPure ||
 		m_kind == Kind::SHA3 ||
 		m_kind == Kind::ECRecover ||
 		m_kind == Kind::SHA256 ||

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -994,9 +994,9 @@ public:
 	}
 	bool hasDeclaration() const { return !!m_declaration; }
 	bool isConstant() const { return m_stateMutability == StateMutability::View; }
+	bool isView() const { return m_stateMutability == StateMutability::View; }
 	/// @returns true if the the result of this function only depends on its arguments
 	/// and it does not modify the state.
-	/// Currently, this will only return true for internal functions like keccak and ecrecover.
 	bool isPure() const;
 	bool isPayable() const { return m_stateMutability == StateMutability::Payable; }
 	/// @return A shared pointer of an ASTString.

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -36,7 +36,10 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 		Json::Value method;
 		method["type"] = "function";
 		method["name"] = it.second->declaration().name();
-		method["constant"] = it.second->isConstant();
+		// FIXME: constant should be removed at the next breaking release
+		method["constant"] = it.second->isView();
+		method["view"] = it.second->isView();
+		method["pure"] = it.second->isPure();
 		method["payable"] = it.second->isPayable();
 		method["inputs"] = formatTypeList(
 			externalFunctionType->parameterNames(),

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -312,8 +312,11 @@ StateMutability Parser::parseStateMutability(Token::Value _token)
 	StateMutability stateMutability(StateMutability::NonPayable);
 	if (_token == Token::Payable)
 		stateMutability = StateMutability::Payable;
-	else if (_token == Token::Constant)
+		// FIXME: constant should be removed at the next breaking release
+	else if (_token == Token::View || _token == Token::Constant)
 		stateMutability = StateMutability::View;
+	else if (_token == Token::Pure)
+		stateMutability = StateMutability::Pure;
 	else
 		solAssert(false, "Invalid state mutability specifier.");
 	m_scanner->next();

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -75,6 +75,8 @@ BOOST_AUTO_TEST_CASE(basic_test)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -118,6 +120,8 @@ BOOST_AUTO_TEST_CASE(multiple_methods)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -136,6 +140,8 @@ BOOST_AUTO_TEST_CASE(multiple_methods)
 	{
 		"name": "g",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -168,6 +174,8 @@ BOOST_AUTO_TEST_CASE(multiple_params)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -206,6 +214,8 @@ BOOST_AUTO_TEST_CASE(multiple_methods_order)
 	{
 		"name": "c",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -224,6 +234,8 @@ BOOST_AUTO_TEST_CASE(multiple_methods_order)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure"; false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -257,6 +269,8 @@ BOOST_AUTO_TEST_CASE(const_function)
 	{
 		"name": "foo",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -279,6 +293,8 @@ BOOST_AUTO_TEST_CASE(const_function)
 	{
 		"name": "boo",
 		"constant": true,
+		"view": true,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [{
@@ -310,6 +326,8 @@ BOOST_AUTO_TEST_CASE(events)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -407,6 +425,8 @@ BOOST_AUTO_TEST_CASE(inherited)
 	{
 		"name": "derivedFunction",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs":
@@ -462,6 +482,8 @@ BOOST_AUTO_TEST_CASE(empty_name_input_parameter_with_named_one)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -504,6 +526,8 @@ BOOST_AUTO_TEST_CASE(empty_name_return_parameter)
 	{
 		"name": "f",
 		"constant": false,
+		"view": false,
+		"pure": false,
 		"payable" : false,
 		"type": "function",
 		"inputs": [
@@ -573,6 +597,8 @@ BOOST_AUTO_TEST_CASE(return_param_in_abi)
 	[
 		{
 			"constant" : false,
+			"view": false,
+			"pure": false,
 			"payable" : false,
 			"inputs" : [],
 			"name" : "ret",
@@ -612,6 +638,8 @@ BOOST_AUTO_TEST_CASE(strings_and_arrays)
 	[
 		{
 			"constant" : false,
+			"view": false,
+		        "pure": false,
 			"payable" : false,
 			"name": "f",
 			"inputs": [
@@ -640,6 +668,8 @@ BOOST_AUTO_TEST_CASE(library_function)
 	[
 		{
 			"constant" : false,
+			"view": false,
+			"pure": false,
 			"payable" : false,
 			"name": "f",
 			"inputs": [
@@ -690,6 +720,8 @@ BOOST_AUTO_TEST_CASE(payable_function)
 	[
 		{
 			"constant" : false,
+			"view": false,
+			"pure": false,
 			"payable": false,
 			"inputs": [],
 			"name": "f",
@@ -698,6 +730,8 @@ BOOST_AUTO_TEST_CASE(payable_function)
 		},
 		{
 			"constant" : false,
+			"view": false,
+			"pure": false,
 			"payable": true,
 			"inputs": [],
 			"name": "g",

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -6525,7 +6525,7 @@ BOOST_AUTO_TEST_CASE(state_variable_under_contract_name)
 		contract Scope {
 			uint stateVar = 42;
 
-			function getStateVar() constant returns (uint stateVar) {
+			function getStateVar() view returns (uint stateVar) {
 				stateVar = Scope.stateVar;
 			}
 		}
@@ -6791,7 +6791,7 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_as_return_type)
 {
 	char const* sourceCode = R"(
 		contract A {
-			function f(uint16 input) constant returns (uint16[5] arr)
+			function f(uint16 input) pure returns (uint16[5] arr)
 			{
 				arr[0] = input;
 				arr[1] = ++input;
@@ -6820,7 +6820,7 @@ BOOST_AUTO_TEST_CASE(internal_types_in_library)
 {
 	char const* sourceCode = R"(
 		library Lib {
-			function find(uint16[] storage _haystack, uint16 _needle) constant returns (uint)
+			function find(uint16[] storage _haystack, uint16 _needle) pure returns (uint)
 			{
 				for (uint i = 0; i < _haystack.length; ++i)
 					if (_haystack[i] == _needle)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1172,7 +1172,7 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 	BOOST_REQUIRE(function && function->hasDeclaration());
 	auto returnParams = function->returnParameterTypes();
 	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(false), "uint256");
-	BOOST_CHECK(function->isConstant());
+	BOOST_CHECK(function->isView());
 
 	function = retrieveFunctionBySignature(*contract, "map(uint256)");
 	BOOST_REQUIRE(function && function->hasDeclaration());
@@ -1180,7 +1180,7 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 	BOOST_CHECK_EQUAL(params.at(0)->canonicalName(false), "uint256");
 	returnParams = function->returnParameterTypes();
 	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(false), "bytes4");
-	BOOST_CHECK(function->isConstant());
+	BOOST_CHECK(function->isView());
 
 	function = retrieveFunctionBySignature(*contract, "multiple_map(uint256,uint256)");
 	BOOST_REQUIRE(function && function->hasDeclaration());
@@ -1189,7 +1189,7 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 	BOOST_CHECK_EQUAL(params.at(1)->canonicalName(false), "uint256");
 	returnParams = function->returnParameterTypes();
 	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(false), "bytes4");
-	BOOST_CHECK(function->isConstant());
+	BOOST_CHECK(function->isView());
 }
 
 BOOST_AUTO_TEST_CASE(function_clash_with_state_variable_accessor)


### PR DESCRIPTION
- [ ] `view` and `pure` cannot use `SSTORE`
- [x] `view` and `pure` cannot be payable
- [ ] `view` and `pure` cannot send ether
- [ ] `view` cannot call functions not declared `view` or `pure`
- [ ] `pure` cannot call functions not declared `pure`
- [ ] `pure` cannot use `SLOAD`
- [ ] `pure` cannot use `msg.*` and `block.*`
- [x] `view` and `pure` are mutually exclusive
- [x] constructor cannot be `view` or `pure`
- [x] fallback cannot be `view` or `pure`
- [x] include `constant` as an alias for `view` in the parser
- [x] include `constant` as an alias for `view` in the JSON ABI
- [x] update grammar.txt

Further things to be sorted: `selfdestruct`, `log` (events), `this.balance`, `address.balance`, `tx.*`, `new` 

Related: #992.
