### PR TITLE
Adding "When Solidity Throws" section in the documentation

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -326,12 +326,12 @@ Currently, there are situations, where exceptions happen automatically in Solidi
 
 1. If you access an array at a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
 2. If you access a fixed-length ``bytesN`` at a too large or negative index.
-3. If you call a function via a message call but it does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.  The low level operations never throw exceptions but indicate failures by return values being ``false``.
-4. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
-5. If you perform an external function call targeting a contract that contains no code.
-6. If you call a contract-creation using the ``new`` keyword but it does not finish properly.
-7. If your contract receives Ether on a public function without ``payable`` modifier (including the constructor and the fallback function).
-8. If your contract receives Ether on a public variable access.
+3. If you call a function via a message call but it does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.  The low level operations never throw exceptions but indicate failures by returning ``false``.
+4. If you create a contract using the ``new`` keyword but the contract creation does not finish properly (see above for the definition of "not finish properly").
+5. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
+6. If you perform an external function call targeting a contract that contains no code.
+7. If your contract receives Ether via a public function without ``payable`` modifier (including the constructor and the fallback function).
+8. If your contract receives Ether via a public accessor function.
 
 Internally, Solidity performs an "invalid jump" when an exception is thrown and thus causes the EVM to revert all changes made to the state. The reason for this is that there is no safe way to continue execution, because an expected effect did not occur. Because we want to retain the atomicity of transactions, the safest thing to do is to revert all changes and make the whole transaction (or at least call) without effect.
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -324,8 +324,8 @@ In the following example, we show how ``throw`` can be used to easily revert an 
 
 Currently, there are situations, where exceptions happen automatically in Solidity:
 
-1. If you access an array on a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
-2. If you access a fixed-length ``bytesN`` on a too large or negative index.
+1. If you access an array at a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
+2. If you access a fixed-length ``bytesN`` at a too large or negative index.
 3. If you call a function via a message call but it does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.  The low level operations never throw exceptions but indicate failures by return values being ``false``.
 4. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
 5. If you perform an external function call targeting a contract that contains no code.

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -322,17 +322,16 @@ In the following example, we show how ``throw`` can be used to easily revert an 
         }
     }
 
-Currently, there are six situations, where exceptions happen automatically in Solidity:
+Currently, there are situations, where exceptions happen automatically in Solidity:
 
 1. If you access an array on a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
-2. If you access a fixed-length ``bytes`` on a too large or negative index.
-3. If a function called via a message call does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.
-4. If a non-existent function on a library is called
-5. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
-6. If you perform an external function call targeting a contract that contains no code.
-7. If a contract-creation call using the ``new`` keyword does not finish properly.
-8. If a contract is called but there are no matching interface or fallback function.
-9. If Ether is sent to a contract interface function without ``payable`` modifier (including the constructor and the fallback function)
+2. If you access a fixed-length ``bytesN`` on a too large or negative index.
+3. If you call a function via a message call but it does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.  The low level operations never throw exceptions but indicate failures by return values being ``false``.
+4. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
+5. If you perform an external function call targeting a contract that contains no code.
+6. If you call a contract-creation using the ``new`` keyword but it does not finish properly.
+7. If your contract receives Ether on a public function without ``payable`` modifier (including the constructor and the fallback function).
+8. If your contract receives Ether on a public variable access.
 
 Internally, Solidity performs an "invalid jump" when an exception is thrown and thus causes the EVM to revert all changes made to the state. The reason for this is that there is no safe way to continue execution, because an expected effect did not occur. Because we want to retain the atomicity of transactions, the safest thing to do is to revert all changes and make the whole transaction (or at least call) without effect.
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -324,12 +324,14 @@ In the following example, we show how ``throw`` can be used to easily revert an 
 
 Currently, there are six situations, where exceptions happen automatically in Solidity:
 
-1. If you access an array beyond its length (i.e. ``x[i]`` where ``i >= x.length``).
-2. If a function called via a message call does not finish properly (i.e. it runs out of gas or throws an exception itself).
-3. If a non-existent function on a library is called or Ether is sent to a library.
-4. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
-5. If you perform an external function call targeting a contract that contains no code.
-6. If a contract-creation call using the ``new`` keyword fails.
+1. If you access an array on or beyond its length (i.e. ``x[i]`` where ``i >= x.length``) or below zero.
+2. If you access a fixed-length bytes on or beyond its length, or below zero.
+3. If a function called via a message call does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.
+4. If a non-existent function on a library is called or Ether is sent to a library.
+5. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
+6. If you perform an external function call targeting a contract that contains no code.
+7. If a contract-creation call using the ``new`` keyword does not finish properly.
+8. If a contract is called but there are no matching interface or fallback function.
 
 Internally, Solidity performs an "invalid jump" when an exception is thrown and thus causes the EVM to revert all changes made to the state. The reason for this is that there is no safe way to continue execution, because an expected effect did not occur. Because we want to retain the atomicity of transactions, the safest thing to do is to revert all changes and make the whole transaction (or at least call) without effect.
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -324,8 +324,8 @@ In the following example, we show how ``throw`` can be used to easily revert an 
 
 Currently, there are six situations, where exceptions happen automatically in Solidity:
 
-1. If you access an array on or beyond its length (i.e. ``x[i]`` where ``i >= x.length``) or below zero.
-2. If you access a fixed-length bytes on or beyond its length, or below zero.
+1. If you access an array on a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
+2. If you access a fixed-length bytes on a too large or negative index.
 3. If a function called via a message call does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.
 4. If a non-existent function on a library is called or Ether is sent to a library.
 5. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -325,7 +325,7 @@ In the following example, we show how ``throw`` can be used to easily revert an 
 Currently, there are six situations, where exceptions happen automatically in Solidity:
 
 1. If you access an array on a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
-2. If you access a fixed-length bytes on a too large or negative index.
+2. If you access a fixed-length ``bytes`` on a too large or negative index.
 3. If a function called via a message call does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.
 4. If a non-existent function on a library is called or Ether is sent to a library.
 5. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -327,11 +327,12 @@ Currently, there are six situations, where exceptions happen automatically in So
 1. If you access an array on a too large or negative index (i.e. ``x[i]`` where ``i >= x.length`` or ``i < 0``).
 2. If you access a fixed-length ``bytes`` on a too large or negative index.
 3. If a function called via a message call does not finish properly (i.e. it runs out of gas, has no matching function, or throws an exception itself), except when a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` is used.
-4. If a non-existent function on a library is called or Ether is sent to a library.
+4. If a non-existent function on a library is called
 5. If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).
 6. If you perform an external function call targeting a contract that contains no code.
 7. If a contract-creation call using the ``new`` keyword does not finish properly.
 8. If a contract is called but there are no matching interface or fallback function.
+9. If Ether is sent to a contract interface function without ``payable`` modifier (including the constructor and the fallback function)
 
 Internally, Solidity performs an "invalid jump" when an exception is thrown and thus causes the EVM to revert all changes made to the state. The reason for this is that there is no safe way to continue execution, because an expected effect did not occur. Because we want to retain the atomicity of transactions, the safest thing to do is to revert all changes and make the whole transaction (or at least call) without effect.
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -65,11 +65,12 @@ A Solidity contract throws an exception for unhealthy operations such as
 - division by zero
 - modulo by zero
 - out-of-bounds index access on an array
-- out-of-bounds index access on a fixed length bytes
-- a Ether transfer seen by a function without ``payable`` mofifier except when the function is a library function
+- out-of-bounds index access on a fixed-length bytes
+- an Ether transfer through an interface function that is not specified as ``payable``
 - execution of ``throw;``
-- a contract invocation with no matching interface function or a fallback function
-- an external call in an exceptional state, for instance, out of gas, invalid jump destination, and so on (however, low level ``call``, ``send``, ``delegatecall`` and ``callcode`` just return zero for such cases).
+- a contract invocation with no matching interface or fallback function
+- an external call in an exceptional state, for instance, out of gas, invalid jump destination, and so on (however, low level ``call``, ``send``, ``delegatecall`` and ``callcode`` just return zero for such cases)
+- an external call on a Solidity contract that throws (again, if the external call is made through a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` the caller does not throw an exception but just sees a zero return value by default)
 
 
 *****************

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -60,13 +60,13 @@ The position of ``data[4][9].b`` is at ``keccak256(uint256(9) . keccak256(uint25
 When Solidity Throws
 ********************
 
-Solidity contract throws an exception for unhealthy operations such as
+A Solidity contract throws an exception for unhealthy operations such as
 
 - division by zero
 - modulo by zero
-- out-of-bounds access on a fixed bytes value
-- out-of-bounds access on an array
-- a positive value seen by a function without ``payable`` mofifier except when the function is a library function
+- out-of-bounds index access on an array
+- out-of-bounds index access on a fixed length bytes
+- a Ether transfer seen by a function without ``payable`` mofifier except when the function is a library function
 - execution of ``throw;``
 - a contract invocation with no matching interface function or a fallback function
 - an external call in an exceptional state, for instance, out of gas, invalid jump destination, and so on (however, low level ``call``, ``send``, ``delegatecall`` and ``callcode`` just return zero for such cases).

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -56,6 +56,22 @@ So for the following contract snippet::
 
 The position of ``data[4][9].b`` is at ``keccak256(uint256(9) . keccak256(uint256(4) . uint256(1))) + 1``.
 
+********************
+When Solidity Throws
+********************
+
+Solidity contract throws an exception for unhealthy operations such as
+
+- division by zero
+- modulo by zero
+- out-of-bounds access on a fixed bytes value
+- out-of-bounds access on an array
+- a positive value seen by a function without ``payable`` mofifier except when the function is a library function
+- execution of ``throw;``
+- a contract invocation with no matching interface function or a fallback function
+- an external call in an exceptional state, for instance, out of gas, invalid jump destination, and so on (however, low level ``call``, ``send``, ``delegatecall`` and ``callcode`` just return zero for such cases).
+
+
 *****************
 Esoteric Features
 *****************

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -56,23 +56,6 @@ So for the following contract snippet::
 
 The position of ``data[4][9].b`` is at ``keccak256(uint256(9) . keccak256(uint256(4) . uint256(1))) + 1``.
 
-********************
-When Solidity Throws
-********************
-
-A Solidity contract throws an exception for unhealthy operations such as
-
-- division by zero
-- modulo by zero
-- out-of-bounds index access on an array
-- out-of-bounds index access on a fixed-length bytes
-- an Ether transfer through an interface function that is not specified as ``payable``
-- execution of ``throw;``
-- a contract invocation with no matching interface or fallback function
-- an external call in an exceptional state, for instance, out of gas, invalid jump destination, and so on (however, low level ``call``, ``send``, ``delegatecall`` and ``callcode`` just return zero for such cases)
-- an external call on a Solidity contract that throws (again, if the external call is made through a low level operation ``call``, ``send``, ``delegatecall`` or ``callcode`` the caller does not throw an exception but just sees a zero return value by default)
-
-
 *****************
 Esoteric Features
 *****************


### PR DESCRIPTION
This PR adds a list of runtime exceptions that Solidity compiler produces.  This PR is split from #1091.
