### PR TITLE
Deprecate use of unary '+'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Features:
  * Inline Assembly: Storage variable access using ``_slot`` and ``_offset`` suffixes.
  * Inline Assembly: Disallow blocks with unbalanced stack.
  * Static analyzer: Warn about statements without effects.
+ * Syntax checker: issue deprecation warning for unary '+'
 
 Bugfixes:
  * Assembly output: Implement missing AssemblyItem types.

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -161,9 +161,7 @@ bool SyntaxChecker::visit(Break const& _breakStatement)
 bool SyntaxChecker::visit(UnaryOperation const& _operation)
 {
 	if (_operation.getOperator() == Token::Add)
-	{
-		warning(_operation.location(), "Use of unary + is deprecated");
-	}
+		warning(_operation.location(), "Use of unary + is deprecated.");
 	return true;
 }
 

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -32,6 +32,16 @@ bool SyntaxChecker::checkSyntax(ASTNode const& _astRoot)
 	return Error::containsOnlyWarnings(m_errors);
 }
 
+void SyntaxChecker::warning(SourceLocation const& _location, string const& _description)
+{
+	auto err = make_shared<Error>(Error::Type::Warning);
+	*err <<
+		errinfo_sourceLocation(_location) <<
+		errinfo_comment(_description);
+
+	m_errors.push_back(err);
+}
+
 void SyntaxChecker::syntaxError(SourceLocation const& _location, std::string const& _description)
 {
 	auto err = make_shared<Error>(Error::Type::SyntaxError);
@@ -145,6 +155,15 @@ bool SyntaxChecker::visit(Break const& _breakStatement)
 	if (m_inLoopDepth <= 0)
 		// we're not in a for/while loop, report syntax error
 		syntaxError(_breakStatement.location(), "\"break\" has to be in a \"for\" or \"while\" loop.");
+	return true;
+}
+
+bool SyntaxChecker::visit(UnaryOperation const& _operation)
+{
+	if (_operation.getOperator() == Token::Add)
+	{
+		warning(_operation.location(), "Use of unary + is deprecated");
+	}
 	return true;
 }
 

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -32,6 +32,7 @@ namespace solidity
  * The module that performs syntax analysis on the AST:
  *  - whether continue/break is in a for/while loop.
  *  - whether a modifier contains at least one '_'
+ *  - issues deprecation warnings for unary '+'
  */
 class SyntaxChecker: private ASTConstVisitor
 {
@@ -43,6 +44,7 @@ public:
 
 private:
 	/// Adds a new error to the list of errors.
+	void warning(SourceLocation const& _location, std::string const& _description);
 	void syntaxError(SourceLocation const& _location, std::string const& _description);
 
 	virtual bool visit(SourceUnit const& _sourceUnit) override;
@@ -59,6 +61,8 @@ private:
 
 	virtual bool visit(Continue const& _continueStatement) override;
 	virtual bool visit(Break const& _breakStatement) override;
+
+	virtual bool visit(UnaryOperation const& _operation) override;
 
 	virtual bool visit(PlaceholderStatement const& _placeholderStatement) override;
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -3938,12 +3938,21 @@ BOOST_AUTO_TEST_CASE(rational_unary_operation)
 	char const* text = R"(
 		contract test {
 			function f() {
-				ufixed8x16 a = +3.25;
+				ufixed8x16 a = 3.25;
 				fixed8x16 b = -3.25;
 			}
 		}
 	)";
 	CHECK_SUCCESS(text);
+	text = R"(
+		contract test {
+			function f() {
+				ufixed8x16 a = +3.25;
+				fixed8x16 b = -3.25;
+			}
+		}
+	)";
+	CHECK_WARNING(text,"Use of unary + is deprecated");
 }
 
 BOOST_AUTO_TEST_CASE(leading_zero_rationals_convert)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -3943,12 +3943,20 @@ BOOST_AUTO_TEST_CASE(rational_unary_operation)
 			}
 		}
 	)";
-	CHECK_SUCCESS(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 	text = R"(
 		contract test {
 			function f() {
 				ufixed8x16 a = +3.25;
 				fixed8x16 b = -3.25;
+			}
+		}
+	)";
+	CHECK_WARNING(text,"Use of unary + is deprecated");
+	text = R"(
+		contract test {
+			function f(uint x) {
+				uint y = +x;
 			}
 		}
 	)";


### PR DESCRIPTION
The unary '+' serves no meaningful purpose in Solidity and it makes it
possible to produce typos with dagerous implications (e.g. 'a =+5 '),
so we are deprecating it.  The SyntaxChecker currently issues warnings
on the unary '+' but will still compile it for now.

This PR resolves issue #1760 