### PR TITLE
Introduce formatExceptionInformation

### DIFF
--- a/libsolidity/interface/SourceReferenceFormatter.h
+++ b/libsolidity/interface/SourceReferenceFormatter.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <ostream>
+#include <sstream>
 #include <functional>
 #include <libevmasm/SourceLocation.h>
 
@@ -53,6 +54,16 @@ public:
 		std::string const& _name,
 		ScannerFromSourceNameFun const& _scannerFromSourceName
 	);
+	static std::string formatExceptionInformation(
+		Exception const& _exception,
+		std::string const& _name,
+		ScannerFromSourceNameFun const& _scannerFromSourceName
+	)
+	{
+		std::ostringstream errorOutput;
+		printExceptionInformation(errorOutput, _exception, _name, _scannerFromSourceName);
+		return errorOutput.str();
+	}
 private:
 	/// Prints source name if location is given.
 	static void printSourceName(

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -50,15 +50,6 @@ extern "C" {
 typedef void (*CStyleReadFileCallback)(char const* _path, char** o_contents, char** o_error);
 }
 
-string formatError(
-	Exception const& _exception,
-	string const& _name,
-	function<Scanner const&(string const&)> const& _scannerFromSourceName
-)
-{
-	return SourceReferenceFormatter::formatExceptionInformation(_exception, _name, _scannerFromSourceName);
-}
-
 Json::Value functionHashes(ContractDefinition const& _contract)
 {
 	Json::Value functionHashes(Json::objectValue);
@@ -168,7 +159,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 		for (auto const& error: compiler.errors())
 		{
 			auto err = dynamic_pointer_cast<Error const>(error);
-			errors.append(formatError(
+			errors.append(SourceReferenceFormatter::formatExceptionInformation(
 				*error,
 				(err->type() == Error::Type::Warning) ? "Warning" : "Error",
 				scannerFromSourceName
@@ -178,19 +169,19 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 	}
 	catch (Error const& error)
 	{
-		errors.append(formatError(error, error.typeName(), scannerFromSourceName));
+		errors.append(SourceReferenceFormatter::formatExceptionInformation(error, error.typeName(), scannerFromSourceName));
 	}
 	catch (CompilerError const& exception)
 	{
-		errors.append(formatError(exception, "Compiler error (" + exception.lineInfo() + ")", scannerFromSourceName));
+		errors.append(SourceReferenceFormatter::formatExceptionInformation(exception, "Compiler error (" + exception.lineInfo() + ")", scannerFromSourceName));
 	}
 	catch (InternalCompilerError const& exception)
 	{
-		errors.append(formatError(exception, "Internal compiler error (" + exception.lineInfo() + ")", scannerFromSourceName));
+		errors.append(SourceReferenceFormatter::formatExceptionInformation(exception, "Internal compiler error (" + exception.lineInfo() + ")", scannerFromSourceName));
 	}
 	catch (UnimplementedFeatureError const& exception)
 	{
-		errors.append(formatError(exception, "Unimplemented feature (" + exception.lineInfo() + ")", scannerFromSourceName));
+		errors.append(SourceReferenceFormatter::formatExceptionInformation(exception, "Unimplemented feature (" + exception.lineInfo() + ")", scannerFromSourceName));
 	}
 	catch (Exception const& exception)
 	{
@@ -243,7 +234,7 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 			{
 				Json::Value errors(Json::arrayValue);
 				for (auto const& error: formalErrors)
-					errors.append(formatError(
+					errors.append(SourceReferenceFormatter::formatExceptionInformation(
 						*error,
 						(error->type() == Error::Type::Warning) ? "Warning" : "Error",
 						scannerFromSourceName

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -56,9 +56,7 @@ string formatError(
 	function<Scanner const&(string const&)> const& _scannerFromSourceName
 )
 {
-	ostringstream errorOutput;
-	SourceReferenceFormatter::printExceptionInformation(errorOutput, _exception, _name, _scannerFromSourceName);
-	return errorOutput.str();
+	return SourceReferenceFormatter::formatExceptionInformation(_exception, _name, _scannerFromSourceName);
 }
 
 Json::Value functionHashes(ContractDefinition const& _contract)


### PR DESCRIPTION
It is also used byte StandardCompiler, hence another code duplication.

Additionally all the `printExceptionInformation` in the CLI could be replaced, though that seems a bit backwards.