### PR TITLE
Enum overflow checking before writing to storage

### DIFF
--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -738,6 +738,10 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 	default:
 		// All other types should not be convertible to non-equal types.
 		solAssert(_typeOnStack == _targetType, "Invalid type conversion requested.");
+		if (_cleanupNeeded && _targetType.canBeStored() && _targetType.storageBytes() < 32)
+				m_context
+					<< ((u256(1) << (8 * _targetType.storageBytes())) - 1)
+					<< Instruction::AND;
 		break;
 	}
 

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -492,11 +492,8 @@ void CompilerUtils::convertType(Type const& _typeOnStack, Type const& _targetTyp
 				{
 					if (typeOnStack.numBits() < 256)
 						m_context
-							<< (u256(1) << (256 - typeOnStack.numBits()))
-							<< Instruction::SWAP1
-							<< Instruction::DUP2
-							<< Instruction::MUL
-							<< Instruction::DIV;
+							<< ((u256(1) << typeOnStack.numBits()) - 1)
+							<< Instruction::AND;
 					chopSignBitsPending = false;
 				}
 			}

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -130,7 +130,7 @@ public:
 	/// if a reference type is converted from calldata or storage to memory.
 	/// If @a _cleanupNeeded, high order bits cleanup is also done if no type conversion would be
 	/// necessary.
-	void convertType(Type const& _typeOnStack, Type const& _targetType, bool _cleanupNeeded = false);
+	void convertType(Type const& _typeOnStack, Type const& _targetType, bool _cleanupNeeded = false, bool _chopSignBits = false);
 
 	/// Creates a zero-value for the given type and puts it onto the stack. This might allocate
 	/// memory for memory references.

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -130,6 +130,7 @@ public:
 	/// if a reference type is converted from calldata or storage to memory.
 	/// If @a _cleanupNeeded, high order bits cleanup is also done if no type conversion would be
 	/// necessary.
+	/// If @a _chopSignBits, the function resets the signed bits out of the width of the signed integer.
 	void convertType(Type const& _typeOnStack, Type const& _targetType, bool _cleanupNeeded = false, bool _chopSignBits = false);
 
 	/// Creates a zero-value for the given type and puts it onto the stack. This might allocate

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -233,8 +233,7 @@ void StorageItem::storeValue(Type const& _sourceType, SourceLocation const& _loc
 				m_context << Instruction::DUP2 << Instruction::SWAP1;
 
 			m_context << Instruction::SWAP1;
-			utils.convertType(_sourceType, _sourceType, true);
-			utils.convertType(*m_dataType, *m_dataType, true, true);
+			utils.convertType(_sourceType, *m_dataType, true);
 			m_context << Instruction::SWAP1;
 
 			m_context << Instruction::SSTORE;
@@ -244,7 +243,7 @@ void StorageItem::storeValue(Type const& _sourceType, SourceLocation const& _loc
 			if (_sourceType.sizeOnStack() == 1)
 			{
 				m_context << Instruction::SWAP2;
-				utils.convertType(_sourceType, _sourceType, true);
+				utils.convertType(_sourceType, *m_dataType, true);
 				m_context << Instruction::SWAP2;
 			}
 

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -221,6 +221,11 @@ void StorageItem::storeValue(Type const& _sourceType, SourceLocation const& _loc
 	{
 		solAssert(m_dataType->storageBytes() <= 32, "Invalid storage bytes size.");
 		solAssert(m_dataType->storageBytes() > 0, "Invalid storage bytes size.");
+
+		m_context << Instruction::SWAP2;
+		CompilerUtils(m_context).convertType(*m_dataType, *m_dataType, true);
+		m_context << Instruction::SWAP2;
+
 		if (m_dataType->storageBytes() == 32)
 		{
 			solAssert(m_dataType->sizeOnStack() == 1, "Invalid stack size.");

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -234,7 +234,7 @@ void StorageItem::storeValue(Type const& _sourceType, SourceLocation const& _loc
 
 			m_context << Instruction::SWAP1;
 			utils.convertType(_sourceType, _sourceType, true);
-			utils.convertType(*m_dataType, *m_dataType, true);
+			utils.convertType(*m_dataType, *m_dataType, true, true);
 			m_context << Instruction::SWAP1;
 
 			m_context << Instruction::SSTORE;
@@ -280,13 +280,7 @@ void StorageItem::storeValue(Type const& _sourceType, SourceLocation const& _loc
 			{
 				solAssert(m_dataType->sizeOnStack() == 1, "Invalid stack size for opaque type.");
 				// remove the higher order bits
-				utils.convertType(*m_dataType, *m_dataType, true);
-				m_context
-					<< (u256(1) << (8 * (32 - m_dataType->storageBytes())))
-					<< Instruction::SWAP1
-					<< Instruction::DUP2
-					<< Instruction::MUL
-					<< Instruction::DIV;
+				utils.convertType(*m_dataType, *m_dataType, true, true);
 			}
 			m_context  << Instruction::MUL << Instruction::OR;
 			// stack: value storage_ref updated_value

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4573,6 +4573,35 @@ BOOST_AUTO_TEST_CASE(invalid_enum_logged)
 	BOOST_CHECK(callContractFunction("test_log()") == encodeArgs());
 }
 
+BOOST_AUTO_TEST_CASE(invalid_enum_stored)
+{
+	char const* sourceCode = R"(
+		contract C {
+			enum X { A, B }
+			X public x;
+
+			function test_store() returns (uint) {
+				X garbled = X.A;
+				assembly {
+					garbled := 5
+				}
+				x = garbled;
+				return 1;
+			}
+			function test_store_ok() returns (uint) {
+				x = X.A;
+				return 1;
+			}
+		}
+		)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("test_store_ok()") == encodeArgs(u256(1)));
+	BOOST_CHECK(callContractFunction("x()") == encodeArgs(u256(0)));
+
+	// should throw
+	BOOST_CHECK(callContractFunction("test_store()") == encodeArgs());
+}
+
 BOOST_AUTO_TEST_CASE(invalid_enum_as_external_ret)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4539,6 +4539,40 @@ BOOST_AUTO_TEST_CASE(invalid_enum_compared)
 	BOOST_CHECK(callContractFunction("test_neq()") == encodeArgs());
 }
 
+BOOST_AUTO_TEST_CASE(invalid_enum_logged)
+{
+	char const* sourceCode = R"(
+		contract C {
+			enum X { A, B }
+			event Log(X);
+
+			function test_log() returns (uint) {
+				X garbled = X.A;
+				assembly {
+					garbled := 5
+				}
+				Log(garbled);
+				return 1;
+			}
+			function test_log_ok() returns (uint) {
+				X x = X.A;
+				Log(x);
+				return 1;
+			}
+		}
+		)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("test_log_ok()") == encodeArgs(u256(1)));
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Log(uint8)")));
+	BOOST_CHECK_EQUAL(h256(m_logs[0].data), h256(u256(0)));
+
+	// should throw
+	BOOST_CHECK(callContractFunction("test_log()") == encodeArgs());
+}
+
 BOOST_AUTO_TEST_CASE(invalid_enum_as_external_ret)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4506,6 +4506,39 @@ BOOST_AUTO_TEST_CASE(external_types_in_calls)
 	BOOST_CHECK(callContractFunction("t2()") == encodeArgs(u256(9)));
 }
 
+BOOST_AUTO_TEST_CASE(invalid_enum_compared)
+{
+	char const* sourceCode = R"(
+		contract C {
+			enum X { A, B }
+
+			function test_eq() returns (bool) {
+				X garbled;
+				assembly {
+					garbled := 5
+				}
+				return garbled == garbled;
+			}
+			function test_eq_ok() returns (bool) {
+				X garbled = X.A;
+				return garbled == garbled;
+			}
+			function test_neq() returns (bool) {
+				X garbled;
+				assembly {
+					garbled := 5
+				}
+				return garbled != garbled;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("test_eq_ok()") == encodeArgs(u256(1)));
+	// both should throw
+	BOOST_CHECK(callContractFunction("test_eq()") == encodeArgs());
+	BOOST_CHECK(callContractFunction("test_neq()") == encodeArgs());
+}
+
 BOOST_AUTO_TEST_CASE(invalid_enum_as_external_ret)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
This fixes #1344 (all the remaining points).

It turned out no fixes are necessary for most cases, but I needed to add cleanups before storing values into the storage.