### PR TITLE
LLL: Correctly label arguments to ecrecover built-in macro.

### DIFF
--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -65,7 +65,7 @@ void CompilerState::populateStandard()
 	"(def 'makeperm (name pos) { (def name (sload pos)) (def name (v) (sstore pos v)) } )"
 	"(def 'permcount 0)"
 	"(def 'perm (name) { (makeperm name permcount) (def 'permcount (+ permcount 1)) } )"
-	"(def 'ecrecover (r s v hash) { [0] r [32] s [64] v [96] hash (msg allgas 1 0 0 128) })"
+	"(def 'ecrecover (hash v r s) { [0] hash [32] v [64] r [96] s (msg allgas 1 0 0 128) })"
 	"(def 'sha256 (data datasize) (msg allgas 2 0 data datasize))"
 	"(def 'ripemd160 (data datasize) (msg allgas 3 0 data datasize))"
 	"(def 'sha256 (val) { [0]:val (sha256 0 32) })"

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -328,6 +328,25 @@ BOOST_AUTO_TEST_CASE(sha3_one_arg)
 		fromHex("b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6")));
 }
 
+BOOST_AUTO_TEST_CASE(ecrecover)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(return
+				(ecrecover
+					; Hash of 'hello world'
+					0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad
+					; v = 1 + 27
+					0x1c
+					; r
+					0xdebaaa0cddb321b2dcaaf846d39605de7b97e77ba6106587855b9106cb104215
+					; s
+					0x61a22d94fa8b8a687ff9c911c844d1c016d1a685a9166858f9c7c1bc85128aca)))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallback() == encodeArgs(fromHex("0x8743523d96a1b2cbe0c6909653a56da18ed484af")));
+}
+
 BOOST_AUTO_TEST_CASE(shift_left)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
(r s v hash) -> (hash v r s) which corresponds to the order that the built-in EVM contract uses.

This ought not affect any existing code - it's just a relabelling. The existing labelling is quite wrong.

Test case included, based on the [example code](https://gist.github.com/axic/5b33912c6f61ae6fd96d6c4a47afde6d) by @axic.