### PR TITLE
formal verification: Extend `toFormalType()` function to deal with address types

### DIFF
--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -73,6 +73,8 @@ string Why3Translator::toFormalType(Type const& _type) const
 		return "bool";
 	else if (auto type = dynamic_cast<IntegerType const*>(&_type))
 	{
+		if (type->isAddress())
+			return "Address.address";
 		if (!type->isAddress() && !type->isSigned() && type->numBits() == 256)
 			return "uint256";
 	}
@@ -130,6 +132,7 @@ bool Why3Translator::visit(ContractDefinition const& _contract)
 	addLine("use import int.ComputerDivision");
 	addLine("use import mach.int.Unsigned");
 	addLine("use import UInt256");
+	addLine("use Address"); // `import` would cause name clashes with Uint256.
 	addLine("exception Revert");
 	addLine("exception Return");
 


### PR DESCRIPTION
Fixes #1062 

This PR allows the `--formal` option to translate the Solidity  `address` type into `Address.address` defined in #1047.
