### PR TITLE
Proper type checking for bound functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Features:
 
 Bugfixes:
  * Disallow unknown options in `solc`
+ * Proper type checking for bound functions.
  * Code Generator: expect zero stack increase after `super` as an expression
  * Inline assembly: support the `address` opcode
  * Inline assembly: fix parsing of assignment after a label.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -241,7 +241,8 @@ MemberList::MemberMap Type::boundFunctions(Type const& _type, ContractDefinition
 				seenFunctions.insert(function);
 				FunctionType funType(*function, false);
 				if (auto fun = funType.asMemberFunction(true, true))
-					members.push_back(MemberList::Member(function->name(), fun, function));
+					if (_type.isImplicitlyConvertibleTo(*fun->selfType()))
+						members.push_back(MemberList::Member(function->name(), fun, function));
 			}
 		}
 	return members;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2069,6 +2069,9 @@ TypePointer FunctionType::copyAndSetGasOrValue(bool _setGas, bool _setValue) con
 
 FunctionTypePointer FunctionType::asMemberFunction(bool _inLibrary, bool _bound) const
 {
+	if (_bound && m_parameterTypes.empty())
+		return FunctionTypePointer();
+
 	TypePointers parameterTypes;
 	for (auto const& t: m_parameterTypes)
 	{

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -872,7 +872,12 @@ public:
 		m_isConstant(_isConstant),
 		m_isPayable(_isPayable),
 		m_declaration(_declaration)
-	{}
+	{
+		solAssert(
+			!m_bound || !m_parameterTypes.empty(),
+			"Attempted construction of bound function without self type"
+		);
+	}
 
 	TypePointers parameterTypes() const;
 	std::vector<std::string> parameterNames() const;
@@ -940,8 +945,9 @@ public:
 	/// removed and the location of reference types is changed from CallData to Memory.
 	/// This is needed if external functions are called on other contracts, as they cannot return
 	/// dynamic values.
+	/// Returns empty shared pointer on a failure. Namely, if a bound function has no parameters.
 	/// @param _inLibrary if true, uses DelegateCall as location.
-	/// @param _bound if true, the argumenst are placed as `arg1.functionName(arg2, ..., argn)`.
+	/// @param _bound if true, the arguments are placed as `arg1.functionName(arg2, ..., argn)`.
 	FunctionTypePointer asMemberFunction(bool _inLibrary, bool _bound = false) const;
 
 private:

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4020,6 +4020,25 @@ BOOST_AUTO_TEST_CASE(invalid_array_as_statement)
 	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(using_directive_for_missing_selftype)
+{
+	char const* text = R"(
+		library B {
+			function b() {}
+		}
+
+		contract A {
+			using B for bytes;
+
+			function a() {
+				bytes memory x;
+				x.b();
+			}
+		}
+	)";
+	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixes #561 and #1216.

The reason this is becoming increasingly complex is that when a `FunctionType` is bound, `parameterTypes()`, `parameterNames()`, etc. will skip the first argument without validation.
