### PR TITLE
disallow more than one errors in name and type tests

### DIFF
--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -62,7 +62,11 @@ parseAnalyseAndReturnError(string const& _source, bool _reportWarnings = false, 
 
 		SyntaxChecker syntaxChecker(errors);
 		if (!syntaxChecker.checkSyntax(*sourceUnit))
+		{
+			if (errors.size() > 1)
+				BOOST_FAIL("Multiple errors found after checking syntax.");
 			return make_pair(sourceUnit, errors.at(0));
+		}
 
 		std::shared_ptr<GlobalContext> globalContext = make_shared<GlobalContext>();
 		NameAndTypeResolver resolver(globalContext->declarations(), errors);
@@ -89,8 +93,12 @@ parseAnalyseAndReturnError(string const& _source, bool _reportWarnings = false, 
 					TypeChecker typeChecker(errors);
 					bool success = typeChecker.checkTypeRequirements(*contract);
 					BOOST_CHECK(success || !errors.empty());
+					if (errors.size() > 1)
+						BOOST_FAIL("Multiple errors found after checking type requirements");
 
 				}
+		if (errors.size() > 1)
+			BOOST_FAIL("Multiple errors found");
 		for (auto const& currentError: errors)
 		{
 			if (


### PR DESCRIPTION
Some days ago @chriseth had an idea of making sure only a single error is generated in a test case.  Currently this policy causes 32 tests to fail, and these should be fixed on this branch.