### PR TITLE
Banning signed exp

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Features:
 
 Bugfixes:
+ * Type checker: forbid signed exponential that led to an incorrect use of EXP opcode.
 
 ### 0.4.3 (2016-10-25)
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -349,10 +349,13 @@ TypePointer IntegerType::binaryOperatorResult(Token::Value _operator, TypePointe
 		return commonType;
 	if (Token::isBooleanOp(_operator))
 		return TypePointer();
-	// Nothing else can be done with addresses
 	if (auto intType = dynamic_pointer_cast<IntegerType const>(commonType))
 	{
+		// Nothing else can be done with addresses
 		if (intType->isAddress())
+			return TypePointer();
+		// Signed EXP is not allowed
+		if (Token::Exp == _operator && intType->isSigned())
 			return TypePointer();
 	}
 	else if (auto fixType = dynamic_pointer_cast<FixedPointType const>(commonType))

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2098,6 +2098,22 @@ BOOST_AUTO_TEST_CASE(integer_boolean_operators)
 	BOOST_CHECK(expectError(sourceCode3) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(exp_signed_variable)
+{
+	char const* sourceCode1 = R"(
+		contract test { function() { uint x = 3; int y = -4; x ** y; } }
+	)";
+	BOOST_CHECK(expectError(sourceCode1) == Error::Type::TypeError);
+	char const* sourceCode2 = R"(
+		contract test { function() { uint x = 3; int y = -4; y ** x; } }
+	)";
+	BOOST_CHECK(expectError(sourceCode2) == Error::Type::TypeError);
+	char const* sourceCode3 = R"(
+		contract test { function() { int x = -3; int y = -4; x ** y; } }
+	)";
+	BOOST_CHECK(expectError(sourceCode3) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_CASE(reference_compare_operators)
 {
 	char const* sourceCode1 = R"(


### PR DESCRIPTION
Signed exponential led to a single `EXP` opcode, which was wrong.  For now this pull-request banns the signed exponential.

Fixes #1246.
