### PR TITLE
Prepare the version of the snap package for the release tags

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: solc
-version: master
+version: develop
+version-script: git describe --exact-match --tags 2> /dev/null || echo "develop"
 summary: The Solidity Contract-Oriented Programming Language
 description: |
   Solidity is a contract-oriented, high-level language whose syntax is similar
@@ -27,3 +28,8 @@ parts:
     plugin: cmake
     build-packages: [build-essential, libboost-all-dev]
     stage-packages: [libicu55]
+    prepare: |
+      if git describe --exact-match --tags 2> /dev/null
+      then
+        touch ../src/prerelease.txt
+      fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,5 +31,5 @@ parts:
     prepare: |
       if git describe --exact-match --tags 2> /dev/null
       then
-        touch ../src/prerelease.txt
+        echo -n > ../src/prerelease.txt
       fi


### PR DESCRIPTION
This will set the snap version to the name of the tag, when building from a commit with a tag.

Also, it will create the prerelease.txt file before building, so `solc --version` prints the right version.