### PR TITLE
add legacy/compact AST-format options to CLI

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -119,7 +119,7 @@ Input Description
         //
         // The available output types are as follows:
         //   abi - ABI
-        //   ast - AST of all source files (not supported atm)
+        //   ast - AST of all source files
         //   legacyAST - legacy AST of all source files
         //   devdoc - Developer documentation (natspec)
         //   userdoc - User documentation (natspec)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -894,7 +894,7 @@ void CommandLineInterface::handleAst(string const& _argStr)
 				}
 				else
 				{
-					ASTJsonConverter(legacyFormat).print(data, m_compiler->ast(sourceCode.first));
+					ASTJsonConverter(legacyFormat, m_compiler->sourceIndices()).print(data, m_compiler->ast(sourceCode.first));
 					postfix += "_json";
 				}
 				boost::filesystem::path path(sourceCode.first);
@@ -917,7 +917,7 @@ void CommandLineInterface::handleAst(string const& _argStr)
 					printer.print(cout);
 				}
 				else
-					ASTJsonConverter(legacyFormat).print(cout, m_compiler->ast(sourceCode.first));
+					ASTJsonConverter(legacyFormat, m_compiler->sourceIndices()).print(cout, m_compiler->ast(sourceCode.first));
 			}
 		}
 	}


### PR DESCRIPTION
- standard-json doc updated saying both formats are supported
- another option --ast-compact-json
- includes extra argument "compact-format" for option --combined-json 
