### PR TITLE
ast: super contract type does not contain native members

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Features:
 Bugfixes:
  * Disallow unknown options in ``solc``.
  * Proper type checking for bound functions.
+ * Type Checker: ``super.x`` does not look up ``x`` in the current contract.
  * Code Generator: expect zero stack increase after `super` as an expression.
  * Inline assembly: support the ``address`` opcode.
  * Inline assembly: fix parsing of assignment after a label.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -23,6 +23,7 @@
 #include <libsolidity/ast/Types.h>
 #include <limits>
 #include <boost/range/adaptor/reversed.hpp>
+#include <boost/range/adaptor/sliced.hpp>
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/CommonData.h>
 #include <libdevcore/SHA3.h>
@@ -1325,13 +1326,9 @@ MemberList::MemberMap ContractType::nativeMembers(ContractDefinition const*) con
 	{
 		// add the most derived of all functions which are visible in derived contracts
 		auto bases = m_contract.annotation().linearizedBaseContracts;
-		if (bases.size() < 1)
-			BOOST_THROW_EXCEPTION(
-				InternalCompilerError() <<
-				errinfo_comment("linearizedBaseContracts should at least contain the most derived contract.")
-			);
-		bases.erase(bases.begin()); // Remove the most derived contract, which should not be searchable from `super`.
-		for (ContractDefinition const* base: bases)
+		solAssert(bases.size() >= 1, "linearizedBaseContracts should at least contain the most derived contract.");
+		// `sliced(1, ...)` ignores the most derived contract, which should not be searchable from `super`.
+		for (ContractDefinition const* base: bases | boost::adaptors::sliced(1, bases.size()))
 			for (FunctionDefinition const* function: base->definedFunctions())
 			{
 				if (!function->isVisibleInDerivedContracts())

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1324,7 +1324,14 @@ MemberList::MemberMap ContractType::nativeMembers(ContractDefinition const*) con
 	if (m_super)
 	{
 		// add the most derived of all functions which are visible in derived contracts
-		for (ContractDefinition const* base: m_contract.annotation().linearizedBaseContracts)
+		auto bases = m_contract.annotation().linearizedBaseContracts;
+		if (bases.size() < 1)
+			BOOST_THROW_EXCEPTION(
+				InternalCompilerError() <<
+				errinfo_comment("linearizedBaseContracts should at least contain the most derived contract.")
+			);
+		bases.erase(bases.begin()); // Remove the most derived contract, which should not be searchable from `super`.
+		for (ContractDefinition const* base: bases)
 			for (FunctionDefinition const* function: base->definedFunctions())
 			{
 				if (!function->isVisibleInDerivedContracts())

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -854,6 +854,23 @@ BOOST_AUTO_TEST_CASE(implicit_base_to_derived_conversion)
 	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(super_excludes_current_contract)
+{
+	char const* text = R"(
+		contract A {
+			function b() {}
+		}
+
+		contract B is A {
+			function f() {
+				super.f();
+			}
+		}
+	)";
+
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_CASE(function_modifier_invocation)
 {
 	char const* text = R"(


### PR DESCRIPTION
When members are sought for a contract whose type is super, the result should not contain the members of the derived contract.

Fixes #1151
