### PR TITLE
Do not push code for `L` in `L.Foo`, an enum Foo defined in a library L

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * Type checker: Proper type checking for bound functions.
  * Type checker: fix crash related to invalid fixed point constants
  * Code generator: expect zero stack increase after ``super`` as an expression.
+ * Code Generator: fixed an internal compiler error for ``L.Foo`` for ``enum Foo`` defined in library ``L``.
  * Inline assembly: support the ``address`` opcode.
  * Inline assembly: fix parsing of assignment after a label.
  * Inline assembly: external variables of unsupported type (such as ``this``, ``super``, etc.)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -861,11 +861,12 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		}
 
 	// Special processing for TypeType because we do not want to visit the library itself
-	// for internal functions.
+	// for internal functions, or enum/struct definitions.
 	if (TypeType const* type = dynamic_cast<TypeType const*>(_memberAccess.expression().annotation().type.get()))
 	{
 		if (dynamic_cast<ContractType const*>(type->actualType().get()))
 		{
+			solAssert(_memberAccess.annotation().type, "_memberAccess has no type");
 			if (auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type.get()))
 			{
 				if (funType->location() != FunctionType::Location::Internal)
@@ -882,6 +883,10 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					solAssert(!!function, "Function not found in member access");
 					m_context << m_context.functionEntryLabel(*function).pushTag();
 				}
+			}
+			else if (dynamic_cast<TypeType const*>(_memberAccess.annotation().type.get()))
+			{
+				// no-op
 			}
 			else
 				_memberAccess.expression().accept(*this);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5905,6 +5905,48 @@ BOOST_AUTO_TEST_CASE(using_library_structs)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(7), u256(8)));
 }
 
+BOOST_AUTO_TEST_CASE(library_struct_as_an_expression)
+{
+	char const* sourceCode = R"(
+		library Arst {
+			struct Foo {
+				int Things;
+				int Stuff;
+			}
+		}
+
+		contract Tsra {
+			function f() returns(uint) {
+				Arst.Foo;
+				return 1;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Tsra");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(1)));
+}
+
+BOOST_AUTO_TEST_CASE(library_enum_as_an_expression)
+{
+	char const* sourceCode = R"(
+		library Arst {
+			enum Foo {
+				Things,
+				Stuff
+			}
+		}
+
+		contract Tsra {
+			function f() returns(uint) {
+				Arst.Foo;
+				return 1;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "Tsra");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(1)));
+}
+
 BOOST_AUTO_TEST_CASE(short_strings)
 {
 	// This test verifies that the byte array encoding that combines length and data works


### PR DESCRIPTION
Fixes #1116 

Before this pull-request, when a library `L` defines an enum `Foo`, an expression `L.Foo` caused the code generation to visit `L` as well as `Foo`.  This left one more element on the stack than expected.  This pull-request prevents the code generation from visiting `L` in `L.Foo`.
