### PR TITLE
Require stable nodejs for deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ matrix:
           dist: trusty
           sudo: required
           compiler: gcc
+          node_js: stable
           services:
               - docker
           before_install:


### PR DESCRIPTION
This is required to be able to compute the swarm hash of the binary (done in the solc-bin repository).