### PR TITLE
LLL: macro with zero args

### DIFF
--- a/liblll/Parser.cpp
+++ b/liblll/Parser.cpp
@@ -109,7 +109,7 @@ void dev::eth::parseTreeLLL(string const& _s, sp::utree& o_out)
 	qi::rule<it, space_type, sp::utree::list_type()> mstore = '[' > element > ']' > -qi::lit(":") > element;
 	qi::rule<it, space_type, sp::utree::list_type()> sstore = qi::lit("[[") > element > qi::lit("]]") > -qi::lit(":") > element;
 	qi::rule<it, space_type, sp::utree::list_type()> calldataload = qi::lit("$") > element;
-	qi::rule<it, space_type, sp::utree::list_type()> list = '(' > +element > ')';
+	qi::rule<it, space_type, sp::utree::list_type()> list = '(' > *element > ')';
 
 	qi::rule<it, space_type, sp::utree()> extra = sload[tagNode<2>()] | mload[tagNode<1>()] | sstore[tagNode<4>()] | mstore[tagNode<3>()] | seq[tagNode<5>()] | calldataload[tagNode<6>()];
 	element = atom | list | extra;

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -284,11 +284,11 @@ BOOST_AUTO_TEST_CASE(zeroarg_macro)
 	char const* sourceCode = R"(
 		(returnlll
 			(seq
-				(def 'zeroarg () (asm INVALID))
+				(def 'zeroarg () (seq (mstore 0 0x1234) (return 0 32)))
 				(zeroarg)))
 	)";
 	compileAndRun(sourceCode);
-	BOOST_CHECK(callFallback() == encodeArgs());
+	BOOST_CHECK(callFallback() == encodeArgs(u256(0x1234)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -279,6 +279,18 @@ BOOST_AUTO_TEST_CASE(assembly_codecopy)
 	BOOST_CHECK(callFallback() == encodeArgs(string("abcdef")));
 }
 
+BOOST_AUTO_TEST_CASE(zeroarg_macro)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(seq
+				(def 'zeroarg () (asm INVALID))
+				(zeroarg)))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallback() == encodeArgs());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/liblll/Parser.cpp
+++ b/test/liblll/Parser.cpp
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(list)
 	BOOST_CHECK_EQUAL(parse(text), R"(( 1234 ))");
 
 	BOOST_CHECK(successParse("( 1234 5467 )"));
-	BOOST_CHECK(!successParse("()"));
+	BOOST_CHECK(successParse("()"));
 }
 
 BOOST_AUTO_TEST_CASE(macro_with_zero_args)

--- a/test/liblll/Parser.cpp
+++ b/test/liblll/Parser.cpp
@@ -174,6 +174,12 @@ BOOST_AUTO_TEST_CASE(list)
 	BOOST_CHECK(!successParse("()"));
 }
 
+BOOST_AUTO_TEST_CASE(macro_with_zero_args)
+{
+	char const* text = "(def 'zeroargs () (asm INVALID))";
+	BOOST_CHECK(successParse(text));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
On `develop`, LLL macros with zero arguments were not definable because `()` was not a valid list.

However, #2350 found a usage for that:  `(panic)`.

This PR modifies the parser so that LLL macros with zero arguments can be defined.