### PR TITLE
Support shl/shr in LLL

### DIFF
--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -74,6 +74,9 @@ void CompilerState::populateStandard()
 	"(def 'szabo 1000000000000)"
 	"(def 'finney 1000000000000000)"
 	"(def 'ether 1000000000000000000)"
+	// these could be replaced by native instructions once supported by EVM
+	"(def 'shl (val shift) (mul val (exp 2 shift)))"
+	"(def 'shr (val shift) (div val (exp 2 shift)))"
 	"}";
 	CodeFragment::compile(s, *this);
 }

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -328,6 +328,26 @@ BOOST_AUTO_TEST_CASE(sha3_one_arg)
 		fromHex("b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6")));
 }
 
+BOOST_AUTO_TEST_CASE(shift_left)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(return (shl 1 8)))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallback() == encodeArgs(u256(256)));
+}
+
+BOOST_AUTO_TEST_CASE(shift_right)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(return (shr 65536 8)))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallback() == encodeArgs(u256(256)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
This will be replaced by native shift operators once they are supported in EVM (EIP145).

Note: with the optimiser enabled, this is optimised to a constant div/mul (or even to a constant literal if both sides are literals).