### PR TITLE
Refactor error reporting

### DIFF
--- a/libjulia/backends/evm/EVMCodeTransform.cpp
+++ b/libjulia/backends/evm/EVMCodeTransform.cpp
@@ -32,14 +32,14 @@ using namespace dev::solidity;
 using namespace dev::solidity::assembly;
 
 CodeTransform::CodeTransform(
-	ErrorList& _errors,
+	ErrorReporter& _errorReporter,
 	AbstractAssembly& _assembly,
 	Block const& _block,
 	AsmAnalysisInfo& _analysisInfo,
 	ExternalIdentifierAccess const& _identifierAccess,
 	int _initialStackHeight
 ):
-	m_errors(_errors),
+	m_errorReporter(_errorReporter),
 	m_assembly(_assembly),
 	m_info(_analysisInfo),
 	m_scope(*_analysisInfo.scopes.at(&_block)),
@@ -91,11 +91,10 @@ int CodeTransform::variableHeightDiff(solidity::assembly::Scope::Variable const&
 	if (heightDiff <= (_forSwap ? 1 : 0) || heightDiff > (_forSwap ? 17 : 16))
 	{
 		//@TODO move this to analysis phase.
-		m_errors.push_back(make_shared<Error>(
-			Error::Type::TypeError,
-			"Variable inaccessible, too deep inside stack (" + boost::lexical_cast<string>(heightDiff) + ")",
-			_location
-		));
+		m_errorReporter.typeError(
+			_location,
+			"Variable inaccessible, too deep inside stack (" + boost::lexical_cast<string>(heightDiff) + ")"
+		);
 		return 0;
 	}
 	else
@@ -124,7 +123,7 @@ void CodeTransform::assignLabelIdIfUnset(Scope::Label& _label)
 
 void CodeTransform::operator()(Block const& _block)
 {
-	CodeTransform(m_errors, m_assembly, _block, m_info, m_identifierAccess, m_initialStackHeight);
+	CodeTransform(m_errorReporter, m_assembly, _block, m_info, m_identifierAccess, m_initialStackHeight);
 	checkStackHeight(&_block);
 }
 

--- a/libjulia/backends/evm/EVMCodeTransform.h
+++ b/libjulia/backends/evm/EVMCodeTransform.h
@@ -20,8 +20,6 @@
 
 #include <libjulia/backends/evm/AbstractAssembly.h>
 
-#include <libsolidity/interface/Exceptions.h>
-
 #include <libsolidity/inlineasm/AsmStack.h>
 #include <libsolidity/inlineasm/AsmScope.h>
 
@@ -31,6 +29,7 @@ namespace dev
 {
 namespace solidity
 {
+class ErrorReporter;
 namespace assembly
 {
 struct Literal;
@@ -59,18 +58,18 @@ public:
 	/// of its creation.
 	/// @param _identifierAccess used to resolve identifiers external to the inline assembly
 	CodeTransform(
-		solidity::ErrorList& _errors,
+		solidity::ErrorReporter& _errorReporter,
 		julia::AbstractAssembly& _assembly,
 		solidity::assembly::Block const& _block,
 		solidity::assembly::AsmAnalysisInfo& _analysisInfo,
 		ExternalIdentifierAccess const& _identifierAccess = ExternalIdentifierAccess()
-	): CodeTransform(_errors, _assembly, _block, _analysisInfo, _identifierAccess, _assembly.stackHeight())
+	): CodeTransform(_errorReporter, _assembly, _block, _analysisInfo, _identifierAccess, _assembly.stackHeight())
 	{
 	}
 
 private:
 	CodeTransform(
-		solidity::ErrorList& _errors,
+		solidity::ErrorReporter& _errorReporter,
 		julia::AbstractAssembly& _assembly,
 		solidity::assembly::Block const& _block,
 		solidity::assembly::AsmAnalysisInfo& _analysisInfo,
@@ -107,7 +106,7 @@ private:
 	/// Assigns the label's id to a value taken from eth::Assembly if it has not yet been set.
 	void assignLabelIdIfUnset(solidity::assembly::Scope::Label& _label);
 
-	solidity::ErrorList& m_errors;
+	solidity::ErrorReporter& m_errorReporter;
 	julia::AbstractAssembly& m_assembly;
 	solidity::assembly::AsmAnalysisInfo& m_info;
 	solidity::assembly::Scope& m_scope;

--- a/libsolidity/analysis/DocStringAnalyser.cpp
+++ b/libsolidity/analysis/DocStringAnalyser.cpp
@@ -23,6 +23,7 @@
 
 #include <libsolidity/analysis/DocStringAnalyser.h>
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include <libsolidity/parsing/DocStringParser.h>
 
 using namespace std;
@@ -110,7 +111,7 @@ void DocStringAnalyser::parseDocStrings(
 	DocStringParser parser;
 	if (_node.documentation() && !_node.documentation()->empty())
 	{
-		if (!parser.parse(*_node.documentation(), m_errors))
+		if (!parser.parse(*_node.documentation(), m_errorReporter))
 			m_errorOccured = true;
 		_annotation.docTags = parser.tags();
 	}
@@ -121,8 +122,6 @@ void DocStringAnalyser::parseDocStrings(
 
 void DocStringAnalyser::appendError(string const& _description)
 {
-	auto err = make_shared<Error>(Error::Type::DocstringParsingError);
-	*err << errinfo_comment(_description);
-	m_errors.push_back(err);
 	m_errorOccured = true;
+	m_errorReporter.docstringParsingError(_description);
 }

--- a/libsolidity/analysis/DocStringAnalyser.h
+++ b/libsolidity/analysis/DocStringAnalyser.h
@@ -30,6 +30,8 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
+
 /**
  * Parses and analyses the doc strings.
  * Stores the parsing results in the AST annotations and reports errors.
@@ -37,7 +39,7 @@ namespace solidity
 class DocStringAnalyser: private ASTConstVisitor
 {
 public:
-	DocStringAnalyser(ErrorList& _errors): m_errors(_errors) {}
+	DocStringAnalyser(ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}
 	bool analyseDocStrings(SourceUnit const& _sourceUnit);
 
 private:
@@ -64,7 +66,7 @@ private:
 	void appendError(std::string const& _description);
 
 	bool m_errorOccured = false;
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 }

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -24,7 +24,7 @@
 
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/analysis/TypeChecker.h>
-#include <libsolidity/interface/Exceptions.h>
+#include <libsolidity/interface/ErrorReporter.h>
 
 using namespace std;
 
@@ -36,10 +36,10 @@ namespace solidity
 NameAndTypeResolver::NameAndTypeResolver(
 	vector<Declaration const*> const& _globals,
 	map<ASTNode const*, shared_ptr<DeclarationContainer>>& _scopes,
-	ErrorList& _errors
+	ErrorReporter& _errorReporter
 ) :
 	m_scopes(_scopes),
-	m_errors(_errors)
+	m_errorReporter(_errorReporter)
 {
 	if (!m_scopes[nullptr])
 		m_scopes[nullptr].reset(new DeclarationContainer());
@@ -52,11 +52,11 @@ bool NameAndTypeResolver::registerDeclarations(ASTNode& _sourceUnit, ASTNode con
 	// The helper registers all declarations in m_scopes as a side-effect of its construction.
 	try
 	{
-		DeclarationRegistrationHelper registrar(m_scopes, _sourceUnit, m_errors, _currentScope);
+		DeclarationRegistrationHelper registrar(m_scopes, _sourceUnit, m_errorReporter, _currentScope);
 	}
 	catch (FatalError const&)
 	{
-		if (m_errors.empty())
+		if (m_errorReporter.errors().empty())
 			throw; // Something is weird here, rather throw again.
 		return false;
 	}
@@ -73,7 +73,7 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 			string const& path = imp->annotation().absolutePath;
 			if (!_sourceUnits.count(path))
 			{
-				reportDeclarationError(
+				m_errorReporter.declarationError(
 					imp->location(),
 					"Import \"" + path + "\" (referenced as \"" + imp->path() + "\") not found."
 				);
@@ -88,7 +88,7 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 					auto declarations = scope->second->resolveName(alias.first->name(), false);
 					if (declarations.empty())
 					{
-						reportDeclarationError(
+						m_errorReporter.declarationError(
 							imp->location(),
 							"Declaration \"" +
 							alias.first->name() +
@@ -106,7 +106,7 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 							ASTString const* name = alias.second ? alias.second.get() : &declaration->name();
 							if (!target.registerDeclaration(*declaration, name))
 							{
-								reportDeclarationError(
+								m_errorReporter.declarationError(
 									imp->location(),
 									"Identifier \"" + *name + "\" already declared."
 								);
@@ -119,7 +119,7 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 					for (auto const& declaration: nameAndDeclaration.second)
 						if (!target.registerDeclaration(*declaration, &nameAndDeclaration.first))
 						{
-							reportDeclarationError(
+							m_errorReporter.declarationError(
 								imp->location(),
 								"Identifier \"" + nameAndDeclaration.first + "\" already declared."
 							);
@@ -137,7 +137,7 @@ bool NameAndTypeResolver::resolveNamesAndTypes(ASTNode& _node, bool _resolveInsi
 	}
 	catch (FatalError const&)
 	{
-		if (m_errors.empty())
+		if (m_errorReporter.errors().empty())
 			throw; // Something is weird here, rather throw again.
 		return false;
 	}
@@ -152,7 +152,7 @@ bool NameAndTypeResolver::updateDeclaration(Declaration const& _declaration)
 	}
 	catch (FatalError const&)
 	{
-		if (m_errors.empty())
+		if (m_errorReporter.errors().empty())
 			throw; // Something is weird here, rather throw again.
 		return false;
 	}
@@ -214,7 +214,7 @@ vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 
 		for (auto parameter: functionType->parameterTypes() + functionType->returnParameterTypes())
 			if (!parameter)
-				reportFatalDeclarationError(_identifier.location(), "Function type can not be used in this context.");
+				m_errorReporter.fatalDeclarationError(_identifier.location(), "Function type can not be used in this context.");
 
 		if (uniqueFunctions.end() == find_if(
 			uniqueFunctions.begin(),
@@ -290,7 +290,7 @@ bool NameAndTypeResolver::resolveNamesAndTypesInternal(ASTNode& _node, bool _res
 	{
 		if (m_scopes.count(&_node))
 			m_currentScope = m_scopes[&_node].get();
-		return ReferencesResolver(m_errors, *this, _resolveInsideCode).resolve(_node);
+		return ReferencesResolver(m_errorReporter, *this, _resolveInsideCode).resolve(_node);
 	}
 }
 
@@ -328,11 +328,10 @@ void NameAndTypeResolver::importInheritedScope(ContractDefinition const& _base)
 						secondDeclarationLocation = declaration->location();
 					}
 
-					reportDeclarationError(
+					m_errorReporter.declarationError(
 						secondDeclarationLocation,
-						"Identifier already declared.",
-						firstDeclarationLocation,
-						"The previous declaration is here:"
+						SecondarySourceLocation().append("The previous declaration is here:", firstDeclarationLocation),
+						"Identifier already declared."
 					);
 				}
 }
@@ -347,19 +346,19 @@ void NameAndTypeResolver::linearizeBaseContracts(ContractDefinition& _contract)
 		UserDefinedTypeName const& baseName = baseSpecifier->name();
 		auto base = dynamic_cast<ContractDefinition const*>(baseName.annotation().referencedDeclaration);
 		if (!base)
-			reportFatalTypeError(baseName.createTypeError("Contract expected."));
+			m_errorReporter.fatalTypeError(baseName.location(), "Contract expected.");
 		// "push_front" has the effect that bases mentioned later can overwrite members of bases
 		// mentioned earlier
 		input.back().push_front(base);
 		vector<ContractDefinition const*> const& basesBases = base->annotation().linearizedBaseContracts;
 		if (basesBases.empty())
-			reportFatalTypeError(baseName.createTypeError("Definition of base has to precede definition of derived contract"));
+			m_errorReporter.fatalTypeError(baseName.location(), "Definition of base has to precede definition of derived contract");
 		input.push_front(list<ContractDefinition const*>(basesBases.begin(), basesBases.end()));
 	}
 	input.back().push_front(&_contract);
 	vector<ContractDefinition const*> result = cThreeMerge(input);
 	if (result.empty())
-		reportFatalTypeError(_contract.createTypeError("Linearization of inheritance graph impossible"));
+		m_errorReporter.fatalTypeError(_contract.location(), "Linearization of inheritance graph impossible");
 	_contract.annotation().linearizedBaseContracts = result;
 	_contract.annotation().contractDependencies.insert(result.begin() + 1, result.end());
 }
@@ -415,61 +414,15 @@ vector<_T const*> NameAndTypeResolver::cThreeMerge(list<list<_T const*>>& _toMer
 	return result;
 }
 
-void NameAndTypeResolver::reportDeclarationError(
-	SourceLocation _sourceLoction,
-	string const& _description,
-	SourceLocation _secondarySourceLocation,
-	string const& _secondaryDescription
-)
-{
-	auto err = make_shared<Error>(Error::Type::DeclarationError); // todo remove Error?
-	*err <<
-		errinfo_sourceLocation(_sourceLoction) <<
-		errinfo_comment(_description) <<
-		errinfo_secondarySourceLocation(
-			SecondarySourceLocation().append(_secondaryDescription, _secondarySourceLocation)
-		);
-
-	m_errors.push_back(err);
-}
-
-void NameAndTypeResolver::reportDeclarationError(SourceLocation _sourceLocation, string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::DeclarationError); // todo remove Error?
-	*err <<	errinfo_sourceLocation(_sourceLocation) << errinfo_comment(_description);
-
-	m_errors.push_back(err);
-}
-
-void NameAndTypeResolver::reportFatalDeclarationError(
-	SourceLocation _sourceLocation,
-	string const& _description
-)
-{
-	reportDeclarationError(_sourceLocation, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
-}
-
-void NameAndTypeResolver::reportTypeError(Error const& _e)
-{
-	m_errors.push_back(make_shared<Error>(_e));
-}
-
-void NameAndTypeResolver::reportFatalTypeError(Error const& _e)
-{
-	reportTypeError(_e);
-	BOOST_THROW_EXCEPTION(FatalError());
-}
-
 DeclarationRegistrationHelper::DeclarationRegistrationHelper(
 	map<ASTNode const*, shared_ptr<DeclarationContainer>>& _scopes,
 	ASTNode& _astRoot,
-	ErrorList& _errors,
+	ErrorReporter& _errorReporter,
 	ASTNode const* _currentScope
 ):
 	m_scopes(_scopes),
 	m_currentScope(_currentScope),
-	m_errors(_errors)
+	m_errorReporter(_errorReporter)
 {
 	_astRoot.accept(*this);
 	solAssert(m_currentScope == _currentScope, "Scopes not correctly closed.");
@@ -633,11 +586,10 @@ void DeclarationRegistrationHelper::registerDeclaration(Declaration& _declaratio
 			secondDeclarationLocation = _declaration.location();
 		}
 
-		declarationError(
+		m_errorReporter.declarationError(
 			secondDeclarationLocation,
-			"Identifier already declared.",
-			firstDeclarationLocation,
-			"The previous declaration is here:"
+			SecondarySourceLocation().append("The previous declaration is here:", firstDeclarationLocation),
+			"Identifier already declared."
 		);
 	}
 
@@ -663,41 +615,6 @@ string DeclarationRegistrationHelper::currentCanonicalName() const
 		}
 	}
 	return ret;
-}
-
-void DeclarationRegistrationHelper::declarationError(
-	SourceLocation _sourceLocation,
-	string const& _description,
-	SourceLocation _secondarySourceLocation,
-	string const& _secondaryDescription
-)
-{
-	auto err = make_shared<Error>(Error::Type::DeclarationError);
-	*err <<
-		errinfo_sourceLocation(_sourceLocation) <<
-		errinfo_comment(_description) <<
-		errinfo_secondarySourceLocation(
-			SecondarySourceLocation().append(_secondaryDescription, _secondarySourceLocation)
-		);
-
-	m_errors.push_back(err);
-}
-
-void DeclarationRegistrationHelper::declarationError(SourceLocation _sourceLocation, string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::DeclarationError);
-	*err <<	errinfo_sourceLocation(_sourceLocation) << errinfo_comment(_description);
-
-	m_errors.push_back(err);
-}
-
-void DeclarationRegistrationHelper::fatalDeclarationError(
-	SourceLocation _sourceLocation,
-	string const& _description
-)
-{
-	declarationError(_sourceLocation, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
 }
 
 }

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -35,6 +35,8 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
+
 /**
  * Resolves name references, typenames and sets the (explicitly given) types for all variable
  * declarations.
@@ -48,7 +50,7 @@ public:
 	NameAndTypeResolver(
 		std::vector<Declaration const*> const& _globals,
 		std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& _scopes,
-		ErrorList& _errors
+		ErrorReporter& _errorReporter
 	);
 	/// Registers all declarations found in the AST node, usually a source unit.
 	/// @returns false in case of error.
@@ -103,24 +105,6 @@ private:
 	template <class _T>
 	static std::vector<_T const*> cThreeMerge(std::list<std::list<_T const*>>& _toMerge);
 
-	// creates the Declaration error and adds it in the errors list
-	void reportDeclarationError(
-		SourceLocation _sourceLoction,
-		std::string const& _description,
-		SourceLocation _secondarySourceLocation,
-		std::string const& _secondaryDescription
-	);
-	// creates the Declaration error and adds it in the errors list
-	void reportDeclarationError(SourceLocation _sourceLocation, std::string const& _description);
-	// creates the Declaration error and adds it in the errors list and throws FatalError
-	void reportFatalDeclarationError(SourceLocation _sourceLocation, std::string const& _description);
-
-	// creates the Declaration error and adds it in the errors list
-	void reportTypeError(Error const& _e);
-	// creates the Declaration error and adds it in the errors list and throws FatalError
-	void reportFatalTypeError(Error const& _e);
-
-
 	/// Maps nodes declaring a scope to scopes, i.e. ContractDefinition and FunctionDeclaration,
 	/// where nullptr denotes the global scope. Note that structs are not scope since they do
 	/// not contain code.
@@ -128,7 +112,7 @@ private:
 	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& m_scopes;
 
 	DeclarationContainer* m_currentScope = nullptr;
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 /**
@@ -145,7 +129,7 @@ public:
 	DeclarationRegistrationHelper(
 		std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& _scopes,
 		ASTNode& _astRoot,
-		ErrorList& _errors,
+		ErrorReporter& _errorReporter,
 		ASTNode const* _currentScope = nullptr
 	);
 
@@ -175,23 +159,11 @@ private:
 
 	/// @returns the canonical name of the current scope.
 	std::string currentCanonicalName() const;
-	// creates the Declaration error and adds it in the errors list
-	void declarationError(
-		SourceLocation _sourceLocation,
-		std::string const& _description,
-		SourceLocation _secondarySourceLocation,
-		std::string const& _secondaryDescription
-	);
-
-	// creates the Declaration error and adds it in the errors list
-	void declarationError(SourceLocation _sourceLocation, std::string const& _description);
-	// creates the Declaration error and adds it in the errors list and throws FatalError
-	void fatalDeclarationError(SourceLocation _sourceLocation, std::string const& _description);
 
 	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& m_scopes;
 	ASTNode const* m_currentScope = nullptr;
 	VariableScope* m_currentFunction = nullptr;
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 }

--- a/libsolidity/analysis/PostTypeChecker.cpp
+++ b/libsolidity/analysis/PostTypeChecker.cpp
@@ -18,6 +18,7 @@
 #include <libsolidity/analysis/PostTypeChecker.h>
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/analysis/SemVerHandler.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include <libsolidity/interface/Version.h>
 
 #include <boost/range/adaptor/map.hpp>
@@ -32,17 +33,7 @@ using namespace dev::solidity;
 bool PostTypeChecker::check(ASTNode const& _astRoot)
 {
 	_astRoot.accept(*this);
-	return Error::containsOnlyWarnings(m_errors);
-}
-
-void PostTypeChecker::typeError(SourceLocation const& _location, std::string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::TypeError);
-	*err <<
-		errinfo_sourceLocation(_location) <<
-		errinfo_comment(_description);
-
-	m_errors.push_back(err);
+	return Error::containsOnlyWarnings(m_errorReporter.errors());
 }
 
 bool PostTypeChecker::visit(ContractDefinition const&)
@@ -57,7 +48,11 @@ void PostTypeChecker::endVisit(ContractDefinition const&)
 	solAssert(!m_currentConstVariable, "");
 	for (auto declaration: m_constVariables)
 		if (auto identifier = findCycle(declaration))
-			typeError(declaration->location(), "The value of the constant " + declaration->name() + " has a cyclic dependency via " + identifier->name() + ".");
+			m_errorReporter.typeError(
+				declaration->location(),
+				"The value of the constant " + declaration->name() +
+				" has a cyclic dependency via " + identifier->name() + "."
+			);
 
 	m_constVariables.clear();
 	m_constVariableDependencies.clear();

--- a/libsolidity/analysis/PostTypeChecker.h
+++ b/libsolidity/analysis/PostTypeChecker.h
@@ -28,6 +28,8 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
+
 /**
  * This module performs analyses on the AST that are done after type checking and assignments of types:
  *  - whether there are circular references in constant state variables
@@ -37,7 +39,7 @@ class PostTypeChecker: private ASTConstVisitor
 {
 public:
 	/// @param _errors the reference to the list of errors and warnings to add them found during type checking.
-	PostTypeChecker(ErrorList& _errors): m_errors(_errors) {}
+	PostTypeChecker(ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}
 
 	bool check(ASTNode const& _astRoot);
 
@@ -58,7 +60,7 @@ private:
 		std::set<VariableDeclaration const*> const& _seen = std::set<VariableDeclaration const*>{}
 	);
 
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 
 	VariableDeclaration const* m_currentConstVariable = nullptr;
 	std::vector<VariableDeclaration const*> m_constVariables; ///< Required for determinism.

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -28,6 +28,7 @@
 #include <libsolidity/inlineasm/AsmAnalysis.h>
 #include <libsolidity/inlineasm/AsmAnalysisInfo.h>
 #include <libsolidity/inlineasm/AsmData.h>
+#include <libsolidity/interface/ErrorReporter.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -111,7 +112,7 @@ void ReferencesResolver::endVisit(FunctionTypeName const& _typeName)
 	case VariableDeclaration::Visibility::External:
 		break;
 	default:
-		typeError(_typeName.location(), "Invalid visibility, can only be \"external\" or \"internal\".");
+		fatalTypeError(_typeName.location(), "Invalid visibility, can only be \"external\" or \"internal\".");
 	}
 
 	if (_typeName.isPayable() && _typeName.visibility() != VariableDeclaration::Visibility::External)
@@ -165,7 +166,8 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 	// the type and size of external identifiers, which would result in false errors.
 	// The only purpose of this step is to fill the inline assembly annotation with
 	// external references.
-	ErrorList errorsIgnored;
+	ErrorList errors;
+	ErrorReporter errorsIgnored(errors);
 	julia::ExternalIdentifierAccess::Resolver resolver =
 	[&](assembly::Identifier const& _identifier, julia::IdentifierContext) {
 		auto declarations = m_resolver.nameFromCurrentScope(_identifier.name);
@@ -303,29 +305,19 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 
 void ReferencesResolver::typeError(SourceLocation const& _location, string const& _description)
 {
-	auto err = make_shared<Error>(Error::Type::TypeError);
-	*err <<	errinfo_sourceLocation(_location) << errinfo_comment(_description);
 	m_errorOccurred = true;
-	m_errors.push_back(err);
+	m_errorReporter.typeError(_location, _description);
 }
 
 void ReferencesResolver::fatalTypeError(SourceLocation const& _location, string const& _description)
 {
-	typeError(_location, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
-}
-
-void ReferencesResolver::declarationError(SourceLocation const& _location, string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::DeclarationError);
-	*err <<	errinfo_sourceLocation(_location) << errinfo_comment(_description);
 	m_errorOccurred = true;
-	m_errors.push_back(err);
+	m_errorReporter.fatalTypeError(_location, _description);
 }
 
 void ReferencesResolver::fatalDeclarationError(SourceLocation const& _location, string const& _description)
 {
-	declarationError(_location, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
+	m_errorOccurred = true;
+	m_errorReporter.fatalDeclarationError(_location, _description);
 }
 

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -33,6 +33,7 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
 class NameAndTypeResolver;
 
 /**
@@ -43,11 +44,11 @@ class ReferencesResolver: private ASTConstVisitor
 {
 public:
 	ReferencesResolver(
-		ErrorList& _errors,
+		ErrorReporter& _errorReporter,
 		NameAndTypeResolver& _resolver,
 		bool _resolveInsideCode = false
 	):
-		m_errors(_errors),
+		m_errorReporter(_errorReporter),
 		m_resolver(_resolver),
 		m_resolveInsideCode(_resolveInsideCode)
 	{}
@@ -77,13 +78,10 @@ private:
 	/// Adds a new error to the list of errors and throws to abort type checking.
 	void fatalTypeError(SourceLocation const& _location, std::string const& _description);
 
-	/// Adds a new error to the list of errors.
-	void declarationError(const SourceLocation& _location, std::string const& _description);
-
 	/// Adds a new error to the list of errors and throws to abort type checking.
-	void fatalDeclarationError(const SourceLocation& _location, std::string const& _description);
+	void fatalDeclarationError(SourceLocation const& _location, std::string const& _description);
 
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 	NameAndTypeResolver& m_resolver;
 	/// Stack of return parameters.
 	std::vector<ParameterList const*> m_returnParameters;

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -44,15 +44,13 @@ class StaticAnalyzer: private ASTConstVisitor
 {
 public:
 	/// @param _errors the reference to the list of errors and warnings to add them found during static analysis.
-	explicit StaticAnalyzer(ErrorList& _errors): m_errors(_errors) {}
+	explicit StaticAnalyzer(ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}
 
 	/// Performs static analysis on the given source unit and all of its sub-nodes.
 	/// @returns true iff all checks passed. Note even if all checks passed, errors() can still contain warnings
 	bool analyze(SourceUnit const& _sourceUnit);
 
 private:
-	/// Adds a new warning to the list of errors.
-	void warning(SourceLocation const& _location, std::string const& _description);
 
 	virtual bool visit(ContractDefinition const& _contract) override;
 	virtual void endVisit(ContractDefinition const& _contract) override;
@@ -67,7 +65,7 @@ private:
 	virtual bool visit(MemberAccess const& _memberAccess) override;
 	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
 
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 
 	/// Flag that indicates whether the current contract definition is a library.
 	bool m_library = false;

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/analysis/SemVerHandler.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include <libsolidity/interface/Version.h>
 
 using namespace std;
@@ -29,27 +30,7 @@ using namespace dev::solidity;
 bool SyntaxChecker::checkSyntax(ASTNode const& _astRoot)
 {
 	_astRoot.accept(*this);
-	return Error::containsOnlyWarnings(m_errors);
-}
-
-void SyntaxChecker::warning(SourceLocation const& _location, string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::Warning);
-	*err <<
-		errinfo_sourceLocation(_location) <<
-		errinfo_comment(_description);
-
-	m_errors.push_back(err);
-}
-
-void SyntaxChecker::syntaxError(SourceLocation const& _location, std::string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::SyntaxError);
-	*err <<
-		errinfo_sourceLocation(_location) <<
-		errinfo_comment(_description);
-
-	m_errors.push_back(err);
+	return Error::containsOnlyWarnings(m_errorReporter.errors());
 }
 
 bool SyntaxChecker::visit(SourceUnit const&)
@@ -74,11 +55,7 @@ void SyntaxChecker::endVisit(SourceUnit const& _sourceUnit)
 				to_string(recommendedVersion.patch());
 				string(";\"");
 
-		auto err = make_shared<Error>(Error::Type::Warning);
-		*err <<
-			errinfo_sourceLocation(_sourceUnit.location()) <<
-			errinfo_comment(errorString);
-		m_errors.push_back(err);
+		m_errorReporter.warning(_sourceUnit.location(), errorString);
 	}
 }
 
@@ -87,7 +64,7 @@ bool SyntaxChecker::visit(PragmaDirective const& _pragma)
 	solAssert(!_pragma.tokens().empty(), "");
 	solAssert(_pragma.tokens().size() == _pragma.literals().size(), "");
 	if (_pragma.tokens()[0] != Token::Identifier || _pragma.literals()[0] != "solidity")
-		syntaxError(_pragma.location(), "Unknown pragma \"" + _pragma.literals()[0] + "\"");
+		m_errorReporter.syntaxError(_pragma.location(), "Unknown pragma \"" + _pragma.literals()[0] + "\"");
 	else
 	{
 		vector<Token::Value> tokens(_pragma.tokens().begin() + 1, _pragma.tokens().end());
@@ -96,7 +73,7 @@ bool SyntaxChecker::visit(PragmaDirective const& _pragma)
 		auto matchExpression = parser.parse();
 		SemVerVersion currentVersion{string(VersionString)};
 		if (!matchExpression.matches(currentVersion))
-			syntaxError(
+			m_errorReporter.syntaxError(
 				_pragma.location(),
 				"Source file requires different compiler version (current compiler is " +
 				string(VersionString) + " - note that nightly builds are considered to be "
@@ -116,7 +93,7 @@ bool SyntaxChecker::visit(ModifierDefinition const&)
 void SyntaxChecker::endVisit(ModifierDefinition const& _modifier)
 {
 	if (!m_placeholderFound)
-		syntaxError(_modifier.body().location(), "Modifier body does not contain '_'.");
+		m_errorReporter.syntaxError(_modifier.body().location(), "Modifier body does not contain '_'.");
 	m_placeholderFound = false;
 }
 
@@ -146,7 +123,7 @@ bool SyntaxChecker::visit(Continue const& _continueStatement)
 {
 	if (m_inLoopDepth <= 0)
 		// we're not in a for/while loop, report syntax error
-		syntaxError(_continueStatement.location(), "\"continue\" has to be in a \"for\" or \"while\" loop.");
+		m_errorReporter.syntaxError(_continueStatement.location(), "\"continue\" has to be in a \"for\" or \"while\" loop.");
 	return true;
 }
 
@@ -154,14 +131,14 @@ bool SyntaxChecker::visit(Break const& _breakStatement)
 {
 	if (m_inLoopDepth <= 0)
 		// we're not in a for/while loop, report syntax error
-		syntaxError(_breakStatement.location(), "\"break\" has to be in a \"for\" or \"while\" loop.");
+		m_errorReporter.syntaxError(_breakStatement.location(), "\"break\" has to be in a \"for\" or \"while\" loop.");
 	return true;
 }
 
 bool SyntaxChecker::visit(UnaryOperation const& _operation)
 {
 	if (_operation.getOperator() == Token::Add)
-		warning(_operation.location(), "Use of unary + is deprecated.");
+		m_errorReporter.warning(_operation.location(), "Use of unary + is deprecated.");
 	return true;
 }
 

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -38,14 +38,11 @@ class SyntaxChecker: private ASTConstVisitor
 {
 public:
 	/// @param _errors the reference to the list of errors and warnings to add them found during type checking.
-	SyntaxChecker(ErrorList& _errors): m_errors(_errors) {}
+	SyntaxChecker(ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}
 
 	bool checkSyntax(ASTNode const& _astRoot);
 
 private:
-	/// Adds a new error to the list of errors.
-	void warning(SourceLocation const& _location, std::string const& _description);
-	void syntaxError(SourceLocation const& _location, std::string const& _description);
 
 	virtual bool visit(SourceUnit const& _sourceUnit) override;
 	virtual void endVisit(SourceUnit const& _sourceUnit) override;
@@ -66,7 +63,7 @@ private:
 
 	virtual bool visit(PlaceholderStatement const& _placeholderStatement) override;
 
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 
 	/// Flag that indicates whether a function modifier actually contains '_'.
 	bool m_placeholderFound = false;

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include <libsolidity/analysis/TypeChecker.h>
 #include <libsolidity/ast/Types.h>
 #include <libsolidity/ast/ASTAnnotations.h>
 #include <libsolidity/ast/ASTForward.h>
@@ -33,6 +32,7 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
 
 /**
  * The module that performs type analysis on the AST, checks the applicability of operations on
@@ -43,7 +43,7 @@ class TypeChecker: private ASTConstVisitor
 {
 public:
 	/// @param _errors the reference to the list of errors and warnings to add them found during type checking.
-	TypeChecker(ErrorList& _errors): m_errors(_errors) {}
+	TypeChecker(ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}
 
 	/// Performs type checking on the given contract and all of its sub-nodes.
 	/// @returns true iff all checks passed. Note even if all checks passed, errors() can still contain warnings
@@ -56,14 +56,6 @@ public:
 	TypePointer const& type(VariableDeclaration const& _variable) const;
 
 private:
-	/// Adds a new error to the list of errors.
-	void typeError(SourceLocation const& _location, std::string const& _description);
-
-	/// Adds a new warning to the list of errors.
-	void warning(SourceLocation const& _location, std::string const& _description);
-
-	/// Adds a new error to the list of errors and throws to abort type checking.
-	void fatalTypeError(SourceLocation const& _location, std::string const& _description);
 
 	virtual bool visit(ContractDefinition const& _contract) override;
 	/// Checks that two functions defined in this contract with the same name have different
@@ -127,7 +119,7 @@ private:
 
 	ContractDefinition const* m_scope = nullptr;
 
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 }

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -520,7 +520,8 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
 bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 {
 	ErrorList errors;
-	assembly::CodeGenerator codeGen(errors);
+	ErrorReporter errorReporter(errors);
+	assembly::CodeGenerator codeGen(errorReporter);
 	unsigned startStackHeight = m_context.stackHeight();
 	julia::ExternalIdentifierAccess identifierAccess;
 	identifierAccess.resolve = [&](assembly::Identifier const& _identifier, julia::IdentifierContext)
@@ -648,7 +649,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 		m_context.nonConstAssembly(),
 		identifierAccess
 	);
-	solAssert(Error::containsOnlyWarnings(errors), "Code generation for inline assembly with errors requested.");
+	solAssert(Error::containsOnlyWarnings(errorReporter.errors()), "Code generation for inline assembly with errors requested.");
 	m_context.setStackOffset(startStackHeight);
 	return false;
 }

--- a/libsolidity/formal/Why3Translator.cpp
+++ b/libsolidity/formal/Why3Translator.cpp
@@ -32,7 +32,7 @@ bool Why3Translator::process(SourceUnit const& _source)
 	try
 	{
 		if (m_lines.size() != 1 || !m_lines.back().contents.empty())
-			fatalError(_source, "Multiple source units not yet supported");
+			fatalError(_source, string("Multiple source units not yet supported"));
 		appendPreface();
 		_source.accept(*this);
 	}
@@ -53,22 +53,6 @@ string Why3Translator::translation() const
 	for (auto const& line: m_lines)
 		result += string(line.indentation, '\t') + line.contents + "\n";
 	return result;
-}
-
-void Why3Translator::error(ASTNode const& _node, string const& _description)
-{
-	auto err = make_shared<Error>(Error::Type::Why3TranslatorError);
-	*err <<
-		errinfo_sourceLocation(_node.location()) <<
-		errinfo_comment(_description);
-	m_errors.push_back(err);
-	m_errorOccured = true;
-}
-
-void Why3Translator::fatalError(ASTNode const& _node, string const& _description)
-{
-	error(_node, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
 }
 
 string Why3Translator::toFormalType(Type const& _type) const
@@ -900,3 +884,15 @@ module Address
 end
    )", 0});
 }
+
+void Why3Translator::error(ASTNode const& _source, std::string const& _description)
+{
+	m_errorOccured = true;
+	m_errorReporter.why3TranslatorError(_source, _description);
+}
+void Why3Translator::fatalError(ASTNode const& _source, std::string const& _description)
+{
+	m_errorOccured = true;
+	m_errorReporter.fatalWhy3TranslatorError(_source, _description);
+}
+

--- a/libsolidity/inlineasm/AsmAnalysis.h
+++ b/libsolidity/inlineasm/AsmAnalysis.h
@@ -22,8 +22,6 @@
 
 #include <libsolidity/inlineasm/AsmStack.h>
 
-#include <libsolidity/interface/Exceptions.h>
-
 #include <boost/variant.hpp>
 
 #include <functional>
@@ -33,6 +31,7 @@ namespace dev
 {
 namespace solidity
 {
+class ErrorReporter;
 namespace assembly
 {
 
@@ -63,10 +62,10 @@ class AsmAnalyzer: public boost::static_visitor<bool>
 public:
 	explicit AsmAnalyzer(
 		AsmAnalysisInfo& _analysisInfo,
-		ErrorList& _errors,
+		ErrorReporter& _errorReporter,
 		bool _julia = false,
 		julia::ExternalIdentifierAccess::Resolver const& _resolver = julia::ExternalIdentifierAccess::Resolver()
-	): m_resolver(_resolver), m_info(_analysisInfo), m_errors(_errors), m_julia(_julia) {}
+	): m_resolver(_resolver), m_info(_analysisInfo), m_errorReporter(_errorReporter), m_julia(_julia) {}
 
 	bool analyze(assembly::Block const& _block);
 
@@ -95,7 +94,7 @@ private:
 	julia::ExternalIdentifierAccess::Resolver const& m_resolver;
 	Scope* m_currentScope = nullptr;
 	AsmAnalysisInfo& m_info;
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 	bool m_julia = false;
 };
 

--- a/libsolidity/inlineasm/AsmCodeGen.cpp
+++ b/libsolidity/inlineasm/AsmCodeGen.cpp
@@ -107,7 +107,7 @@ eth::Assembly assembly::CodeGenerator::assemble(
 {
 	eth::Assembly assembly;
 	EthAssemblyAdapter assemblyAdapter(assembly);
-	julia::CodeTransform(m_errors, assemblyAdapter, _parsedData, _analysisInfo, _identifierAccess);
+	julia::CodeTransform(m_errorReporter, assemblyAdapter, _parsedData, _analysisInfo, _identifierAccess);
 	return assembly;
 }
 
@@ -119,5 +119,5 @@ void assembly::CodeGenerator::assemble(
 )
 {
 	EthAssemblyAdapter assemblyAdapter(_assembly);
-	julia::CodeTransform(m_errors, assemblyAdapter, _parsedData, _analysisInfo, _identifierAccess);
+	julia::CodeTransform(m_errorReporter, assemblyAdapter, _parsedData, _analysisInfo, _identifierAccess);
 }

--- a/libsolidity/inlineasm/AsmCodeGen.h
+++ b/libsolidity/inlineasm/AsmCodeGen.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <libsolidity/inlineasm/AsmAnalysis.h>
-#include <libsolidity/interface/Exceptions.h>
 
 #include <functional>
 
@@ -35,6 +34,7 @@ class Assembly;
 }
 namespace solidity
 {
+class ErrorReporter;
 namespace assembly
 {
 struct Block;
@@ -42,8 +42,8 @@ struct Block;
 class CodeGenerator
 {
 public:
-	CodeGenerator(ErrorList& _errors):
-		m_errors(_errors) {}
+	CodeGenerator(ErrorReporter& _errorReporter):
+		m_errorReporter(_errorReporter) {}
 	/// Performs code generation and @returns the result.
 	eth::Assembly assemble(
 		Block const& _parsedData,
@@ -59,7 +59,7 @@ public:
 	);
 
 private:
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 }

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -21,10 +21,10 @@
  */
 
 #include <libsolidity/inlineasm/AsmParser.h>
+#include <libsolidity/parsing/Scanner.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include <ctype.h>
 #include <algorithm>
-#include <libsolidity/parsing/Scanner.h>
-#include <libsolidity/interface/Exceptions.h>
 
 using namespace std;
 using namespace dev;
@@ -40,7 +40,7 @@ shared_ptr<assembly::Block> Parser::parse(std::shared_ptr<Scanner> const& _scann
 	}
 	catch (FatalError const&)
 	{
-		if (m_errors.empty())
+		if (m_errorReporter.errors().empty())
 			throw; // Something is weird here, rather throw again.
 	}
 	return nullptr;

--- a/libsolidity/inlineasm/AsmParser.h
+++ b/libsolidity/inlineasm/AsmParser.h
@@ -37,7 +37,7 @@ namespace assembly
 class Parser: public ParserBase
 {
 public:
-	explicit Parser(ErrorList& _errors, bool _julia = false): ParserBase(_errors), m_julia(_julia) {}
+	explicit Parser(ErrorReporter& _errorReporter, bool _julia = false): ParserBase(_errorReporter), m_julia(_julia) {}
 
 	/// Parses an inline assembly block starting with `{` and ending with `}`.
 	/// @returns an empty shared pointer on error.

--- a/libsolidity/inlineasm/AsmScopeFiller.h
+++ b/libsolidity/inlineasm/AsmScopeFiller.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include <libsolidity/interface/Exceptions.h>
-
 #include <boost/variant.hpp>
 
 #include <functional>
@@ -29,8 +27,10 @@
 
 namespace dev
 {
+struct SourceLocation;
 namespace solidity
 {
+class ErrorReporter;
 namespace assembly
 {
 
@@ -58,7 +58,7 @@ struct AsmAnalysisInfo;
 class ScopeFiller: public boost::static_visitor<bool>
 {
 public:
-	ScopeFiller(AsmAnalysisInfo& _info, ErrorList& _errors);
+	ScopeFiller(AsmAnalysisInfo& _info, ErrorReporter& _errorReporter);
 
 	bool operator()(assembly::Instruction const&) { return true; }
 	bool operator()(assembly::Literal const&) { return true; }
@@ -84,7 +84,7 @@ private:
 
 	Scope* m_currentScope = nullptr;
 	AsmAnalysisInfo& m_info;
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 }

--- a/libsolidity/inlineasm/AsmStack.h
+++ b/libsolidity/inlineasm/AsmStack.h
@@ -22,9 +22,8 @@
 
 #pragma once
 
-#include <libsolidity/interface/Exceptions.h>
-
 #include <libjulia/backends/evm/AbstractAssembly.h>
+#include <libsolidity/interface/ErrorReporter.h>
 
 #include <string>
 #include <functional>
@@ -46,6 +45,8 @@ struct Identifier;
 class InlineAssemblyStack
 {
 public:
+	InlineAssemblyStack():
+		m_errorReporter(m_errorList) {}
 	/// Parse the given inline assembly chunk starting with `{` and ending with the corresponding `}`.
 	/// @return false or error.
 	bool parse(
@@ -65,11 +66,12 @@ public:
 		julia::ExternalIdentifierAccess const& _identifierAccess = julia::ExternalIdentifierAccess()
 	);
 
-	ErrorList const& errors() const { return m_errors; }
+	ErrorList const& errors() const { return m_errorReporter.errors(); }
 
 private:
 	std::shared_ptr<Block> m_parserResult;
-	ErrorList m_errors;
+	ErrorList m_errorList;
+	ErrorReporter m_errorReporter;
 };
 
 }

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -45,13 +45,13 @@ bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string 
 {
 	m_analysisSuccessful = false;
 	m_scanner = make_shared<Scanner>(CharStream(_source), _sourceName);
-	m_parserResult = assembly::Parser(m_errors, m_language == Language::JULIA).parse(m_scanner);
-	if (!m_errors.empty())
+	m_parserResult = assembly::Parser(m_errorReporter, m_language == Language::JULIA).parse(m_scanner);
+	if (!m_errorReporter.errors().empty())
 		return false;
 	solAssert(m_parserResult, "");
 
 	m_analysisInfo = make_shared<assembly::AsmAnalysisInfo>();
-	assembly::AsmAnalyzer analyzer(*m_analysisInfo, m_errors);
+	assembly::AsmAnalyzer analyzer(*m_analysisInfo, m_errorReporter);
 	m_analysisSuccessful = analyzer.analyze(*m_parserResult);
 	return m_analysisSuccessful;
 }
@@ -66,7 +66,7 @@ eth::LinkerObject AssemblyStack::assemble(Machine _machine)
 	{
 	case Machine::EVM:
 	{
-		auto assembly = assembly::CodeGenerator(m_errors).assemble(*m_parserResult, *m_analysisInfo);
+		auto assembly = assembly::CodeGenerator(m_errorReporter).assemble(*m_parserResult, *m_analysisInfo);
 		return assembly.assemble();
 	}
 	case Machine::EVM15:

--- a/libsolidity/interface/AssemblyStack.h
+++ b/libsolidity/interface/AssemblyStack.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/inlineasm/AsmAnalysisInfo.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include <libevmasm/LinkerObject.h>
 
 #include <string>
@@ -50,7 +50,7 @@ public:
 	enum class Machine { EVM, EVM15, eWasm };
 
 	explicit AssemblyStack(Language _language = Language::Assembly):
-		m_language(_language)
+		m_language(_language), m_errorReporter(m_errors)
 	{}
 
 	/// @returns the scanner used during parsing
@@ -79,6 +79,7 @@ private:
 	std::shared_ptr<assembly::Block> m_parserResult;
 	std::shared_ptr<assembly::AsmAnalysisInfo> m_analysisInfo;
 	ErrorList m_errors;
+	ErrorReporter m_errorReporter;
 };
 
 }

--- a/libsolidity/interface/ErrorReporter.cpp
+++ b/libsolidity/interface/ErrorReporter.cpp
@@ -1,0 +1,186 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Rhett <roadriverrail@gmail.com>
+ * @date 2017
+ * Error helper class.
+ */
+
+#include <libsolidity/interface/ErrorReporter.h>
+#include <libsolidity/ast/AST.h>
+#include <memory>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+ErrorReporter& ErrorReporter::operator=(ErrorReporter const& _errorReporter)
+{
+	if (&_errorReporter == this)
+		return *this;
+	m_errorList = _errorReporter.m_errorList;
+	return *this;
+}
+
+
+void ErrorReporter::warning(string const& _description)
+{
+	error(Error::Type::Warning, SourceLocation(), _description);
+}
+
+void ErrorReporter::warning(SourceLocation const& _location, string const& _description)
+{
+	error(Error::Type::Warning, _location, _description);
+}
+
+void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, string const& _description)
+{
+	auto err = make_shared<Error>(_type);
+	*err <<
+		errinfo_sourceLocation(_location) <<
+		errinfo_comment(_description);
+
+	m_errorList.push_back(err);
+}
+
+void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, SecondarySourceLocation const& _secondaryLocation, string const& _description)
+{
+	auto err = make_shared<Error>(_type);
+	*err <<
+		errinfo_sourceLocation(_location) <<
+		errinfo_secondarySourceLocation(_secondaryLocation) <<
+		errinfo_comment(_description);
+
+	m_errorList.push_back(err);
+}
+
+
+void ErrorReporter::fatalError(Error::Type _type, SourceLocation const& _location, string const& _description)
+{
+	error(_type, _location, _description);
+	BOOST_THROW_EXCEPTION(FatalError());
+}
+
+ErrorList const& ErrorReporter::errors() const
+{
+	return m_errorList;
+}
+
+void ErrorReporter::clear()
+{
+	m_errorList.clear();
+}
+
+void ErrorReporter::declarationError(SourceLocation const& _location, SecondarySourceLocation const&_secondaryLocation, string const& _description)
+{
+	error(
+		Error::Type::DeclarationError,
+		_location,
+		_secondaryLocation,
+		_description
+	);
+}
+
+void ErrorReporter::declarationError(SourceLocation const& _location, string const& _description)
+{
+	error(
+		Error::Type::DeclarationError,
+		_location,
+		_description
+	);
+}
+
+void ErrorReporter::fatalDeclarationError(SourceLocation const& _location, std::string const& _description)
+{
+	fatalError(
+		Error::Type::DeclarationError,
+		_location,
+		_description);
+}
+
+void ErrorReporter::parserError(SourceLocation const& _location, string const& _description)
+{
+	error(
+		Error::Type::ParserError,
+		_location,
+		_description
+	);
+}
+
+void ErrorReporter::fatalParserError(SourceLocation const& _location, string const& _description)
+{
+	fatalError(
+		Error::Type::ParserError,
+		_location,
+		_description
+	);
+}
+
+void ErrorReporter::syntaxError(SourceLocation const& _location, string const& _description)
+{
+	error(
+		Error::Type::SyntaxError,
+		_location,
+		_description
+	);
+}
+
+void ErrorReporter::typeError(SourceLocation const& _location, string const& _description)
+{
+	error(
+		Error::Type::TypeError,
+		_location,
+		_description
+	);
+}
+
+
+void ErrorReporter::fatalTypeError(SourceLocation const& _location, string const& _description)
+{
+	fatalError(Error::Type::TypeError,
+		_location,
+		_description
+	);
+}
+
+void ErrorReporter::docstringParsingError(string const& _description)
+{
+	error(
+		Error::Type::DocstringParsingError,
+		SourceLocation(),
+		_description
+	);
+}
+
+void ErrorReporter::why3TranslatorError(ASTNode const& _location, std::string const& _description)
+{
+	error(
+		Error::Type::Why3TranslatorError,
+		_location.location(),
+		_description
+	);
+}
+
+void ErrorReporter::fatalWhy3TranslatorError(ASTNode const& _location, std::string const& _description)
+{
+	fatalError(
+		Error::Type::Why3TranslatorError,
+		_location.location(),
+		_description
+	);
+}
+

--- a/libsolidity/interface/ErrorReporter.h
+++ b/libsolidity/interface/ErrorReporter.h
@@ -1,0 +1,106 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Rhett <roadriverrail@gmail.com>
+ * @date 2017
+ * Error reporting helper class.
+ */
+
+#pragma once
+
+#include <libsolidity/interface/Exceptions.h>
+#include <libevmasm/SourceLocation.h>
+
+namespace dev
+{
+namespace solidity
+{
+
+class ASTNode;
+
+class ErrorReporter
+{
+public:
+
+	ErrorReporter(ErrorList& _errors):
+		m_errorList(_errors) { }
+
+	ErrorReporter& operator=(ErrorReporter const& _errorReporter);
+
+	void warning(std::string const& _description = std::string());
+
+	void warning(
+		SourceLocation const& _location = SourceLocation(),
+		std::string const& _description = std::string()
+	);
+
+	void error(
+		Error::Type _type,
+		SourceLocation const& _location = SourceLocation(),
+		std::string const& _description = std::string()
+	);
+
+	void declarationError(
+		SourceLocation const& _location,
+		SecondarySourceLocation const& _secondaryLocation = SecondarySourceLocation(),
+		std::string const& _description = std::string()
+	);
+
+	void declarationError(
+		SourceLocation const& _location,
+		std::string const& _description = std::string()
+	);
+
+	void fatalDeclarationError(SourceLocation const& _location, std::string const& _description);
+
+	void parserError(SourceLocation const& _location, std::string const& _description);
+
+	void fatalParserError(SourceLocation const& _location, std::string const& _description);
+
+	void syntaxError(SourceLocation const& _location, std::string const& _description);
+
+	void typeError(SourceLocation const& _location, std::string const& _description);
+
+	void fatalTypeError(SourceLocation const& _location, std::string const& _description);
+
+	void docstringParsingError(std::string const& _location);
+
+	void why3TranslatorError(ASTNode const& _location, std::string const& _description);
+
+	void fatalWhy3TranslatorError(ASTNode const& _location, std::string const& _description);
+
+	ErrorList const& errors() const;
+
+	void clear();
+
+private:
+	void error(Error::Type _type,
+		SourceLocation const& _location,
+		SecondarySourceLocation const& _secondaryLocation,
+		std::string const& _description = std::string());
+
+	void fatalError(Error::Type _type,
+		SourceLocation const& _location = SourceLocation(),
+		std::string const& _description = std::string());
+
+	ErrorList& m_errorList;
+};
+
+
+}
+}
+

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -1,5 +1,6 @@
 
 #include <libsolidity/parsing/DocStringParser.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include <libsolidity/interface/Utils.h>
 
 #include <boost/range/irange.hpp>
@@ -51,9 +52,9 @@ string::const_iterator skipWhitespace(
 
 }
 
-bool DocStringParser::parse(string const& _docString, ErrorList& _errors)
+bool DocStringParser::parse(string const& _docString, ErrorReporter& _errorReporter)
 {
-	m_errors = &_errors;
+	m_errorReporter = &_errorReporter;
 	m_errorsOccurred = false;
 	m_lastTag = nullptr;
 
@@ -172,8 +173,6 @@ void DocStringParser::newTag(string const& _tagName)
 
 void DocStringParser::appendError(string const& _description)
 {
-	auto err = make_shared<Error>(Error::Type::DocstringParsingError);
-	*err << errinfo_comment(_description);
-	m_errors->push_back(err);
 	m_errorsOccurred = true;
+	m_errorReporter->docstringParsingError(_description);
 }

--- a/libsolidity/parsing/DocStringParser.h
+++ b/libsolidity/parsing/DocStringParser.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <string>
-#include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/ast/ASTAnnotations.h>
 
 namespace dev
@@ -31,12 +30,14 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
+
 class DocStringParser
 {
 public:
 	/// Parse the given @a _docString and stores the parsed components internally.
 	/// @returns false on error and appends the error to @a _errors.
-	bool parse(std::string const& _docString, ErrorList& _errors);
+	bool parse(std::string const& _docString, ErrorReporter& _errorReporter);
 
 	std::multimap<std::string, DocTag> const& tags() const { return m_docTags; }
 
@@ -62,7 +63,7 @@ private:
 	/// Mapping tag name -> content.
 	std::multimap<std::string, DocTag> m_docTags;
 	DocTag* m_lastTag = nullptr;
-	ErrorList* m_errors = nullptr;
+	ErrorReporter* m_errorReporter = nullptr;
 	bool m_errorsOccurred = false;
 };
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -26,7 +26,7 @@
 #include <libsolidity/parsing/Parser.h>
 #include <libsolidity/parsing/Scanner.h>
 #include <libsolidity/inlineasm/AsmParser.h>
-#include <libsolidity/interface/Exceptions.h>
+#include <libsolidity/interface/ErrorReporter.h>
 
 using namespace std;
 
@@ -94,7 +94,7 @@ ASTPointer<SourceUnit> Parser::parse(shared_ptr<Scanner> const& _scanner)
 	}
 	catch (FatalError const&)
 	{
-		if (m_errors.empty())
+		if (m_errorReporter.errors().empty())
 			throw; // Something is weird here, rather throw again.
 		return nullptr;
 	}
@@ -865,7 +865,7 @@ ASTPointer<InlineAssembly> Parser::parseInlineAssembly(ASTPointer<ASTString> con
 		m_scanner->next();
 	}
 
-	assembly::Parser asmParser(m_errors);
+	assembly::Parser asmParser(m_errorReporter);
 	shared_ptr<assembly::Block> block = asmParser.parse(m_scanner);
 	nodeFactory.markEndPosition();
 	return nodeFactory.createNode<InlineAssembly>(_docString, block);

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -35,7 +35,7 @@ class Scanner;
 class Parser: public ParserBase
 {
 public:
-	Parser(ErrorList& _errors): ParserBase(_errors) {}
+	Parser(ErrorReporter& _errorReporter): ParserBase(_errorReporter) {}
 
 	ASTPointer<SourceUnit> parse(std::shared_ptr<Scanner> const& _scanner);
 

--- a/libsolidity/parsing/ParserBase.cpp
+++ b/libsolidity/parsing/ParserBase.cpp
@@ -22,6 +22,7 @@
 
 #include <libsolidity/parsing/ParserBase.h>
 #include <libsolidity/parsing/Scanner.h>
+#include <libsolidity/interface/ErrorReporter.h>
 
 using namespace std;
 using namespace dev;
@@ -82,16 +83,10 @@ void ParserBase::expectToken(Token::Value _value)
 
 void ParserBase::parserError(string const& _description)
 {
-	auto err = make_shared<Error>(Error::Type::ParserError);
-	*err <<
-		errinfo_sourceLocation(SourceLocation(position(), position(), sourceName())) <<
-		errinfo_comment(_description);
-
-	m_errors.push_back(err);
+	m_errorReporter.parserError(SourceLocation(position(), position(), sourceName()), _description);
 }
 
 void ParserBase::fatalParserError(string const& _description)
 {
-	parserError(_description);
-	BOOST_THROW_EXCEPTION(FatalError());
+	m_errorReporter.fatalParserError(SourceLocation(position(), position(), sourceName()), _description);
 }

--- a/libsolidity/parsing/ParserBase.h
+++ b/libsolidity/parsing/ParserBase.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <memory>
-#include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/parsing/Scanner.h>
 #include <libsolidity/parsing/Token.h>
 
@@ -32,12 +31,13 @@ namespace dev
 namespace solidity
 {
 
+class ErrorReporter;
 class Scanner;
 
 class ParserBase
 {
 public:
-	ParserBase(ErrorList& errors): m_errors(errors) {}
+	ParserBase(ErrorReporter& errorReporter): m_errorReporter(errorReporter) {}
 
 	std::shared_ptr<std::string const> const& sourceName() const;
 
@@ -67,7 +67,7 @@ protected:
 
 	std::shared_ptr<Scanner> m_scanner;
 	/// The reference to the list of errors and warning to add errors/warnings during parsing
-	ErrorList& m_errors;
+	ErrorReporter& m_errorReporter;
 };
 
 }

--- a/solc/jsonCompiler.cpp
+++ b/solc/jsonCompiler.cpp
@@ -218,12 +218,13 @@ string compile(StringMap const& _sources, bool _optimize, CStyleReadFileCallback
 		{
 			// Do not taint the internal error list
 			ErrorList formalErrors;
-			if (compiler.prepareFormalAnalysis(&formalErrors))
+			ErrorReporter errorReporter(formalErrors);
+			if (compiler.prepareFormalAnalysis(&errorReporter))
 				output["formal"]["why3"] = compiler.formalTranslation();
-			if (!formalErrors.empty())
+			if (!errorReporter.errors().empty())
 			{
 				Json::Value errors(Json::arrayValue);
-				for (auto const& error: formalErrors)
+				for (auto const& error: errorReporter.errors())
 					errors.append(SourceReferenceFormatter::formatExceptionInformation(
 						*error,
 						(error->type() == Error::Type::Warning) ? "Warning" : "Error",

--- a/test/libjulia/Parser.cpp
+++ b/test/libjulia/Parser.cpp
@@ -45,16 +45,16 @@ namespace test
 namespace
 {
 
-bool parse(string const& _source, ErrorList& errors)
+bool parse(string const& _source, ErrorReporter& errorReporter)
 {
 	try
 	{
 		auto scanner = make_shared<Scanner>(CharStream(_source));
-		auto parserResult = assembly::Parser(errors, true).parse(scanner);
+		auto parserResult = assembly::Parser(errorReporter, true).parse(scanner);
 		if (parserResult)
 		{
 			assembly::AsmAnalysisInfo analysisInfo;
-			return (assembly::AsmAnalyzer(analysisInfo, errors, true)).analyze(*parserResult);
+			return (assembly::AsmAnalyzer(analysisInfo, errorReporter, true)).analyze(*parserResult);
 		}
 	}
 	catch (FatalError const&)
@@ -67,7 +67,8 @@ bool parse(string const& _source, ErrorList& errors)
 boost::optional<Error> parseAndReturnFirstError(string const& _source, bool _allowWarnings = true)
 {
 	ErrorList errors;
-	if (!parse(_source, errors))
+	ErrorReporter errorReporter(errors);
+	if (!parse(_source, errorReporter))
 	{
 		BOOST_REQUIRE_EQUAL(errors.size(), 1);
 		return *errors.front();

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include <libsolidity/parsing/Scanner.h>
 #include <libsolidity/parsing/Parser.h>
-#include <libsolidity/interface/Exceptions.h>
+#include <libsolidity/interface/ErrorReporter.h>
 #include "../TestHelper.h"
 #include "ErrorCheck.h"
 
@@ -41,7 +41,8 @@ namespace
 {
 ASTPointer<ContractDefinition> parseText(std::string const& _source, ErrorList& _errors)
 {
-	ASTPointer<SourceUnit> sourceUnit = Parser(_errors).parse(std::make_shared<Scanner>(CharStream(_source)));
+	ErrorReporter errorReporter(_errors);
+	ASTPointer<SourceUnit> sourceUnit = Parser(errorReporter).parse(std::make_shared<Scanner>(CharStream(_source)));
 	if (!sourceUnit)
 		return ASTPointer<ContractDefinition>();
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())


### PR DESCRIPTION
Every component in Solidity was effectively carrying its own implementation
of error( ) and warning( ).  This commit consolidates those implementations
into an ErrorReporter class which can operate on an ErrorList.  ErrorLists
are passed around by reference so that you can make a new ErrorReporter while
sharing common ErrorLists.

Left to do:

1) It hasn't been tested very well yet, but it "seems to work"
2) Really, there are objects being sent ErrorList& that probably could use an
   ErrorReporter& (NameAndTypeResolver is an example), but I haven't gotten
   to those yet

Note:

You need to run `cmake .` in order to update your makefiles to find the new
ErrorReporter sources.

This resolves issue #2209 