### PR TITLE
Breaking: overflow detection for SDIV - minInt / (-1)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### 0.5.0 (unreleased)
+
+Breaking Changes:
+ * codegen: The execution throws when the smallest 256-bit signed integer is divided by -1.
+
 ### 0.4.12 (unreleased)
 
 Features:

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -389,6 +389,7 @@ Currently, Solidity automatically generates a runtime exception in the following
 #. If you call a function via a message call but it does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.  The low level operations never throw exceptions but indicate failures by returning ``false``.
 #. If you create a contract using the ``new`` keyword but the contract creation does not finish properly (see above for the definition of "not finish properly").
 #. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
+#. If you divide the smallest 256-bit signed integer by -1.
 #. If you shift by a negative amount.
 #. If you convert a value too big or negative into an enum type.
 #. If you perform an external function call targeting a contract that contains no code.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1453,13 +1453,10 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		// Test for (minInt) / (-1)
 		if (c_isSigned && _operator == Token::Div)
 		{
-			m_context << Instruction::DUP1 // x
-				<< (u256(1) << 255) << Instruction::EQ;
-			// y, x, (x == 2 ** 255)
-			m_context << Instruction::DUP3 << Instruction::NOT //y
-				<< Instruction::ISZERO;
-			// y, x, (x == 2 ** 255), (y == -1)
-			m_context << Instruction::AND;
+			m_context.appendInlineAssembly(R"(
+				and(eq(x, u256(1) << 255), eq(y, -1))
+			)",
+			{ "x", "y" });
 			m_context.appendConditionalInvalid();
 		}
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1460,7 +1460,7 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 				<< Instruction::ISZERO;
 			// y, x, (x == 2 ** 255), (y == -1)
 			m_context << Instruction::AND;
-			m_context.appendConditionalJumpTo(m_context.errorTag());
+			m_context.appendConditionalInvalid();
 		}
 
 		if (_operator == Token::Div)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1454,8 +1454,7 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		if (c_isSigned && _operator == Token::Div)
 		{
 			m_context << Instruction::DUP1 // x
-				<< u256(255) << u256(2) << Instruction::EXP // 2 ** 255
-				<< Instruction::EQ;
+				<< (u256(1) << 255) << Instruction::EQ;
 			// y, x, (x == 2 ** 255)
 			m_context << Instruction::DUP3 << Instruction::NOT //y
 				<< Instruction::ISZERO;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1453,11 +1453,11 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 		// Test for (minInt) / (-1)
 		if (c_isSigned && _operator == Token::Div)
 		{
-			m_context.appendInlineAssembly(R"(
-				and(eq(x, u256(1) << 255), eq(y, -1))
-			)",
-			{ "x", "y" });
-			m_context.appendConditionalInvalid();
+			m_context.appendInlineAssembly(R"({
+				jumpi(invalidJumpLabel, and(eq(y, exp(2,255)), iszero(add(x, 1))))
+			})",
+			{ "x", "y" }
+			);
 		}
 
 		if (_operator == Token::Div)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7089,7 +7089,7 @@ BOOST_AUTO_TEST_CASE(sdiv_minint_by_negone)
 			function div(int a, int b) returns (int) {
 				return a / b;
 			}
-			funciton test() returns (int) {
+			function test() returns (int) {
 				return div(minInt(), -1);
 			}
 		}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7083,14 +7083,14 @@ BOOST_AUTO_TEST_CASE(sdiv_minint_by_negone)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function minInt() returns (int) {
+			function minInt() external returns (int) {
 				return -2**255;
 			}
 			function div(int a, int b) returns (int) {
 				return a / b;
 			}
 			function test() returns (int) {
-				return div(minInt(), -1);
+				return div(this.minInt(), -1);
 			}
 		}
 	)";

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7089,14 +7089,14 @@ BOOST_AUTO_TEST_CASE(sdiv_minint_by_negone)
 			function div(int a, int b) returns (int) {
 				return a / b;
 			}
-			funciton main() returns (int) {
+			funciton test() returns (int) {
 				return div(minInt(), -1);
 			}
 		}
 	)";
 	compileAndRun(sourceCode);
 	// throws
-	BOOST_CHECK(callContractFunction("main()") == encodeArgs());
+	BOOST_CHECK(callContractFunction("test()") == encodeArgs());
 }
 
 BOOST_AUTO_TEST_CASE(string_allocation_bug)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7079,6 +7079,26 @@ BOOST_AUTO_TEST_CASE(divisiod_by_zero)
 	BOOST_CHECK(callContractFunction("mod(uint256,uint256)", 7, 0) == encodeArgs());
 }
 
+BOOST_AUTO_TEST_CASE(sdiv_minint_by_negone)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function minInt() returns (int) {
+				return -2**255;
+			}
+			function div(int a, int b) returns (int) {
+				return a / b;
+			}
+			funciton main() returns (int) {
+				return div(minInt(), -1);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	// throws
+	BOOST_CHECK(callContractFunction("main()") == encodeArgs());
+}
+
 BOOST_AUTO_TEST_CASE(string_allocation_bug)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Trying to fix #1087.

First I'm trying to catch this in the CI servers.
