### PR TITLE
Convert license to character array.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,11 @@ include(EthExecutableHelper)
 include(EthUtils)
 
 # Create license.h from LICENSE.txt and template
-file(READ ${CMAKE_SOURCE_DIR}/LICENSE.txt LICENSE_TEXT)
+# Converting to char array is required due to MSVC's string size limit.
+file(READ ${CMAKE_SOURCE_DIR}/LICENSE.txt LICENSE_TEXT HEX)
+string(REGEX MATCHALL ".." LICENSE_TEXT "${LICENSE_TEXT}")
+string(REGEX REPLACE ";" ",\t0x" LICENSE_TEXT "${LICENSE_TEXT}")
+
 configure_file("${CMAKE_SOURCE_DIR}/cmake/templates/license.h.in" "license.h")
 
 include(EthOptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ include(EthUtils)
 # Converting to char array is required due to MSVC's string size limit.
 file(READ ${CMAKE_SOURCE_DIR}/LICENSE.txt LICENSE_TEXT HEX)
 string(REGEX MATCHALL ".." LICENSE_TEXT "${LICENSE_TEXT}")
-string(REGEX REPLACE ";" ",\t0x" LICENSE_TEXT "${LICENSE_TEXT}")
+string(REGEX REPLACE ";" ",\n\t0x" LICENSE_TEXT "${LICENSE_TEXT}")
+set(LICENSE_TEXT "0x${LICENSE_TEXT}")
 
 configure_file("${CMAKE_SOURCE_DIR}/cmake/templates/license.h.in" "license.h")
 

--- a/cmake/templates/license.h.in
+++ b/cmake/templates/license.h.in
@@ -1,5 +1,5 @@
 #pragma once
 
-static char licenseText[] = {
-	0x@LICENSE_TEXT@
+static char const licenseText[] = {
+	@LICENSE_TEXT@
 };

--- a/cmake/templates/license.h.in
+++ b/cmake/templates/license.h.in
@@ -1,3 +1,5 @@
 #pragma once
 
-static char const* licenseText = R"(@LICENSE_TEXT@)";
+static char licenseText[] = {
+	0x@LICENSE_TEXT@
+};


### PR DESCRIPTION
MSVC has a limit on the size of a string literal (2kb), but I heard this does not apply to character arrays, so this should fix our build issues.