### PR TITLE
Change Mapping example to valid (executable) code

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -815,9 +815,10 @@ for each ``_KeyType``, recursively.
     }
 
     contract MappingUser {
-        address contractAddress = 0x42;
         function f() returns (uint) {
-            return MappingExample(contractAddress).balances(this);
+            MappingExample m = new MappingExample();
+            m.update(100);
+            return m.balances(this);
         }
     }
 


### PR DESCRIPTION
Current example will not compile and would need to be compiled in separate files, unlike how it is shown (see https://github.com/ethereum/solidity/pull/2618).

The proposed changes provide both a source code that compiles and a easier to understand Contract creation (using new instead of a contract address).