### PR TITLE
Fix memory resize costs during call

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ### 0.4.2
 
  * Type Checker: Fixed a crash about invalid array types.
+ * Code Generator: Fixed a call gas bug that became visible after
+   version 0.4.0 for calls where the output is larger than the input.
 
 ### 0.4.1 (2016-09-09)
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7191,7 +7191,7 @@ BOOST_AUTO_TEST_CASE(mem_resize_is_not_paid_at_call)
 	// This tests that memory resize for return values is not paid during the call, which would
 	// make the gas calculation overly complex. We access the end of the output area before
 	// the call is made.
-	// Tests that this also survivecs the optimizer.
+	// Tests that this also survives the optimizer.
 	char const* sourceCode = R"(
 		contract C {
 			function f() returns (uint[200]) {}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7186,6 +7186,33 @@ BOOST_AUTO_TEST_CASE(no_nonpayable_circumvention_by_modifier)
 	BOOST_CHECK_EQUAL(balanceAt(m_contractAddress), 0);
 }
 
+BOOST_AUTO_TEST_CASE(mem_resize_is_not_paid_at_call)
+{
+	// This tests that memory resize for return values is not paid during the call, which would
+	// make the gas calculation overly complex. We access the end of the output area before
+	// the call is made.
+	// Tests that this also survivecs the optimizer.
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (uint[200]) {}
+		}
+		contract D {
+			function f(C c) returns (uint) { c.f(); return 7; }
+		}
+	)";
+
+	compileAndRun(sourceCode, 0, "C");
+	u160 cAddr = m_contractAddress;
+	compileAndRun(sourceCode, 0, "D");
+	BOOST_CHECK(callContractFunction("f(address)", cAddr) == encodeArgs(u256(7)));
+
+	m_optimize = true;
+
+	compileAndRun(sourceCode, 0, "C");
+	u160 cAddrOpt = m_contractAddress;
+	compileAndRun(sourceCode, 0, "D");
+	BOOST_CHECK(callContractFunction("f(address)", cAddrOpt) == encodeArgs(u256(7)));
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
If the output size of a call is larger than the input size, we have to pay for the memory resize as part of the call opcode. If we want to send all gas along with the call, we have to subtract the exact costs of the call opcode from the current gas value. As this is a quite complex calculation (and we also have to take the cost of the calculation itself into account), this is currently not done. Instead, we resize the memory before the call.

A tricky part in this change is to make the resize in a way that is not removed by the optimized.

Fixes #1083
