### PR TITLE
Add import remapping documentation to `solc --help`

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -401,7 +401,10 @@ Usage: solc [options] [input_file...]
 Compiles the given Solidity input files (or the standard input if none given or
 "-" is used as a file name) and outputs the components specified in the options
 at standard output or in files in the output directory, if specified.
-Example: solc --bin -o /tmp/solcoutput contract.sol
+Imports are automatically read from the filesystem, but it is also possible to
+remap paths using the context:prefix=path syntax.
+Example:
+    solc --bin -o /tmp/solcoutput dapp-bin=/usr/local/lib/dapp-bin contract.sol
 
 Allowed options)",
 		po::options_description::m_default_line_length,


### PR DESCRIPTION
Derived from the docs found [here](https://solidity.readthedocs.io/en/develop/miscellaneous.html#using-the-commandline-compiler).
Fixes #1207.
