### PR TITLE
Use mobile type for singleton array.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1014,7 +1014,7 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 						fatalTypeError(components[i]->location(), "Invalid mobile type.");
 
 					if (i == 0)
-						inlineArrayType = types[i];
+						inlineArrayType = types[i]->mobileType();
 					else if (inlineArrayType)
 						inlineArrayType = Type::commonType(inlineArrayType, types[i]);
 				}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7260,6 +7260,20 @@ BOOST_AUTO_TEST_CASE(inline_array_return)
 	BOOST_CHECK(callContractFunction("f()") == encodeArgs(1, 2, 3, 4, 5));
 }
 
+BOOST_AUTO_TEST_CASE(inline_array_singleton)
+{
+	// This caused a failure since the type was not converted to its mobile type.
+	char const* sourceCode = R"(
+		contract C {
+			function f() returns (uint) {
+				return [4][0];
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(u256(4)));
+}
+
 BOOST_AUTO_TEST_CASE(inline_long_string_return)
 {
 		char const* sourceCode = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1709 and https://github.com/ethereum/solidity/issues/1722