### PR TITLE
Update solidity-by-example.rst. Fixes accepted bids

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -362,8 +362,8 @@ together with the bid. Since value transfers cannot
 be blinded in Ethereum, anyone can see the value.
 
 The following contract solves this problem by
-accepting any value that is at least as large as
-the bid. Since this can of course only be checked during
+accepting any value that is larger than the highest
+bid. Since this can of course only be checked during
 the reveal phase, some bids might be **invalid**, and
 this is on purpose (it even provides an explicit
 flag to place invalid bids with high value transfers):


### PR DESCRIPTION
Only accept bid values higher than highest bid. Since returns early from `placeBid` function if `value <= highestBid`