### PR TITLE
LLL: Fix for edge case in the create macros.

### DIFF
--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -54,8 +54,9 @@ void CompilerState::populateStandard()
 	"(def 'msg (gaslimit to value data) { [0]:data (msg gaslimit to value 0 32) })"
 	"(def 'msg (to value data) { [0]:data (msg allgas to value 0 32) })"
 	"(def 'msg (to data) { [0]:data (msg allgas to 0 0 32) })"
-	"(def 'create (value code) { [0]:(msize) (create value @0 (lll code @0)) })"
-	"(def 'create (code) { [0]:(msize) (create 0 @0 (lll code @0)) })"
+	// NOTE: in the create macros, memory location 0 is set in order to force msize to be at least 32 bytes.
+	"(def 'create (value code) { [0]:0 [0]:(msize) (create value @0 (lll code @0)) })"
+	"(def 'create (code) { [0]:0 [0]:(msize) (create 0 @0 (lll code @0)) })"
 	"(def 'sha3 (loc len) (keccak256 loc len))"
 	"(def 'sha3 (val) { [0]:val (sha3 0 32) })"
 	"(def 'sha3pair (a b) { [0]:a [32]:b (sha3 0 64) })"

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -304,6 +304,34 @@ BOOST_AUTO_TEST_CASE(keccak256_32bytes)
 		fromHex("b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6")));
 }
 
+BOOST_AUTO_TEST_CASE(create_1_arg)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(seq
+				(call allgas
+					(create (returnlll (return 42)))
+					0 0 0 0x00 0x20)
+				(return 0x00 0x20)))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallback() == encodeArgs(u256(42)));
+}
+
+BOOST_AUTO_TEST_CASE(create_2_args)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(seq
+				(call allgas
+					(create 42 (returnlll (return (balance (address)))))
+					0 0 0 0x00 0x20)
+				(return 0x00 0x20)))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallbackWithValue(42) == encodeArgs(u256(42)));
+}
+
 BOOST_AUTO_TEST_CASE(sha3_two_args)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
When (msize) is initially zero, the former create commands failed due to the "lll" expression overwriting the memory at 0x00. This fix reserves memory location 0x00 before calling msize. If msize is already 32 or greater it has no effect.

Test cases are included.