### PR TITLE
formal verification: Move the `invariant { ... }` clause to the `type account` declaration

### DIFF
--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -157,12 +157,12 @@ bool Why3Translator::visit(ContractDefinition const& _contract)
 	addLine("storage: state");
 	unindent();
 	addLine("}");
+	addSourceFromDocStrings(m_currentContract.contract->annotation());
 
 	addLine("val external_call (this: account): bool");
 	indent();
 	addLine("ensures { result = false -> this = (old this) }");
 	addLine("writes { this }");
-	addSourceFromDocStrings(m_currentContract.contract->annotation());
 	unindent();
 
 	if (!_contract.baseContracts().empty())

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -245,7 +245,6 @@ bool Why3Translator::visit(FunctionDefinition const& _function)
 	addSourceFromDocStrings(_function.annotation());
 	if (!m_currentContract.contract)
 		error(_function, "Only functions inside contracts allowed.");
-	addSourceFromDocStrings(m_currentContract.contract->annotation());
 
 	if (_function.isDeclaredConst())
 		addLine("ensures { (old this) = this }");


### PR DESCRIPTION
Before this commit, when an invariant is specified for a contract, the invariant was copied to the declaration of `external_call` function that models reentrancy.  Unfortunately, WhyML function declarations do not take `invariant` keyword.  This caused a syntax error in Why3 (#1054).

After this PR, the invariant specification moves to `type account` that keeps the whole state of the account, including the storage and the balance.

This PR fixes #1054 .
