### PR TITLE
Accept any kind of whitespace after natspec tags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Features:
 Bugfixes:
  * Code generator: Allow recursive structs.
  * Type checker: Allow multiple events of the same name (but with different arities or argument types)
+ * Natspec parser: Fix error with ``@param`` parsing and whitespace.
 
 ### 0.4.8 (2017-01-13)
 

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -99,7 +99,13 @@ DocStringParser::iter DocStringParser::parseDocTagLine(iter _pos, iter _end, boo
 	solAssert(!!m_lastTag, "");
 	auto nlPos = find(_pos, _end, '\n');
 	if (_appending && _pos < _end && *_pos != ' ' && *_pos != '\t')
+	{
 		m_lastTag->content += " ";
+	}
+	else if (!_appending)
+	{
+		_pos = skipWhitespace(_pos, _end);
+	}
 	copy(_pos, nlPos, back_inserter(m_lastTag->content));
 	return skipLineOrEOS(nlPos, _end);
 }

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -31,8 +31,8 @@ static inline string::const_iterator firstWsOrNl(
 	string::const_iterator _end
 )
 {
+	auto nlPos = find(_pos, _end, '\n');
 	auto wsPos = firstSpaceOrTab(_pos, _end);
-	auto nlPos = find(wsPos, _end, '\n');
 	return (wsPos < nlPos) ? wsPos : nlPos;
 }
 

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -26,7 +26,7 @@ static inline string::const_iterator firstSpaceOrTab(
 	return (spacePos < tabPos) ? spacePos : tabPos;
 }
 
-static inline string::const_iterator firstWsOrNl(
+static inline string::const_iterator firstWhitespaceOrNewline(
 	string::const_iterator _pos,
 	string::const_iterator _end
 )
@@ -66,7 +66,7 @@ bool DocStringParser::parse(string const& _docString, ErrorList& _errors)
 		if (tagPos != end && tagPos < nlPos)
 		{
 			// we found a tag
-			auto tagNameEndPos = firstWsOrNl(tagPos, end);
+			auto tagNameEndPos = firstWhitespaceOrNewline(tagPos, end);
 			if (tagNameEndPos == end)
 			{
 				appendError("End of tag " + string(tagPos, tagNameEndPos) + "not found");

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -635,6 +635,48 @@ BOOST_AUTO_TEST_CASE(dev_documenting_nonexistent_param)
 	expectNatspecError(sourceCode);
 }
 
+BOOST_AUTO_TEST_CASE(dev_documenting_no_paramname)
+{
+	char const* sourceCode = R"(
+		contract test {
+			/// @dev Multiplies a number by 7 and adds second parameter
+			/// @param a Documentation for the first parameter
+			/// @param 
+			function mul(uint a, uint second) returns(uint d) { return a * 7 + second; }
+		}
+	)";
+
+	expectNatspecError(sourceCode);
+}
+
+BOOST_AUTO_TEST_CASE(dev_documenting_no_paramname_end)
+{
+	char const* sourceCode = R"(
+		contract test {
+			/// @dev Multiplies a number by 7 and adds second parameter
+			/// @param a Documentation for the first parameter
+			/// @param se
+			function mul(uint a, uint second) returns(uint d) { return a * 7 + second; }
+		}
+	)";
+
+	expectNatspecError(sourceCode);
+}
+
+BOOST_AUTO_TEST_CASE(dev_documenting_no_param_description)
+{
+	char const* sourceCode = R"(
+		contract test {
+			/// @dev Multiplies a number by 7 and adds second parameter
+			/// @param a Documentation for the first parameter
+			/// @param second 
+			function mul(uint a, uint second) returns(uint d) { return a * 7 + second; }
+		}
+	)";
+
+	expectNatspecError(sourceCode);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(dev_desc_after_nl)
 	char const* natspec = "{"
 	"\"methods\":{"
 	"    \"mul(uint256,uint256)\":{ \n"
-	"        \"details\": \" Multiplies a number by 7 and adds second parameter\",\n"
+	"        \"details\": \"Multiplies a number by 7 and adds second parameter\",\n"
 	"        \"params\": {\n"
 	"            \"a\": \"Documentation for the first parameter\",\n"
 	"            \"second\": \"Documentation for the second parameter\"\n"
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(dev_return_desc_after_nl)
 	"            \"a\": \"Documentation for the first parameter starts here. Since it's a really complicated parameter we need 2 lines\",\n"
 	"            \"second\": \"Documentation for the second parameter\"\n"
 	"        },\n"
-	"        \"return\": \" The result of the multiplication\"\n"
+	"        \"return\": \"The result of the multiplication\"\n"
 	"    }\n"
 	"}}";
 

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -56,7 +56,7 @@ public:
 		m_reader.parse(_expectedDocumentationString, expectedDocumentation);
 		BOOST_CHECK_MESSAGE(
 			expectedDocumentation == generatedDocumentation,
-			"Expected " << expectedDocumentation.toStyledString() <<
+			"Expected:\n" << expectedDocumentation.toStyledString() <<
 			"\n but got:\n" << generatedDocumentation.toStyledString()
 		);
 	}

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -251,6 +251,29 @@ BOOST_AUTO_TEST_CASE(dev_multiple_params)
 	checkNatspec(sourceCode, natspec, false);
 }
 
+BOOST_AUTO_TEST_CASE(dev_multiple_params_mixed_whitespace)
+{
+	char const* sourceCode = "contract test {\n"
+	"  /// @dev	 Multiplies a number by 7 and adds second parameter\n"
+	"  /// @param 	 a Documentation for the first parameter\n"
+	"  /// @param	 second			 Documentation for the second parameter\n"
+	"  function mul(uint a, uint second) returns(uint d) { return a * 7 + second; }\n"
+	"}\n";
+
+	char const* natspec = "{"
+	"\"methods\":{"
+	"    \"mul(uint256,uint256)\":{ \n"
+	"        \"details\": \"Multiplies a number by 7 and adds second parameter\",\n"
+	"        \"params\": {\n"
+	"            \"a\": \"Documentation for the first parameter\",\n"
+	"            \"second\": \"Documentation for the second parameter\"\n"
+	"        }\n"
+	"    }\n"
+	"}}";
+
+	checkNatspec(sourceCode, natspec, false);
+}
+
 BOOST_AUTO_TEST_CASE(dev_mutiline_param_description)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
If you added two spaces after `@param` then the compilation failed since it could not properly parse the param name. Fixed that particular parsing error and also made it resistant to either tabs or spaces.