### PR TITLE
Add ElementaryTypeNameExpression to grammar.txt

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -82,7 +82,12 @@ Expression =
   | Expression? (',' Expression)
   | PrimaryExpression
 
-PrimaryExpression = Identifier | BooleanLiteral | NumberLiteral | HexLiteral | StringLiteral
+PrimaryExpression = Identifier
+                  | BooleanLiteral
+                  | NumberLiteral
+                  | HexLiteral
+                  | StringLiteral
+                  | ElementaryTypeNameExpression
 
 FunctionCall = ( PrimaryExpression | NewExpression | TypeName ) ( ( '.' Identifier ) | ( '[' Expression ']' ) )* '(' Expression? ( ',' Expression )* ')'
 NewExpression = 'new' Identifier
@@ -99,6 +104,8 @@ Identifier = [a-zA-Z_] [a-zA-Z_0-9]*
 
 HexNumber = '0x' [0-9a-fA-F]+
 DecimalNumber = [0-9]+
+
+ElementaryTypeNameExpression = ElementaryTypeName
 
 ElementaryTypeName = 'address' | 'bool' | 'string' | 'var'
                    | Int | Uint | Byte | Fixed | Ufixed


### PR DESCRIPTION
~The name is still awkward. Perhaps we can rename it to TypeCast or ElementaryTypeCast before standarizing the AST output.~