### PR TITLE
Docs: Change contract init with value section to be solc 0.4.0 compatible.

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -709,10 +709,12 @@ How do I initialize a contract with only a specific amount of wei?
 Currently the approach is a little ugly, but there is little that can be done to improve it.
 In the case of a ``contract A`` calling a new instance of ``contract B``, parentheses have to be used around
 ``new B`` because ``B.value`` would refer to a member of ``B`` called ``value``.
-You will need to make sure that you have both contracts aware of each other's presence.
+You will need to make sure that you have both contracts aware of each other's presence and that ``contract B`` has a ``payable`` constructor.
 In this example::
 
-    contract B {}
+    contract B {
+        function B() payable {}
+    }
 
 
     contract A {


### PR DESCRIPTION
After solidity 0.4.0 we need to make the constructor `payable` if we are
to provide value during contract creation.
