### PR TITLE
Add the command to install the stable solc snap

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -85,9 +85,13 @@ If you want to use the cutting edge developer version:
     
 We are also releasing a `snap package <https://snapcraft.io/>`_, which is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To install the latest stable version of solc:
 
+.. code:: bash
+
     sudo snap install solc
 
 Or if you want to help testing the unstable solc with the most recent changes from the development branch:
+
+.. code:: bash
 
     sudo snap install solc --edge
 

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -83,7 +83,11 @@ If you want to use the cutting edge developer version:
     sudo apt-get update
     sudo apt-get install solc
     
-We are also releasing a `snap package <https://snapcraft.io/>`_, which is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To help testing the unstable solc with the most recent changes from the development branch:
+We are also releasing a `snap package <https://snapcraft.io/>`_, which is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To install the latest stable version of solc:
+
+    sudo snap install solc
+
+Or if you want to help testing the unstable solc with the most recent changes from the development branch:
 
     sudo snap install solc --edge
 


### PR DESCRIPTION
Now that v0.4.14 was released, all the changes in the snapcraft.yaml landed, the continuous delivery is configured both for edge and candidate snaps, and we have been testing the snap for a while, I have pushed it to the stable channel in the Ubuntu store.