### PR TITLE
Suggest correct version for pragma.

### DIFF
--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -52,13 +52,22 @@ void SyntaxChecker::endVisit(SourceUnit const& _sourceUnit)
 {
 	if (!m_versionPragmaFound)
 	{
+		string errorString("Source file does not specify required compiler version!");
+		SemVerVersion recommendedVersion{string(VersionString)};
+		if (!recommendedVersion.isPrerelease())
+			errorString +=
+				"Consider adding \"pragma solidity ^" +
+				to_string(recommendedVersion.major()) +
+				string(".") +
+				to_string(recommendedVersion.minor()) +
+				string(".") +
+				to_string(recommendedVersion.patch());
+				string(";\"");
+
 		auto err = make_shared<Error>(Error::Type::Warning);
 		*err <<
 			errinfo_sourceLocation(_sourceUnit.location()) <<
-			errinfo_comment(
-				string("Source file does not specify required compiler version! ") +
-				string("Consider adding \"pragma solidity ^") + VersionNumber + string(";\".")
-			);
+			errinfo_comment(errorString);
 		m_errors.push_back(err);
 	}
 }


### PR DESCRIPTION
Previously, the _current_ version was suggested for a missing version pragma, which does not work if the current version is a prerelease.
