### PR TITLE
Add a null-pointer check

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -574,7 +574,11 @@ bool RationalNumberType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	{
 		FixedBytesType const& fixedBytes = dynamic_cast<FixedBytesType const&>(_convertTo);
 		if (!isFractional())
-			return fixedBytes.numBytes() * 8 >= integerType()->numBits();
+		{
+			if (integerType())
+				return fixedBytes.numBytes() * 8 >= integerType()->numBits();
+			return false;
+		}
 		else
 			return false;
 	}


### PR DESCRIPTION
Fixes #1150.

After the change, the crashing example

```
 contract A {
     function a() {
            bytes32 s = 0x10000000000000000000000000000000000000000000000000000000000000000;
     }
 }
```

produces an error message

```
crash.sol:3:13: Error: Type int_const 115792089237316195423570985008687907853269984665640564039457584007913129639936 is not implicitly convertible to expected type bytes32.
            bytes32 s = 0x10000000000000000000000000000000000000000000000000000000000000000;
            ^-----------------------------------------------------------------------------^
```
