### PR TITLE
Add jsoncpp-devel to Fedora dependencies

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -242,7 +242,8 @@ case $(uname -s) in
                     gcc \
                     gcc-c++ \
                     git \
-                    libtool
+                    libtool \
+                    jsoncpp-devel
 
                 ;;
 


### PR DESCRIPTION
Without this dependency installed, the cmake step of the build fails.
