### PR TITLE
Compare source files in source locations

### DIFF
--- a/libevmasm/SourceLocation.h
+++ b/libevmasm/SourceLocation.h
@@ -55,7 +55,11 @@ struct SourceLocation
 		return *this;
 	}
 
-	bool operator==(SourceLocation const& _other) const { return start == _other.start && end == _other.end;}
+	bool operator==(SourceLocation const& _other) const
+	{
+		return start == _other.start && end == _other.end &&
+			((!sourceName && !_other.sourceName) || (sourceName && _other.sourceName && *sourceName == *_other.sourceName));
+	}
 	bool operator!=(SourceLocation const& _other) const { return !operator==(_other); }
 	inline bool operator<(SourceLocation const& _other) const;
 	inline bool contains(SourceLocation const& _other) const;
@@ -79,20 +83,21 @@ inline std::ostream& operator<<(std::ostream& _out, SourceLocation const& _locat
 bool SourceLocation::operator<(SourceLocation const& _other) const
 {
 	if (!sourceName || !_other.sourceName)
-		return int(!!sourceName) < int(!!_other.sourceName);
-	return make_tuple(*sourceName, start, end) < make_tuple(*_other.sourceName, _other.start, _other.end);
+		return std::make_tuple(int(!!sourceName), start, end) < std::make_tuple(int(!!_other.sourceName), _other.start, _other.end);
+	else
+		return std::make_tuple(*sourceName, start, end) < std::make_tuple(*_other.sourceName, _other.start, _other.end);
 }
 
 bool SourceLocation::contains(SourceLocation const& _other) const
 {
-	if (isEmpty() || _other.isEmpty() || !sourceName || !_other.sourceName || *sourceName != *_other.sourceName)
+	if (isEmpty() || _other.isEmpty() || ((!sourceName || !_other.sourceName || *sourceName != *_other.sourceName) && (sourceName || _other.sourceName)))
 		return false;
 	return start <= _other.start && _other.end <= end;
 }
 
 bool SourceLocation::intersects(SourceLocation const& _other) const
 {
-	if (isEmpty() || _other.isEmpty() || !sourceName || !_other.sourceName || *sourceName != *_other.sourceName)
+	if (isEmpty() || _other.isEmpty() || ((!sourceName || !_other.sourceName || *sourceName != *_other.sourceName) && (sourceName || _other.sourceName)))
 		return false;
 	return _other.start < end && start < _other.end;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_policy(SET CMP0015 NEW)
 aux_source_directory(. SRC_LIST)
 aux_source_directory(contracts SRC_LIST)
 aux_source_directory(libsolidity SRC_LIST)
+aux_source_directory(libevmasm SRC_LIST)
 
 get_filename_component(TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
 

--- a/test/libevmasm/SourceLocation.cpp
+++ b/test/libevmasm/SourceLocation.cpp
@@ -1,0 +1,50 @@
+/*
+    This file is part of cpp-ethereum.
+
+    cpp-ethereum is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    cpp-ethereum is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Yoichi Hirai <yoichi@ethereum.org>
+ * @date 2016
+ * Unit tests for the SourceLocation class.
+ */
+
+#include <libevmasm/SourceLocation.h>
+
+#include "../TestHelper.h"
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+BOOST_AUTO_TEST_SUITE(SourceLocationTest)
+
+BOOST_AUTO_TEST_CASE(test_fail)
+{
+	BOOST_CHECK(SourceLocation() == SourceLocation());
+	BOOST_CHECK(SourceLocation(0, 3, std::make_shared<std::string>("sourceA")) != SourceLocation(0, 3, std::make_shared<std::string>("sourceB")));
+	BOOST_CHECK(SourceLocation(0, 3, std::make_shared<std::string>("source")) == SourceLocation(0, 3, std::make_shared<std::string>("source")));
+	BOOST_CHECK(SourceLocation(3, 7, std::make_shared<std::string>("source")).contains(SourceLocation(4, 6, std::make_shared<std::string>("source"))));
+	BOOST_CHECK(!SourceLocation(3, 7, std::make_shared<std::string>("sourceA")).contains(SourceLocation(4, 6, std::make_shared<std::string>("sourceB"))));
+	BOOST_CHECK(SourceLocation(3, 7, std::make_shared<std::string>("sourceA")) < SourceLocation(4, 6, std::make_shared<std::string>("sourceB")));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+} // end namespaces

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -91,8 +91,10 @@ void checkAssemblyLocations(AssemblyItems const& _items, vector<SourceLocation> 
 		BOOST_CHECK_MESSAGE(
 			_items[i].location() == _locations[i],
 			"Location mismatch for assembly item " + to_string(i) + ". Found: " +
+					(_items[i].location().sourceName ? *_items[i].location().sourceName + ":" : "(null source name)") +
 					to_string(_items[i].location().start) + "-" +
 					to_string(_items[i].location().end) + ", expected: " +
+					(_locations[i].sourceName ? *_locations[i].sourceName + ":" : "(null source name)") +
 					to_string(_locations[i].start) + "-" +
 					to_string(_locations[i].end));
 	}
@@ -111,7 +113,7 @@ BOOST_AUTO_TEST_CASE(location_test)
 		}
 	}
 	)";
-	shared_ptr<string const> n = make_shared<string>("source");
+	shared_ptr<string const> n = make_shared<string>("");
 	AssemblyItems items = compileContract(sourceCode);
 	vector<SourceLocation> locations =
 		vector<SourceLocation>(18, SourceLocation(2, 75, n)) +


### PR DESCRIPTION
This pull-request makes the equality comparison `==` of source locations more accurate by taking the file names into account.  At the same time `<` is also made accurate by considering the cases where the file name of both sides are null.