### PR TITLE
Added change to make compile happy on MacOS 10.9.5

### DIFF
--- a/libsolidity/analysis/PostTypeChecker.h
+++ b/libsolidity/analysis/PostTypeChecker.h
@@ -55,7 +55,7 @@ private:
 
 	VariableDeclaration const* findCycle(
 		VariableDeclaration const* _startingFrom,
-		std::set<VariableDeclaration const*> const& _seen = {}
+		std::set<VariableDeclaration const*> const& _seen = std::set<VariableDeclaration const*>{}
 	);
 
 	ErrorList& m_errors;


### PR DESCRIPTION
Fixes #2227.

I had an issue with build failing for the release branch of solidity on MacOS 10.9.5

The error I got:
$ cmake .. && make
...
error:
expected '(' for function-style cast or type construction
...const> const& _seen = std::set<VariableDeclaration const*> const{}*

# Issue 
https://github.com/ethereum/solidity/issues/2227

I added a bit more code to be more explicit which allowed me to build.

My first pull request, please let me know if I missed anything.