### PR TITLE
LLL: Improve error reporting in certain cases.

### DIFF
--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -203,7 +203,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 		else if (us == "INCLUDE")
 		{
 			if (_t.size() != 2)
-				error<IncorrectParameterCount>();
+				error<IncorrectParameterCount>(us);
 			string fileName = firstAsString();
 			if (fileName.empty())
 				error<InvalidName>("Empty file name provided");
@@ -215,7 +215,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 		else if (us == "SET")
 		{
 			if (_t.size() != 3)
-				error<IncorrectParameterCount>();
+				error<IncorrectParameterCount>(us);
 			int c = 0;
 			for (auto const& i: _t)
 				if (c++ == 2)
@@ -226,7 +226,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 		else if (us == "GET")
 		{
 			if (_t.size() != 2)
-				error<IncorrectParameterCount>();
+				error<IncorrectParameterCount>(us);
 			m_asm.append((u256)varAddress(firstAsString()));
 			m_asm.append(Instruction::MLOAD);
 		}
@@ -237,7 +237,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 			string n;
 			unsigned ii = 0;
 			if (_t.size() != 3 && _t.size() != 4)
-				error<IncorrectParameterCount>();
+				error<IncorrectParameterCount>(us);
 			vector<string> args;
 			for (auto const& i: _t)
 			{
@@ -288,7 +288,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 		else if (us == "LIT")
 		{
 			if (_t.size() < 3)
-				error<IncorrectParameterCount>();
+				error<IncorrectParameterCount>(us);
 			unsigned ii = 0;
 			CodeFragment pos;
 			bytes data;
@@ -303,7 +303,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 				{
 					pos = CodeFragment(i, _s);
 					if (pos.m_asm.deposit() != 1)
-						error<InvalidDeposit>();
+						error<InvalidDeposit>(us);
 				}
 				else if (i.tag() != 0)
 				{
@@ -384,10 +384,10 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 				else
 					code.push_back(CodeFragment(i, _s));
 			}
-		auto requireSize = [&](unsigned s) { if (code.size() != s) error<IncorrectParameterCount>(); };
-		auto requireMinSize = [&](unsigned s) { if (code.size() < s) error<IncorrectParameterCount>(); };
-		auto requireMaxSize = [&](unsigned s) { if (code.size() > s) error<IncorrectParameterCount>(); };
-		auto requireDeposit = [&](unsigned i, int s) { if (code[i].m_asm.deposit() != s) error<InvalidDeposit>(); };
+		auto requireSize = [&](unsigned s) { if (code.size() != s) error<IncorrectParameterCount>(us); };
+		auto requireMinSize = [&](unsigned s) { if (code.size() < s) error<IncorrectParameterCount>(us); };
+		auto requireMaxSize = [&](unsigned s) { if (code.size() > s) error<IncorrectParameterCount>(us); };
+		auto requireDeposit = [&](unsigned i, int s) { if (code[i].m_asm.deposit() != s) error<InvalidDeposit>(us); };
 
 		if (_s.macros.count(make_pair(s, code.size())))
 		{
@@ -475,7 +475,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 			m_asm.append(code[1].m_asm, minDep);
 			m_asm << end.tag();
 			if (m_asm.deposit() != deposit)
-				error<InvalidDeposit>();
+				error<InvalidDeposit>(us);
 		}
 		else if (us == "WHEN" || us == "UNLESS")
 		{


### PR DESCRIPTION
Trivial additions that improve the compiler's reporting of where "incorrect parameter count" and "invalid deposit" errors are occurring in the code being parsed.

Before:

```
> echo "(def 'a () [0]:1 [32]:2)" | lllc

Parse error.
/home/ben/Everything/Ethereum/solidity/liblll/CodeFragment.h(53): Throw in function void dev::eth::CodeFragment::error() const [with T = dev::eth::IncorrectParameterCount]
Dynamic exception type: boost::exception_detail::clone_impl<dev::eth::IncorrectParameterCount>
std::exception::what: 
```

_Hmm... could be anywhere..._

After:

```
> echo "(def 'a () [0]:1 [32]:2)" | lllc

Parse error.
/home/ben/Everything/Ethereum/solidity/liblll/CodeFragment.h(57): Throw in function void dev::eth::CodeFragment::error(const string&) const [with T = dev::eth::IncorrectParameterCount; std::__cxx11::string = std::__cxx11::basic_string<char>]
Dynamic exception type: boost::exception_detail::clone_impl<dev::eth::IncorrectParameterCount>
std::exception::what: DEF
[dev::tag_comment*] = DEF
```

_OK, now I've got a clue._

This is not a comprehensive re-work of the compiler error reporting, just enough for now to save my sanity.