### PR TITLE
Add workaround to support pop() in inline assembly

### DIFF
--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -225,6 +225,12 @@ FunctionalInstruction Parser::parseFunctionalInstruction(assembly::Statement&& _
 	unsigned args = unsigned(instrInfo.args);
 	for (unsigned i = 0; i < args; ++i)
 	{
+		// workaround to support pop()
+		if ((i == 0) && (instr == solidity::Instruction::POP) && (m_scanner->currentToken() == Token::RParen))
+		{
+			break;
+		}
+
 		ret.arguments.emplace_back(parseExpression());
 		if (i != args - 1)
 		{


### PR DESCRIPTION
Fixes #1118.

I'm a bit torn whether we should have it this way or not.
