### PR TITLE
fix for linker wrt binaries generated with import statements

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -426,7 +426,9 @@ bool CommandLineInterface::parseLibraryOption(string const& _input)
 	for (string const& lib: libraries)
 		if (!lib.empty())
 		{
-			auto colon = lib.find(':');
+			//search for last colon in string as our binaries output placeholders in the form of file:Name
+			//so we need to search for the second `:` in the string
+			auto colon = lib.rfind(':');
 			if (colon == string::npos)
 			{
 				cerr << "Colon separator missing in library address specifier \"" << lib << "\"" << endl;


### PR DESCRIPTION
I ran into a problem and found out that it was actually a bug with how we've set up our linker. I also am not quite sure how we should test for this, so any ideas for that are also welcome. The problem can be outlined like this:

suppose that I have an import statement in one of my contracts that leads to a library. Suppose I also use the `-o` option to get `.bin` files (solc -o binaries --bin myfile.sol). Currently, that will generate a placeholder in the `.bin` file in the form of `__theFileThisLibraryIsFrom.sol:LibraryName______`. Couple this with the way linking CURRENTLY works (we search for the first `:`) and you can see that this leads to a problem when coming into linking as no matter what you do, you are bound to hit that first `:` and thus your library name gets included as your address along with an additional `:`. This fixes that by looking for `:` in reverse. Very simple fix. But not very sure how it should be tested. Any suggestions and I will write them up. 

Signed-off-by: VoR0220 <rj@erisindustries.com>