### PR TITLE
Remappings reference and fixes

### DIFF
--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -128,18 +128,21 @@ and then run the compiler as
 
   solc github.com/ethereum/dapp-bin/=/usr/local/dapp-bin/ source.sol
 
-As a more complex example, suppose you rely on some module that uses a
-very old version of dapp-bin. That old version of dapp-bin is checked
+As a more complex example, suppose you rely on some modules `module1` and `module2`. Further,
+suppose that `module1` uses a very old version of dapp-bin. That old version of dapp-bin is checked
 out at ``/usr/local/dapp-bin_old``, then you can use
 
 .. code-block:: bash
 
-  solc module1:github.com/ethereum/dapp-bin/=/usr/local/dapp-bin/ \
-       module2:github.com/ethereum/dapp-bin/=/usr/local/dapp-bin_old/ \
+  solc module1/=/path/to/module1/ \
+       module2/=/path/to/module2/ \
+       @module1:github.com/ethereum/dapp-bin/=/usr/local/dapp-bin/ \
+       @module2:github.com/ethereum/dapp-bin/=/usr/local/dapp-bin_old/ \
        source.sol
 
 so that all imports in ``module2`` point to the old version but imports
-in ``module1`` get the new version.
+in ``module1`` get the new version. Note that the `@` is actually referencing your
+previous remappings' prefix and substituting the path that it maps to.
 
 Note that solc only allows you to include files from certain directories:
 They have to be in the directory (or subdirectory) of one of the explicitly

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -553,25 +553,27 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 		return abs(a) < abs(b);
 	};
 
+	using filepath = boost::filesystem::path;
+	filepath context(_context);
 	size_t longestPrefix = 0;
 	string longestPrefixTarget;
 	string currentClosestContext;
-	string referenceContext = _context.substr(0, _context.find_last_of('/')+1);
+	string referenceContext = context.parent_path().generic_string();
 	for (auto const& redir: m_remappings)
 	{
+		filepath redirContext(redir.context);
 		// Skip if we already have a closer match.
 		if (longestPrefix > 0 && redir.prefix.length() < longestPrefix)
 			continue;
 		// Skip if redir.context is not a prefix of _context
-		if (!isPrefixOf(redir.context, _context))
+		if (!isPrefixOf(redirContext.generic_string(), _context))
 			continue;
 		// Skip if the prefix does not match.
 		if (!isPrefixOf(redir.prefix, _path))
 			continue;
 		// Skip if there is a prefix collision and the current context is closer
-		if (redir.prefix.length() == longestPrefix && !isClosestContext(redir.context, currentClosestContext, referenceContext))
+		if (redir.prefix.length() == longestPrefix && !isClosestContext(redirContext.generic_string(), currentClosestContext, referenceContext))
 			continue;
-
 		currentClosestContext = redir.context;
 		longestPrefix = redir.prefix.length();
 		longestPrefixTarget = redir.target;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -569,7 +569,7 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 		longestPrefix = redir.prefix.length();
 		longestPrefixTarget = redir.target;
 	}
-	string path = longestPrefixTarget; 
+	string path = longestPrefixTarget;
 	path.append(_path.begin() + longestPrefix, _path.end());
 	return path;
 }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -59,6 +59,8 @@ CompilerStack::CompilerStack(ReadFileCallback const& _readFile):
 void CompilerStack::setRemappings(vector<string> const& _remappings)
 {
 	vector<Remapping> remappings;
+	map<string, int> index;
+	map<string, int> contextReferences;
 	for (auto const& remapping: _remappings)
 	{
 		auto eq = find(remapping.begin(), remapping.end(), '=');
@@ -70,6 +72,26 @@ void CompilerStack::setRemappings(vector<string> const& _remappings)
 		r.prefix = colon == eq ? string(remapping.begin(), eq) : string(colon + 1, eq);
 		r.target = string(eq + 1, remapping.end());
 		remappings.push_back(r);
+		if (r.context.empty())
+		{
+			string prefix = r.prefix;
+			index.emplace(prefix, remappings.size()-1);
+		}
+		else
+		{
+			string context = r.context;
+			contextReferences.emplace(context, remappings.size()-1);
+		}
+	}
+	// fill references
+	for (auto const& key: contextReferences)
+	{
+		string reference = key.first;
+		if (reference.front() != '@')
+			continue; // ignore
+		reference = string(reference.begin()+1, reference.end());
+		string referencedPrefix = remappings.at(index.at(reference)).target;
+		remappings[key.second].context = referencedPrefix;
 	}
 	swap(m_remappings, remappings);
 }
@@ -508,12 +530,30 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 		return std::equal(_a.begin(), _a.end(), _b.begin());
 	};
 
+	// Try to find whether _a is a closer match for context _reference than _b
+	// Defaults to longest prefix in case of a tie.
+	auto isClosestContext = [](string const& _a, string const& _b, string const& _reference)
+	{
+		int a = _reference.compare(_a);
+		int b = _reference.compare(_b);
+		if (a == 0)
+			return true;
+		else if (b == 0)
+			return false;
+		else if (abs(a) == abs(b)) {
+			return a > 0;
+		}
+		return abs(a) < abs(b);
+	};
+
 	size_t longestPrefix = 0;
 	string longestPrefixTarget;
+	string currentClosestContext;
+	string referenceContext = _context.substr(0, _context.find_last_of('/'));
 	for (auto const& redir: m_remappings)
 	{
 		// Skip if we already have a closer match.
-		if (longestPrefix > 0 && redir.prefix.length() <= longestPrefix)
+		if (longestPrefix > 0 && redir.prefix.length() < longestPrefix)
 			continue;
 		// Skip if redir.context is not a prefix of _context
 		if (!isPrefixOf(redir.context, _context))
@@ -521,11 +561,15 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 		// Skip if the prefix does not match.
 		if (!isPrefixOf(redir.prefix, _path))
 			continue;
+		// Skip if there is a prefix collision and the current context is closer
+		if (redir.prefix.length() == longestPrefix && !isClosestContext(redir.context, currentClosestContext, referenceContext))
+			continue;
 
+		currentClosestContext = redir.context;
 		longestPrefix = redir.prefix.length();
 		longestPrefixTarget = redir.target;
 	}
-	string path = longestPrefixTarget;
+	string path = longestPrefixTarget; 
 	path.append(_path.begin() + longestPrefix, _path.end());
 	return path;
 }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -90,8 +90,15 @@ void CompilerStack::setRemappings(vector<string> const& _remappings)
 		if (reference.front() != '@')
 			continue; // ignore
 		reference = string(reference.begin()+1, reference.end());
-		string referencedPrefix = remappings.at(index.at(reference)).target;
-		remappings[key.second].context = referencedPrefix;
+		try
+		{
+			string referencedTarget = remappings.at(index.at(reference)).target;
+			remappings[key.second].context = referencedTarget;
+		}
+		catch (...)
+		{
+			continue;
+		}
 	}
 	swap(m_remappings, remappings);
 }
@@ -549,7 +556,7 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 	size_t longestPrefix = 0;
 	string longestPrefixTarget;
 	string currentClosestContext;
-	string referenceContext = _context.substr(0, _context.find_last_of('/'));
+	string referenceContext = _context.substr(0, _context.find_last_of('/')+1);
 	for (auto const& redir: m_remappings)
 	{
 		// Skip if we already have a closer match.

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -192,8 +192,19 @@ BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory
 	c.setRemappings(vector<string>{"foo=vendor/foo", "bar=vendor/bar/2.0.0", "@foo:bar=vendor/bar/1.0.0"});
 	c.addSource("main.sol", "import {Foo} from \"foo/foo.sol\"; import \"bar/bar.sol\"; contract Main is Foo, Bar {function Main(){IsTwo();}} pragma solidity >=0.0;");
 	c.addSource("vendor/foo/foo.sol", "import \"bar/bar.sol\"; contract Foo is Bar{function Foo(){IsOne();}} pragma solidity >=0.0;");
-	c.addSource("vendor/bar/1.0.0", "contract Bar{function IsOne(){}} pragma solidity >=0.0;");
-	c.addSource("vendor/bar/2.0.0", "contract Bar{function IsTwo(){}} pragma solidity >=0.0;");
+	c.addSource("vendor/bar/1.0.0/bar.sol", "contract Bar{function IsOne(){}} pragma solidity >=0.0;");
+	c.addSource("vendor/bar/2.0.0/bar.sol", "contract Bar{function IsTwo(){}} pragma solidity >=0.0;");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory_ordering_does_not_matter)
+{
+	CompilerStack c;
+	c.setRemappings(vector<string>{"foo=vendor/foo", "@foo:bar=vendor/bar/1.0.0", "bar=vendor/bar/2.0.0"});
+	c.addSource("main.sol", "import {Foo} from \"foo/foo.sol\"; import \"bar/bar.sol\"; contract Main is Foo, Bar {function Main(){IsTwo();}} pragma solidity >=0.0;");
+	c.addSource("vendor/foo/foo.sol", "import \"bar/bar.sol\"; contract Foo is Bar{function Foo(){IsOne();}} pragma solidity >=0.0;");
+	c.addSource("vendor/bar/1.0.0/bar.sol", "contract Bar{function IsOne(){}} pragma solidity >=0.0;");
+	c.addSource("vendor/bar/2.0.0/bar.sol", "contract Bar{function IsTwo(){}} pragma solidity >=0.0;");
 	BOOST_CHECK(c.compile());
 }
 

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -197,6 +197,17 @@ BOOST_AUTO_TEST_CASE(remappings_reference_a_directory_tree)
 	BOOST_CHECK(c.compile());
 }
 
+BOOST_AUTO_TEST_CASE(remappings_improperly_reference_a_directory_tree)
+{
+	CompilerStack c;
+	c.setRemappings(vector<string>{"@foo:s=s_1.4.6", "@bar:s=s_1.4.7", "foo/0.0.1/=Foo", "bar/0.0.1/=Bar"});
+	c.addSource("Foo/foo.sol", "import \"s/s.sol\"; contract Foo is SSix {} pragma solidity >=0.0;");
+	c.addSource("Bar/bar.sol", "import \"s/s.sol\"; contract Bar is SSeven {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.6/s.sol", "contract SSix {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.7/s.sol", "contract SSeven {} pragma solidity >=0.0;");
+	BOOST_CHECK(!c.compile());
+}
+
 BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory)
 {
 	CompilerStack c;

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -164,6 +164,39 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings)
 	BOOST_CHECK(c.compile());
 }
 
+BOOST_AUTO_TEST_CASE(context_dependent_remappings_referencing_previous_remappings)
+{
+	CompilerStack c;
+	c.setRemappings(vector<string>{"foo=Foo", "bar=Bar", "@foo:s=s_1.4.6", "@bar:s=s_1.4.7"});
+	c.addSource("Foo/foo.sol", "import \"s/s.sol\"; contract Foo is SSix {} pragma solidity >=0.0;");
+	c.addSource("Bar/bar.sol", "import \"s/s.sol\"; contract Bar is SSeven {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.6/s.sol", "contract SSix {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.7/s.sol", "contract SSeven {} pragma solidity >=0.0;");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(remappings_ensure_order_doesnt_matter_in_reference)
+{
+	CompilerStack c;
+	c.setRemappings(vector<string>{"@foo:s=s_1.4.6", "@bar:s=s_1.4.7", "foo=Foo", "bar=Bar"});
+	c.addSource("Foo/foo.sol", "import \"s/s.sol\"; contract Foo is SSix {} pragma solidity >=0.0;");
+	c.addSource("Bar/bar.sol", "import \"s/s.sol\"; contract Bar is SSeven {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.6/s.sol", "contract SSix {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.7/s.sol", "contract SSeven {} pragma solidity >=0.0;");
+	BOOST_CHECK(c.compile());
+}
+
+BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory)
+{
+	CompilerStack c;
+	c.setRemappings(vector<string>{"foo=vendor/foo", "bar=vendor/bar/2.0.0", "@foo:bar=vendor/bar/1.0.0"});
+	c.addSource("main.sol", "import {Foo} from \"foo/foo.sol\"; import \"bar/bar.sol\"; contract Main is Foo, Bar {function Main(){IsTwo();}} pragma solidity >=0.0;");
+	c.addSource("vendor/foo/foo.sol", "import \"bar/bar.sol\"; contract Foo is Bar{function Foo(){IsOne();}} pragma solidity >=0.0;");
+	c.addSource("vendor/bar/1.0.0", "contract Bar{function IsOne(){}} pragma solidity >=0.0;");
+	c.addSource("vendor/bar/2.0.0", "contract Bar{function IsTwo(){}} pragma solidity >=0.0;");
+	BOOST_CHECK(c.compile());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -186,6 +186,17 @@ BOOST_AUTO_TEST_CASE(remappings_ensure_order_doesnt_matter_in_reference)
 	BOOST_CHECK(c.compile());
 }
 
+BOOST_AUTO_TEST_CASE(remappings_reference_a_directory_tree)
+{
+	CompilerStack c;
+	c.setRemappings(vector<string>{"@foo/0.0.1/:s=s_1.4.6", "@bar/0.0.1/:s=s_1.4.7", "foo/0.0.1/=Foo", "bar/0.0.1/=Bar"});
+	c.addSource("Foo/foo.sol", "import \"s/s.sol\"; contract Foo is SSix {} pragma solidity >=0.0;");
+	c.addSource("Bar/bar.sol", "import \"s/s.sol\"; contract Bar is SSeven {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.6/s.sol", "contract SSix {} pragma solidity >=0.0;");
+	c.addSource("s_1.4.7/s.sol", "contract SSeven {} pragma solidity >=0.0;");
+	BOOST_CHECK(c.compile());
+}
+
 BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory)
 {
 	CompilerStack c;
@@ -200,7 +211,7 @@ BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory
 BOOST_AUTO_TEST_CASE(ensure_global_remapping_preserved_through_complex_directory_ordering_does_not_matter)
 {
 	CompilerStack c;
-	c.setRemappings(vector<string>{"foo=vendor/foo", "@foo:bar=vendor/bar/1.0.0", "bar=vendor/bar/2.0.0"});
+	c.setRemappings(vector<string>{"@foo:bar=vendor/bar/1.0.0", "foo=vendor/foo", "bar=vendor/bar/2.0.0"});
 	c.addSource("main.sol", "import {Foo} from \"foo/foo.sol\"; import \"bar/bar.sol\"; contract Main is Foo, Bar {function Main(){IsTwo();}} pragma solidity >=0.0;");
 	c.addSource("vendor/foo/foo.sol", "import \"bar/bar.sol\"; contract Foo is Bar{function Foo(){IsOne();}} pragma solidity >=0.0;");
 	c.addSource("vendor/bar/1.0.0/bar.sol", "contract Bar{function IsOne(){}} pragma solidity >=0.0;");


### PR DESCRIPTION
This provides something of an upgrade to remappings. It resolves problems laid out in #1520 . 

WHAT DOES IT DO?:

Remappings now come with a reference handler ('@') that will allow you to resolve context in a far easier way by referencing a previous remapping. 

Example: 

`solc foo=/usr/Foo/ @foo:bar=/usr/Bar-1.0/ main.sol` is the same as 
`solc foo=/usr/Foo/ /usr/Foo/:bar=/usr/Bar-1.0/ main.sol`. 

Furthermore, the previous version of remappings did not do a good job checking to make sure that we were getting the exact context we were looking for. For instance, if I passed in a global remapping of `foo=/usr/Foo-1.0` but also passed in a context clue for a certain module, it would default to the global no matter what. This resolves that.

Let me know if there are any concerns (please before the winter's end). 