### PR TITLE
Split Mapping example

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -813,9 +813,14 @@ for each ``_KeyType``, recursively.
             balances[msg.sender] = newBalance;
         }
     }
+  
+::
+
+    pragma solidity ^0.4.0;
 
     contract MappingUser {
-        address contractAddress = 0x42;
+        // the address of a MappingExample contract
+        address contractAddress = 0x42...;
         function f() returns (uint) {
             return MappingExample(contractAddress).balances(this);
         }

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -820,7 +820,7 @@ for each ``_KeyType``, recursively.
 
     contract MappingUser {
         // the address of a MappingExample contract
-        address contractAddress = 0x42...;
+        address contractAddress = 0x42;
         function f() returns (uint) {
             return MappingExample(contractAddress).balances(this);
         }


### PR DESCRIPTION
MappingExample contract should be deployed independently of MappingUser, in order to instantiate it by address as currently done.

This change split the example in two "files" and add a clarification about the used address.