### PR TITLE
Add git submodule init to build instructions

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -119,6 +119,11 @@ you should fork Solidity and add your personal fork as a second remote:
     cd solidity
     git remote add personal git@github.com:[username]/solidity.git
 
+Solidity has git submodules.  Ensure they are properly loaded:
+
+.. code:: bash
+
+   git submodule update --init --recursive
 
 Prerequisites - macOS
 ---------------------


### PR DESCRIPTION
I noticed this was missing from the build instructions when I set up my new workstation environment.