### PR TITLE
Warn deprecated usage of parameter names in function types

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -387,10 +387,10 @@ Example that shows how to use internal function types::
       }
       function reduce(
         uint[] memory self,
-        function (uint x, uint y) returns (uint) f
+        function (uint, uint) returns (uint) f
       )
         internal
-        returns (uint r)
+        returns (uint)
       {
         r = self[0];
         for (uint i = 1; i < self.length; i++) {

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -148,3 +148,15 @@ bool SyntaxChecker::visit(PlaceholderStatement const&)
 	return true;
 }
 
+bool SyntaxChecker::visit(FunctionTypeName const& _node)
+{
+	for (auto const& decl: _node.parameterTypeList()->parameters())
+		if (!decl->name().empty())
+			m_errorReporter.warning(decl->location(), "Naming function type parameters is deprecated.");
+
+	for (auto const& decl: _node.returnParameterTypeList()->parameters())
+		if (!decl->name().empty())
+			m_errorReporter.warning(decl->location(), "Naming function type return parameters is deprecated.");
+
+	return true;
+}

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -63,6 +63,8 @@ private:
 
 	virtual bool visit(PlaceholderStatement const& _placeholderStatement) override;
 
+	virtual bool visit(FunctionTypeName const& _node) override;
+
 	ErrorReporter& m_errorReporter;
 
 	/// Flag that indicates whether a function modifier actually contains '_'.

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5022,6 +5022,26 @@ BOOST_AUTO_TEST_CASE(external_function_type_to_uint)
 	CHECK_ERROR(text, TypeError, "Explicit type conversion not allowed");
 }
 
+BOOST_AUTO_TEST_CASE(warn_function_type_parameters_with_names)
+{
+	char const* text = R"(
+		contract C {
+			function(uint a) f;
+		}
+	)";
+	CHECK_WARNING(text, "Naming function type parameters is deprecated.");
+}
+
+BOOST_AUTO_TEST_CASE(warn_function_type_return_parameters_with_names)
+{
+	char const* text = R"(
+		contract C {
+			function(uint) returns(bool ret) f;
+		}
+	)";
+	CHECK_WARNING(text, "Naming function type return parameters is deprecated.");
+}
+
 BOOST_AUTO_TEST_CASE(shift_constant_left_negative_rvalue)
 {
 	char const* text = R"(


### PR DESCRIPTION
Refs #2428