### PR TITLE
formal verification: translation of the `address` type

### DIFF
--- a/libdevcore/Assertions.h
+++ b/libdevcore/Assertions.h
@@ -73,7 +73,7 @@ inline bool assertEqualAux(A const& _a, B const& _b, char const* _aStr, char con
 /// Use it as assertThrow(1 == 1, ExceptionType, "Mathematics is wrong.");
 /// Do NOT supply an exception object as the second parameter.
 #define assertThrow(_condition, _ExceptionType, _description) \
-	::dev::assertThrowAux<_ExceptionType>(_condition, _description, __LINE__, __FILE__, ETH_FUNC)
+	::dev::assertThrowAux<_ExceptionType>(!!(_condition), _description, __LINE__, __FILE__, ETH_FUNC)
 
 using errinfo_comment = boost::error_info<struct tag_comment, std::string>;
 
@@ -94,18 +94,6 @@ inline void assertThrowAux(
 			::boost::throw_file(_file) <<
 			::boost::throw_line(_line)
 		);
-}
-
-template <class _ExceptionType>
-inline void assertThrowAux(
-	void const* _pointer,
-	::std::string const& _errorDescription,
-	unsigned _line,
-	char const* _file,
-	char const* _function
-)
-{
-	assertThrowAux<_ExceptionType>(_pointer != nullptr, _errorDescription, _line, _file, _function);
 }
 
 }

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -77,12 +77,26 @@ string Why3Translator::toFormalType(Type const& _type) const
 			return "uint256";
 	}
 	else if (auto type = dynamic_cast<ArrayType const*>(&_type))
+	{
 		if (!type->isByteArray() && type->isDynamicallySized() && type->dataStoredIn(DataLocation::Memory))
 		{
 			string base = toFormalType(*type->baseType());
 			if (!base.empty())
 				return "array " + base;
 		}
+	}
+	else if (auto mappingType = dynamic_cast<MappingType const*>(&_type))
+	{
+		solAssert(mappingType->keyType(), "A mappingType misses a keyType.");
+		if (dynamic_cast<IntegerType const*>(&*mappingType->keyType()))
+		{
+			//@TODO Use the information from the key type and specify the length of the array as an invariant.
+			// Also the constructor need to specify the length of the array.
+			string valueType = toFormalType(*mappingType->valueType());
+			if (!valueType.empty())
+				return "array " + valueType;
+		}
+	}
 
 	return "";
 }

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -36,6 +36,10 @@ bool Why3Translator::process(SourceUnit const& _source)
 		appendPreface();
 		_source.accept(*this);
 	}
+	catch (NoFormalType&)
+	{
+		solAssert(false, "There is a call to toFormalType() that does not catch NoFormalType exceptions.");
+	}
 	catch (FatalError& /*_e*/)
 	{
 		solAssert(m_errorOccured, "");

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -77,6 +77,8 @@ string Why3Translator::toFormalType(Type const& _type) const
 		return "bool";
 	else if (auto type = dynamic_cast<IntegerType const*>(&_type))
 	{
+		if (type->isAddress())
+			return "Address.address";
 		if (!type->isAddress() && !type->isSigned() && type->numBits() == 256)
 			return "uint256";
 	}
@@ -150,6 +152,7 @@ bool Why3Translator::visit(ContractDefinition const& _contract)
 	addLine("use import int.ComputerDivision");
 	addLine("use import mach.int.Unsigned");
 	addLine("use import UInt256");
+	addLine("use Address"); // `import` would cause name clashes with Uint256.
 	addLine("exception Revert");
 	addLine("exception Return");
 

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -798,5 +798,14 @@ module UInt256
 		type t = uint256,
 		constant max = max_uint256
 end
+
+module Address
+	use import mach.int.Unsigned
+	type address
+	constant max_address: int = 0xffffffffffffffffffffffffffffffffffffffff (* 160 bit = 40 f's *)
+	clone export mach.int.Unsigned with
+		type t = address,
+		constant max = max_address
+end
    )", 0});
 }

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -287,7 +287,6 @@ bool Why3Translator::visit(FunctionDefinition const& _function)
 	addSourceFromDocStrings(_function.annotation());
 	if (!m_currentContract.contract)
 		error(_function, "Only functions inside contracts allowed.");
-	addSourceFromDocStrings(m_currentContract.contract->annotation());
 
 	if (_function.isDeclaredConst())
 		addLine("ensures { (old this) = this }");

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -185,12 +185,12 @@ bool Why3Translator::visit(ContractDefinition const& _contract)
 	addLine("storage: state");
 	unindent();
 	addLine("}");
+	addSourceFromDocStrings(m_currentContract.contract->annotation());
 
 	addLine("val external_call (this: account): bool");
 	indent();
 	addLine("ensures { result = false -> this = (old this) }");
 	addLine("writes { this }");
-	addSourceFromDocStrings(m_currentContract.contract->annotation());
 	unindent();
 
 	if (!_contract.baseContracts().empty())

--- a/libsolidity/formal/Why3Translator.h
+++ b/libsolidity/formal/Why3Translator.h
@@ -60,9 +60,10 @@ private:
 	/// Appends imports and constants use throughout the formal code.
 	void appendPreface();
 
-	/// @returns a string representation of the corresponding formal type or the empty string
-	/// if the type is not supported.
+	/// @returns a string representation of the corresponding formal type or throws NoFormalType exception.
 	std::string toFormalType(Type const& _type) const;
+	using errinfo_noFormalTypeFrom = boost::error_info<struct tag_noFormalTypeFrom, std::string /* name of the type that cannot be translated */ >;
+	struct NoFormalType: virtual Exception {};
 
 	void indent() { newLine(); m_lines.back().indentation++; }
 	void unindent();


### PR DESCRIPTION
This comes after #1045, #1047 and #1059.

This is a rather simple PR about translating `address` Solidity type into `Address.address` WhyML type introduced in #1047.
