### PR TITLE
Add lost payable attribute to sample withdrawal pattern contract in docs

### DIFF
--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -81,7 +81,7 @@ This is as opposed to the more intuitive sending pattern:
             mostSent = msg.value;
         }
 
-        function becomeRichest() returns (bool) {
+        function becomeRichest() payable returns (bool) {
             if (msg.value > mostSent) {
                 // Check if call succeeds to prevent an attacker
                 // from trapping the previous person's funds in


### PR DESCRIPTION
I'm not sure that it is really typo. As I understand, every fallback function that receive ether must has `payable` attribute.