### PR TITLE
Peephole optimizer for double push.

### DIFF
--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -148,6 +148,14 @@ private:
 
 using AssemblyItems = std::vector<AssemblyItem>;
 
+inline size_t bytesRequired(AssemblyItems const& _items, size_t _addressLength)
+{
+	size_t size = 0;
+	for (AssemblyItem const& item: _items)
+		size += item.bytesRequired(_addressLength);
+	return size;
+}
+
 std::ostream& operator<<(std::ostream& _out, AssemblyItem const& _item);
 inline std::ostream& operator<<(std::ostream& _out, AssemblyItems const& _items)
 {

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -99,10 +99,7 @@ bigint ConstantOptimisationMethod::dataGas(bytes const& _data) const
 
 size_t ConstantOptimisationMethod::bytesRequired(AssemblyItems const& _items)
 {
-	size_t size = 0;
-	for (AssemblyItem const& item: _items)
-		size += item.bytesRequired(3); // assume 3 byte addresses
-	return size;
+	return eth::bytesRequired(_items, 3); // assume 3 byte addresses
 }
 
 void ConstantOptimisationMethod::replaceConstants(

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(assembly_codecopy)
 			(seq
 				(lit 0x00 "abcdef")
 				(asm
-					0x06 0x16 0x20 codecopy
+					0x06 6 codesize sub 0x20 codecopy
 					0x20 0x20 return)))
 	)";
 	compileAndRun(sourceCode);

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -1189,6 +1189,32 @@ BOOST_AUTO_TEST_CASE(clear_unreachable_code)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(peephole_double_push)
+{
+	AssemblyItems items{
+		u256(0),
+		u256(0),
+		u256(5),
+		u256(5),
+		u256(4),
+		u256(5)
+	};
+	AssemblyItems expectation{
+		u256(0),
+		Instruction::DUP1,
+		u256(5),
+		Instruction::DUP1,
+		u256(4),
+		u256(5)
+	};
+	PeepholeOptimiser peepOpt(items);
+	BOOST_REQUIRE(peepOpt.optimise());
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		items.begin(), items.end(),
+		expectation.begin(), expectation.end()
+	);
+}
+
 BOOST_AUTO_TEST_CASE(computing_constants)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
This replaces `0 0` by `0 DUP1` (which is 1 byte shorter)