### PR TITLE
styleguide: Order of Functions

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -150,6 +150,74 @@ No::
         ...
     }
 
+Order of Functions
+==================
+
+Ordering helps readers identify which functions they can call, and to find the "specials" (constructor and fallback function).
+
+Functions should be grouped according to their visibility and ordered:
+
+- constructor
+- fallback function (if exists)
+- external
+- public
+- internal
+- private
+
+Within a grouping, place the `constant` functions last.
+
+Yes::
+
+    contract A {
+        function A() {
+            ...
+        }
+        
+        function () payable {
+            ...
+        }
+        
+        // External functions
+        // ...
+        
+        // External functions that are constant
+        // ...
+        
+        // Public functions
+        // ...
+        
+        // Internal functions
+        // ...
+        
+        // Private functions
+        // ...
+    }
+
+No::
+
+    contract A {
+        
+        // External functions
+        // ...
+
+        // Private functions
+        // ...
+
+        // Public functions
+        // ...
+
+        function A() {
+            ...
+        }
+        
+        function () payable {
+            ...
+        }
+
+        // Internal functions
+        // ...       
+    }
+
 Whitespace in Expressions
 =========================
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -173,7 +173,7 @@ Yes::
             ...
         }
         
-        function() payable {
+        function() {
             ...
         }
         
@@ -210,7 +210,7 @@ No::
             ...
         }
         
-        function() payable {
+        function() {
             ...
         }
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -173,7 +173,7 @@ Yes::
             ...
         }
         
-        function () payable {
+        function() payable {
             ...
         }
         
@@ -210,7 +210,7 @@ No::
             ...
         }
         
-        function () payable {
+        function() payable {
             ...
         }
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -153,7 +153,7 @@ No::
 Order of Functions
 ==================
 
-Ordering helps readers identify which functions they can call, and to find the "specials" (constructor and fallback function).
+Ordering helps readers identify which functions they can call and to find the constructor and fallback definitions easier.
 
 Functions should be grouped according to their visibility and ordered:
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -262,6 +262,19 @@ No::
     y             = 2;
     long_variable = 3;
 
+Don't include a whitespace in the fallback function:
+
+Yes::
+
+    function() {
+        ...
+    }
+
+No::
+   
+    function () {
+        ...
+    }
 
 Control Structures
 ==================


### PR DESCRIPTION
Ordering would help readers identify which functions they can call, and to find the "specials" (constructor and fallback function).  Mixing the "specials" in the middle of the code, as well as internal functions between external and public functions, don't help readers

Based on ConsenSys/MultiSigWallet#19