### PR TITLE
[WIP] Make memcopy safe for overlapping regions.

### DIFF
--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -338,7 +338,7 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 			return;
 		}
 
-		// memcpy using the built-in contract
+		// memcopy
 		if (_sourceType.isDynamicallySized())
 		{
 			// change pointer to data part
@@ -353,10 +353,8 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		// We can resort to copying full 32 bytes only if
 		// - the length is known to be a multiple of 32 or
 		// - we will pad to full 32 bytes later anyway.
-		if (((baseSize % 32) == 0) || _padToWordBoundaries)
-			utils.memoryCopy32();
-		else
-			utils.memoryCopy();
+		bool const copyFullWords = ((baseSize % 32) == 0) || _padToWordBoundaries;
+		utils.memoryCopy(copyFullWords);
 
 		m_context << Instruction::SWAP1 << Instruction::POP;
 		// stack: <target> <size>

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -302,48 +302,66 @@ void CompilerUtils::zeroInitialiseMemoryArray(ArrayType const& _type)
 	m_context << Instruction::SWAP1 << Instruction::POP;
 }
 
-void CompilerUtils::memoryCopy32()
+void CompilerUtils::memoryCopy(bool _copyFullWords)
 {
 	// Stack here: size target source
 
-	m_context.appendInlineAssembly(R"(
+	string wordCopyCode = R"(
+		jumpi(skipwordcopy, eq(len, 0))
 		{
-			for { let i := 0 } lt(i, len) { i := add(i, 32) } {
-				mstore(add(dst, i), mload(add(src, i)))
+			let last := add(src, and(sub(len, 1), not(31)))
+			let delta := 32
+			jumpi(startwordcopy, or(gt(src, dst), lt(add(last, 31), dst)))
+			// We have to copy in reverse to avoid overwriting
+			delta := sub(0, delta)
+			dst := add(dst, sub(last, src))
+			{
+				let t := src
+				src := last
+				last := t
+			}
+			startwordcopy:
+			mstore(dst, mload(src))
+			jumpi(endwordcopy, eq(src, last))
+			dst := add(dst, delta)
+			src := add(src, delta)
+			jump(startwordcopy)
+			endwordcopy:
+		}
+		skipwordcopy:
+	)";
+
+	if (_copyFullWords)
+		m_context.appendInlineAssembly("{" + wordCopyCode + "}", { "len", "dst", "src" });
+	else
+		// pseudo-function-invocation
+		m_context.appendInlineAssembly(R"(
+		{
+			jumpi(copyRemainder, lt(lenPartial, 33))
+			{
+				// number of bytes copied as full words
+				let fullWordCopy := and(sub(lenPartial, 1), 31)
+				{
+					let len := fullWordCopy
+					let dst := dstPartial
+					let src := srcPartial
+		)" + wordCopyCode + R"(
+				}
+				dstPartial := add(dstPartial, fullWordCopy)
+				srcPartial := add(srcPartial, fullWordCopy)
+				lenPartial := sub(lenPartial, fullWordCopy)
+			}
+			copyRemainder:
+			{
+				// copy the remainder (0 <= lenPartial < 33)
+				let mask := sub(exp(256, sub(32, lenPartial)), 1)
+				let srcpart := and(mload(srcPartial), not(mask))
+				let dstpart := and(mload(dstPartial), mask)
+				mstore(dstPartial, or(srcpart, dstpart))
 			}
 		}
-	)",
-		{ "len", "dst", "src" }
-	);
-	m_context << Instruction::POP << Instruction::POP << Instruction::POP;
-}
-
-void CompilerUtils::memoryCopy()
-{
-	// Stack here: size target source
-
-	m_context.appendInlineAssembly(R"(
-		{
-			// copy 32 bytes at once
-			for
-				{}
-				iszero(lt(len, 32))
-				{
-					dst := add(dst, 32)
-					src := add(src, 32)
-					len := sub(len, 32)
-				}
-				{ mstore(dst, mload(src)) }
-
-			// copy the remainder (0 < len < 32)
-			let mask := sub(exp(256, sub(32, len)), 1)
-			let srcpart := and(mload(src), not(mask))
-			let dstpart := and(mload(dst), mask)
-			mstore(dst, or(srcpart, dstpart))
-		}
-	)",
-		{ "len", "dst", "src" }
-	);
+		)",
+		{ "lenPartial", "dstPartial", "srcPartial" });
 	m_context << Instruction::POP << Instruction::POP << Instruction::POP;
 }
 

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -109,16 +109,12 @@ public:
 	/// Stack post: <updated_memptr>
 	void zeroInitialiseMemoryArray(ArrayType const& _type);
 
-	/// Copies full 32 byte words in memory (regions cannot overlap), i.e. may copy more than length.
+	/// Copies areas in memory that might overlap.
 	/// Length can be zero, in this case, it copies nothing.
+	/// @param _copyFullWords if set, copies full 32 byte words, i.e. may copy more than length.
 	/// Stack pre: <size> <target> <source>
 	/// Stack post:
-	void memoryCopy32();
-	/// Copies data in memory (regions cannot overlap).
-	/// Length can be zero, in this case, it copies nothing.
-	/// Stack pre: <size> <target> <source>
-	/// Stack post:
-	void memoryCopy();
+	void memoryCopy(bool _copyFullWords);
 
 	/// Converts the combined and left-aligned (right-aligned if @a _rightAligned is true)
 	/// external function type <address><function identifier> into two stack slots:


### PR DESCRIPTION
Fixes #1510.

There is one test failure I am too tired to debug now.