### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,h}]
+indent_style = tab
+
+[*.{py,rst,sh,yml}]
+indent_style = space
+indent_size = 4
+
+[std/**.sol]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) is a standard supported by several editors and makes it really easy to set them up according to the project style rules.

I also did some work with `clang-format` but some bugs make it hard to configure it to follow the exact current style, and I don't want it to force major style changes in the project.