### PR TITLE
Optimizer: generate code starting with empty state

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Features:
  * Support shifting constant numbers.
 
 Bugfixes:
+ * Optimizer: fix related to stale knowledge about SHA3 operations
  * Disallow unknown options in ``solc``.
  * Proper type checking for bound functions.
  * Code Generator: expect zero stack increase after `super` as an expression.

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -327,8 +327,10 @@ Assembly& Assembly::optimise(bool _enable, bool _isCreation, size_t _runs)
 			AssemblyItems optimisedItems;
 			for (BasicBlock const& block: cfg.optimisedBlocks())
 			{
-				assertThrow(!!block.startState, OptimizerException, "");
-				CommonSubexpressionEliminator eliminator(*block.startState);
+				// We used to start with the block's initial state but it caused
+				// too many inconsistencies.
+				KnownState emptyState;
+				CommonSubexpressionEliminator eliminator(emptyState);
 				auto iter = m_items.begin() + block.begin;
 				auto const end = m_items.begin() + block.end;
 				while (iter < end)


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1265
