### PR TITLE
LLL: Add support for 'until', the inverse of 'while'.

### DIFF
--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -472,14 +472,15 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 			m_asm << end.tag();
 			m_asm.donePaths();
 		}
-		else if (us == "WHILE")
+		else if (us == "WHILE" || us == "UNTIL")
 		{
 			requireSize(2);
 			requireDeposit(0, 1);
 
 			auto begin = m_asm.append();
 			m_asm.append(code[0].m_asm);
-			m_asm.append(Instruction::ISZERO);
+			if (us == "WHILE")
+				m_asm.append(Instruction::ISZERO);
 			auto end = m_asm.appendJumpI();
 			m_asm.append(code[1].m_asm, 0);
 			m_asm.appendJump(begin);


### PR DESCRIPTION
In an effort to support keywords that are in Serpent's LLL implementation but missing in the Solidity LLL compiler, I added an `until` keyword.
