### PR TITLE
Introduce virtual blocks for function arguments.

### DIFF
--- a/libsolidity/inlineasm/AsmAnalysis.h
+++ b/libsolidity/inlineasm/AsmAnalysis.h
@@ -91,10 +91,6 @@ private:
 	Scope& scope(assembly::Block const* _block);
 	void expectValidType(std::string const& type, SourceLocation const& _location);
 
-	/// This is used when we enter the body of a function definition. There, the parameters
-	/// and return parameters appear as variables which are already on the stack before
-	/// we enter the block.
-	int m_virtualVariablesInNextBlock = 0;
 	int m_stackHeight = 0;
 	julia::ExternalIdentifierAccess::Resolver const& m_resolver;
 	Scope* m_currentScope = nullptr;

--- a/libsolidity/inlineasm/AsmAnalysisInfo.h
+++ b/libsolidity/inlineasm/AsmAnalysisInfo.h
@@ -24,6 +24,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 namespace dev
 {
@@ -55,6 +56,8 @@ struct AsmAnalysisInfo
 	using Scopes = std::map<assembly::Block const*, std::shared_ptr<Scope>>;
 	Scopes scopes;
 	StackHeightInfo stackHeightInfo;
+	/// Virtual blocks which will be used for scopes for function arguments and return values.
+	std::map<FunctionDefinition const*, std::shared_ptr<assembly::Block const>> virtualBlocks;
 };
 
 }

--- a/libsolidity/inlineasm/AsmScopeFiller.h
+++ b/libsolidity/inlineasm/AsmScopeFiller.h
@@ -49,6 +49,7 @@ struct FunctionCall;
 struct Switch;
 
 struct Scope;
+struct AsmAnalysisInfo;
 
 /**
  * Fills scopes with identifiers and checks for name clashes.
@@ -57,8 +58,7 @@ struct Scope;
 class ScopeFiller: public boost::static_visitor<bool>
 {
 public:
-	using Scopes = std::map<assembly::Block const*, std::shared_ptr<Scope>>;
-	ScopeFiller(Scopes& _scopes, ErrorList& _errors);
+	ScopeFiller(AsmAnalysisInfo& _info, ErrorList& _errors);
 
 	bool operator()(assembly::Instruction const&) { return true; }
 	bool operator()(assembly::Literal const&) { return true; }
@@ -83,7 +83,7 @@ private:
 	Scope& scope(assembly::Block const* _block);
 
 	Scope* m_currentScope = nullptr;
-	Scopes& m_scopes;
+	AsmAnalysisInfo& m_info;
 	ErrorList& m_errors;
 };
 


### PR DESCRIPTION
Refactoring that moves the function argument and return values into their own scope and removes some weird workarounds.