### PR TITLE
Forbid trailing commas in named arguments

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1328,16 +1328,21 @@ pair<vector<ASTPointer<Expression>>, vector<ASTPointer<ASTString>>> Parser::pars
 	{
 		// call({arg1 : 1, arg2 : 2 })
 		expectToken(Token::LBrace);
+
+		bool first = true;
 		while (m_scanner->currentToken() != Token::RBrace)
 		{
+			if (!first)
+				expectToken(Token::Comma);
+
+			if (m_scanner->currentToken() == Token::RBrace)
+				fatalParserError("Unexpected trailing comma.");
+
 			ret.second.push_back(expectIdentifierToken());
 			expectToken(Token::Colon);
 			ret.first.push_back(parseExpression());
 
-			if (m_scanner->currentToken() == Token::Comma)
-				expectToken(Token::Comma);
-			else
-				break;
+			first = false;
 		}
 		expectToken(Token::RBrace);
 	}

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -199,6 +199,17 @@ BOOST_AUTO_TEST_CASE(missing_argument_in_named_args)
 	CHECK_PARSE_ERROR(text, "Expected primary expression");
 }
 
+BOOST_AUTO_TEST_CASE(trailing_comma_in_named_args)
+{
+	char const* text = R"(
+		contract test {
+			function a(uint a, uint b, uint c) returns (uint r) { r = a * 100 + b * 10 + c * 1; }
+			function b() returns (uint r) { r = a({a: 1, b: 2, c: 3, }); }
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma");
+}
+
 BOOST_AUTO_TEST_CASE(two_exact_functions)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes #2385. Error position is reported incorrectly, but that requires an error API that can receive a custom SourceLocation object.