### PR TITLE
Disallow unknown options in solc

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ Features:
  * Inline assembly: support both `sucide` and `selfdestruct` opcodes
    (note: `suicide` is deprecated)
 
+Bugfixes:
+ * Disallow unknown options in `solc`
+
 ### 0.4.2 (2016-09-17)
 
 Bugfixes:

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -471,7 +471,7 @@ Allowed options)",
 	try
 	{
 		po::command_line_parser cmdLineParser(_argc, _argv);
-		cmdLineParser.options(allOptions).positional(filesPositions).allow_unregistered();
+		cmdLineParser.options(allOptions).positional(filesPositions);
 		po::store(cmdLineParser.run(), m_args);
 	}
 	catch (po::error const& _exception)


### PR DESCRIPTION
Fixes #1121.

I do not see where those unknown options would be collected later on, so this shouldn't have any adverse effects.
