### PR TITLE
codegen: assertion did not assert non-nullness

### DIFF
--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -583,7 +583,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 				// lvalue context
 				auto variable = dynamic_cast<VariableDeclaration const*>(decl);
 				solAssert(
-					!!variable || !m_context.isLocalVariable(variable),
+					!!variable && m_context.isLocalVariable(variable),
 					"Can only assign to stack variables in inline assembly."
 				);
 				unsigned size = variable->type()->sizeOnStack();

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4521,7 +4521,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_storage)
 			}
 		}
 	)";
-	CHECK_ERROR(text, DeclarationError, "");
+	CHECK_ERROR(text, DeclarationError, "not found, not unique or not lvalue.");
 }
 
 BOOST_AUTO_TEST_CASE(inline_assembly_storage_in_modifiers)


### PR DESCRIPTION
This PR strengthens an assertion so that it makes sure that a pointer is not null.
Moreover, `isLocalVariable(variable)` is now positively asserted, following the error message.

This was found by the Clang Static Analyzer.