### PR TITLE
MLOAD has side-effects, treat it like that in the optimiser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ Bugfixes:
  * Code Generator: Fix negative stack size checks.
  * Inline Assembly: Enforce function arguments when parsing functional instructions.
  * Fixed segfault with constant function parameters
+ * Optimizer: Disallow optimizations involving ``MLOAD`` because it changes ``MSIZE``.
 
 ### 0.4.11 (2017-05-03)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Features:
  * Static Analyzer: Warn about deprecation of ``callcode``.
 
 Bugfixes:
+ * Assembly: mark ``MLOAD`` to have side effects in the optimiser.
  * Code generator: Use ``REVERT`` instead of ``INVALID`` for generated input validation routines.
  * Type Checker: Fix address literals not being treated as compile-time constants.
  * Type Checker: Disallow invoking the same modifier multiple times.

--- a/libevmasm/Instruction.cpp
+++ b/libevmasm/Instruction.cpp
@@ -216,7 +216,7 @@ static const std::map<Instruction, InstructionInfo> c_instructionInfo =
 	{ Instruction::DIFFICULTY,	{ "DIFFICULTY",		0, 0, 1, false, Tier::Base } },
 	{ Instruction::GASLIMIT,	{ "GASLIMIT",		0, 0, 1, false, Tier::Base } },
 	{ Instruction::POP,			{ "POP",			0, 1, 0, false, Tier::Base } },
-	{ Instruction::MLOAD,		{ "MLOAD",			0, 1, 1, false, Tier::VeryLow } },
+	{ Instruction::MLOAD,		{ "MLOAD",			0, 1, 1, true, Tier::VeryLow } },
 	{ Instruction::MSTORE,		{ "MSTORE",			0, 2, 0, true, Tier::VeryLow } },
 	{ Instruction::MSTORE8,		{ "MSTORE8",		0, 2, 0, true, Tier::VeryLow } },
 	{ Instruction::SLOAD,		{ "SLOAD",			0, 1, 1, false, Tier::Special } },


### PR DESCRIPTION
The side effect is memory extension. Code may rely on this fact (e.g. in the case of subsequent `MSIZE` or gas calculations).

Result of #2465.