### PR TITLE
Estimate contract creation properly

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -322,7 +322,7 @@ void CommandLineInterface::handleGasEstimation(string const& _contract)
 	if (eth::AssemblyItems const* items = m_compiler->assemblyItems(_contract))
 	{
 		Gas gas = GasEstimator::functionalEstimation(*items);
-		u256 bytecodeSize(m_compiler->runtimeObject(_contract).bytecode.size());
+		u256 bytecodeSize(m_compiler->object(_contract).bytecode.size());
 		cout << "construction:" << endl;
 		cout << "   " << gas << " + " << (bytecodeSize * eth::GasCosts::createDataGas) << " = ";
 		gas += bytecodeSize * eth::GasCosts::createDataGas;

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -86,7 +86,7 @@ Json::Value estimateGas(CompilerStack const& _compiler, string const& _contract)
 	if (eth::AssemblyItems const* items = _compiler.assemblyItems(_contract))
 	{
 		Gas gas = GasEstimator::functionalEstimation(*items);
-		u256 bytecodeSize(_compiler.runtimeObject(_contract).bytecode.size());
+		u256 bytecodeSize(_compiler.object(_contract).bytecode.size());
 		Json::Value creationGas(Json::arrayValue);
 		creationGas[0] = gasToJson(gas);
 		creationGas[1] = gasToJson(bytecodeSize * eth::GasCosts::createDataGas);


### PR DESCRIPTION
It should take the size of the creation code in consideration and not the deployed one.