### PR TITLE
Analyze InlineAssembly for variable use

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ### 0.4.12 (unreleased)
 
+Bugfixes:
+ * Unused variable warnings no longer issued for variables used inside inline assembly
+
 ### 0.4.11 (2017-05-03)
 
 Features:

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -65,6 +65,7 @@ private:
 	virtual bool visit(Identifier const& _identifier) override;
 	virtual bool visit(Return const& _return) override;
 	virtual bool visit(MemberAccess const& _memberAccess) override;
+	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
 
 	ErrorList& m_errors;
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5718,6 +5718,20 @@ BOOST_AUTO_TEST_CASE(no_unused_dec_after_use)
 	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
+BOOST_AUTO_TEST_CASE(no_unused_inline_asm)
+{
+	char const* text = R"(
+		contract C {
+			function f() {
+				uint a;
+				assembly {
+					a := 1
+				}
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
 
 
 


### PR DESCRIPTION
The unused variable checker in StaticAnalyzer did not conssider
InlineAssembly objects.  This commit introduces that missing feature.

This resolves issue #2242, #2249, #2251.