### PR TITLE
Convert reference types to pointers in member function conversion.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Bugfixes:
  * Type system: Fix a crash caused by continuing on fatal errors in the code.
  * Type system: Disallow arrays with negative length.
  * Type system: Fix a crash related to invalid binary operators.
+ * Type system: Correctly convert function argument types to pointers for member functions.
  * Inline assembly: Charge one stack slot for non-value types during analysis.
  * Assembly output: Print source location before the operation it refers to instead of after.
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2493,7 +2493,7 @@ FunctionTypePointer FunctionType::asMemberFunction(bool _inLibrary, bool _bound)
 	{
 		auto refType = dynamic_cast<ReferenceType const*>(t.get());
 		if (refType && refType->location() == DataLocation::CallData)
-			parameterTypes.push_back(refType->copyForLocation(DataLocation::Memory, false));
+			parameterTypes.push_back(refType->copyForLocation(DataLocation::Memory, true));
 		else
 			parameterTypes.push_back(t);
 	}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4736,6 +4736,23 @@ BOOST_AUTO_TEST_CASE(delete_external_function_type_invalid)
 	CHECK_ERROR(text, TypeError, "");
 }
 
+BOOST_AUTO_TEST_CASE(external_function_to_function_type_calldata_parameter)
+{
+	// This is a test that checks that the type of the `bytes` parameter is
+	// correctly changed from its own type `bytes calldata` to `bytes memory`
+	// when converting to a function type.
+	char const* text = R"(
+		contract C {
+			function f(function(bytes memory x) external g) { }
+			function callback(bytes x) external {}
+			function g() {
+				f(this.callback);
+			}
+		}
+	)";
+	CHECK_SUCCESS(text);
+}
+
 BOOST_AUTO_TEST_CASE(external_function_type_to_address)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes #1415 

The function `asMemberFunction` takes a function type and converts it to the type that is used for `myContract.functionName` or `this.f`, i.e. the view on an external function when it is called from outside. Because of that, calldata types are converted to memory types since this is how the arguments have to be encoded for the call (you cannot encode anything into calldata, only decode from calldata). During this conversions, everything was taken as a reference type as opposed to a pointer type. Non-pointer reference types are only used for state variables because then, they can be used as lvalues. Since function arguments are never state variables, the correct way to do the conversion here is to convert to pointers.