### PR TITLE
formal verification: accessing mapping (address => X)

### DIFF
--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -294,8 +294,6 @@ bool Why3Translator::visit(FunctionDefinition const& _function)
 
 	if (_function.isDeclaredConst())
 		addLine("ensures { (old this) = this }");
-	else
-		addLine("writes { this }");
 
 	addLine("=");
 
@@ -700,11 +698,6 @@ bool Why3Translator::visit(IndexAccess const& _node)
 		error(_node, "Index access only supported for arrays or mappings.");
 		return true;
 	}
-	if (_node.annotation().lValueRequested)
-	{
-		error(_node, "Assignment to array or mapping elements not supported.");
-		return true;
-	}
 	add("(");
 	_node.baseExpression().accept(*this);
 	auto indexIntegerType = dynamic_cast<IntegerType const*>(_node.indexExpression()->annotation().type.get());
@@ -720,6 +713,10 @@ bool Why3Translator::visit(IndexAccess const& _node)
 	_node.indexExpression()->accept(*this);
 	add("]");
 	add(")");
+	if (_node.annotation().lValueRequested)
+	{
+		m_currentLValueIsRef = false; /* because <- should be used. */
+	}
 
 	return false;
 }

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -77,6 +77,8 @@ string Why3Translator::toFormalType(Type const& _type) const
 		return "bool";
 	else if (auto type = dynamic_cast<IntegerType const*>(&_type))
 	{
+		if (type->isAddress())
+			return "Address.address";
 		if (!type->isAddress() && !type->isSigned() && type->numBits() == 256)
 			return "uint256";
 	}
@@ -150,6 +152,7 @@ bool Why3Translator::visit(ContractDefinition const& _contract)
 	addLine("use import int.ComputerDivision");
 	addLine("use import mach.int.Unsigned");
 	addLine("use import UInt256");
+	addLine("use Address"); // `import` would cause name clashes with Uint256.
 	addLine("exception Revert");
 	addLine("exception Return");
 

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -501,7 +501,7 @@ bool Why3Translator::visit(UnaryOperation const& _unaryOperation)
 	catch (NoFormalType &err)
 	{
 		string const* typeNamePtr = boost::get_error_info<errinfo_noFormalTypeFrom>(err);
-		error(_unaryOperation, "Type \"" + (typeNamePtr ? *typeNamePtr : "") + "\" supported in unary operation.");
+		error(_unaryOperation, "Type \"" + (typeNamePtr ? *typeNamePtr : "") + "\" not supported in unary operation.");
 	}
 
 	switch (_unaryOperation.getOperator())


### PR DESCRIPTION
This PR adds support for `map[idx]` read & write access in `--formal` option.

Fixes #1062, fixes #1065 and fixes #1066.
