### PR TITLE
Disallow uninitialized mapping variables.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -730,13 +730,16 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 		if (auto ref = dynamic_cast<ReferenceType const*>(type(varDecl).get()))
 		{
 			if (ref->dataStoredIn(DataLocation::Storage))
-			{
 				warning(
 					varDecl.location(),
 					"Uninitialized storage pointer. Did you mean '<type> memory " + varDecl.name() + "'?"
 				);
-			}
 		}
+		else if (dynamic_cast<MappingType const*>(type(varDecl).get()))
+			typeError(
+				varDecl.location(),
+				"Uninitialized mapping. Mappings cannot be created dynamically, you have to assign them from a state variable."
+			);
 		varDecl.accept(*this);
 		return false;
 	}

--- a/libsolidity/interface/Exceptions.cpp
+++ b/libsolidity/interface/Exceptions.cpp
@@ -27,7 +27,8 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-Error::Error(Type _type): m_type(_type)
+Error::Error(Type _type, SourceLocation const& _location, string const& _description):
+	m_type(_type)
 {
 	switch(m_type)
 	{
@@ -56,6 +57,11 @@ Error::Error(Type _type): m_type(_type)
 		solAssert(false, "");
 		break;
 	}
+
+	if (!_location.isEmpty())
+		*this << errinfo_sourceLocation(_location);
+	if (!_description.empty())
+		*this << errinfo_comment(_description);
 }
 
 string Exception::lineInfo() const

--- a/libsolidity/interface/Exceptions.h
+++ b/libsolidity/interface/Exceptions.h
@@ -53,7 +53,11 @@ public:
 		Warning
 	};
 
-	explicit Error(Type _type);
+	explicit Error(
+		Type _type,
+		SourceLocation const& _location = SourceLocation(),
+		std::string const& _description = std::string()
+	);
 
 	Type type() const { return m_type; }
 	std::string const& typeName() const { return m_typeName; }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2501,6 +2501,30 @@ BOOST_AUTO_TEST_CASE(storage_assign_to_different_local_variable)
 	CHECK_ERROR(sourceCode, TypeError, "");
 }
 
+BOOST_AUTO_TEST_CASE(uninitialized_mapping_variable)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() {
+				mapping(uint => uint) x;
+			}
+		}
+	)";
+	CHECK_ERROR(sourceCode, TypeError, "Uninitialized mapping. Mappings cannot be created dynamically, you have to assign them from a state variable");
+}
+
+BOOST_AUTO_TEST_CASE(uninitialized_mapping_array_variable)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f() {
+				mapping(uint => uint)[] x;
+			}
+		}
+	)";
+	CHECK_WARNING(sourceCode, "Uninitialized storage pointer");
+}
+
 BOOST_AUTO_TEST_CASE(no_delete_on_storage_pointers)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1731