### PR TITLE
New number unit keywords

### DIFF
--- a/docs/utils/SolidityLexer.py
+++ b/docs/utils/SolidityLexer.py
@@ -67,6 +67,7 @@ class SolidityLexer(RegexLexer):
                  ['ufixed%dx%d' % ((i), (j + 8)) for i in range(0, 256, 8) for j in range(0, 256 - i, 8)] +
                  ['fixed%dx%d' % ((i), (j + 8)) for i in range(0, 256, 8) for j in range(0, 256 - i, 8)]
              ) + r')\b', Keyword.Type, 'slashstartsregex'),
+            (r'(wei|szabo|finney|ether|seconds|minutes|hours|days|weeks|years)\b', Keyword.Type, 'slashstartsregex'),
             (r'(abstract|boolean|byte|char|class|const|debugger|double|enum|export|'
              r'extends|final|float|goto|implements|int|interface|long|native|'
              r'package|private|protected|public|short|static|super|synchronized|throws|'


### PR DESCRIPTION
The keywords were taken from the rule `NumberUnit` specified in
http://solidity.readthedocs.io/en/develop/miscellaneous.html?highlight=minutes#language-grammar
