### PR TITLE
Rename onChainMetadata to metadata

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -474,12 +474,12 @@ Json::Value CompilerStack::methodIdentifiers(string const& _contractName) const
 	return methodIdentifiers;
 }
 
-string const& CompilerStack::onChainMetadata(string const& _contractName) const
+string const& CompilerStack::metadata(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
 
-	return contract(_contractName).onChainMetadata;
+	return contract(_contractName).metadata;
 }
 
 Scanner const& CompilerStack::scanner(string const& _sourceName) const
@@ -673,11 +673,11 @@ void CompilerStack::compileContract(
 
 	shared_ptr<Compiler> compiler = make_shared<Compiler>(m_optimize, m_optimizeRuns);
 	Contract& compiledContract = m_contracts.at(_contract.fullyQualifiedName());
-	string onChainMetadata = createOnChainMetadata(compiledContract);
+	string metadata = createMetadata(compiledContract);
 	bytes cborEncodedMetadata =
-		// CBOR-encoding of {"bzzr0": dev::swarmHash(onChainMetadata)}
+		// CBOR-encoding of {"bzzr0": dev::swarmHash(metadata)}
 		bytes{0xa1, 0x65, 'b', 'z', 'z', 'r', '0', 0x58, 0x20} +
-		dev::swarmHash(onChainMetadata).asBytes();
+		dev::swarmHash(metadata).asBytes();
 	solAssert(cborEncodedMetadata.size() <= 0xffff, "Metadata too large");
 	// 16-bit big endian length
 	cborEncodedMetadata += toCompactBigEndian(cborEncodedMetadata.size(), 2);
@@ -710,7 +710,7 @@ void CompilerStack::compileContract(
 		BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment("Assembly exception for deployed bytecode"));
 	}
 
-	compiledContract.onChainMetadata = onChainMetadata;
+	compiledContract.metadata = metadata;
 	_compiledContracts[compiledContract.contract] = &compiler->assembly();
 
 	try
@@ -771,7 +771,7 @@ CompilerStack::Source const& CompilerStack::source(string const& _sourceName) co
 	return it->second;
 }
 
-string CompilerStack::createOnChainMetadata(Contract const& _contract) const
+string CompilerStack::createMetadata(Contract const& _contract) const
 {
 	Json::Value meta;
 	meta["version"] = 1;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -183,7 +183,7 @@ public:
 	/// @returns a JSON representing a map of method identifiers (hashes) to function names.
 	Json::Value methodIdentifiers(std::string const& _contractName) const;
 
-	std::string const& onChainMetadata(std::string const& _contractName) const;
+	std::string const& metadata(std::string const& _contractName) const;
 	void useMetadataLiteralSources(bool _metadataLiteralSources) { m_metadataLiteralSources = _metadataLiteralSources; }
 
 	/// @returns a JSON representing the estimated gas usage for contract creation, internal and external functions
@@ -223,7 +223,7 @@ private:
 		eth::LinkerObject object;
 		eth::LinkerObject runtimeObject;
 		eth::LinkerObject cloneObject;
-		std::string onChainMetadata; ///< The metadata json that will be hashed into the chain.
+		std::string metadata; ///< The metadata json that will be hashed into the chain.
 		mutable std::unique_ptr<Json::Value const> abi;
 		mutable std::unique_ptr<Json::Value const> userDocumentation;
 		mutable std::unique_ptr<Json::Value const> devDocumentation;
@@ -255,7 +255,7 @@ private:
 	/// does not exist.
 	ContractDefinition const& contractDefinition(std::string const& _contractName) const;
 
-	std::string createOnChainMetadata(Contract const& _contract) const;
+	std::string createMetadata(Contract const& _contract) const;
 	std::string computeSourceMapping(eth::AssemblyItems const& _items) const;
 	Json::Value const& contractABI(Contract const&) const;
 	Json::Value const& natspec(Contract const&, DocumentationType _type) const;

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -386,7 +386,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		// ABI, documentation and metadata
 		Json::Value contractData(Json::objectValue);
 		contractData["abi"] = m_compilerStack.contractABI(contractName);
-		contractData["metadata"] = m_compilerStack.onChainMetadata(contractName);
+		contractData["metadata"] = m_compilerStack.metadata(contractName);
 		contractData["userdoc"] = m_compilerStack.natspec(contractName, DocumentationType::NatspecUser);
 		contractData["devdoc"] = m_compilerStack.natspec(contractName, DocumentationType::NatspecDev);
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -292,12 +292,12 @@ void CommandLineInterface::handleSignatureHashes(string const& _contract)
 		cout << "Function signatures: " << endl << out;
 }
 
-void CommandLineInterface::handleOnChainMetadata(string const& _contract)
+void CommandLineInterface::handleMetadata(string const& _contract)
 {
 	if (!m_args.count(g_argMetadata))
 		return;
 
-	string data = m_compiler->onChainMetadata(_contract);
+	string data = m_compiler->metadata(_contract);
 	if (m_args.count(g_argOutputDir))
 		createFile(m_compiler->filesystemFriendlyName(_contract) + "_meta.json", data);
 	else
@@ -850,7 +850,7 @@ void CommandLineInterface::handleCombinedJSON()
 		if (requests.count(g_strAbi))
 			contractData[g_strAbi] = dev::jsonCompactPrint(m_compiler->contractABI(contractName));
 		if (requests.count("metadata"))
-			contractData["metadata"] = m_compiler->onChainMetadata(contractName);
+			contractData["metadata"] = m_compiler->metadata(contractName);
 		if (requests.count(g_strBinary))
 			contractData[g_strBinary] = m_compiler->object(contractName).toHex();
 		if (requests.count(g_strBinaryRuntime))
@@ -1164,7 +1164,7 @@ void CommandLineInterface::outputCompilationResults()
 
 		handleBytecode(contract);
 		handleSignatureHashes(contract);
-		handleOnChainMetadata(contract);
+		handleMetadata(contract);
 		handleABI(contract);
 		handleNatspec(DocumentationType::NatspecDev, contract);
 		handleNatspec(DocumentationType::NatspecUser, contract);

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -64,7 +64,7 @@ private:
 	void handleOpcode(std::string const& _contract);
 	void handleBytecode(std::string const& _contract);
 	void handleSignatureHashes(std::string const& _contract);
-	void handleOnChainMetadata(std::string const& _contract);
+	void handleMetadata(std::string const& _contract);
 	void handleABI(std::string const& _contract);
 	void handleNatspec(DocumentationType _type, std::string const& _contract);
 	void handleGasEstimation(std::string const& _contract);

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 	/// NOTE: compiles without optimisations
 	ETH_TEST_REQUIRE_NO_THROW(compilerStack.compile(), "Compiling contract failed");
 	bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
-	std::string const& metadata = compilerStack.onChainMetadata("test");
+	std::string const& metadata = compilerStack.metadata("test");
 	BOOST_CHECK(dev::test::isValidMetadata(metadata));
 	bytes hash = dev::swarmHash(metadata).asBytes();
 	BOOST_REQUIRE(hash.size() == 32);


### PR DESCRIPTION
After the previous refactorings (when metadata() was shared by this and natspec)  this change can be done.