### PR TITLE
Remove LINKABLE from Emscripten

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -166,8 +166,6 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdata-sections -ffunction-sections -Wl,--gc-sections -fvisibility=hidden")
 			# Optimisation level
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-			# Keep every public symbols (disables dead code elimination)
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s LINKABLE=1")
 			# Re-enable exception catching (optimisations above -O1 disable it)
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s DISABLE_EXCEPTION_CATCHING=0")
 			# Remove any code related to exit (such as atexit)


### PR DESCRIPTION
Note: this flag is unncessary to have because of https://github.com/ethereum/solidity/blob/develop/solc/CMakeLists.txt#L21