### PR TITLE
optimizing ADD; POP and similar

### DIFF
--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -14,7 +14,7 @@
 	You should have received a copy of the GNU General Public License
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file Assembly.h
+/** @file AssemblyItem.h
  * @author Gav Wood <i@gavwood.com>
  * @date 2014
  */

--- a/libevmasm/PeepholeOptimiser.cpp
+++ b/libevmasm/PeepholeOptimiser.cpp
@@ -68,14 +68,15 @@ struct AddPop
 		{
 			Instruction i0 = _in[0].instruction();
 			if (instructionInfo(i0).ret == 1 &&
-				instructionInfo(i0).args == 2 &&
 				!SemanticInformation::invalidatesMemory(i0) &&
-				!SemanticInformation::invalidatesStorage(i0)
+				!SemanticInformation::invalidatesStorage(i0) &&
+				!SemanticInformation::altersControlFlow(i0) &&
+				!instructionInfo(i0).sideEffects
 			)
 			{
-				*_out = Instruction::POP;
-				*_out = Instruction::POP;
-			return true;
+				for (int j = 0; j < instructionInfo(i0).args; j++)
+					*_out = Instruction::POP;
+				return true;
 			}
 		}
 		return false;


### PR DESCRIPTION
This pull-request adds a peep-hole optimization that replaces `ADD; POP` with `POP; POP`.  This enables some further optimizations.

Example:
```
contract C {
   function f (int a) {
       a + a;
   }
}
```

Before this PR, without `--optimize` option, the compiler produces `...DUP1 DUP2 ADD POP...`

After this PR, without `--optimize` option, this sequence disappears.