### PR TITLE
Change LLL opcode generated by "panic" to INVALID

### DIFF
--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -573,10 +573,6 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 				m_asm.append(i.m_asm);
 			m_asm.popTo(1);
 		}
-		else if (us == "PANIC")
-		{
-			m_asm.appendJump(m_asm.errorTag());
-		}
 		else if (us == "BYTECODESIZE")
 		{
 			m_asm.appendProgramSize();

--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -45,6 +45,7 @@ CodeFragment const& CompilerState::getDef(std::string const& _s)
 void CompilerState::populateStandard()
 {
 	static const string s = "{"
+	"(def 'panic () (asm INVALID))"
 	"(def 'allgas (- (gas) 21))"
 	"(def 'send (to value) (call allgas to value 0 0 0 0))"
 	"(def 'send (gaslimit to value) (call gaslimit to value 0 0 0 0))"


### PR DESCRIPTION
EIP-141 ethereum/EIPs#141 has preserved 0xfe as an invalid opcode for aborting EVM execution. The EVM assembler supports this via the INVALID opcode. 

The LLL "panic" expression used to generate a jump to an invalid location in order to abort EVM execution.  This change brings "panic" into line with EIP-141 by generating the INVALID opcode instead.