### PR TITLE
Disallow conversion of string literal into strings when the literal is not a valid UTF-8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### 0.4.7 (unreleased)
+
+Bugfixes:
+ * Type checker: string literals that are not valid UTF-8 cannot be converted to string type
+
 ### 0.4.6 (2016-11-22)
 
 Bugfixes:

--- a/libdevcore/UTF8.h
+++ b/libdevcore/UTF8.h
@@ -29,7 +29,7 @@ namespace dev
 {
 
 /// Validate an input for UTF8 encoding
-/// @returns true if it is invalid and the first invalid position in invalidPosition
+/// @returns false if it is invalid and the first invalid position in invalidPosition
 bool validate(std::string const& _input, size_t& _invalidPosition);
 
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -879,7 +879,8 @@ bool StringLiteralType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	else if (auto arrayType = dynamic_cast<ArrayType const*>(&_convertTo))
 		return
 			arrayType->isByteArray() &&
-			!(arrayType->dataStoredIn(DataLocation::Storage) && arrayType->isPointer());
+			!(arrayType->dataStoredIn(DataLocation::Storage) && arrayType->isPointer()) &&
+            !(arrayType->isString() && !isValidUTF8());
 	else
 		return false;
 }
@@ -904,6 +905,12 @@ std::string StringLiteralType::toString(bool) const
 TypePointer StringLiteralType::mobileType() const
 {
 	return make_shared<ArrayType>(DataLocation::Memory, true);
+}
+
+bool StringLiteralType::isValidUTF8() const
+{
+	size_t dontCare {};
+	return dev::validate(m_value, dontCare);
 }
 
 shared_ptr<FixedBytesType> FixedBytesType::smallestTypeForLiteral(string const& _literal)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -880,7 +880,7 @@ bool StringLiteralType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 		return
 			arrayType->isByteArray() &&
 			!(arrayType->dataStoredIn(DataLocation::Storage) && arrayType->isPointer()) &&
-            !(arrayType->isString() && !isValidUTF8());
+			!(arrayType->isString() && !isValidUTF8());
 	else
 		return false;
 }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -425,6 +425,8 @@ public:
 	virtual std::string toString(bool) const override;
 	virtual TypePointer mobileType() const override;
 
+	bool isValidUTF8() const;
+
 	std::string const& value() const { return m_value; }
 
 private:

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2045,7 +2045,7 @@ BOOST_AUTO_TEST_CASE(invalid_utf8)
 			string s = "\xa0\x00";
 		}
 	)";
-	CHECK_ERROR(sourceCode, TypeError, "Invalid UTF-8");
+	CHECK_ERROR(sourceCode, TypeError, "invalid UTF-8");
 }
 
 BOOST_AUTO_TEST_CASE(string_index)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2038,7 +2038,7 @@ BOOST_AUTO_TEST_CASE(string)
 	BOOST_CHECK_NO_THROW(parseAndAnalyse(sourceCode));
 }
 
-BOOST_AUTO_TEST_CASE(invalid_utf8)
+BOOST_AUTO_TEST_CASE(invalid_utf8_implicit)
 {
 	char const* sourceCode = R"(
 		contract C {
@@ -2046,6 +2046,16 @@ BOOST_AUTO_TEST_CASE(invalid_utf8)
 		}
 	)";
 	CHECK_ERROR(sourceCode, TypeError, "invalid UTF-8");
+}
+
+BOOST_AUTO_TEST_CASE(invalid_utf8_explicit)
+{
+	char const* sourceCode = R"(
+		contract C {
+			string s = string("\xa0\x00");
+		}
+	)";
+	CHECK_ERROR(sourceCode, TypeError, "Explicit type conversion not allowed");
 }
 
 BOOST_AUTO_TEST_CASE(string_index)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2038,6 +2038,16 @@ BOOST_AUTO_TEST_CASE(string)
 	BOOST_CHECK_NO_THROW(parseAndAnalyse(sourceCode));
 }
 
+BOOST_AUTO_TEST_CASE(invalid_utf8)
+{
+	char const* sourceCode = R"(
+		contract C {
+			string s = "\xa0\x00";
+		}
+	)";
+	CHECK_ERROR(sourceCode, TypeError, "Invalid UTF-8");
+}
+
 BOOST_AUTO_TEST_CASE(string_index)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Fixes #883.