### PR TITLE
docs: Remove named return

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -25,7 +25,7 @@ Storage
             storedData = x;
         }
 
-        function get() constant returns (uint retVal) {
+        function get() constant returns (uint) {
             return storedData;
         }
     }
@@ -136,7 +136,7 @@ like this one. The accessor function created by the ``public`` keyword
 is a bit more complex in this case. It roughly looks like the
 following::
 
-    function balances(address _account) returns (uint balance) {
+    function balances(address _account) returns (uint) {
         return balances[_account];
     }
 


### PR DESCRIPTION
Named returns are not explained in this introduction; they also provide little value in these examples.