### PR TITLE
Include bytecode of created contracts only once.

### DIFF
--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8992,6 +8992,35 @@ BOOST_AUTO_TEST_CASE(contracts_separated_with_comment)
 	compileAndRun(sourceCode, 0, "C2");
 }
 
+BOOST_AUTO_TEST_CASE(include_creation_bytecode_only_once)
+{
+	char const* sourceCode = R"(
+		contract D {
+			bytes a = hex"1237651237125387136581271652831736512837126583171583712358126123765123712538713658127165283173651283712658317158371235812612376512371253871365812716528317365128371265831715837123581261237651237125387136581271652831736512837126583171583712358126";
+			bytes b = hex"1237651237125327136581271252831736512837126583171383712358126123765125712538713658127165253173651283712658357158371235812612376512371a5387136581271652a317365128371265a317158371235812612a765123712538a13658127165a83173651283712a58317158371235a126";
+			function D(uint) {}
+		}
+		contract Double {
+			function f() {
+				new D(2);
+			}
+			function g() {
+				new D(3);
+			}
+		}
+		contract Single {
+			function f() {
+				new D(2);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK_LE(
+		double(m_compiler.object("Double").bytecode.size()),
+		1.1 * double(m_compiler.object("Single").bytecode.size())
+	);
+}
+
 BOOST_AUTO_TEST_CASE(recursive_structs)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1092