### PR TITLE
Support "standardised" JSON compiler input/output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,10 @@
 ### 0.4.11 (unreleased)
 
 Features:
+ * Implement the Standard JSON Input / Output API
  * Support ``interface`` contracts.
+ * C API (``jsonCompiler``): Add the ``compileStandard()`` method to process a Standard JSON I/O.
+ * Commandline interface: Add the ``--standard-json`` parameter to process a Standard JSON I/O.
  * Commandline interface: Support ``--allow-paths`` to define trusted import paths. Note: the
    path(s) of the supplied source file(s) is always trusted.
 

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -121,7 +121,8 @@ Input Description
         //
         // The available output types are as follows:
         //   abi - ABI
-        //   ast - AST of all source files
+        //   ast - AST of all source files (not supported atm)
+        //   legacyAST - legacy AST of all source files
         //   why3 - Why3 translated output
         //   devdoc - Developer documentation (natspec)
         //   userdoc - User documentation (natspec)
@@ -155,9 +156,9 @@ Input Description
           "*": {
             "*": [ "evm.sourceMap" ]
           },
-          // Enable the AST and Why3 output of every single file.
+          // Enable the legacy AST and Why3 output of every single file.
           "*": {
-            "": [ "ast", "why3" ]
+            "": [ "legacyAST", "why3" ]
           }
         }
       }
@@ -197,7 +198,9 @@ Output Description
           // Identifier (used in source maps)
           id: 1,
           // The AST object
-          ast: {}
+          ast: {},
+          // The legacy AST object
+          legacyAST: {}
         }
       },
       // This contains the contract-level outputs. It can be limited/filtered by the outputSelection settings.

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -29,7 +29,7 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-Json::Value StandardCompiler::compile(Json::Value const& _input)
+Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 {
 	m_compilerStack.reset(false);
 
@@ -137,6 +137,18 @@ Json::Value StandardCompiler::compile(Json::Value const& _input)
 	output["contracts"][""] = contractsOutput;
 
 	return output;
+}
+
+Json::Value StandardCompiler::compile(Json::Value const& _input)
+{
+	try
+	{
+		return compileInternal(_input);
+	}
+	catch (...)
+	{
+		return "{\"errors\":\"[{\"type\":\"InternalCompilerError\",\"component\":\"general\",\"severity\":\"error\",\"message\":\"Internal exception in StandardCompiler::compilerInternal\"}]}";
+	}
 }
 
 string StandardCompiler::compile(string const& _input)

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1,0 +1,31 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Alex Beregszaszi
+ * @date 2016
+ * Standard JSON compiler interface.
+ */
+
+#include <libsolidity/interface/StandardCompiler.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+string StandardCompiler::compile(string const& _input)
+{
+}

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -99,6 +99,14 @@ StringMap createSourceList(Json::Value const& _input)
 	return sources;
 }
 
+Json::Value methodIdentifiers(ContractDefinition const& _contract)
+{
+	Json::Value methodIdentifiers(Json::objectValue);
+	for (auto const& it: _contract.interfaceFunctions())
+		methodIdentifiers[it.second->externalSignature()] = toHex(it.first.ref());
+	return methodIdentifiers;
+}
+
 Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 {
 	m_compilerStack.reset(false);
@@ -259,7 +267,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		ostringstream unused;
 		evmData["legacyAssembly"] = m_compilerStack.streamAssembly(unused, contractName, createSourceList(_input), true);
 		evmData["opcodes"] = solidity::disassemble(m_compilerStack.object(contractName).bytecode);
-		// @TODO: add methodIdentifiers
+		evmData["methodIdentifiers"] = methodIdentifiers(m_compilerStack.contractDefinition(contractName));
 		// @TODO: add gasEstimates
 
 		// EVM bytecode

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -337,6 +337,30 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 	}
 	output["contracts"] = contractsOutput;
 
+	{
+		ErrorList formalErrors;
+		if (m_compilerStack.prepareFormalAnalysis(&formalErrors))
+			output["why3"] = m_compilerStack.formalTranslation();
+
+		for (auto const& error: formalErrors)
+		{
+			auto err = dynamic_pointer_cast<Error const>(error);
+
+			errors.append(formatErrorWithException(
+				*error,
+				err->type() == Error::Type::Warning,
+				err->typeName(),
+				"general",
+				"",
+				scannerFromSourceName
+			));
+		}
+
+		// FIXME!!
+		if (!formalErrors.empty())
+			output["errors"] = errors;
+	}
+
 	return output;
 }
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -22,6 +22,7 @@
 
 #include <libsolidity/interface/StandardCompiler.h>
 #include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <libsolidity/ast/ASTJsonConverter.h>
 #include <libevmasm/Instruction.h>
 #include <libdevcore/JSON.h>
 
@@ -141,7 +142,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 	{
 		Json::Value sourceResult = Json::objectValue;
 		sourceResult["id"] = sourceIndex++;
-		// @TODO add ast
+		sourceResult["ast"] = ASTJsonConverter(m_compilerStack.ast(source), m_compilerStack.sourceIndices()).json();
 		output["sources"][source] = sourceResult;
 	}
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -263,9 +263,10 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		// EVM
 		Json::Value evmData(Json::objectValue);
 		// @TODO: add ir
-		// @TODO: add assembly
-		ostringstream unused;
-		evmData["legacyAssembly"] = m_compilerStack.streamAssembly(unused, contractName, createSourceList(_input), true);
+		ostringstream tmp;
+		m_compilerStack.streamAssembly(tmp, contractName, createSourceList(_input), false);
+		evmData["assembly"] = tmp.str();
+		evmData["legacyAssembly"] = m_compilerStack.streamAssembly(tmp, contractName, createSourceList(_input), true);
 		evmData["methodIdentifiers"] = methodIdentifiers(m_compilerStack.contractDefinition(contractName));
 		// @TODO: add gasEstimates
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -50,6 +50,14 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 	unsigned optimizeRuns = optimizerSettings.get("runs", Json::Value(200u)).asUInt();
 
 	map<string, h160> libraries;
+	Json::Value jsonLibraries = settings.get("libraries", Json::Value());
+	for (auto const& sourceName: jsonLibraries.getMemberNames())
+	{
+		auto const& jsonSourceName = jsonLibraries[sourceName];
+		for (auto const& library: jsonSourceName.getMemberNames())
+			// @TODO use libraries only for the given source
+			libraries[library] = h160(jsonSourceName[library].asString());
+	}
 
 	auto scannerFromSourceName = [&](string const& _sourceName) -> solidity::Scanner const& { return m_compilerStack.scanner(_sourceName); };
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -135,6 +135,16 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 
 	Json::Value output = Json::objectValue;
 
+	output["sources"] = Json::objectValue;
+	unsigned sourceIndex = 0;
+	for (auto const& source: m_compilerStack.sourceNames())
+	{
+		Json::Value sourceResult = Json::objectValue;
+		sourceResult["id"] = sourceIndex++;
+		// @TODO add ast
+		output["sources"][source] = sourceResult;
+	}
+
 	Json::Value contractsOutput = Json::objectValue;
 	for (string const& contractName: m_compilerStack.contractNames())
 	{

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -152,6 +152,12 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 {
 	m_compilerStack.reset(false);
 
+	if (!_input.isObject())
+		return formatFatalError("JSONError", "Input is not a JSON object.");
+
+	if (_input["language"] != "Solidity")
+		return formatFatalError("JSONError", "Only \"Solidity\" is supported as a language.");
+
 	Json::Value const& sources = _input["sources"];
 	if (!sources)
 		return formatFatalError("JSONError", "No input sources specified.");

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -29,6 +29,21 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
+Json::Value formatFatalError(string const& _type, string const& _description)
+{
+	Json::Value error = Json::objectValue;
+	error["type"] = _type;
+	error["component"] = "general";
+	error["severity"] = "error";
+	error["message"] = _description;
+
+	Json::Value output = Json::objectValue;
+	output["errors"] = Json::arrayValue;
+	output["errors"].append(error);
+
+	return output;
+}
+
 Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 {
 	m_compilerStack.reset(false);

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -178,15 +178,21 @@ Json::Value StandardCompiler::compile(Json::Value const& _input)
 	}
 	catch (...)
 	{
-		return "{\"errors\":\"[{\"type\":\"InternalCompilerError\",\"component\":\"general\",\"severity\":\"error\",\"message\":\"Internal exception in StandardCompiler::compilerInternal\"}]}";
+		return formatFatalError("InternalCompilerError", "Internal exception in StandardCompiler::compilerInternal");
 	}
 }
 
 string StandardCompiler::compile(string const& _input)
 {
 	Json::Value input;
+	Json::Reader reader;
 
-	if (!Json::Reader().parse(_input, input, false))
+	try
+	{
+		if (!reader.parse(_input, input, false))
+			return jsonCompactPrint(formatFatalError("JSONError", reader.getFormattedErrorMessages()));
+	}
+	catch(...)
 	{
 		return "{\"errors\":\"[{\"type\":\"JSONError\",\"component\":\"general\",\"severity\":\"error\",\"message\":\"Error parsing input JSON.\"}]}";
 	}

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -45,6 +45,11 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 
 	Json::Value const& settings = _input.get("settings", Json::Value());
 
+	vector<string> remappings;
+	for (auto const& remapping: settings.get("remappings", Json::Value()))
+		remappings.push_back(remapping.asString());
+	m_compilerStack.setRemappings(remappings);
+
 	Json::Value optimizerSettings = settings.get("optimizer", Json::Value());
 	bool optimize = optimizerSettings.get("enabled", Json::Value(false)).asBool();
 	unsigned optimizeRuns = optimizerSettings.get("runs", Json::Value(200u)).asUInt();

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -308,7 +308,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		evmData["assembly"] = tmp.str();
 		evmData["legacyAssembly"] = m_compilerStack.streamAssembly(tmp, contractName, createSourceList(_input), true);
 		evmData["methodIdentifiers"] = methodIdentifiers(m_compilerStack.contractDefinition(contractName));
-		// @TODO: add gasEstimates
+		evmData["gasEstimates"] = m_compilerStack.gasEstimates(contractName);
 
 		// EVM bytecode
 		Json::Value bytecode(Json::objectValue);

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -61,10 +61,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 
 	Json::Value const& sources = _input["sources"];
 	if (!sources)
-	{
-		// @TODO report error
-		return Json::Value();
-	}
+		return formatFatalError("JSONError", "No input sources specified.");
 
 	for (auto const& sourceName: sources.getMemberNames())
 		m_compilerStack.addSource(sourceName, sources[sourceName]["content"].asString());

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -301,7 +301,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 	{
 		Json::Value sourceResult = Json::objectValue;
 		sourceResult["id"] = sourceIndex++;
-		sourceResult["ast"] = ASTJsonConverter(m_compilerStack.ast(source), m_compilerStack.sourceIndices()).json();
+		sourceResult["legacyAST"] = ASTJsonConverter(m_compilerStack.ast(source), m_compilerStack.sourceIndices()).json();
 		output["sources"][source] = sourceResult;
 	}
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -166,6 +166,9 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 			libraries[library] = h160(jsonSourceName[library].asString());
 	}
 
+	Json::Value metadataSettings = settings.get("metadata", Json::Value());
+	m_compilerStack.useMetadataLiteralSources(metadataSettings.get("useLiteralContent", Json::Value(false)).asBool());
+
 	auto scannerFromSourceName = [&](string const& _sourceName) -> solidity::Scanner const& { return m_compilerStack.scanner(_sourceName); };
 
 	Json::Value errors = Json::arrayValue;

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -44,6 +44,16 @@ Json::Value formatFatalError(string const& _type, string const& _description)
 	return output;
 }
 
+StringMap createSourceList(Json::Value const& _input)
+{
+	StringMap sources;
+	Json::Value const& jsonSources = _input["sources"];
+	if (jsonSources.isObject())
+		for (auto const& sourceName: jsonSources.getMemberNames())
+			sources[sourceName] = jsonSources[sourceName]["content"].asString();
+	return sources;
+}
+
 Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 {
 	m_compilerStack.reset(false);
@@ -139,7 +149,8 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		Json::Value evmData(Json::objectValue);
 		// @TODO: add ir
 		// @TODO: add assembly
-		// @TODO: add legacyAssemblyJSON
+		ostringstream unused;
+		evmData["legacyAssembly"] = m_compilerStack.streamAssembly(unused, contractName, createSourceList(_input), true);
 		evmData["opcodes"] = solidity::disassemble(m_compilerStack.object(contractName).bytecode);
 		// @TODO: add methodIdentifiers
 		// @TODO: add gasEstimates

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -280,6 +280,11 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 	Json::Value contractsOutput = Json::objectValue;
 	for (string const& contractName: m_compilerStack.contractNames())
 	{
+		size_t colon = contractName.find(':');
+		solAssert(colon != string::npos, "");
+		string file = contractName.substr(0, colon);
+		string name = contractName.substr(colon + 1);
+
 		// ABI, documentation and metadata
 		Json::Value contractData(Json::objectValue);
 		contractData["abi"] = dev::jsonCompactPrint(m_compilerStack.metadata(contractName, DocumentationType::ABIInterface));
@@ -317,10 +322,12 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 
 		contractData["evm"] = evmData;
 
-		contractsOutput[contractName] = contractData;
+		if (!contractsOutput.isMember(file))
+			contractsOutput[file] = Json::objectValue;
+
+		contractsOutput[file][name] = contractData;
 	}
-	output["contracts"] = Json::objectValue;
-	output["contracts"][""] = contractsOutput;
+	output["contracts"] = contractsOutput;
 
 	return output;
 }

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -30,18 +30,31 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-Json::Value formatFatalError(string const& _type, string const& _description)
+Json::Value formatError(
+	bool _warning,
+	string const& _type,
+	string const& _component,
+	string const& _message,
+	string const& _formattedMessage = "",
+	Json::Value const& _sourceLocation = Json::Value()
+)
 {
 	Json::Value error = Json::objectValue;
 	error["type"] = _type;
-	error["component"] = "general";
-	error["severity"] = "error";
-	error["message"] = _description;
+	error["component"] = _component;
+	error["severity"] = _warning ? "warning" : "error";
+	error["message"] = _message;
+	error["formattedMessage"] = (_formattedMessage.length() > 0) ? _formattedMessage : _message;
+	if (_sourceLocation.isObject())
+		error["sourceLocation"] = _sourceLocation;
+	return error;
+}
 
+Json::Value formatFatalError(string const& _type, string const& _message)
+{
 	Json::Value output = Json::objectValue;
 	output["errors"] = Json::arrayValue;
-	output["errors"].append(error);
-
+	output["errors"].append(formatError(false, _type, "general", _message));
 	return output;
 }
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -143,7 +143,12 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		return formatFatalError("JSONError", "No input sources specified.");
 
 	for (auto const& sourceName: sources.getMemberNames())
-		m_compilerStack.addSource(sourceName, sources[sourceName]["content"].asString());
+		if (sources[sourceName]["content"].isString())
+			m_compilerStack.addSource(sourceName, sources[sourceName]["content"].asString());
+		else if (sources[sourceName]["urls"].isArray())
+			return formatFatalError("UnimplementedFeatureError", "Input URLs not supported yet.");
+		else
+			return formatFatalError("JSONError", "Invalid input source specified.");
 
 	Json::Value const& settings = _input.get("settings", Json::Value());
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -266,13 +266,13 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		// @TODO: add assembly
 		ostringstream unused;
 		evmData["legacyAssembly"] = m_compilerStack.streamAssembly(unused, contractName, createSourceList(_input), true);
-		evmData["opcodes"] = solidity::disassemble(m_compilerStack.object(contractName).bytecode);
 		evmData["methodIdentifiers"] = methodIdentifiers(m_compilerStack.contractDefinition(contractName));
 		// @TODO: add gasEstimates
 
 		// EVM bytecode
 		Json::Value bytecode(Json::objectValue);
 		bytecode["object"] = m_compilerStack.object(contractName).toHex();
+		bytecode["opcodes"] = solidity::disassemble(m_compilerStack.object(contractName).bytecode);
 		auto sourceMap = m_compilerStack.sourceMapping(contractName);
 		bytecode["sourceMap"] = sourceMap ? *sourceMap : "";
 		// @TODO: add linkReferences
@@ -281,6 +281,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		// EVM deployed bytecode
 		Json::Value deployedBytecode(Json::objectValue);
 		deployedBytecode["object"] = m_compilerStack.runtimeObject(contractName).toHex();
+		deployedBytecode["opcodes"] = solidity::disassemble(m_compilerStack.runtimeObject(contractName).bytecode);
 		auto runtimeSourceMap = m_compilerStack.runtimeSourceMapping(contractName);
 		deployedBytecode["sourceMap"] = runtimeSourceMap ? *runtimeSourceMap : "";
 		// @TODO: add linkReferences

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -43,9 +43,12 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 	for (auto const& sourceName: sources.getMemberNames())
 		m_compilerStack.addSource(sourceName, sources[sourceName]["content"].asString());
 
-	// @TODO parse settings
-	bool optimize = false;
-	unsigned optimizeRuns = 200;
+	Json::Value const& settings = _input.get("settings", Json::Value());
+
+	Json::Value optimizerSettings = settings.get("optimizer", Json::Value());
+	bool optimize = optimizerSettings.get("enabled", Json::Value(false)).asBool();
+	unsigned optimizeRuns = optimizerSettings.get("runs", Json::Value(200u)).asUInt();
+
 	map<string, h160> libraries;
 
 	auto scannerFromSourceName = [&](string const& _sourceName) -> solidity::Scanner const& { return m_compilerStack.scanner(_sourceName); };

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -30,6 +30,8 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
+namespace {
+
 Json::Value formatError(
 	bool _warning,
 	string const& _type,
@@ -132,6 +134,8 @@ Json::Value formatLinkReferences(std::map<size_t, std::string> const& linkRefere
 	}
 
 	return ret;
+}
+
 }
 
 Json::Value StandardCompiler::compileInternal(Json::Value const& _input)

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -1,0 +1,59 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Alex Beregszaszi
+ * @date 2016
+ * Standard JSON compiler interface.
+ */
+
+#pragma once
+
+#include <libsolidity/interface/CompilerStack.h>
+
+namespace dev
+{
+
+namespace solidity
+{
+
+/**
+ * Standard JSON compiler interface, which expects a JSON input and returns a JSON ouput.
+ * See docs/using-the-compiler#compiler-input-and-output-json-description.
+ */
+class StandardCompiler: boost::noncopyable
+{
+public:
+	/// Creates a new StandardCompiler.
+	/// @param _readFile callback to used to read files for import statements. Should return
+	StandardCompiler(ReadFile::Callback const& _readFile = ReadFile::Callback())
+		: m_compilerStack(_readFile)
+	{
+	}
+
+	/// Sets all input parameters according to @a _input which conforms to the standardized input
+	/// format, performs compilation and returns a standardized output.
+	Json::Value compile(Json::Value const& _input);
+	/// Parses input as JSON and peforms the above processing steps, returning a serialized JSON
+	/// output. Parsing errors are returned as regular errors.
+	std::string compile(std::string const& _input);
+
+private:
+	CompilerStack m_compilerStack;
+};
+
+}
+}

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -52,6 +52,8 @@ public:
 	std::string compile(std::string const& _input);
 
 private:
+	Json::Value compileInternal(Json::Value const& _input);
+
 	CompilerStack m_compilerStack;
 };
 

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -36,6 +36,7 @@
 #include <libsolidity/analysis/NameAndTypeResolver.h>
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/interface/CompilerStack.h>
+#include <libsolidity/interface/StandardCompiler.h>
 #include <libsolidity/interface/SourceReferenceFormatter.h>
 #include <libsolidity/ast/ASTJsonConverter.h>
 #include <libsolidity/interface/Version.h>
@@ -48,6 +49,41 @@ extern "C" {
 /// Callback used to retrieve additional source files. "Returns" two pointers that should be
 /// heap-allocated and are free'd by the caller.
 typedef void (*CStyleReadFileCallback)(char const* _path, char** o_contents, char** o_error);
+}
+
+ReadFile::Callback wrapReadCallback(CStyleReadFileCallback _readCallback = nullptr)
+{
+	ReadFile::Callback readCallback;
+	if (_readCallback)
+	{
+		readCallback = [=](string const& _path)
+		{
+			char* contents_c = nullptr;
+			char* error_c = nullptr;
+			_readCallback(_path.c_str(), &contents_c, &error_c);
+			ReadFile::Result result;
+			result.success = true;
+			if (!contents_c && !error_c)
+			{
+				result.success = false;
+				result.contentsOrErrorMessage = "File not found.";
+			}
+			if (contents_c)
+			{
+				result.success = true;
+				result.contentsOrErrorMessage = string(contents_c);
+				free(contents_c);
+			}
+			if (error_c)
+			{
+				result.success = false;
+				result.contentsOrErrorMessage = string(error_c);
+				free(error_c);
+			}
+			return result;
+		};
+	}
+	return readCallback;
 }
 
 Json::Value functionHashes(ContractDefinition const& _contract)
@@ -103,37 +139,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 {
 	Json::Value output(Json::objectValue);
 	Json::Value errors(Json::arrayValue);
-	ReadFile::Callback readCallback;
-	if (_readCallback)
-	{
-		readCallback = [=](string const& _path)
-		{
-			char* contents_c = nullptr;
-			char* error_c = nullptr;
-			_readCallback(_path.c_str(), &contents_c, &error_c);
-			ReadFile::Result result;
-			result.success = true;
-			if (!contents_c && !error_c)
-			{
-				result.success = false;
-				result.contentsOrErrorMessage = "File not found.";
-			}
-			if (contents_c)
-			{
-				result.success = true;
-				result.contentsOrErrorMessage = string(contents_c);
-				free(contents_c);
-			}
-			if (error_c)
-			{
-				result.success = false;
-				result.contentsOrErrorMessage = string(error_c);
-				free(error_c);
-			}
-			return result;
-		};
-	}
-	CompilerStack compiler(readCallback);
+	CompilerStack compiler(wrapReadCallback(_readCallback));
 	auto scannerFromSourceName = [&](string const& _sourceName) -> solidity::Scanner const& { return compiler.scanner(_sourceName); };
 	bool success = false;
 	try
@@ -287,6 +293,13 @@ string compileSingle(string const& _input, bool _optimize)
 	return compile(sources, _optimize, nullptr);
 }
 
+
+string compileStandardInternal(string const& _input, CStyleReadFileCallback _readCallback = nullptr)
+{
+	StandardCompiler compiler(wrapReadCallback(_readCallback));
+	return compiler.compile(_input);
+}
+
 static string s_outputBuffer;
 
 extern "C"
@@ -308,6 +321,11 @@ extern char const* compileJSONMulti(char const* _input, bool _optimize)
 extern char const* compileJSONCallback(char const* _input, bool _optimize, CStyleReadFileCallback _readCallback)
 {
 	s_outputBuffer = compileMulti(_input, _optimize, _readCallback);
+	return s_outputBuffer.c_str();
+}
+extern char const* compileStandard(char const* _input, CStyleReadFileCallback _readCallback)
+{
+	s_outputBuffer = compileStandardInternal(_input, _readCallback);
 	return s_outputBuffer.c_str();
 }
 }

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -87,7 +87,17 @@ BOOST_AUTO_TEST_SUITE(StandardCompiler)
 
 BOOST_AUTO_TEST_CASE(assume_object_input)
 {
-	Json::Value result = compile("");
+	Json::Value result;
+
+	/// Use the native JSON interface of StandardCompiler to trigger these
+	solidity::StandardCompiler compiler;
+	result = compiler.compile(Json::Value());
+	BOOST_CHECK(containsError(result, "JSONError", "Input is not a JSON object."));
+	result = compiler.compile(Json::Value("INVALID"));
+	BOOST_CHECK(containsError(result, "JSONError", "Input is not a JSON object."));
+
+	/// Use the string interface of StandardCompiler to trigger these
+	result = compile("");
 	BOOST_CHECK(containsError(result, "JSONError", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n"));
 	result = compile("invalid");
 	BOOST_CHECK(containsError(result, "JSONError", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n"));

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -1,0 +1,155 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @date 2017
+ * Unit tests for interface/StandardCompiler.h.
+ */
+
+#include <string>
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+#include <libsolidity/interface/StandardCompiler.h>
+
+
+using namespace std;
+using namespace dev::eth;
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+namespace
+{
+
+/// Helper to match a specific error type and message
+bool containsError(Json::Value const& _compilerResult, string const& _type, string const& _message)
+{
+	if (!_compilerResult.isMember("errors"))
+		return false;
+
+	for (auto const& error: _compilerResult["errors"])
+	{
+		BOOST_REQUIRE(error.isObject());
+		BOOST_REQUIRE(error["type"].isString());
+		BOOST_REQUIRE(error["message"].isString());
+		if ((error["type"].asString() == _type) && (error["message"].asString() == _message))
+			return true;
+	}
+
+	return false;
+}
+
+bool containsAtMostWarnings(Json::Value const& _compilerResult)
+{
+	if (!_compilerResult.isMember("errors"))
+		return true;
+
+	for (auto const& error: _compilerResult["errors"])
+	{
+		BOOST_REQUIRE(error.isObject());
+		BOOST_REQUIRE(error["severity"].isString());
+		if (error["severity"].asString() != "warning")
+			return false;
+	}
+
+	return true;
+}
+
+Json::Value compile(string const& _input)
+{
+	StandardCompiler compiler;
+	string output = compiler.compile(_input);
+	Json::Value ret;
+	BOOST_REQUIRE(Json::Reader().parse(output, ret, false));
+	return ret;
+}
+
+} // end anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(StandardCompiler)
+
+BOOST_AUTO_TEST_CASE(assume_object_input)
+{
+	Json::Value result = compile("");
+	BOOST_CHECK(containsError(result, "JSONError", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n"));
+	result = compile("invalid");
+	BOOST_CHECK(containsError(result, "JSONError", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n"));
+	result = compile("\"invalid\"");
+	BOOST_CHECK(containsError(result, "JSONError", "Input is not a JSON object."));
+	BOOST_CHECK(!containsError(result, "JSONError", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n"));
+	result = compile("{}");
+	BOOST_CHECK(!containsError(result, "JSONError", "* Line 1, Column 1\n  Syntax error: value, object or array expected.\n"));
+	BOOST_CHECK(!containsAtMostWarnings(result));
+}
+
+BOOST_AUTO_TEST_CASE(invalid_language)
+{
+	char const* input = R"(
+	{
+		"language": "INVALID"
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "Only \"Solidity\" is supported as a language."));
+}
+
+BOOST_AUTO_TEST_CASE(valid_language)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity"
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(!containsError(result, "JSONError", "Only \"Solidity\" is supported as a language."));
+}
+
+BOOST_AUTO_TEST_CASE(no_sources)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity"
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "No input sources specified."));
+}
+
+BOOST_AUTO_TEST_CASE(smoke_test)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"sources": {
+			"empty": {
+				"content": ""
+			}
+		}
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(containsAtMostWarnings(result));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+} // end namespaces

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -255,7 +255,12 @@ BOOST_AUTO_TEST_CASE(basic_compilation)
 		"{\"creation\":{\"codeDepositCost\":\"10200\",\"executionCost\":\"62\",\"totalCost\":\"10262\"}}");
 	BOOST_CHECK(contract["metadata"].isString());
 	BOOST_CHECK(isValidMetadata(contract["metadata"].asString()));
-	/// @TODO check "sources" (ast)
+	BOOST_CHECK(result["sources"].isObject());
+	BOOST_CHECK(result["sources"]["fileA"].isObject());
+	BOOST_CHECK(result["sources"]["fileA"]["legacyAST"].isObject());
+	BOOST_CHECK(dev::jsonCompactPrint(result["sources"]["fileA"]["legacyAST"]) ==
+		"{\"children\":[{\"attributes\":{\"fullyImplemented\":true,\"isLibrary\":false,\"linearizedBaseContracts\":[1],"
+		"\"name\":\"A\"},\"children\":[],\"id\":1,\"name\":\"ContractDefinition\",\"src\":\"0:14:0\"}],\"name\":\"SourceUnit\"}");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Implements #1387. Replaces #712.

Fixes #579, #863, #1645, https://github.com/ethereum/solidity/issues/1809.

Todo:
- [x] clean up includes in `StandardCompiler.cpp`
- [x] proper error reporting for compiler errors
- [ ] catch exceptions on individual output items (similar to how `jsonCompiler` works)
- [x] support AST output
- [x] support Why3 output
- [x] support `gasEstimates` output (depends on #2114)
- [x] support `methodIdentifiers` output
- [x] support `linkReferences` output
- [x] control outputs by input selection (likely postponed to a subsequent PR)
- [x] support URLs in input sources (likely postponed to a subsequent PR)
- [x] verify input sources against supplied hash (likely postponed to a subsequent PR)
- [x] support `metadata.useLiteralContent`
- [x] add tests