### PR TITLE
Keep internal results in JSON

### DIFF
--- a/libdevcore/JSON.h
+++ b/libdevcore/JSON.h
@@ -1,0 +1,44 @@
+/*
+	This file is part of cpp-ethereum.
+
+	cpp-ethereum is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	cpp-ethereum is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file JSON.h
+ * @date 2016
+ *
+ * JSON related helpers
+ */
+
+#pragma once
+
+#include <json/json.h>
+
+namespace dev
+{
+
+/// Serialise the JSON object (@a _input) with identation
+std::string jsonPrettyPrint(Json::Value const& _input)
+{
+	return Json::StyledWriter().write(_input);
+}
+
+/// Serialise theJ SON object (@a _input) without identation
+std::string jsonCompactPrint(Json::Value const& _input)
+{
+	Json::FastWriter writer;
+	writer.omitEndingLineFeed();
+	return writer.write(_input);
+}
+
+}

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -160,22 +160,22 @@ vector<pair<FixedHash<4>, FunctionTypePointer>> const& ContractDefinition::inter
 	return *m_interfaceFunctionList;
 }
 
-string const& ContractDefinition::devDocumentation() const
+Json::Value const& ContractDefinition::devDocumentation() const
 {
 	return m_devDocumentation;
 }
 
-string const& ContractDefinition::userDocumentation() const
+Json::Value const& ContractDefinition::userDocumentation() const
 {
 	return m_userDocumentation;
 }
 
-void ContractDefinition::setDevDocumentation(string const& _devDocumentation)
+void ContractDefinition::setDevDocumentation(Json::Value const& _devDocumentation)
 {
 	m_devDocumentation = _devDocumentation;
 }
 
-void ContractDefinition::setUserDocumentation(string const& _userDocumentation)
+void ContractDefinition::setUserDocumentation(Json::Value const& _userDocumentation)
 {
 	m_userDocumentation = _userDocumentation;
 }

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -35,6 +35,7 @@
 #include <libsolidity/ast/Types.h>
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/ast/ASTAnnotations.h>
+#include <json/json.h>
 
 namespace dev
 {
@@ -343,11 +344,11 @@ public:
 	/// Returns the fallback function or nullptr if no fallback function was specified.
 	FunctionDefinition const* fallbackFunction() const;
 
-	std::string const& userDocumentation() const;
-	void setUserDocumentation(std::string const& _userDocumentation);
+	Json::Value const& userDocumentation() const;
+	void setUserDocumentation(Json::Value const& _userDocumentation);
 
-	std::string const& devDocumentation() const;
-	void setDevDocumentation(std::string const& _devDocumentation);
+	Json::Value const& devDocumentation() const;
+	void setDevDocumentation(Json::Value const& _devDocumentation);
 
 	virtual TypePointer type() const override;
 
@@ -359,8 +360,8 @@ private:
 	bool m_isLibrary;
 
 	// parsed Natspec documentation of the contract.
-	std::string m_userDocumentation;
-	std::string m_devDocumentation;
+	Json::Value m_userDocumentation;
+	Json::Value m_devDocumentation;
 
 	std::vector<ContractDefinition const*> m_linearizedBaseContracts;
 	mutable std::unique_ptr<std::vector<std::pair<FixedHash<4>, FunctionTypePointer>>> m_interfaceFunctionList;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -345,17 +345,17 @@ map<string, unsigned> CompilerStack::sourceIndices() const
 	return indices;
 }
 
-string const& CompilerStack::interface(string const& _contractName) const
+Json::Value const& CompilerStack::interface(string const& _contractName) const
 {
 	return metadata(_contractName, DocumentationType::ABIInterface);
 }
 
-string const& CompilerStack::metadata(string const& _contractName, DocumentationType _type) const
+Json::Value const& CompilerStack::metadata(string const& _contractName, DocumentationType _type) const
 {
 	if (!m_parseSuccessful)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
 
-	std::unique_ptr<string const>* doc;
+	std::unique_ptr<Json::Value const>* doc;
 	Contract const& currentContract = contract(_contractName);
 
 	// checks wheather we already have the documentation
@@ -376,7 +376,7 @@ string const& CompilerStack::metadata(string const& _contractName, Documentation
 
 	// caches the result
 	if (!*doc)
-		doc->reset(new string(InterfaceHandler::documentation(*currentContract.contract, _type)));
+		doc->reset(new Json::Value(InterfaceHandler::documentation(*currentContract.contract, _type)));
 
 	return *(*doc);
 }

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -162,14 +162,14 @@ public:
 	/// @returns a mapping assigning each source name its index inside the vector returned
 	/// by sourceNames().
 	std::map<std::string, unsigned> sourceIndices() const;
-	/// @returns a string representing the contract interface in JSON.
+	/// @returns a JSON representing the contract interface.
 	/// Prerequisite: Successful call to parse or compile.
-	std::string const& interface(std::string const& _contractName = "") const;
-	/// @returns a string representing the contract's documentation in JSON.
+	Json::Value const& interface(std::string const& _contractName = "") const;
+	/// @returns a JSON representing the contract's documentation.
 	/// Prerequisite: Successful call to parse or compile.
 	/// @param type The type of the documentation to get.
 	/// Can be one of 4 types defined at @c DocumentationType
-	std::string const& metadata(std::string const& _contractName, DocumentationType _type) const;
+	Json::Value const& metadata(std::string const& _contractName, DocumentationType _type) const;
 
 	/// @returns the previously used scanner, useful for counting lines during error reporting.
 	Scanner const& scanner(std::string const& _sourceName = "") const;
@@ -213,9 +213,9 @@ private:
 		eth::LinkerObject object;
 		eth::LinkerObject runtimeObject;
 		eth::LinkerObject cloneObject;
-		mutable std::unique_ptr<std::string const> interface;
-		mutable std::unique_ptr<std::string const> userDocumentation;
-		mutable std::unique_ptr<std::string const> devDocumentation;
+		mutable std::unique_ptr<Json::Value const> interface;
+		mutable std::unique_ptr<Json::Value const> userDocumentation;
+		mutable std::unique_ptr<Json::Value const> devDocumentation;
 		mutable std::unique_ptr<std::string const> sourceMapping;
 		mutable std::unique_ptr<std::string const> runtimeSourceMapping;
 	};

--- a/libsolidity/interface/InterfaceHandler.cpp
+++ b/libsolidity/interface/InterfaceHandler.cpp
@@ -8,7 +8,7 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-string InterfaceHandler::documentation(
+Json::Value InterfaceHandler::documentation(
 	ContractDefinition const& _contractDef,
 	DocumentationType _type
 )
@@ -24,10 +24,9 @@ string InterfaceHandler::documentation(
 	}
 
 	BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Unknown documentation type"));
-	return "";
 }
 
-string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
+Json::Value InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 {
 	Json::Value abi(Json::arrayValue);
 
@@ -104,12 +103,10 @@ string InterfaceHandler::abiInterface(ContractDefinition const& _contractDef)
 		abi.append(event);
 	}
 
-	Json::FastWriter writer;
-	writer.omitEndingLineFeed();
-	return writer.write(abi);
+	return abi;
 }
 
-string InterfaceHandler::userDocumentation(ContractDefinition const& _contractDef)
+Json::Value InterfaceHandler::userDocumentation(ContractDefinition const& _contractDef)
 {
 	Json::Value doc;
 	Json::Value methods(Json::objectValue);
@@ -129,10 +126,10 @@ string InterfaceHandler::userDocumentation(ContractDefinition const& _contractDe
 			}
 	doc["methods"] = methods;
 
-	return Json::StyledWriter().write(doc);
+	return doc;
 }
 
-string InterfaceHandler::devDocumentation(ContractDefinition const& _contractDef)
+Json::Value InterfaceHandler::devDocumentation(ContractDefinition const& _contractDef)
 {
 	Json::Value doc;
 	Json::Value methods(Json::objectValue);
@@ -178,7 +175,7 @@ string InterfaceHandler::devDocumentation(ContractDefinition const& _contractDef
 	}
 	doc["methods"] = methods;
 
-	return Json::StyledWriter().write(doc);
+	return doc;
 }
 
 string InterfaceHandler::extractDoc(multimap<string, DocTag> const& _tags, string const& _name)

--- a/libsolidity/interface/InterfaceHandler.h
+++ b/libsolidity/interface/InterfaceHandler.h
@@ -64,24 +64,24 @@ public:
 	/// @param _contractDef The contract definition
 	/// @param _type        The type of the documentation. Can be one of the
 	///                     types provided by @c DocumentationType
-	/// @return             A string with the json representation of provided type
-	static std::string documentation(
+	/// @return             A JSON representation of provided type
+	static Json::Value documentation(
 		ContractDefinition const& _contractDef,
 		DocumentationType _type
 	);
 	/// Get the ABI Interface of the contract
 	/// @param _contractDef The contract definition
-	/// @return             A string with the json representation of the contract's ABI Interface
-	static std::string abiInterface(ContractDefinition const& _contractDef);
+	/// @return             A JSONrepresentation of the contract's ABI Interface
+	static Json::Value abiInterface(ContractDefinition const& _contractDef);
 	/// Get the User documentation of the contract
 	/// @param _contractDef The contract definition
-	/// @return             A string with the json representation of the contract's user documentation
-	static std::string userDocumentation(ContractDefinition const& _contractDef);
+	/// @return             A JSON representation of the contract's user documentation
+	static Json::Value userDocumentation(ContractDefinition const& _contractDef);
 	/// Genereates the Developer's documentation of the contract
 	/// @param _contractDef The contract definition
-	/// @return             A string with the json representation
+	/// @return             A JSON representation
 	///                     of the contract's developer documentation
-	static std::string devDocumentation(ContractDefinition const& _contractDef);
+	static Json::Value devDocumentation(ContractDefinition const& _contractDef);
 
 private:
 	/// @returns concatenation of all content under the given tag name.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -41,6 +41,7 @@
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonData.h>
 #include <libdevcore/CommonIO.h>
+#include <libdevcore/JSON.h>
 #include <libevmasm/Instruction.h>
 #include <libevmasm/GasMeter.h>
 #include <libsolidity/interface/Version.h>
@@ -105,18 +106,6 @@ static void version()
 		dev::solidity::VersionString <<
 		endl;
 	exit(0);
-}
-
-string jsonPrettyPrint(Json::Value const& input)
-{
-	return Json::StyledWriter().write(input);
-}
-
-string jsonCompactPrint(Json::Value const& input)
-{
-        Json::FastWriter writer;
-        writer.omitEndingLineFeed();
-        return writer.write(input);
 }
 
 static bool needsHumanTargetedStdout(po::variables_map const& _args)
@@ -244,9 +233,9 @@ void CommandLineInterface::handleMeta(DocumentationType _type, string const& _co
 	{
 		std::string output;
 		if (_type == DocumentationType::ABIInterface)
-			output = jsonCompactPrint(m_compiler->metadata(_contract, _type));
+			output = dev::jsonCompactPrint(m_compiler->metadata(_contract, _type));
 		else
-			output = jsonPrettyPrint(m_compiler->metadata(_contract, _type));
+			output = dev::jsonPrettyPrint(m_compiler->metadata(_contract, _type));
 
 		if (m_args.count("output-dir"))
 			createFile(_contract + suffix, output);
@@ -669,7 +658,7 @@ void CommandLineInterface::handleCombinedJSON()
 	{
 		Json::Value contractData(Json::objectValue);
 		if (requests.count("abi"))
-			contractData["abi"] = jsonCompactPrint(m_compiler->interface(contractName));
+			contractData["abi"] = dev::jsonCompactPrint(m_compiler->interface(contractName));
 		if (requests.count("bin"))
 			contractData["bin"] = m_compiler->object(contractName).toHex();
 		if (requests.count("bin-runtime"))
@@ -694,9 +683,9 @@ void CommandLineInterface::handleCombinedJSON()
 			contractData["srcmap-runtime"] = map ? *map : "";
 		}
 		if (requests.count("devdoc"))
-			contractData["devdoc"] = jsonCompactPrint(m_compiler->metadata(contractName, DocumentationType::NatspecDev));
+			contractData["devdoc"] = dev::jsonCompactPrint(m_compiler->metadata(contractName, DocumentationType::NatspecDev));
 		if (requests.count("userdoc"))
-			contractData["userdoc"] = jsonCompactPrint(m_compiler->metadata(contractName, DocumentationType::NatspecUser));
+			contractData["userdoc"] = dev::jsonCompactPrint(m_compiler->metadata(contractName, DocumentationType::NatspecUser));
 		output["contracts"][contractName] = contractData;
 	}
 
@@ -720,7 +709,7 @@ void CommandLineInterface::handleCombinedJSON()
 			output["sources"][sourceCode.first]["AST"] = converter.json();
 		}
 	}
-	cout << jsonCompactPrint(output) << endl;
+	cout << dev::jsonCompactPrint(output) << endl;
 }
 
 void CommandLineInterface::handleAst(string const& _argStr)

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -125,6 +125,13 @@ Json::Value estimateGas(CompilerStack const& _compiler, string const& _contract)
 	return gasEstimates;
 }
 
+string jsonCompactPrint(Json::Value const& input)
+{
+	Json::FastWriter writer;
+	writer.omitEndingLineFeed();
+	return writer.write(input);
+}
+
 string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback _readCallback)
 {
 	Json::Value output(Json::objectValue);
@@ -213,7 +220,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 			for (string const& contractName: compiler.contractNames())
 			{
 				Json::Value contractData(Json::objectValue);
-				contractData["interface"] = compiler.interface(contractName);
+				contractData["interface"] = jsonCompactPrint(compiler.interface(contractName));
 				contractData["bytecode"] = compiler.object(contractName).toHex();
 				contractData["runtimeBytecode"] = compiler.runtimeObject(contractName).toHex();
 				contractData["opcodes"] = solidity::disassemble(compiler.object(contractName).bytecode);
@@ -274,7 +281,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 
 	try
 	{
-		return Json::FastWriter().write(output);
+		return jsonCompactPrint(output);
 	}
 	catch (...)
 	{
@@ -292,7 +299,7 @@ string compileMulti(string const& _input, bool _optimize, CStyleReadFileCallback
 		errors.append("Error parsing input JSON: " + reader.getFormattedErrorMessages());
 		Json::Value output(Json::objectValue);
 		output["errors"] = errors;
-		return Json::FastWriter().write(output);
+		return jsonCompactPrint(output);
 	}
 	else
 	{

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -27,6 +27,7 @@
 #include <libdevcore/Common.h>
 #include <libdevcore/CommonData.h>
 #include <libdevcore/CommonIO.h>
+#include <libdevcore/JSON.h>
 #include <libevmasm/Instruction.h>
 #include <libevmasm/GasMeter.h>
 #include <libsolidity/parsing/Scanner.h>
@@ -125,13 +126,6 @@ Json::Value estimateGas(CompilerStack const& _compiler, string const& _contract)
 	return gasEstimates;
 }
 
-string jsonCompactPrint(Json::Value const& input)
-{
-	Json::FastWriter writer;
-	writer.omitEndingLineFeed();
-	return writer.write(input);
-}
-
 string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback _readCallback)
 {
 	Json::Value output(Json::objectValue);
@@ -220,7 +214,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 			for (string const& contractName: compiler.contractNames())
 			{
 				Json::Value contractData(Json::objectValue);
-				contractData["interface"] = jsonCompactPrint(compiler.interface(contractName));
+				contractData["interface"] = dev::jsonCompactPrint(compiler.interface(contractName));
 				contractData["bytecode"] = compiler.object(contractName).toHex();
 				contractData["runtimeBytecode"] = compiler.runtimeObject(contractName).toHex();
 				contractData["opcodes"] = solidity::disassemble(compiler.object(contractName).bytecode);
@@ -281,7 +275,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 
 	try
 	{
-		return jsonCompactPrint(output);
+		return dev::jsonCompactPrint(output);
 	}
 	catch (...)
 	{
@@ -299,7 +293,7 @@ string compileMulti(string const& _input, bool _optimize, CStyleReadFileCallback
 		errors.append("Error parsing input JSON: " + reader.getFormattedErrorMessages());
 		Json::Value output(Json::objectValue);
 		output["errors"] = errors;
-		return jsonCompactPrint(output);
+		return dev::jsonCompactPrint(output);
 	}
 	else
 	{

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -40,12 +40,14 @@ public:
 	void checkInterface(std::string const& _code, std::string const& _expectedInterfaceString)
 	{
 		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse("pragma solidity >=0.0;\n" + _code), "Parsing contract failed");
+
 		Json::Value generatedInterface = m_compilerStack.metadata("", DocumentationType::ABIInterface);
 		Json::Value expectedInterface;
 		m_reader.parse(_expectedInterfaceString, expectedInterface);
 		BOOST_CHECK_MESSAGE(
 			expectedInterface == generatedInterface,
-			"Expected:\n" << expectedInterface.toStyledString() << "\n but got:\n" << generatedInterface.toStyledString()
+			"Expected:\n" << expectedInterface.toStyledString() <<
+			"\n but got:\n" << generatedInterface.toStyledString()
 		);
 	}
 

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -40,9 +40,7 @@ public:
 	void checkInterface(std::string const& _code, std::string const& _expectedInterfaceString)
 	{
 		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse("pragma solidity >=0.0;\n" + _code), "Parsing contract failed");
-		std::string generatedInterfaceString = m_compilerStack.metadata("", DocumentationType::ABIInterface);
-		Json::Value generatedInterface;
-		m_reader.parse(generatedInterfaceString, generatedInterface);
+		Json::Value generatedInterface = m_compilerStack.metadata("", DocumentationType::ABIInterface);
 		Json::Value expectedInterface;
 		m_reader.parse(_expectedInterfaceString, expectedInterface);
 		BOOST_CHECK_MESSAGE(

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -26,7 +26,6 @@
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/Exceptions.h>
 #include <libdevcore/Exceptions.h>
-#include <libdevcore/JSON.h>
 
 namespace dev
 {
@@ -46,9 +45,9 @@ public:
 		bool _userDocumentation
 	)
 	{
-		Json::Value generatedDocumentation;
 		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse("pragma solidity >=0.0;\n" + _code), "Parsing failed");
 
+		Json::Value generatedDocumentation;
 		if (_userDocumentation)
 			generatedDocumentation = m_compilerStack.metadata("", DocumentationType::NatspecUser);
 		else
@@ -57,8 +56,8 @@ public:
 		m_reader.parse(_expectedDocumentationString, expectedDocumentation);
 		BOOST_CHECK_MESSAGE(
 			expectedDocumentation == generatedDocumentation,
-			"Expected " << _expectedDocumentationString <<
-			"\n but got:\n" << dev::jsonPrettyPrint(generatedDocumentation)
+			"Expected " << expectedDocumentation.toStyledString() <<
+			"\n but got:\n" << generatedDocumentation.toStyledString()
 		);
 	}
 

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -45,21 +45,19 @@ public:
 		bool _userDocumentation
 	)
 	{
-		std::string generatedDocumentationString;
+		Json::Value generatedDocumentation;
 		ETH_TEST_REQUIRE_NO_THROW(m_compilerStack.parse("pragma solidity >=0.0;\n" + _code), "Parsing failed");
 
 		if (_userDocumentation)
-			generatedDocumentationString = m_compilerStack.metadata("", DocumentationType::NatspecUser);
+			generatedDocumentation = m_compilerStack.metadata("", DocumentationType::NatspecUser);
 		else
-			generatedDocumentationString = m_compilerStack.metadata("", DocumentationType::NatspecDev);
-		Json::Value generatedDocumentation;
-		m_reader.parse(generatedDocumentationString, generatedDocumentation);
+			generatedDocumentation = m_compilerStack.metadata("", DocumentationType::NatspecDev);
 		Json::Value expectedDocumentation;
 		m_reader.parse(_expectedDocumentationString, expectedDocumentation);
 		BOOST_CHECK_MESSAGE(
 			expectedDocumentation == generatedDocumentation,
 			"Expected " << _expectedDocumentationString <<
-			"\n but got:\n" << generatedDocumentationString
+			"\n but got:\n" << Json::StyledWriter().write(generatedDocumentation)
 		);
 	}
 

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -26,6 +26,7 @@
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/Exceptions.h>
 #include <libdevcore/Exceptions.h>
+#include <libdevcore/JSON.h>
 
 namespace dev
 {
@@ -57,7 +58,7 @@ public:
 		BOOST_CHECK_MESSAGE(
 			expectedDocumentation == generatedDocumentation,
 			"Expected " << _expectedDocumentationString <<
-			"\n but got:\n" << Json::StyledWriter().write(generatedDocumentation)
+			"\n but got:\n" << dev::jsonPrettyPrint(generatedDocumentation)
 		);
 	}
 


### PR DESCRIPTION
Split out of #760.

The real benefit I can see is that we don't need to return stringified JSON's after the overhaul of the input/output JSON. We can just keep everything as an object and serialise once. By doing that, the compact vs. pretty print serialisation can be removed too.

The current PR doesn't change external behaviour though.