### PR TITLE
Warn if base of exponentiation operation is a literal.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Features:
  * Code generator: Support ``revert()`` to abort with rolling back, but not consuming all gas.
  * Inline assembly: Support ``revert`` (EIP140) as an opcode.
  * Type system: Support explicit conversion of external function to address.
+ * Type system: Warn if base of exponentiation is literal (result type might be unexpected).
 
 Bugfixes:
  * Commandline interface: Always escape filenames (replace ``/``, ``:`` and ``.`` with ``_``).

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1092,6 +1092,26 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 		Token::isCompareOp(_operation.getOperator()) ?
 		make_shared<BoolType>() :
 		commonType;
+	if (_operation.getOperator() == Token::Exp)
+	{
+		if (
+			leftType->category() == Type::Category::RationalNumber &&
+			rightType->category() != Type::Category::RationalNumber
+		)
+			if ((
+				commonType->category() == Type::Category::Integer &&
+				dynamic_cast<IntegerType const&>(*commonType).numBits() != 256
+			) || (
+				commonType->category() == Type::Category::FixedPoint &&
+				dynamic_cast<FixedPointType const&>(*commonType).numBits() != 256
+			))
+				warning(
+					_operation.location(),
+					"Result of exponentiation has type " + commonType->toString() + " and thus "
+					"might overflow. Silence this warning by converting the literal to the "
+					"expected type."
+				);
+	}
 }
 
 bool TypeChecker::visit(FunctionCall const& _functionCall)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1658,6 +1658,36 @@ BOOST_AUTO_TEST_CASE(exp_operator_exponent_too_big)
 	CHECK_ERROR(sourceCode, TypeError, "");
 }
 
+BOOST_AUTO_TEST_CASE(exp_warn_literal_base)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f() returns(uint d) {
+				uint8 x = 100;
+				return 10**x;
+			}
+		}
+	)";
+	CHECK_WARNING(sourceCode, "might overflow");
+	sourceCode = R"(
+		contract test {
+			function f() returns(uint d) {
+				uint8 x = 100;
+				return uint8(10)**x;
+			}
+		}
+	)";
+	CHECK_SUCCESS(sourceCode);
+	sourceCode = R"(
+		contract test {
+			function f() returns(uint d) {
+				return 2**80;
+			}
+		}
+	)";
+	CHECK_SUCCESS(sourceCode);
+}
+
 BOOST_AUTO_TEST_CASE(enum_member_access)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1745