### PR TITLE
Do now allow declaring variables with inferred empty tuple type.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Bugfixes:
  * Type system: Fix a crash caused by continuing on fatal errors in the code.
  * Type system: Disallow arrays with negative length.
  * Type system: Fix a crash related to invalid binary operators.
+ * Type system: Disallow ``var`` declaration with empty tuple type.
  * Type system: Correctly convert function argument types to pointers for member functions.
  * Inline assembly: Charge one stack slot for non-value types during analysis.
  * Assembly output: Print source location before the operation it refers to instead of after.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -824,6 +824,11 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 				else
 					solAssert(false, "");
 			}
+			else if (*var.annotation().type == TupleType())
+				typeError(
+					var.location(),
+					"Cannot declare variable with void (empty tuple) type."
+				);
 			var.accept(*this);
 		}
 		else

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2950,6 +2950,19 @@ BOOST_AUTO_TEST_CASE(multi_variable_declaration_wildcards_fail_6)
 	CHECK_ERROR(text, TypeError, "");
 }
 
+BOOST_AUTO_TEST_CASE(tuple_assignment_from_void_function)
+{
+	char const* text = R"(
+		contract C {
+			function f() { }
+			function g() {
+				var (x,) = (f(), f());
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Cannot declare variable with void (empty tuple) type.");
+}
+
 BOOST_AUTO_TEST_CASE(member_access_parser_ambiguity)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes #1250 