### PR TITLE
Fix address literals not being treated as compile-time constants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Features:
  * Code Generator: Added the Whiskers template system.
 
 Bugfixes:
+ * Type Checker: Fix address literals not being treated as compile-time constants.
  * Type Checker: Make UTF8-validation a bit more sloppy to include more valid sequences.
  * Fixed crash concerning non-callable types.
  * Unused variable warnings no longer issued for variables used inside inline assembly.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1726,10 +1726,7 @@ void TypeChecker::endVisit(Literal const& _literal)
 	if (_literal.looksLikeAddress())
 	{
 		if (_literal.passesAddressChecksum())
-		{
 			_literal.annotation().type = make_shared<IntegerType>(0, IntegerType::Modifier::Address);
-			return;
-		}
 		else
 			m_errorReporter.warning(
 				_literal.location(),
@@ -1737,10 +1734,13 @@ void TypeChecker::endVisit(Literal const& _literal)
 				"If this is not used as an address, please prepend '00'."
 			);
 	}
-	_literal.annotation().type = Type::forLiteral(_literal);
-	_literal.annotation().isPure = true;
+	if (!_literal.annotation().type)
+		_literal.annotation().type = Type::forLiteral(_literal);
+
 	if (!_literal.annotation().type)
 		m_errorReporter.fatalTypeError(_literal.location(), "Invalid literal value.");
+
+	_literal.annotation().isPure = true;
 }
 
 bool TypeChecker::contractDependenciesAreCyclic(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2284,6 +2284,16 @@ BOOST_AUTO_TEST_CASE(constant_struct)
 	CHECK_ERROR(text, TypeError, "implemented");
 }
 
+BOOST_AUTO_TEST_CASE(address_is_constant)
+{
+	char const* text = R"(
+		contract C {
+			address constant x = 0x1212121212121212121212121212121212121212;
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
 BOOST_AUTO_TEST_CASE(uninitialized_const_variable)
 {
 	char const* text = R"(


### PR DESCRIPTION
The early return implemented for address literals in TypeChecker was preventing the isPure annotation from getting applied. Closes #2441