### PR TITLE
Throw if calling the identity precompile (memoryCopy) failed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
  * Optimizer: Some dead code elimination.
 
 Bugfixes:
+ * Code generator: throw if calling the identity precompile failed during memory (array) copying.
  * Type checker: string literals that are not valid UTF-8 cannot be converted to string type
 
 ### 0.4.6 (2016-11-22)

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -312,7 +312,8 @@ void CompilerUtils::memoryCopy()
 	m_context << Instruction::DIV << u256(c_identityWordGas) << Instruction::MUL;
 	m_context << u256(c_identityGas) << Instruction::ADD;
 	m_context << Instruction::CALL;
-	m_context << Instruction::POP; // ignore return value
+	m_context << Instruction::ISZERO;
+	m_context.appendConditionalJumpTo(m_context.errorTag());
 }
 
 void CompilerUtils::splitExternalFunctionType(bool _leftAligned)


### PR DESCRIPTION
Fixes #1469.