### PR TITLE
Updated link for getter-functions for consistency in docs/contracts.rst

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -246,7 +246,7 @@ In the following example, ``D``, can call ``c.getData()`` to retrieve the value 
     }
 
 .. index:: ! getter;function, ! function;getter
-.. _getter_functions:
+.. _getter-functions:
 
 Getter Functions
 ================


### PR DESCRIPTION
Used a dash for a space rather than an underscore.