### PR TITLE
cmdlineTests: print solc output instead of contract code on error

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -32,6 +32,8 @@ REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
 echo $REPO_ROOT
 SOLC="$REPO_ROOT/build/solc/solc"
 
+FULLARGS="--optimize --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
+
 echo "Checking that the bug list is up to date..."
 "$REPO_ROOT"/scripts/update_bugs_by_version.py
 
@@ -43,15 +45,13 @@ function compileFull()
 {
     files="$*"
     set +e
-    "$SOLC" --optimize \
-    --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc \
-    $files >/dev/null 2>&1
+    output=$( ("$SOLC" $FULLARGS  $files) 2>&1 )
     failed=$?
     set -e
     if [ $failed -ne 0 ]
     then
         echo "Compilation failed on:"
-        cat $files
+        echo "$output"
         false
     fi
 }

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -43,11 +43,13 @@ test "${output//[[:blank:]]/}" = "3"
 
 function compileFull()
 {
-    files="$*"
+    local files="$*"
+
     set +e
-    output=$( ("$SOLC" $FULLARGS  $files) 2>&1 )
-    failed=$?
+    local output=$( ("$SOLC" $FULLARGS $files) 2>&1 )
+    local failed=$?
     set -e
+
     if [ $failed -ne 0 ]
     then
         echo "Compilation failed on:"
@@ -58,14 +60,16 @@ function compileFull()
 
 function compileWithoutWarning()
 {
-    files="$*"
+    local files="$*"
+
     set +e
-    output=$("$SOLC" $files 2>&1)
-    failed=$?
+    local output=$("$SOLC" $files 2>&1)
+    local failed=$?
     # Remove the pre-release warning from the compiler output
     output=$(echo "$output" | grep -v 'pre-release')
     echo "$output"
     set -e
+
     test -z "$output" -a "$failed" -eq 0
 }
 

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -41,19 +41,28 @@ echo "Checking that StandardToken.sol, owned.sol and mortal.sol produce bytecode
 output=$("$REPO_ROOT"/build/solc/solc --bin "$REPO_ROOT"/std/*.sol 2>/dev/null | grep "ffff" | wc -l)
 test "${output//[[:blank:]]/}" = "3"
 
+function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
+
+function printError() { echo "$(tput setaf 1)$1$(tput sgr0)"; }
+
 function compileFull()
 {
     local files="$*"
+    local output failed
 
     set +e
-    local output=$( ("$SOLC" $FULLARGS $files) 2>&1 )
-    local failed=$?
+    output=$( ("$SOLC" $FULLARGS $files) 2>&1 )
+    failed=$?
     set -e
 
     if [ $failed -ne 0 ]
     then
-        echo "Compilation failed on:"
+        printError "Compilation failed on:"
         echo "$output"
+        printError "While calling:"
+        echo "\"$SOLC\" $FULLARGS $files"
+        printError "Inside directory:"
+        pwd
         false
     fi
 }
@@ -61,10 +70,11 @@ function compileFull()
 function compileWithoutWarning()
 {
     local files="$*"
+    local output failed
 
     set +e
-    local output=$("$SOLC" $files 2>&1)
-    local failed=$?
+    output=$("$SOLC" $files 2>&1)
+    failed=$?
     # Remove the pre-release warning from the compiler output
     output=$(echo "$output" | grep -v 'pre-release')
     echo "$output"
@@ -73,7 +83,7 @@ function compileWithoutWarning()
     test -z "$output" -a "$failed" -eq 0
 }
 
-echo "Compiling various other contracts and libraries..."
+printTask "Compiling various other contracts and libraries..."
 (
 cd "$REPO_ROOT"/test/compilationTests/
 for dir in *
@@ -88,7 +98,7 @@ do
 done
 )
 
-echo "Compiling all files in std and examples..."
+printTask "Compiling all files in std and examples..."
 
 for f in "$REPO_ROOT"/std/*.sol
 do
@@ -96,7 +106,7 @@ do
     compileWithoutWarning "$f"
 done
 
-echo "Compiling all examples from the documentation..."
+printTask "Compiling all examples from the documentation..."
 TMPDIR=$(mktemp -d)
 (
     set -e
@@ -113,14 +123,14 @@ TMPDIR=$(mktemp -d)
 rm -rf "$TMPDIR"
 echo "Done."
 
-echo "Testing library checksum..."
+printTask "Testing library checksum..."
 echo '' | "$SOLC" --link --libraries a:0x90f20564390eAe531E810af625A22f51385Cd222
 ! echo '' | "$SOLC" --link --libraries a:0x80f20564390eAe531E810af625A22f51385Cd222 2>/dev/null
 
-echo "Testing long library names..."
+printTask "Testing long library names..."
 echo '' | "$SOLC" --link --libraries aveeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerylonglibraryname:0x90f20564390eAe531E810af625A22f51385Cd222
 
-echo "Testing overwriting files"
+printTask "Testing overwriting files"
 TMPDIR=$(mktemp -d)
 (
     set -e
@@ -133,7 +143,7 @@ TMPDIR=$(mktemp -d)
 )
 rm -rf "$TMPDIR"
 
-echo "Testing soljson via the fuzzer..."
+printTask "Testing soljson via the fuzzer..."
 TMPDIR=$(mktemp -d)
 (
     set -e
@@ -147,14 +157,14 @@ TMPDIR=$(mktemp -d)
         set +e
         "$REPO_ROOT"/build/test/solfuzzer --quiet < "$f"
         if [ $? -ne 0 ]; then
-            echo "Fuzzer failed on:"
+            printError "Fuzzer failed on:"
             cat "$f"
             exit 1
         fi
 
         "$REPO_ROOT"/build/test/solfuzzer --without-optimizer --quiet < "$f"
         if [ $? -ne 0 ]; then
-            echo "Fuzzer (without optimizer) failed on:"
+            printError "Fuzzer (without optimizer) failed on:"
             cat "$f"
             exit 1
         fi


### PR DESCRIPTION
I recently triggered an error with these tests and it was unpleasant to see the contents of all those globbed files, which didn't provide any meaningful information. Much better to see the actual compiler output.