### PR TITLE
Reorganize travis ci and update scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,17 @@ branches:
         - develop
         - release
         - /^v[0-9]/
+
+env:
+    global:
+        - ENCRYPTION_LABEL="6d4541b72666"
+        - SOLC_BUILD_TYPE=RelWithDebInfo
+        - SOLC_DOCS=Off
+        - SOLC_EMSCRIPTEN=Off
+        - SOLC_INSTALL_DEPS_TRAVIS=On
+        - SOLC_RELEASE=On
+        - SOLC_TESTS=On
+
 matrix:
     include:
         # Ubuntu 14.04 LTS "Trusty Tahr"
@@ -61,10 +72,12 @@ matrix:
           dist: trusty
           sudo: required
           compiler: gcc
+          before_install:
+            - sudo apt-get -y install python-sphinx 
           env:
-              - TRAVIS_DOCS=On
-              - TRAVIS_RELEASE=Off
-              - TRAVIS_TESTS=Off
+              - SOLC_DOCS=On
+              - SOLC_RELEASE=Off
+              - SOLC_TESTS=Off
 
         # Emscripten target, which compiles 'solc' to javascript and uploads the resulting .js
         # files to https://github.com/ethereum/solc-bin.  These binaries are used in Browser-Solidity
@@ -79,10 +92,10 @@ matrix:
           before_install:
               - docker pull trzeci/emscripten:sdk-tag-1.35.4-64bit
           env:
-              - TRAVIS_EMSCRIPTEN=On
-              - TRAVIS_INSTALL_DEPS=Off
-              - TRAVIS_RELEASE=Off
-              - TRAVIS_TESTS=Off
+              - SOLC_EMSCRIPTEN=On
+              - SOLC_INSTALL_DEPS_TRAVIS=Off
+              - SOLC_RELEASE=Off
+              - SOLC_TESTS=Off
 
         # OS X Mavericks (10.9)
         # https://en.wikipedia.org/wiki/OS_X_Mavericks
@@ -143,41 +156,15 @@ cache:
         - $HOME/.local
 
 install:
-    - test $TRAVIS_INSTALL_DEPS != On || ./scripts/install_deps.sh
+    - test $SOLC_INSTALL_DEPS_TRAVIS != On || ./scripts/install_deps.sh
     - test "$TRAVIS_OS_NAME" != "linux" || ./scripts/install_cmake.sh
     - echo -n "$TRAVIS_COMMIT" > commit_hash.txt
 before_script:
-    - test $TRAVIS_EMSCRIPTEN != On || ./scripts/build_emscripten.sh
-    - test $TRAVIS_RELEASE != On || (mkdir -p build
-      && cd build
-      && cmake .. -DCMAKE_BUILD_TYPE=$TRAVIS_BUILD_TYPE
-      && make -j2
-      && cd ..
-      && ./scripts/release.sh $ZIP_SUFFIX
-      && ./scripts/create_source_tarball.sh )
+    - test $SOLC_EMSCRIPTEN != On || ./scripts/build_emscripten.sh
+    - test $SOLC_RELEASE != On || ./scripts/build.sh $SOLC_BUILD_TYPE
 script:
-    - test $TRAVIS_DOCS != On || ./scripts/docs.sh
-
-    # There are a variety of reliability issues with the Solidity unit-tests at the time of
-    # writing (especially on macOS), so within TravisCI we will try to run the unit-tests
-    # up to 3 times before giving up and declaring the tests as broken.
-    #
-    # We should aim to remove this "retry logic" as soon as we can, because it is a
-    # band-aid for issues which need solving at their root.  Some of those issues will be
-    # in Solidity's RPC setup and some will be in 'eth'.  It seems unlikely that Solidity
-    # itself is broken from the failure messages which we are seeing.
-    #
-    # More details on known issues at https://github.com/ethereum/solidity/issues/769
-    - test $TRAVIS_TESTS != On || (cd $TRAVIS_BUILD_DIR && (./scripts/tests.sh || ./scripts/tests.sh || ./scripts/tests.sh) )
-env:
-    global:
-        - ENCRYPTION_LABEL="6d4541b72666"
-        - TRAVIS_BUILD_TYPE=RelWithDebInfo
-        - TRAVIS_DOCS=Off
-        - TRAVIS_EMSCRIPTEN=Off
-        - TRAVIS_INSTALL_DEPS=On
-        - TRAVIS_RELEASE=On
-        - TRAVIS_TESTS=On
+    - test $SOLC_DOCS != On || ./scripts/docs.sh
+    - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && ./scripts/tests.sh )
 
 deploy:
     # This is the deploy target for the Emscripten build.
@@ -187,7 +174,7 @@ deploy:
     # configurations (not for macOS).  That is controlled by conditionals within the bash
     # scripts because TravisCI doesn't provide much in the way of conditional logic.
     - provider: script
-      script: test $TRAVIS_EMSCRIPTEN != On || scripts/release_emscripten.sh
+      script: test $SOLC_EMSCRIPTEN != On || scripts/release_emscripten.sh
       skip_cleanup: true
       on:
           branch:
@@ -211,4 +198,4 @@ deploy:
       on:
           all_branches: true
           tags: true
-          condition: $TRAVIS_RELEASE == On
+          condition: $SOLC_RELEASE == On

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -197,7 +197,12 @@ Building Solidity is quite similar on Linux, macOS and other Unices:
     cd build
     cmake .. && make
 
-And even on Windows:
+or even easier:
+
+.. code:: bash
+    ./scripts/build.sh --Release #specifies the build type
+
+And even for Windows:
 
 .. code:: bash
 

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -200,6 +200,7 @@ Building Solidity is quite similar on Linux, macOS and other Unices:
 or even easier:
 
 .. code:: bash
+
     ./scripts/build.sh --Release #specifies the build type
 
 And even for Windows:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,5 +11,5 @@ cd $(git rev-parse --show-toplevel)
 mkdir -p build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
-make -j2 && install -s solc/solc /usr/bin && install -s test/soltest
+make -j2 && install solc/solc /usr/bin && install test/soltest
 cd "$PWD"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then 
+    BUILD_TYPE=Release
+else 
+    BUILD_TYPE="$1"
+fi
+
+PWD=$(pwd)
+cd $(git rev-parse --show-toplevel)
+mkdir -p build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+make -j2 && install -s solc/solc /usr/bin && install -s test/soltest
+cd "$PWD"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -94,7 +94,7 @@ case $(uname -s) in
         # Check for Homebrew install and abort if it is not installed.
         brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - solidity requires a Homebrew install.  See http://brew.sh."; exit 1; }
 
-        if [$CI = true]; then
+        if ["$CI" = true]; then
             brew update
             brew upgrade cmake
             brew install boost
@@ -315,8 +315,7 @@ case $(uname -s) in
                     cmake \
                     git \
                     libboost-all-dev
-                
-                if [$CI = true]; then
+                if [ "$CI" = true ]; then
                     # Install 'eth', for use in the Solidity Tests-over-IPC.
                     sudo add-apt-repository -y ppa:ethereum/ethereum
                     sudo add-apt-repository -y ppa:ethereum/ethereum-dev

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -94,19 +94,20 @@ case $(uname -s) in
         # Check for Homebrew install and abort if it is not installed.
         brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - solidity requires a Homebrew install.  See http://brew.sh."; exit 1; }
 
-        brew update
-        brew upgrade
+        if [$CI = true]; then
+            brew update
+            brew upgrade cmake
+            brew install boost
+            brew tap ethereum/ethereum
+            brew install cpp-ethereum
+            brew linkapps cpp-ethereum
+        else
+            brew update
+            brew upgrade
 
-        brew install boost
-        brew install cmake
-
-        # We should really 'brew install' our eth client here, but at the time of writing
-        # the bottle is known broken, so we will just cheat and use a hardcoded ZIP for
-        # the time being, which is good enough.   The cause of the breaks will go away
-        # when we commit the repository reorg changes anyway.
-        curl -L -O https://github.com/bobsummerwill/cpp-ethereum/releases/download/v1.3.0/cpp-ethereum-osx-mavericks-v1.3.0.zip
-        unzip cpp-ethereum-osx-mavericks-v1.3.0.zip
-
+            brew install boost
+            brew install cmake
+        fi
         ;;
 
 #------------------------------------------------------------------------------
@@ -207,7 +208,6 @@ case $(uname -s) in
                 # Install "normal packages"
                 sudo apt-get -y update
                 sudo apt-get -y install \
-                    python-sphinx \
                     build-essential \
                     cmake \
                     g++ \
@@ -311,17 +311,18 @@ case $(uname -s) in
 
                 sudo apt-get -y update
                 sudo apt-get -y install \
-                    python-sphinx \
                     build-essential \
                     cmake \
                     git \
                     libboost-all-dev
-
-                # Install 'eth', for use in the Solidity Tests-over-IPC.
-                sudo add-apt-repository -y ppa:ethereum/ethereum
-                sudo add-apt-repository -y ppa:ethereum/ethereum-dev
-                sudo apt-get -y update
-                sudo apt-get -y install eth
+                
+                if [$CI = true]; then
+                    # Install 'eth', for use in the Solidity Tests-over-IPC.
+                    sudo add-apt-repository -y ppa:ethereum/ethereum
+                    sudo add-apt-repository -y ppa:ethereum/ethereum-dev
+                    sudo apt-get -y update
+                    sudo apt-get -y install eth
+                fi
 
                 ;;
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -33,14 +33,8 @@ REPO_ROOT="$(dirname "$0")"/..
 echo "Running commandline tests..."
 "$REPO_ROOT/test/cmdlineTests.sh"
 
-# This conditional is only needed because we don't have a working Homebrew
-# install for `eth` at the time of writing, so we unzip the ZIP file locally
-# instead.  This will go away soon.
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    ETH_PATH="$REPO_ROOT/eth"
-else
-    ETH_PATH="eth"
-fi
+ETH_PATH="eth"
+
 
 # This trailing ampersand directs the shell to run the command in the background,
 # that is, it is forked and run in a separate sub-shell, as a job,


### PR DESCRIPTION
I found a couple of things hard to understand while trying to work on the CI, so I changed a couple of things. Included are:

* I added a build.sh script that works from wherever you are in the repo and added documentation to note this.
* I editted the install_deps.sh script to not include sphinx (as this should only be a concern of the CI document job)
* I made it so that the only time ./install_deps.sh installs cpp-ethereum client is when it is in the CI (for Travis atleast)...I suppose you also would get that with Arch as well. 
* I moved global envs to the top of .travis.yml and changed the names because they were confusing me when looking through Travis documentation.
* No longer do we test three times for the end to end tests because...that's been pretty well taken care of by now. 