### PR TITLE
Fixed point multiplication

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Features:
  * Function types
+ * Fixed point types
  * Do-while loops: support for a C-style do{<block>}while(<expr>); control structure
  * Inline assembly: support ``invalidJumpLabel`` as a jump label.
  * Type checker: now more eagerly searches for a common type of an inline array with mixed types

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -135,6 +135,14 @@ inline u256 s2u(s256 _u)
 		return u256(c_end + _u);
 }
 
+inline std::ostream& operator<<(std::ostream& os, bytes const& _bytes)
+{
+	std::ostringstream ss;
+	std::copy(_bytes.begin(), _bytes.end(), std::ostream_iterator<int>(ss, ","));
+	os << "[" + ss.str() + "]";
+	return os;
+}
+
 template <size_t n> inline u256 exp10()
 {
 	return exp10<n - 1>() * u256(10);

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -212,9 +212,13 @@ void CompilerContext::appendInlineAssembly(
 				errinfo_comment("Stack too deep, try removing local variables.")
 			);
 		if (_context == assembly::CodeGenerator::IdentifierContext::RValue)
+		{
+			cout << "hitting dup instruction" << endl;
 			_assembly.append(dupInstruction(stackDiff));
+		}
 		else
 		{
+			cout << "hitting swap and pop instruction" << endl;
 			_assembly.append(swapInstruction(stackDiff));
 			_assembly.append(Instruction::POP);
 		}

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -198,8 +198,12 @@ void CompilerContext::appendInlineAssembly(
 		assembly::CodeGenerator::IdentifierContext _context
 	) {
 		auto it = std::find(_localVariables.begin(), _localVariables.end(), _identifier.name);
+		cout << "trying to find stack vars: " << *it << endl;
 		if (it == _localVariables.end())
+		{
+			cout << "uh oh, we couldn't find it" << endl;
 			return false;
+		}
 		unsigned stackDepth = _localVariables.end() - it;
 		int stackDiff = _assembly.deposit() - startStackHeight + stackDepth;
 		if (stackDiff < 1 || stackDiff > 16)

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -947,7 +947,7 @@ void CompilerUtils::cleanHigherOrderBits(Type const& _typeOnStack)
 	else if (auto fixedType = dynamic_cast<FixedPointType const*>(&_typeOnStack)) 
 		cleanBits(fixedType->numBits(), fixedType->isSigned());
 	else
-		solAssert("", "Invalid type passed in to have higher bits cleaned.");
+		solAssert(false, "Invalid type passed in to have higher bits cleaned.");
 }
 
 void CompilerUtils::convertFixedPointNumber(FixedPointType const& _stackType, FixedPointType const& _targetType)

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -415,7 +415,6 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 		}
 		break;
 	case Type::Category::FixedPoint:
-		solUnimplemented("Not yet implemented - FixedPointType.");
 	case Type::Category::Integer:
 	case Type::Category::Contract:
 	case Type::Category::RationalNumber:
@@ -450,12 +449,34 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 				stackTypeCategory == Type::Category::FixedPoint,
 				"Invalid conversion to FixedMxNType requested."
 			);
-			//shift all integer bits onto the left side of the fixed type
 			FixedPointType const& targetFixedPointType = dynamic_cast<FixedPointType const&>(_targetType);
-			if (auto typeOnStack = dynamic_cast<IntegerType const*>(&_typeOnStack))
-				if (targetFixedPointType.integerBits() > typeOnStack->numBits())
-					cleanHigherOrderBits(*typeOnStack);
-			solUnimplemented("Not yet implemented - FixedPointType.");
+			if (auto intType = dynamic_cast<IntegerType const*>(&_typeOnStack))
+ 			{
+				if (targetFixedPointType.integerBits() > intType->numBits())
+					cleanHigherOrderBits(_typeOnStack);
+				u256 shiftFactor = u256(1) << (targetFixedPointType.fractionalBits());
+				m_context << shiftFactor << Instruction::MUL;
+			}
+			else if (auto rationalType = dynamic_cast<RationalNumberType const*>(&_typeOnStack))
+			{
+				bool isValidType = (
+					targetFixedPointType.integerBits() > rationalType->fixedPointType()->integerBits() || 
+					targetFixedPointType.fractionalBits() > rationalType->fixedPointType()->fractionalBits()
+				);
+				if (isValidType && _cleanupNeeded)
+					cleanHigherOrderBits(_typeOnStack);
+				convertFixedPointNumber(*rationalType->fixedPointType(), targetFixedPointType);
+			}
+			else 
+			{
+				FixedPointType const& stackFixedType = dynamic_cast<FixedPointType const&>(_typeOnStack);
+				if (
+					targetFixedPointType.integerBits() > stackFixedType.integerBits() || 
+					targetFixedPointType.fractionalBits() > stackFixedType.fractionalBits()
+				)
+					cleanHigherOrderBits(_typeOnStack);
+				convertFixedPointNumber(stackFixedType, targetFixedPointType);
+			}
 		}
 		else
 		{
@@ -468,7 +489,7 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 				RationalNumberType const& constType = dynamic_cast<RationalNumberType const&>(_typeOnStack);
 				// We know that the stack is clean, we only have to clean for a narrowing conversion
 				// where cleanup is forced.
-				solUnimplementedAssert(!constType.isFractional(), "Not yet implemented - FixedPointType.");
+				solAssert(!constType.isFractional(), "Invalid Rational to Integer conversion.");
 				if (targetType.numBits() < constType.integerType()->numBits() && _cleanupNeeded)
 					cleanHigherOrderBits(targetType);
 			}
@@ -910,14 +931,40 @@ unsigned CompilerUtils::loadFromMemoryHelper(Type const& _type, bool _fromCallda
 	return numBytes;
 }
 
-void CompilerUtils::cleanHigherOrderBits(IntegerType const& _typeOnStack)
+void CompilerUtils::cleanHigherOrderBits(Type const& _typeOnStack)
 {
-	if (_typeOnStack.numBits() == 256)
-		return;
-	else if (_typeOnStack.isSigned())
-		m_context << u256(_typeOnStack.numBits() / 8 - 1) << Instruction::SIGNEXTEND;
+	auto cleanBits = [this](int const numBits, bool const isSigned) {
+		if (numBits == 256)
+			return;
+		else if (isSigned)
+			m_context << u256(numBits / 8 - 1) << Instruction::SIGNEXTEND;
+		else
+			m_context << ((u256(1) << numBits) - 1) << Instruction::AND;
+	};
+
+	if (auto intType = dynamic_cast<IntegerType const*>(&_typeOnStack)) 
+		cleanBits(intType->numBits(), intType->isSigned());
+	else if (auto fixedType = dynamic_cast<FixedPointType const*>(&_typeOnStack)) 
+		cleanBits(fixedType->numBits(), fixedType->isSigned());
 	else
-		m_context << ((u256(1) << _typeOnStack.numBits()) - 1) << Instruction::AND;
+		solAssert("", "Invalid type passed in to have higher bits cleaned.");
+}
+
+void CompilerUtils::convertFixedPointNumber(FixedPointType const& _stackType, FixedPointType const& _targetType)
+{
+	u256 shiftFactor;
+	int difference = _stackType.fractionalBits() - _targetType.fractionalBits();
+
+	if (difference > 0)
+	{
+		shiftFactor = (u256(1) << (difference));
+		m_context << shiftFactor << Instruction::SWAP1 << Instruction::DIV;
+	}
+	else if (difference < 0)
+	{
+		shiftFactor = (u256(1) << (abs(difference)));
+		m_context << shiftFactor << Instruction::MUL;
+	}
 }
 
 unsigned CompilerUtils::prepareMemoryStore(Type const& _type, bool _padToWordBoundaries) const

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -180,8 +180,12 @@ private:
 	/// Stack post:
 	void storeStringData(bytesConstRef _data);
 
-	/// Appends code that cleans higher-order bits for integer types.
-	void cleanHigherOrderBits(IntegerType const& _typeOnStack);
+	/// Helper function for shifting values of fixed points to correct value while changing types eg fixed56x56 -> fixed128x128
+	/// essentially just moving an imaginary decimal point.
+	void convertFixedPointNumber(FixedPointType const& _stackType, FixedPointType const& _targetType);
+
+	/// Appends code that cleans higher-order bits for integer and fixed point types.
+	void cleanHigherOrderBits(Type const& _typeOnStack);
 
 	/// Prepares the given type for storing in memory by shifting it if necessary.
 	unsigned prepareMemoryStore(Type const& _type, bool _padToWordBoundaries) const;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1392,10 +1392,11 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 			{
 				//take two numbers, cut them in half, multiply them, simple as that.
 				m_context.appendInlineAssembly(R"(
-					{
-						let runningTotal := mul($div(firstNum, $halfShift), $div(secondNum, $halfShift))
+					{	let A := $div(firstNum, $halfShift)
+						let B := $div(secondNum, $halfShift)
+						finalAnswer := mul(firstNum, secondNum)
 					}
-				)", {"secondNum", "firstNum"}, map<string, string> {
+				)", {"finalAnswer", "secondNum", "firstNum"}, map<string, string> {
 						{"$div", (isSigned ? "sdiv" : "div")},
 						{"$halfShift", toString(halfShift)}
 				});
@@ -1433,8 +1434,9 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 							runningTotal := add(runningTotal, mul(D, A))
 						//C*B
 							runningTotal := add(runningTotal, mul(C, B))
+							finalAnswer := runningTotal
 						}
-					)", {"secondNum", "firstNum"}, map<string, string> {
+					)", {"finalAnswer", "secondNum", "firstNum"}, map<string, string> {
 							{"$div", (isSigned ? "sdiv" : "div")},
 							{"$halfShift", toString(halfShift)},
 							{"$fractionShift", toString(fractionShift)},
@@ -1459,8 +1461,9 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 							runningTotal := add(runningTotal, mul(D, A))
 						//C*B
 							runningTotal := add(runningTotal, mul(C, B))
+							finalAnswer := runningTotal
 						}
-					)", {"secondNum", "firstNum"}, map<string, string> {
+					)", {"finalAnswer", "secondNum", "firstNum"}, map<string, string> {
 							{"$fractionShift", toString(fractionShift)},
 							{"$mod", (isSigned ? "smod" : "mod")},
 							{"$div", (isSigned ? "sdiv" : "div")}
@@ -1489,8 +1492,9 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 						let fraction := $div(mul(firstNum, secondNum), $fractionShift)
 						let integer := mul(div(secondNum, $fractionShift), firstNum)
 						let runningTotal := add(integer, fraction)
+						finalAnswer := runningTotal
 					}
-				)", {"secondNum", "firstNum"}, map<string, string> {
+				)", {"finalAnswer", "secondNum", "firstNum"}, map<string, string> {
 						{"$div", (isSigned ? "sdiv" : "div")},
 						{"$fractionShift", toString(fractionShift)},
 				});

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1355,6 +1355,8 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 	u256 fractionShift = u256(1);
 	u256 halfShift = u256(1);
 	int fractionalBits = 0;
+	int intBits = 0;
+	int numBits = 0;
 
 	if (_type.category() == Type::Category::Integer)
 	{
@@ -1366,6 +1368,8 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		FixedPointType const& type = dynamic_cast<FixedPointType const&>(_type);
 		isSigned = type.isSigned();		
 		isFractional = true;
+		numBits = type.numBits();
+		intBits = type.integerBits();
 		fractionalBits = type.fractionalBits();
 		fractionShift = (u256(1) << (fractionalBits));
 		halfShift = (u256(1) << (fractionalBits / 2));

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1371,7 +1371,7 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		halfShift = (u256(1) << (fractionalBits / 2));
 	}
 	else
-		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Expected numeric type."));
+		solAssert(false, "Expected numeric type.");
 
 	switch (_operator)
 	{
@@ -1383,7 +1383,7 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		break;
 	case Token::Mul:
 		if (isFractional)
-			solAssert(false, "Multiplication not yet implemented - FixedPointType.");
+			solUnimplementedAssert(false, "Multiplication not yet implemented - FixedPointType.");
 		m_context << Instruction::MUL;
 		break;
 	case Token::Div:
@@ -1395,10 +1395,10 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 
 		if (_operator == Token::Div)
 		{
+			//divide...this is your integer.
+			m_context << (isSigned ? Instruction::SDIV : Instruction::DIV);
 			if (isFractional)
 			{
-				//divide, then shift left...this is your integer.
-				m_context << (isSigned ? Instruction::SDIV : Instruction::DIV) << fractionShift << Instruction::MUL;
 				//now redo the process...
 				m_context << Instruction::DUP2 << Instruction::DUP4;
 				//but this time, get the fraction portion.
@@ -1406,8 +1406,6 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 				//add
 				m_context << Instruction::ADD;
 			}
- 			else
-				m_context << (isSigned ? Instruction::SDIV : Instruction::DIV);
 		}
 		else
 			m_context << (isSigned ? Instruction::SMOD : Instruction::MOD);

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1392,18 +1392,16 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 			{
 				//take two numbers, cut them in half, multiply them, simple as that.
 				m_context.appendInlineAssembly(R"(
-					{	let A := $div(firstNum, $halfShift)
-						let B := $div(secondNum, $halfShift)
-						finalAnswer := mul(firstNum, secondNum)
+					{
+						firstNum := $div(firstNum, $halfShift)
+						secondNum := $div(secondNum, $halfShift)
 					}
-				)", {"finalAnswer", "secondNum", "firstNum"}, map<string, string> {
+				)", {"secondNum", "firstNum"}, map<string, string> {
 						{"$div", (isSigned ? "sdiv" : "div")},
 						{"$halfShift", toString(halfShift)}
 				});
 
-				/*m_context << halfShift << Instruction::DUP1 << Instruction::SWAP2 << (isSigned ? Instruction::SDIV : Instruction::DIV); 
-				m_context << Instruction::SWAP2 << (isSigned ? Instruction::SDIV : Instruction::DIV) << Instruction::MUL;
-				*/
+				m_context << Instruction::MUL;
 			}
 			else if (numBits > 128)
 			{
@@ -1436,7 +1434,7 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 							runningTotal := add(runningTotal, mul(C, B))
 							finalAnswer := runningTotal
 						}
-					)", {"finalAnswer", "secondNum", "firstNum"}, map<string, string> {
+					)", {"secondNum", "firstNum"}, map<string, string> {
 							{"$div", (isSigned ? "sdiv" : "div")},
 							{"$halfShift", toString(halfShift)},
 							{"$fractionShift", toString(fractionShift)},

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1266,7 +1266,7 @@ void ExpressionCompiler::endVisit(Literal const& _literal)
 	case Type::Category::StringLiteral:
 		break; // will be done during conversion
 	default:
-		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Only integer, rational, boolean and string literals implemented for now."));
+		solUnimplementedAssert("", "Only integer, rational, boolean and string literals implemented for now.");
 	}
 }
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -307,6 +307,7 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 		break;
 	case Token::Inc: // ++ (pre- or postfix)
 	case Token::Dec: // -- (pre- or postfix)
+	{
 		solAssert(!!m_currentLValue, "LValue not retrieved.");
 		m_currentLValue->retrieveValue(_unaryOperation.location());
 		if (!_unaryOperation.isPrefixOperation())
@@ -318,7 +319,15 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 				for (unsigned i = 1 + m_currentLValue->sizeOnStack(); i > 0; --i)
 					m_context << swapInstruction(i);
 		}
-		m_context << u256(1);
+		u256 oneValue;
+		if (_unaryOperation.annotation().type->category() == Type::Category::FixedPoint)
+		{
+			FixedPointType const& fixedType = dynamic_cast<FixedPointType const&>(*_unaryOperation.subExpression().annotation().type);
+			oneValue = u256(1) << fixedType.fractionalBits();		
+		}	
+		else
+			oneValue = u256(1);
+		m_context << oneValue;
 		if (_unaryOperation.getOperator() == Token::Inc)
 			m_context << Instruction::ADD;
 		else
@@ -332,6 +341,7 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 			!_unaryOperation.isPrefixOperation());
 		m_currentLValue.reset();
 		break;
+	}
 	case Token::Add: // +
 		// unary add, so basically no-op
 		break;
@@ -363,7 +373,11 @@ bool ExpressionCompiler::visit(BinaryOperation const& _binaryOperation)
 		bool cleanupNeeded = false;
 		if (Token::isCompareOp(c_op))
 			cleanupNeeded = true;
-		if (commonType.category() == Type::Category::Integer && (c_op == Token::Div || c_op == Token::Mod))
+		if (
+			(commonType.category() == Type::Category::Integer && 
+			(c_op == Token::Div || c_op == Token::Mod)) ||
+			commonType.category() == Type::Category::FixedPoint
+		)
 			cleanupNeeded = true;
 
 		// for commutative operators, push the literal as late as possible to allow improved optimization
@@ -1252,7 +1266,7 @@ void ExpressionCompiler::endVisit(Literal const& _literal)
 	case Type::Category::StringLiteral:
 		break; // will be done during conversion
 	default:
-		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Only integer, boolean and string literals implemented for now."));
+		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Only integer, rational, boolean and string literals implemented for now."));
 	}
 }
 
@@ -1294,6 +1308,8 @@ void ExpressionCompiler::appendCompareOperatorCode(Token::Value _operator, Type 
 	{
 		bool isSigned = false;
 		if (auto type = dynamic_cast<IntegerType const*>(&_type))
+			isSigned = type->isSigned();
+		else if (auto type = dynamic_cast<FixedPointType const*>(&_type))
 			isSigned = type->isSigned();
 
 		switch (_operator)

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -181,17 +181,14 @@ void StorageItem::retrieveValue(SourceLocation const&, bool _remove) const
 		m_context
 			<< Instruction::SWAP1 << Instruction::SLOAD << Instruction::SWAP1
 			<< u256(0x100) << Instruction::EXP << Instruction::SWAP1 << Instruction::DIV;
-		if (m_dataType->category() == Type::Category::FixedPoint)
-			// implementation should be very similar to the integer case.
-			solUnimplemented("Not yet implemented - FixedPointType.");
 		if (m_dataType->category() == Type::Category::FixedBytes)
 		{
 			m_context << (u256(0x1) << (256 - 8 * m_dataType->storageBytes())) << Instruction::MUL;
 			cleaned = true;
 		}
 		else if (
-			m_dataType->category() == Type::Category::Integer &&
-			dynamic_cast<IntegerType const&>(*m_dataType).isSigned()
+			(m_dataType->category() == Type::Category::Integer && dynamic_cast<IntegerType const&>(*m_dataType).isSigned()) ||
+			(m_dataType->category() == Type::Category::FixedPoint && dynamic_cast<FixedPointType const&>(*m_dataType).isSigned())
 		)
 		{
 			m_context << u256(m_dataType->storageBytes() - 1) << Instruction::SIGNEXTEND;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8691,6 +8691,7 @@ BOOST_AUTO_TEST_CASE(fixed_type_multiplication)
 	BOOST_CHECK(callContractFunction("full()") == encodeArgs(make_pair(rational(999, 8), 128)));
 	cout << callContractFunction("full()") << endl;
 	BOOST_CHECK(callContractFunction("fullFractionSide()") == fullFracBytes);
+	cout << callContractFunction("fullFractionSide()") << endl;
 	BOOST_CHECK(callContractFunction("largerFractionSide()") == largeFracBytes);
 	BOOST_CHECK(callContractFunction("largerIntSide()") == encodeArgs(make_pair(rational(96028001, 16), 32)));
 	BOOST_CHECK(callContractFunction("small()") == encodeArgs(make_pair(rational(4539, 256), 32)));

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8652,6 +8652,48 @@ BOOST_AUTO_TEST_CASE(fixed_type_division)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(337, 4), 128)));
 }
 
+BOOST_AUTO_TEST_CASE(fixed_type_multiplication)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function full() returns (ufixed) {
+				ufixed a = 55.5;
+				ufixed b = 2.25;
+				return (a * b);
+			}
+			function fullFractionSide() returns (ufixed0x256) {
+				ufixed0x256 a = ufixed0x256(2/9);
+				ufixed0x256 b = ufixed0x256(4/5);
+				return a * b;
+			}
+			function largerFractionSide() returns (ufixed32x192) {
+				ufixed32x192 a = ufixed24x184(8 + 1/3);
+				ufixed32x192 b = 3.5;
+				return a * b;
+			}
+			function largerIntSide() returns (ufixed184x32) {
+				ufixed184x24 a = 3000.125;
+				ufixed176x24 b = 2000.5;
+				return a * b;
+			}
+			function small() returns (ufixed16x32) {
+				ufixed0x8 a = 0.5;
+				ufixed16x32 b = 35.4609375;
+				return (a * b);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	//because we don't have a decent rounding system implemented yet, this will have to do.
+	vector<uint8_t> fullFracBytes = {45,130,216,45,130,216,45,130,216,45,130,216,45,130,216,44,159,73,244,159,73,244,159,73,244,159,73,244,159,73,244,160};
+	vector<uint8_t> largeFracBytes = {0,0,0,0,0,0,0,29,42,170,170,170,170,170,170,170,170,170,170,170,127,255,255,255,255,255,255,255,255,255,255,0};
+	BOOST_CHECK(callContractFunction("full()") == encodeArgs(make_pair(rational(999, 8), 128)));
+	BOOST_CHECK(callContractFunction("fullFractionSide()") == fullFracBytes);
+	BOOST_CHECK(callContractFunction("largerFractionSide()") == largeFracBytes);
+	BOOST_CHECK(callContractFunction("largerIntSide()") == encodeArgs(make_pair(rational(96028001, 16), 32)));
+	BOOST_CHECK(callContractFunction("small()") == encodeArgs(make_pair(rational(4539, 256), 32)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8649,6 +8649,7 @@ BOOST_AUTO_TEST_CASE(fixed_type_division)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
+	cout << callContractFunction("f()") << endl;
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(337, 4), 128)));
 }
 
@@ -8688,6 +8689,7 @@ BOOST_AUTO_TEST_CASE(fixed_type_multiplication)
 	vector<uint8_t> fullFracBytes = {45,130,216,45,130,216,45,130,216,45,130,216,45,130,216,44,159,73,244,159,73,244,159,73,244,159,73,244,159,73,244,160};
 	vector<uint8_t> largeFracBytes = {0,0,0,0,0,0,0,29,42,170,170,170,170,170,170,170,170,170,170,170,127,255,255,255,255,255,255,255,255,255,255,0};
 	BOOST_CHECK(callContractFunction("full()") == encodeArgs(make_pair(rational(999, 8), 128)));
+	cout << callContractFunction("full()") << endl;
 	BOOST_CHECK(callContractFunction("fullFractionSide()") == fullFracBytes);
 	BOOST_CHECK(callContractFunction("largerFractionSide()") == largeFracBytes);
 	BOOST_CHECK(callContractFunction("largerIntSide()") == encodeArgs(make_pair(rational(96028001, 16), 32)));

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8539,6 +8539,119 @@ BOOST_AUTO_TEST_CASE(inline_array_rationals_return)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(7,2),8), make_pair(rational(33,8),8), make_pair(rational(5,2),8), make_pair(rational(4,1),8)));
 }
 
+BOOST_AUTO_TEST_CASE(fixed_type_incrementing_decrementing)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function incPre() returns (ufixed) {
+				ufixed a = 1.25;
+				return ++a;
+			}
+			function decPre() returns (ufixed) {
+				ufixed a = 4.5;
+				return --a;
+			}
+			function incPost() returns (ufixed a) {
+				a = 1.25;
+				a++;
+				return a;
+			}
+			function decPost() returns (ufixed a) {
+				a = 4.5;
+				a--;
+				return a;
+			}
+			function daWhile() returns (ufixed8x8) {
+				var i = 3.25;
+				while ( i < 5.5) {
+					i++;
+				}
+				return i;
+			}
+			function daFor() returns (ufixed8x8) {
+				for (var i = 3.25; i < 5.5; i++) {
+					var j = i;
+				}
+				return j;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("incPre()") == encodeArgs(make_pair(rational(9, 4), 128)));
+	BOOST_CHECK(callContractFunction("decPre()") == encodeArgs(make_pair(rational(7, 2), 128)));
+	BOOST_CHECK(callContractFunction("incPost()") == encodeArgs(make_pair(rational(9, 4), 128)));
+	BOOST_CHECK(callContractFunction("decPost()") == encodeArgs(make_pair(rational(7, 2), 128)));
+	BOOST_CHECK(callContractFunction("daWhile()") == encodeArgs(make_pair(rational(25, 4), 8)));
+	BOOST_CHECK(callContractFunction("daFor()") == encodeArgs(make_pair(rational(21, 4), 8)));
+}
+
+BOOST_AUTO_TEST_CASE(fixed_type_addition)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function simpleAdd() returns (fixed) {
+				fixed a = 3.125;
+				fixed b = 2.5;
+				return (a + b);
+			}
+
+			function complexAdd() returns (fixed) {
+				fixed a = 3.125;
+				ufixed0x8 b = 0.5;
+				ufixed32x32 c = 35.25;
+				return (a + b + c);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("simpleAdd()") == encodeArgs(make_pair(rational(45, 8), 128)));
+	BOOST_CHECK(callContractFunction("complexAdd()") == encodeArgs(make_pair(rational(311, 8), 128)));
+}
+
+BOOST_AUTO_TEST_CASE(fixed_type_modulus)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (ufixed) {
+				ufixed a = 2 % 1.25;
+				return a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(3, 4), 128)));
+}
+
+BOOST_AUTO_TEST_CASE(fixed_type_subtraction)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (fixed) {
+				fixed a = 3.5;
+				fixed b = 32.25;
+				return (a - b);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(-115, 4), 128)));
+}
+
+BOOST_AUTO_TEST_CASE(fixed_type_division)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (fixed) {
+				fixed a = 42.125;
+				fixed b = 0.5;
+				return (a / b);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(337, 4), 128)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8693,8 +8693,11 @@ BOOST_AUTO_TEST_CASE(fixed_type_multiplication)
 	BOOST_CHECK(callContractFunction("fullFractionSide()") == fullFracBytes);
 	cout << callContractFunction("fullFractionSide()") << endl;
 	BOOST_CHECK(callContractFunction("largerFractionSide()") == largeFracBytes);
+	cout << callContractFunction("largerFractionSide()") << endl;
 	BOOST_CHECK(callContractFunction("largerIntSide()") == encodeArgs(make_pair(rational(96028001, 16), 32)));
+	cout << callContractFunction("largerIntSide()") << endl;
 	BOOST_CHECK(callContractFunction("small()") == encodeArgs(make_pair(rational(4539, 256), 32)));
+	cout << callContractFunction("small()") << endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8269,6 +8269,276 @@ BOOST_AUTO_TEST_CASE(inline_assembly_invalidjumplabel)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs());
 }
 
+BOOST_AUTO_TEST_CASE(fixed_type_explicit_conversion_shifting)
+{
+	char const* sourceCode = R"(
+		contract Test {
+			function A() returns (fixed a) {
+				a = fixed(1/3);
+			}
+			function B() returns (fixed0x248 b) {
+				b = fixed0x248(1/3);
+			}
+			function C() returns (fixed248x8 c) {
+				c = fixed248x8(1/3);
+			}
+			function D() returns (fixed8x248 d) {
+				d = fixed8x248(-0.125);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Test");
+
+	BOOST_CHECK(callContractFunction("A()") == encodeArgs(make_pair(rational(1, 3), 128)));
+	BOOST_CHECK(callContractFunction("B()") == encodeArgs(make_pair(rational(1, 3), 248)));
+	BOOST_CHECK(callContractFunction("C()") == encodeArgs(make_pair(rational(1, 3), 8)));
+	BOOST_CHECK(callContractFunction("D()") == encodeArgs(make_pair(rational(-1, 8), 248)));
+}
+
+BOOST_AUTO_TEST_CASE(fixed_type_function_multi_return)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (fixed a, fixed b, fixed c) {
+				(a, b, c) = (325.5, 450.25, 23924029.9375);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(
+		callContractFunction("f()") == encodeArgs(
+			make_pair(rational(651, 2), 128), 
+			make_pair(rational(1801, 4), 128), 
+			make_pair(rational(382784479, 16), 128)
+		)
+	);
+}
+
+BOOST_AUTO_TEST_CASE(fixed_type_arguments)
+{
+	char const* sourceCode = R"(
+		contract B {
+			function callFixed(fixed a, fixed b) returns (fixed, fixed) {
+				return (a, b);
+			}
+		}
+
+		contract C {
+			B b = new B();
+			function f(fixed a, fixed b) returns (fixed, fixed) {
+				return (a, b);
+			}
+
+			function callFmem() returns (fixed a, fixed b) {
+				(a, b) = f(.25, .5);
+			}
+
+			function callDataloadB() returns (fixed a) {
+				(a, ) = b.callFixed(.5, .25);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(fixed128x128,fixed128x128)", make_pair(rational(1, 3), 128), make_pair(rational(1, 2), 128)) == encodeArgs(make_pair(rational(1, 3), 128), make_pair(rational(1, 2), 128)));
+}
+
+BOOST_AUTO_TEST_CASE(int_to_fixed_type)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f(uint128 a) returns (ufixed b) {
+				b = a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f(uint128)", u256(3)) == encodeArgs(make_pair(rational(3, 1), 128)));
+}
+
+BOOST_AUTO_TEST_CASE(boolean_operations_on_fixed_point){
+	char const* sourceCode = R"(
+		contract C {
+			function greaterInts() returns (bool) {
+				ufixed a = 4.5;
+				uint128 b = 4;
+				if (a > b) {
+					return true;
+				}
+				return false;
+			}
+			function equalInts() returns (bool) {
+				ufixed a = 4;
+				uint128 b = 4;
+				if (b == a) {
+					return true;
+				}
+				return false;
+			}
+			function lessThanInts() returns (bool) {
+				ufixed a = 3.5;
+				uint128 b = 4;
+				if (a < b) {
+					return true;
+				}
+				return false;
+			}
+			function equalUFixedShort() returns (bool) {
+				ufixed a = 3.5;
+				ufixed8x8 b = 3.5;
+				ufixed16x16 c = 3.5;
+				if (a == b && b == c) {
+					return true;
+				}
+				return false;
+			}
+			function greaterUFixedShort() returns (bool) {
+				ufixed a = 2.5;
+				ufixed8x8 b = 3.5;
+				ufixed16x16 c = 1.5;
+				if (b > a && a > c) {
+					return true;
+				}
+				return false;
+			}
+			function lessThanUFixedShort() returns (bool) {
+				ufixed a = 2.5;
+				ufixed8x8 b = 3.5;
+				ufixed16x16 c = 1.5;
+				if (a < b && c < a) {
+					return true;
+				}
+				return false;
+			}
+			function equalFixedShort() returns (bool) {
+				fixed a = fixed(3.5);
+				fixed8x8 b = fixed8x8(3.5);
+				fixed16x16 c = fixed16x16(3.5);
+				if (a == b && b == c) {
+					return true;
+				}
+				return false;
+			}
+			function greaterFixedShort() returns (bool) {
+				fixed a = fixed(2.5);
+				fixed8x8 b = fixed8x8(3.5);
+				fixed16x16 c = fixed16x16(1.5);
+				if (b > a && a > c) {
+					return true;
+				}
+				return false;
+			}
+			function lessThanFixedShort() returns (bool) {
+				fixed a = fixed(2.5);
+				fixed8x8 b = fixed8x8(3.5);
+				fixed16x16 c = fixed16x16(1.5);
+				if (a < b && c < a) {
+					return true;
+				}
+				return false;
+			}
+			function equalUFixedLong() returns (bool) {
+				ufixed a = 3.5;
+				ufixed240x16 b = 3.5;
+				ufixed16x240 c = 3.5;
+				if (ufixed240x16(a) == b && ufixed16x240(b) == c) {
+					return true;
+				}
+				return false;
+			}
+			function greaterUFixedLong() returns (bool) {
+				ufixed a = 2.5;
+				ufixed240x16 b = 3.5;
+				ufixed16x240 c = 1.5;
+				if (b > ufixed240x16(a) && ufixed16x240(b) > c) {
+					return true;
+				}
+				return false;
+			}
+			function lessThanUFixedLong() returns (bool) {
+				ufixed a = 2.5;
+				ufixed240x16 b = 3.5;
+				ufixed16x240 c = 1.5;
+				if (ufixed240x16(a) < b && c < ufixed16x240(b)) {
+					return true;
+				}
+				return false;
+			}
+			function equalFixedLong() returns (bool) {
+				fixed a = fixed(3.5);
+				fixed240x16 b = fixed240x16(3.5);
+				fixed16x240 c = fixed16x240(3.5);
+				if (fixed240x16(a) == b && fixed16x240(b) == c) {
+					return true;
+				}
+				return false;
+			}
+			function greaterFixedLong() returns (bool) {
+				fixed a = fixed(2.5);
+				fixed240x16 b = fixed240x16(-3.5);
+				fixed16x240 c = fixed16x240(1.5);
+				if (fixed240x16(a) > b && c > fixed16x240(b)) {
+					return true;
+				}
+				return false;
+			}
+			function lessThanFixedLong() returns (bool) {
+				fixed a = fixed(2.5);
+				fixed240x16 b = fixed240x16(-3.5);
+				fixed16x240 c = fixed16x240(1.5);
+				if (b < fixed240x16(a) && fixed16x240(b) < c) {
+					return true;
+				}
+				return false;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("greaterInts()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("equalInts()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("lessThanInts()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("greaterUFixedShort()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("equalUFixedShort()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("lessThanUFixedShort()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("greaterFixedShort()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("equalFixedShort()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("lessThanFixedShort()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("greaterUFixedLong()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("equalUFixedLong()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("lessThanUFixedLong()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("greaterFixedLong()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("equalFixedLong()") == encodeArgs(true));
+	BOOST_CHECK(callContractFunction("lessThanFixedLong()") == encodeArgs(true));
+}
+
+BOOST_AUTO_TEST_CASE(var_and_fixed_one_third_equivalent)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (bool) {
+				var a = 1/3;
+				ufixed0x256 b = ufixed0x256(1/3);
+				return (a == b);
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(true));
+}
+
+BOOST_AUTO_TEST_CASE(inline_array_rationals_return)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (ufixed8x8[4]) {
+				ufixed8x8[4] memory a = [3.5, 4.125, 2.5, 4.0];
+				return a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(make_pair(rational(7,2),8), make_pair(rational(33,8),8), make_pair(rational(5,2),8), make_pair(rational(4,1),8)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
This is the last and probably hardest piece of the puzzle. Currently, if we were to uncomment the opcodes, it does indeed work. However...it is not optimizable in terms of the multiplication in its current state, hence why we are looking to turn it into inline assembly and feed it to the compiler (I may be wrong, but I think this will be the first feature to do that). Furthermore we are running into problems that tend to naturally occur in fixed points, that being that they lose resolution the larger and larger you make them. This could also do for some help in terms of helping to design a rounding system to try to get as much accuracy as possible when multiplying fractional fields larger than 128. 
