### PR TITLE
[WIP] Struct encoder

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -145,6 +145,13 @@ inline std::string toHex(u256 val, HexPrefix prefix = HexPrefix::DontAdd)
 	return (prefix == HexPrefix::Add) ? "0x" + str : str;
 }
 
+inline std::string toCompactHexWithPrefix(u256 val)
+{
+	std::ostringstream ret;
+	ret << std::hex << val;
+	return "0x" + ret.str();
+}
+
 // Algorithms for string and string-like collections.
 
 /// Escapes a string into the C-string representation.

--- a/libdevcore/Whiskers.cpp
+++ b/libdevcore/Whiskers.cpp
@@ -90,7 +90,7 @@ string Whiskers::replace(
 		string tagName(_match[1]);
 		if (!tagName.empty())
 		{
-			assertThrow(_parameters.count(tagName), WhiskersError, "Tag " + tagName + " not found.");
+			assertThrow(_parameters.count(tagName), WhiskersError, "Value for tag " + tagName + " not provided.");
 			return _parameters.at(tagName);
 		}
 		else

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -573,7 +573,7 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 		_variable.visibility() >= VariableDeclaration::Visibility::Public &&
 		!FunctionType(_variable).interfaceFunctionType()
 	)
-		m_errorReporter.typeError(_variable.location(), "Internal type is not allowed for public state variables.");
+		m_errorReporter.typeError(_variable.location(), "Internal or recursive type is not allowed for public state variables.");
 
 	if (varType->category() == Type::Category::Array)
 		if (auto arrayType = dynamic_cast<ArrayType const*>(varType.get()))
@@ -664,7 +664,7 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 		if (!type(*var)->canLiveOutsideStorage())
 			m_errorReporter.typeError(var->location(), "Type is required to live outside storage.");
 		if (!type(*var)->interfaceType(false))
-			m_errorReporter.typeError(var->location(), "Internal type is not allowed as event parameter type.");
+			m_errorReporter.typeError(var->location(), "Internal or recursive type is not allowed as event parameter type.");
 	}
 	return false;
 }

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -483,7 +483,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		if (!type(*var)->canLiveOutsideStorage())
 			m_errorReporter.typeError(var->location(), "Type is required to live outside storage.");
 		if (_function.visibility() >= FunctionDefinition::Visibility::Public && !(type(*var)->interfaceType(isLibraryFunction)))
-			m_errorReporter.fatalTypeError(var->location(), "Internal type is not allowed for public or external functions.");
+			m_errorReporter.fatalTypeError(var->location(), "Internal or recursive type is not allowed for public or external functions.");
 
 		var->accept(*this);
 	}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -33,6 +33,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/adaptor/reversed.hpp>
+#include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -1464,7 +1465,7 @@ string ArrayType::toString(bool _short) const
 	return ret;
 }
 
-string ArrayType::canonicalName(bool _addDataLocation) const
+string ArrayType::canonicalName() const
 {
 	string ret;
 	if (isString())
@@ -1473,14 +1474,27 @@ string ArrayType::canonicalName(bool _addDataLocation) const
 		ret = "bytes";
 	else
 	{
-		ret = baseType()->canonicalName(false) + "[";
+		ret = baseType()->canonicalName() + "[";
 		if (!isDynamicallySized())
 			ret += length().str();
 		ret += "]";
 	}
-	if (_addDataLocation && location() == DataLocation::Storage)
-		ret += " storage";
 	return ret;
+}
+
+string ArrayType::signatureInExternalFunction(bool _structsByName) const
+{
+	if (isByteArray())
+		return canonicalName();
+	else
+	{
+		solAssert(baseType(), "");
+		return
+			baseType()->signatureInExternalFunction(_structsByName) +
+			"[" +
+			(isDynamicallySized() ? "" : length().str()) +
+			"]";
+	}
 }
 
 MemberList::MemberMap ArrayType::nativeMembers(ContractDefinition const*) const
@@ -1591,7 +1605,7 @@ string ContractType::toString(bool) const
 		m_contract.name();
 }
 
-string ContractType::canonicalName(bool) const
+string ContractType::canonicalName() const
 {
 	return m_contract.annotation().canonicalName;
 }
@@ -1721,9 +1735,8 @@ bool StructType::isDynamicallyEncoded() const
 u256 StructType::memorySize() const
 {
 	u256 size;
-	for (auto const& member: members(nullptr))
-		if (member.type->canLiveOutsideStorage())
-			size += member.type->memoryHeadSize();
+	for (auto const& t: memoryMemberTypes())
+		size += t->memoryHeadSize();
 	return size;
 }
 
@@ -1776,12 +1789,25 @@ TypePointer StructType::copyForLocation(DataLocation _location, bool _isPointer)
 	return copy;
 }
 
-string StructType::canonicalName(bool _addDataLocation) const
+string StructType::signatureInExternalFunction(bool _structsByName) const
 {
-	string ret = m_struct.annotation().canonicalName;
-	if (_addDataLocation && location() == DataLocation::Storage)
-		ret += " storage";
-	return ret;
+	if (_structsByName)
+		return canonicalName();
+	else
+	{
+		TypePointers memberTypes = memoryMemberTypes();
+		auto memberTypeStrings = memberTypes | boost::adaptors::transformed([&](TypePointer _t) -> string
+		{
+			solAssert(_t, "Parameter should have external type.");
+			return _t->signatureInExternalFunction(_structsByName);
+		});
+		return "(" + boost::algorithm::join(memberTypeStrings, ",") + ")";
+	}
+}
+
+string StructType::canonicalName() const
+{
+	return m_struct.annotation().canonicalName;
 }
 
 FunctionTypePointer StructType::constructorType() const
@@ -1821,6 +1847,15 @@ u256 StructType::memoryOffsetOfMember(string const& _name) const
 			offset += member.type->memoryHeadSize();
 	solAssert(false, "Member not found in struct.");
 	return 0;
+}
+
+TypePointers StructType::memoryMemberTypes() const
+{
+	TypePointers types;
+	for (ASTPointer<VariableDeclaration> const& variable: m_struct.members())
+		if (variable->annotation().type->canLiveOutsideStorage())
+			types.push_back(variable->annotation().type);
+	return types;
 }
 
 set<string> StructType::membersMissingInMemory() const
@@ -1887,7 +1922,7 @@ string EnumType::toString(bool) const
 	return string("enum ") + m_enum.annotation().canonicalName;
 }
 
-string EnumType::canonicalName(bool) const
+string EnumType::canonicalName() const
 {
 	return m_enum.annotation().canonicalName;
 }
@@ -2313,7 +2348,7 @@ TypePointer FunctionType::binaryOperatorResult(Token::Value _operator, TypePoint
 	return TypePointer();
 }
 
-string FunctionType::canonicalName(bool) const
+string FunctionType::canonicalName() const
 {
 	solAssert(m_kind == Kind::External, "");
 	return "function";
@@ -2556,20 +2591,19 @@ string FunctionType::externalSignature() const
 	solAssert(m_declaration != nullptr, "External signature of function needs declaration");
 	solAssert(!m_declaration->name().empty(), "Fallback function has no signature.");
 
-	bool _inLibrary = dynamic_cast<ContractDefinition const&>(*m_declaration->scope()).isLibrary();
-
-	string ret = m_declaration->name() + "(";
-
+	bool const inLibrary = dynamic_cast<ContractDefinition const&>(*m_declaration->scope()).isLibrary();
 	FunctionTypePointer external = interfaceFunctionType();
 	solAssert(!!external, "External function type requested.");
-	TypePointers externalParameterTypes = external->parameterTypes();
-	for (auto it = externalParameterTypes.cbegin(); it != externalParameterTypes.cend(); ++it)
+	auto parameterTypes = external->parameterTypes();
+	auto typeStrings = parameterTypes | boost::adaptors::transformed([&](TypePointer _t) -> string
 	{
-		solAssert(!!(*it), "Parameter should have external type");
-		ret += (*it)->canonicalName(_inLibrary) + (it + 1 == externalParameterTypes.cend() ? "" : ",");
-	}
-
-	return ret + ")";
+		solAssert(_t, "Parameter should have external type.");
+		string typeName = _t->signatureInExternalFunction(inLibrary);
+		if (inLibrary && _t->dataStoredIn(DataLocation::Storage))
+			typeName += " storage";
+		return typeName;
+	});
+	return m_declaration->name() + "(" + boost::algorithm::join(typeStrings, ",") + ")";
 }
 
 u256 FunctionType::externalIdentifier() const
@@ -2700,9 +2734,9 @@ string MappingType::toString(bool _short) const
 	return "mapping(" + keyType()->toString(_short) + " => " + valueType()->toString(_short) + ")";
 }
 
-string MappingType::canonicalName(bool) const
+string MappingType::canonicalName() const
 {
-	return "mapping(" + keyType()->canonicalName(false) + " => " + valueType()->canonicalName(false) + ")";
+	return "mapping(" + keyType()->canonicalName() + " => " + valueType()->canonicalName() + ")";
 }
 
 string TypeType::identifier() const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1764,7 +1764,7 @@ TypePointer StructType::interfaceType(bool _inLibrary) const
 	if (_inLibrary && location() == DataLocation::Storage)
 		return shared_from_this();
 	else
-		return TypePointer();
+		return copyForLocation(DataLocation::Memory, true);
 }
 
 TypePointer StructType::copyForLocation(DataLocation _location, bool _isPointer) const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1763,8 +1763,10 @@ TypePointer StructType::interfaceType(bool _inLibrary) const
 {
 	if (_inLibrary && location() == DataLocation::Storage)
 		return shared_from_this();
-	else
+	else if (!recursive())
 		return copyForLocation(DataLocation::Memory, true);
+	else
+		return TypePointer();
 }
 
 TypePointer StructType::copyForLocation(DataLocation _location, bool _isPointer) const
@@ -1828,6 +1830,29 @@ set<string> StructType::membersMissingInMemory() const
 		if (!variable->annotation().type->canLiveOutsideStorage())
 			missing.insert(variable->name());
 	return missing;
+}
+
+bool StructType::recursive() const
+{
+	set<StructDefinition const*> structsSeen;
+	function<bool(StructType const*)> check = [&](StructType const* t) -> bool
+	{
+		StructDefinition const* str = &t->structDefinition();
+		if (structsSeen.count(str))
+			return true;
+		structsSeen.insert(str);
+		for (ASTPointer<VariableDeclaration> const& variable: str->members())
+		{
+			Type const* memberType = variable->annotation().type.get();
+			while (dynamic_cast<ArrayType const*>(memberType))
+				memberType = dynamic_cast<ArrayType const*>(memberType)->baseType().get();
+			if (StructType const* innerStruct = dynamic_cast<StructType const*>(memberType))
+				if (check(innerStruct))
+					return true;
+		}
+		return false;
+	};
+	return check(this);
 }
 
 TypePointer EnumType::unaryOperatorResult(Token::Value _operator) const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1777,6 +1777,8 @@ TypePointer StructType::interfaceType(bool _inLibrary) const
 	if (_inLibrary && location() == DataLocation::Storage)
 		return shared_from_this();
 	else if (!recursive())
+		// TODO this might not be enough, we have to convert all members to
+		// their interfaceType
 		return copyForLocation(DataLocation::Memory, true);
 	else
 		return TypePointer();
@@ -1799,7 +1801,9 @@ string StructType::signatureInExternalFunction(bool _structsByName) const
 		auto memberTypeStrings = memberTypes | boost::adaptors::transformed([&](TypePointer _t) -> string
 		{
 			solAssert(_t, "Parameter should have external type.");
-			return _t->signatureInExternalFunction(_structsByName);
+			auto t = _t->interfaceType(_structsByName);
+			solAssert(t, "");
+			return t->signatureInExternalFunction(_structsByName);
 		});
 		return "(" + boost::algorithm::join(memberTypeStrings, ",") + ")";
 	}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1729,7 +1729,15 @@ unsigned StructType::calldataEncodedSize(bool _padded) const
 
 bool StructType::isDynamicallyEncoded() const
 {
-	solAssert(false, "Structs are not yet supported in the ABI.");
+	solAssert(!recursive(), "");
+	for (auto t: memoryMemberTypes())
+	{
+		solAssert(t, "Parameter should have external type.");
+		t = t->interfaceType(false);
+		if (t->isDynamicallyEncoded())
+			return true;
+	}
+	return false;
 }
 
 u256 StructType::memorySize() const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1408,6 +1408,11 @@ unsigned ArrayType::calldataEncodedSize(bool _padded) const
 	return unsigned(size);
 }
 
+bool ArrayType::isDynamicallyEncoded() const
+{
+	return isDynamicallySized() || baseType()->isDynamicallyEncoded();
+}
+
 u256 ArrayType::storageSize() const
 {
 	if (isDynamicallySized())
@@ -1522,8 +1527,6 @@ TypePointer ArrayType::interfaceType(bool _inLibrary) const
 		return this->copyForLocation(DataLocation::Memory, true);
 	TypePointer baseExt = m_baseType->interfaceType(_inLibrary);
 	if (!baseExt)
-		return TypePointer();
-	if (m_baseType->category() == Category::Array && m_baseType->isDynamicallySized())
 		return TypePointer();
 
 	if (isDynamicallySized())
@@ -1708,6 +1711,11 @@ unsigned StructType::calldataEncodedSize(bool _padded) const
 			size += memberSize;
 		}
 	return size;
+}
+
+bool StructType::isDynamicallyEncoded() const
+{
+	solAssert(false, "Structs are not yet supported in the ABI.");
 }
 
 u256 StructType::memorySize() const

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -187,6 +187,7 @@ public:
 	/// @returns number of bytes used by this type when encoded for CALL. If it is a dynamic type,
 	/// returns the size of the pointer (usually 32). Returns 0 if the type cannot be encoded
 	/// in calldata.
+	/// @note: This should actually not be called on types, where isDynamicallyEncoded returns true.
 	/// If @a _padded then it is assumed that each element is padded to a multiple of 32 bytes.
 	virtual unsigned calldataEncodedSize(bool _padded) const { (void)_padded; return 0; }
 	/// @returns the size of this data type in bytes when stored in memory. For memory-reference
@@ -194,8 +195,10 @@ public:
 	virtual unsigned memoryHeadSize() const { return calldataEncodedSize(); }
 	/// Convenience version of @see calldataEncodedSize(bool)
 	unsigned calldataEncodedSize() const { return calldataEncodedSize(true); }
-	/// @returns true if the type is dynamically encoded in calldata
+	/// @returns true if the type is a dynamic array
 	virtual bool isDynamicallySized() const { return false; }
+	/// @returns true if the type is dynamically encoded in the ABI
+	virtual bool isDynamicallyEncoded() const { return false; }
 	/// @returns the number of storage slots required to hold this value in storage.
 	/// For dynamically "allocated" types, it returns the size of the statically allocated head,
 	virtual u256 storageSize() const { return 1; }
@@ -609,6 +612,7 @@ public:
 	virtual bool operator==(const Type& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	virtual bool isDynamicallySized() const override { return m_hasDynamicLength; }
+	virtual bool isDynamicallyEncoded() const override;
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
 	virtual unsigned sizeOnStack() const override;
@@ -723,6 +727,7 @@ public:
 	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
+	virtual bool isDynamicallyEncoded() const override;
 	u256 memorySize() const;
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return true; }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -243,9 +243,15 @@ public:
 
 	virtual std::string toString(bool _short) const = 0;
 	std::string toString() const { return toString(false); }
-	/// @returns the canonical name of this type for use in function signatures.
-	/// @param _addDataLocation if true, includes data location for reference types if it is "storage".
-	virtual std::string canonicalName(bool /*_addDataLocation*/) const { return toString(true); }
+	/// @returns the canonical name of this type for use in library function signatures.
+	virtual std::string canonicalName() const { return toString(true); }
+	/// @returns the signature of this type in external functions, i.e. `uint256` for integers
+	/// or `(uint256, bytes8)[2]` for an array of structs. If @a _structsByName,
+	/// structs are given by canonical name like `ContractName.StructName[2]`.
+	virtual std::string signatureInExternalFunction(bool /*_structsByName*/) const
+	{
+		return canonicalName();
+	}
 	virtual u256 literalValue(Literal const*) const
 	{
 		solAssert(false, "Literal value requested for type without literals.");
@@ -617,7 +623,8 @@ public:
 	virtual bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
 	virtual unsigned sizeOnStack() const override;
 	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName(bool _addDataLocation) const override;
+	virtual std::string canonicalName() const override;
+	virtual std::string signatureInExternalFunction(bool _structsByName) const override;
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 	virtual TypePointer encodingType() const override;
 	virtual TypePointer decodingType() const override;
@@ -675,7 +682,7 @@ public:
 	virtual unsigned sizeOnStack() const override { return m_super ? 0 : 1; }
 	virtual bool isValueType() const override { return true; }
 	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName(bool _addDataLocation) const override;
+	virtual std::string canonicalName() const override;
 
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 	virtual TypePointer encodingType() const override
@@ -742,7 +749,8 @@ public:
 
 	TypePointer copyForLocation(DataLocation _location, bool _isPointer) const override;
 
-	virtual std::string canonicalName(bool _addDataLocation) const override;
+	virtual std::string canonicalName() const override;
+	virtual std::string signatureInExternalFunction(bool _structsByName) const override;
 
 	/// @returns a function that peforms the type conversion between a list of struct members
 	/// and a memory struct of this type.
@@ -753,6 +761,8 @@ public:
 
 	StructDefinition const& structDefinition() const { return m_struct; }
 
+	/// @returns the vector of types of members available in memory.
+	TypePointers memoryMemberTypes() const;
 	/// @returns the set of all members that are removed in the memory version (typically mappings).
 	std::set<std::string> membersMissingInMemory() const;
 
@@ -782,7 +792,7 @@ public:
 	virtual unsigned storageBytes() const override;
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName(bool _addDataLocation) const override;
+	virtual std::string canonicalName() const override;
 	virtual bool isValueType() const override { return true; }
 
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
@@ -958,7 +968,7 @@ public:
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override;
-	virtual std::string canonicalName(bool /*_addDataLocation*/) const override;
+	virtual std::string canonicalName() const override;
 	virtual std::string toString(bool _short) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	virtual bool canBeStored() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
@@ -1061,7 +1071,7 @@ public:
 	virtual std::string identifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName(bool _addDataLocation) const override;
+	virtual std::string canonicalName() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
 	virtual TypePointer encodingType() const override

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -756,6 +756,10 @@ public:
 	/// @returns the set of all members that are removed in the memory version (typically mappings).
 	std::set<std::string> membersMissingInMemory() const;
 
+	/// @returns true if the same struct is used recursively in one of its members. Only
+	/// analyziz the "memory" representation, i.e. mappings are ignored in all structs.
+	bool recursive() const;
+
 private:
 	StructDefinition const& m_struct;
 };

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -743,7 +743,7 @@ public:
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 	virtual TypePointer encodingType() const override
 	{
-		return location() == DataLocation::Storage ? std::make_shared<IntegerType>(256) : TypePointer();
+		return location() == DataLocation::Storage ? std::make_shared<IntegerType>(256) : shared_from_this();
 	}
 	virtual TypePointer interfaceType(bool _inLibrary) const override;
 

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -1,0 +1,1186 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <chris@ethereum.org>
+ * @date 2017
+ * Routines that generate JULIA code related to ABI encoding, decoding and type conversions.
+ */
+
+#include <libsolidity/codegen/ABIFunctions.h>
+
+#include <libdevcore/Whiskers.h>
+
+#include <libsolidity/ast/AST.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+ABIFunctions::~ABIFunctions()
+{
+	// This throws an exception and thus might cause immediate termination, but hey,
+	// it's a failed assertion anyway :-)
+//TODO	solAssert(m_requestedFunctions.empty(), "Forgot to call ``requestedFunctions()``.");
+}
+
+string ABIFunctions::tupleEncoder(
+	TypePointers const& _givenTypes,
+	TypePointers const& _targetTypes,
+	bool _encodeAsLibraryTypes
+)
+{
+	// stack: <$value0> <$value1> ... <$value(n-1)> <$headStart>
+
+	solAssert(!_givenTypes.empty(), "");
+	size_t const headSize_ = headSize(_targetTypes);
+
+	Whiskers encoder(R"(
+		{
+			let tail := add($headStart, <headSize>)
+			<encodeElements>
+			<deepestStackElement> := tail
+		}
+	)");
+	encoder("headSize", to_string(headSize_));
+	string encodeElements;
+	size_t headPos = 0;
+	size_t stackPos = 0;
+	for (size_t i = 0; i < _givenTypes.size(); ++i)
+	{
+		solAssert(_givenTypes[i], "");
+		solAssert(_targetTypes[i], "");
+		size_t sizeOnStack = _givenTypes[i]->sizeOnStack();
+		string valueNames = "";
+		for (size_t j = 0; j < sizeOnStack; j++)
+			valueNames += "$value" + to_string(stackPos++) + ", ";
+		bool dynamic = _targetTypes[i]->isDynamicallyEncoded();
+		Whiskers elementTempl(
+			dynamic ?
+			string(R"(
+				mstore(add($headStart, <pos>), sub(tail, $headStart))
+				tail := <abiEncode>(<values> tail)
+			)") :
+			string(R"(
+				<abiEncode>(<values> add($headStart, <pos>))
+			)")
+		);
+		elementTempl("values", valueNames);
+		elementTempl("pos", to_string(headPos));
+		elementTempl("abiEncode", abiEncodingFunction(*_givenTypes[i], *_targetTypes[i], _encodeAsLibraryTypes, false));
+		encodeElements += elementTempl.render();
+		headPos += dynamic ? 0x20 : _targetTypes[i]->calldataEncodedSize();
+	}
+	solAssert(headPos == headSize_, "");
+	encoder("encodeElements", encodeElements);
+	encoder("deepestStackElement", stackPos > 0 ? "$value0" : "$headStart");
+
+	return encoder.render();
+}
+
+string ABIFunctions::requestedFunctions()
+{
+	string result;
+	for (auto const& f: m_requestedFunctions)
+		result += f.second;
+	m_requestedFunctions.clear();
+	return result;
+}
+
+string ABIFunctions::cleanupFunction(Type const& _type, bool _revertOnFailure)
+{
+	string functionName = string("cleanup_") + (_revertOnFailure ? "revert_" : "assert_") + _type.identifier();
+	return createFunction(functionName, [&]() {
+		Whiskers templ(R"(
+			function <functionName>(value) -> cleaned {
+				<body>
+			}
+		)");
+		templ("functionName", functionName);
+		switch (_type.category())
+		{
+		case Type::Category::Integer:
+		{
+			IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
+			if (type.numBits() == 256)
+				templ("body", "cleaned := value");
+			else if (type.isSigned())
+				templ("body", "cleaned := signextend(" + to_string(type.numBits() / 8 - 1) + ", value)");
+			else
+				templ("body", "cleaned := and(value, " + toCompactHexWithPrefix((u256(1) << type.numBits()) - 1) + ")");
+			break;
+		}
+		case Type::Category::RationalNumber:
+			templ("body", "cleaned := value");
+			break;
+		case Type::Category::Bool:
+			templ("body", "cleaned := iszero(iszero(value))");
+			break;
+		case Type::Category::FixedPoint:
+			solUnimplemented("Fixed point types not implemented.");
+			break;
+		case Type::Category::Array:
+			solAssert(false, "Array cleanup requested.");
+			break;
+		case Type::Category::Struct:
+			solAssert(false, "Struct cleanup requested.");
+			break;
+		case Type::Category::FixedBytes:
+		{
+			FixedBytesType const& type = dynamic_cast<FixedBytesType const&>(_type);
+			if (type.numBytes() == 32)
+				templ("body", "cleaned := value");
+			else if (type.numBytes() == 0)
+				templ("body", "cleaned := 0");
+			else
+			{
+				size_t numBits = type.numBytes() * 8;
+				u256 mask = ((u256(1) << numBits) - 1) << (256 - numBits);
+				templ("body", "cleaned := and(value, " + toCompactHexWithPrefix(mask) + ")");
+			}
+			break;
+		}
+		case Type::Category::Contract:
+			templ("body", "cleaned := " + cleanupFunction(IntegerType(120, IntegerType::Modifier::Address)) + "(value)");
+			break;
+		case Type::Category::Enum:
+		{
+			size_t members = dynamic_cast<EnumType const&>(_type).numberOfMembers();
+			solAssert(members > 0, "empty enum should have caused a parser error.");
+			Whiskers w("switch lt(value, <members>) case 0 { <failure> } cleaned := value");
+			w("members", to_string(members));
+			if (_revertOnFailure)
+				w("failure", "revert(0, 0)");
+			else
+				w("failure", "invalid()");
+			templ("body", w.render());
+			break;
+		}
+		default:
+			solAssert(false, "Cleanup of type " + _type.identifier() + " requested.");
+		}
+
+		return templ.render();
+	});
+}
+
+string ABIFunctions::conversionFunction(Type const& _from, Type const& _to)
+{
+	string functionName =
+		"convert_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier();
+	return createFunction(functionName, [&]() {
+		Whiskers templ(R"(
+			function <functionName>(value) -> converted {
+				<body>
+			}
+		)");
+		templ("functionName", functionName);
+		string body;
+		auto toCategory = _to.category();
+		auto fromCategory = _from.category();
+		switch (fromCategory)
+		{
+		case Type::Category::Integer:
+		case Type::Category::RationalNumber:
+		case Type::Category::Contract:
+		{
+			if (RationalNumberType const* rational = dynamic_cast<RationalNumberType const*>(&_from))
+				solUnimplementedAssert(!rational->isFractional(), "Not yet implemented - FixedPointType.");
+			if (toCategory == Type::Category::FixedBytes)
+			{
+				solAssert(
+					fromCategory == Type::Category::Integer || fromCategory == Type::Category::RationalNumber,
+					"Invalid conversion to FixedBytesType requested."
+				);
+				FixedBytesType const& toBytesType = dynamic_cast<FixedBytesType const&>(_to);
+				body =
+					Whiskers("converted := <shiftLeft>(<clean>(value))")
+					("shiftLeft", shiftLeftFunction(256 - toBytesType.numBytes() * 8))
+					("clean", cleanupFunction(_from))
+					.render();
+			}
+			else if (toCategory == Type::Category::Enum)
+			{
+				solAssert(_from.mobileType(), "");
+				body =
+					Whiskers("converted := <cleanEnum>(<cleanInt>(value))")
+					("cleanEnum", cleanupFunction(_to, false))
+					// "mobileType()" returns integer type for rational
+					("cleanInt", cleanupFunction(*_from.mobileType()))
+					.render();
+			}
+			else if (toCategory == Type::Category::FixedPoint)
+			{
+				solUnimplemented("Not yet implemented - FixedPointType.");
+			}
+			else
+			{
+				solAssert(
+					toCategory == Type::Category::Integer ||
+					toCategory == Type::Category::Contract,
+				"");
+				IntegerType const addressType(0, IntegerType::Modifier::Address);
+				IntegerType const& to =
+					toCategory == Type::Category::Integer ?
+					dynamic_cast<IntegerType const&>(_to) :
+					addressType;
+
+				// Clean according to the "to" type, except if this is
+				// a widening conversion.
+				IntegerType const* cleanupType = &to;
+				if (fromCategory != Type::Category::RationalNumber)
+				{
+					IntegerType const& from =
+						fromCategory == Type::Category::Integer ?
+						dynamic_cast<IntegerType const&>(_from) :
+						addressType;
+					if (to.numBits() > from.numBits())
+						cleanupType = &from;
+				}
+				body =
+					Whiskers("converted := <cleanInt>(value)")
+					("cleanInt", cleanupFunction(*cleanupType))
+					.render();
+			}
+			break;
+		}
+		case Type::Category::Bool:
+		{
+			solAssert(_from == _to, "Invalid conversion for bool.");
+			body =
+				Whiskers("converted := <clean>(value)")
+				("clean", cleanupFunction(_from))
+				.render();
+			break;
+		}
+		case Type::Category::FixedPoint:
+			solUnimplemented("Fixed point types not implemented.");
+			break;
+		case Type::Category::Array:
+			solUnimplementedAssert(false, "Array conversion not implemented.");
+			break;
+		case Type::Category::Struct:
+			solUnimplementedAssert(false, "Struct conversion not implemented.");
+			break;
+		case Type::Category::FixedBytes:
+		{
+			FixedBytesType const& from = dynamic_cast<FixedBytesType const&>(_from);
+			if (toCategory == Type::Category::Integer)
+				body =
+					Whiskers("converted := <convert>(<shift>(value))")
+					("shift", shiftRightFunction(256 - from.numBytes() * 8, false))
+					("convert", conversionFunction(IntegerType(from.numBytes() * 8), _to))
+					.render();
+			else
+			{
+				// clear for conversion to longer bytes
+				solAssert(toCategory == Type::Category::FixedBytes, "Invalid type conversion requested.");
+				body =
+					Whiskers("converted := <clean>(value)")
+					("clean", cleanupFunction(from))
+					.render();
+			}
+			break;
+		}
+		case Type::Category::Function:
+		{
+			solAssert(false, "Cleanup should not be called for function types.");
+			break;
+		}
+		case Type::Category::Enum:
+		{
+			solAssert(toCategory == Type::Category::Integer || _from == _to, "");
+			EnumType const& enumType = dynamic_cast<decltype(enumType)>(_from);
+			body =
+				Whiskers("converted := <clean>(value)")
+				("clean", cleanupFunction(enumType))
+				.render();
+			break;
+		}
+		case Type::Category::Tuple:
+		{
+			solUnimplementedAssert(false, "Tuple conversion not implemented.");
+			break;
+		}
+		default:
+			solAssert(false, "");
+		}
+
+		solAssert(!body.empty(), "");
+		templ("body", body);
+		return templ.render();
+	});
+}
+
+string ABIFunctions::cleanupCombinedExternalFunctionIdFunction()
+{
+	string functionName = "cleanup_combined_external_function_id";
+	return createFunction(functionName, [&]() {
+		return Whiskers(R"(
+			function <functionName>(addr_and_selector) -> cleaned {
+				cleaned := <clean>(addr_and_selector)
+			}
+		)")
+		("functionName", functionName)
+		("clean", cleanupFunction(FixedBytesType(24)))
+		.render();
+	});
+}
+
+string ABIFunctions::abiEncodingFunction(
+	Type const& _from,
+	Type const& _to,
+	bool _encodeAsLibraryTypes,
+	bool _compacted
+)
+{
+	solUnimplementedAssert(
+		_to.mobileType() &&
+		_to.mobileType()->interfaceType(_encodeAsLibraryTypes) &&
+		_to.mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType(),
+		"Encoding type \"" + _to.toString() + "\" not yet implemented."
+	);
+	TypePointer toInterface = _to.mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType();
+	Type const& to = *toInterface;
+
+	if (_from.category() == Type::Category::StringLiteral)
+		return abiEncodingFunctionStringLiteral(_from, to, _encodeAsLibraryTypes);
+	else if (auto toArray = dynamic_cast<ArrayType const*>(&to))
+	{
+		solAssert(_from.category() == Type::Category::Array, "");
+		solAssert(to.dataStoredIn(DataLocation::Memory), "");
+		ArrayType const& fromArray = dynamic_cast<ArrayType const&>(_from);
+		if (fromArray.location() == DataLocation::CallData)
+			return abiEncodingFunctionCalldataArray(fromArray, *toArray, _encodeAsLibraryTypes);
+		else if (!fromArray.isByteArray() && (
+				fromArray.location() == DataLocation::Memory ||
+				fromArray.baseType()->storageBytes() > 16
+		))
+			return abiEncodingFunctionSimpleArray(fromArray, *toArray, _encodeAsLibraryTypes);
+		else if (fromArray.location() == DataLocation::Memory)
+			return abiEncodingFunctionMemoryByteArray(fromArray, *toArray, _encodeAsLibraryTypes);
+		else if (fromArray.location() == DataLocation::Storage)
+			return abiEncodingFunctionCompactStorageArray(fromArray, *toArray, _encodeAsLibraryTypes);
+		else
+			solAssert(false, "");
+	}
+	else if (auto const* toStruct = dynamic_cast<StructType const*>(&to))
+	{
+		StructType const* fromStruct = dynamic_cast<StructType const*>(&_from);
+		solAssert(fromStruct, "");
+		return abiEncodingFunctionStruct(*fromStruct, *toStruct, _encodeAsLibraryTypes);
+	}
+	else if (_from.category() == Type::Category::Function)
+		return abiEncodingFunctionFunctionType(
+			dynamic_cast<FunctionType const&>(_from),
+			to,
+			_encodeAsLibraryTypes,
+			_compacted
+		);
+
+	solAssert(_from.sizeOnStack() == 1, "");
+	solAssert(to.isValueType(), "");
+	solAssert(to.calldataEncodedSize() == 32, "");
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+	return createFunction(functionName, [&]() {
+		solAssert(!to.isDynamicallyEncoded(), "");
+
+		Whiskers templ(R"(
+			function <functionName>(value, pos) {
+				mstore(pos, <cleanupConvert>)
+			}
+		)");
+		templ("functionName", functionName);
+
+		if (_from.dataStoredIn(DataLocation::Storage) && to.isValueType())
+		{
+			// special case: convert storage reference type to value type - this is only
+			// possible for library calls where we just forward the storage reference
+			solAssert(_encodeAsLibraryTypes, "");
+			solAssert(to == IntegerType(256), "");
+			templ("cleanupConvert", "value");
+		}
+		else
+		{
+			if (_from == to)
+				templ("cleanupConvert", cleanupFunction(_from) + "(value)");
+			else
+				templ("cleanupConvert", conversionFunction(_from, to) + "(value)");
+		}
+		return templ.render();
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionCalldataArray(
+	Type const& _from,
+	Type const& _to,
+	bool _encodeAsLibraryTypes
+)
+{
+	solAssert(_to.isDynamicallySized(), "");
+	solAssert(_from.category() == Type::Category::Array, "Unknown dynamic type.");
+	solAssert(_to.category() == Type::Category::Array, "Unknown dynamic type.");
+	auto const& fromArrayType = dynamic_cast<ArrayType const&>(_from);
+	auto const& toArrayType = dynamic_cast<ArrayType const&>(_to);
+
+	solAssert(fromArrayType.location() == DataLocation::CallData, "");
+
+	solAssert(
+		*fromArrayType.copyForLocation(DataLocation::Memory, true) ==
+		*toArrayType.copyForLocation(DataLocation::Memory, true),
+		""
+	);
+
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+	return createFunction(functionName, [&]() {
+		solUnimplementedAssert(fromArrayType.isByteArray(), "");
+		// TODO if this is not a byte array, we might just copy byte-by-byte anyway,
+		// because the encoding is position-independent, but we have to check that.
+		Whiskers templ(R"(
+			function <functionName>(start, length, pos) -> end {
+				<storeLength>
+				<copyFun>(start, pos, length)
+				end := add(pos, <roundUpFun>(length))
+			}
+		)");
+		templ("storeLength", _to.isDynamicallySized() ? "mstore(pos, length) pos := add(pos, 0x20)" : "");
+		templ("functionName", functionName);
+		templ("copyFun", copyToMemoryFunction(true));
+		templ("roundUpFun", roundUpFunction());
+		return templ.render();
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionSimpleArray(
+	ArrayType const& _from,
+	ArrayType const& _to,
+	bool _encodeAsLibraryTypes
+)
+{
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+
+	solAssert(_from.isDynamicallySized() == _to.isDynamicallySized(), "");
+	solAssert(_from.length() == _to.length(), "");
+	solAssert(_from.dataStoredIn(DataLocation::Memory) || _from.dataStoredIn(DataLocation::Storage), "");
+	solAssert(!_from.isByteArray(), "");
+	solAssert(_from.dataStoredIn(DataLocation::Memory) || _from.baseType()->storageBytes() > 16, "");
+
+	return createFunction(functionName, [&]() {
+		bool dynamic = _to.isDynamicallyEncoded();
+		bool dynamicBase = _to.baseType()->isDynamicallyEncoded();
+		bool inMemory = _from.dataStoredIn(DataLocation::Memory);
+		Whiskers templ(
+			dynamicBase ?
+			R"(
+				function <functionName>(value, pos) <return> {
+					let length := <lengthFun>(value)
+					<storeLength> // might update pos
+					let headStart := pos
+					let tail := add(pos, mul(length, 0x20))
+					let srcPtr := <dataAreaFun>(value)
+					for { let i := 0 } lt(i, length) { i := add(i, 1) }
+					{
+						mstore(pos, sub(tail, headStart))
+						tail := <encodeToMemoryFun>(<arrayElementAccess>(srcPtr), tail)
+						srcPtr := <nextArrayElement>(srcPtr)
+						pos := add(pos, <elementEncodedSize>)
+					}
+					pos := tail
+					<assignEnd>
+				}
+			)" :
+			R"(
+				function <functionName>(value, pos) <return> {
+					let length := <lengthFun>(value)
+					<storeLength> // might update pos
+					let srcPtr := <dataAreaFun>(value)
+					for { let i := 0 } lt(i, length) { i := add(i, 1) }
+					{
+						<encodeToMemoryFun>(<arrayElementAccess>(srcPtr), pos)
+						srcPtr := <nextArrayElement>(srcPtr)
+						pos := add(pos, <elementEncodedSize>)
+					}
+					<assignEnd>
+				}
+			)"
+		);
+		templ("functionName", functionName);
+		templ("return", dynamic ? " -> end " : "");
+		templ("assignEnd", dynamic ? "end := pos" : "");
+		templ("lengthFun", arrayLengthFunction(_from));
+		if (_to.isDynamicallySized())
+			templ("storeLength", "mstore(pos, length) pos := add(pos, 0x20)");
+		else
+			templ("storeLength", "");
+		templ("dataAreaFun", arrayDataAreaFunction(_from));
+		templ("elementEncodedSize", toCompactHexWithPrefix(_to.baseType()->calldataEncodedSize()));
+		templ("encodeToMemoryFun", abiEncodingFunction(
+			*_from.baseType(),
+			*_to.baseType(),
+			_encodeAsLibraryTypes,
+			true
+		));
+		templ("arrayElementAccess", inMemory ? "mload" : "sload");
+		templ("nextArrayElement", nextArrayElementFunction(_from));
+		return templ.render();
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionMemoryByteArray(
+	ArrayType const& _from,
+	ArrayType const& _to,
+	bool _encodeAsLibraryTypes
+)
+{
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+
+	solAssert(_from.isDynamicallySized() == _to.isDynamicallySized(), "");
+	solAssert(_from.length() == _to.length(), "");
+	solAssert(_from.dataStoredIn(DataLocation::Memory), "");
+	solAssert(_from.isByteArray(), "");
+
+	return createFunction(functionName, [&]() {
+		solAssert(_to.isByteArray(), "");
+		Whiskers templ(R"(
+			function <functionName>(value, pos) -> end {
+				let length := <lengthFun>(value)
+				mstore(pos, length)
+				<copyFun>(add(value, 0x20), add(pos, 0x20), length)
+				end := add(add(pos, 0x20), <roundUpFun>(length))
+			}
+		)");
+		templ("functionName", functionName);
+		templ("lengthFun", arrayLengthFunction(_from));
+		templ("copyFun", copyToMemoryFunction(false));
+		templ("roundUpFun", roundUpFunction());
+		return templ.render();
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionCompactStorageArray(
+	ArrayType const& _from,
+	ArrayType const& _to,
+	bool _encodeAsLibraryTypes
+)
+{
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+
+	solAssert(_from.isDynamicallySized() == _to.isDynamicallySized(), "");
+	solAssert(_from.length() == _to.length(), "");
+	solAssert(_from.dataStoredIn(DataLocation::Storage), "");
+
+	return createFunction(functionName, [&]() {
+		if (_from.isByteArray())
+		{
+			solAssert(_to.isByteArray(), "");
+			Whiskers templ(R"(
+				function <functionName>(value, pos) -> ret {
+					let slotValue := sload(value)
+					switch and(slotValue, 1)
+					case 0 {
+						// short byte array
+						let length := and(div(slotValue, 2), 0x7f)
+						mstore(pos, length)
+						mstore(add(pos, 0x20), and(slotValue, not(0xff)))
+						ret := add(pos, 0x40)
+					}
+					case 1 {
+						// long byte array
+						let length := div(slotValue, 2)
+						mstore(pos, length)
+						pos := add(pos, 0x20)
+						let dataPos := <arrayDataSlot>(value)
+						let i := 0
+						for { } lt(i, length) { i := add(i, 0x20) } {
+							mstore(add(pos, i), sload(dataPos))
+							dataPos := add(dataPos, 1)
+						}
+						ret := add(pos, i)
+					}
+				}
+			)");
+			templ("functionName", functionName);
+			templ("arrayDataSlot", arrayDataAreaFunction(_from));
+			return templ.render();
+		}
+		else
+		{
+			// Multiple items per slot
+			solAssert(_from.baseType()->storageBytes() <= 16, "");
+			solAssert(!_from.baseType()->isDynamicallyEncoded(), "");
+			solAssert(_from.baseType()->isValueType(), "");
+			bool dynamic = _to.isDynamicallyEncoded();
+			size_t storageBytes = _from.baseType()->storageBytes();
+			size_t itemsPerSlot = 32 / storageBytes;
+			// This always writes full slot contents to memory, which might be
+			// more than desired, i.e. it writes beyond the end of memory.
+			Whiskers templ(
+				R"(
+					function <functionName>(value, pos) <return> {
+						let length := <lengthFun>(value)
+						<storeLength> // might update pos
+						let originalPos := pos
+						let srcPtr := <dataArea>(value)
+						for { let i := 0 } lt(i, length) { i := add(i, <itemsPerSlot>) }
+						{
+							let data := sload(srcPtr)
+							<#items>
+								<encodeToMemoryFun>(<shiftRightFun>(data), pos)
+								pos := add(pos, <elementEncodedSize>)
+							</items>
+							srcPtr := add(srcPtr, 1)
+						}
+						pos := add(originalPos, mul(length, <elementEncodedSize>))
+						<assignEnd>
+					}
+				)"
+			);
+			templ("functionName", functionName);
+			templ("return", dynamic ? " -> end " : "");
+			templ("assignEnd", dynamic ? "end := pos" : "");
+			templ("lengthFun", arrayLengthFunction(_from));
+			if (_to.isDynamicallySized())
+				templ("storeLength", "mstore(pos, length) pos := add(pos, 0x20)");
+			else
+				templ("storeLength", "");
+			templ("dataArea", arrayDataAreaFunction(_from));
+			templ("itemsPerSlot", to_string(itemsPerSlot));
+			string elementEncodedSize = toCompactHexWithPrefix(_to.baseType()->calldataEncodedSize());
+			templ("elementEncodedSize", elementEncodedSize);
+			string encodeToMemoryFun = abiEncodingFunction(
+				*_from.baseType(),
+				*_to.baseType(),
+				_encodeAsLibraryTypes,
+				true
+			);
+			templ("encodeToMemoryFun", encodeToMemoryFun);
+			std::vector<std::map<std::string, std::string>> items(itemsPerSlot);
+			for (size_t i = 0; i < itemsPerSlot; ++i)
+				items[i]["shiftRightFun"] = shiftRightFunction(i * storageBytes * 8, false);
+			templ("items", items);
+			return templ.render();
+		}
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionStruct(
+	StructType const& _from,
+	StructType const& _to,
+	bool _encodeAsLibraryTypes
+)
+{
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+
+	solUnimplementedAssert(!_from.dataStoredIn(DataLocation::CallData), "");
+	solAssert(&_from.structDefinition() == &_to.structDefinition(), "");
+
+	return createFunction(functionName, [&]() {
+		bool fromStorage = _from.location() == DataLocation::Storage;
+		bool dynamic = _to.isDynamicallyEncoded();
+		Whiskers templ(R"(
+			function <functionName>(value, pos) <return> {
+				let tail := add(pos, <headSize>)
+				<init>
+				<#members>
+				{
+					<encode>
+				}
+				</members>
+				<assignEnd>
+			}
+		)");
+		templ("functionName", functionName);
+		templ("return", dynamic ? " -> end " : "");
+		templ("assignEnd", dynamic ? "end := tail" : "");
+		templ("init", fromStorage ? "let slotValue := 0" : "");
+		// to avoid multiple loads from the same slot
+		u256 previousSlotOffset(-1);
+		u256 encodingOffset = 0;
+		vector<map<string, string>> members;
+		for (auto const& member: _to.members(nullptr))
+		{
+			solAssert(member.type, "");
+			if (!member.type->canLiveOutsideStorage())
+				continue;
+			members.push_back({});
+			solUnimplementedAssert(
+				member.type->mobileType() &&
+				member.type->mobileType()->interfaceType(_encodeAsLibraryTypes) &&
+				member.type->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType(),
+				"Encoding type \"" + member.type->toString() + "\" not yet implemented."
+			);
+			auto memberTypeTo = member.type->mobileType()->interfaceType(_encodeAsLibraryTypes)->encodingType();
+			auto memberTypeFrom = _from.memberType(member.name);
+			solAssert(memberTypeFrom, "");
+			bool dynamicMember = memberTypeTo->isDynamicallyEncoded();
+			if (dynamicMember)
+				solAssert(dynamic, "");
+			Whiskers memberTempl(R"(
+				<preprocess>
+				let memberValue := <retrieveValue>
+				)" + (
+					dynamicMember ?
+					string(R"(
+						mstore(add(pos, <encodingOffset>), sub(tail, pos))
+						tail := <abiEncode>(memberValue, tail)
+					)") :
+					string(R"(
+						<abiEncode>(memberValue, add(pos, <encodingOffset>))
+					)")
+				)
+			);
+			if (fromStorage)
+			{
+				u256 storageSlotOffset;
+				size_t intraSlotOffset;
+				tie(storageSlotOffset, intraSlotOffset) = _from.storageOffsetsOfMember(member.name);
+				if (memberTypeFrom->isValueType())
+				{
+					if (storageSlotOffset != previousSlotOffset)
+					{
+						memberTempl("preprocess", "slotValue := sload(add(value, " + toCompactHexWithPrefix(storageSlotOffset) + "))");
+						previousSlotOffset = storageSlotOffset;
+					}
+					else
+						memberTempl("preprocess", "");
+					memberTempl("retrieveValue", shiftRightFunction(intraSlotOffset, false) + "(slotValue)");
+				}
+				else
+				{
+					memberTempl("preprocess", "");
+					memberTempl("retrieveValue", "add(value, " + toCompactHexWithPrefix(storageSlotOffset) + "))");
+				}
+			}
+			else
+			{
+				memberTempl("preprocess", "");
+				string sourceOffset = toCompactHexWithPrefix(_from.memoryOffsetOfMember(member.name));
+				members.back()["retrieveValue"] = "mload(add(value, " + sourceOffset + "))";
+			}
+			memberTempl("encodingOffset", toCompactHexWithPrefix(encodingOffset));
+			encodingOffset += dynamicMember ? 0x20 : memberTypeTo->calldataEncodedSize();
+			memberTempl("abiEncode", abiEncodingFunction(*memberTypeFrom, *memberTypeTo, _encodeAsLibraryTypes, false));
+
+			members.back()["encode"] = memberTempl.render();
+		}
+		templ("headSize", toCompactHexWithPrefix(encodingOffset));
+		return templ.render();
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionStringLiteral(
+	Type const& _from,
+	Type const& _to,
+	bool _encodeAsLibraryTypes
+)
+{
+	solAssert(_from.category() == Type::Category::StringLiteral, "");
+
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "");
+	return createFunction(functionName, [&]() {
+		auto const& strType = dynamic_cast<StringLiteralType const&>(_from);
+		string const& value = strType.value();
+		solAssert(_from.sizeOnStack() == 0, "");
+
+		if (_to.isDynamicallySized())
+		{
+			Whiskers templ(R"(
+				function <functionName>(pos) -> end {
+					mstore(pos, <length>)
+					<#word>
+						mstore(add(pos, <offset>), <wordValue>)
+					</word>
+					end := add(pos, <overallSize>)
+				}
+			)");
+			templ("functionName", functionName);
+
+			// TODO this can make use of CODECOPY for large strings once we have that in JULIA
+			size_t words = (value.size() + 31) / 32;
+			templ("overallSize", to_string(32 + words * 32));
+			templ("length", to_string(value.size()));
+			vector<map<string, string>> wordParams(words);
+			for (size_t i = 0; i < words; ++i)
+			{
+				wordParams[i]["offset"] = to_string(32 + i * 32);
+				wordParams[i]["wordValue"] = "0x" + h256(value.substr(32 * i, 32), h256::AlignLeft).hex();
+			}
+			templ("word", wordParams);
+			return templ.render();
+		}
+		else
+		{
+			solAssert(_to.category() == Type::Category::FixedBytes, "");
+			solAssert(value.size() <= 32, "");
+			Whiskers templ(R"(
+				function <functionName>(pos) {
+					mstore(pos, <wordValue>)
+				}
+			)");
+			templ("functionName", functionName);
+			templ("wordValue", "0x" + h256(value, h256::AlignLeft).hex());
+			return templ.render();
+		}
+	});
+}
+
+string ABIFunctions::abiEncodingFunctionFunctionType(
+	FunctionType const& _from,
+	Type const& _to,
+	bool _encodeAsLibraryTypes,
+	bool _compacted
+)
+{
+	solAssert(_from.kind() == FunctionType::Kind::External, "");
+	solAssert(_from == _to, "");
+
+	string functionName =
+		"abi_encode_" +
+		_from.identifier() +
+		"_to_" +
+		_to.identifier() +
+		(_encodeAsLibraryTypes ? "_lib" : "") +
+		(_compacted ? "_comp" : "");
+
+	if (_compacted)
+	{
+		return createFunction(functionName, [&]() {
+			return Whiskers(R"(
+				function <functionName>(addr_and_function_id, pos) {
+					mstore(pos, <cleanExtFun>(addr_and_function_id))
+				}
+			)")
+			("functionName", functionName)
+			("cleanExtFun", cleanupCombinedExternalFunctionIdFunction())
+			.render();
+		});
+	}
+	else
+	{
+		return createFunction(functionName, [&]() {
+			return Whiskers(R"(
+				function <functionName>(addr, function_id, pos) {
+					mstore(pos, <combineExtFun>(addr, function_id))
+				}
+			)")
+			("functionName", functionName)
+			("combineExtFun", combineExternalFunctionIdFunction())
+			.render();
+		});
+	}
+}
+
+string ABIFunctions::combineExternalFunctionIdFunction()
+{
+	string functionName = "combine_external_function_id";
+	return createFunction(functionName, [&]() {
+		return Whiskers(R"(
+			function <functionName>(addr, selector) -> combined {
+				combined := <shl64>(or(<shl32>(addr), and(selector, 0xffffffff)))
+			}
+		)")
+		("functionName", functionName)
+		("shl32", shiftLeftFunction(32))
+		("shl64", shiftLeftFunction(64))
+		.render();
+	});
+}
+
+string ABIFunctions::copyToMemoryFunction(bool _fromCalldata)
+{
+	string functionName = "copy_" + string(_fromCalldata ? "calldata" : "memory") + "_to_memory";
+	return createFunction(functionName, [&]() {
+		if (_fromCalldata)
+		{
+			return Whiskers(R"(
+				function <functionName>(src, dst, length) {
+					calldatacopy(dst, src, length)
+					// clear end
+					mstore(add(dst, length), 0)
+				}
+			)")
+			("functionName", functionName)
+			.render();
+		}
+		else
+		{
+			return Whiskers(R"(
+				function <functionName>(src, dst, length) {
+					let i := 0
+					for { } lt(i, length) { i := add(i, 32) }
+					{
+						mstore(add(dst, i), mload(add(src, i)))
+					}
+					switch eq(i, length)
+					case 0 {
+						// clear end
+						mstore(add(dst, length), 0)
+					}
+				}
+			)")
+			("functionName", functionName)
+			.render();
+		}
+	});
+}
+
+string ABIFunctions::shiftLeftFunction(size_t _numBits)
+{
+	string functionName = "shift_left_" + to_string(_numBits);
+	return createFunction(functionName, [&]() {
+		solAssert(_numBits < 256, "");
+		return
+			Whiskers(R"(function <functionName>(value) -> newValue {
+				newValue := mul(value, <multiplier>)
+			})")
+			("functionName", functionName)
+			("multiplier", toCompactHexWithPrefix(u256(1) << _numBits))
+			.render();
+	});
+}
+
+string ABIFunctions::shiftRightFunction(size_t _numBits, bool _signed)
+{
+	string functionName = "shift_right_" + to_string(_numBits) + (_signed ? "_signed" : "_unsigned");
+	return createFunction(functionName, [&]() {
+		solAssert(_numBits < 256, "");
+		return
+			Whiskers(R"(function <functionName>(value) -> newValue {
+				newValue := <div>(value, <multiplier>)
+			})")
+			("functionName", functionName)
+			("div", _signed ? "sdiv" : "div")
+			("multiplier", toCompactHexWithPrefix(u256(1) << _numBits))
+			.render();
+	});
+}
+
+string ABIFunctions::roundUpFunction()
+{
+	string functionName = "round_up_to_mul_of_32";
+	return createFunction(functionName, [&]() {
+		return
+			Whiskers(R"(function <functionName>(value) -> result {
+				result := and(add(value, 31), not(31))
+			})")
+			("functionName", functionName)
+			.render();
+	});
+}
+
+string ABIFunctions::arrayLengthFunction(ArrayType const& _type)
+{
+	string functionName = "array_length_" + _type.identifier();
+	return createFunction(functionName, [&]() {
+		Whiskers w(R"(
+			function <functionName>(value) -> length {
+				<body>
+			}
+		)");
+		w("functionName", functionName);
+		string body;
+		if (!_type.isDynamicallySized())
+			body = "length := " + toCompactHexWithPrefix(_type.length());
+		else
+		{
+			switch (_type.location())
+			{
+			case DataLocation::CallData:
+				solAssert(false, "called regular array length function on calldata array");
+				break;
+			case DataLocation::Memory:
+				body = "length := mload(value)";
+				break;
+			case DataLocation::Storage:
+				if (_type.isByteArray())
+				{
+					// Retrieve length both for in-place strings and off-place strings:
+					// Computes (x & (0x100 * (ISZERO (x & 1)) - 1)) / 2
+					// i.e. for short strings (x & 1 == 0) it does (x & 0xff) / 2 and for long strings it
+					// computes (x & (-1)) / 2, which is equivalent to just x / 2.
+					body = R"(
+						length := sload(value)
+						let mask := sub(mul(0x100, iszero(and(length, 1))), 1)
+						length := div(and(length, mask), 2)
+					)";
+				}
+				else
+					body = "length := sload(value)";
+				break;
+			}
+		}
+		solAssert(!body.empty(), "");
+		w("body", body);
+		return w.render();
+	});
+}
+
+string ABIFunctions::arrayDataAreaFunction(ArrayType const& _type)
+{
+	string functionName = "array_dataslot_" + _type.identifier();
+	return createFunction(functionName, [&]() {
+		if (_type.dataStoredIn(DataLocation::Memory))
+		{
+			if (_type.isDynamicallySized())
+				return Whiskers(R"(
+					function <functionName>(memPtr) -> dataPtr {
+						dataPtr := add(memPtr, 0x20)
+					}
+				)")
+				("functionName", functionName)
+				.render();
+			else
+				return Whiskers(R"(
+					function <functionName>(memPtr) -> dataPtr {
+						dataPtr := memPtr
+					}
+				)")
+				("functionName", functionName)
+				.render();
+		}
+		else if (_type.dataStoredIn(DataLocation::Storage))
+		{
+			if (_type.isDynamicallySized())
+			{
+				Whiskers w(R"(
+					function <functionName>(slot) -> dataSlot {
+						mstore(0, slot)
+						dataSlot := keccak256(0, 0x20)
+					}
+				)");
+				w("functionName", functionName);
+				return w.render();
+			}
+			else
+			{
+				Whiskers w(R"(
+					function <functionName>(slot) -> dataSlot {
+						dataSlot := slot
+					}
+				)");
+				w("functionName", functionName);
+				return w.render();
+			}
+		}
+		else
+		{
+			// Not used for calldata
+			solAssert(false, "");
+		}
+	});
+}
+
+string ABIFunctions::nextArrayElementFunction(ArrayType const& _type)
+{
+	solAssert(!_type.isByteArray(), "");
+	solAssert(
+		_type.location() == DataLocation::Memory ||
+		_type.location() == DataLocation::Storage,
+		""
+	);
+	solAssert(
+		_type.location() == DataLocation::Memory ||
+		_type.baseType()->storageBytes() > 16,
+		""
+	);
+	string functionName = "array_nextElement_" + _type.identifier();
+	return createFunction(functionName, [&]() {
+		if (_type.location() == DataLocation::Memory)
+			return Whiskers(R"(
+				function <functionName>(memPtr) -> nextPtr {
+					nextPtr := add(memPtr, 0x20)
+				}
+			)")
+			("functionName", functionName)
+			.render();
+		else if (_type.location() == DataLocation::Storage)
+			return Whiskers(R"(
+				function <functionName>(slot) -> nextSlot {
+					nextSlot := add(slot, 1)
+				}
+			)")
+			("functionName", functionName)
+			.render();
+		else
+			solAssert(false, "");
+	});
+}
+
+string ABIFunctions::createFunction(string const& _name, function<string ()> const& _creator)
+{
+	if (!m_requestedFunctions.count(_name))
+	{
+		auto fun = _creator();
+		solAssert(!fun.empty(), "");
+		m_requestedFunctions[_name] = fun;
+	}
+	return _name;
+}
+
+size_t ABIFunctions::headSize(TypePointers const& _targetTypes)
+{
+	size_t headSize = 0;
+	for (auto const& t: _targetTypes)
+	{
+		if (t->isDynamicallyEncoded())
+			headSize += 0x20;
+		else
+		{
+			solAssert(t->calldataEncodedSize() > 0, "");
+			headSize += t->calldataEncodedSize();
+		}
+	}
+
+	return headSize;
+}

--- a/libsolidity/codegen/ABIFunctions.h
+++ b/libsolidity/codegen/ABIFunctions.h
@@ -1,0 +1,172 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Christian <chris@ethereum.org>
+ * @date 2017
+ * Routines that generate JULIA code related to ABI encoding, decoding and type conversions.
+ */
+
+#pragma once
+
+#include <libsolidity/ast/ASTForward.h>
+
+#include <vector>
+#include <functional>
+#include <map>
+
+namespace dev {
+namespace solidity {
+
+class Type;
+class ArrayType;
+class StructType;
+class FunctionType;
+using TypePointer = std::shared_ptr<Type const>;
+using TypePointers = std::vector<TypePointer>;
+
+///
+/// Class to generate encoding and decoding functions. Also maintains a collection
+/// of "functions to be generated" in order to avoid generating the same function
+/// multiple times.
+///
+/// Make sure to include the result of ``requestedFunctions()`` to a block that
+/// is visible from the code that was generated here.
+class ABIFunctions
+{
+public:
+	~ABIFunctions();
+
+	/// @returns TODO
+	std::string tupleEncoder(
+		TypePointers const& _givenTypes,
+		TypePointers const& _targetTypes,
+		bool _encodeAsLibraryTypes = false
+	);
+
+	std::string requestedFunctions();
+
+private:
+	/// @returns the name of the cleanup function for the given type and
+	/// adds its implementation to the requested functions.
+	/// @param _revertOnFailure if true, causes revert on invalid data,
+	/// otherwise an assertion failure.
+	std::string cleanupFunction(Type const& _type, bool _revertOnFailure = false);
+
+	/// @returns the name of the function that converts a value of type @a _from
+	/// to a value of type @a _to. The resulting vale is guaranteed to be in range
+	/// (i.e. "clean"). Asserts on failure.
+	std::string conversionFunction(Type const& _from, Type const& _to);
+
+	std::string cleanupCombinedExternalFunctionIdFunction();
+
+	/// @returns the name of the ABI encoding function with the given type
+	/// and queues the generation of the function to the requested functions.
+	/// @param _compacted if true, the input value was just loaded from storage
+	/// or memory and thus might be compacted into a single slot (depending on the type).
+	std::string abiEncodingFunction(
+		Type const& _givenType,
+		Type const& _targetType,
+		bool _encodeAsLibraryTypes,
+		bool _compacted
+	);
+	/// Part of @a abiEncodingFunction for array target type and given calldata array.
+	std::string abiEncodingFunctionCalldataArray(
+		Type const& _givenType,
+		Type const& _targetType,
+		bool _encodeAsLibraryTypes
+	);
+	/// Part of @a abiEncodingFunction for array target type and given memory array or
+	/// a given storage array with one item per slot.
+	std::string abiEncodingFunctionSimpleArray(
+		ArrayType const& _givenType,
+		ArrayType const& _targetType,
+		bool _encodeAsLibraryTypes
+	);
+	std::string abiEncodingFunctionMemoryByteArray(
+		ArrayType const& _givenType,
+		ArrayType const& _targetType,
+		bool _encodeAsLibraryTypes
+	);
+	/// Part of @a abiEncodingFunction for array target type and given storage array
+	/// where multiple items are packed into the same storage slot.
+	std::string abiEncodingFunctionCompactStorageArray(
+		ArrayType const& _givenType,
+		ArrayType const& _targetType,
+		bool _encodeAsLibraryTypes
+	);
+
+	std::string abiEncodingFunctionStruct(
+		StructType const& _from,
+		StructType const& _to,
+		bool _encodeAsLibraryTypes
+	);
+
+
+	// @returns the name of the ABI encoding function with the given type
+	// and queues the generation of the function to the requested functions.
+	// Case for _givenType being a string literal
+	std::string abiEncodingFunctionStringLiteral(
+		Type const& _givenType,
+		Type const& _targetType,
+		bool _encodeAsLibraryTypes
+	);
+
+	std::string abiEncodingFunctionFunctionType(
+		FunctionType const& _from,
+		Type const& _to,
+		bool _encodeAsLibraryTypes,
+		bool _compacted
+	);
+
+	/// @returns a function that combines the address and selector to a single value
+	/// for use in the ABI.
+	std::string combineExternalFunctionIdFunction();
+
+	/// @returns a function that copies raw bytes of dynamic length from calldata
+	/// or memory to memory.
+	/// Pads with zeros and might write more than exactly length.
+	std::string copyToMemoryFunction(bool _fromCalldata);
+
+	std::string shiftLeftFunction(size_t _numBits);
+	std::string shiftRightFunction(size_t _numBits, bool _signed);
+	/// @returns the name of a function that rounds its input to the next multiple
+	/// of 32 or the input if it is a multiple of 32.
+	std::string roundUpFunction();
+
+	std::string arrayLengthFunction(ArrayType const& _type);
+	/// @returns the name of a function that converts a storage slot number
+	/// or a memory pointer to the slot number / memory pointer for the data position of an array
+	/// which is stored in that slot / memory area.
+	std::string arrayDataAreaFunction(ArrayType const& _type);
+	/// @returns the name of a function that advances an array data pointer to the next element.
+	/// Only works for memory arrays and storage arrays that store one item per slot.
+	std::string nextArrayElementFunction(ArrayType const& _type);
+
+	/// Helper function that uses @a _creator to create a function and add it to
+	/// @a m_requestedFunctions if it has not been created yet and returns @a _name in both
+	/// cases.
+	std::string createFunction(std::string const& _name, std::function<std::string()> const& _creator);
+
+	/// @returns the size of the static part of the encoding of the given types.
+	size_t headSize(TypePointers const& _targetTypes);
+
+	/// Map from function name to code for a multi-use function.
+	std::map<std::string, std::string> m_requestedFunctions;
+};
+
+}
+}

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -25,6 +25,7 @@
 #include <libevmasm/Instruction.h>
 #include <libsolidity/codegen/ArrayUtils.h>
 #include <libsolidity/codegen/LValue.h>
+#include <libsolidity/codegen/ABIFunctions.h>
 
 using namespace std;
 
@@ -182,6 +183,14 @@ void CompilerUtils::encodeToMemory(
 
 	if (_givenTypes.empty())
 		return;
+	else if (_padToWordBoundaries && !_copyDynamicDataInPlace)
+	{
+		// Use the new JULIA-based encoding function
+		auto stackHeightBefore = m_context.stackHeight();
+		abiEncode(_givenTypes, targetTypes, _encodeAsLibraryTypes);
+		solAssert(stackHeightBefore - m_context.stackHeight() == sizeOnStack(_givenTypes), "");
+		return;
+	}
 
 	// Stack during operation:
 	// <v1> <v2> ... <vn> <mem_start> <dyn_head_1> ... <dyn_head_r> <end_of_mem>
@@ -287,6 +296,30 @@ void CompilerUtils::encodeToMemory(
 	// remove unneeded stack elements (and retain memory pointer)
 	m_context << swapInstruction(argSize + dynPointers + 1);
 	popStackSlots(argSize + dynPointers + 1);
+}
+
+void CompilerUtils::abiEncode(
+	TypePointers const& _givenTypes,
+	TypePointers const& _targetTypes,
+	bool _encodeAsLibraryTypes
+)
+{
+	// stack: <$value0> <$value1> ... <$value(n-1)> <$headStart>
+
+	vector<string> variables;
+	size_t numValues = sizeOnStack(_givenTypes);
+	for (size_t i = 0; i < numValues; ++i)
+			variables.push_back("$value" + to_string(i));
+	variables.push_back("$headStart");
+
+	ABIFunctions funs;
+	string routine = funs.tupleEncoder(_givenTypes, _targetTypes, _encodeAsLibraryTypes);
+	routine += funs.requestedFunctions();
+//	cout << " --------------------- encoder routine ------------------" << endl;
+//	cout << routine << endl << endl;
+	m_context.appendInlineAssembly("{" + routine + "}", variables);
+	// Remove everyhing except for "value0" / the final memory pointer.
+	popStackSlots(numValues);
 }
 
 void CompilerUtils::zeroInitialiseMemoryArray(ArrayType const& _type)

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -103,6 +103,18 @@ public:
 		bool _encodeAsLibraryTypes = false
 	);
 
+	void abiEncode(
+		TypePointers const& _givenTypes,
+		TypePointers const& _targetTypes,
+		bool _encodeAsLibraryTypes = false
+	);
+
+	std::string abiEncodingFunction(
+		TypePointer const& _givenType,
+		TypePointer const& _targetType,
+		bool _encodeAsLibraryTypes = false
+	);
+
 	/// Zero-initialises (the data part of) an already allocated memory array.
 	/// Length has to be nonzero!
 	/// Stack pre: <length> <memptr>

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -325,7 +325,7 @@ void ContractCompiler::appendCalldataUnpacker(TypePointers const& _typeParameter
 	{
 		// stack: v1 v2 ... v(k-1) base_offset current_offset
 		TypePointer type = parameterType->decodingType();
-		solAssert(type, "No decoding type found.");
+		solUnimplementedAssert(type, "No decoding type found.");
 		if (type->category() == Type::Category::Array)
 		{
 			auto const& arrayType = dynamic_cast<ArrayType const&>(*type);

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -116,12 +116,13 @@ Json::Value ABI::formatType(string const& _name, Type const& _type, bool _forLib
 {
 	Json::Value ret;
 	ret["name"] = _name;
+	string suffix = (_forLibrary && _type.dataStoredIn(DataLocation::Storage)) ? " storage" : "";
 	if (_type.isValueType() || (_forLibrary && _type.dataStoredIn(DataLocation::Storage)))
-		ret["type"] = _type.canonicalName(_forLibrary);
+		ret["type"] = _type.canonicalName() + suffix;
 	else if (ArrayType const* arrayType = dynamic_cast<ArrayType const*>(&_type))
 	{
 		if (arrayType->isByteArray())
-			ret["type"] = _type.canonicalName(_forLibrary);
+			ret["type"] = _type.canonicalName() + suffix;
 		else
 		{
 			string suffix;

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -132,25 +132,25 @@ Json::Value ABI::formatType(string const& _name, Type const& _type, bool _forLib
 				suffix = string("[") + arrayType->length().str() + "]";
 			solAssert(arrayType->baseType(), "");
 			Json::Value subtype = formatType("", *arrayType->baseType(), _forLibrary);
-			if (subtype["type"].isString() && !subtype.isMember("subtype"))
-				ret["type"] = subtype["type"].asString() + suffix;
-			else
+			if (subtype.isMember("components"))
 			{
-				ret["type"] = suffix;
-				solAssert(!subtype.isMember("subtype"), "");
-				ret["subtype"] = subtype["type"];
+				ret["type"] = subtype["type"].asString() + suffix;
+				ret["components"] = subtype["components"];
 			}
+			else
+				ret["type"] = subtype["type"].asString() + suffix;
 		}
 	}
 	else if (StructType const* structType = dynamic_cast<StructType const*>(&_type))
 	{
-		ret["type"] = Json::arrayValue;
+		ret["type"] = string();
+		ret["components"] = Json::arrayValue;
 		for (auto const& member: structType->members(nullptr))
 		{
 			solAssert(member.type, "");
 			auto t = member.type->interfaceType(_forLibrary);
 			solAssert(t, "");
-			ret["type"].append(formatType(member.name, *t, _forLibrary));
+			ret["components"].append(formatType(member.name, *t, _forLibrary));
 		}
 	}
 	else

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -82,12 +82,12 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 		Json::Value params(Json::arrayValue);
 		for (auto const& p: it->parameters())
 		{
-			solAssert(!!p->annotation().type->interfaceType(false), "");
+			auto type = p->annotation().type->interfaceType(false);
+			solAssert(type, "");
 			Json::Value input;
-			input["name"] = p->name();
-			input["type"] = p->annotation().type->interfaceType(false)->canonicalName(false);
-			input["indexed"] = p->isIndexed();
-			params.append(input);
+			auto param = formatType(p->name(), *type, false);
+			param["indexed"] = p->isIndexed();
+			params.append(param);
 		}
 		event["inputs"] = params;
 		abi.append(event);
@@ -107,10 +107,50 @@ Json::Value ABI::formatTypeList(
 	for (unsigned i = 0; i < _names.size(); ++i)
 	{
 		solAssert(_types[i], "");
-		Json::Value param;
-		param["name"] = _names[i];
-		param["type"] = _types[i]->canonicalName(_forLibrary);
-		params.append(param);
+		params.append(formatType(_names[i], *_types[i], _forLibrary));
 	}
 	return params;
+}
+
+Json::Value ABI::formatType(string const& _name, Type const& _type, bool _forLibrary)
+{
+	Json::Value ret;
+	ret["name"] = _name;
+	if (_type.isValueType() || (_forLibrary && _type.dataStoredIn(DataLocation::Storage)))
+		ret["type"] = _type.canonicalName(_forLibrary);
+	else if (ArrayType const* arrayType = dynamic_cast<ArrayType const*>(&_type))
+	{
+		if (arrayType->isByteArray())
+			ret["type"] = _type.canonicalName(_forLibrary);
+		else
+		{
+			string suffix;
+			if (arrayType->isDynamicallySized())
+				suffix = "[]";
+			else
+				suffix = string("[") + arrayType->length().str() + "]";
+			solAssert(arrayType->baseType(), "");
+			Json::Value subtype = formatType("", *arrayType->baseType(), _forLibrary);
+			if (subtype["type"].isString() && !subtype.isMember("subtype"))
+				ret["type"] = subtype["type"].asString() + suffix;
+			else
+			{
+				ret["type"] = suffix;
+				solAssert(!subtype.isMember("subtype"), "");
+				ret["subtype"] = subtype["type"];
+			}
+		}
+	}
+	else if (StructType const* structType = dynamic_cast<StructType const*>(&_type))
+	{
+		ret["type"] = Json::arrayValue;
+		for (auto const& member: structType->members(nullptr))
+		{
+			solAssert(member.type, "");
+			ret["type"].append(formatType(member.name, *member.type, _forLibrary));
+		}
+	}
+	else
+		solAssert(false, "Invalid type.");
+	return ret;
 }

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -148,7 +148,9 @@ Json::Value ABI::formatType(string const& _name, Type const& _type, bool _forLib
 		for (auto const& member: structType->members(nullptr))
 		{
 			solAssert(member.type, "");
-			ret["type"].append(formatType(member.name, *member.type, _forLibrary));
+			auto t = member.type->interfaceType(_forLibrary);
+			solAssert(t, "");
+			ret["type"].append(formatType(member.name, *t, _forLibrary));
 		}
 	}
 	else

--- a/libsolidity/interface/ABI.h
+++ b/libsolidity/interface/ABI.h
@@ -50,6 +50,10 @@ private:
 		std::vector<TypePointer> const& _types,
 		bool _forLibrary
 	);
+	/// @returns a Json object with "name", "type" and potentially "subtype" keys, according
+	/// to the ABI specification.
+	/// If it is possible to express the type as a single string, it is allowed to return a single string.
+	static Json::Value formatType(std::string const& _name, Type const& _type, bool _forLibrary);
 };
 
 }

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -46,6 +46,7 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 	if (dev::test::Options::get().disableIPC)
 	{
 		for (auto suite: {
+			"ABIEncoderTest",
 			"SolidityAuctionRegistrar",
 			"SolidityFixedFeeRegistrar",
 			"SolidityWallet",

--- a/test/libsolidity/ABIEncoderTests.cpp
+++ b/test/libsolidity/ABIEncoderTests.cpp
@@ -1,0 +1,255 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Unit tests for Solidity's ABI encoder.
+ */
+
+#include <functional>
+#include <string>
+#include <tuple>
+#include <boost/test/unit_test.hpp>
+#include <libsolidity/interface/Exceptions.h>
+#include <test/libsolidity/SolidityExecutionFramework.h>
+
+using namespace std;
+using namespace std::placeholders;
+using namespace dev::test;
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+#define REQUIRE_LOG_DATA(DATA) do { \
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1); \
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress); \
+	BOOST_CHECK_EQUAL(toHex(m_logs[0].data), toHex(DATA)); \
+} while (false)
+
+BOOST_FIXTURE_TEST_SUITE(ABIEncoderTest, SolidityExecutionFramework)
+
+BOOST_AUTO_TEST_CASE(value_types)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(uint a, uint16 b, uint24 c, int24 d, bytes3 x, bool, C);
+			function f() {
+				bytes6 x = hex"1bababababa2";
+				bool b;
+				assembly { b := 7 }
+				C c;
+				assembly { c := sub(0, 5) }
+				E(10, uint16(uint256(-2)), uint24(0x12121212), int24(int256(-1)), bytes3(x), b, c);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(
+		10, u256(65534), u256(0x121212), u256(-1), string("\x1b\xab\xab"), true, u160(u256(-5))
+	));
+}
+
+BOOST_AUTO_TEST_CASE(string_literal)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(string, bytes20, string);
+			function f() {
+				E("abcdef", "abcde", "abcdefabcdefgehabcabcasdfjklabcdefabcedefghabcabcasdfjklabcdefabcdefghabcabcasdfjklabcdeefabcdefghabcabcasdefjklabcdefabcdefghabcabcasdfjkl");
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(
+		0x60, string("abcde"), 0xa0,
+		6, string("abcdef"),
+		0x8b, string("abcdefabcdefgehabcabcasdfjklabcdefabcedefghabcabcasdfjklabcdefabcdefghabcabcasdfjklabcdeefabcdefghabcabcasdefjklabcdefabcdefghabcabcasdfjkl")
+	));
+}
+
+
+BOOST_AUTO_TEST_CASE(enum_type_cleanup)
+{
+	char const* sourceCode = R"(
+		contract C {
+			enum E { A, B }
+			function f(uint x) returns (E en) {
+				assembly { en := x }
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f(uint256)", 0) == encodeArgs(0));
+	BOOST_CHECK(callContractFunction("f(uint256)", 1) == encodeArgs(1));
+	BOOST_CHECK(callContractFunction("f(uint256)", 2) == encodeArgs());
+}
+
+BOOST_AUTO_TEST_CASE(conversion)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(bytes4, bytes4, uint16, uint8, int16, int8);
+			function f() {
+				bytes2 x; assembly { x := 0xf1f2f3f400000000000000000000000000000000000000000000000000000000 }
+				uint8 a;
+				uint16 b = 0x1ff;
+				int8 c;
+				int16 d;
+				assembly { a := sub(0, 1) c := 0x0101ff d := 0xff01 }
+				E(10, x, a, uint8(b), c, int8(d));
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(
+		string(3, 0) + string("\x0a"), string("\xf1\xf2"),
+		0xff, 0xff, u256(-1), u256(1)
+	));
+}
+
+BOOST_AUTO_TEST_CASE(storage_byte_array)
+{
+	char const* sourceCode = R"(
+		contract C {
+			bytes short;
+			bytes long;
+			event E(bytes s, bytes l);
+			function f() {
+				short = "123456789012345678901234567890a";
+				long = "ffff123456789012345678901234567890afffffffff123456789012345678901234567890a";
+				E(short, long);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(
+		0x40, 0x80,
+		31, string("123456789012345678901234567890a"),
+		75, string("ffff123456789012345678901234567890afffffffff123456789012345678901234567890a")
+	));
+}
+
+BOOST_AUTO_TEST_CASE(storage_array)
+{
+	char const* sourceCode = R"(
+		contract C {
+			address[3] addr;
+			event E(address[3] a);
+			function f() {
+				assembly {
+					sstore(0, sub(0, 1))
+					sstore(1, sub(0, 2))
+					sstore(2, sub(0, 3))
+				}
+				E(addr);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(u160(-1), u160(-2), u160(-3)));
+}
+
+BOOST_AUTO_TEST_CASE(storage_array_dyn)
+{
+	char const* sourceCode = R"(
+		contract C {
+			address[] addr;
+			event E(address[] a);
+			function f() {
+				addr.push(1);
+				addr.push(2);
+				addr.push(3);
+				E(addr);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(0x20, 3, u160(1), u160(2), u160(3)));
+}
+
+BOOST_AUTO_TEST_CASE(storage_array_compact)
+{
+	char const* sourceCode = R"(
+		contract C {
+			int72[] x;
+			event E(int72[]);
+			function f() {
+				x.push(-1);
+				x.push(2);
+				x.push(-3);
+				x.push(4);
+				x.push(-5);
+				x.push(6);
+				x.push(-7);
+				x.push(8);
+				E(x);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(
+		0x20, 8, u256(-1), 2, u256(-3), 4, u256(-5), 6, u256(-7), 8
+	));
+}
+
+BOOST_AUTO_TEST_CASE(external_function)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(function(uint) external returns (uint), function(uint) external returns (uint));
+			function(uint) external returns (uint) g;
+			function f(uint) returns (uint) {
+				g = this.f;
+				E(this.f, g);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+}
+
+BOOST_AUTO_TEST_CASE(external_function_cleanup)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(function(uint) external returns (uint), function(uint) external returns (uint));
+			function(uint) external returns (uint) g;
+			function f(uint) returns (uint) {
+				function(uint) external returns (uint)[1] memory h;
+				assembly { sstore(0, sub(0, 1)) mstore(h, sub(0, 1)) }
+				E(h[0], g);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f(uint256)");
+	REQUIRE_LOG_DATA(encodeArgs(string(24, 0xff), string(24, 0xff)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+} // end namespaces

--- a/test/libsolidity/ABIEncoderTests.cpp
+++ b/test/libsolidity/ABIEncoderTests.cpp
@@ -126,6 +126,73 @@ BOOST_AUTO_TEST_CASE(conversion)
 	));
 }
 
+BOOST_AUTO_TEST_CASE(memory_array_one_dim)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(uint a, int16[] b, uint c);
+			function f() {
+				int16[] memory x = new int16[](3);
+				assembly {
+					for { let i := 0 } lt(i, 3) { i := add(i, 1) } {
+						mstore(add(x, mul(add(i, 1), 0x20)), add(0xfffffffe, i))
+					}
+				}
+				E(10, x, 11);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(10, 0x60, 11, 3, u256(-2), u256(-1), u256(0)));
+}
+
+BOOST_AUTO_TEST_CASE(memory_array_two_dim)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(uint a, int16[][2] b, uint c);
+			function f() {
+				int16[][2] memory x;
+				x[0] = new int16[](3);
+				x[1] = new int16[](2);
+				x[0][0] = 7;
+				x[0][1] = int16(0x010203040506);
+				x[0][2] = -1;
+				x[1][0] = 4;
+				x[1][1] = 5;
+				E(10, x, 11);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(10, 0x60, 11, 0x40, 0xc0, 3, 7, 0x0506, u256(-1), 2, 4, 5));
+}
+
+BOOST_AUTO_TEST_CASE(memory_byte_array)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(uint a, bytes[] b, uint c);
+			function f() {
+				bytes[] memory x = new bytes[](2);
+				x[0] = "abcabcdefghjklmnopqrsuvwabcdefgijklmnopqrstuwabcdefgijklmnoprstuvw";
+				x[1] = "abcdefghijklmnopqrtuvwabcfghijklmnopqstuvwabcdeghijklmopqrstuvw";
+				E(10, x, 11);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("f()");
+	REQUIRE_LOG_DATA(encodeArgs(
+		10, 0x60, 11,
+		2, 0x40, 0xc0,
+		66, string("abcabcdefghjklmnopqrsuvwabcdefgijklmnopqrstuwabcdefgijklmnoprstuvw"),
+		63, string("abcdefghijklmnopqrtuvwabcfghijklmnopqstuvwabcdeghijklmopqrstuvw")
+	));
+}
+
 BOOST_AUTO_TEST_CASE(storage_byte_array)
 {
 	char const* sourceCode = R"(
@@ -247,6 +314,104 @@ BOOST_AUTO_TEST_CASE(external_function_cleanup)
 	callContractFunction("f(uint256)");
 	REQUIRE_LOG_DATA(encodeArgs(string(24, 0xff), string(24, 0xff)));
 }
+
+BOOST_AUTO_TEST_CASE(calldata)
+{
+	char const* sourceCode = R"(
+		contract C {
+			event E(bytes);
+			function f(bytes a) external {
+				E(a);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	string s("abcdef");
+	string t("abcdefgggggggggggggggggggggggggggggggggggggggghhheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeggg");
+	callContractFunction("f(bytes)", 0x20, s.size(), s);
+	REQUIRE_LOG_DATA(encodeArgs(0x20, s.size(), s));
+	callContractFunction("f(bytes)", 0x20, t.size(), t);
+	REQUIRE_LOG_DATA(encodeArgs(0x20, t.size(), t));
+}
+
+BOOST_AUTO_TEST_CASE(structs)
+{
+	char const* sourceCode = R"(
+		contract C {
+			struct S { uint a; T[] sub; }
+			struct T { uint[2] x; }
+			function f() returns (uint x, S s) {
+				x = 7;
+				s.a = 8;
+				s.sub = new T[](3);
+				s.sub[0].x[0] = 9;
+				s.sub[1].x[0] = 10;
+				s.sub[2].x[1] = 11;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(
+		7, 0x40,
+		8, 0x40,
+		3, 9, 0, 10, 0, 0, 11
+	));
+}
+
+BOOST_AUTO_TEST_CASE(struct_from_storage)
+{
+	char const* sourceCode = R"(
+		contract C {
+			struct S { uint120 a; uint120 b; T[] sub; uint8 c; }
+			struct T { uint24[2] x; }
+			S s;
+			event E(S);
+			function f() {
+				s.a = 0xf1f2f3f4f5f6f7f8f9fafb;
+				s.b = ~s.a;
+				s.c = 0xfa;
+				s.sub.length = 3;
+				s.sub[0].x[0] = 8;
+				s.sub[0].x[1] = 9;
+				s.sub[1].x[0] = 10;
+				s.sub[2].x[1] = 11;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs());
+	REQUIRE_LOG_DATA(encodeArgs(
+		0x20,
+		u256("0xf1f2f3f4f5f6f7f8f9fafb"), u256(0), 0x80, 0xfa,
+		3,
+		8, 9, 10, 0, 0, 11
+	));
+}
+
+BOOST_AUTO_TEST_CASE(struct_with_mapping)
+{
+	char const* sourceCode = R"(
+		contract C {
+			struct S { uint8 a; uint8 b; mapping(uint => uint) m; uint8 d; }
+			S s;
+			event E(S);
+			function f() {
+				s.a = 7;
+				s.b = 9;
+				s.d = 10;
+				E(s);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callContractFunction("f()") == encodeArgs(
+		7, 0x40,
+		8, 0x40,
+		3, 9, 0, 10, 0, 0, 11
+	));
+}
+
+
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -765,32 +765,39 @@ BOOST_AUTO_TEST_CASE(return_structs)
 		}
 	)";
 	char const* interface = R"(
-	[
-	{
+	[{
 		"constant" : false,
-		"payable": false,
-		"inputs": [],
-		"name": "f",
-		"outputs": [{
-			"name": "x",
-			"type": "uint256"
-		}, {
-			"name": "s",
-			"type": [{
-				"name": "a",
-				"type": "uint256"
-			}, {
-				"name": "sub",
-				"subtype": [{
-					"name": "x",
-					"type": "uint256[2]"
-				}],
-				"type": "[]"
-			}]
-		}],
+		"inputs" : [],
+		"name" : "f",
+		"outputs" : [
+			{
+			"name" : "x",
+			"type" : "uint256"
+			},
+			{
+			"components" : [
+				{
+					"name" : "a",
+					"type" : "uint256"
+				},
+				{
+					"components" : [
+						{
+						"name" : "x",
+						"type" : "uint256[2]"
+						}
+					],
+					"name" : "sub",
+					"type" : "[]"
+				}
+			],
+			"name" : "s",
+			"type" : ""
+			}
+		],
+		"payable" : false,
 		"type" : "function"
-	}
-	]
+	}]
 	)";
 	checkInterface(text, interface);
 }
@@ -805,28 +812,33 @@ BOOST_AUTO_TEST_CASE(return_structs_with_contracts)
 		}
 	)";
 	char const* interface = R"(
-	[
-	{
-		"constant" : false,
-		"payable": false,
+	[{
+		"constant": false,
 		"inputs": [],
 		"name": "f",
-		"outputs" : [{
-			"name" : "s",
-			"type" : [{
-				"name" : "x",
-				"type" : "address[]"
-			}, {
-				"name" : "y",
-				"type" : "address"
-			}]
-		}, {
-			"name" : "c",
-			"type" : "address"
-		}],
-		"type" : "function"
-	}
-	]
+		"outputs": [
+			{
+				"components": [
+					{
+						"name": "x",
+						"type": "address[]"
+					},
+					{
+						"name": "y",
+						"type": "address"
+					}
+				],
+				"name": "s",
+				"type": ""
+			},
+			{
+				"name": "c",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"type": "function"
+	}]
 	)";
 	checkInterface(text, interface);
 }
@@ -840,36 +852,49 @@ BOOST_AUTO_TEST_CASE(event_structs)
 			event E(T t, S s);
 		}
 	)";
-	char const* interface = R"(
-	[{
-		"anonymous" : false,
-		"inputs" : [{
-			"indexed" : false,
-			"name" : "t",
-			"type" : [{
-				"name" : "x",
-				"type" : "uint256[2]"
-			}]
-		}, {
-			"indexed" : false,
-			"name" : "s",
-			"type" : [{
-					"name" : "a",
-					"type" : "uint256"
-				}, {
-					"name" : "sub",
-					"subtype" : [{
-						"name" : "x",
-						"type" : "uint256[2]"
-					}],
-					"type" : "[]"
-				}, {
-					"name" : "b",
-					"type" : "bytes"
-				}]
-		}],
-		"name" : "E",
-		"type" : "event"
+	char const *interface = R"(
+		[{
+		"anonymous": false,
+		"inputs": [
+			{
+				"components": [
+					{
+						"name": "x",
+						"type": "uint256[2]"
+					}
+				],
+				"indexed": false,
+				"name": "t",
+				"type": ""
+			},
+			{
+				"components": [
+					{
+						"name": "a",
+						"type": "uint256"
+					},
+					{
+						"components": [
+							{
+								"name": "x",
+								"type": "uint256[2]"
+							}
+						],
+						"name": "sub",
+						"type": "[]"
+					},
+					{
+						"name": "b",
+						"type": "bytes"
+					}
+				],
+				"indexed": false,
+				"name": "s",
+				"type": ""
+			}
+		],
+		"name": "E",
+		"type": "event"
 	}]
 	)";
 	checkInterface(text, interface);
@@ -887,38 +912,50 @@ BOOST_AUTO_TEST_CASE(structs_in_libraries)
 	)";
 	char const* interface = R"(
 	[{
-		"constant" : false,
-		"inputs" : [{
-			"name" : "s",
-			"type" : [{
-				"name" : "a",
-				"type" : "uint256"
-			}, {
-				"name" : "sub",
-				"subtype" : [{
-					"name" : "x",
-					"type" : "uint256[2]"
-				}],
-				"type" : "[]"
-			}, {
-				"name" : "b",
-				"type" : "bytes"
-			}]
-		}],
-		"name" : "g",
-		"outputs" : [],
-		"payable" : false,
-		"type" : "function"
-	}, {
-		"constant" : false,
-		"inputs" : [{
-			"name" : "s",
-			"type" : "L.S storage"
-		}],
-		"name" : "f",
-		"outputs" : [],
-		"payable" : false,
-		"type" : "function"
+		"constant": false,
+		"inputs": [
+			{
+				"components": [
+					{
+						"name": "a",
+						"type": "uint256"
+					},
+					{
+						"components": [
+							{
+								"name": "x",
+								"type": "uint256[2]"
+							}
+						],
+						"name": "sub",
+						"type": "[]"
+					},
+					{
+						"name": "b",
+						"type": "bytes"
+					}
+				],
+				"name": "s",
+				"type": ""
+			}
+		],
+		"name": "g",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "s",
+				"type": "L.S storage"
+			}
+		],
+		"name": "f",
+		"outputs": [],
+		"payable": false,
+		"type": "function"
 	}]
 	)";
 	checkInterface(text, interface);

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -795,6 +795,42 @@ BOOST_AUTO_TEST_CASE(return_structs)
 	checkInterface(text, interface);
 }
 
+BOOST_AUTO_TEST_CASE(return_structs_with_contracts)
+{
+	char const* text = R"(
+		contract C {
+			struct S { C[] x; C y; }
+			function f() returns (S s, C c) {
+			}
+		}
+	)";
+	char const* interface = R"(
+	[
+	{
+		"constant" : false,
+		"payable": false,
+		"inputs": [],
+		"name": "f",
+		"outputs" : [{
+			"name" : "s",
+			"type" : [{
+				"name" : "x",
+				"type" : "address[]"
+			}, {
+				"name" : "y",
+				"type" : "address"
+			}]
+		}, {
+			"name" : "c",
+			"type" : "address"
+		}],
+		"type" : "function"
+	}
+	]
+	)";
+	checkInterface(text, interface);
+}
+
 BOOST_AUTO_TEST_CASE(event_structs)
 {
 	char const* text = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -3157,6 +3157,31 @@ BOOST_AUTO_TEST_CASE(event_really_lots_of_data_from_storage)
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(uint256,bytes,uint256)")));
 }
 
+BOOST_AUTO_TEST_CASE(event_really_really_lots_of_data_from_storage)
+{
+	char const* sourceCode = R"(
+		contract ClientReceipt {
+			bytes x;
+			event Deposit(uint fixeda, bytes dynx, uint fixedb);
+			function deposit() {
+				x.length = 31;
+				x[0] = "A";
+				x[1] = "B";
+				x[2] = "C";
+				x[30] = "Z";
+				Deposit(10, x, 15);
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	callContractFunction("deposit()");
+	BOOST_REQUIRE_EQUAL(m_logs.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].address, m_contractAddress);
+	BOOST_CHECK(m_logs[0].data == encodeArgs(10, 0x60, 15, 31, string("ABC") + string(27, 0) + "Z"));
+	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 1);
+	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("Deposit(uint256,bytes,uint256)")));
+}
+
 BOOST_AUTO_TEST_CASE(event_indexed_string)
 {
 	char const* sourceCode = R"(
@@ -4400,6 +4425,75 @@ BOOST_AUTO_TEST_CASE(array_copy_storage_storage_struct)
 	compileAndRun(sourceCode);
 	BOOST_CHECK(callContractFunction("test()") == encodeArgs(4, 5));
 	BOOST_CHECK(storageEmpty(m_contractAddress));
+}
+
+BOOST_AUTO_TEST_CASE(array_copy_storage_abi)
+{
+	// NOTE: This does not really test copying from storage to ABI directly,
+	// because it will always copy to memory first.
+	char const* sourceCode = R"(
+		contract c {
+			uint8[] x;
+			uint16[] y;
+			uint24[] z;
+			function test1() returns (uint8[]) {
+				for (uint i = 0; i < 101; ++i)
+					x.push(uint8(i));
+				return x;
+			}
+			function test2() returns (uint16[]) {
+				for (uint i = 0; i < 101; ++i)
+					y.push(uint16(i));
+				return y;
+			}
+			function test3() returns (uint24[]) {
+				for (uint i = 0; i < 101; ++i)
+					z.push(uint24(i));
+				return z;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	bytes valueSequence;
+	for (size_t i = 0; i < 101; ++i)
+		valueSequence += toBigEndian(u256(i));
+	BOOST_CHECK(callContractFunction("test1()") == encodeArgs(0x20, 101) + valueSequence);
+	BOOST_CHECK(callContractFunction("test2()") == encodeArgs(0x20, 101) + valueSequence);
+	BOOST_CHECK(callContractFunction("test3()") == encodeArgs(0x20, 101) + valueSequence);
+}
+
+BOOST_AUTO_TEST_CASE(array_copy_storage_abi_signed)
+{
+	// NOTE: This does not really test copying from storage to ABI directly,
+	// because it will always copy to memory first.
+	char const* sourceCode = R"(
+		contract c {
+			int16[] x;
+			function test() returns (int16[]) {
+				x.push(int16(-1));
+				x.push(int16(-1));
+				x.push(int16(8));
+				x.push(int16(-16));
+				x.push(int16(-2));
+				x.push(int16(6));
+				x.push(int16(8));
+				x.push(int16(-1));
+				return x;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	bytes valueSequence;
+	BOOST_CHECK(callContractFunction("test()") == encodeArgs(0x20, 8,
+		u256(-1),
+		u256(-1),
+		u256(8),
+		u256(-16),
+		u256(-2),
+		u256(6),
+		u256(8),
+		u256(-1)
+	));
 }
 
 BOOST_AUTO_TEST_CASE(array_push)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -9681,7 +9681,10 @@ BOOST_AUTO_TEST_CASE(return_structs)
 			}
 		}
 	)";
-	compileAndRun(sourceCode, 0, "C");
+	// This will throw "unimplemented" until it is implemented.
+	BOOST_CHECK_THROW(
+		compileAndRun(sourceCode, 0, "C"),
+		Exception);
 
 //	Will calculate the exact encoding later.
 //	BOOST_CHECK(callContractFunction("f()") == encodeArgs(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -9665,6 +9665,47 @@ BOOST_AUTO_TEST_CASE(contracts_separated_with_comment)
 	compileAndRun(sourceCode, 0, "C2");
 }
 
+BOOST_AUTO_TEST_CASE(return_structs)
+{
+	char const* sourceCode = R"(
+		contract C {
+			struct S { uint a; T[] sub; }
+			struct T { uint[2] x; }
+			function f() returns (uint x, S s) {
+				x = 7;
+				s.a = 8;
+				s.sub = new S[](3);
+				s.sub[0][0] = 9;
+				s.sub[1][0] = 10;
+				s.sub[2][1] = 11;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+
+//	Will calculate the exact encoding later.
+//	BOOST_CHECK(callContractFunction("f()") == encodeArgs(
+//		u256(7), u256(0x40),
+//		u256(8), u256(0x40),
+//		u256(3),
+//		// s.sub[0]
+//		u256(9), u256(0xc0),
+//		// s.sub[1]
+//		u256(10), u256(0xe0),
+//		// s.sub[2]
+//		u256(11), u256(0x100),
+//		// s.sub[0].sub
+//		u256(2)
+//		// s.sub[0].sub[0].a
+//		u256(8),
+//		u256()
+//		// s.sub[1].sub
+//		u256(0)
+//		// s.sub[2].sub
+//		u256(2)
+//					));
+}
+
 BOOST_AUTO_TEST_CASE(include_creation_bytecode_only_once)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -9674,10 +9674,10 @@ BOOST_AUTO_TEST_CASE(return_structs)
 			function f() returns (uint x, S s) {
 				x = 7;
 				s.a = 8;
-				s.sub = new S[](3);
-				s.sub[0][0] = 9;
-				s.sub[1][0] = 10;
-				s.sub[2][1] = 11;
+				s.sub = new T[](3);
+				s.sub[0].x[0] = 9;
+				s.sub[1].x[0] = 10;
+				s.sub[2].x[1] = 11;
 			}
 		}
 	)";

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -792,11 +792,35 @@ BOOST_AUTO_TEST_CASE(enum_external_type)
 
 BOOST_AUTO_TEST_CASE(external_structs)
 {
-	BOOST_FAIL("This should test external structs");
-	// More test ideas:
-	// external function type as part of a struct and array
-	// external function type taking structs and arrays...
+	ASTPointer<SourceUnit> sourceUnit;
+	char const* text = R"(
+		contract Test {
+			enum ActionChoices { GoLeft, GoRight, GoStraight, Sit }
+			struct Empty {}
+			struct Nested { X[2][] a; mapping(uint => uint) m; uint y; }
+			struct X { bytes32 x; Test t; Empty[] e; }
+			function f(ActionChoices, uint, Empty) external {}
+			function g(Nested) external {}
+			function h(function(Nested) external returns (uint)[]) external {}
+			function i(Nested[]) external {}
+		}
+	)";
+	ETH_TEST_REQUIRE_NO_THROW(sourceUnit = parseAndAnalyse(text), "Parsing and name Resolving failed");
+	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
+		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
+		{
+			auto functions = contract->definedFunctions();
+			BOOST_REQUIRE(!functions.empty());
+			for (auto const& f: functions)
+				cout << f->externalSignature() << endl;
+			BOOST_CHECK_EQUAL("f(uint8,uint256,())", functions[0]->externalSignature());
+			BOOST_CHECK_EQUAL("g(((bytes32,address,()[])[2][],uint256))", functions[1]->externalSignature());
+			BOOST_CHECK_EQUAL("h(function[])", functions[2]->externalSignature());
+			BOOST_CHECK_EQUAL("i(((bytes32,address,()[])[2][],uint256)[])", functions[3]->externalSignature());
+		}
 }
+
+// TODO: Add a test that checks the signature of library functions taking structs
 
 BOOST_AUTO_TEST_CASE(function_external_call_allowed_conversion)
 {

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(external_structs)
 			struct Nested { X[2][] a; mapping(uint => uint) m; uint y; }
 			struct X { bytes32 x; Test t; Empty[] e; }
 			function f(ActionChoices, uint, Empty) external {}
-			function g(Nested) external {}
+			function g(Test, Nested) external {}
 			function h(function(Nested) external returns (uint)[]) external {}
 			function i(Nested[]) external {}
 		}
@@ -811,10 +811,8 @@ BOOST_AUTO_TEST_CASE(external_structs)
 		{
 			auto functions = contract->definedFunctions();
 			BOOST_REQUIRE(!functions.empty());
-			for (auto const& f: functions)
-				cout << f->externalSignature() << endl;
 			BOOST_CHECK_EQUAL("f(uint8,uint256,())", functions[0]->externalSignature());
-			BOOST_CHECK_EQUAL("g(((bytes32,address,()[])[2][],uint256))", functions[1]->externalSignature());
+			BOOST_CHECK_EQUAL("g(address,((bytes32,address,()[])[2][],uint256))", functions[1]->externalSignature());
 			BOOST_CHECK_EQUAL("h(function[])", functions[2]->externalSignature());
 			BOOST_CHECK_EQUAL("i(((bytes32,address,()[])[2][],uint256)[])", functions[3]->externalSignature());
 		}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -790,6 +790,14 @@ BOOST_AUTO_TEST_CASE(enum_external_type)
 		}
 }
 
+BOOST_AUTO_TEST_CASE(external_structs)
+{
+	BOOST_FAIL("This should test external structs");
+	// More test ideas:
+	// external function type as part of a struct and array
+	// external function type taking structs and arrays...
+}
+
 BOOST_AUTO_TEST_CASE(function_external_call_allowed_conversion)
 {
 	char const* text = R"(
@@ -1162,24 +1170,24 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 	FunctionTypePointer function = retrieveFunctionBySignature(*contract, "foo()");
 	BOOST_REQUIRE(function && function->hasDeclaration());
 	auto returnParams = function->returnParameterTypes();
-	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(false), "uint256");
+	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(), "uint256");
 	BOOST_CHECK(function->isConstant());
 
 	function = retrieveFunctionBySignature(*contract, "map(uint256)");
 	BOOST_REQUIRE(function && function->hasDeclaration());
 	auto params = function->parameterTypes();
-	BOOST_CHECK_EQUAL(params.at(0)->canonicalName(false), "uint256");
+	BOOST_CHECK_EQUAL(params.at(0)->canonicalName(), "uint256");
 	returnParams = function->returnParameterTypes();
-	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(false), "bytes4");
+	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(), "bytes4");
 	BOOST_CHECK(function->isConstant());
 
 	function = retrieveFunctionBySignature(*contract, "multiple_map(uint256,uint256)");
 	BOOST_REQUIRE(function && function->hasDeclaration());
 	params = function->parameterTypes();
-	BOOST_CHECK_EQUAL(params.at(0)->canonicalName(false), "uint256");
-	BOOST_CHECK_EQUAL(params.at(1)->canonicalName(false), "uint256");
+	BOOST_CHECK_EQUAL(params.at(0)->canonicalName(), "uint256");
+	BOOST_CHECK_EQUAL(params.at(1)->canonicalName(), "uint256");
 	returnParams = function->returnParameterTypes();
-	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(false), "bytes4");
+	BOOST_CHECK_EQUAL(returnParams.at(0)->canonicalName(), "bytes4");
 	BOOST_CHECK(function->isConstant());
 }
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5526,6 +5526,56 @@ BOOST_AUTO_TEST_CASE(constructible_internal_constructor)
 	success(text);
 }
 
+BOOST_AUTO_TEST_CASE(return_structs)
+{
+	char const* text = R"(
+		contract C {
+			struct S { uint a; T[] sub; }
+			struct T { uint[] x; }
+			function f() returns (uint x, S s) {
+			}
+		}
+	)";
+	success(text);
+}
+
+BOOST_AUTO_TEST_CASE(return_recursive_structs)
+{
+	char const* text = R"(
+		contract C {
+			struct S { uint a; S[] sub; }
+			function f() returns (uint x, S s) {
+			}
+		}
+	)";
+	success(text);
+}
+
+BOOST_AUTO_TEST_CASE(return_recursive_structs2)
+{
+	char const* text = R"(
+		contract C {
+			struct S { uint a; S[2] sub; }
+			function f() returns (uint x, S s) {
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "recursive data types in external functions.");
+}
+
+BOOST_AUTO_TEST_CASE(return_recursive_structs3)
+{
+	char const* text = R"(
+		contract C {
+			struct S { uint a; S sub; }
+			struct T { S s; }
+			function f() returns (uint x, T t) {
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "recursive data types in external functions.");
+}
+
 BOOST_AUTO_TEST_CASE(address_checksum_type_deduction)
 {
 	char const* text = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -3420,7 +3420,7 @@ BOOST_AUTO_TEST_CASE(library_memory_struct)
 			function f() returns (S ) {}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "");
+	CHECK_SUCCESS(text);
 }
 
 BOOST_AUTO_TEST_CASE(using_for_arbitrary_mismatch)
@@ -5532,7 +5532,7 @@ BOOST_AUTO_TEST_CASE(return_structs)
 		contract C {
 			struct S { uint a; T[] sub; }
 			struct T { uint[] x; }
-			function f() returns (uint x, S s) {
+			function f() returns (uint, S) {
 			}
 		}
 	)";
@@ -5544,36 +5544,36 @@ BOOST_AUTO_TEST_CASE(return_recursive_structs)
 	char const* text = R"(
 		contract C {
 			struct S { uint a; S[] sub; }
-			function f() returns (uint x, S s) {
+			function f() returns (uint, S) {
 			}
 		}
 	)";
-	success(text);
+	CHECK_ERROR(text, TypeError, "Internal or recursive type is not allowed for public or external functions.");
 }
 
 BOOST_AUTO_TEST_CASE(return_recursive_structs2)
 {
 	char const* text = R"(
 		contract C {
-			struct S { uint a; S[2] sub; }
-			function f() returns (uint x, S s) {
+			struct S { uint a; S[2][] sub; }
+			function f() returns (uint, S) {
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "recursive data types in external functions.");
+	CHECK_ERROR(text, TypeError, "Internal or recursive type is not allowed for public or external functions.");
 }
 
 BOOST_AUTO_TEST_CASE(return_recursive_structs3)
 {
 	char const* text = R"(
 		contract C {
-			struct S { uint a; S sub; }
+			struct S { uint a; S[][][] sub; }
 			struct T { S s; }
 			function f() returns (uint x, T t) {
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "recursive data types in external functions.");
+	CHECK_ERROR(text, TypeError, "Internal or recursive type is not allowed for public or external functions.");
 }
 
 BOOST_AUTO_TEST_CASE(address_checksum_type_deduction)


### PR DESCRIPTION
 - [x] reduce duplication of generated code
 - [ ] simple JULIA optimizer stage
 - [x] check where ABI encoders from storage are used, verify code coverage and add tests if needed

Currently, we can only reduce duplication if all encoders are handled in a single pass of the JULIA parser, because only then we can have different JULIA functions referencing themselves. This is only possible if the ABI encoder has a label we can jump to. This requires the following refactorings:

Each call to `encodeToMemory` has to be changed to an actual function call and for that, the return label has to be put onto the stack before the values to encode are put onto the stack.

Furthermore, we have to have a way to reference a label in a piece of JULIA code from outside of that JULIA code and this also has to be possible before that code is even parsed.

I think the best solution to this problem is to provide a string as a hint to `AbstractAssembly::newLabelID` so that the EVM assembly can specially prepare some label ids to be linked properly.

Depends on #1673 and #2704.