### PR TITLE
Type identifiers.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Features:
  * Compiler Interface: Contracts and libraries can be referenced with a `file:` prefix to make them unique.
  * AST: Use deterministic node identifiers.
+ * Type system: Introduce type identifier strings.
  * Metadata: Do not include platform in the version number.
 
 ### 0.4.8 (2017-01-13)

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -34,16 +34,34 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
+class IDDispenser
+{
+public:
+	static size_t next() { return ++instance(); }
+	static void reset() { instance() = 0; }
+private:
+	static size_t& instance()
+	{
+		static IDDispenser dispenser;
+		return dispenser.id;
+	}
+	size_t id = 0;
+};
+
 ASTNode::ASTNode(SourceLocation const& _location):
+	m_id(IDDispenser::next()),
 	m_location(_location)
 {
-	static size_t id = 0;
-	m_id = ++id;
 }
 
 ASTNode::~ASTNode()
 {
 	delete m_annotation;
+}
+
+void ASTNode::resetID()
+{
+	IDDispenser::reset();
 }
 
 ASTAnnotation& ASTNode::annotation() const

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -99,7 +99,7 @@ public:
 	///@}
 
 protected:
-	size_t m_id = 0;
+	size_t const m_id = 0;
 	/// Annotation - is specialised in derived classes, is created upon request (because of polymorphism).
 	mutable ASTAnnotation* m_annotation = nullptr;
 

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -59,6 +59,8 @@ public:
 
 	/// @returns an identifier of this AST node that is unique for a single compilation run.
 	size_t id() const { return m_id; }
+	/// Resets the global ID counter. This invalidates all previous IDs.
+	static void resetID();
 
 	virtual void accept(ASTVisitor& _visitor) = 0;
 	virtual void accept(ASTConstVisitor& _visitor) const = 0;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -31,6 +31,7 @@
 #include <libdevcore/UTF8.h>
 
 #include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/adaptor/transformed.hpp>
@@ -163,7 +164,7 @@ string identifierList(TypePointer const& _type1, TypePointer const& _type2)
 
 string parenthesizeUserIdentifier(string const& _internal)
 {
-	return parenthesizeIdentifier(boost::replace_all_copy(_internal, "$", "$$$"));
+	return parenthesizeIdentifier(boost::algorithm::replace_all_copy(_internal, "$", "$$$"));
 }
 
 }
@@ -2109,9 +2110,9 @@ string FunctionType::identifier() const
 		id += "_constant";
 	id += identifierList(m_parameterTypes) + "returns" + identifierList(m_returnParameterTypes);
 	if (m_gasSet)
-		id += "gas_set_";
+		id += "gas";
 	if (m_valueSet)
-		id += "value_set_";
+		id += "value";
 	if (bound())
 		id += "bound_to" + identifierList(selfType());
 	return id;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -22,17 +22,20 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <map>
-#include <boost/noncopyable.hpp>
-#include <boost/rational.hpp>
-#include <libdevcore/Common.h>
-#include <libdevcore/CommonIO.h>
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/ast/ASTForward.h>
 #include <libsolidity/parsing/Token.h>
+
+#include <libdevcore/Common.h>
+#include <libdevcore/CommonIO.h>
 #include <libdevcore/UndefMacros.h>
+
+#include <boost/noncopyable.hpp>
+#include <boost/rational.hpp>
+
+#include <memory>
+#include <string>
+#include <map>
 
 namespace dev
 {
@@ -158,6 +161,9 @@ public:
 	/// @returns a valid solidity identifier such that two types should compare equal if and
 	/// only if they have the same identifier.
 	/// The identifier should start with "t_".
+	/// More complex identifier strings use "parentheses", where $_ is interpreted as as
+	/// "opening parenthesis", _$ as "closing parenthesis", _$_ as "comma" and any $ that
+	/// appears as part of a user-supplied identifier is escaped as _$$$_.
 	virtual std::string identifier() const = 0;
 	virtual bool isImplicitlyConvertibleTo(Type const& _other) const { return *this == _other; }
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const
@@ -912,7 +918,7 @@ public:
 	std::vector<std::string> const& returnParameterNames() const { return m_returnParameterNames; }
 	std::vector<std::string> const returnParameterTypeNames(bool _addDataLocation) const;
 	/// @returns the "self" parameter type for a bound function
-	TypePointer selfType() const;
+	TypePointer const& selfType() const;
 
 	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -155,6 +155,10 @@ public:
 	static TypePointer commonType(TypePointer const& _a, TypePointer const& _b);
 
 	virtual Category category() const = 0;
+	/// @returns a valid solidity identifier such that two types should compare equal if and
+	/// only if they have the same identifier.
+	/// The identifier should start with "t_".
+	virtual std::string identifier() const = 0;
 	virtual bool isImplicitlyConvertibleTo(Type const& _other) const { return *this == _other; }
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const
 	{
@@ -288,6 +292,7 @@ public:
 
 	explicit IntegerType(int _bits, Modifier _modifier = Modifier::Unsigned);
 
+	virtual std::string identifier() const override;
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
@@ -329,6 +334,7 @@ public:
 
 	explicit FixedPointType(int _integerBits, int _fractionalBits, Modifier _modifier = Modifier::Unsigned);
 
+	virtual std::string identifier() const override;
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
@@ -378,6 +384,7 @@ public:
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
 	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
 
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 
 	virtual bool canBeStored() const override { return false; }
@@ -416,6 +423,7 @@ public:
 		return TypePointer();
 	}
 
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 
 	virtual bool canBeStored() const override { return false; }
@@ -449,6 +457,7 @@ public:
 
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
 	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
@@ -476,6 +485,7 @@ class BoolType: public Type
 public:
 	BoolType() {}
 	virtual Category category() const override { return Category::Bool; }
+	virtual std::string identifier() const override { return "t_bool"; }
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
 	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
 
@@ -533,6 +543,8 @@ protected:
 	TypePointer copyForLocationIfReference(TypePointer const& _type) const;
 	/// @returns a human-readable description of the reference part of the type.
 	std::string stringForReferencePart() const;
+	/// @returns the suffix computed from the reference part to be used by identifier();
+	std::string identifierLocationSuffix() const;
 
 	DataLocation m_location = DataLocation::Storage;
 	bool m_isPointer = true;
@@ -573,6 +585,7 @@ public:
 
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	virtual std::string identifier() const override;
 	virtual bool operator==(const Type& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	virtual bool isDynamicallySized() const override { return m_hasDynamicLength; }
@@ -622,6 +635,7 @@ public:
 	/// Contracts can be converted to themselves and to integers.
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded ) const override
 	{
@@ -677,6 +691,7 @@ public:
 	explicit StructType(StructDefinition const& _struct, DataLocation _location = DataLocation::Storage):
 		ReferenceType(_location), m_struct(_struct) {}
 	virtual bool isImplicitlyConvertibleTo(const Type& _convertTo) const override;
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	u256 memorySize() const;
@@ -720,6 +735,7 @@ public:
 	virtual Category category() const override { return Category::Enum; }
 	explicit EnumType(EnumDefinition const& _enum): m_enum(_enum) {}
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override
 	{
@@ -760,6 +776,7 @@ public:
 	virtual Category category() const override { return Category::Tuple; }
 	explicit TupleType(std::vector<TypePointer> const& _types = std::vector<TypePointer>()): m_components(_types) {}
 	virtual bool isImplicitlyConvertibleTo(Type const& _other) const override;
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
 	virtual std::string toString(bool) const override;
@@ -897,6 +914,7 @@ public:
 	/// @returns the "self" parameter type for a bound function
 	TypePointer selfType() const;
 
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
 	virtual std::string canonicalName(bool /*_addDataLocation*/) const override;
@@ -995,6 +1013,7 @@ public:
 	MappingType(TypePointer const& _keyType, TypePointer const& _valueType):
 		m_keyType(_keyType), m_valueType(_valueType) {}
 
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
 	virtual std::string canonicalName(bool _addDataLocation) const override;
@@ -1029,6 +1048,7 @@ public:
 	TypePointer const& actualType() const { return m_actualType; }
 
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
 	virtual u256 storageSize() const override;
@@ -1056,6 +1076,7 @@ public:
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override { return 0; }
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
 
@@ -1080,6 +1101,7 @@ public:
 		return TypePointer();
 	}
 
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
@@ -1109,6 +1131,7 @@ public:
 		return TypePointer();
 	}
 
+	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
@@ -1132,6 +1155,7 @@ class InaccessibleDynamicType: public Type
 public:
 	virtual Category category() const override { return Category::InaccessibleDynamic; }
 
+	virtual std::string identifier() const override { return "t_inaccessible"; }
 	virtual bool isImplicitlyConvertibleTo(Type const&) const override { return false; }
 	virtual bool isExplicitlyConvertibleTo(Type const&) const override { return false; }
 	virtual unsigned calldataEncodedSize(bool _padded) const override { (void)_padded; return 32; }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -112,6 +112,7 @@ bool CompilerStack::parse()
 {
 	//reset
 	m_errors.clear();
+	ASTNode::resetID();
 	m_parseSuccessful = false;
 
 	if (SemVerVersion{string(VersionString)}.isPrerelease())

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -90,6 +90,7 @@ BOOST_AUTO_TEST_CASE(storage_layout_arrays)
 
 BOOST_AUTO_TEST_CASE(type_identifiers)
 {
+	ASTNode::resetID();
 	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("uint128")->identifier(), "t_uint128");
 	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("int128")->identifier(), "t_int128");
 	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("address")->identifier(), "t_address");

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -109,39 +109,39 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes")->identifier(), "t_bytes_storage_ptr");
 	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("string")->identifier(), "t_string_storage_ptr");
 	ArrayType largeintArray(DataLocation::Memory, Type::fromElementaryTypeName("int128"), u256("2535301200456458802993406410752"));
-	BOOST_CHECK_EQUAL(largeintArray.identifier(), "t_int128_array2535301200456458802993406410752_memory_ptr");
+	BOOST_CHECK_EQUAL(largeintArray.identifier(), "t_array$_t_int128_$2535301200456458802993406410752_memory_ptr");
 	TypePointer stringArray = make_shared<ArrayType>(DataLocation::Storage, Type::fromElementaryTypeName("string"), u256("20"));
 	TypePointer multiArray = make_shared<ArrayType>(DataLocation::Storage, stringArray);
-	BOOST_CHECK_EQUAL(multiArray->identifier(), "t_string_storage_array20_storage_arraydyn_storage_ptr");
+	BOOST_CHECK_EQUAL(multiArray->identifier(), "t_array$_t_array$_t_string_storage_$20_storage_$dyn_storage_ptr");
 
-	ContractDefinition c(SourceLocation{}, make_shared<string>("MyContract"), {}, {}, {}, false);
-	BOOST_CHECK_EQUAL(c.type()->identifier(), "t_type_t_contract_MyContract_2");
-	BOOST_CHECK_EQUAL(ContractType(c, true).identifier(), "t_super_MyContract_2");
+	ContractDefinition c(SourceLocation{}, make_shared<string>("MyContract$"), {}, {}, {}, false);
+	BOOST_CHECK_EQUAL(c.type()->identifier(), "t_type$_t_contract$_MyContract$$$_$2_$");
+	BOOST_CHECK_EQUAL(ContractType(c, true).identifier(), "t_super$_MyContract$$$_$2");
 
 	StructDefinition s({}, make_shared<string>("Struct"), {});
-	BOOST_CHECK_EQUAL(s.type()->identifier(), "t_type_t_struct_Struct_3_storage_ptr");
+	BOOST_CHECK_EQUAL(s.type()->identifier(), "t_type$_t_struct$_Struct_$3_storage_ptr_$");
 
 	EnumDefinition e({}, make_shared<string>("Enum"), {});
-	BOOST_CHECK_EQUAL(e.type()->identifier(), "t_type_t_enum_Enum_4");
+	BOOST_CHECK_EQUAL(e.type()->identifier(), "t_type$_t_enum$_Enum_$4_$");
 
 	TupleType t({e.type(), s.type(), stringArray, nullptr});
-	BOOST_CHECK_EQUAL(t.identifier(), "t_tuple4_t_type_t_enum_Enum_4_t_type_t_struct_Struct_3_storage_ptr_t_string_storage_array20_storage_ptr_t_empty_tuple_end");
+	BOOST_CHECK_EQUAL(t.identifier(), "t_tuple$_t_type$_t_enum$_Enum_$4_$_$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$_t_array$_t_string_storage_$20_storage_ptr_$__$");
 
 	TypePointer sha3fun = make_shared<FunctionType>(strings{}, strings{}, FunctionType::Location::SHA3);
-	BOOST_CHECK_EQUAL(sha3fun->identifier(), "t_function_sha3_param0_return0_function_end");
+	BOOST_CHECK_EQUAL(sha3fun->identifier(), "t_function_sha3$__$returns$__$");
 
 	FunctionType metaFun(TypePointers{sha3fun}, TypePointers{s.type()});
-	BOOST_CHECK_EQUAL(metaFun.identifier(), "t_function_internal_param1_t_function_sha3_param0_return0_function_end_return1_t_type_t_struct_Struct_3_storage_ptr_function_end");
+	BOOST_CHECK_EQUAL(metaFun.identifier(), "t_function_internal$_t_function_sha3$__$returns$__$_$returns$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$");
 
 	TypePointer m = make_shared<MappingType>(Type::fromElementaryTypeName("bytes32"), s.type());
 	MappingType m2(Type::fromElementaryTypeName("uint64"), m);
-	BOOST_CHECK_EQUAL(m2.identifier(), "t_mapping_t_uint64_to_t_mapping_t_bytes32_to_t_type_t_struct_Struct_3_storage_ptr_mapping_end_mapping_end");
+	BOOST_CHECK_EQUAL(m2.identifier(), "t_mapping$_t_uint64_$_t_mapping$_t_bytes32_$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$_$");
 
 	// TypeType is tested with contract
 
 	auto emptyParams = make_shared<ParameterList>(SourceLocation(), std::vector<ASTPointer<VariableDeclaration>>());
 	ModifierDefinition mod(SourceLocation{}, make_shared<string>("modif"), {}, emptyParams, {});
-	BOOST_CHECK_EQUAL(ModifierType(mod).identifier(), "t_modifier_param0_end_modifier");
+	BOOST_CHECK_EQUAL(ModifierType(mod).identifier(), "t_modifier$__$");
 
 	SourceUnit su({}, {});
 	BOOST_CHECK_EQUAL(ModuleType(su).identifier(), "t_module_7");

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -21,6 +21,8 @@
  */
 
 #include <libsolidity/ast/Types.h>
+#include <libsolidity/ast/AST.h>
+#include <libdevcore/SHA3.h>
 #include <boost/test/unit_test.hpp>
 
 using namespace std;
@@ -84,6 +86,70 @@ BOOST_AUTO_TEST_CASE(storage_layout_arrays)
 	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(7), 9).storageSize() == 3);
 	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(31), 9).storageSize() == 9);
 	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(32), 9).storageSize() == 9);
+}
+
+BOOST_AUTO_TEST_CASE(type_identifiers)
+{
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("uint128")->identifier(), "t_uint128");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("int128")->identifier(), "t_int128");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("address")->identifier(), "t_address");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("uint8")->identifier(), "t_uint8");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("ufixed8x64")->identifier(), "t_ufixed8x64");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("fixed128x8")->identifier(), "t_fixed128x8");
+	BOOST_CHECK_EQUAL(RationalNumberType(rational(7, 1)).identifier(), "t_rational_7_by_1");
+	BOOST_CHECK_EQUAL(RationalNumberType(rational(200, 77)).identifier(), "t_rational_200_by_77");
+	BOOST_CHECK_EQUAL(RationalNumberType(rational(2 * 200, 2 * 77)).identifier(), "t_rational_200_by_77");
+	BOOST_CHECK_EQUAL(
+		StringLiteralType(Literal(SourceLocation{}, Token::StringLiteral, make_shared<string>("abc - def"))).identifier(),
+		 "t_stringliteral_196a9142ee0d40e274a6482393c762b16dd8315713207365e1e13d8d85b74fc4"
+	);
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes8")->identifier(), "t_bytes8");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes32")->identifier(), "t_bytes32");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bool")->identifier(), "t_bool");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes")->identifier(), "t_bytes_storage_ptr");
+	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("string")->identifier(), "t_string_storage_ptr");
+	ArrayType largeintArray(DataLocation::Memory, Type::fromElementaryTypeName("int128"), u256("2535301200456458802993406410752"));
+	BOOST_CHECK_EQUAL(largeintArray.identifier(), "t_int128_array2535301200456458802993406410752_memory_ptr");
+	TypePointer stringArray = make_shared<ArrayType>(DataLocation::Storage, Type::fromElementaryTypeName("string"), u256("20"));
+	TypePointer multiArray = make_shared<ArrayType>(DataLocation::Storage, stringArray);
+	BOOST_CHECK_EQUAL(multiArray->identifier(), "t_string_storage_array20_storage_arraydyn_storage_ptr");
+
+	ContractDefinition c(SourceLocation{}, make_shared<string>("MyContract"), {}, {}, {}, false);
+	BOOST_CHECK_EQUAL(c.type()->identifier(), "t_type_t_contract_MyContract_2");
+	BOOST_CHECK_EQUAL(ContractType(c, true).identifier(), "t_super_MyContract_2");
+
+	StructDefinition s({}, make_shared<string>("Struct"), {});
+	BOOST_CHECK_EQUAL(s.type()->identifier(), "t_type_t_struct_Struct_3_storage_ptr");
+
+	EnumDefinition e({}, make_shared<string>("Enum"), {});
+	BOOST_CHECK_EQUAL(e.type()->identifier(), "t_type_t_enum_Enum_4");
+
+	TupleType t({e.type(), s.type(), stringArray, nullptr});
+	BOOST_CHECK_EQUAL(t.identifier(), "t_tuple4_t_type_t_enum_Enum_4_t_type_t_struct_Struct_3_storage_ptr_t_string_storage_array20_storage_ptr_t_empty_tuple_end");
+
+	TypePointer sha3fun = make_shared<FunctionType>(strings{}, strings{}, FunctionType::Location::SHA3);
+	BOOST_CHECK_EQUAL(sha3fun->identifier(), "t_function_sha3_param0_return0_function_end");
+
+	FunctionType metaFun(TypePointers{sha3fun}, TypePointers{s.type()});
+	BOOST_CHECK_EQUAL(metaFun.identifier(), "t_function_internal_param1_t_function_sha3_param0_return0_function_end_return1_t_type_t_struct_Struct_3_storage_ptr_function_end");
+
+	TypePointer m = make_shared<MappingType>(Type::fromElementaryTypeName("bytes32"), s.type());
+	MappingType m2(Type::fromElementaryTypeName("uint64"), m);
+	BOOST_CHECK_EQUAL(m2.identifier(), "t_mapping_t_uint64_to_t_mapping_t_bytes32_to_t_type_t_struct_Struct_3_storage_ptr_mapping_end_mapping_end");
+
+	// TypeType is tested with contract
+
+	auto emptyParams = make_shared<ParameterList>(SourceLocation(), std::vector<ASTPointer<VariableDeclaration>>());
+	ModifierDefinition mod(SourceLocation{}, make_shared<string>("modif"), {}, emptyParams, {});
+	BOOST_CHECK_EQUAL(ModifierType(mod).identifier(), "t_modifier_param0_end_modifier");
+
+	SourceUnit su({}, {});
+	BOOST_CHECK_EQUAL(ModuleType(su).identifier(), "t_module_7");
+	BOOST_CHECK_EQUAL(MagicType(MagicType::Kind::Block).identifier(), "t_magic_block");
+	BOOST_CHECK_EQUAL(MagicType(MagicType::Kind::Message).identifier(), "t_magic_message");
+	BOOST_CHECK_EQUAL(MagicType(MagicType::Kind::Transaction).identifier(), "t_magic_transaction");
+
+	BOOST_CHECK_EQUAL(InaccessibleDynamicType().identifier(), "t_inaccessible");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The purpose of this PR is to generate unique names for all types that compare different to each other, so that these names can later be used for assembly function names.

This probably has to be improved, currently it is possible to game the system by using specially crafted names for structs and contracts. Furthermore, I'm not 100% sure that this system actually provide unique identifiers, especially since most types are composed by prefixing, but arrays are composed by suffixing.

My proposal would be to escape or specially mark user-supplied names (e.g. `$UserSuppliedName$`, where `$`-symbols in `UserSuppliedName` are replaced by some escape sequence), but I don't have a good proposal how to reflect the associative structure of e.g. tuple types.