### PR TITLE
[WIP] Desugar asm functions (aka. EVM codegen from Julia)

### DIFF
--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -880,6 +880,7 @@ Pseudocode::
     desugar item: AST -> AST =
     match item {
     AssemblyFunctionDefinition('function' name '(' arg1, ..., argn ')' '->' ( '(' ret1, ..., retm ')' body) ->
+      jump($after_<name>)
       <name>:
       {
         jump($<name>_start)
@@ -891,6 +892,7 @@ Pseudocode::
         jump
         0 (1 + n times) to compensate removal of arg1, ..., argn and $retPC
       }
+      $after_<name>:
     AssemblyFor('for' { init } condition post body) ->
       {
         init // cannot be its own block because we want variable scope to extend into the body
@@ -938,7 +940,7 @@ Pseudocode::
         if identifier is function <name> with n args and m ret values ->
           {
             // find I such that $funcallI_* does not exist
-            $funcallI_return argn  ... arg2 arg1 jump(<name>)
+            $funcallI_return desugar(argn)  ... desugar(arg2) desugar(arg1) jump(<name>)
             pop (n + 1 times)
             if the current context is `let (id1, ..., idm) := f(...)` ->
               let id1 := 0 ... let idm := 0
@@ -952,7 +954,9 @@ Pseudocode::
         else -> desugar(children of node)
       }
     default node ->
-      desugar(children of node)
+      desugar(children of node), exploding functional notation into statement
+      notation whenever desugaring turned a functional expression into a
+      list of statements
     }
 
 Opcode Stream Generation

--- a/libsolidity/inlineasm/AsmAnalysis.cpp
+++ b/libsolidity/inlineasm/AsmAnalysis.cpp
@@ -21,6 +21,8 @@
 #include <libsolidity/inlineasm/AsmAnalysis.h>
 
 #include <libsolidity/inlineasm/AsmData.h>
+#include <libsolidity/inlineasm/AsmScopeFiller.h>
+#include <libsolidity/inlineasm/AsmScope.h>
 
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/interface/Utils.h>
@@ -36,68 +38,16 @@ using namespace dev::solidity;
 using namespace dev::solidity::assembly;
 
 
-bool Scope::registerLabel(string const& _name)
+AsmAnalyzer::AsmAnalyzer(AsmAnalyzer::Scopes& _scopes, ErrorList& _errors, bool _allowFailedLookups):
+	m_allowFailedLookups(_allowFailedLookups), m_scopes(_scopes), m_errors(_errors)
 {
-	if (exists(_name))
+}
+
+bool AsmAnalyzer::analyze(Block const& _block)
+{
+	if (!(ScopeFiller(m_scopes, m_errors))(_block))
 		return false;
-	identifiers[_name] = Label();
-	return true;
-}
-
-bool Scope::registerVariable(string const& _name)
-{
-	if (exists(_name))
-		return false;
-	identifiers[_name] = Variable();
-	return true;
-}
-
-bool Scope::registerFunction(string const& _name, size_t _arguments, size_t _returns)
-{
-	if (exists(_name))
-		return false;
-	identifiers[_name] = Function(_arguments, _returns);
-	return true;
-}
-
-Scope::Identifier* Scope::lookup(string const& _name)
-{
-	bool crossedFunctionBoundary = false;
-	for (Scope* s = this; s; s = s->superScope)
-	{
-		auto id = identifiers.find(_name);
-		if (id != identifiers.end())
-		{
-			if (crossedFunctionBoundary && id->second.type() == typeid(Scope::Variable))
-				return nullptr;
-			else
-				return &id->second;
-		}
-
-		if (s->functionScope)
-			crossedFunctionBoundary = true;
-	}
-	return nullptr;
-}
-
-bool Scope::exists(string const& _name)
-{
-	if (identifiers.count(_name))
-		return true;
-	else if (superScope)
-		return superScope->exists(_name);
-	else
-		return false;
-}
-
-AsmAnalyzer::AsmAnalyzer(AsmAnalyzer::Scopes& _scopes, ErrorList& _errors):
-	m_scopes(_scopes), m_errors(_errors)
-{
-	// Make the Solidity ErrorTag available to inline assembly
-	Scope::Label errorLabel;
-	errorLabel.id = Scope::Label::errorLabelId;
-	scope(nullptr).identifiers["invalidJumpLabel"] = errorLabel;
-	m_currentScope = &scope(nullptr);
+	return (*this)(_block);
 }
 
 bool AsmAnalyzer::operator()(assembly::Literal const& _literal)
@@ -113,6 +63,47 @@ bool AsmAnalyzer::operator()(assembly::Literal const& _literal)
 	return true;
 }
 
+bool AsmAnalyzer::operator()(assembly::Identifier const& _identifier)
+{
+	bool success = true;
+	if (m_currentScope->lookup(_identifier.name, Scope::Visitor(
+		[&](Scope::Variable const& _var)
+		{
+			if (!_var.active)
+			{
+				m_errors.push_back(make_shared<Error>(
+					Error::Type::DeclarationError,
+					"Variable " + _identifier.name + " used before it was declared.",
+					_identifier.location
+				));
+				success = false;
+			}
+		},
+		[&](Scope::Label const&) {},
+		[&](Scope::Function const&)
+		{
+			m_errors.push_back(make_shared<Error>(
+				Error::Type::TypeError,
+				"Function " + _identifier.name + " used without being called.",
+			_identifier.location
+			));
+			success = false;
+		}
+	)))
+	{
+	}
+	else if (!m_allowFailedLookups)
+	{
+		m_errors.push_back(make_shared<Error>(
+			Error::Type::DeclarationError,
+			"Identifier not found.",
+			_identifier.location
+		));
+		success = false;
+	}
+	return success;
+}
+
 bool AsmAnalyzer::operator()(FunctionalInstruction const& _instr)
 {
 	bool success = true;
@@ -124,74 +115,105 @@ bool AsmAnalyzer::operator()(FunctionalInstruction const& _instr)
 	return success;
 }
 
-bool AsmAnalyzer::operator()(Label const& _item)
+bool AsmAnalyzer::operator()(Label const&)
 {
-	if (!m_currentScope->registerLabel(_item.name))
-	{
-		//@TODO secondary location
-		m_errors.push_back(make_shared<Error>(
-			Error::Type::DeclarationError,
-			"Label name " + _item.name + " already taken in this scope.",
-			_item.location
-		));
-		return false;
-	}
 	return true;
+}
+
+bool AsmAnalyzer::operator()(assembly::Assignment const& _assignment)
+{
+	return checkAssignment(_assignment.variableName);
 }
 
 bool AsmAnalyzer::operator()(FunctionalAssignment const& _assignment)
 {
-	return boost::apply_visitor(*this, *_assignment.value);
+	bool success = boost::apply_visitor(*this, *_assignment.value);
+	if (!checkAssignment(_assignment.variableName))
+		success = false;
+	return success;
 }
 
 bool AsmAnalyzer::operator()(assembly::VariableDeclaration const& _varDecl)
 {
 	bool success = boost::apply_visitor(*this, *_varDecl.value);
-	if (!registerVariable(_varDecl.name, _varDecl.location, *m_currentScope))
-		success = false;
+	boost::get<Scope::Variable>(m_currentScope->identifiers.at(_varDecl.name)).active = true;
 	return success;
 }
 
 bool AsmAnalyzer::operator()(assembly::FunctionDefinition const& _funDef)
 {
-	bool success = true;
-	if (!m_currentScope->registerFunction(_funDef.name, _funDef.arguments.size(), _funDef.returns.size()))
-	{
-		//@TODO secondary location
-		m_errors.push_back(make_shared<Error>(
-			Error::Type::DeclarationError,
-			"Function name " + _funDef.name + " already taken in this scope.",
-			_funDef.location
-		));
-		success = false;
-	}
-	Scope& body = scope(&_funDef.body);
-	body.superScope = m_currentScope;
-	body.functionScope = true;
+	Scope& bodyScope = scope(&_funDef.body);
 	for (auto const& var: _funDef.arguments + _funDef.returns)
-		if (!registerVariable(var, _funDef.location, body))
-			success = false;
+		boost::get<Scope::Variable>(bodyScope.identifiers.at(var)).active = true;
 
-	(*this)(_funDef.body);
-
-	return success;
+	return (*this)(_funDef.body);
 }
 
 bool AsmAnalyzer::operator()(assembly::FunctionCall const& _funCall)
 {
 	bool success = true;
+	size_t arguments = 0;
+	size_t returns = 0;
+	if (!m_currentScope->lookup(_funCall.functionName.name, Scope::Visitor(
+		[&](Scope::Variable const&)
+		{
+			m_errors.push_back(make_shared<Error>(
+				Error::Type::TypeError,
+				"Attempt to call variable instead of function.",
+				_funCall.functionName.location
+			));
+			success = false;
+		},
+		[&](Scope::Label const&)
+		{
+			m_errors.push_back(make_shared<Error>(
+				Error::Type::TypeError,
+				"Attempt to call label instead of function.",
+				_funCall.functionName.location
+				));
+			success = false;
+		},
+		[&](Scope::Function const& _fun)
+		{
+			arguments = _fun.arguments;
+			returns = _fun.returns;
+		}
+	)))
+	{
+		m_errors.push_back(make_shared<Error>(
+			Error::Type::DeclarationError,
+			"Function not found.",
+			_funCall.functionName.location
+		));
+		success = false;
+	}
+	if (success)
+	{
+		if (_funCall.arguments.size() != arguments)
+		{
+			m_errors.push_back(make_shared<Error>(
+				Error::Type::TypeError,
+				"Expected " +
+				boost::lexical_cast<string>(arguments) +
+				" arguments but got " +
+				boost::lexical_cast<string>(_funCall.arguments.size()) +
+				".",
+				_funCall.functionName.location
+				));
+			success = false;
+		}
+		//@todo check the number of returns - depends on context and should probably
+		// be only done once we have stack height checks
+	}
 	for (auto const& arg: _funCall.arguments | boost::adaptors::reversed)
 		if (!boost::apply_visitor(*this, arg))
 			success = false;
-	// TODO actually look up the function (can only be done in a second pass)
-	// and check that the number of arguments and of returns matches the context
 	return success;
 }
 
 bool AsmAnalyzer::operator()(Block const& _block)
 {
 	bool success = true;
-	scope(&_block).superScope = m_currentScope;
 	m_currentScope = &scope(&_block);
 
 	for (auto const& s: _block.statements)
@@ -202,25 +224,29 @@ bool AsmAnalyzer::operator()(Block const& _block)
 	return success;
 }
 
-bool AsmAnalyzer::registerVariable(string const& _name, SourceLocation const& _location, Scope& _scope)
+bool AsmAnalyzer::checkAssignment(assembly::Identifier const& _variable)
 {
-	if (!_scope.registerVariable(_name))
-	{
-		//@TODO secondary location
-		m_errors.push_back(make_shared<Error>(
-			Error::Type::DeclarationError,
-			"Variable name " + _name + " already taken in this scope.",
-			_location
-		));
+	if (!(*this)(_variable))
 		return false;
+	else if (!m_allowFailedLookups)
+	{
+		// Check that it is a variable
+		if (m_currentScope->lookup(_variable.name)->type() != typeid(Scope::Variable))
+		{
+			m_errors.push_back(make_shared<Error>(
+				Error::Type::TypeError,
+				"Assignment requires variable.",
+				_variable.location
+			));
+			return false;
+		}
 	}
 	return true;
 }
 
 Scope& AsmAnalyzer::scope(Block const* _block)
 {
-	auto& scope = m_scopes[_block];
-	if (!scope)
-		scope = make_shared<Scope>();
-	return *scope;
+	auto scopePtr = m_scopes.at(_block);
+	solAssert(scopePtr, "Scope requested but not present.");
+	return *scopePtr;
 }

--- a/libsolidity/inlineasm/AsmAnalysis.cpp
+++ b/libsolidity/inlineasm/AsmAnalysis.cpp
@@ -214,13 +214,14 @@ bool AsmAnalyzer::operator()(assembly::FunctionCall const& _funCall)
 bool AsmAnalyzer::operator()(Block const& _block)
 {
 	bool success = true;
+	Scope *previous = m_currentScope;
 	m_currentScope = &scope(&_block);
 
 	for (auto const& s: _block.statements)
 		if (!boost::apply_visitor(*this, s))
 			success = false;
 
-	m_currentScope = m_currentScope->superScope;
+	m_currentScope = previous;
 	return success;
 }
 

--- a/libsolidity/inlineasm/AsmCodeGen.cpp
+++ b/libsolidity/inlineasm/AsmCodeGen.cpp
@@ -66,7 +66,7 @@ struct GeneratorState
 		return size_t(id);
 	}
 
-	std::map<assembly::Block const*, shared_ptr<Scope>> scopes;
+	AsmAnalyzer::Scopes scopes;
 	ErrorList& errors;
 	eth::Assembly& assembly;
 };

--- a/libsolidity/inlineasm/AsmDesugar.cpp
+++ b/libsolidity/inlineasm/AsmDesugar.cpp
@@ -1,0 +1,227 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <c@ethdev.com>
+ * @date 2017
+ * Desugars assembly, i.e. converts the parsed ast and removes functions, switches and loops.
+ */
+
+#include <libsolidity/inlineasm/AsmDesugar.h>
+
+#include <libsolidity/inlineasm/AsmData.h>
+
+#include <boost/range/algorithm/transform.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/adaptor/reversed.hpp>
+
+#include <memory>
+#include <functional>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+using namespace dev::solidity::assembly;
+
+
+Statement ASTNodeReplacement::asStatement()
+{
+	assertThrow(!secondValid, DesugaringError, "Tried to convert pair of statements to single.");
+	return std::move(node);
+}
+
+bool ASTNodeReplacement::isBlock() const
+{
+	assertThrow(!secondValid, DesugaringError, "Expected single statement but was pair.");
+	return node.type() == typeid(assembly::Block);
+}
+
+ASTNodeReplacement::operator assembly::Statement() &&
+{
+	assertThrow(!secondValid, DesugaringError, "Tried to convert pair of statements to single.");
+	return std::move(node);
+}
+
+Block AsmDesugar::run(Block const& _in)
+{
+	return boost::get<Block>((*this)(_in).asStatement());
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::Instruction const& _instruction)
+{
+	return {_instruction};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::Literal const& _literal)
+{
+	return {_literal};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::Identifier const& _identifier)
+{
+	return {_identifier};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionalInstruction const& _functionalInstruction)
+{
+	bool haveToExplode = false;
+	vector<ASTNodeReplacement> arguments;
+	for (auto const& arg: _functionalInstruction.arguments)
+	{
+		arguments.push_back(std::move(boost::apply_visitor(*this, arg)));
+		if (arguments.back().isBlock())
+			haveToExplode = true;
+	}
+	if (haveToExplode)
+	{
+		assembly::Block block;
+		block.location = _functionalInstruction.location;
+		std::move(arguments.rbegin(), arguments.rend(), std::back_inserter(block.statements));
+		block.statements.push_back(_functionalInstruction.instruction);
+		return {block};
+	}
+	else
+	{
+		FunctionalInstruction result;
+		result.location = _functionalInstruction.location;
+		result.instruction = _functionalInstruction.instruction;
+		std::move(arguments.begin(), arguments.end(), std::back_inserter(result.arguments));
+		return {result};
+	}
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::Label const& _label)
+{
+	return {_label};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::Assignment const& _assignment)
+{
+	return {_assignment};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionalAssignment const& _functionalAssignment)
+{
+	ASTNodeReplacement value = boost::apply_visitor(*this, *_functionalAssignment.value);
+	if (value.isBlock())
+		return {value.asStatement(), Assignment{_functionalAssignment.location, _functionalAssignment.variableName}};
+	else
+	{
+		FunctionalAssignment result;
+		result.location = _functionalAssignment.location;
+		result.variableName = _functionalAssignment.variableName;
+		result.value = make_shared<Statement>(value.asStatement());
+		return {result};
+	}
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::VariableDeclaration const& _variableDeclaration)
+{
+	//@TODO handle special case of `let x := f()` where return label and variable introduction label can be combined.
+	ASTNodeReplacement value = boost::apply_visitor(*this, *_variableDeclaration.value);
+	if (value.isBlock())
+		//@TODO make the name unique
+		return {value.asStatement(), Label{
+			_variableDeclaration.location,
+			"$introduce_" + _variableDeclaration.name,
+			{_variableDeclaration.name}
+		}};
+	else
+	{
+		VariableDeclaration result;
+		result.location = _variableDeclaration.location;
+		result.name = _variableDeclaration.name;
+		result.value = make_shared<Statement>(value.asStatement());
+		return {result};
+	}
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionDefinition const& _functionDefinition)
+{
+	auto loc = _functionDefinition.location;
+	//@TODO make labels unique
+	Block body = boost::get<Block>((*this)(_functionDefinition.body).asStatement());
+	Block env{loc, {}};
+	env.statements.push_back(Label{loc, "$" + _functionDefinition.name + "_start", _functionDefinition.arguments});
+	for (auto const& r: _functionDefinition.returns)
+		env.statements.push_back(VariableDeclaration{loc, r, make_shared<Statement>(Literal{loc, true, "0"})});
+	env.statements.push_back(std::move(body));
+
+	size_t const args = _functionDefinition.arguments.size();
+	size_t const rets = _functionDefinition.returns.size();
+	// Reorganise stack from
+	// retpc arg1 ... argn ret1 ... retm
+	// to
+	// ret1 ... retm retpc
+	// Current layout with indices showing the target index (-1 means pop), i.e. should be
+	// m -1 ... -1 0 1 ... (m-1)
+	vector<int> stackTargetPos(1 + args + rets, -1);
+	stackTargetPos[0] = rets;
+	for (size_t i = 0; i < rets; ++i)
+			stackTargetPos[1 + args + i] = i;
+
+	while (stackTargetPos.back() != int(stackTargetPos.size() - 1))
+		if (stackTargetPos.back() < 0)
+		{
+			env.statements.push_back(Instruction{loc, solidity::Instruction::POP});
+			stackTargetPos.pop_back();
+		}
+		else
+		{
+			int sw = stackTargetPos.size() - stackTargetPos.back() - 1;
+			assertThrow(1 <= sw && sw <= 16, DesugaringError, "Invalid swap / too many function arguments.");
+
+			env.statements.push_back(Instruction{loc, solidity::swapInstruction(sw)});
+			swap(stackTargetPos[stackTargetPos.back()], stackTargetPos.back());
+		}
+	for (size_t i = 0; i < stackTargetPos.size(); ++i)
+		assertThrow(stackTargetPos[i] == int(i), DesugaringError, "Invalid stack reshuffling.");
+	env.statements.push_back(Instruction{loc, solidity::Instruction::JUMP});
+
+	return {Label{loc, _functionDefinition.name, {}}, env};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionCall const& _functionCall)
+{
+	//@TODO check that the number of arguments and return values match up
+	//@TOOD Make the identifiers unique
+	auto loc = _functionCall.location;
+	string retlabel = "$funcall_" + _functionCall.functionName.name + "_return";
+	Block ret{loc, {}};
+	ret.statements.push_back(Identifier{loc, retlabel});
+	for (auto const& arg: _functionCall.arguments | boost::adaptors::reversed)
+		ret.statements.push_back(boost::apply_visitor(*this, arg).asStatement());
+	ret.statements.push_back(FunctionalInstruction{loc, Instruction{loc, solidity::Instruction::JUMP}, {_functionCall.functionName}});
+	//@TODO add proper stack info here
+	ret.statements.push_back(Label{loc, retlabel, {}});
+
+	return {ret};
+}
+
+ASTNodeReplacement AsmDesugar::operator()(Block const& _block)
+{
+	Block block{_block.location, {}};
+	for (auto const& statement: _block.statements)
+	{
+		ASTNodeReplacement replacement = boost::apply_visitor(*this, statement);
+		block.statements.push_back(std::move(replacement.node));
+		if (replacement.secondValid)
+			block.statements.push_back(std::move(replacement.secondNode));
+	}
+	return {block};
+}
+
+

--- a/libsolidity/inlineasm/AsmDesugar.cpp
+++ b/libsolidity/inlineasm/AsmDesugar.cpp
@@ -46,11 +46,17 @@ Statement ASTNodeReplacement::asStatement()
 	return statements.front();
 }
 
-bool ASTNodeReplacement::isBlock() const
+void ASTNodeReplacement::moveAppend(std::vector<Statement>& _target)
 {
-	assertThrow(statements.size() == 1, DesugaringError, "Expected single statement but was multiple.");
-	return statements.front().type() == typeid(assembly::Block);
+	std::move(statements.begin(), statements.end(), std::back_inserter(_target));
 }
+
+bool ASTNodeReplacement::isMultipleOrBlock() const
+{
+	assertThrow(statements.size() > 0, DesugaringError, "Invalid empty replacement.");
+	return statements.size() > 1 || statements.front().type() == typeid(assembly::Block);
+}
+
 
 ASTNodeReplacement::operator assembly::Statement() &&
 {
@@ -85,16 +91,16 @@ ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionalInstruction const&
 	for (auto const& arg: _functionalInstruction.arguments)
 	{
 		arguments.push_back(std::move(boost::apply_visitor(*this, arg)));
-		if (arguments.back().isBlock())
+		if (arguments.back().isMultipleOrBlock())
 			haveToExplode = true;
 	}
 	if (haveToExplode)
 	{
-		assembly::Block block;
-		block.location = _functionalInstruction.location;
-		std::move(arguments.rbegin(), arguments.rend(), std::back_inserter(block.statements));
-		block.statements.push_back(_functionalInstruction.instruction);
-		return {std::move(block)};
+		vector<assembly::Statement> statements;
+		for (ASTNodeReplacement& rep: arguments | boost::adaptors::reversed)
+			rep.moveAppend(statements);
+		statements.push_back(_functionalInstruction.instruction);
+		return {std::move(statements)};
 	}
 	else
 	{
@@ -119,8 +125,13 @@ ASTNodeReplacement AsmDesugar::operator()(assembly::Assignment const& _assignmen
 ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionalAssignment const& _functionalAssignment)
 {
 	ASTNodeReplacement value = boost::apply_visitor(*this, *_functionalAssignment.value);
-	if (value.isBlock())
-		return {value.asStatement(), Assignment{_functionalAssignment.location, _functionalAssignment.variableName}};
+	if (value.isMultipleOrBlock())
+	{
+		vector<assembly::Statement> statements;
+		value.moveAppend(statements);
+		statements.push_back(Assignment{_functionalAssignment.location, _functionalAssignment.variableName});
+		return {std::move(statements)};
+	}
 	else
 	{
 		FunctionalAssignment result;
@@ -135,13 +146,17 @@ ASTNodeReplacement AsmDesugar::operator()(assembly::VariableDeclaration const& _
 {
 	//@TODO handle special case of `let x := f()` where return label and variable introduction label can be combined.
 	ASTNodeReplacement value = boost::apply_visitor(*this, *_variableDeclaration.value);
-	if (value.isBlock())
-		//@TODO make the name unique
-		return {value.asStatement(), Label{
+	if (value.isMultipleOrBlock())
+	{
+		vector<Statement> statements;
+		value.moveAppend(statements);
+		statements.push_back(Label{
 			_variableDeclaration.location,
-			"$introduce_" + _variableDeclaration.name,
+			generateIdentifier("$" + _variableDeclaration.name + "_"),
 			{_variableDeclaration.name}
-		}};
+		});
+		return {std::move(statements)};
+	}
 	else
 	{
 		VariableDeclaration result;
@@ -154,32 +169,42 @@ ASTNodeReplacement AsmDesugar::operator()(assembly::VariableDeclaration const& _
 
 ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionDefinition const& _functionDefinition)
 {
-	//@TODO make labels unique
 	auto loc = _functionDefinition.location;
 
+	string afterFunction = generateIdentifier("$after_" + _functionDefinition.name);
 	vector<Statement> result;
-	result.push_back(FunctionalInstruction{loc, Instruction{loc, solidity::Instruction::JUMP}, {Identifier{loc, "$" + _functionDefinition.name + "_after"}}});
-	result.push_back(Label{loc, _functionDefinition.name, {}});
+	result.push_back(FunctionalInstruction{
+		loc,
+		Instruction{loc, solidity::Instruction::JUMP},
+		{Identifier{loc, afterFunction}}
+	});
+	result.push_back(Label{loc, _functionDefinition.name, {""}});
 
 	Block body = boost::get<Block>((*this)(_functionDefinition.body).asStatement());
 	Block env{loc, {}};
-	env.statements.push_back(Label{loc, "$" + _functionDefinition.name + "_start", _functionDefinition.arguments});
-	for (auto const& r: _functionDefinition.returns)
+	vector<string> arguments(1, generateIdentifier("$ret"));
+	copy(_functionDefinition.arguments.rbegin(), _functionDefinition.arguments.rend(), back_inserter(arguments));
+	env.statements.push_back(Label{
+		loc,
+		generateIdentifier("$" + _functionDefinition.name + "_start"),
+		arguments
+	});
+	for (auto const& r: _functionDefinition.returns | boost::adaptors::reversed)
 		env.statements.push_back(VariableDeclaration{loc, r, make_shared<Statement>(Literal{loc, true, "0"})});
 	env.statements.push_back(std::move(body));
 
 	size_t const args = _functionDefinition.arguments.size();
 	size_t const rets = _functionDefinition.returns.size();
 	// Reorganise stack from
-	// retpc arg1 ... argn ret1 ... retm
+	// retpc argn ... arg1 retm ... ret1
 	// to
-	// ret1 ... retm retpc
+	// retm ... ret1 retpc
 	// Current layout with indices showing the target index (-1 means pop), i.e. should be
 	// m -1 ... -1 0 1 ... (m-1)
 	vector<int> stackTargetPos(1 + args + rets, -1);
 	stackTargetPos[0] = rets;
 	for (size_t i = 0; i < rets; ++i)
-			stackTargetPos[1 + args + i] = i;
+		stackTargetPos[1 + args + i] = i;
 
 	while (stackTargetPos.back() != int(stackTargetPos.size() - 1))
 		if (stackTargetPos.back() < 0)
@@ -200,26 +225,25 @@ ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionDefinition const& _f
 	env.statements.push_back(Instruction{loc, solidity::Instruction::JUMP});
 
 	result.push_back(std::move(env));
-	result.push_back(Label{loc, "$" + _functionDefinition.name + "_after", {}});
+	result.push_back(Label{loc, afterFunction, {}});
 
 	return {std::move(result)};
 }
 
 ASTNodeReplacement AsmDesugar::operator()(assembly::FunctionCall const& _functionCall)
 {
-	//@TOOD Make the identifiers unique
 	auto loc = _functionCall.location;
-	string retlabel = "$funcall_" + _functionCall.functionName.name + "_return";
-	Block ret{loc, {}};
-	ret.statements.push_back(Identifier{loc, retlabel});
+	string retlabel = generateIdentifier("$returnFrom_" + _functionCall.functionName.name);
+	vector<assembly::Statement> ret;
+	ret.push_back(Identifier{loc, retlabel});
 	for (auto const& arg: _functionCall.arguments | boost::adaptors::reversed)
-		ret.statements.push_back(boost::apply_visitor(*this, arg).asStatement());
-	ret.statements.push_back(FunctionalInstruction{loc, Instruction{loc, solidity::Instruction::JUMP}, {_functionCall.functionName}});
+		boost::apply_visitor(*this, arg).moveAppend(ret);
+	ret.push_back(FunctionalInstruction{loc, Instruction{loc, solidity::Instruction::JUMP}, {_functionCall.functionName}});
 	Scope::Identifier const* function = m_currentScope->lookup(_functionCall.functionName.name);
 	solAssert(function, "");
 	size_t arguments = boost::get<Scope::Function>(*function).arguments;
 	size_t returns = boost::get<Scope::Function>(*function).returns;
-	ret.statements.push_back(Label{loc, retlabel, {boost::lexical_cast<string>(int(arguments) - int(returns) - 1)}});
+	ret.push_back(Label{loc, retlabel, {boost::lexical_cast<string>(int(arguments) - int(returns) - 1)}});
 
 	return {std::move(ret)};
 }
@@ -230,16 +254,28 @@ ASTNodeReplacement AsmDesugar::operator()(Block const& _block)
 	m_currentScope = m_scopes.at(&_block).get();
 	Block block{_block.location, {}};
 	for (auto const& statement: _block.statements)
-	{
-		ASTNodeReplacement replacement = boost::apply_visitor(*this, statement);
-		std::move(
-			replacement.statements.begin(),
-			replacement.statements.end(),
-			std::back_inserter(block.statements)
-		);
-	}
+		boost::apply_visitor(*this, statement).moveAppend(block.statements);
 	m_currentScope = previousScope;
 	return {block};
 }
 
+string AsmDesugar::generateIdentifier(string const& _hint, Scope const* _scope)
+{
+	if (_scope == nullptr)
+		_scope = m_currentScope;
+	for (size_t counter = 0; counter < 100000; ++counter)
+	{
+		string identifier = _hint + (counter > 0 ? "_" + boost::lexical_cast<string>(counter) : "");
 
+		if (
+			!m_generatedIdentifiers.count(identifier) &&
+			!_scope->exists(identifier) &&
+			!_scope->existsIncludingSubscopes(identifier)
+		)
+		{
+			m_generatedIdentifiers.insert(identifier);
+			return identifier;
+		}
+	}
+	solAssert(false, "Unable to find suitable new identifier.");
+}

--- a/libsolidity/inlineasm/AsmDesugar.h
+++ b/libsolidity/inlineasm/AsmDesugar.h
@@ -1,0 +1,102 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <c@ethdev.com>
+ * @date 2017
+ * Desugars assembly, i.e. converts the parsed ast and removes functions, switches and loops.
+ */
+
+#pragma once
+
+#include <libdevcore/Assertions.h>
+
+//@TODO try to get rid of this
+#include <libsolidity/inlineasm/AsmData.h>
+
+#include <boost/variant.hpp>
+
+namespace dev
+{
+namespace solidity
+{
+namespace assembly
+{
+
+struct DesugaringError: virtual Exception {};
+
+struct Instruction;
+struct Literal;
+struct Identifier;
+struct FunctionalInstruction;
+struct Label;
+struct Assignment;
+struct FunctionalAssignment;
+struct VariableDeclaration;
+struct FunctionDefinition;
+struct FunctionCall;
+struct Block;
+using Statement = boost::variant<Instruction, Literal, Label, Assignment, Identifier, FunctionalAssignment, FunctionCall, FunctionalInstruction, VariableDeclaration, FunctionDefinition, Block>;
+
+struct ASTNodeReplacement
+{
+	ASTNodeReplacement() = default;
+	ASTNodeReplacement(ASTNodeReplacement const&) = default;
+	ASTNodeReplacement(ASTNodeReplacement&&) = default;
+	ASTNodeReplacement& operator=(ASTNodeReplacement const&) = default;
+	ASTNodeReplacement& operator=(ASTNodeReplacement&&) = default;
+	ASTNodeReplacement(assembly::Statement&& _statement):
+		node(std::move(_statement))
+	{}
+	ASTNodeReplacement(assembly::Statement const& _statement):
+		node(_statement)
+	{}
+	ASTNodeReplacement(assembly::Statement const& _st1, assembly::Statement const& _st2):
+		node(_st1), secondNode(_st2), secondValid(true)
+	{}
+	operator assembly::Statement() &&;
+	/// Converts to single node (throws if secondValid) and MOVES contents there.
+	assembly::Statement asStatement();
+
+	/// @returns true iff the node is a single block.
+	bool isBlock() const;
+
+	assembly::Statement node;
+	assembly::Statement secondNode;
+	bool secondValid = false;
+};
+
+class AsmDesugar: public boost::static_visitor<ASTNodeReplacement>
+{
+public:
+	Block run(Block const& _in);
+
+	ASTNodeReplacement operator()(assembly::Instruction const& _instruction);
+	ASTNodeReplacement operator()(assembly::Literal const& _literal);
+	ASTNodeReplacement operator()(assembly::Identifier const& _identifier);
+	ASTNodeReplacement operator()(assembly::FunctionalInstruction const& _functionalInstruction);
+	ASTNodeReplacement operator()(assembly::Label const& _label);
+	ASTNodeReplacement operator()(assembly::Assignment const& _assignment);
+	ASTNodeReplacement operator()(assembly::FunctionalAssignment const& _functionalAssignment);
+	ASTNodeReplacement operator()(assembly::VariableDeclaration const& _variableDeclaration);
+	ASTNodeReplacement operator()(assembly::FunctionDefinition const& _functionDefinition);
+	ASTNodeReplacement operator()(assembly::FunctionCall const& _functionCall);
+	ASTNodeReplacement operator()(assembly::Block const& _block);
+};
+
+}
+}
+}

--- a/libsolidity/inlineasm/AsmDesugar.h
+++ b/libsolidity/inlineasm/AsmDesugar.h
@@ -79,10 +79,13 @@ struct ASTNodeReplacement
 	operator assembly::Statement() &&;
 	/// Converts to single node (throws if secondValid) and MOVES contents there.
 	assembly::Statement asStatement();
+	/// Move-appends the statements to the given vector.
+	void moveAppend(std::vector<assembly::Statement>& _target);
 
-	/// @returns true iff the node is a single block.
-	bool isBlock() const;
+	/// @returns true iff the node contains multiple statements or a single block.
+	bool isMultipleOrBlock() const;
 
+private:
 	std::vector<assembly::Statement> statements;
 };
 
@@ -105,9 +108,19 @@ public:
 	ASTNodeReplacement operator()(assembly::FunctionDefinition const& _functionDefinition);
 	ASTNodeReplacement operator()(assembly::FunctionCall const& _functionCall);
 	ASTNodeReplacement operator()(assembly::Block const& _block);
+
 private:
+	/// Generates a new identifier that starts with @a _hint and may have an additional suffix
+	/// so that it does not clash with identifiers in @a _scope, including super- and subscopes.
+	/// If _scope is null, it defaults to the current scope.
+	std::string generateIdentifier(std::string const& _hint, Scope const* _scope = nullptr);
+
 	Scopes const& m_scopes;
 	Scope const* m_currentScope = nullptr;
+
+	/// Set of all newly generated identifiers as part of the translation. Used to avoid
+	/// name clashes.
+	std::set<std::string> m_generatedIdentifiers;
 };
 
 }

--- a/libsolidity/inlineasm/AsmScope.cpp
+++ b/libsolidity/inlineasm/AsmScope.cpp
@@ -1,0 +1,79 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Scopes for identifiers.
+ */
+
+#include <libsolidity/inlineasm/AsmScope.h>
+
+using namespace std;
+using namespace dev::solidity::assembly;
+
+
+bool Scope::registerLabel(string const& _name)
+{
+	if (exists(_name))
+		return false;
+	identifiers[_name] = Label();
+	return true;
+}
+
+bool Scope::registerVariable(string const& _name)
+{
+	if (exists(_name))
+		return false;
+	identifiers[_name] = Variable();
+	return true;
+}
+
+bool Scope::registerFunction(string const& _name, size_t _arguments, size_t _returns)
+{
+	if (exists(_name))
+		return false;
+	identifiers[_name] = Function(_arguments, _returns);
+	return true;
+}
+
+Scope::Identifier* Scope::lookup(string const& _name)
+{
+	bool crossedFunctionBoundary = false;
+	for (Scope* s = this; s; s = s->superScope)
+	{
+		auto id = s->identifiers.find(_name);
+		if (id != s->identifiers.end())
+		{
+			if (crossedFunctionBoundary && id->second.type() == typeid(Scope::Variable))
+				return nullptr;
+			else
+				return &id->second;
+		}
+
+		if (s->functionScope)
+			crossedFunctionBoundary = true;
+	}
+	return nullptr;
+}
+
+bool Scope::exists(string const& _name)
+{
+	if (identifiers.count(_name))
+		return true;
+	else if (superScope)
+		return superScope->exists(_name);
+	else
+		return false;
+}

--- a/libsolidity/inlineasm/AsmScope.cpp
+++ b/libsolidity/inlineasm/AsmScope.cpp
@@ -20,6 +20,8 @@
 
 #include <libsolidity/inlineasm/AsmScope.h>
 
+#include <queue>
+
 using namespace std;
 using namespace dev::solidity::assembly;
 
@@ -73,7 +75,7 @@ Scope::Identifier const* Scope::lookup(string const& _name) const
 	return const_cast<Scope*>(this)->lookup(_name);
 }
 
-bool Scope::exists(string const& _name)
+bool Scope::exists(string const& _name) const
 {
 	if (identifiers.count(_name))
 		return true;
@@ -81,4 +83,14 @@ bool Scope::exists(string const& _name)
 		return superScope->exists(_name);
 	else
 		return false;
+}
+
+bool Scope::existsIncludingSubscopes(string const& _name) const
+{
+	if (identifiers.count(_name))
+		return true;
+	for (Scope const* s: subScopes)
+		if (s->exists(_name))
+			return true;
+	return false;
 }

--- a/libsolidity/inlineasm/AsmScope.cpp
+++ b/libsolidity/inlineasm/AsmScope.cpp
@@ -68,6 +68,11 @@ Scope::Identifier* Scope::lookup(string const& _name)
 	return nullptr;
 }
 
+Scope::Identifier const* Scope::lookup(string const& _name) const
+{
+	return const_cast<Scope*>(this)->lookup(_name);
+}
+
 bool Scope::exists(string const& _name)
 {
 	if (identifiers.count(_name))

--- a/libsolidity/inlineasm/AsmScope.h
+++ b/libsolidity/inlineasm/AsmScope.h
@@ -1,0 +1,127 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Scopes for identifiers.
+ */
+
+#pragma once
+
+#include <libsolidity/interface/Exceptions.h>
+
+#include <boost/variant.hpp>
+
+#include <functional>
+#include <memory>
+
+namespace dev
+{
+namespace solidity
+{
+namespace assembly
+{
+
+template <class...>
+struct GenericVisitor{};
+
+template <class Visitable, class... Others>
+struct GenericVisitor<Visitable, Others...>: public GenericVisitor<Others...>
+{
+	using GenericVisitor<Others...>::operator ();
+	explicit GenericVisitor(
+		std::function<void(Visitable&)> _visitor,
+		std::function<void(Others&)>... _otherVisitors
+	):
+		GenericVisitor<Others...>(_otherVisitors...),
+		m_visitor(_visitor)
+	{}
+
+	void operator()(Visitable& _v) const { m_visitor(_v); }
+
+	std::function<void(Visitable&)> m_visitor;
+};
+template <>
+struct GenericVisitor<>: public boost::static_visitor<> {
+	void operator()() const {}
+};
+
+
+struct Scope
+{
+	struct Variable
+	{
+		/// Used during code generation to store the stack height. @todo move there.
+		int stackHeight = 0;
+		/// Used during analysis to check whether we already passed the declaration inside the block.
+		/// @todo move there.
+		bool active = false;
+	};
+
+	struct Label
+	{
+		size_t id = unassignedLabelId;
+		static const size_t errorLabelId = -1;
+		static const size_t unassignedLabelId = 0;
+	};
+
+	struct Function
+	{
+		Function(size_t _arguments, size_t _returns): arguments(_arguments), returns(_returns) {}
+		size_t arguments = 0;
+		size_t returns = 0;
+	};
+
+	using Identifier = boost::variant<Variable, Label, Function>;
+	using Visitor = GenericVisitor<Variable const, Label const, Function const>;
+	using NonconstVisitor = GenericVisitor<Variable, Label, Function>;
+
+	bool registerVariable(std::string const& _name);
+	bool registerLabel(std::string const& _name);
+	bool registerFunction(std::string const& _name, size_t _arguments, size_t _returns);
+
+	/// Looks up the identifier in this or super scopes and returns a valid pointer if found
+	/// or a nullptr if not found. Variable lookups up across function boundaries will fail, as
+	/// will any lookups across assembly boundaries.
+	/// The pointer will be invalidated if the scope is modified.
+	/// @param _crossedFunction if true, we already crossed a function boundary during recursive lookup
+	Identifier* lookup(std::string const& _name);
+	/// Looks up the identifier in this and super scopes (will not find variables across function
+	/// boundaries and generally stops at assembly boundaries) and calls the visitor, returns
+	/// false if not found.
+	template <class V>
+	bool lookup(std::string const& _name, V const& _visitor)
+	{
+		if (Identifier* id = lookup(_name))
+		{
+			boost::apply_visitor(_visitor, *id);
+			return true;
+		}
+		else
+			return false;
+	}
+	/// @returns true if the name exists in this scope or in super scopes (also searches
+	/// across function and assembly boundaries).
+	bool exists(std::string const& _name);
+	Scope* superScope = nullptr;
+	/// If true, variables from the super scope are not visible here (other identifiers are),
+	/// but they are still taken into account to prevent shadowing.
+	bool functionScope = false;
+	std::map<std::string, Identifier> identifiers;
+};
+
+}
+}
+}

--- a/libsolidity/inlineasm/AsmScope.h
+++ b/libsolidity/inlineasm/AsmScope.h
@@ -98,6 +98,7 @@ struct Scope
 	/// The pointer will be invalidated if the scope is modified.
 	/// @param _crossedFunction if true, we already crossed a function boundary during recursive lookup
 	Identifier* lookup(std::string const& _name);
+	Identifier const* lookup(std::string const& _name) const;
 	/// Looks up the identifier in this and super scopes (will not find variables across function
 	/// boundaries and generally stops at assembly boundaries) and calls the visitor, returns
 	/// false if not found.

--- a/libsolidity/inlineasm/AsmScope.h
+++ b/libsolidity/inlineasm/AsmScope.h
@@ -115,8 +115,13 @@ struct Scope
 	}
 	/// @returns true if the name exists in this scope or in super scopes (also searches
 	/// across function and assembly boundaries).
-	bool exists(std::string const& _name);
+	bool exists(std::string const& _name) const;
+	/// @returns true if the name exists in this scope or in sub-scopes
+	/// (also searches across function and assembly boundaries).
+	bool existsIncludingSubscopes(std::string const& _name) const;
+
 	Scope* superScope = nullptr;
+	std::vector<Scope*> subScopes;
 	/// If true, variables from the super scope are not visible here (other identifiers are),
 	/// but they are still taken into account to prevent shadowing.
 	bool functionScope = false;

--- a/libsolidity/inlineasm/AsmScopeFiller.cpp
+++ b/libsolidity/inlineasm/AsmScopeFiller.cpp
@@ -1,0 +1,158 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Module responsible for registering identifiers inside their scopes.
+ */
+
+#include <libsolidity/inlineasm/AsmScopeFiller.h>
+
+#include <libsolidity/inlineasm/AsmData.h>
+#include <libsolidity/inlineasm/AsmScope.h>
+
+#include <libsolidity/interface/Exceptions.h>
+#include <libsolidity/interface/Utils.h>
+
+#include <boost/range/adaptor/reversed.hpp>
+
+#include <memory>
+#include <functional>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+using namespace dev::solidity::assembly;
+
+ScopeFiller::ScopeFiller(ScopeFiller::Scopes& _scopes, ErrorList& _errors):
+	m_scopes(_scopes), m_errors(_errors)
+{
+	// Make the Solidity ErrorTag available to inline assembly
+	Scope::Label errorLabel;
+	errorLabel.id = Scope::Label::errorLabelId;
+	scope(nullptr).identifiers["invalidJumpLabel"] = errorLabel;
+	m_currentScope = &scope(nullptr);
+}
+
+bool ScopeFiller::operator()(FunctionalInstruction const& _instr)
+{
+	bool success = true;
+	for (auto const& arg: _instr.arguments | boost::adaptors::reversed)
+		if (!boost::apply_visitor(*this, arg))
+			success = false;
+	if (!(*this)(_instr.instruction))
+		success = false;
+	return success;
+}
+
+bool ScopeFiller::operator()(Label const& _item)
+{
+	if (!m_currentScope->registerLabel(_item.name))
+	{
+		//@TODO secondary location
+		m_errors.push_back(make_shared<Error>(
+			Error::Type::DeclarationError,
+			"Label name " + _item.name + " already taken in this scope.",
+			_item.location
+		));
+		return false;
+	}
+	return true;
+}
+
+bool ScopeFiller::operator()(FunctionalAssignment const& _assignment)
+{
+	return boost::apply_visitor(*this, *_assignment.value);
+}
+
+bool ScopeFiller::operator()(assembly::VariableDeclaration const& _varDecl)
+{
+	bool success = boost::apply_visitor(*this, *_varDecl.value);
+	if (!registerVariable(_varDecl.name, _varDecl.location, *m_currentScope))
+		success = false;
+	return success;
+}
+
+bool ScopeFiller::operator()(assembly::FunctionDefinition const& _funDef)
+{
+	bool success = true;
+	if (!m_currentScope->registerFunction(_funDef.name, _funDef.arguments.size(), _funDef.returns.size()))
+	{
+		//@TODO secondary location
+		m_errors.push_back(make_shared<Error>(
+			Error::Type::DeclarationError,
+			"Function name " + _funDef.name + " already taken in this scope.",
+			_funDef.location
+		));
+		success = false;
+	}
+	Scope& body = scope(&_funDef.body);
+	body.superScope = m_currentScope;
+	body.functionScope = true;
+	for (auto const& var: _funDef.arguments + _funDef.returns)
+		if (!registerVariable(var, _funDef.location, body))
+			success = false;
+
+	if (!(*this)(_funDef.body))
+		success = false;
+
+	return success;
+}
+
+bool ScopeFiller::operator()(assembly::FunctionCall const& _funCall)
+{
+	bool success = true;
+	for (auto const& arg: _funCall.arguments | boost::adaptors::reversed)
+		if (!boost::apply_visitor(*this, arg))
+			success = false;
+	return success;
+}
+
+bool ScopeFiller::operator()(Block const& _block)
+{
+	bool success = true;
+	scope(&_block).superScope = m_currentScope;
+	m_currentScope = &scope(&_block);
+
+	for (auto const& s: _block.statements)
+		if (!boost::apply_visitor(*this, s))
+			success = false;
+
+	m_currentScope = m_currentScope->superScope;
+	return success;
+}
+
+bool ScopeFiller::registerVariable(string const& _name, SourceLocation const& _location, Scope& _scope)
+{
+	if (!_scope.registerVariable(_name))
+	{
+		//@TODO secondary location
+		m_errors.push_back(make_shared<Error>(
+			Error::Type::DeclarationError,
+			"Variable name " + _name + " already taken in this scope.",
+			_location
+		));
+		return false;
+	}
+	return true;
+}
+
+Scope& ScopeFiller::scope(Block const* _block)
+{
+	auto& scope = m_scopes[_block];
+	if (!scope)
+		scope = make_shared<Scope>();
+	return *scope;
+}

--- a/libsolidity/inlineasm/AsmScopeFiller.h
+++ b/libsolidity/inlineasm/AsmScopeFiller.h
@@ -15,7 +15,7 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 /**
- * Analysis part of inline assembly.
+ * Module responsible for registering identifiers inside their scopes.
  */
 
 #pragma once
@@ -49,26 +49,21 @@ struct FunctionCall;
 struct Scope;
 
 /**
- * Performs the full analysis stage, calls the ScopeFiller internally, then resolves
- * references and performs other checks.
- * @todo Does not yet check for stack height issues.
+ * Fills scopes with identifiers and checks for name clashes.
+ * Does not resolve references.
  */
-class AsmAnalyzer: public boost::static_visitor<bool>
+class ScopeFiller: public boost::static_visitor<bool>
 {
 public:
 	using Scopes = std::map<assembly::Block const*, std::shared_ptr<Scope>>;
-	/// @param _allowFailedLookups if true, allow failed lookups for variables (they
-	/// will be provided from the environment later on)
-	AsmAnalyzer(Scopes& _scopes, ErrorList& _errors, bool _allowFailedLookups);
-
-	bool analyze(assembly::Block const& _block);
+	ScopeFiller(Scopes& _scopes, ErrorList& _errors);
 
 	bool operator()(assembly::Instruction const&) { return true; }
-	bool operator()(assembly::Literal const& _literal);
-	bool operator()(assembly::Identifier const&);
+	bool operator()(assembly::Literal const&) { return true; }
+	bool operator()(assembly::Identifier const&) { return true; }
 	bool operator()(assembly::FunctionalInstruction const& _functionalInstruction);
 	bool operator()(assembly::Label const& _label);
-	bool operator()(assembly::Assignment const&);
+	bool operator()(assembly::Assignment const&) { return true; }
 	bool operator()(assembly::FunctionalAssignment const& _functionalAssignment);
 	bool operator()(assembly::VariableDeclaration const& _variableDeclaration);
 	bool operator()(assembly::FunctionDefinition const& _functionDefinition);
@@ -76,10 +71,14 @@ public:
 	bool operator()(assembly::Block const& _block);
 
 private:
-	bool checkAssignment(assembly::Identifier const& _assignment);
+	bool registerVariable(
+		std::string const& _name,
+		SourceLocation const& _location,
+		Scope& _scope
+	);
+
 	Scope& scope(assembly::Block const* _block);
 
-	bool m_allowFailedLookups = false;
 	Scope* m_currentScope = nullptr;
 	Scopes& m_scopes;
 	ErrorList& m_errors;

--- a/libsolidity/inlineasm/AsmScopeFiller.h
+++ b/libsolidity/inlineasm/AsmScopeFiller.h
@@ -78,6 +78,7 @@ private:
 	);
 
 	Scope& scope(assembly::Block const* _block);
+	Scope& createScope(assembly::Block const* _forBlock, Scope* _superScope);
 
 	Scope* m_currentScope = nullptr;
 	Scopes& m_scopes;

--- a/libsolidity/inlineasm/AsmStack.cpp
+++ b/libsolidity/inlineasm/AsmStack.cpp
@@ -49,7 +49,7 @@ bool InlineAssemblyStack::parse(shared_ptr<Scanner> const& _scanner)
 
 	*m_parserResult = std::move(*result);
 	AsmAnalyzer::Scopes scopes;
-	return (AsmAnalyzer(scopes, m_errors))(*m_parserResult);
+	return (AsmAnalyzer(scopes, m_errors, false)).analyze(*m_parserResult);
 }
 
 string InlineAssemblyStack::toString()

--- a/libsolidity/inlineasm/AsmStack.cpp
+++ b/libsolidity/inlineasm/AsmStack.cpp
@@ -25,6 +25,7 @@
 #include <libsolidity/inlineasm/AsmParser.h>
 #include <libsolidity/inlineasm/AsmCodeGen.h>
 #include <libsolidity/inlineasm/AsmPrinter.h>
+#include <libsolidity/inlineasm/AsmDesugar.h>
 #include <libsolidity/inlineasm/AsmAnalysis.h>
 
 #include <libsolidity/parsing/Scanner.h>
@@ -59,6 +60,14 @@ string InlineAssemblyStack::toString()
 
 eth::Assembly InlineAssemblyStack::assemble()
 {
+	if (!m_desugared)
+	{
+		cout << "Before desugar: " << endl << print() << endl;
+		//@TODO move?
+		*m_parserResult = AsmDesugar().run(*m_parserResult);
+		m_desugared = true;
+		cout << "After desugar: " << endl << print() << endl;
+	}
 	CodeGenerator codeGen(*m_parserResult, m_errors);
 	return codeGen.assemble();
 }
@@ -74,6 +83,9 @@ bool InlineAssemblyStack::parseAndAssemble(
 	auto parserResult = Parser(errors).parse(scanner);
 	if (!errors.empty())
 		return false;
+	print();
+	//@TODO move?
+	*parserResult = AsmDesugar().run(*parserResult);
 
 	CodeGenerator(*parserResult, errors).assemble(_assembly, _identifierAccess);
 

--- a/libsolidity/inlineasm/AsmStack.h
+++ b/libsolidity/inlineasm/AsmStack.h
@@ -64,6 +64,7 @@ public:
 private:
 	std::shared_ptr<Block> m_parserResult;
 	ErrorList m_errors;
+	bool m_desugared = false;
 };
 
 }

--- a/libsolidity/inlineasm/AsmStack.h
+++ b/libsolidity/inlineasm/AsmStack.h
@@ -39,6 +39,7 @@ class Scanner;
 namespace assembly
 {
 struct Block;
+struct Scope;
 
 class InlineAssemblyStack
 {
@@ -52,6 +53,8 @@ public:
 
 	eth::Assembly assemble();
 
+	void desugar();
+
 	/// Parse and assemble a string in one run - for use in Solidity code generation itself.
 	bool parseAndAssemble(
 		std::string const& _input,
@@ -63,6 +66,7 @@ public:
 
 private:
 	std::shared_ptr<Block> m_parserResult;
+	std::map<assembly::Block const*, std::shared_ptr<Scope>> m_scopes;
 	ErrorList m_errors;
 	bool m_desugared = false;
 };

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -63,7 +63,7 @@ boost::optional<Error> parseAndReturnFirstError(string const& _source, bool _ass
 	}
 	if (!success)
 	{
-		BOOST_CHECK_EQUAL(stack.errors().size(), 1);
+		BOOST_REQUIRE_EQUAL(stack.errors().size(), 1);
 		return *stack.errors().front();
 	}
 	else
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(vardecl)
 
 BOOST_AUTO_TEST_CASE(assignment)
 {
-	BOOST_CHECK(successParse("{ 7 8 add =: x }"));
+	BOOST_CHECK(successParse("{ let x := 2 7 8 add =: x }"));
 }
 
 BOOST_AUTO_TEST_CASE(label)
@@ -177,22 +177,28 @@ BOOST_AUTO_TEST_CASE(label_complex)
 
 BOOST_AUTO_TEST_CASE(functional)
 {
-	BOOST_CHECK(successParse("{ add(7, mul(6, x)) add mul(7, 8) }"));
+	BOOST_CHECK(successParse("{ let x := 2 add(7, mul(6, x)) mul(7, 8) add }"));
 }
 
 BOOST_AUTO_TEST_CASE(functional_assignment)
 {
-	BOOST_CHECK(successParse("{ x := 7 }"));
+	BOOST_CHECK(successParse("{ let x := 2 x := 7 }"));
 }
 
 BOOST_AUTO_TEST_CASE(functional_assignment_complex)
 {
-	BOOST_CHECK(successParse("{ x := add(7, mul(6, x)) add mul(7, 8) }"));
+	BOOST_CHECK(successParse("{ let x := 2 x := add(7, mul(6, x)) mul(7, 8) add }"));
 }
 
 BOOST_AUTO_TEST_CASE(vardecl_complex)
 {
-	BOOST_CHECK(successParse("{ let x := add(7, mul(6, x)) add mul(7, 8) }"));
+	BOOST_CHECK(successParse("{ let y := 2 let x := add(7, mul(6, y)) add mul(7, 8) }"));
+}
+
+BOOST_AUTO_TEST_CASE(variable_use_before_decl)
+{
+	CHECK_PARSE_ERROR("{ x := 2 let x := 3 }", DeclarationError, "Variable x used before it was declared.");
+	CHECK_PARSE_ERROR("{ let x := mul(2, x) }", DeclarationError, "Variable x used before it was declared.");
 }
 
 BOOST_AUTO_TEST_CASE(blocks)
@@ -212,7 +218,28 @@ BOOST_AUTO_TEST_CASE(function_definitions_multiple_args)
 
 BOOST_AUTO_TEST_CASE(function_calls)
 {
-	BOOST_CHECK(successParse("{ g(1, 2, f(mul(2, 3))) x() }"));
+	BOOST_CHECK(successParse("{ function f(a) {} function g(a, b, c) {} function x() { g(1, 2, f(mul(2, 3))) x() } }"));
+}
+
+BOOST_AUTO_TEST_CASE(opcode_for_functions)
+{
+	CHECK_PARSE_ERROR("{ function gas() { } }", ParserError, "Cannot use instruction names for identifier names.");
+}
+
+BOOST_AUTO_TEST_CASE(opcode_for_function_args)
+{
+	CHECK_PARSE_ERROR("{ function f(gas) { } }", ParserError, "Cannot use instruction names for identifier names.");
+	CHECK_PARSE_ERROR("{ function f() -> (gas) { } }", ParserError, "Cannot use instruction names for identifier names.");
+}
+
+BOOST_AUTO_TEST_CASE(name_clashes)
+{
+	CHECK_PARSE_ERROR("{ let g := 2 function g() { } }", DeclarationError, "Function name g already taken in this scope");
+}
+
+BOOST_AUTO_TEST_CASE(variable_access_cross_functions)
+{
+	CHECK_PARSE_ERROR("{ let x := 2 function g() { x } }", DeclarationError, "Identifier not found.");
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -272,7 +299,9 @@ BOOST_AUTO_TEST_CASE(function_definitions_multiple_args)
 
 BOOST_AUTO_TEST_CASE(function_calls)
 {
-	parsePrintCompare("{\n    g(1, mul(2, x), f(mul(2, 3)))\n    x()\n}");
+	parsePrintCompare(
+		"{\n    function y()\n    {\n    }\n    function f(a)\n    {\n    }\n    function g(a, b, c)\n    {\n    }\n    g(1, mul(2, address), f(mul(2, caller)))\n    y()\n}"
+	);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -296,8 +325,8 @@ BOOST_AUTO_TEST_CASE(assignment_after_tag)
 
 BOOST_AUTO_TEST_CASE(magic_variables)
 {
-	CHECK_ASSEMBLE_ERROR("{ this pop }", DeclarationError, "Identifier not found or not unique");
-	CHECK_ASSEMBLE_ERROR("{ ecrecover pop }", DeclarationError, "Identifier not found or not unique");
+	CHECK_ASSEMBLE_ERROR("{ this pop }", DeclarationError, "Identifier not found");
+	CHECK_ASSEMBLE_ERROR("{ ecrecover pop }", DeclarationError, "Identifier not found");
 	BOOST_CHECK(successAssemble("{ let ecrecover := 1 ecrecover }"));
 }
 


### PR DESCRIPTION
Issues:

 - [x] function definitions should be jumped across (also have to update documentation there)
 - [ ] Tests for: existence of new identifiers has to be checked also in subscopes
 - [ ] we have to specify that the stack height is reset to just the variables after a function definition.
 - [ ] check docs that function arguments are "reversed"
 - [ ] (probably general bug) if undeclared variables are used, they are simply skipped, example (this was an example at the time where argument and return variables were not yet registered):

```js
{
  function f(a, b) -> (c) {
    c := add(a, b)
  }
  let g := f(1, 2)
}
```
 - [ ] the assembler still generates some "unbalanced block" warnings for e.g.
```js
{
    function ack(x, y) -> (z)
    {
        jumpi(first, eq(x, 0))
        jumpi(second, eq(y, 0))
        z := ack(sub(x, 1), ack(x, sub(y, 1)))
        jump(ret)
        first:
        z := add(y, 1)
        jump(ret)
        second:
        z := ack(sub(x, 1), 1)
        ret:
    }
}
```