### PR TITLE
Issue 2279: Log JSON RPC requests and responses when --log_level=mess…

### DIFF
--- a/test/RPCSession.cpp
+++ b/test/RPCSession.cpp
@@ -316,9 +316,9 @@ Json::Value RPCSession::rpcCall(string const& _methodName, vector<string> const&
 	request += "],\"id\":" + to_string(m_rpcSequence) + "}";
 	++m_rpcSequence;
 
-	// cout << "Request: " << request << endl;
+	BOOST_TEST_MESSAGE("Request: " + request);
 	string reply = m_ipcSocket.sendRequest(request);
-	// cout << "Reply: " << reply << endl;
+	BOOST_TEST_MESSAGE("Reply: " + reply);
 
 	Json::Value result;
 	BOOST_REQUIRE(Json::Reader().parse(reply, result, false));


### PR DESCRIPTION
This changes allows using the Boost Test --log_level parameter to see RCP requests and responses. the feature can be seen by running:

./soltest --log_level=message -- --ipcpath /tmp/testeth/geth.ipc

This was very valuable in getting details on why RPC tests were failing when executing soltest against the latest version of cpp-ethereum.