### PR TITLE
Update solidity-by-example.rst fix variable and explain divide/multiply by 2

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -540,6 +540,9 @@ Safe Remote Purchase
         enum State { Created, Locked, Inactive }
         State public state;
 
+        /// Solidity only allows integer arithmetic with even payments.
+        /// An odd number divided by 2 truncates the decimal such that when 
+        /// subsequent re-multiplication by 2 does not equal the same number
         function Purchase() payable {
             seller = msg.sender;
             value = msg.value / 2;
@@ -604,8 +607,8 @@ Safe Remote Purchase
         {
             ItemReceived();
             // It is important to change the state first because
-            // otherwise, the contracts called using `send` below
-            // can call in again here.
+            // otherwise, the contracts called using `transfer` below
+            // can call in here again.
             state = State.Inactive;
 
             // NOTE: This actually allows both the buyer and the seller to


### PR DESCRIPTION
Change to `transfer` since no `send` exists.
Add summary explaining what purchase value needs to be divided by two and then multiplied by two again for comparison. Explanation source: https://ethereum.stackexchange.com/questions/18135/solidity-docs-code-example-divide-by-two-then-require-multiply-quotient-by-two/18150#18150.