### PR TITLE
Replace link to dapple in the docs with our next generation development tool

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,8 +78,8 @@ Discontinued:
 Solidity Tools
 --------------
 
-* `Dapple <https://github.com/nexusdev/dapple>`_
-    Package and deployment manager for Solidity.
+* `Dapp <https://dapp.readthedocs.io>`_
+    Build tool, package manager, and deployment assistant for Solidity.
 
 * `Solidity REPL <https://github.com/raineorshine/solidity-repl>`_
     Try Solidity instantly with a command-line Solidity console.


### PR DESCRIPTION
Hi,

DappHub has deprecated our build tool Dapple in favor of a new and much simpler CLI called [Dapp](https://github.com/dapphub/dapp). We would like to replace the link in the Solidity docs to reflect this and prevent confusion.