### PR TITLE
Add upper bound for computing constants.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ Bugfixes:
  * Type system: Correctly convert function argument types to pointers for member functions.
  * Inline assembly: Charge one stack slot for non-value types during analysis.
  * Assembly output: Print source location before the operation it refers to instead of after.
+ * Optimizer: Stop trying to optimize tricky constants after a while.
 
 ### 0.4.9 (2017-01-31)
 

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -194,7 +194,7 @@ AssemblyItems ComputeMethod::findRepresentation(u256 const& _value)
 		// Is not always better, try literal and decomposition method.
 		AssemblyItems routine{u256(_value)};
 		bigint bestGas = gasNeeded(routine);
-		for (unsigned bits = 255; bits > 8; --bits)
+		for (unsigned bits = 255; bits > 8 && m_maxSteps > 0; --bits)
 		{
 			unsigned gapDetector = unsigned(_value >> (bits - 8)) & 0x1ff;
 			if (gapDetector != 0xff && gapDetector != 0x100)
@@ -219,6 +219,8 @@ AssemblyItems ComputeMethod::findRepresentation(u256 const& _value)
 			else if (lowerPart < 0)
 				newRoutine.push_back(Instruction::SUB);
 
+			if (m_maxSteps > 0)
+				m_maxSteps--;
 			bigint newGas = gasNeeded(newRoutine);
 			if (newGas < bestGas)
 			{

--- a/libevmasm/ConstantOptimiser.h
+++ b/libevmasm/ConstantOptimiser.h
@@ -143,6 +143,8 @@ protected:
 	AssemblyItems findRepresentation(u256 const& _value);
 	bigint gasNeeded(AssemblyItems const& _routine);
 
+	/// Counter for the complexity of optimization, will stop when it reaches zero.
+	size_t m_maxSteps = 10000;
 	AssemblyItems m_routine;
 };
 


### PR DESCRIPTION
During constants optimization, multiple representations of a constant as an expression are tried. This PR limits the search space.

Fixes https://github.com/ethereum/solidity/issues/1466