### PR TITLE
AppVeyor: build only pushes to master and develop branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,10 @@
 # (c) 2016 cpp-ethereum contributors.
 #------------------------------------------------------------------------------
 
+branches:
+  only:
+    - master
+    - develop
 os: Visual Studio 2015
 configuration:
     - RelWithDebInfo


### PR DESCRIPTION
This fixes the issue when PRs from a branch in main repo are built twice.
