### PR TITLE
Add an option for disabling inclusion of on-chain metadata

### DIFF
--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -177,6 +177,7 @@ public:
 
 	std::string const& onChainMetadata(std::string const& _contractName) const;
 	void useMetadataLiteralSources(bool _metadataLiteralSources) { m_metadataLiteralSources = _metadataLiteralSources; }
+	void disableOnChainMetadata(bool _disableOnChainMetadata) { m_disableOnChainMetadata = _disableOnChainMetadata; }
 
 	/// @returns a JSON representing the estimated gas usage for contract creation, internal and external functions
 	Json::Value gasEstimates(std::string const& _contractName) const;
@@ -287,6 +288,7 @@ private:
 	ErrorList m_errorList;
 	ErrorReporter m_errorReporter;
 	bool m_metadataLiteralSources = false;
+	bool m_disableOnChainMetadata = false;
 	State m_stackState = Empty;
 };
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -262,6 +262,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 
 	Json::Value metadataSettings = settings.get("metadata", Json::Value());
 	m_compilerStack.useMetadataLiteralSources(metadataSettings.get("useLiteralContent", Json::Value(false)).asBool());
+	m_compilerStack.disableOnChainMetadata(metadataSettings.get("disableOnChainMetadata", Json::Value(false)).asBool());
 
 	auto scannerFromSourceName = [&](string const& _sourceName) -> solidity::Scanner const& { return m_compilerStack.scanner(_sourceName); };
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -98,6 +98,7 @@ static string const g_strLicense = "license";
 static string const g_strLibraries = "libraries";
 static string const g_strLink = "link";
 static string const g_strMetadata = "metadata";
+static string const g_strMetadataDisable = "metadata-disable";
 static string const g_strMetadataLiteral = "metadata-literal";
 static string const g_strNatspecDev = "devdoc";
 static string const g_strNatspecUser = "userdoc";
@@ -137,6 +138,7 @@ static string const g_argLibraries = g_strLibraries;
 static string const g_argLink = g_strLink;
 static string const g_argMachine = "machine";
 static string const g_argMetadata = g_strMetadata;
+static string const g_argMetadataDisable = g_strMetadataDisable;
 static string const g_argMetadataLiteral = g_strMetadataLiteral;
 static string const g_argNatspecDev = g_strNatspecDev;
 static string const g_argNatspecUser = g_strNatspecUser;
@@ -582,6 +584,7 @@ Allowed options)",
 			"and modify binaries in place."
 		)
 		(g_argMetadataLiteral.c_str(), "Store referenced sources are literal data in the metadata output.")
+		(g_argMetadataDisable.c_str(), "Disable on-chain metadata inclusion in compiled objects.")
 		(
 			g_argAllowPaths.c_str(),
 			po::value<string>()->value_name("path(s)"),
@@ -769,6 +772,8 @@ bool CommandLineInterface::processInput()
 	{
 		if (m_args.count(g_argMetadataLiteral) > 0)
 			m_compiler->useMetadataLiteralSources(true);
+		if (m_args.count(g_argMetadataDisable) > 0)
+			m_compiler->disableOnChainMetadata(true);
 		if (m_args.count(g_argInputFile))
 			m_compiler->setRemappings(m_args[g_argInputFile].as<vector<string>>());
 		for (auto const& sourceCode: m_sourceCodes)


### PR DESCRIPTION
Hello!

Recently we've encountered an issue with some elements of our software stack which we've determined to be caused by the inclusion of on-chain metadata in contract binaries. We've noticed that this behavior was added in somewhere between v0.3.6 and v0.4.11, and found that there is no way to disable it.

This PR simply adds a command line flag, `--metadata-disable` as well as the corresponding setting in the JSON input (`settings.metadata.disableOnChainMetadata`) which skips calculation and appending of metadata to the compiled binaries.