### PR TITLE
Fix crash in throw.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,17 +9,17 @@ Features:
  * Support shifting constant numbers.
 
 Bugfixes:
- * Optimizer: fix related to stale knowledge about SHA3 operations
- * Disallow unknown options in ``solc``.
- * Proper type checking for bound functions.
- * Type Checker: ``super.x`` does not look up ``x`` in the current contract.
- * Code Generator: expect zero stack increase after `super` as an expression.
- * Allow inheritance of ``enum`` definitions.
+ * Commandline interface: Disallow unknown options in ``solc``.
+ * Name resolver: Allow inheritance of ``enum`` definitions.
+ * Type checker: Proper type checking for bound functions.
+ * Type checker: fix crash related to invalid fixed point constants
+ * Code generator: expect zero stack increase after ``super`` as an expression.
  * Inline assembly: support the ``address`` opcode.
  * Inline assembly: fix parsing of assignment after a label.
  * Inline assembly: external variables of unsupported type (such as ``this``, ``super``, etc.)
    are properly detected as unusable.
  * Inline assembly: support variables within modifiers.
+ * Optimizer: fix related to stale knowledge about SHA3 operations
 
 ### 0.4.2 (2016-09-17)
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -483,7 +483,7 @@ tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _literal
 				!all_of(radixPoint + 1, _literal.value().end(), ::isdigit) || 
 				!all_of(_literal.value().begin(), radixPoint, ::isdigit) 
 			)
-				throw;
+				return make_tuple(false, rational(0));
 			//Only decimal notation allowed here, leading zeros would switch to octal.
 			auto fractionalBegin = find_if_not(
 				radixPoint + 1, 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4088,6 +4088,18 @@ BOOST_AUTO_TEST_CASE(using_directive_for_missing_selftype)
 	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(invalid_fixed_point_literal)
+{
+	char const* text = R"(
+		contract A {
+			function a() {
+				.8E0;
+			}
+		}
+	)";
+	BOOST_CHECK(expectError(text, false) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_CASE(shift_constant_left_negative_rvalue)
 {
 	char const* text = R"(


### PR DESCRIPTION
The reason why the exception is not caught in the catch clause below is not clear to me.
