### PR TITLE
Remove wrong syntax highlighting in docs

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -570,3 +570,4 @@ Language Grammar
 ================
 
 .. literalinclude:: grammar.txt
+   :language: none


### PR DESCRIPTION
Sphinx was messing up the syntax highlighting of the grammar description.