### PR TITLE
LLL: alloc issues round-up

### DIFF
--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -523,14 +523,30 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 			requireSize(1);
 			requireDeposit(0, 1);
 
-			m_asm.append(Instruction::MSIZE);
-			m_asm.append(u256(0));
+			// (alloc N):
+			//  - Evaluates to (msize) before the allocation - the start of the allocated memory
+			//  - Does not allocate memory when N is zero
+			//  - Size of memory allocated is N bytes rounded up to a multiple of 32
+			//  - Uses MLOAD to expand MSIZE to avoid modifying memory.
+
+			auto end = m_asm.newTag();
+			m_asm.append(Instruction::MSIZE); // Result will be original top of memory
+			m_asm.append(code[0].m_asm, 1);	  // The alloc argument N
+			m_asm.append(Instruction::DUP1);
+			m_asm.append(Instruction::ISZERO);// (alloc 0) does not change MSIZE
+			m_asm.appendJumpI(end);
 			m_asm.append(u256(1));
-			m_asm.append(code[0].m_asm, 1);
-			m_asm.append(Instruction::MSIZE);
+			m_asm.append(Instruction::DUP2);  // Copy N
+			m_asm.append(Instruction::SUB);	  // N-1
+			m_asm.append(u256(0x1f));         // Bit mask
+			m_asm.append(Instruction::NOT);	  // Invert
+			m_asm.append(Instruction::AND);	  // Align N-1 on 32 byte boundary
+			m_asm.append(Instruction::MSIZE); // MSIZE is cheap
 			m_asm.append(Instruction::ADD);
-			m_asm.append(Instruction::SUB);
-			m_asm.append(Instruction::MSTORE8);
+			m_asm.append(Instruction::MLOAD); // Updates MSIZE
+			m_asm.append(Instruction::POP);	  // Discard the result of the MLOAD
+			m_asm.append(end);
+			m_asm.append(Instruction::POP);	  // Discard duplicate N
 
 			_s.usedAlloc = true;
 		}

--- a/liblll/CompilerState.cpp
+++ b/liblll/CompilerState.cpp
@@ -46,6 +46,8 @@ void CompilerState::populateStandard()
 {
 	static const string s = "{"
 	"(def 'panic () (asm INVALID))"
+	// Alternative macro version of alloc, which is currently implemented in the parser
+	// "(def 'alloc (n) (raw (msize) (when n (pop (mload (+ (msize) (& (- n 1) (~ 0x1f))))))))"
 	"(def 'allgas (- (gas) 21))"
 	"(def 'send (to value) (call allgas to value 0 0 0 0))"
 	"(def 'send (gaslimit to value) (call gaslimit to value 0 0 0 0))"


### PR DESCRIPTION
This is an attempt to move the LLL `alloc` issue on.  It supersedes PRs #2489 and #2463, and resolves Issue #2465.

The proposed change to the generated bytecode is the tightest code I can make that handles both the edge cases `(alloc 0)` and `MSIZE` being initially zero.

Notes:

  * `(alloc 0)` does not allocate any memory. This is contra @chriseth, but in line with @axic.
  * It uses `MLOAD` rather than `MSTORE8` to increase `MSIZE`. This is a belt-and-braces guard against memory corruption.
  * It handles the edge case of `MSIZE` being intially zero, which is a problem for @axic's approach in #2489.

 A bunch of test cases is included that should be comprehensive.

Fixes #2465.