### PR TITLE
Unimplemented features moved to their own exception

### DIFF
--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -270,7 +270,7 @@ void ArrayUtils::copyArrayToStorage(ArrayType const& _targetType, ArrayType cons
 
 void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWordBoundaries) const
 {
-	solAssert(
+	solUnimplementedAssert(
 		!_sourceType.baseType()->isDynamicallySized(),
 		"Nested dynamic arrays not implemented here."
 	);

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -138,7 +138,7 @@ void CompilerUtils::storeInMemoryDynamic(Type const& _type, bool _padToWordBound
 		unsigned numBytes = prepareMemoryStore(_type, _padToWordBoundaries);
 		if (numBytes > 0)
 		{
-			solAssert(
+			solUnimplementedAssert(
 				_type.sizeOnStack() == 1,
 				"Memory store of types with stack size != 1 not implemented."
 			);
@@ -161,7 +161,7 @@ void CompilerUtils::encodeToMemory(
 	solAssert(targetTypes.size() == _givenTypes.size(), "");
 	for (TypePointer& t: targetTypes)
 	{
-		solAssert(
+		solUnimplementedAssert(
 			t->mobileType() &&
 			t->mobileType()->interfaceType(_encodeAsLibraryTypes) &&
 			t->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType(),
@@ -351,7 +351,7 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 		solAssert(targetTypeCategory == Type::Category::Integer || targetTypeCategory == Type::Category::Enum, "");
 		break;
 	case Type::Category::FixedPoint:
-		solAssert(false, "Not yet implemented - FixedPointType.");
+		solUnimplemented("Not yet implemented - FixedPointType.");
 	case Type::Category::Integer:
 	case Type::Category::Contract:
 	case Type::Category::RationalNumber:
@@ -386,7 +386,7 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 			if (auto typeOnStack = dynamic_cast<IntegerType const*>(&_typeOnStack))
 				if (targetFixedPointType.integerBits() > typeOnStack->numBits())
 					cleanHigherOrderBits(*typeOnStack);
-			solAssert(false, "Not yet implemented - FixedPointType.");
+			solUnimplemented("Not yet implemented - FixedPointType.");
 		}
 		else
 		{
@@ -399,7 +399,7 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 				RationalNumberType const& constType = dynamic_cast<RationalNumberType const&>(_typeOnStack);
 				// We know that the stack is clean, we only have to clean for a narrowing conversion
 				// where cleanup is forced.
-				solAssert(!constType.isFractional(), "Not yet implemented - FixedPointType.");
+				solUnimplementedAssert(!constType.isFractional(), "Not yet implemented - FixedPointType.");
 				if (targetType.numBits() < constType.integerType()->numBits() && _cleanupNeeded)
 					cleanHigherOrderBits(targetType);
 			}

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -296,10 +296,10 @@ void ContractCompiler::appendCalldataUnpacker(TypePointers const& _typeParameter
 		if (type->category() == Type::Category::Array)
 		{
 			auto const& arrayType = dynamic_cast<ArrayType const&>(*type);
-			solAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
+			solUnimplementedAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
 			if (_fromMemory)
 			{
-				solAssert(
+				solUnimplementedAssert(
 					arrayType.baseType()->isValueType(),
 					"Nested memory arrays not yet implemented here."
 				);

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1243,7 +1243,7 @@ void ExpressionCompiler::endVisit(Literal const& _literal)
 	case Type::Category::StringLiteral:
 		break; // will be done during conversion
 	default:
-		BOOST_THROW_EXCEPTION(UnimplementedFeatureError() << errinfo_comment("Only integer, boolean and string literals implemented for now."));
+		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Only integer, boolean and string literals implemented for now."));
 	}
 }
 
@@ -1382,7 +1382,7 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
 	case Token::SHR:
 		break;
 	default:
-		BOOST_THROW_EXCEPTION(UnimplementedFeatureError() << errinfo_comment("Unknown shift operator."));
+		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown shift operator."));
 	}
 }
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -99,7 +99,7 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 		if (auto mappingType = dynamic_cast<MappingType const*>(returnType.get()))
 		{
 			solAssert(CompilerUtils::freeMemoryPointer >= 0x40, "");
-			solAssert(
+			solUnimplementedAssert(
 				!paramTypes[i]->isDynamicallySized(),
 				"Accessors for mapping with dynamically-sized keys not yet implemented."
 			);
@@ -211,7 +211,7 @@ bool ExpressionCompiler::visit(Assignment const& _assignment)
 	Token::Value op = _assignment.assignmentOperator();
 	if (op != Token::Assign) // compound assignment
 	{
-		solAssert(_assignment.annotation().type->isValueType(), "Compound operators not implemented for non-value types.");
+		solUnimplementedAssert(_assignment.annotation().type->isValueType(), "Compound operators not implemented for non-value types.");
 		unsigned lvalueSize = m_currentLValue->sizeOnStack();
 		unsigned itemSize = _assignment.annotation().type->sizeOnStack();
 		if (lvalueSize > 0)
@@ -312,7 +312,7 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 		if (!_unaryOperation.isPrefixOperation())
 		{
 			// store value for later
-			solAssert(_unaryOperation.annotation().type->sizeOnStack() == 1, "Stack size != 1 not implemented.");
+			solUnimplementedAssert(_unaryOperation.annotation().type->sizeOnStack() == 1, "Stack size != 1 not implemented.");
 			m_context << Instruction::DUP1;
 			if (m_currentLValue->sizeOnStack() > 0)
 				for (unsigned i = 1 + m_currentLValue->sizeOnStack(); i > 0; --i)
@@ -1141,7 +1141,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 			break;
 		case DataLocation::CallData:
 			//@todo if we implement this, the value in calldata has to be added to the base offset
-			solAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
+			solUnimplementedAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
 			if (arrayType.baseType()->isValueType())
 				CompilerUtils(m_context).loadFromMemoryDynamic(
 					*arrayType.baseType(),
@@ -1243,7 +1243,7 @@ void ExpressionCompiler::endVisit(Literal const& _literal)
 	case Type::Category::StringLiteral:
 		break; // will be done during conversion
 	default:
-		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Only integer, boolean and string literals implemented for now."));
+		BOOST_THROW_EXCEPTION(UnimplementedFeatureError() << errinfo_comment("Only integer, boolean and string literals implemented for now."));
 	}
 }
 
@@ -1318,7 +1318,7 @@ void ExpressionCompiler::appendArithmeticOperatorCode(Token::Value _operator, Ty
 	bool const c_isSigned = type.isSigned();
 
 	if (_type.category() == Type::Category::FixedPoint)
-		solAssert(false, "Not yet implemented - FixedPointType.");
+		solUnimplemented("Not yet implemented - FixedPointType.");
 
 	switch (_operator)
 	{
@@ -1372,7 +1372,7 @@ void ExpressionCompiler::appendBitOperatorCode(Token::Value _operator)
 
 void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
 {
-	BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Shift operators not yet implemented."));
+	BOOST_THROW_EXCEPTION(UnimplementedFeatureError() << errinfo_comment("Shift operators not yet implemented."));
 	switch (_operator)
 	{
 	case Token::SHL:
@@ -1382,7 +1382,7 @@ void ExpressionCompiler::appendShiftOperatorCode(Token::Value _operator)
 	case Token::SHR:
 		break;
 	default:
-		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown shift operator."));
+		BOOST_THROW_EXCEPTION(UnimplementedFeatureError() << errinfo_comment("Unknown shift operator."));
 	}
 }
 
@@ -1634,7 +1634,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 
 void ExpressionCompiler::appendExpressionCopyToMemory(Type const& _expectedType, Expression const& _expression)
 {
-	solAssert(_expectedType.isValueType(), "Not implemented for non-value types.");
+	solUnimplementedAssert(_expectedType.isValueType(), "Not implemented for non-value types.");
 	_expression.accept(*this);
 	utils().convertType(*_expression.annotation().type, _expectedType, true);
 	utils().storeInMemoryDynamic(_expectedType);

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -120,7 +120,7 @@ void MemoryItem::storeValue(Type const& _sourceType, SourceLocation const&, bool
 	}
 	else
 	{
-		solAssert(_sourceType == *m_dataType, "Conversion not implemented for assignment to memory.");
+		solUnimplementedAssert(_sourceType == *m_dataType, "Conversion not implemented for assignment to memory.");
 
 		solAssert(m_dataType->sizeOnStack() == 1, "");
 		if (!_move)
@@ -181,7 +181,7 @@ void StorageItem::retrieveValue(SourceLocation const&, bool _remove) const
 			<< u256(0x100) << Instruction::EXP << Instruction::SWAP1 << Instruction::DIV;
 		if (m_dataType->category() == Type::Category::FixedPoint)
 			// implementation should be very similar to the integer case.
-			solAssert(false, "Not yet implemented - FixedPointType.");
+			solUnimplemented("Not yet implemented - FixedPointType.");
 		if (m_dataType->category() == Type::Category::FixedBytes)
 			m_context << (u256(0x1) << (256 - 8 * m_dataType->storageBytes())) << Instruction::MUL;
 		else if (

--- a/libsolidity/interface/Exceptions.h
+++ b/libsolidity/interface/Exceptions.h
@@ -37,6 +37,7 @@ using ErrorList = std::vector<std::shared_ptr<Error const>>;
 struct CompilerError: virtual Exception {};
 struct InternalCompilerError: virtual Exception {};
 struct FatalError: virtual Exception {};
+struct UnimplementedFeatureError: virtual Exception{};
 
 class Error: virtual public Exception
 {

--- a/libsolidity/interface/Utils.h
+++ b/libsolidity/interface/Utils.h
@@ -30,6 +30,7 @@ namespace dev
 namespace solidity
 {
 struct InternalCompilerError;
+struct UnimplementedFeatureError;
 }
 }
 
@@ -37,3 +38,8 @@ struct InternalCompilerError;
 #define solAssert(CONDITION, DESCRIPTION) \
 	assertThrow(CONDITION, ::dev::solidity::InternalCompilerError, DESCRIPTION)
 
+#define solUnimplementedAssert(CONDITION, DESCRIPTION) \
+	assertThrow(CONDITION, ::dev::solidity::UnimplementedFeatureError, DESCRIPTION)
+
+#define solUnimplemented(DESCRIPTION) \
+	solUnimplementedAssert(false, DESCRIPTION)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -604,6 +604,12 @@ bool CommandLineInterface::processInput()
 			 << boost::diagnostic_information(_exception);
 		return false;
 	}
+	catch (UnimplementedFeatureError const& _exception)
+	{
+		cerr << "Unimplemented compliler feature:" << endl
+			 << boost::diagnostic_information(_exception);
+		return false;
+	}
 	catch (Error const& _error)
 	{
 		if (_error.type() == Error::Type::DocstringParsingError)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -606,7 +606,7 @@ bool CommandLineInterface::processInput()
 	}
 	catch (UnimplementedFeatureError const& _exception)
 	{
-		cerr << "Unimplemented compliler feature:" << endl
+		cerr << "Unimplemented feature:" << endl
 			 << boost::diagnostic_information(_exception);
 		return false;
 	}

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -189,6 +189,10 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 	{
 		errors.append(formatError(exception, "Internal compiler error", scannerFromSourceName));
 	}
+	catch (UnimplementedFeatureError const& exception)
+	{
+		errors.append(formatError(exception, "Unimplemented feature", scannerFromSourceName));
+	}
 	catch (Exception const& exception)
 	{
 		errors.append("Exception during compilation: " + boost::diagnostic_information(exception));


### PR DESCRIPTION
InternalCompilerError is an exception that really should be reserved for
actual internal errors of the compiler.  Unimplemented features can now
use either solUnimplemented( ) or, if it should be conditional, then
solUnimplementedAssert( ).

fixes #1133 