### PR TITLE
Option to show messages in tests.

### DIFF
--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -46,6 +46,7 @@ string getIPCSocketPath()
 ExecutionFramework::ExecutionFramework() :
 	m_rpc(RPCSession::instance(getIPCSocketPath())),
 	m_optimize(dev::test::Options::get().optimize),
+	m_showMessages(dev::test::Options::get().showMessages),
 	m_sender(m_rpc.account(0))
 {
 	m_rpc.test_rewindToBlock(0);
@@ -53,6 +54,13 @@ ExecutionFramework::ExecutionFramework() :
 
 void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 const& _value)
 {
+	if (m_showMessages)
+	{
+		if (_isCreation)
+			cout << "CREATE " << toHex(m_sender) << ": " << toHex(_data) << endl;
+		else
+			cout << "CALL   " << toHex(m_sender) << " -> " << toHex(m_contractAddress) << ": " << toHex(_data) << endl;
+	}
 	RPCSession::TransactionData d;
 	d.data = "0x" + toHex(_data);
 	d.from = "0x" + toString(m_sender);
@@ -78,6 +86,9 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 		string code = m_rpc.eth_getCode(receipt.contractAddress, "latest");
 		m_output = fromHex(code, WhenError::Throw);
 	}
+
+	if (m_showMessages)
+		cout << " -> " << toHex(m_output) << endl;
 
 	m_gasUsed = u256(receipt.gasUsed);
 	m_logs.clear();

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -57,9 +57,12 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 	if (m_showMessages)
 	{
 		if (_isCreation)
-			cout << "CREATE " << toHex(m_sender) << ": " << toHex(_data) << endl;
+			cout << "CREATE " << m_sender.hex() << ":" << endl;
 		else
-			cout << "CALL   " << toHex(m_sender) << " -> " << toHex(m_contractAddress) << ": " << toHex(_data) << endl;
+			cout << "CALL   " << m_sender.hex() << " -> " << m_contractAddress.hex() << ":" << endl;
+		if (_value > 0)
+			cout << " value: " << _value << endl;
+		cout << " in: " << toHex(_data) << endl;
 	}
 	RPCSession::TransactionData d;
 	d.data = "0x" + toHex(_data);
@@ -88,7 +91,7 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 	}
 
 	if (m_showMessages)
-		cout << " -> " << toHex(m_output) << endl;
+		cout << " out: " << toHex(m_output) << endl;
 
 	m_gasUsed = u256(receipt.gasUsed);
 	m_logs.clear();

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -281,6 +281,7 @@ protected:
 
 	unsigned m_optimizeRuns = 200;
 	bool m_optimize = false;
+	bool m_showMessages = false;
 	Address m_sender;
 	Address m_contractAddress;
 	u256 const m_gasPrice = 100 * szabo;

--- a/test/TestHelper.cpp
+++ b/test/TestHelper.cpp
@@ -41,6 +41,8 @@ Options::Options()
 		}
 		else if (string(suite.argv[i]) == "--optimize")
 			optimize = true;
+		else if (string(suite.argv[i]) == "--show-messages")
+			showMessages = true;
 
 	if (ipcPath.empty())
 		if (auto path = getenv("ETH_TEST_IPC"))

--- a/test/TestHelper.h
+++ b/test/TestHelper.h
@@ -106,6 +106,7 @@ namespace test
 struct Options: boost::noncopyable
 {
 	std::string ipcPath;
+	bool showMessages = false;
 	bool optimize = false;
 
 	static Options const& get();


### PR DESCRIPTION
If you use `soltest -- --show-messages` it will print the call and return data of each transaction during testing.