### PR TITLE
`super`'s size on stack is zero

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Features:
 
 Bugfixes:
  * Disallow unknown options in `solc`
+ * Code Generator: expect zero stack increase after `super` as an expression
  * Inline assembly: support the `address` opcode
  * Inline assembly: fix parsing of assignment after a label.
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -623,6 +623,7 @@ public:
 	}
 	virtual unsigned storageBytes() const override { return 20; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
+	virtual unsigned sizeOnStack() const override { return m_super ? 0 : 1; }
 	virtual bool isValueType() const override { return true; }
 	virtual std::string toString(bool _short) const override;
 	virtual std::string canonicalName(bool _addDataLocation) const override;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2513,6 +2513,15 @@ BOOST_AUTO_TEST_CASE(super_in_constructor)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(1 | 2 | 4 | 8));
 }
 
+BOOST_AUTO_TEST_CASE(super_alone)
+{
+	char const* sourceCode = R"(
+		contract A { function f() { super; } }
+	)";
+	compileAndRun(sourceCode, 0, "A");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs());
+}
+
 BOOST_AUTO_TEST_CASE(fallback_function)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
because the expression compiler does not push anything onto stack when it sees `super`.
