### PR TITLE
Invalid enum as external ret

### DIFF
--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -315,7 +315,7 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 	Type::Category stackTypeCategory = _typeOnStack.category();
 	Type::Category targetTypeCategory = _targetType.category();
 
-	bool enumOverflowCheckPending = (targetTypeCategory == Type::Category::Enum);
+	bool enumOverflowCheckPending = (targetTypeCategory == Type::Category::Enum || stackTypeCategory == Type::Category::Enum);
 
 	switch (stackTypeCategory)
 	{
@@ -353,7 +353,7 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 		solAssert(_targetType == _typeOnStack || targetTypeCategory == Type::Category::Integer, "");
 		if (enumOverflowCheckPending)
 		{
-			EnumType const& enumType = dynamic_cast<decltype(enumType)>(_targetType);
+			EnumType const& enumType = dynamic_cast<decltype(enumType)>(_typeOnStack);
 			solAssert(enumType.numberOfMembers() > 0, "empty enum should have caused a parser error.");
 			m_context << u256(enumType.numberOfMembers() - 1) << Instruction::DUP2 << Instruction::GT;
 			m_context.appendConditionalJumpTo(m_context.errorTag());

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4499,6 +4499,40 @@ BOOST_AUTO_TEST_CASE(external_types_in_calls)
 	BOOST_CHECK(callContractFunction("t2()") == encodeArgs(u256(9)));
 }
 
+BOOST_AUTO_TEST_CASE(invalid_enum_as_external_ret)
+{
+	char const* sourceCode = R"(
+		contract C {
+			enum X { A, B }
+
+			function test_return() returns (X) {
+				X garbled;
+				assembly {
+					garbled := 5
+				}
+				return garbled;
+			}
+			function test_inline_assignment() returns (X _ret) {
+				assembly {
+					_ret := 5
+				}
+			}
+			function test_assignment() returns (X _ret) {
+				X tmp;
+				assembly {
+					tmp := 5
+				}
+				_ret = tmp;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	// both should throw
+	BOOST_CHECK(callContractFunction("test_return()") == encodeArgs());
+	BOOST_CHECK(callContractFunction("test_inline_assignment()") == encodeArgs());
+	BOOST_CHECK(callContractFunction("test_assignment()") == encodeArgs());
+}
+
 BOOST_AUTO_TEST_CASE(proper_order_of_overwriting_of_attributes)
 {
 	// bug #1798


### PR DESCRIPTION
This pull-request adds overflow checking on enum values that are being returned from an interface function.

This solves a bullet point in https://github.com/ethereum/solidity/issues/1344#issuecomment-260330861