### PR TITLE
LLL: Fix msg macro with six arguments.

### DIFF
--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -49,7 +49,8 @@ void CompilerState::populateStandard()
 	"(def 'allgas (- (gas) 21))"
 	"(def 'send (to value) (call allgas to value 0 0 0 0))"
 	"(def 'send (gaslimit to value) (call gaslimit to value 0 0 0 0))"
-	"(def 'msg (gaslimit to value data datasize outsize) { (set x outsize) (set y (alloc @32)) (call gaslimit to value data datasize @0 @32) @0 })"
+	// NOTE: in this macro, memory location 0 is set in order to force msize to be at least 32 bytes.
+	"(def 'msg (gaslimit to value data datasize outsize) { [0]:0 [0]:(msize) (call gaslimit to value data datasize @0 outsize) @0 })"
 	"(def 'msg (gaslimit to value data datasize) { (call gaslimit to value data datasize 0 32) @0 })"
 	"(def 'msg (gaslimit to value data) { [0]:data (msg gaslimit to value 0 32) })"
 	"(def 'msg (to value data) { [0]:data (msg allgas to value 0 32) })"

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -366,6 +366,23 @@ BOOST_AUTO_TEST_CASE(keccak256_32bytes)
 		fromHex("b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6")));
 }
 
+BOOST_AUTO_TEST_CASE(msg_six_args)
+{
+	char const* sourceCode = R"(
+		(returnlll
+			(seq
+				(when (= 0 (calldatasize))
+					(seq
+						(mstore 0x40 1)
+						(def 'outsize 0x20)
+						(return (msg 1000 (address) 42 0x40 0x20 outsize) outsize)))
+				(when (= 1 (calldataload 0x00))
+					(return (callvalue)))))
+	)";
+	compileAndRun(sourceCode);
+	BOOST_CHECK(callFallbackWithValue(42) == encodeArgs(u256(42)));
+}
+
 BOOST_AUTO_TEST_CASE(create_1_arg)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
The previous macro used the set built-in in a way incompatible with the current
implementation of set. This commit updates the macro to be more transparent in how it's
working and avoids the use of the set and alloc built-ins.

Test case included.