### PR TITLE
Implement missing assembly output functions and do not use PushString for assembly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
 
 Bugfixes:
  * Type system: Contract inheriting from base with unimplemented constructor should be abstract.
+ * Assembly output: Implement missing AssemblyItem types.
 
 ### 0.4.10 (2017-03-15)
 

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -205,7 +205,8 @@ ostream& Assembly::streamAsm(ostream& _out, string const& _prefix, StringMap con
 	{
 		_out << _prefix << "stop" << endl;
 		for (auto const& i: m_data)
-			assertThrow(u256(i.first) < m_subs.size(), AssemblyException, "Data not yet implemented.");
+			if (u256(i.first) >= m_subs.size())
+				_out << _prefix << "data_" << toHex(u256(i.first)) << " " << toHex(i.second) << endl;
 
 		for (size_t i = 0; i < m_subs.size(); ++i)
 		{

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -159,18 +159,25 @@ string AssemblyItem::toAssemblyText() const
 		text = toHex(toCompactBigEndian(data(), 1), 1, HexPrefix::Add);
 		break;
 	case PushString:
-		assertThrow(false, AssemblyException, "Push string assembly output not implemented.");
+		text = string("data_") + toHex(data());
 		break;
 	case PushTag:
-		assertThrow(data() < 0x10000, AssemblyException, "Sub-assembly tags not yet implemented.");
-		text = string("tag_") + to_string(size_t(data()));
+	{
+		size_t sub;
+		size_t tag;
+		tie(sub, tag) = splitForeignPushTag();
+		if (sub == size_t(-1))
+			text = string("tag_") + to_string(tag);
+		else
+			text = string("tag_") + to_string(sub) + "_" + to_string(tag);
 		break;
+	}
 	case Tag:
-		assertThrow(data() < 0x10000, AssemblyException, "Sub-assembly tags not yet implemented.");
+		assertThrow(data() < 0x10000, AssemblyException, "Declaration of sub-assembly tag.");
 		text = string("tag_") + to_string(size_t(data())) + ":";
 		break;
 	case PushData:
-		assertThrow(false, AssemblyException, "Push data not implemented.");
+		text = string("data_") + toHex(data());
 		break;
 	case PushSub:
 		text = string("dataOffset(sub_") + to_string(size_t(data())) + ")";

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -163,8 +163,8 @@ string AssemblyItem::toAssemblyText() const
 		break;
 	case PushTag:
 	{
-		size_t sub;
-		size_t tag;
+		size_t sub{0};
+		size_t tag{0};
 		tie(sub, tag) = splitForeignPushTag();
 		if (sub == size_t(-1))
 			text = string("tag_") + to_string(tag);

--- a/libsolidity/inlineasm/AsmCodeGen.cpp
+++ b/libsolidity/inlineasm/AsmCodeGen.cpp
@@ -130,7 +130,7 @@ public:
 		else
 		{
 			solAssert(_literal.value.size() <= 32, "");
-			m_state.assembly.append(_literal.value);
+			m_state.assembly.append(u256(h256(_literal.value, h256::FromBinary, h256::AlignLeft)));
 		}
 	}
 	void operator()(assembly::Identifier const& _identifier)


### PR DESCRIPTION
Without this pull request, `solc --optimize --asm` sometimes throws exceptions.