### PR TITLE
Remove release tag file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.commit_hash.txt
-.prerelease.txt
+commit_hash.txt
+prerelease.txt
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
An accidental merge from release into develop also brought the empty `prerelease.txt` file, which makes solc produce an incorrect version string on develop.