### PR TITLE
LLL: move broken parsing of Ethereum subunits to macros

### DIFF
--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -69,6 +69,10 @@ void CompilerState::populateStandard()
 	"(def 'ripemd160 (data datasize) (msg allgas 3 0 data datasize))"
 	"(def 'sha256 (val) { [0]:val (sha256 0 32) })"
 	"(def 'ripemd160 (val) { [0]:val (ripemd160 0 32) })"
+	"(def 'wei 1)"
+	"(def 'szabo 1000000000000)"
+	"(def 'finney 1000000000000000)"
+	"(def 'ether 1000000000000000000)"
 	"}";
 	CodeFragment::compile(s, *this);
 }

--- a/liblll/Parser.cpp
+++ b/liblll/Parser.cpp
@@ -96,19 +96,13 @@ void dev::eth::parseTreeLLL(string const& _s, sp::utree& o_out)
 	using symbol_type = sp::basic_string<std::string, sp::utree_type::symbol_type>;
 	using it = string::const_iterator;
 
-	static const u256 ether = u256(1000000000) * 1000000000;
-	static const u256 finney = u256(1000000000) * 1000000;
-	static const u256 szabo = u256(1000000000) * 1000;
-
 	qi::rule<it, space_type, sp::utree()> element;
 	qi::rule<it, string()> str = '"' > qi::lexeme[+(~qi::char_(std::string("\"") + '\0'))] > '"';
 	qi::rule<it, string()> strsh = '\'' > qi::lexeme[+(~qi::char_(std::string(" ;$@()[]{}:\n\t") + '\0'))];
 	qi::rule<it, symbol_type()> symbol = qi::lexeme[+(~qi::char_(std::string(" $@[]{}:();\"\x01-\x1f\x7f") + '\0'))];
 	qi::rule<it, string()> intstr = qi::lexeme[ qi::no_case["0x"][qi::_val = "0x"] >> *qi::char_("0-9a-fA-F")[qi::_val += qi::_1]] | qi::lexeme[+qi::char_("0-9")[qi::_val += qi::_1]];
 	qi::rule<it, bigint()> integer = intstr;
-	qi::rule<it, bigint()> multiplier = qi::lit("wei")[qi::_val = 1] | qi::lit("szabo")[qi::_val = szabo] | qi::lit("finney")[qi::_val = finney] | qi::lit("ether")[qi::_val = ether];
-	qi::rule<it, space_type, bigint()> quantity = integer[qi::_val = qi::_1] >> -multiplier[qi::_val *= qi::_1];
-	qi::rule<it, space_type, sp::utree()> atom = quantity[qi::_val = px::construct<sp::any_ptr>(px::new_<bigint>(qi::_1))] | (str | strsh)[qi::_val = qi::_1] | symbol[qi::_val = qi::_1];
+	qi::rule<it, space_type, sp::utree()> atom = integer[qi::_val = px::construct<sp::any_ptr>(px::new_<bigint>(qi::_1))] | (str | strsh)[qi::_val = qi::_1] | symbol[qi::_val = qi::_1];
 	qi::rule<it, space_type, sp::utree::list_type()> seq = '{' > *element > '}';
 	qi::rule<it, space_type, sp::utree::list_type()> mload = '@' > element;
 	qi::rule<it, space_type, sp::utree::list_type()> sload = qi::lit("@@") > element;


### PR DESCRIPTION
Fixes #1197.

This is a breaking change. Current parser zealously will replace all `<number> szabo` occurences (even replacing `1 szabounit` with `1000000000000 unit`).

The new syntax with macros is `(* 1 szabo)`.
