### PR TITLE
Check for payable when comparing function types + boolean refactor

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2224,27 +2224,20 @@ bool FunctionType::operator==(Type const& _other) const
 {
 	if (_other.category() != category())
 		return false;
+
 	FunctionType const& other = dynamic_cast<FunctionType const&>(_other);
-
-	if (m_kind != other.m_kind)
+	if (m_kind != other.m_kind ||
+	    m_isConstant != other.isConstant() ||
+           m_isPayable != other.isPayable() ||
+	    m_parameterTypes.size() != other.m_parameterTypes.size() ||
+	    m_returnParameterTypes.size() != other.m_returnParameterTypes.size())
 		return false;
 
-	if (m_isConstant != other.isConstant())
-		return false;
-
-	if (m_isPayable != other.isPayable())
-		return false;
-
-	if (m_parameterTypes.size() != other.m_parameterTypes.size() ||
-			m_returnParameterTypes.size() != other.m_returnParameterTypes.size())
-		return false;
 	auto typeCompare = [](TypePointer const& _a, TypePointer const& _b) -> bool { return *_a == *_b; };
-
 	if (!equal(m_parameterTypes.cbegin(), m_parameterTypes.cend(),
-			   other.m_parameterTypes.cbegin(), typeCompare))
-		return false;
-	if (!equal(m_returnParameterTypes.cbegin(), m_returnParameterTypes.cend(),
-			   other.m_returnParameterTypes.cbegin(), typeCompare))
+                   other.m_parameterTypes.cbegin(), typeCompare) ||
+	    !equal(m_returnParameterTypes.cbegin(), m_returnParameterTypes.cend(),
+		   other.m_returnParameterTypes.cbegin(), typeCompare))
 		return false;
 	//@todo this is ugly, but cannot be prevented right now
 	if (m_gasSet != other.m_gasSet || m_valueSet != other.m_valueSet)


### PR DESCRIPTION
Based off PR by @axic https://github.com/ethereum/solidity/pull/2724
(might as well refactor the similar checks into less ifs, there was one already that had an `||`)