### PR TITLE
Enforce commas in tuple/array syntax

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Features:
  * Metadata: Store experimental flag in metadata CBOR.
 
 Bugfixes:
+ * Parser: Enforce commas between array and tuple elements.
 
 ### 0.4.15 (2017-08-08)
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1300,10 +1300,11 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 					parserError("Expected expression (inline array elements cannot be omitted).");
 				else
 					components.push_back(ASTPointer<Expression>());
+
 				if (m_scanner->currentToken() == oppositeToken)
 					break;
-				else if (m_scanner->currentToken() == Token::Comma)
-					m_scanner->next();
+
+				expectToken(Token::Comma);
 			}
 		nodeFactory.markEndPosition();
 		expectToken(oppositeToken);

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1187,6 +1187,18 @@ BOOST_AUTO_TEST_CASE(tuples)
 	BOOST_CHECK(successParse(text));
 }
 
+BOOST_AUTO_TEST_CASE(tuples_without_commas)
+{
+	char const* text = R"(
+		contract C {
+			function f() {
+				var a = (2 2);
+			}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Expected token Comma");
+}
+
 BOOST_AUTO_TEST_CASE(member_access_parser_ambiguity)
 {
 	char const* text = R"(


### PR DESCRIPTION
See #2713. Should I add a regression test for this? 