### PR TITLE
Fix invalid "explicit storage keyword" warning for reference members of structs.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Features:
 
 Bugfixes:
+ * Type Checker: Fix invalid "specify storage keyword" warning for reference members of structs.
 
 
 ### 0.4.13 (2017-07-06)

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -295,7 +295,7 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 					else
 					{
 						typeLoc = DataLocation::Storage;
-						if (!_variable.isStateVariable())
+						if (_variable.isLocalVariable())
 							m_errorReporter.warning(
 								_variable.location(),
 								"Variable is declared as a storage pointer. "

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -6160,7 +6160,7 @@ BOOST_AUTO_TEST_CASE(warn_unspecified_storage)
 {
 	char const* text = R"(
 		contract C {
-			struct S { uint a; }
+			struct S { uint a; string b; }
 			S x;
 			function f() {
 				S storage y = x;


### PR DESCRIPTION
Fixes #2549 