### PR TITLE
Corrected explanation of recursive contract creation

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -208,7 +208,7 @@ Creating Contracts via ``new``
 
 A contract can create a new contract using the ``new`` keyword. The full
 code of the contract being created has to be known and, thus, recursive
-creation-dependencies are now possible.
+creation-dependencies are not possible.
 
 ::
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -207,8 +207,8 @@ Creating Contracts via ``new``
 ==============================
 
 A contract can create a new contract using the ``new`` keyword. The full
-code of the contract being created has to be known; though recursive
-creation-dependencies are possible, cyclic dependencies are not.
+code of the contract being created has to be known in advance, so recursive
+creation-dependencies are not possible.
 
 ::
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -207,8 +207,8 @@ Creating Contracts via ``new``
 ==============================
 
 A contract can create a new contract using the ``new`` keyword. The full
-code of the contract being created has to be known and, thus, recursive
-creation-dependencies are not possible.
+code of the contract being created has to be known; though recursive
+creation-dependencies are possible, cyclic dependencies are not.
 
 ::
 


### PR DESCRIPTION
"now possible" should instead read "not possible."