### PR TITLE
disallow inheritance overriding of variables by functions, functions by modifiers, etc (still accessors can override external functions)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Features:
  * Optimizer: Some dead code elimination.
+ * Type checker: allow state variable accessors to implement abstract functions
 
 Bugfixes:
  * Type checker: string literals that are not valid UTF-8 cannot be converted to string type

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
 
 Bugfixes:
  * Type checker: string literals that are not valid UTF-8 cannot be converted to string type
+ * Type checker, code generator: enable access to events of base contracts' names
 
 ### 0.4.6 (2016-11-22)
 

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -49,6 +49,14 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 			if (!dynamic_cast<FunctionDefinition const*>(declaration))
 				return declaration;
 	}
+	else if (dynamic_cast<EventDefinition const*>(&_declaration))
+	{
+		// Check that all other declarations with the same name are events.
+		// It is a deliberate choice that functions and events cannot share one name.
+		for (Declaration const* declaration: declarations)
+			if (!dynamic_cast<EventDefinition const*>(declaration))
+				return declaration;
+	}
 	else if (declarations.size() == 1 && declarations.front() == &_declaration)
 		return nullptr;
 	else if (!declarations.empty())

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -64,6 +64,13 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 			if (!dynamic_cast<VariableDeclaration const*>(declaration))
 				return declaration;
 	}
+	else if (dynamic_cast<ModifierDefinition const*>(&_declaration))
+	{
+		// Check that all other declarations with the same name are variables.
+		for (Declaration const* declaration: declarations)
+			if (!dynamic_cast<ModifierDefinition const*>(declaration))
+				return declaration;
+	}
 	else if (declarations.size() == 1 && declarations.front() == &_declaration)
 		return nullptr;
 	else if (!declarations.empty())

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -57,6 +57,13 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 			if (!dynamic_cast<EventDefinition const*>(declaration))
 				return declaration;
 	}
+	else if (dynamic_cast<VariableDeclaration const*>(&_declaration))
+	{
+		// Check that all other declarations with the same name are variables.
+		for (Declaration const* declaration: declarations)
+			if (!dynamic_cast<VariableDeclaration const*>(declaration))
+				return declaration;
+	}
 	else if (declarations.size() == 1 && declarations.front() == &_declaration)
 		return nullptr;
 	else if (!declarations.empty())

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -46,18 +46,24 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 	// Since functions can be overloaded even within a single contract, `_inheriting` is not checked.
 	if (dynamic_cast<FunctionDefinition const*>(&_declaration))
 	{
-		// check that all other declarations with the same name are functions
+		// check that all other declarations with the same name are functions or state variables.
 		for (Declaration const* declaration: declarations)
 			if (!dynamic_cast<FunctionDefinition const*>(declaration))
-				return declaration;
+			{
+				if (!dynamic_cast<VariableDeclaration const*>(declaration))
+					return declaration;
+				// A function definition might be clashing with a variable declaration.
+				// This is only allowed when the function definition comes from inheritance.
+				if (!_inheriting)
+					return declaration;
+			}
 	}
 	// Until we implement #1245, there are no special cases for events
 	else if (_inheriting && dynamic_cast<VariableDeclaration const*>(&_declaration))
 	{
-		// Check that all other declarations with the same name are variables or functions.
+		// Check that all other declarations with the same name are variables.
 		for (Declaration const* declaration: declarations)
-			if (!dynamic_cast<VariableDeclaration const*>(declaration) &&
-                !dynamic_cast<FunctionDefinition const*>(declaration))
+			if (!dynamic_cast<FunctionDefinition const*>(declaration))
 				return declaration;
 	}
 	else if (_inheriting && dynamic_cast<ModifierDefinition const*>(&_declaration))

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -51,14 +51,7 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 			if (!dynamic_cast<FunctionDefinition const*>(declaration))
 				return declaration;
 	}
-	else if (_inheriting && dynamic_cast<EventDefinition const*>(&_declaration))
-	{
-		// Check that all other declarations with the same name are events.
-		// It is a deliberate choice that functions and events cannot share one name.
-		for (Declaration const* declaration: declarations)
-			if (!dynamic_cast<EventDefinition const*>(declaration))
-				return declaration;
-	}
+	// Until we implement #1245, there are no special cases for events
 	else if (_inheriting && dynamic_cast<VariableDeclaration const*>(&_declaration))
 	{
 		// Check that all other declarations with the same name are variables or functions.

--- a/libsolidity/analysis/DeclarationContainer.h
+++ b/libsolidity/analysis/DeclarationContainer.h
@@ -50,12 +50,12 @@ public:
 	/// @param _invisible if true, registers the declaration, reports name clashes but does not return it in @a resolveName
 	/// @param _update if true, replaces a potential declaration that is already present
 	/// @returns false if the name was already declared.
-	bool registerDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr, bool _invisible = false, bool _update = false);
+	bool registerDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr, bool _invisible = false, bool _update = false, bool _inheriting = false);
 	std::vector<Declaration const*> resolveName(ASTString const& _name, bool _recursive = false) const;
 	ASTNode const* enclosingNode() const { return m_enclosingNode; }
 	std::map<ASTString, std::vector<Declaration const*>> const& declarations() const { return m_declarations; }
 	/// @returns whether declaration is valid, and if not also returns previous declaration.
-	Declaration const* conflictingDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr) const;
+	Declaration const* conflictingDeclaration(bool _inheriting, Declaration const& _declaration, ASTString const* _name = nullptr) const;
 
 private:
 	ASTNode const* m_enclosingNode;

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -25,6 +25,8 @@
 #include <libsolidity/analysis/TypeChecker.h>
 #include <libsolidity/interface/Exceptions.h>
 
+#include <memory>
+
 using namespace std;
 
 namespace dev
@@ -309,22 +311,42 @@ vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 	for (auto it = _declarations.begin(); it != _declarations.end(); ++it)
 	{
 		solAssert(*it, "");
-		// the declaration is functionDefinition while declarations > 1
-		solAssert(dynamic_cast<FunctionDefinition const*>(*it), "Found overloading of non-functions");
+		// the declaration is functionDefinition or a VariableDeclaration while declarations > 1
+		solAssert(dynamic_cast<FunctionDefinition const*>(*it) || dynamic_cast<VariableDeclaration const*>(*it),
+			"Found overloading involving something not a function or a variable");
 
-		FunctionDefinition const& functionDefinition = dynamic_cast<FunctionDefinition const&>(**it);
-		FunctionType functionType(functionDefinition);
-		for (auto parameter: functionType.parameterTypes() + functionType.returnParameterTypes())
-			if (!parameter)
-				reportFatalDeclarationError(_identifier.location(), "Function type can not be used in this context");
+		shared_ptr<FunctionType const> functionType {};
+
+		if (FunctionDefinition const* functionDefinition = dynamic_cast<FunctionDefinition const*>(*it))
+		{
+			functionType = make_shared<FunctionType const>(*functionDefinition);
+			for (auto parameter: functionType->parameterTypes() + functionType->returnParameterTypes())
+				if (!parameter)
+					reportFatalDeclarationError(_identifier.location(), "Function type can not be used in this context");
+		}
+		else
+		{
+			VariableDeclaration const* variableDeclaration = dynamic_cast<VariableDeclaration const*>(*it);
+			functionType = make_shared<FunctionType const>(*variableDeclaration);
+		}
+		solAssert(functionType, "failed to determine the function type of the overloaded");
 
 		if (uniqueFunctions.end() == find_if(
 			uniqueFunctions.begin(),
 			uniqueFunctions.end(),
 			[&](Declaration const* d)
 			{
-				FunctionType newFunctionType(dynamic_cast<FunctionDefinition const&>(*d));
-				return functionType.hasEqualArgumentTypes(newFunctionType);
+				if (FunctionDefinition const* functionDefinition = dynamic_cast<FunctionDefinition const*>(d))
+				{
+					FunctionType const newFunctionType(*functionDefinition);
+					return functionType->hasEqualArgumentTypes(newFunctionType);
+				}
+				else if (VariableDeclaration const* variableDeclaration = dynamic_cast<VariableDeclaration const*>(d))
+				{
+					FunctionType const newFunctionType(*variableDeclaration);
+					return functionType->hasEqualArgumentTypes(newFunctionType);
+				}
+				return false; // to make compiler happy
 			}
 		))
 			uniqueFunctions.push_back(*it);

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -302,7 +302,7 @@ void NameAndTypeResolver::reportConflict(bool _inheriting, DeclarationContainer*
 	Declaration const* conflictingDeclaration = _scope->conflictingDeclaration(_inheriting, _declaration);
 	solAssert(conflictingDeclaration, "");
 
-	if (_declaration.location().start < conflictingDeclaration->location().start)
+	if (_inheriting || _declaration.location().start < conflictingDeclaration->location().start)
 	{
 		firstDeclarationLocation = _declaration.location();
 		secondDeclarationLocation = conflictingDeclaration->location();
@@ -315,7 +315,7 @@ void NameAndTypeResolver::reportConflict(bool _inheriting, DeclarationContainer*
 
 	reportDeclarationError(
 		secondDeclarationLocation,
-		"Identifier already declared.",
+		string("Identifier already declared") + (_inheriting ? " in a base contract" : "") + ".",
 		firstDeclarationLocation,
 		"The previous declaration is here:",
 		_errors

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -315,11 +315,11 @@ vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 		solAssert(dynamic_cast<FunctionDefinition const*>(*it) || dynamic_cast<VariableDeclaration const*>(*it),
 			"Found overloading involving something not a function or a variable");
 
-		shared_ptr<FunctionType const> functionType {};
+		unique_ptr<FunctionType const> functionType {};
 
 		if (FunctionDefinition const* functionDefinition = dynamic_cast<FunctionDefinition const*>(*it))
 		{
-			functionType = make_shared<FunctionType const>(*functionDefinition);
+			functionType = unique_ptr<FunctionType const>(new FunctionType(*functionDefinition));
 			for (auto parameter: functionType->parameterTypes() + functionType->returnParameterTypes())
 				if (!parameter)
 					reportFatalDeclarationError(_identifier.location(), "Function type can not be used in this context");
@@ -327,7 +327,7 @@ vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 		else
 		{
 			VariableDeclaration const* variableDeclaration = dynamic_cast<VariableDeclaration const*>(*it);
-			functionType = make_shared<FunctionType const>(*variableDeclaration);
+			functionType = unique_ptr<FunctionType const>(new FunctionType(*variableDeclaration));
 		}
 		solAssert(functionType, "failed to determine the function type of the overloaded");
 

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -76,6 +76,9 @@ public:
 		std::vector<Declaration const*> const& _declarations
 	);
 
+	// reports a conflict of two declarations sharing a name
+	static void reportConflict(DeclarationContainer* _scope, Declaration const& _declaration, ErrorList& _errors);
+
 private:
 	void reset();
 
@@ -91,11 +94,12 @@ private:
 	static std::vector<_T const*> cThreeMerge(std::list<std::list<_T const*>>& _toMerge);
 
 	// creates the Declaration error and adds it in the errors list
-	void reportDeclarationError(
+	static void reportDeclarationError(
 		SourceLocation _sourceLoction,
 		std::string const& _description,
 		SourceLocation _secondarySourceLocation,
-		std::string const& _secondaryDescription
+		std::string const& _secondaryDescription,
+		ErrorList &_errors
 	);
 	// creates the Declaration error and adds it in the errors list
 	void reportDeclarationError(SourceLocation _sourceLocation, std::string const& _description);

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -77,7 +77,7 @@ public:
 	);
 
 	// reports a conflict of two declarations sharing a name
-	static void reportConflict(DeclarationContainer* _scope, Declaration const& _declaration, ErrorList& _errors);
+	static void reportConflict(bool _inheriting, DeclarationContainer* _scope, Declaration const& _declaration, ErrorList& _errors);
 
 private:
 	void reset();

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -76,9 +76,6 @@ public:
 		std::vector<Declaration const*> const& _declarations
 	);
 
-	// reports a conflict of two declarations sharing a name
-	static void reportConflict(bool _inheriting, DeclarationContainer* _scope, Declaration const& _declaration, ErrorList& _errors);
-
 private:
 	void reset();
 
@@ -93,14 +90,6 @@ private:
 	template <class _T>
 	static std::vector<_T const*> cThreeMerge(std::list<std::list<_T const*>>& _toMerge);
 
-	// creates the Declaration error and adds it in the errors list
-	static void reportDeclarationError(
-		SourceLocation _sourceLoction,
-		std::string const& _description,
-		SourceLocation _secondarySourceLocation,
-		std::string const& _secondaryDescription,
-		ErrorList &_errors
-	);
 	// creates the Declaration error and adds it in the errors list
 	void reportDeclarationError(SourceLocation _sourceLocation, std::string const& _description);
 	// creates the Declaration error and adds it in the errors list and throws FatalError

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1500,8 +1500,23 @@ bool TypeChecker::visit(Identifier const& _identifier)
 	if (!annotation.referencedDeclaration)
 	{
 		if (!annotation.argumentTypes)
-			fatalTypeError(_identifier.location(), "Unable to determine overloaded type.");
-		if (annotation.overloadedDeclarations.empty())
+		{
+			// The identifier should be a public state variable shadowing other functions
+			vector<Declaration const*> candidates;
+
+			for (Declaration const* declaration: annotation.overloadedDeclarations)
+			{
+				if (VariableDeclaration const* variableDeclaration = dynamic_cast<decltype(variableDeclaration)>(declaration))
+					candidates.push_back(declaration);
+			}
+			if (candidates.empty())
+				fatalTypeError(_identifier.location(), "No matching declaration found after variable lookup.");
+			else if (candidates.size() == 1)
+				annotation.referencedDeclaration = candidates.front();
+			else
+				fatalTypeError(_identifier.location(), "No unique declaration found after variable lookup.");
+		}
+		else if (annotation.overloadedDeclarations.empty())
 			fatalTypeError(_identifier.location(), "No candidates for overload resolution found.");
 		else if (annotation.overloadedDeclarations.size() == 1)
 			annotation.referencedDeclaration = *annotation.overloadedDeclarations.begin();

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -208,6 +208,9 @@ vector<Declaration const*> const& ContractDefinition::inheritableMembers() const
 
 		for (EnumDefinition const* e: definedEnums())
 			addInheritableMember(e);
+
+		for (EventDefinition const* e: events())
+			addInheritableMember(e);
 	}
 	return *m_inheritableMembers;
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2522,3 +2522,13 @@ string MagicType::toString(bool) const
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown kind of magic."));
 	}
 }
+
+bool FunctionType::locationIsEvent(Location _location)
+{
+	return _location == Location::Log0
+		|| _location == Location::Log1
+		|| _location == Location::Log2
+		|| _location == Location::Log3
+		|| _location == Location::Log4
+		|| _location == Location::Event;
+}

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -818,6 +818,7 @@ public:
 		ByteArrayPush, ///< .push() to a dynamically sized byte array in storage
 		ObjectCreation ///< array creation using new
 	};
+	static bool locationIsEvent(Location _location);
 
 	virtual Category category() const override { return Category::Function; }
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -880,13 +880,9 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			solAssert(_memberAccess.annotation().type, "_memberAccess has no type");
 			if (auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type.get()))
 			{
-				if (funType->location() != FunctionType::Location::Internal && !FunctionType::locationIsEvent(funType->location()))
+				switch (funType->location())
 				{
-					_memberAccess.expression().accept(*this);
-					m_context << funType->externalIdentifier();
-				}
-				else
-				{
+				case FunctionType::Location::Internal:
 					// We do not visit the expression here on purpose, because in the case of an
 					// internal library function call, this would push the library address forcing
 					// us to link against it although we actually do not need it.
@@ -897,7 +893,34 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 						// no-op because the parent node (which should be a FunctionCall node) does the job
 					}
 					else
-						solAssert(false, "Neither a function nor an event found in member access");
+						solAssert(false, "function not found");
+					break;
+				case FunctionType::Location::Log0:
+				case FunctionType::Location::Log1:
+				case FunctionType::Location::Log2:
+				case FunctionType::Location::Log3:
+				case FunctionType::Location::Log4:
+				case FunctionType::Location::Event:
+					if (!dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+						solAssert(false, "event not found");
+					// no-op, because the parent node will do the job
+					break;
+				case FunctionType::Location::External:
+				case FunctionType::Location::Creation:
+				case FunctionType::Location::DelegateCall:
+				case FunctionType::Location::CallCode:
+				case FunctionType::Location::Send:
+				case FunctionType::Location::Bare:
+				case FunctionType::Location::BareCallCode:
+				case FunctionType::Location::BareDelegateCall:
+					_memberAccess.expression().accept(*this);
+					m_context << funType->externalIdentifier();
+					break;
+				case FunctionType::Location::ECRecover:
+				case FunctionType::Location::SHA256:
+				case FunctionType::Location::RIPEMD160:
+				default:
+					solAssert(false, "unsupported member function");
 				}
 			}
 			else if (dynamic_cast<TypeType const*>(_memberAccess.annotation().type.get()))

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -888,18 +888,9 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					// us to link against it although we actually do not need it.
 					if (auto const* function = dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
 						utils().pushCombinedFunctionEntryLabel(*function);
-					else if (dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration))
-					{
-						// no-op because the parent node (which should be a FunctionCall node) does the job
-					}
 					else
 						solAssert(false, "function not found");
 					break;
-				case FunctionType::Location::Log0:
-				case FunctionType::Location::Log1:
-				case FunctionType::Location::Log2:
-				case FunctionType::Location::Log3:
-				case FunctionType::Location::Log4:
 				case FunctionType::Location::Event:
 					if (!dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration))
 						solAssert(false, "event not found");
@@ -916,6 +907,11 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					_memberAccess.expression().accept(*this);
 					m_context << funType->externalIdentifier();
 					break;
+				case FunctionType::Location::Log0:
+				case FunctionType::Location::Log1:
+				case FunctionType::Location::Log2:
+				case FunctionType::Location::Log3:
+				case FunctionType::Location::Log4:
 				case FunctionType::Location::ECRecover:
 				case FunctionType::Location::SHA256:
 				case FunctionType::Location::RIPEMD160:

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4819,58 +4819,69 @@ BOOST_AUTO_TEST_CASE(proper_order_of_overwriting_of_attributes)
 	BOOST_CHECK(callContractFunction("ok()") == encodeArgs(false));
 }
 
-BOOST_AUTO_TEST_CASE(proper_overwriting_accessor_by_function)
+BOOST_AUTO_TEST_CASE(override_by_is_base_ordering)
 {
-	// bug #1798
-	char const* sourceCode = R"(
-		contract attribute {
-			bool ok = false;
-		}
-		contract func {
-			function ok() returns (bool) { return true; }
-		}
-
-		contract attr_func is attribute, func {
-			function checkOk() returns (bool) { return ok(); }
-		}
-		contract func_attr is func, attribute {
-			function checkOk() returns (bool) { return ok; }
-		}
-	)";
-	compileAndRun(sourceCode, 0, "attr_func");
-	BOOST_CHECK(callContractFunction("ok()") == encodeArgs(true));
-	compileAndRun(sourceCode, 0, "func_attr");
-	BOOST_CHECK(callContractFunction("checkOk()") == encodeArgs(false));
-}
-
-
-BOOST_AUTO_TEST_CASE(overwriting_inheritance)
-{
-	// bug #1798
-	char const* sourceCode = R"(
+	char const* text = R"(
 		contract A {
-			function ok() returns (uint) { return 1; }
+			function dup() returns (uint) {
+				return 1;
+			}
 		}
 		contract B {
-			function ok() returns (uint) { return 2; }
+			function dup() returns (uint) {
+				return 2;
+			}
 		}
-		contract C {
-			uint ok = 6;
-		}
-		contract AB is A, B {
-			function ok() returns (uint) { return 4; }
-		}
-		contract reversedE is C, AB {
-			function checkOk() returns (uint) { return ok(); }
-		}
-		contract E is AB, C {
-			function checkOk() returns (uint) { return ok; }
+		contract C is A, B {
+			function f() returns (uint) {
+				return dup();
+			}
 		}
 	)";
-	compileAndRun(sourceCode, 0, "reversedE");
-	BOOST_CHECK(callContractFunction("checkOk()") == encodeArgs(4));
-	compileAndRun(sourceCode, 0, "E");
-	BOOST_CHECK(callContractFunction("checkOk()") == encodeArgs(6));
+	compileAndRun(text, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(2));
+}
+
+BOOST_AUTO_TEST_CASE(inherited_function_clash_with_this)
+{
+	char const* sourceCode = R"(
+		contract A {
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+		contract B is A {
+			function dup() returns (uint) {
+				return 2;
+			}
+			function f() returns (uint) {
+				return this.dup();
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "B");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(2));
+}
+
+BOOST_AUTO_TEST_CASE(inherited_function_clash_with_derived_name)
+{
+	char const* sourceCode = R"(
+		contract A {
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+		contract B is A {
+			function dup() returns (uint) {
+				return 2;
+			}
+			function f() returns (uint) {
+				return dup();
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "B");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(2));
 }
 
 BOOST_AUTO_TEST_CASE(struct_assign_reference_to_struct)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2587,6 +2587,23 @@ BOOST_AUTO_TEST_CASE(function_modifier_overriding)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(false));
 }
 
+BOOST_AUTO_TEST_CASE(shadow_function_by_accessor)
+{
+	char const* sourceCode = R"(
+		contract A {
+			function f() returns (uint) { return 1; }
+		}
+		contract B is A {
+			uint256 public f;
+			function B() {
+				f = 2;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "B");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(2));
+}
+
 BOOST_AUTO_TEST_CASE(function_modifier_calling_functions_in_creation_context)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2604,6 +2604,23 @@ BOOST_AUTO_TEST_CASE(shadow_function_by_accessor)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(2));
 }
 
+BOOST_AUTO_TEST_CASE(implement_interface_by_accessor)
+{
+	char const* sourceCode = R"(
+		contract A {
+			function f() returns (uint);
+		}
+		contract B is A {
+			uint256 public f;
+			function B() {
+				f = 2;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "B");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(2));
+}
+
 BOOST_AUTO_TEST_CASE(function_modifier_calling_functions_in_creation_context)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -964,7 +964,7 @@ BOOST_AUTO_TEST_CASE(modifier_overrides_function)
 		contract A { modifier mod(uint a) { _; } }
 		contract B is A { function mod(uint a) { } }
 	)";
-	CHECK_ERROR(text, TypeError, "");
+	CHECK_ERROR(text, DeclarationError, "");
 }
 
 BOOST_AUTO_TEST_CASE(function_overrides_modifier)
@@ -973,7 +973,7 @@ BOOST_AUTO_TEST_CASE(function_overrides_modifier)
 		contract A { function mod(uint a) { } }
 		contract B is A { modifier mod(uint a) { _; } }
 	)";
-	CHECK_ERROR(text, TypeError, "");
+	CHECK_ERROR(text, DeclarationError, "");
 }
 
 BOOST_AUTO_TEST_CASE(modifier_returns_value)
@@ -1281,6 +1281,76 @@ BOOST_AUTO_TEST_CASE(multiple_events_argument_clash)
 			event e2(uint a, uint e1, uint e2);
 		})";
 	CHECK_SUCCESS(text);
+}
+
+BOOST_AUTO_TEST_CASE(event_function_clash)
+{
+	char const* text = R"(
+		contract A {
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+		contract B {
+			event dup();
+		}
+		contract C is A, B {
+		}
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
+}
+
+BOOST_AUTO_TEST_CASE(function_event_clash)
+{
+	char const* text = R"(
+		contract B {
+			event dup();
+		}
+		contract A {
+			function dup() returns (uint) {
+				return 1;
+			}
+		}
+		contract C is B, A {
+		}
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
+}
+
+BOOST_AUTO_TEST_CASE(accessor_function_clash)
+{
+	// bug #1798 (cpp-ethereum), related to #1286 (solidity)
+	char const* text = R"(
+		contract attribute {
+			bool ok = false;
+		}
+		contract func {
+			function ok() returns (bool) { return true; }
+		}
+
+		contract func_attr is func, attribute {
+			function checkOk() returns (bool) { return ok; }
+		}
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
+}
+
+BOOST_AUTO_TEST_CASE(function_accessor_clash)
+{
+	// bug #1798 (cpp-ethereum), related to #1286 (solidity)
+	char const* text = R"(
+		contract attribute {
+			bool ok = false;
+		}
+		contract func {
+			function ok() returns (bool) { return true; }
+		}
+
+		contract attr_func is attribute, func {
+			function checkOk() returns (bool) { return ok(); }
+		}
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
 }
 
 BOOST_AUTO_TEST_CASE(access_to_default_function_visibility)
@@ -2596,6 +2666,78 @@ BOOST_AUTO_TEST_CASE(multi_variable_declaration_fail)
 		contract C { function f() { var (x,y); } }
 	)";
 	CHECK_ERROR(text, TypeError, "");
+}
+
+BOOST_AUTO_TEST_CASE(creation_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { new A.A(); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
+}
+
+BOOST_AUTO_TEST_CASE(sha256_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.sha256(); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(ripemd160_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.ripemd160(); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(ecrecover_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.ecrecover(); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(bare_call_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.call("7885"); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(send_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.send(10); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(delegatecall_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.delegatecall("abbc"); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
+}
+
+BOOST_AUTO_TEST_CASE(callcode_with_base_name)
+{
+	char const* text = R"(
+		contract A { }
+		contract B is A { function f() { A.callcode("abbc"); } }
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::TypeError);
 }
 
 BOOST_AUTO_TEST_CASE(multi_variable_declaration_wildcards_fine)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1283,6 +1283,23 @@ BOOST_AUTO_TEST_CASE(multiple_events_argument_clash)
 	CHECK_SUCCESS(text);
 }
 
+BOOST_AUTO_TEST_CASE(multiple_event_iniheritrance)
+{
+	// This should throw an error until #1245 is implemented
+	char const* text = R"(
+		contract A
+		{
+			event E;
+		}
+		contract B
+		{
+			event E(uint a);
+		}
+		contract C is A, B {
+		}
+	)";
+	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
+}
 BOOST_AUTO_TEST_CASE(event_function_clash)
 {
 	char const* text = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1334,24 +1334,6 @@ BOOST_AUTO_TEST_CASE(function_event_clash)
 	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
 }
 
-BOOST_AUTO_TEST_CASE(accessor_function_clash)
-{
-	// bug #1798 (cpp-ethereum), related to #1286 (solidity)
-	char const* text = R"(
-		contract attribute {
-			bool ok = false;
-		}
-		contract func {
-			function ok() returns (bool) { return true; }
-		}
-
-		contract func_attr is func, attribute {
-			function checkOk() returns (bool) { return ok; }
-		}
-	)";
-	BOOST_CHECK(expectError(text).type() == Error::Type::DeclarationError);
-}
-
 BOOST_AUTO_TEST_CASE(function_accessor_clash)
 {
 	// bug #1798 (cpp-ethereum), related to #1286 (solidity)


### PR DESCRIPTION
Fixes #1286, also solves #1084 .