### PR TITLE
Run metadata and gas meter tests when optimiser is on too

### DIFF
--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -49,8 +49,7 @@ public:
 	{
 		m_compiler.reset(false);
 		m_compiler.addSource("", "pragma solidity >=0.0;\n" + _sourceCode);
-		/// NOTE: compiles without optimisations
-		ETH_TEST_REQUIRE_NO_THROW(m_compiler.compile(), "Compiling contract failed");
+		ETH_TEST_REQUIRE_NO_THROW(m_compiler.compile(dev::test::Options::get().optimize), "Compiling contract failed");
 
 		AssemblyItems const* items = m_compiler.runtimeAssemblyItems("");
 		ASTNode const& sourceUnit = m_compiler.ast();

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -44,8 +44,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 	)";
 	CompilerStack compilerStack;
 	compilerStack.addSource("", std::string(sourceCode));
-	/// NOTE: compiles without optimisations
-	ETH_TEST_REQUIRE_NO_THROW(compilerStack.compile(), "Compiling contract failed");
+	ETH_TEST_REQUIRE_NO_THROW(compilerStack.compile(dev::test::Options::get().optimize), "Compiling contract failed");
 	bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
 	std::string const& metadata = compilerStack.onChainMetadata("test");
 	BOOST_CHECK(dev::test::isValidMetadata(metadata));


### PR DESCRIPTION
Follow up of #2585.

It turns out both should work properly if optimiser is on.