### PR TITLE
Fix multiple binaries and publish from release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,9 @@ deploy:
       script: test $TRAVIS_EMSCRIPTEN != On || scripts/release_emscripten.sh
       skip_cleanup: true
       on:
-          branch: develop
+          branch:
+            - develop
+            - release
 
     # This is the deploy target for the native build (Linux and macOS)
     # which generates ZIPs per commit.  We are in agreement that

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -29,7 +29,12 @@
 set -e
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
-    date -u +"nightly.%Y.%-m.%-d" > prerelease.txt
+    if [ "$TRAVIS_BRANCH" = release ]
+    then
+        echo -n > prerelease.txt
+    else
+        date -u +"nightly.%Y.%-m.%-d" > prerelease.txt
+    fi
     ./scripts/travis-emscripten/install_deps.sh
     docker run -v $(pwd):/src trzeci/emscripten:sdk-tag-1.35.4-64bit ./scripts/travis-emscripten/build_emscripten.sh
 fi

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -59,7 +59,7 @@ commitdate=`git show --format=%ci HEAD | head -n 1 | cut - -b1-10 | sed -e 's/-0
 echo "$commithash" > commit_hash.txt
 if [ $branch = develop ]
 then
-    debversion="$version-nightly-$commitdate-$commithash"
+    debversion="$version-develop-$commitdate-$commithash"
 else
     debversion="$version"
     echo -n > prerelease.txt # proper release

--- a/scripts/travis-emscripten/publish_binary.sh
+++ b/scripts/travis-emscripten/publish_binary.sh
@@ -54,21 +54,37 @@ git config user.name "travis"
 git config user.email "chris@ethereum.org"
 git checkout -B gh-pages origin/gh-pages
 git clean -f -d -x
-# We only want one release per day and we do not want to push the same commit twice.
-if ls ./bin/soljson-"$VER-nightly.$DATE"*.js || ls ./bin/soljson-*"commit.$COMMIT.js"
+
+
+FULLVERSION=INVALID
+if [ "$TRAVIS_BRANCH" = release ]
 then
-  echo "Not publishing, we already published this version today."
-  exit 0
+    # We only want one file with this version
+    if ls ./bin/soljson-"$VER+"*.js
+    then
+      echo "Not publishing, we already published this version."
+      exit 0
+    fi
+    FULLVERSION="$VER+commit.$COMMIT"
+elif [ "$TRAVIS_BRANCH" = develop ]
+    # We only want one release per day and we do not want to push the same commit twice.
+    if ls ./bin/soljson-"$VER-nightly.$DATE"*.js || ls ./bin/soljson-*"commit.$COMMIT.js"
+    then
+      echo "Not publishing, we already published this version today."
+      exit 0
+    fi
+    FULLVERSION="$VER-nightly.$DATE+commit.$COMMIT"
+else
+      echo "Not publishing, wrong branch."
+      exit 0
 fi
 
+
 # This file is assumed to be the product of the build_emscripten.sh script.
-cp ../soljson.js ./bin/"soljson-$VER-nightly.$DATE+commit.$COMMIT.js"
+cp ../soljson.js ./bin/"soljson-$FULLVERSION.js"
 node ./update
 cd bin
-LATEST=$(ls -r soljson-v* | head -n 1)
-cp "$LATEST" soljson-latest.js
-cp soljson-latest.js ../soljson.js
 git add .
 git add ../soljson.js
-git commit -m "Added compiler version $LATEST"
+git commit -m "Added compiler version $VER"
 git push origin gh-pages

--- a/scripts/travis-emscripten/publish_binary.sh
+++ b/scripts/travis-emscripten/publish_binary.sh
@@ -86,5 +86,5 @@ node ./update
 cd bin
 git add .
 git add ../soljson.js
-git commit -m "Added compiler version $VER"
+git commit -m "Added compiler version $FULLVERSION"
 git push origin gh-pages

--- a/scripts/travis-emscripten/publish_binary.sh
+++ b/scripts/travis-emscripten/publish_binary.sh
@@ -55,7 +55,7 @@ git config user.email "chris@ethereum.org"
 git checkout -B gh-pages origin/gh-pages
 git clean -f -d -x
 # We only want one release per day and we do not want to push the same commit twice.
-if ls ./bin/soljson-"$VER-nightly.$DATE"-*.js || ls ./bin/soljson-*"commit.$COMMIT.js"
+if ls ./bin/soljson-"$VER-nightly.$DATE"*.js || ls ./bin/soljson-*"commit.$COMMIT.js"
 then
   echo "Not publishing, we already published this version today."
   exit 0


### PR DESCRIPTION
This fixes a problem where multiple binaries per day were uploaded and also publishes the release binary.

TODO: Modify the emscripten build so that it does not create a prerelease on the release branch.
