### PR TITLE
Allow multiple events of the same name

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ Features:
  * Code generator: Inject the Swarm hash of a metadata file into the bytecode.
  * Code generator: Replace expensive memcpy precompile by simple assembly loop.
  * Optimizer: Some dead code elimination.
+ * Type checker: Allow multiple events of the same name (but with different arities or argument types)
 
 Bugfixes:
  * Code generator: throw if calling the identity precompile failed during memory (array) copying.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
  * AST: Use deterministic node identifiers.
  * Type system: Introduce type identifier strings.
  * Metadata: Do not include platform in the version number.
+ * Type checker: Allow multiple events of the same name (but with different arities or argument types)
 
 ### 0.4.8 (2017-01-13)
 
@@ -26,7 +27,6 @@ Features:
  * Code generator: Inject the Swarm hash of a metadata file into the bytecode.
  * Code generator: Replace expensive memcpy precompile by simple assembly loop.
  * Optimizer: Some dead code elimination.
- * Type checker: Allow multiple events of the same name (but with different arities or argument types)
 
 Bugfixes:
  * Code generator: throw if calling the identity precompile failed during memory (array) copying.

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -58,6 +58,13 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 			return declaration;
 		}
 	}
+	else if (dynamic_cast<EventDefinition const*>(&_declaration))
+	{
+		// check that all other declarations with the same name are events
+		for (Declaration const* declaration: declarations)
+			if (!dynamic_cast<EventDefinition const*>(declaration))
+				return declaration;
+	}
 	else if (declarations.size() == 1 && declarations.front() == &_declaration)
 		return nullptr;
 	else if (!declarations.empty())

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -42,28 +42,25 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 	if (m_invisibleDeclarations.count(*_name))
 		declarations += m_invisibleDeclarations.at(*_name);
 
-	if (dynamic_cast<FunctionDefinition const*>(&_declaration))
+	if (dynamic_cast<FunctionDefinition const*>(&_declaration) ||
+		dynamic_cast<EventDefinition const*>(&_declaration)
+		)
 	{
-		// check that all other declarations with the same name are functions or a public state variable
+		// check that all other declarations with the same name are functions or a public state variable or events.
+		// And then check that the signatures are different.
 		for (Declaration const* declaration: declarations)
 		{
-			if (dynamic_cast<FunctionDefinition const*>(declaration))
-				continue;
 			if (auto variableDeclaration = dynamic_cast<VariableDeclaration const*>(declaration))
 			{
 				if (variableDeclaration->isStateVariable() && !variableDeclaration->isConstant() && variableDeclaration->isPublic())
 					continue;
 				return declaration;
 			}
-			return declaration;
-		}
-	}
-	else if (dynamic_cast<EventDefinition const*>(&_declaration))
-	{
-		// check that all other declarations with the same name are events
-		for (Declaration const* declaration: declarations)
-			if (!dynamic_cast<EventDefinition const*>(declaration))
+			if (!dynamic_cast<FunctionDefinition const*>(declaration) &&
+				!dynamic_cast<EventDefinition const*>(declaration))
 				return declaration;
+			// Or, continue.
+		}
 	}
 	else if (declarations.size() == 1 && declarations.front() == &_declaration)
 		return nullptr;

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -58,7 +58,12 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 				return declaration;
 			}
 			if (
-				!dynamic_cast<FunctionDefinition const*>(declaration) &&
+				dynamic_cast<FunctionDefinition const*>(&_declaration) &&
+				!dynamic_cast<FunctionDefinition const*>(declaration)
+			)
+				return declaration;
+			if (
+				dynamic_cast<EventDefinition const*>(&_declaration) &&
 				!dynamic_cast<EventDefinition const*>(declaration)
 			)
 				return declaration;

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -42,9 +42,10 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 	if (m_invisibleDeclarations.count(*_name))
 		declarations += m_invisibleDeclarations.at(*_name);
 
-	if (dynamic_cast<FunctionDefinition const*>(&_declaration) ||
+	if (
+		dynamic_cast<FunctionDefinition const*>(&_declaration) ||
 		dynamic_cast<EventDefinition const*>(&_declaration)
-		)
+	)
 	{
 		// check that all other declarations with the same name are functions or a public state variable or events.
 		// And then check that the signatures are different.
@@ -56,8 +57,10 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 					continue;
 				return declaration;
 			}
-			if (!dynamic_cast<FunctionDefinition const*>(declaration) &&
-				!dynamic_cast<EventDefinition const*>(declaration))
+			if (
+				!dynamic_cast<FunctionDefinition const*>(declaration) &&
+				!dynamic_cast<EventDefinition const*>(declaration)
+			)
 				return declaration;
 			// Or, continue.
 		}

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -260,8 +260,8 @@ vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 	for (auto it = _declarations.begin(); it != _declarations.end(); ++it)
 	{
 		solAssert(*it, "");
-		// the declaration is functionDefinition or a VariableDeclaration while declarations > 1
-		solAssert(dynamic_cast<FunctionDefinition const*>(*it) || dynamic_cast<VariableDeclaration const*>(*it),
+		// the declaration is functionDefinition, eventDefinition or a VariableDeclaration while declarations > 1
+		solAssert(dynamic_cast<FunctionDefinition const*>(*it) || dynamic_cast<EventDefinition const*>(*it) || dynamic_cast<VariableDeclaration const*>(*it),
 			"Found overloading involving something not a function or a variable");
 
 		shared_ptr<FunctionType const> functionType { (*it)->functionType(false) };

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2800,35 +2800,38 @@ BOOST_AUTO_TEST_CASE(events_with_same_name)
 			event Deposit;
 			event Deposit(address _addr);
 			event Deposit(address _addr, uint _amount);
-			function deposit() {
+			function deposit() returns (uint) {
 				Deposit();
+				return 1;
 			}
-			function deposit(address _addr) {
+			function deposit(address _addr) returns (uint) {
 				Deposit(_addr);
+				return 1;
 			}
-			function deposit(address _addr, uint _amount) {
+			function deposit(address _addr, uint _amount) returns (uint) {
 				Deposit(_addr, _amount);
+				return 1;
 			}
 		}
 	)";
 	u160 const c_loggedAddress = m_contractAddress;
 
 	compileAndRun(sourceCode);
-	callContractFunction("deposit()");
+	BOOST_CHECK(callContractFunction("deposit()") == encodeArgs(u256(1)));
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
 	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
 	BOOST_CHECK(m_logs[0].data.empty());
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit()")));
 
-	callContractFunction("deposit(address)", c_loggedAddress);
+	BOOST_CHECK(callContractFunction("deposit(address)", c_loggedAddress) == encodeArgs(u256(1)));
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[1].address, m_contractAddress);
 	BOOST_CHECK(m_logs[1].data == encodeArgs(c_loggedAddress));
 	BOOST_REQUIRE_EQUAL(m_logs[1].topics.size(), 1);
 	BOOST_CHECK_EQUAL(m_logs[1].topics[0], dev::keccak256(string("Deposit(address)")));
 
-	callContractFunction("deposit(address, uint256)", c_loggedAddress, u256(100));
+	BOOST_CHECK(callContractFunction("deposit(address,uint256)", c_loggedAddress, u256(100)) == encodeArgs(u256(1)));
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 3);
 	BOOST_CHECK_EQUAL(m_logs[2].address, m_contractAddress);
 	BOOST_CHECK(m_logs[2].data == encodeArgs(c_loggedAddress, 100));

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2839,6 +2839,58 @@ BOOST_AUTO_TEST_CASE(events_with_same_name)
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(address,uint256)")));
 }
 
+BOOST_AUTO_TEST_CASE(events_with_same_name_inherited)
+{
+	char const* sourceCode = R"(
+		contract A {
+			event Deposit;
+		}
+
+		contract B {
+			event Deposit(address _addr);
+		}
+
+		contract ClientReceipt is A, B {
+			event Deposit(address _addr, uint _amount);
+			function deposit() returns (uint) {
+				Deposit();
+				return 1;
+			}
+			function deposit(address _addr) returns (uint) {
+				Deposit(_addr);
+				return 1;
+			}
+			function deposit(address _addr, uint _amount) returns (uint) {
+				Deposit(_addr, _amount);
+				return 1;
+			}
+		}
+	)";
+	u160 const c_loggedAddress = m_contractAddress;
+
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("deposit()") == encodeArgs(u256(1)));
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_CHECK(m_logs[0].data.empty());
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit()")));
+
+	BOOST_CHECK(callContractFunction("deposit(address)", c_loggedAddress) == encodeArgs(u256(1)));
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_CHECK(m_logs[0].data == encodeArgs(c_loggedAddress));
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(address)")));
+
+	BOOST_CHECK(callContractFunction("deposit(address,uint256)", c_loggedAddress, u256(100)) == encodeArgs(u256(1)));
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_CHECK(m_logs[0].data == encodeArgs(c_loggedAddress, 100));
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(address,uint256)")));
+}
+
 BOOST_AUTO_TEST_CASE(event_anonymous)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2825,18 +2825,18 @@ BOOST_AUTO_TEST_CASE(events_with_same_name)
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit()")));
 
 	BOOST_CHECK(callContractFunction("deposit(address)", c_loggedAddress) == encodeArgs(u256(1)));
-	BOOST_REQUIRE_EQUAL(m_logs.size(), 2);
-	BOOST_CHECK_EQUAL(m_logs[1].address, m_contractAddress);
-	BOOST_CHECK(m_logs[1].data == encodeArgs(c_loggedAddress));
-	BOOST_REQUIRE_EQUAL(m_logs[1].topics.size(), 1);
-	BOOST_CHECK_EQUAL(m_logs[1].topics[0], dev::keccak256(string("Deposit(address)")));
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_CHECK(m_logs[0].data == encodeArgs(c_loggedAddress));
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(address)")));
 
 	BOOST_CHECK(callContractFunction("deposit(address,uint256)", c_loggedAddress, u256(100)) == encodeArgs(u256(1)));
-	BOOST_REQUIRE_EQUAL(m_logs.size(), 3);
-	BOOST_CHECK_EQUAL(m_logs[2].address, m_contractAddress);
-	BOOST_CHECK(m_logs[2].data == encodeArgs(c_loggedAddress, 100));
-	BOOST_REQUIRE_EQUAL(m_logs[2].topics.size(), 1);
-	BOOST_CHECK_EQUAL(m_logs[2].topics[0], dev::keccak256(string("Deposit(address,uint256)")));
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_CHECK(m_logs[0].data == encodeArgs(c_loggedAddress, 100));
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(address,uint256)")));
 }
 
 BOOST_AUTO_TEST_CASE(event_anonymous)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2761,6 +2761,7 @@ BOOST_AUTO_TEST_CASE(event_no_arguments)
 			}
 		}
 	)";
+
 	compileAndRun(sourceCode);
 	callContractFunction("deposit()");
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
@@ -2810,6 +2811,8 @@ BOOST_AUTO_TEST_CASE(events_with_same_name)
 			}
 		}
 	)";
+	u160 const c_loggedAddress = m_contractAddress;
+
 	compileAndRun(sourceCode);
 	callContractFunction("deposit()");
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
@@ -2818,17 +2821,17 @@ BOOST_AUTO_TEST_CASE(events_with_same_name)
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit()")));
 
-	callContractFunction("deposit(0xabcdeabcdeabcdeabcde)");
+	callContractFunction("deposit(address)", c_loggedAddress);
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[1].address, m_contractAddress);
-	BOOST_CHECK(m_logs[1].data == encodeArgs(0));
+	BOOST_CHECK(m_logs[1].data == encodeArgs(c_loggedAddress));
 	BOOST_REQUIRE_EQUAL(m_logs[1].topics.size(), 1);
 	BOOST_CHECK_EQUAL(m_logs[1].topics[0], dev::keccak256(string("Deposit(address)")));
 
-	callContractFunction("deposit(0xabcdeabcdeabcdeabcde, 100)");
+	callContractFunction("deposit(address, uint256)", c_loggedAddress, u256(100));
 	BOOST_REQUIRE_EQUAL(m_logs.size(), 3);
 	BOOST_CHECK_EQUAL(m_logs[2].address, m_contractAddress);
-	BOOST_CHECK(m_logs[2].data == encodeArgs(0,100));
+	BOOST_CHECK(m_logs[2].data == encodeArgs(c_loggedAddress, 100));
 	BOOST_REQUIRE_EQUAL(m_logs[2].topics.size(), 1);
 	BOOST_CHECK_EQUAL(m_logs[2].topics[0], dev::keccak256(string("Deposit(address,uint256)")));
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1365,6 +1365,17 @@ BOOST_AUTO_TEST_CASE(anonymous_event_too_many_indexed)
 	CHECK_ERROR(text, TypeError, "");
 }
 
+BOOST_AUTO_TEST_CASE(events_with_same_name)
+{
+	char const* text = R"(
+		contract TestIt {
+			event A();
+			event A(uint i);
+		}
+	)";
+	BOOST_CHECK(success(text));
+}
+
 BOOST_AUTO_TEST_CASE(event_call)
 {
 	char const* text = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1387,6 +1387,53 @@ BOOST_AUTO_TEST_CASE(event_call)
 	CHECK_SUCCESS(text);
 }
 
+BOOST_AUTO_TEST_CASE(event_function_inheritance_clash)
+{
+	char const* text = R"(
+		contract A {
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+		contract B {
+			event dup();
+		}
+		contract C is A, B {
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier already declared.");
+}
+
+BOOST_AUTO_TEST_CASE(function_event_inheritance_clash)
+{
+	char const* text = R"(
+		contract B {
+			event dup();
+		}
+		contract A {
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+		contract C is B, A {
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier already declared.");
+}
+
+BOOST_AUTO_TEST_CASE(function_event_in_contract_clash)
+{
+	char const* text = R"(
+		contract A {
+			event dup();
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier already declared.");
+}
+
 BOOST_AUTO_TEST_CASE(event_inheritance)
 {
 	char const* text = R"(


### PR DESCRIPTION
After this PR the compiler does not complain when there are multiple events of the same name in the scope.  The treatment is similar to functions.  This fixes #1215.
