### PR TITLE
tolerant type checking for inline arrays, by computing the common type in a more tolerant way

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Features:
  * Do-while loops: support for a C-style do{<block>}while(<expr>); control structure
+ * Type checker: now more eagerly searches for a common type of an inline array with mixed types
 
 ### 0.4.4 (2016-10-31)
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -996,9 +996,9 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 						fatalTypeError(components[i]->location(), "Invalid mobile type.");
 
 					if (i == 0)
-						inlineArrayType = types[i]->mobileType();
+						inlineArrayType = types[i];
 					else if (inlineArrayType)
-						inlineArrayType = Type::commonType(inlineArrayType, types[i]->mobileType());
+						inlineArrayType = Type::commonType(inlineArrayType, types[i]);
 				}
 			}
 			else

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -200,10 +200,10 @@ TypePointer Type::commonType(TypePointer const& _a, TypePointer const& _b)
 {
 	if (!_a || !_b)
 		return TypePointer();
-	else if (_b->isImplicitlyConvertibleTo(*_a))
-		return _a;
-	else if (_a->isImplicitlyConvertibleTo(*_b))
-		return _b;
+	else if (_b->isImplicitlyConvertibleTo(*_a->mobileType()))
+		return _a->mobileType();
+	else if (_a->isImplicitlyConvertibleTo(*_b->mobileType()))
+		return _b->mobileType();
 	else
 		return TypePointer();
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -6353,6 +6353,20 @@ BOOST_AUTO_TEST_CASE(decayed_tuple)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(2)));
 }
 
+BOOST_AUTO_TEST_CASE(inline_tuple_with_rational_numbers)
+{
+	char const* sourceCode = R"(
+		contract c {
+			function f() returns (int8) {
+				int8[5] memory foo3 = [int8(1), -1, 0, 0, 0];
+				return foo3[0];
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(1)));
+}
+
 BOOST_AUTO_TEST_CASE(destructuring_assignment)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Before this pull-request, type checking on `[int8(1), 0]` failed because the mobile type of `0` is `uint8`, which is incompatible with `int8`.  There are no integer types that are compatible both with `uint8` and `int8`.  So I chose not to compute the mobile type of a rational number type here.

This fixes #621.
