### PR TITLE
Refactor NameAndTypeResolver and SyntaxChecker to allow other entry points.

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -139,7 +139,7 @@ bool NameAndTypeResolver::resolveNamesAndTypes(ASTNode& _node, bool _resolveInsi
 			solAssert(!!m_currentScope, "");
 
 			for (ASTPointer<InheritanceSpecifier> const& baseContract: contract->baseContracts())
-				if (!resolveNamesAndTypes(*baseContract, false))
+				if (!resolveNamesAndTypes(*baseContract, true))
 					success = false;
 
 			m_currentScope = m_scopes[contract].get();

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -34,8 +34,10 @@ namespace solidity
 
 NameAndTypeResolver::NameAndTypeResolver(
 	vector<Declaration const*> const& _globals,
+	map<ASTNode const*, shared_ptr<DeclarationContainer>>& _scopes,
 	ErrorList& _errors
 ) :
+	m_scopes(_scopes),
 	m_errors(_errors)
 {
 	if (!m_scopes[nullptr])

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -42,6 +42,9 @@ namespace solidity
 class NameAndTypeResolver: private boost::noncopyable
 {
 public:
+	/// Creates the resolver with the given declarations added to the global scope.
+	/// @param _scopes mapping of scopes to be used (usually default constructed), these
+	/// are filled during the lifetime of this object.
 	NameAndTypeResolver(
 		std::vector<Declaration const*> const& _globals,
 		std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& _scopes,
@@ -57,7 +60,7 @@ public:
 	/// Resolves all names and types referenced from the given AST Node.
 	/// This is usually only called at the contract level, but with a bit of care, it can also
 	/// be called at deeper levels.
-	/// @param _avoidCode if false, does not descend into nodes that contain code.
+	/// @param _resolveInsideCode if false, does not descend into nodes that contain code.
 	/// @returns false in case of error.
 	bool resolveNamesAndTypes(ASTNode& _node, bool _resolveInsideCode = true);
 	/// Updates the given global declaration (used for "this"). Not to be used with declarations

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -49,7 +49,9 @@ public:
 	);
 	/// Registers all declarations found in the AST node, usually a source unit.
 	/// @returns false in case of error.
-	bool registerDeclarations(ASTNode& _sourceUnit);
+	/// @param _currentScope should be nullptr but can be used to inject new declarations into
+	/// existing scopes, used by the snippets feature.
+	bool registerDeclarations(ASTNode& _sourceUnit, ASTNode const* _currentScope = nullptr);
 	/// Applies the effect of import directives.
 	bool performImports(SourceUnit& _sourceUnit, std::map<std::string, SourceUnit const*> const& _sourceUnits);
 	/// Resolves all names and types referenced from the given AST Node.
@@ -130,10 +132,15 @@ private:
 class DeclarationRegistrationHelper: private ASTVisitor
 {
 public:
+	/// Registers declarations in their scopes and creates new scopes as a side-effect
+	/// of construction.
+	/// @param _currentScope should be nullptr if we start at SourceUnit, but can be different
+	/// to inject new declarations into an existing scope, used by snippets.
 	DeclarationRegistrationHelper(
 		std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& _scopes,
 		ASTNode& _astRoot,
-		ErrorList& _errors
+		ErrorList& _errors,
+		ASTNode const* _currentScope = nullptr
 	);
 
 private:

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -42,7 +42,11 @@ namespace solidity
 class NameAndTypeResolver: private boost::noncopyable
 {
 public:
-	NameAndTypeResolver(std::vector<Declaration const*> const& _globals, ErrorList& _errors);
+	NameAndTypeResolver(
+		std::vector<Declaration const*> const& _globals,
+		std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& _scopes,
+		ErrorList& _errors
+	);
 	/// Registers all declarations found in the AST node, usually a source unit.
 	/// @returns false in case of error.
 	bool registerDeclarations(ASTNode& _sourceUnit);
@@ -113,7 +117,7 @@ private:
 	/// where nullptr denotes the global scope. Note that structs are not scope since they do
 	/// not contain code.
 	/// Aliases (for example `import "x" as y;`) create multiple pointers to the same scope.
-	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>> m_scopes;
+	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& m_scopes;
 
 	DeclarationContainer* m_currentScope = nullptr;
 	ErrorList& m_errors;

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -48,9 +48,12 @@ public:
 	bool registerDeclarations(SourceUnit& _sourceUnit);
 	/// Applies the effect of import directives.
 	bool performImports(SourceUnit& _sourceUnit, std::map<std::string, SourceUnit const*> const& _sourceUnits);
-	/// Resolves all names and types referenced from the given contract.
+	/// Resolves all names and types referenced from the given AST Node.
+	/// This is usually only called at the contract level, but with a bit of care, it can also
+	/// be called at deeper levels.
+	/// @param _avoidCode if false, does not descend into nodes that contain code.
 	/// @returns false in case of error.
-	bool resolveNamesAndTypes(ContractDefinition& _contract);
+	bool resolveNamesAndTypes(ASTNode& _node, bool _resolveInsideCode = true);
 	/// Updates the given global declaration (used for "this"). Not to be used with declarations
 	/// that create their own scope.
 	/// @returns false in case of error.
@@ -77,8 +80,6 @@ public:
 	);
 
 private:
-	void reset();
-
 	/// Imports all members declared directly in the given contract (i.e. does not import inherited members)
 	/// into the current scope if they are not present already.
 	void importInheritedScope(ContractDefinition const& _base);

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -43,9 +43,9 @@ class NameAndTypeResolver: private boost::noncopyable
 {
 public:
 	NameAndTypeResolver(std::vector<Declaration const*> const& _globals, ErrorList& _errors);
-	/// Registers all declarations found in the source unit.
+	/// Registers all declarations found in the AST node, usually a source unit.
 	/// @returns false in case of error.
-	bool registerDeclarations(SourceUnit& _sourceUnit);
+	bool registerDeclarations(ASTNode& _sourceUnit);
 	/// Applies the effect of import directives.
 	bool performImports(SourceUnit& _sourceUnit, std::map<std::string, SourceUnit const*> const& _sourceUnits);
 	/// Resolves all names and types referenced from the given AST Node.
@@ -133,6 +133,8 @@ public:
 	);
 
 private:
+	bool visit(SourceUnit& _sourceUnit) override;
+	void endVisit(SourceUnit& _sourceUnit) override;
 	bool visit(ImportDirective& _declaration) override;
 	bool visit(ContractDefinition& _contract) override;
 	void endVisit(ContractDefinition& _contract) override;

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -65,6 +65,30 @@ bool ReferencesResolver::visit(ElementaryTypeName const& _typeName)
 	return true;
 }
 
+bool ReferencesResolver::visit(FunctionDefinition const& _functionDefinition)
+{
+	m_returnParameters.push_back(_functionDefinition.returnParameterList().get());
+	return true;
+}
+
+void ReferencesResolver::endVisit(FunctionDefinition const&)
+{
+	solAssert(!m_returnParameters.empty(), "");
+	m_returnParameters.pop_back();
+}
+
+bool ReferencesResolver::visit(ModifierDefinition const&)
+{
+	m_returnParameters.push_back(nullptr);
+	return true;
+}
+
+void ReferencesResolver::endVisit(ModifierDefinition const&)
+{
+	solAssert(!m_returnParameters.empty(), "");
+	m_returnParameters.pop_back();
+}
+
 void ReferencesResolver::endVisit(UserDefinedTypeName const& _typeName)
 {
 	Declaration const* declaration = m_resolver.pathFromCurrentScope(_typeName.namePath());
@@ -161,7 +185,8 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 
 bool ReferencesResolver::visit(Return const& _return)
 {
-	_return.annotation().functionReturnParameters = m_returnParameters;
+	solAssert(!m_returnParameters.empty(), "");
+	_return.annotation().functionReturnParameters = m_returnParameters.back();
 	return true;
 }
 

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -45,12 +45,10 @@ public:
 	ReferencesResolver(
 		ErrorList& _errors,
 		NameAndTypeResolver& _resolver,
-		ParameterList const* _returnParameters,
 		bool _resolveInsideCode = false
 	):
 		m_errors(_errors),
 		m_resolver(_resolver),
-		m_returnParameters(_returnParameters),
 		m_resolveInsideCode(_resolveInsideCode)
 	{}
 
@@ -61,6 +59,10 @@ private:
 	virtual bool visit(Block const&) override { return m_resolveInsideCode; }
 	virtual bool visit(Identifier const& _identifier) override;
 	virtual bool visit(ElementaryTypeName const& _typeName) override;
+	virtual bool visit(FunctionDefinition const& _functionDefinition) override;
+	virtual void endVisit(FunctionDefinition const& _functionDefinition) override;
+	virtual bool visit(ModifierDefinition const& _modifierDefinition) override;
+	virtual void endVisit(ModifierDefinition const& _modifierDefinition) override;
 	virtual void endVisit(UserDefinedTypeName const& _typeName) override;
 	virtual void endVisit(FunctionTypeName const& _typeName) override;
 	virtual void endVisit(Mapping const& _typeName) override;
@@ -83,7 +85,8 @@ private:
 
 	ErrorList& m_errors;
 	NameAndTypeResolver& m_resolver;
-	ParameterList const* m_returnParameters;
+	/// Stack of return parameters.
+	std::vector<ParameterList const*> m_returnParameters;
 	bool const m_resolveInsideCode;
 	bool m_errorOccurred = false;
 };

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -26,9 +26,9 @@ using namespace dev;
 using namespace dev::solidity;
 
 
-bool SyntaxChecker::checkSyntax(SourceUnit const& _sourceUnit)
+bool SyntaxChecker::checkSyntax(ASTNode const& _astRoot)
 {
-	_sourceUnit.accept(*this);
+	_astRoot.accept(*this);
 	return Error::containsOnlyWarnings(m_errors);
 }
 

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -39,7 +39,7 @@ public:
 	/// @param _errors the reference to the list of errors and warnings to add them found during type checking.
 	SyntaxChecker(ErrorList& _errors): m_errors(_errors) {}
 
-	bool checkSyntax(SourceUnit const& _sourceUnit);
+	bool checkSyntax(ASTNode const& _astRoot);
 
 private:
 	/// Adds a new error to the list of errors.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -32,11 +32,11 @@ using namespace dev;
 using namespace dev::solidity;
 
 
-bool TypeChecker::checkTypeRequirements(ContractDefinition const& _contract)
+bool TypeChecker::checkTypeRequirements(ASTNode const& _contract)
 {
 	try
 	{
-		visit(_contract);
+		_contract.accept(*this);
 	}
 	catch (FatalError const&)
 	{

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -427,12 +427,9 @@ bool TypeChecker::visit(StructDefinition const& _struct)
 
 bool TypeChecker::visit(FunctionDefinition const& _function)
 {
-	bool isLibraryFunction = false;
-	if (
+	bool isLibraryFunction =
 		dynamic_cast<ContractDefinition const*>(_function.scope()) &&
-		dynamic_cast<ContractDefinition const*>(_function.scope())->isLibrary()
-	)
-		isLibraryFunction = true;
+		dynamic_cast<ContractDefinition const*>(_function.scope())->isLibrary();
 	if (_function.isPayable())
 	{
 		if (isLibraryFunction)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -427,7 +427,12 @@ bool TypeChecker::visit(StructDefinition const& _struct)
 
 bool TypeChecker::visit(FunctionDefinition const& _function)
 {
-	bool isLibraryFunction = dynamic_cast<ContractDefinition const&>(*_function.scope()).isLibrary();
+	bool isLibraryFunction = false;
+	if (
+		dynamic_cast<ContractDefinition const*>(_function.scope()) &&
+		dynamic_cast<ContractDefinition const*>(_function.scope())->isLibrary()
+	)
+		isLibraryFunction = true;
 	if (_function.isPayable())
 	{
 		if (isLibraryFunction)

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -47,7 +47,7 @@ public:
 
 	/// Performs type checking on the given contract and all of its sub-nodes.
 	/// @returns true iff all checks passed. Note even if all checks passed, errors() can still contain warnings
-	bool checkTypeRequirements(ContractDefinition const& _contract);
+	bool checkTypeRequirements(ASTNode const& _contract);
 
 	/// @returns the type of an expression and asserts that it is present.
 	TypePointer const& type(Expression const& _expression) const;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -88,6 +88,7 @@ void CompilerStack::reset(bool _keepSources)
 	m_optimize = false;
 	m_optimizeRuns = 200;
 	m_globalContext.reset();
+	m_scopes.clear();
 	m_sourceOrder.clear();
 	m_contracts.clear();
 	m_errors.clear();
@@ -165,7 +166,7 @@ bool CompilerStack::parse()
 			noErrors = false;
 
 	m_globalContext = make_shared<GlobalContext>();
-	NameAndTypeResolver resolver(m_globalContext->declarations(), m_errors);
+	NameAndTypeResolver resolver(m_globalContext->declarations(), m_scopes, m_errors);
 	for (Source const* source: m_sourceOrder)
 		if (!resolver.registerDeclarations(*source->ast))
 			return false;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -52,6 +52,7 @@ namespace solidity
 
 // forward declarations
 class Scanner;
+class ASTNode;
 class ContractDefinition;
 class FunctionDefinition;
 class SourceUnit;
@@ -59,6 +60,7 @@ class Compiler;
 class GlobalContext;
 class InterfaceHandler;
 class Error;
+class DeclarationContainer;
 
 enum class DocumentationType: uint8_t
 {
@@ -271,6 +273,7 @@ private:
 	bool m_parseSuccessful;
 	std::map<std::string const, Source> m_sources;
 	std::shared_ptr<GlobalContext> m_globalContext;
+	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>> m_scopes;
 	std::vector<Source const*> m_sourceOrder;
 	std::map<std::string const, Contract> m_contracts;
 	std::string m_formalTranslation;

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -53,7 +53,8 @@ eth::AssemblyItems compileContract(const string& _sourceCode)
 	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(make_shared<Scanner>(CharStream(_sourceCode))));
 	BOOST_CHECK(!!sourceUnit);
 
-	NameAndTypeResolver resolver({}, errors);
+	map<ASTNode const*, shared_ptr<DeclarationContainer>> scopes;
+	NameAndTypeResolver resolver({}, scopes, errors);
 	solAssert(Error::containsOnlyWarnings(errors), "");
 	resolver.registerDeclarations(*sourceUnit);
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -114,7 +114,8 @@ bytes compileFirstExpression(
 		declarations.push_back(variable.get());
 
 	ErrorList errors;
-	NameAndTypeResolver resolver(declarations, errors);
+	map<ASTNode const*, shared_ptr<DeclarationContainer>> scopes;
+	NameAndTypeResolver resolver(declarations, scopes, errors);
 	resolver.registerDeclarations(*sourceUnit);
 
 	vector<ContractDefinition const*> inheritanceHierarchy;

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -66,7 +66,8 @@ parseAnalyseAndReturnError(string const& _source, bool _reportWarnings = false, 
 			return make_pair(sourceUnit, errors.at(0));
 
 		std::shared_ptr<GlobalContext> globalContext = make_shared<GlobalContext>();
-		NameAndTypeResolver resolver(globalContext->declarations(), errors);
+		map<ASTNode const*, shared_ptr<DeclarationContainer>> scopes;
+		NameAndTypeResolver resolver(globalContext->declarations(), scopes, errors);
 		solAssert(Error::containsOnlyWarnings(errors), "");
 		resolver.registerDeclarations(*sourceUnit);
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1080,7 +1080,7 @@ BOOST_AUTO_TEST_CASE(modifier_returns_value)
 			modifier mod(uint a) { _; return 7; }
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "");
+	CHECK_ERROR(text, TypeError, "Return arguments not allowed.");
 }
 
 BOOST_AUTO_TEST_CASE(state_variable_accessors)


### PR DESCRIPTION
This is needed for the "snippets" feature, so that we can resolve identifiers starting from AST nodes that are not contracts.