### PR TITLE
Document the .value() and .gas() modifiers

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -127,8 +127,8 @@ the gas can be specified with special options ``.value()`` and ``.gas()``, respe
         function callFeed() { feed.info.value(10).gas(800)(); }
     }
 
-The modifier ``payable`` has to be used for ``info``, because otherwise,
-we would not be able to send Ether to it in the call ``feed.info.value(10).gas(800)()``.
+The modifier ``payable`` has to be used for ``info``, because otherwise, the `.value()`
+option would not be available.
 
 Note that the expression ``InfoFeed(addr)`` performs an explicit type conversion stating
 that "we know that the type of the contract at the given address is ``InfoFeed``" and

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -113,8 +113,8 @@ actual contract has not been created yet.
 Functions of other contracts have to be called externally. For an external call,
 all function arguments have to be copied to memory.
 
-When calling functions
-of other contracts, the amount of Wei sent with the call and the gas can be specified::
+When calling functions of other contracts, the amount of Wei sent with the call and
+the gas can be specified with special options ``.value()`` and ``.gas()``, respectively::
 
     contract InfoFeed {
         function info() payable returns (uint ret) { return 42; }
@@ -235,7 +235,7 @@ creation-dependencies are not possible.
         }
     }
 
-As seen in the example, it is possible to forward Ether to the creation,
+As seen in the example, it is possible to forward Ether to the creation using the ``.value()`` option,
 but it is not possible to limit the amount of gas. If the creation fails
 (due to out-of-stack, not enough balance or other problems), an exception
 is thrown.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -123,6 +123,8 @@ In a similar way, the function ``delegatecall`` can be used: The difference is t
 
 All three functions ``call``, ``delegatecall`` and ``callcode`` are very low-level functions and should only be used as a *last resort* as they break the type-safety of Solidity.
 
+The ``.gas()`` option is available on all three methods, while the ``.value()`` option is not supported for ``delegatecall``.
+
 .. note::
     All contracts inherit the members of address, so it is possible to query the balance of the
     current contract using ``this.balance``.


### PR DESCRIPTION
Fixes #1363.