### PR TITLE
absolute path detection is not confused by ".dir"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 BugFixes:
  * Type checker, code generator: enable access to events of base contracts' names.
+ * Imports: ``import ".dir/a"`` is not a relative path.  Relative paths begin with directory ``.`` or ``..``.
 
 ### 0.4.7 (2016-12-15)
 

--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -79,8 +79,9 @@ Paths
 -----
 
 In the above, ``filename`` is always treated as a path with ``/`` as directory separator,
-``.`` as the current and ``..`` as the parent directory. Path names that do not start
-with ``.`` are treated as absolute paths.
+``.`` as the current and ``..`` as the parent directory.  When ``.`` or ``..`` is followed by a character except ``/``,
+it is not considered as the current or the parent directory.
+All path names are treated as absolute paths unless they start with the current ``.`` or the parent directory ``..``.
 
 To import a file ``x`` from the same directory as the current file, use ``import "./x" as x;``.
 If you use ``import "x" as x;`` instead, a different file could be referenced

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -593,11 +593,11 @@ bool CompilerStack::checkLibraryNameClashes()
 
 string CompilerStack::absolutePath(string const& _path, string const& _reference) const
 {
-	// Anything that does not start with `.` is an absolute path.
-	if (_path.empty() || _path.front() != '.')
-		return _path;
 	using path = boost::filesystem::path;
 	path p(_path);
+	// Anything that does not start with `.` is an absolute path.
+	if (p.begin() == p.end() || (*p.begin() != "." && *p.begin() != ".."))
+		return _path;
 	path result(_reference);
 	result.remove_filename();
 	for (path::iterator it = p.begin(); it != p.end(); ++it)

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -164,6 +164,14 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings)
 	BOOST_CHECK(c.compile());
 }
 
+BOOST_AUTO_TEST_CASE(filename_with_period)
+{
+	CompilerStack c;
+	c.addSource("a/a.sol", "import \".b.sol\"; contract A is B {} pragma solidity >=0.0;");
+	c.addSource("a/.b.sol", "contract B {} pragma solidity >=0.0;");
+	BOOST_CHECK(!c.compile());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
When paths are parsed, `.dir` is now considered as an absolute path.  This change fixes the disagreement of the doc and the implementation, as observed in #1534.