### PR TITLE
LLL: Improve nested IF expressions [FOR COMMENT]

### DIFF
--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -83,6 +83,7 @@ public:
 	template <class T> Assembly& operator<<(T const& _d) { append(_d); return *this; }
 	AssemblyItems const& items() const { return m_items; }
 	AssemblyItem const& back() const { return m_items.back(); }
+	void pop_back() { m_items.pop_back(); }
 	std::string backString() const { return m_items.size() && m_items.back().type() == PushString ? m_strings.at((h256)m_items.back().data()) : std::string(); }
 
 	void injectStart(AssemblyItem const& _i);

--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -462,7 +462,15 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 			/// The else branch.
 			int startDeposit = m_asm.deposit();
 			m_asm.append(code[2].m_asm, minDep);
-			auto end = m_asm.appendJump();
+
+			// We're about to insert a jump to the end of the IF expression.
+			// But if the last element of the else branch is a jump destination tag
+			// then we move it to the end and instead insert a jump to that.
+			// This avoids nested IFs generating a load of chained jumps.
+			auto lastAssembly = m_asm.back();
+			if (lastAssembly.type() == Tag)
+				m_asm.pop_back();
+			auto end = lastAssembly.type() == Tag ? m_asm.appendJump(lastAssembly) : m_asm.appendJump();
 			int deposit = m_asm.deposit();
 			m_asm.setDeposit(startDeposit);
 


### PR DESCRIPTION
@axic, would you kindly please review and comment on these suggested changes?  I think the idea is sound, but my C++ totally sucks, so I'd appreciate your guidance.

The point is that when LLL IF expressions are nested in the "else" branches, the compiler currently produces chains of pointless jumps. Consider this code:

```
(seq
  (def 'input (calldataload 0x04))
  ;; Calculates width in bytes of utf-8 characters.
  (return
    (if (< input 0x80) 1
      (if (< input 0xE0) 2
        (if (< input 0xF0) 3
          (if (< input 0xF8) 4
            (if (< input 0xFC) 5
              6)))))))
```

Before these changes:

```
  jumpi(tag_12, lt(calldataload(0x4), 0x80))
  jumpi(tag_19, lt(calldataload(0x4), 0xe0))
  jumpi(tag_26, lt(calldataload(0x4), 0xf0))
  jumpi(tag_33, lt(calldataload(0x4), 0xf8))
  jumpi(tag_40, lt(calldataload(0x4), 0xfc))
  0x6
  jump(tag_42)  ;; Note how it jumps 42 -> 44 -> 46 -> 48 -> 50.
tag_40:
  0x5
tag_42:
  jump(tag_44)
tag_33:
  0x4
tag_44:
  jump(tag_46)
tag_26:
  0x3
tag_46:
  jump(tag_48)
tag_19:
  0x2
tag_48:
  jump(tag_50)
tag_12:
  0x1
tag_50:
  0x0
  mstore
  return(0x0, 0x20)
```

After these changes:

```
  jumpi(tag_12, lt(calldataload(0x4), 0x80))
  jumpi(tag_19, lt(calldataload(0x4), 0xe0))
  jumpi(tag_26, lt(calldataload(0x4), 0xf0))
  jumpi(tag_33, lt(calldataload(0x4), 0xf8))
  jumpi(tag_40, lt(calldataload(0x4), 0xfc))
  0x6
  jump(tag_42)  ;; Now it jumps straight to the end.
tag_40:
  0x5
  jump(tag_42)
tag_33:
  0x4
  jump(tag_42)
tag_26:
  0x3
  jump(tag_42)
tag_19:
  0x2
  jump(tag_42)
tag_12:
  0x1
tag_42:
  0x0
  mstore
  return(0x0, 0x20)
```

This leads to a nice reduction in execution gas and smaller, simpler assembly code.  The optimiser doesn't seem able to spot this behaviour, and in any case it's better to eliminate the inefficiency at source. For non-nested IF expressions it has no effect. It also has no effect if the nesting is in the "then" branch (there are some smaller improvements to be made here - redundant jumpdests - but I want to check this out with you first).