### PR TITLE
Do not crash on long linker commandline argument.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Features:
 Bugfixes:
  * Commandline interface: Always escape filenames (replace ``/``, ``:`` and ``.`` with ``_``).
  * Commandline interface: Do not try creating paths ``.`` and ``..``.
+ * Commandline interface: Allow long library names.
  * Parser: Disallow octal literals.
  * Type system: Fix a crash caused by continuing on fatal errors in the code.
  * Type system: Disallow compound assignment for tuples.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -420,7 +420,16 @@ void CommandLineInterface::readInputFilesAndConfigureRemappings()
 bool CommandLineInterface::parseLibraryOption(string const& _input)
 {
 	namespace fs = boost::filesystem;
-	string data = fs::is_regular_file(_input) ? contentsString(_input) : _input;
+	string data = _input;
+	try
+	{
+		if (fs::is_regular_file(_input))
+			data = contentsString(_input);
+	}
+	catch (fs::filesystem_error const&)
+	{
+		// Thrown e.g. if path is too long.
+	}
 
 	vector<string> libraries;
 	boost::split(libraries, data, boost::is_space() || boost::is_any_of(","), boost::token_compress_on);

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -50,6 +50,9 @@ echo "Testing library checksum..."
 echo '' | "$SOLC" --link --libraries a:0x90f20564390eAe531E810af625A22f51385Cd222
 ! echo '' | "$SOLC" --link --libraries a:0x80f20564390eAe531E810af625A22f51385Cd222 2>/dev/null
 
+echo "Testing long library names..."
+echo '' | "$SOLC" --link --libraries aveeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerylonglibraryname:0x90f20564390eAe531E810af625A22f51385Cd222
+
 echo "Testing overwriting files"
 TMPDIR=$(mktemp -d)
 (


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1717