### PR TITLE
test: add a test case about returning a struct in memory from a library

### DIFF
--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2817,6 +2817,17 @@ BOOST_AUTO_TEST_CASE(using_for_not_used)
 	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
 }
 
+BOOST_AUTO_TEST_CASE(library_memory_struct)
+{
+	char const* text = R"(
+		library c {
+			struct S { uint x; }
+			function f() returns (S ) {}
+		}
+	)";
+	BOOST_CHECK(expectError(text) == Error::Type::TypeError);
+}
+
 BOOST_AUTO_TEST_CASE(using_for_arbitrary_mismatch)
 {
 	// Bound to a, but self type does not match.


### PR DESCRIPTION
This pull-request adds the first test case that is dependent on the interface type of non-storage structs in libraries.

This fixes #1378.