### PR TITLE
Fix early exits for fatal errors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Features:
 Bugfixes:
  * Commandline interface: Always escape filenames (replace ``/``, ``:`` and ``.`` with ``_``).
  * Commandline interface: Do not try creating paths ``.`` and ``..``.
+ * Type system: Fix a crash caused by continuing on fatal errors in the code.
  * Type system: Disallow arrays with negative length.
 
 ### 0.4.9 (2017-01-31)

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -89,6 +89,9 @@ public:
 	);
 
 private:
+	/// Internal version of @a resolveNamesAndTypes (called from there) throws exceptions on fatal errors.
+	bool resolveNamesAndTypesInternal(ASTNode& _node, bool _resolveInsideCode = true);
+
 	/// Imports all members declared directly in the given contract (i.e. does not import inherited members)
 	/// into the current scope if they are not present already.
 	void importInheritedScope(ContractDefinition const& _base);

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -35,14 +35,7 @@ using namespace dev::solidity;
 
 bool ReferencesResolver::resolve(ASTNode const& _root)
 {
-	try
-	{
-		_root.accept(*this);
-	}
-	catch (FatalError const&)
-	{
-		solAssert(m_errorOccurred, "");
-	}
+	_root.accept(*this);
 	return !m_errorOccurred;
 }
 

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -52,7 +52,7 @@ public:
 		m_resolveInsideCode(_resolveInsideCode)
 	{}
 
-	/// @returns true if no errors during resolving
+	/// @returns true if no errors during resolving and throws exceptions on fatal errors.
 	bool resolve(ASTNode const& _root);
 
 private:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1652,6 +1652,7 @@ MemberList::MemberMap StructType::nativeMembers(ContractDefinition const*) const
 	for (ASTPointer<VariableDeclaration> const& variable: m_struct.members())
 	{
 		TypePointer type = variable->annotation().type;
+		solAssert(type, "");
 		// Skip all mapping members if we are not in storage.
 		if (location() != DataLocation::Storage && !type->canLiveOutsideStorage())
 			continue;
@@ -1964,6 +1965,8 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 	if (auto structType = dynamic_cast<StructType const*>(returnType.get()))
 	{
 		for (auto const& member: structType->members(nullptr))
+		{
+			solAssert(member.type, "");
 			if (member.type->category() != Category::Mapping)
 			{
 				if (auto arrayType = dynamic_cast<ArrayType const*>(member.type.get()))
@@ -1972,6 +1975,7 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 				retParams.push_back(member.type);
 				retParamNames.push_back(member.name);
 			}
+		}
 	}
 	else
 	{

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5079,6 +5079,22 @@ BOOST_AUTO_TEST_CASE(invalid_address_length)
 	CHECK_WARNING(text, "checksum");
 }
 
+BOOST_AUTO_TEST_CASE(early_exit_on_fatal_errors)
+{
+	// This tests a crash that occured because we did not stop for fatal errors.
+	char const* text = R"(
+		contract C {
+			struct S {
+				ftring a;
+			}
+			S public s;
+			function s() s {
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier not found or not unique");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
This fixes a crash that occured  because the references resolver continued after fatal errors. It was introduced with a recent refactoring.