### PR TITLE
Implement memcpy without the identity precompile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Features:
  * Type checker: Warn when ``msg.value`` is used in non-payable function.
  * Code generator: Inject the Swarm hash of a metadata file into the bytecode.
+ * Code generator: Replace expensive memcpy precompile by simple assembly loop.
  * Optimizer: Some dead code elimination.
 
 Bugfixes:

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -335,9 +335,14 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		if (baseSize > 1)
 			m_context << u256(baseSize) << Instruction::MUL;
 		// stack: <target> <source> <size>
-		//@TODO do not use ::CALL if less than 32 bytes?
 		m_context << Instruction::DUP1 << Instruction::DUP4 << Instruction::DUP4;
-		utils.memoryCopy();
+		// We can resort to copying full 32 bytes only if
+		// - the length is known to be a multiple of 32 or
+		// - we will pad to full 32 bytes later anyway.
+		if (((baseSize % 32) == 0) || _padToWordBoundaries)
+			utils.memoryCopy32();
+		else
+			utils.memoryCopy();
 
 		m_context << Instruction::SWAP1 << Instruction::POP;
 		// stack: <target> <size>

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -202,6 +202,8 @@ void CompilerContext::appendInlineAssembly(
 			return false;
 		unsigned stackDepth = _localVariables.end() - it;
 		int stackDiff = _assembly.deposit() - startStackHeight + stackDepth;
+		if (_context == assembly::CodeGenerator::IdentifierContext::LValue)
+			stackDiff -= 1;
 		if (stackDiff < 1 || stackDiff > 16)
 			BOOST_THROW_EXCEPTION(
 				CompilerError() <<
@@ -218,7 +220,6 @@ void CompilerContext::appendInlineAssembly(
 	};
 
 	solAssert(assembly::InlineAssemblyStack().parseAndAssemble(*assembly, *m_asm, identifierAccess), "Failed to assemble inline assembly block.");
-	setStackOffset(startStackHeight);
 }
 
 FunctionDefinition const& CompilerContext::resolveVirtualFunction(

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -217,7 +217,7 @@ void CompilerContext::appendInlineAssembly(
 		return true;
 	};
 
-	solAssert(assembly::InlineAssemblyStack().parseAndAssemble(*assembly, *m_asm, identifierAccess), "");
+	solAssert(assembly::InlineAssemblyStack().parseAndAssemble(*assembly, *m_asm, identifierAccess), "Failed to assemble inline assembly block.");
 }
 
 FunctionDefinition const& CompilerContext::resolveVirtualFunction(

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -218,6 +218,7 @@ void CompilerContext::appendInlineAssembly(
 	};
 
 	solAssert(assembly::InlineAssemblyStack().parseAndAssemble(*assembly, *m_asm, identifierAccess), "Failed to assemble inline assembly block.");
+	setStackOffset(startStackHeight);
 }
 
 FunctionDefinition const& CompilerContext::resolveVirtualFunction(

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -298,9 +298,16 @@ void CompilerUtils::zeroInitialiseMemoryArray(ArrayType const& _type)
 	m_context << Instruction::SWAP1 << Instruction::POP;
 }
 
-void CompilerUtils::memoryCopy()
+void CompilerUtils::memoryCopy(bool _useIdentityPrecompile)
 {
 	// Stack here: size target source
+
+	if (!_useIdentityPrecompile)
+	{
+		// FIXME
+		return;
+	}
+
 	// stack for call: outsize target size source value contract gas
 	//@TODO do not use ::CALL if less than 32 bytes?
 	m_context << Instruction::DUP3 << Instruction::SWAP1;

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -112,7 +112,7 @@ public:
 	/// Uses a CALL to the identity contract to perform a memory-to-memory copy.
 	/// Stack pre: <size> <target> <source>
 	/// Stack post:
-	void memoryCopy();
+	void memoryCopy(bool _useIdentityPrecompile = true);
 
 	/// Converts the combined and left-aligned (right-aligned if @a _rightAligned is true)
 	/// external function type <address><function identifier> into two stack slots:

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -112,7 +112,15 @@ public:
 	/// Uses a CALL to the identity contract to perform a memory-to-memory copy.
 	/// Stack pre: <size> <target> <source>
 	/// Stack post:
-	void memoryCopy(bool _useIdentityPrecompile = false);
+	void memoryCopyPrecompile();
+	/// Copies full 32 byte words in memory (regions cannot overlap), i.e. may copy more than length.
+	/// Stack pre: <size> <target> <source>
+	/// Stack post:
+	void memoryCopy32();
+	/// Copies data in memory (regions cannot overlap).
+	/// Stack pre: <size> <target> <source>
+	/// Stack post:
+	void memoryCopy();
 
 	/// Converts the combined and left-aligned (right-aligned if @a _rightAligned is true)
 	/// external function type <address><function identifier> into two stack slots:

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -112,7 +112,7 @@ public:
 	/// Uses a CALL to the identity contract to perform a memory-to-memory copy.
 	/// Stack pre: <size> <target> <source>
 	/// Stack post:
-	void memoryCopy(bool _useIdentityPrecompile = true);
+	void memoryCopy(bool _useIdentityPrecompile = false);
 
 	/// Converts the combined and left-aligned (right-aligned if @a _rightAligned is true)
 	/// external function type <address><function identifier> into two stack slots:


### PR DESCRIPTION
Fixes #1248.

However, it costs more than the identity, so I'm not sure it should be turned on.

See a testing toolkit: https://gist.github.com/axic/3746cb1228ced4345ae882d8ec9773b9

< 32 bytes:
Identity: 1011gas
Assembly: 1001gas
Solidity: 1021gas

194 bytes:
Identity: 1762 gas
Assembly: 2262 gas
Solidity: 2324 gas