### PR TITLE
Link: members-of-addresses in docs/types.rst

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -83,6 +83,8 @@ Operators:
 
 * ``<=``, ``<``, ``==``, ``!=``, ``>=`` and ``>``
 
+.. _members-of-addresses:
+
 Members of Addresses
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
For referencing, e.g. [here](https://solidity.readthedocs.io/en/develop/control-structures.html#error-handling-assert-require-revert-and-exceptions), where it mentions low-level codes: "exceptions to this rule are send and the low-level functions call, delegatecall and callcode – those return false in case of an exception instead of “bubbling up”."