### PR TITLE
LLL: Implement a "switch" expression

### DIFF
--- a/test/liblll/Compiler.cpp
+++ b/test/liblll/Compiler.cpp
@@ -1,0 +1,128 @@
+/*
+    This file is part of solidity.
+
+    solidity is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    solidity is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Alex Beregszaszi
+ * @date 2017
+ * Unit tests for the LLL compiler.
+ */
+
+#include <string>
+#include <memory>
+#include <boost/test/unit_test.hpp>
+#include <liblll/Compiler.h>
+
+using namespace std;
+
+namespace dev
+{
+namespace lll
+{
+namespace test
+{
+
+namespace
+{
+
+bool successCompile(std::string const& _sourceCode)
+{
+	std::vector<std::string> errors;
+	bytes bytecode = eth::compileLLL(_sourceCode, false, &errors);
+	if (!errors.empty())
+		return false;
+	if (bytecode.empty())
+		return false;
+	return true;
+}
+
+}
+
+BOOST_AUTO_TEST_SUITE(LLLCompiler)
+
+BOOST_AUTO_TEST_CASE(smoke_test)
+{
+	char const* sourceCode = "1";
+	BOOST_CHECK(successCompile(sourceCode));
+}
+
+BOOST_AUTO_TEST_CASE(switch_valid)
+{
+	char const* sourceCode = R"(
+		(switch (origin))
+	)";
+	BOOST_CHECK(successCompile(sourceCode));
+	sourceCode = R"(
+		(switch
+			1 (panic)
+			2 (panic))
+	)";
+	BOOST_CHECK(successCompile(sourceCode));
+	sourceCode = R"(
+		(switch
+			1 (panic)
+			2 (panic)
+			(panic))
+	)";
+	BOOST_CHECK(successCompile(sourceCode));
+	sourceCode = R"(
+		(switch
+			1 (origin)
+			2 (origin)
+			(origin))
+	)";
+	BOOST_CHECK(successCompile(sourceCode));
+}
+
+BOOST_AUTO_TEST_CASE(switch_invalid_arg_count)
+{
+	char const* sourceCode = R"(
+		(switch)
+	)";
+	BOOST_CHECK(!successCompile(sourceCode));
+}
+
+BOOST_AUTO_TEST_CASE(switch_inconsistent_return_count)
+{
+	// cannot return stack items if the default case is not present
+	char const* sourceCode = R"(
+		(switch
+			1 (origin)
+			2 (origin)
+	)";
+	BOOST_CHECK(!successCompile(sourceCode));
+	// return count mismatch
+	sourceCode = R"(
+		(switch
+			1 (origin)
+			2 (origin)
+			(panic))
+	)";
+	BOOST_CHECK(!successCompile(sourceCode));
+	// return count mismatch
+	sourceCode = R"(
+		(switch
+			1 (panic)
+			2 (panic)
+			(origin))
+	)";
+	BOOST_CHECK(!successCompile(sourceCode));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+} // end namespaces


### PR DESCRIPTION
### Introduction

This is an implementation of a `switch` expression in LLL.  The background is in #2611: in short,

  1. the compiler does not generate particularly efficient code for nested `if` expressions, and

  2. deeply nested `if`s are visually difficult to decode.

### Description

The basic pattern is

    (switch
      COND1 EXPR1
      COND2 EXPR2
      ...
      CONDn EXPRn
      EXPR0)

Each `CONDx` is evaluated in turn:

  * If `CONDx` evaluates to non-zero then the immediately following expression, `EXPRx`, is evaluated and evaluation stops.  `EXPRx` provides the overall value of the `switch` expression.
  
  * If `CONDx` evaluates to zero then evaluaton moves to the next `COND` and `EXPRx` is ignored.

The final `EXPR0` is optional and provides a default or fallback value.  If all of the `COND`s evaluate to zero then,

  * If `EXPR0` is present the `switch` expression evaluates to `EXPR0`.

  * If `EXPR0` is not present the `switch` expression evaluates to `void` (nothing on the stack; no action performed).

All of the `EXPR`s must leave the same number of values on the stack, either zero or one. As a consequence, if the default `EXPR0` is not present, then all of the `EXPR` must leave zero items on the stack.

A `switch` with only one argument (i.e. no `COND` expressions) evaluates to that argument: `(switch EXPR)` is identical to `EXPR`.

### Examples

    (switch 1)        => 1

    (switch 1 [0]:42) => (mstore 0 42)

    (switch 0 [0]:42) => <void>

    (switch
      0 1
      1 2)            => does not compile ("InvalidDeposit")

    (switch
      0 [0]:0
      1 [32]:1)       => (mstore 32 1)

    (switch
      0 1
      2 3
      4)              => 3

    (switch
      0 [0]:0
      0 [32]:1
      [64]:2)         => (mstore 64 2)

### Naming

On naming, this structure resembles Lisp's `cond` statement, but is not exactly the same, thus we are proposing to use a different name, `switch`.  Lisp also has a `case` statement that is quite different, so best to avoid that name as well.

### Performance

With a single conditional, the gas usage of `switch` is the same as that of the equivalent `if` expression.  With more conditionals, the performance of `switch` is increasingly better than the equivalent nested `if`s.  Asymptotically, the nested `if` structure adds an overhead of 12 gas per branch evaluated when compared with the equivalent `switch` expression.

Extending each structure with extra conditionals adds one less byte of EVM code per conditional when using `switch` than when using `if`.