### PR TITLE
Removes reference to stack depth attack

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -277,9 +277,9 @@ activate themselves.
             if (highestBidder != 0) {
                 // Sending back the money by simply using
                 // highestBidder.send(highestBid) is a security risk
-                // because it can be prevented by the caller by e.g.
-                // raising the call stack to 1023. It is always safer
-                // to let the recipients withdraw their money themselves.
+                // because it could execute an untrusted contract.
+                // It is always safer to let the recipients
+                // withdraw their money themselves.
                 pendingReturns[highestBidder] += highestBid;
             }
             highestBidder = msg.sender;


### PR DESCRIPTION
Changed the old stack depth attack reference to a generic execution of an untrusted contract to keep the suggestion of the withdrawal pattern.