### PR TITLE
More readable format for sourceformatter

### DIFF
--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -110,9 +110,8 @@ void SourceReferenceFormatter::printExceptionInformation(
 	{
 		for (auto info: secondarylocation->infos)
 		{
-			_stream << info.first << " ";
 			printSourceName(_stream, &info.second, _scannerFromSourceName);
-			_stream << endl;
+			_stream << info.first << endl;
 			printSourceLocation(_stream, &info.second, _scannerFromSourceName);
 		}
 		_stream << endl;

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -101,6 +101,8 @@ void SourceReferenceFormatter::printExceptionInformation(
 	_stream << _name;
 	if (string const* description = boost::get_error_info<errinfo_comment>(_exception))
 		_stream << ": " << *description << endl;
+	else
+		_stream << endl;
 
 	printSourceLocation(_stream, location, _scannerFromSourceName);
 


### PR DESCRIPTION
Before:
```
_1712.sol:8:12: Error: Trying to create an instance of an abstract contract.
    return new A();
           ^---^
Missing implementation: _1712.sol:2:3: 
  function f();
  ^-----------^
```

After:
```
_1712.sol:8:12: Error: Trying to create an instance of an abstract contract.
    return new A();
           ^---^
_1712.sol:2:3: Missing implementation:
  function f();
  ^-----------^
```

Though this is subjective.