### PR TITLE
Fix PostTypeChecker retaining state across contracts

### DIFF
--- a/libsolidity/analysis/PostTypeChecker.cpp
+++ b/libsolidity/analysis/PostTypeChecker.cpp
@@ -58,6 +58,9 @@ void PostTypeChecker::endVisit(ContractDefinition const&)
 	for (auto declaration: m_constVariables)
 		if (auto identifier = findCycle(declaration))
 			typeError(declaration->location(), "The value of the constant " + declaration->name() + " has a cyclic dependency via " + identifier->name() + ".");
+
+	m_constVariables.clear();
+	m_constVariableDependencies.clear();
 }
 
 bool PostTypeChecker::visit(VariableDeclaration const& _variable)


### PR DESCRIPTION
Closes #2108

The `m_constVariableDependencies.empty()` solAssert in `visit(ContractDefinition const&)` was failing because the visitor retained constants from previous contracts.