### PR TITLE
Disallow octal numbers in parser.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Features:
 Bugfixes:
  * Commandline interface: Always escape filenames (replace ``/``, ``:`` and ``.`` with ``_``).
  * Commandline interface: Do not try creating paths ``.`` and ``..``.
+ * Parser: Disallow octal literals.
  * Type system: Fix a crash caused by continuing on fatal errors in the code.
  * Type system: Disallow arrays with negative length.
  * Type system: Fix a crash related to invalid binary operators.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -197,10 +197,9 @@ Rational and Integer Literals
 
 Integer literals are formed from a sequence of numbers in the range 0-9.
 They are interpreted as decimals. For example, ``69`` means sixty nine.
-Octal literals do not exist in Solidity and leading zeros are ignored.
-For example, ``0100`` means one hundred.
+Octal literals do not exist in Solidity and leading zeros are invalid.
 
-Decimal literals are formed by a ``.`` with at least one number on
+Decimal fraction literals are formed by a ``.`` with at least one number on
 one side.  Examples include ``1.``, ``.1`` and ``1.3``.
 
 Number literal expressions retain arbitrary precision until they are converted to a non-literal type (i.e. by

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -758,6 +758,9 @@ Token::Value Scanner::scanNumber(char _charSeen)
 				while (isHexDigit(m_char))
 					addLiteralCharAndAdvance();
 			}
+			else if (isDecimalDigit(m_char))
+				// We do not allow octal numbers
+				return Token::Illegal;
 		}
 		// Parse decimal digits and allow trailing fractional part.
 		if (kind == DECIMAL)

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -97,6 +97,24 @@ BOOST_AUTO_TEST_CASE(hex_numbers)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
+BOOST_AUTO_TEST_CASE(octal_numbers)
+{
+	Scanner scanner(CharStream("07"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
+	scanner.reset(CharStream("007"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
+	scanner.reset(CharStream("-07"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Sub);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	scanner.reset(CharStream("-.07"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Sub);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	scanner.reset(CharStream("0"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	scanner.reset(CharStream("0.1"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+}
+
 BOOST_AUTO_TEST_CASE(negative_numbers)
 {
 	Scanner scanner(CharStream("var x = -.2 + -0x78 + -7.3 + 8.9;"));


### PR DESCRIPTION
Previous versions of Solidity would parse octal numbers as octal while the documentation stated that they were interpreted as decimal numbers. Since the arcaneness-to-usefulness-ratio of octal numbers is quite high, they are disallowed to avoid confusion.

Fixes https://github.com/ethereum/solidity/issues/1724