### PR TITLE
Scanner requires only the SourcesSet state

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -507,7 +507,7 @@ string const& CompilerStack::onChainMetadata(string const& _contractName) const
 
 Scanner const& CompilerStack::scanner(string const& _sourceName) const
 {
-	if (m_stackState < ParsingSuccessful)
+	if (m_stackState < SourcesSet)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
 
 	return *source(_sourceName).scanner;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -508,7 +508,7 @@ string const& CompilerStack::onChainMetadata(string const& _contractName) const
 Scanner const& CompilerStack::scanner(string const& _sourceName) const
 {
 	if (m_stackState < SourcesSet)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
+		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("No sources set."));
 
 	return *source(_sourceName).scanner;
 }


### PR DESCRIPTION
Basically without this, inline assembly parser errors within Solidity code result in a generic "Parsing was not successful." error.