### PR TITLE
Guard ReadFileCallback exceptions

### DIFF
--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -79,7 +79,8 @@ class CompilerStack: boost::noncopyable
 {
 public:
 	/// Creates a new compiler stack.
-	/// @param _readFile callback to used to read files for import statements. Should return
+	/// @param _readFile callback to used to read files for import statements. Must return
+	/// and must not emit exceptions.
 	explicit CompilerStack(ReadFile::Callback const& _readFile = ReadFile::Callback());
 
 	/// Sets path remappings in the format "context:prefix=target"

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -38,7 +38,8 @@ class StandardCompiler: boost::noncopyable
 {
 public:
 	/// Creates a new StandardCompiler.
-	/// @param _readFile callback to used to read files for import statements. Should return
+	/// @param _readFile callback to used to read files for import statements. Must return
+	/// and must not emit exceptions.
 	StandardCompiler(ReadFile::Callback const& _readFile = ReadFile::Callback())
 		: m_compilerStack(_readFile), m_readFile(_readFile)
 	{

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -618,32 +618,43 @@ bool CommandLineInterface::processInput()
 {
 	ReadFile::Callback fileReader = [this](string const& _path)
 	{
-		auto path = boost::filesystem::path(_path);
-		auto canonicalPath = boost::filesystem::canonical(path);
-		bool isAllowed = false;
-		for (auto const& allowedDir: m_allowedDirectories)
+		try
 		{
-			// If dir is a prefix of boostPath, we are fine.
-			if (
-				std::distance(allowedDir.begin(), allowedDir.end()) <= std::distance(canonicalPath.begin(), canonicalPath.end()) &&
-				std::equal(allowedDir.begin(), allowedDir.end(), canonicalPath.begin())
-			)
+			auto path = boost::filesystem::path(_path);
+			auto canonicalPath = boost::filesystem::canonical(path);
+			bool isAllowed = false;
+			for (auto const& allowedDir: m_allowedDirectories)
 			{
-				isAllowed = true;
-				break;
+				// If dir is a prefix of boostPath, we are fine.
+				if (
+					std::distance(allowedDir.begin(), allowedDir.end()) <= std::distance(canonicalPath.begin(), canonicalPath.end()) &&
+					std::equal(allowedDir.begin(), allowedDir.end(), canonicalPath.begin())
+				)
+				{
+					isAllowed = true;
+					break;
+				}
+			}
+			if (!isAllowed)
+				return ReadFile::Result{false, "File outside of allowed directories."};
+			else if (!boost::filesystem::exists(path))
+				return ReadFile::Result{false, "File not found."};
+			else if (!boost::filesystem::is_regular_file(canonicalPath))
+				return ReadFile::Result{false, "Not a valid file."};
+			else
+			{
+				auto contents = dev::contentsString(canonicalPath.string());
+				m_sourceCodes[path.string()] = contents;
+				return ReadFile::Result{true, contents};
 			}
 		}
-		if (!isAllowed)
-			return ReadFile::Result{false, "File outside of allowed directories."};
-		else if (!boost::filesystem::exists(path))
-			return ReadFile::Result{false, "File not found."};
-		else if (!boost::filesystem::is_regular_file(canonicalPath))
-			return ReadFile::Result{false, "Not a valid file."};
-		else
+		catch (Exception const& _exception)
 		{
-			auto contents = dev::contentsString(canonicalPath.string());
-			m_sourceCodes[path.string()] = contents;
-			return ReadFile::Result{true, contents};
+			return ReadFile::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
+		}
+		catch (...)
+		{
+			return ReadFile::Result{false, "Unknown exception in read callback."};
 		}
 	};
 


### PR DESCRIPTION
Do not allow `ReadFileCallback` to bubble exceptions. It should return the error message properly instead.