### PR TITLE
Issue proper warning trying to access calldata variables in inline assembly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.14 (unreleased)
 
 Features:
+ * Inline Assembly: Show useful error message if trying to access calldata variables.
 
 Bugfixes:
  * Type Checker: Fix invalid "specify storage keyword" warning for reference members of structs.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -723,7 +723,10 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			}
 			else if (var->type()->sizeOnStack() != 1)
 			{
-				m_errorReporter.typeError(_identifier.location, "Only types that use one stack slot are supported.");
+				if (var->type()->dataStoredIn(DataLocation::CallData))
+					m_errorReporter.typeError(_identifier.location, "Call data elements cannot be accessed directly. Copy to a local variable first or use \"calldataload\" or \"calldatacopy\" with manually determined offsets and sizes.");
+				else
+					m_errorReporter.typeError(_identifier.location, "Only types that use one stack slot are supported.");
 				return size_t(-1);
 			}
 		}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5428,6 +5428,20 @@ BOOST_AUTO_TEST_CASE(inline_assembly_storage_variable_access_out_of_functions)
 	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
+BOOST_AUTO_TEST_CASE(inline_assembly_calldata_variables)
+{
+	char const* text = R"(
+		contract C {
+			function f(bytes bytesAsCalldata) external {
+				assembly {
+					let x := bytesAsCalldata
+				}
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Call data elements cannot be accessed directly.");
+}
+
 BOOST_AUTO_TEST_CASE(invalid_mobile_type)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes #2555.