### PR TITLE
Remove an unused function `successAssemble`

### DIFF
--- a/test/libjulia/Parser.cpp
+++ b/test/libjulia/Parser.cpp
@@ -89,11 +89,6 @@ bool successParse(std::string const& _source, bool _allowWarnings = true)
 	return !parseAndReturnFirstError(_source, _allowWarnings);
 }
 
-bool successAssemble(string const& _source, bool _allowWarnings = true)
-{
-	return successParse(_source, _allowWarnings);
-}
-
 Error expectError(std::string const& _source, bool _allowWarnings = false)
 {
 


### PR DESCRIPTION
Fixes #2257.

Otherwise, I see a build failure:
```
    test/libjulia/Parser.cpp:92:6: error: ‘bool dev::solidity::test::{anonymous}::successAssemble(const string&, bool)’ defined but not used [-Werror=unused-function]
     bool successAssemble(string const& _source, bool _allowWarnings = true)
          ^~~~~~~~~~~~~~~
    cc1plus: all warnings being treated as errors
```