### PR TITLE
Add enums as inheritable members

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Bugfixes:
  * Disallow unknown options in ``solc``.
  * Proper type checking for bound functions.
  * Code Generator: expect zero stack increase after `super` as an expression.
+ * Allow inheritance of ``enum`` definitions.
  * Inline assembly: support the ``address`` opcode.
  * Inline assembly: fix parsing of assignment after a label.
  * Inline assembly: external variables of unsupported type (such as ``this``, ``super``, etc.)

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -204,6 +204,9 @@ vector<Declaration const*> const& ContractDefinition::inheritableMembers() const
 
 		for (StructDefinition const* s: definedStructs())
 			addInheritableMember(s);
+
+		for (EnumDefinition const* e: definedEnums())
+			addInheritableMember(e);
 	}
 	return *m_inheritableMembers;
 }

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -189,6 +189,7 @@ vector<Declaration const*> const& ContractDefinition::inheritableMembers() const
 		m_inheritableMembers.reset(new vector<Declaration const*>());
 		auto addInheritableMember = [&](Declaration const* _decl)
 		{
+			solAssert(_decl, "addInheritableMember got a nullpointer.");
 			if (memberSeen.count(_decl->name()) == 0 && _decl->isVisibleInDerivedContracts())
 			{
 				memberSeen.insert(_decl->name());

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -3314,6 +3314,57 @@ BOOST_AUTO_TEST_CASE(using_enums)
 	BOOST_CHECK(callContractFunction("getChoice()") == encodeArgs(2));
 }
 
+BOOST_AUTO_TEST_CASE(using_contract_enums_with_explicit_contract_name)
+{
+	char const* sourceCode = R"(
+			contract test {
+				enum Choice { A, B, C }
+				function answer () returns (test.Choice _ret)
+				{
+					_ret = test.Choice.B;
+				}
+			}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("answer()") == encodeArgs(1));
+}
+
+BOOST_AUTO_TEST_CASE(using_inherited_enum)
+{
+	char const* sourceCode = R"(
+			contract base {
+				enum Choice { A, B, C }
+			}
+
+			contract test is base {
+				function answer () returns (Choice _ret)
+				{
+					_ret = Choice.B;
+				}
+			}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("answer()") == encodeArgs(1));
+}
+
+BOOST_AUTO_TEST_CASE(using_inherited_enum_excplicitly)
+{
+	char const* sourceCode = R"(
+			contract base {
+				enum Choice { A, B, C }
+			}
+
+			contract test is base {
+				function answer () returns (base.Choice _ret)
+				{
+					_ret = base.Choice.B;
+				}
+			}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("answer()") == encodeArgs(1));
+}
+
 BOOST_AUTO_TEST_CASE(constructing_enums_from_ints)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1500,6 +1500,23 @@ BOOST_AUTO_TEST_CASE(enum_duplicate_values)
 	BOOST_CHECK(expectError(text) == Error::Type::DeclarationError);
 }
 
+BOOST_AUTO_TEST_CASE(enum_name_resolution_under_current_contract_name)
+{
+	char const* text = R"(
+		contract A {
+			enum Foo {
+				First,
+				Second
+			}
+
+			function a() {
+				A.Foo;
+			}
+		}
+	)";
+	BOOST_CHECK(success(text));
+}
+
 BOOST_AUTO_TEST_CASE(private_visibility)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1439,6 +1439,21 @@ BOOST_AUTO_TEST_CASE(enum_invalid_member_access)
 	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(enum_invalid_direct_member_access)
+{
+	char const* text = R"(
+			contract test {
+				enum ActionChoices { GoLeft, GoRight, GoStraight, Sit }
+				function test()
+				{
+					choices = Sit;
+				}
+				ActionChoices choices;
+			}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::DeclarationError);
+}
+
 BOOST_AUTO_TEST_CASE(enum_explicit_conversion_is_okay)
 {
 	char const* text = R"(


### PR DESCRIPTION
Since `struct` definitions can be inherited, `enum` definitions should also be inheritable.

This fixes #1131.
