### PR TITLE
Disallow gas modifier on sha256/ripemd160/ecrecover

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Features:
 
 Bugfixes:
  * Code Generator: Provide "new account gas" for low-level ``callcode`` and ``delegatecall``.
+ * Type Checker: Disallow the ``.gas()`` modifier on ``ecrecover``, ``sha256`` and ``ripemd160``.
 
 ### 0.4.14 (2017-07-31)
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2402,9 +2402,6 @@ MemberList::MemberMap FunctionType::nativeMembers(ContractDefinition const*) con
 	{
 	case Kind::External:
 	case Kind::Creation:
-	case Kind::ECRecover:
-	case Kind::SHA256:
-	case Kind::RIPEMD160:
 	case Kind::BareCall:
 	case Kind::BareCallCode:
 	case Kind::BareDelegateCall:

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2399,21 +2399,6 @@ BOOST_AUTO_TEST_CASE(gas_and_value_basic)
 	BOOST_REQUIRE(callContractFunction("checkState()") == encodeArgs(false, 20 - 5));
 }
 
-BOOST_AUTO_TEST_CASE(gas_for_builtin)
-{
-	char const* sourceCode = R"(
-		contract Contract {
-			function test(uint g) returns (bytes32 data, bool flag) {
-				data = ripemd160.gas(g)("abc");
-				flag = true;
-			}
-		}
-	)";
-	compileAndRun(sourceCode);
-	BOOST_CHECK(callContractFunction("test(uint256)", 500) == bytes());
-	BOOST_CHECK(callContractFunction("test(uint256)", 800) == encodeArgs(u256("0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc000000000000000000000000"), true));
-}
-
 BOOST_AUTO_TEST_CASE(value_complex)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -6461,6 +6461,30 @@ BOOST_AUTO_TEST_CASE(builtin_reject_gas)
 		}
 	)";
 	CHECK_ERROR(text, TypeError, "Member \"gas\" not found or not visible after argument-dependent lookup");
+	text = R"(
+		contract C {
+			function f() {
+				sha256.gas();
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Member \"gas\" not found or not visible after argument-dependent lookup");
+	text = R"(
+		contract C {
+			function f() {
+				ripemd160.gas();
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Member \"gas\" not found or not visible after argument-dependent lookup");
+	text = R"(
+		contract C {
+			function f() {
+				ecrecover.gas();
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Member \"gas\" not found or not visible after argument-dependent lookup");
 }
 
 BOOST_AUTO_TEST_CASE(builtin_reject_value)


### PR DESCRIPTION
Fixes #2671. Depends on #2674.