### PR TITLE
Warn on unused local variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Features:
  * Inline Assembly: Storage variable access using ``_slot`` and ``_offset`` suffixes.
  * Inline Assembly: Disallow blocks with unbalanced stack.
  * Static analyzer: Warn about statements without effects.
+ * Static analyzer: Warn about unused local variables, parameters, and return parameters.
  * Syntax checker: issue deprecation warning for unary '+'
 
 Bugfixes:

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -50,6 +50,7 @@ bool StaticAnalyzer::visit(FunctionDefinition const& _function)
 {
 	if (_function.isImplemented())
 		m_inFunction = true;
+	m_currentFunction = &_function;
 	m_localVarUseCount.clear();
 	m_nonPayablePublic = _function.isPublic() && !_function.isPayable();
 	return true;
@@ -93,6 +94,17 @@ bool StaticAnalyzer::visit(VariableDeclaration const& _variable)
 			m_localVarUseCount[&_variable];
 		}
 	}
+	return true;
+}
+
+bool StaticAnalyzer::visit(Return const& _return)
+{
+	// If the return has an expression, it counts as
+	// a "use" of the return parameters.
+	if (m_inFunction && _return.expression() != NULL)
+		for (auto const& var: m_currentFunction->returnParameterList()->parameters())
+			if (var->name() != "")
+				m_localVarUseCount[var.get()] += 1;
 	return true;
 }
 

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -63,7 +63,7 @@ private:
 	virtual bool visit(ExpressionStatement const& _statement) override;
 	virtual bool visit(VariableDeclaration const& _variable) override;
 	virtual bool visit(Identifier const& _identifier) override;
-
+	virtual bool visit(Return const& _return) override;
 	virtual bool visit(MemberAccess const& _memberAccess) override;
 
 	ErrorList& m_errors;
@@ -76,6 +76,7 @@ private:
 
 	std::map<VariableDeclaration const*, int> m_localVarUseCount;
 
+	const FunctionDefinition *m_currentFunction;
 	bool m_inFunction = false;
 };
 

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -76,8 +76,7 @@ private:
 
 	std::map<VariableDeclaration const*, int> m_localVarUseCount;
 
-	const FunctionDefinition *m_currentFunction;
-	bool m_inFunction = false;
+	FunctionDefinition const* m_currentFunction = nullptr;
 };
 
 }

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -61,6 +61,8 @@ private:
 	virtual void endVisit(FunctionDefinition const& _function) override;
 
 	virtual bool visit(ExpressionStatement const& _statement) override;
+	virtual bool visit(VariableDeclaration const& _variable) override;
+	virtual bool visit(Identifier const& _identifier) override;
 
 	virtual bool visit(MemberAccess const& _memberAccess) override;
 
@@ -71,6 +73,10 @@ private:
 
 	/// Flag that indicates whether a public function does not contain the "payable" modifier.
 	bool m_nonPayablePublic = false;
+
+	std::map<VariableDeclaration const*, int> m_localVarUseCount;
+
+	bool m_inFunction = false;
 };
 
 }

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -74,6 +74,7 @@ private:
 	/// Flag that indicates whether a public function does not contain the "payable" modifier.
 	bool m_nonPayablePublic = false;
 
+	/// Number of uses of each (named) local variable in a function, counter is initialized with zero.
 	std::map<VariableDeclaration const*, int> m_localVarUseCount;
 
 	FunctionDefinition const* m_currentFunction = nullptr;

--- a/std/StandardToken.sol
+++ b/std/StandardToken.sol
@@ -22,7 +22,7 @@ contract StandardToken is Token {
 	}
 
 	function transfer(address _to, uint256 _value) returns (bool success) {
-		success = doTransfer(msg.sender, _to, _value);
+		return doTransfer(msg.sender, _to, _value);
 	}
 
 	function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
@@ -36,7 +36,7 @@ contract StandardToken is Token {
 		}
 	}
 
-	function doTransfer(address _from, address _to, uint _value) internal returns (bool) {
+	function doTransfer(address _from, address _to, uint _value) internal returns (bool success) {
 		if (balance[_from] >= _value && balance[_to] + _value >= balance[_to]) {
 			balance[_from] -= _value;
 			balance[_to] += _value;
@@ -47,7 +47,7 @@ contract StandardToken is Token {
 		}
 	}
 
-	function approve(address _spender, uint256 _value) returns (bool) {
+	function approve(address _spender, uint256 _value) returns (bool success) {
 		m_allowance[msg.sender][_spender] = _value;
 		Approval(msg.sender, _spender, _value);
 		return true;

--- a/std/StandardToken.sol
+++ b/std/StandardToken.sol
@@ -22,10 +22,10 @@ contract StandardToken is Token {
 	}
 
 	function transfer(address _to, uint256 _value) returns (bool success) {
-		return doTransfer(msg.sender, _to, _value);
+		success = doTransfer(msg.sender, _to, _value);
 	}
 
-	function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
+	function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
 		if (m_allowance[_from][msg.sender] >= _value) {
 			if (doTransfer(_from, _to, _value)) {
 				m_allowance[_from][msg.sender] -= _value;
@@ -36,7 +36,7 @@ contract StandardToken is Token {
 		}
 	}
 
-	function doTransfer(address _from, address _to, uint _value) internal returns (bool success) {
+	function doTransfer(address _from, address _to, uint _value) internal returns (bool) {
 		if (balance[_from] >= _value && balance[_to] + _value >= balance[_to]) {
 			balance[_from] -= _value;
 			balance[_to] += _value;
@@ -47,13 +47,13 @@ contract StandardToken is Token {
 		}
 	}
 
-	function approve(address _spender, uint256 _value) returns (bool success) {
+	function approve(address _spender, uint256 _value) returns (bool) {
 		m_allowance[msg.sender][_spender] = _value;
 		Approval(msg.sender, _spender, _value);
 		return true;
 	}
 
-	function allowance(address _owner, address _spender) constant returns (uint256 remaining) {
+	function allowance(address _owner, address _spender) constant returns (uint256) {
 		return m_allowance[_owner][_spender];
 	}
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(name_shadowing)
 	char const* text = R"(
 		contract test {
 			uint256 variable;
-			function f() { uint32 variable; variable; }
+			function f() { uint32 variable; variable = 2; }
 		}
 	)";
 	CHECK_SUCCESS(text);
@@ -5640,7 +5640,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_param)
 	CHECK_WARNING(text, "Unused");
 	text = R"(
 		contract C {
-			function f(uint) {
+			function f(uint a) {
 			}
 		}
 	)";
@@ -5662,7 +5662,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 			}
 		}
 	)";
-	success(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 	text = R"(
 		contract C {
 			function f() returns (uint a) {
@@ -5670,7 +5670,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 			}
 		}
 	)";
-	success(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 	text = R"(
 		contract C {
 			function f() returns (uint a) {
@@ -5678,7 +5678,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 			}
 		}
 	)";
-	success(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
 BOOST_AUTO_TEST_CASE(no_unused_warnings)
@@ -5691,7 +5691,7 @@ BOOST_AUTO_TEST_CASE(no_unused_warnings)
 			}
 		}
 	)";
-	success(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
 BOOST_AUTO_TEST_CASE(no_unused_dec_after_use)
@@ -5704,7 +5704,7 @@ BOOST_AUTO_TEST_CASE(no_unused_dec_after_use)
 			}
 		}
 	)";
-	success(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5658,6 +5658,14 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 	CHECK_WARNING(text, "Unused");
 	text = R"(
 		contract C {
+			function f() returns (uint a) {
+				return;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Unused");
+	text = R"(
+		contract C {
 			function f() returns (uint) {
 			}
 		}
@@ -5699,8 +5707,8 @@ BOOST_AUTO_TEST_CASE(no_unused_dec_after_use)
 	char const* text = R"(
 		contract C {
 			function f() {
-			a = 7;
-			uint a;
+				a = 7;
+				uint a;
 			}
 		}
 	)";

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5663,6 +5663,22 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 		}
 	)";
 	success(text);
+	text = R"(
+		contract C {
+			function f() returns (uint a) {
+				a = 1;
+			}
+		}
+	)";
+	success(text);
+	text = R"(
+		contract C {
+			function f() returns (uint a) {
+				return 1;
+			}
+		}
+	)";
+	success(text);
 }
 
 BOOST_AUTO_TEST_CASE(no_unused_warnings)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -3961,6 +3961,8 @@ BOOST_AUTO_TEST_CASE(rational_unary_operation)
 			function f() {
 				ufixed8x16 a = 3.25;
 				fixed8x16 b = -3.25;
+				a;
+				b;
 			}
 		}
 	)";
@@ -3979,6 +3981,7 @@ BOOST_AUTO_TEST_CASE(rational_unary_operation)
 		contract test {
 			function f(uint x) {
 				uint y = +x;
+				y;
 			}
 		}
 	)";


### PR DESCRIPTION
Analyze functions for all local variables, parameters, and named
return variables which are never used in the function, and issue
a warning.

This partially resolves issue #718 