### PR TITLE
Ignore qtcreator settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ docs/utils/__pycache__
 # IDE files
 .idea
 browse.VC.db
+CMakeLists.txt.user


### PR DESCRIPTION
Qtcreator keeps its project settings in CMakeLists.txt.user.  Probably worth ignoring it like we do with the others.