### PR TITLE
codegen: this commit removes one of duplicate assignments

### DIFF
--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -862,8 +862,6 @@ void ContractCompiler::appendModifierOrFunctionCode()
 				CompilerUtils::sizeOnStack(modifier.parameters()) +
 				CompilerUtils::sizeOnStack(modifier.localVariables());
 			codeBlock = &modifier.body();
-
-			codeBlock = &modifier.body();
 		}
 	}
 


### PR DESCRIPTION
There were two identical assignments one immediately following the other.  This PR removes one of these.

This was found by the Clang Static Analyzer.