### PR TITLE
Constructor index in docs/contracts.rst

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -10,7 +10,7 @@ variables. Calling a function on a different contract (instance) will perform
 an EVM function call and thus switch the context such that state variables are
 inaccessible.
 
-.. index:: ! contract;creation
+.. index:: ! contract;creation, constructor
 
 ******************
 Creating Contracts
@@ -20,7 +20,7 @@ Contracts can be created "from outside" or from Solidity contracts.
 When a contract is created, its constructor (a function with the same
 name as the contract) is executed once.
 
-A constructor is optional. Only one constructor is allowed, and this means
+A ``constructor`` is optional. Only one constructor is allowed, and this means
 overloading is not supported.
 
 From ``web3.js``, i.e. the JavaScript

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -20,7 +20,7 @@ Contracts can be created "from outside" or from Solidity contracts.
 When a contract is created, its constructor (a function with the same
 name as the contract) is executed once.
 
-A ``constructor`` is optional. Only one constructor is allowed, and this means
+A constructor is optional. Only one constructor is allowed, and this means
 overloading is not supported.
 
 From ``web3.js``, i.e. the JavaScript


### PR DESCRIPTION
For referencing, especially when it has been mentioned previously but not discussed in detail, e.g. [here ](https://solidity.readthedocs.io/en/develop/control-structures.html?highlight=constructor#external-function-calls) and [here](https://solidity.readthedocs.io/en/develop/introduction-to-smart-contracts.html?highlight=constructor#subcurrency-example). 