### PR TITLE
Enabling --combined-json to output to file using the -o flag

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -910,7 +910,11 @@ void CommandLineInterface::handleCombinedJSON()
 			output[g_strSources][sourceCode.first]["AST"] = converter.toJson(m_compiler->ast(sourceCode.first));
 		}
 	}
-	cout << dev::jsonCompactPrint(output) << endl;
+
+	if (m_args.count(g_argOutputDir))
+		createJson("combined", output);
+	else
+		cout << dev::jsonCompactPrint(output) << endl;
 }
 
 void CommandLineInterface::handleAst(string const& _argStr)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -508,6 +508,11 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 		BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + pathName));
 }
 
+void CommandLineInterface::createJson(string const& _fileName, Json::Value const& _json)
+{
+	createFile(boost::filesystem::basename(_fileName) + string(".json"), dev::jsonCompactPrint(_json));
+}
+
 bool CommandLineInterface::parseArguments(int _argc, char** _argv)
 {
 	// Declare the supported options.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -112,10 +112,12 @@ static string const g_strSourceList = "sourceList";
 static string const g_strSrcMap = "srcmap";
 static string const g_strSrcMapRuntime = "srcmap-runtime";
 static string const g_strStandardJSON = "standard-json";
+static string const g_strPrettyJson = "pretty-json";
 static string const g_strVersion = "version";
 
 static string const g_argAbi = g_strAbi;
 static string const g_argAddStandard = g_strAddStandard;
+static string const g_argPrettyJson = g_strPrettyJson;
 static string const g_argAllowPaths = g_strAllowPaths;
 static string const g_argAsm = g_strAsm;
 static string const g_argAsmJson = g_strAsmJson;
@@ -508,9 +510,9 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 		BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + pathName));
 }
 
-void CommandLineInterface::createJson(string const& _fileName, Json::Value const& _json)
+void CommandLineInterface::createJson(string const& _fileName, string const& _json)
 {
-	createFile(boost::filesystem::basename(_fileName) + string(".json"), dev::jsonCompactPrint(_json));
+	createFile(boost::filesystem::basename(_fileName) + string(".json"), _json);
 }
 
 bool CommandLineInterface::parseArguments(int _argc, char** _argv)
@@ -546,6 +548,7 @@ Allowed options)",
 			"Estimated number of contract runs for optimizer tuning."
 		)
 		(g_argAddStandard.c_str(), "Add standard contracts.")
+		(g_argPrettyJson.c_str(), "Output JSON in pretty format. Currently it only works with the combined JSON output.")
 		(
 			g_argLibraries.c_str(),
 			po::value<vector<string>>()->value_name("libs"),
@@ -911,10 +914,12 @@ void CommandLineInterface::handleCombinedJSON()
 		}
 	}
 
+	string json = m_args.count(g_argPrettyJson) ? dev::jsonPrettyPrint(output) : dev::jsonCompactPrint(output);
+
 	if (m_args.count(g_argOutputDir))
-		createJson("combined", output);
+		createJson("combined", json);
 	else
-		cout << dev::jsonCompactPrint(output) << endl;
+		cout << json << endl;
 }
 
 void CommandLineInterface::handleAst(string const& _argStr)

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -81,6 +81,11 @@ private:
 	/// @arg _data to be written
 	void createFile(std::string const& _fileName, std::string const& _data);
 
+	/// Create a json file in the given directory
+	/// @arg _fileName the name of the file (the extension will be replaced with .json)
+	/// @arg _json to be written
+	void createJson(std::string const& _fileName, Json::Value const& _json);
+
 	bool m_error = false; ///< If true, some error occurred.
 
 	bool m_onlyAssemble = false;

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -83,8 +83,8 @@ private:
 
 	/// Create a json file in the given directory
 	/// @arg _fileName the name of the file (the extension will be replaced with .json)
-	/// @arg _json to be written
-	void createJson(std::string const& _fileName, Json::Value const& _json);
+	/// @arg _json json string to be written
+	void createJson(std::string const& _fileName, std::string const& _json);
 
 	bool m_error = false; ///< If true, some error occurred.
 


### PR DESCRIPTION
Prior to these changes `solc --combined-json abi,bin Contract.sol -o outdir` ignored the output dir and wrote the output to stdout. 

This PR enables you to specify the output dir for the JSON file to be written to.