### PR TITLE
Update the snap metadata to allow stable releases

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ description: |
   It is possible to create contracts for voting, crowdfunding, blind auctions,
   multi-signature wallets and more.
 
-grade: devel # must be 'stable' to release into candidate/stable channels
+grade: stable
 confinement: strict
 
 apps:


### PR DESCRIPTION
With this change, we will be ready to move the next tag you release to the candidate channel in the store, and make the final testing rounds to then put it in the stable channel and make it visible to all the Ubuntu users.