### PR TITLE
docs typo: remove duplicate period and unnecessary spaces in intro

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -35,7 +35,7 @@ Solidity version 0.4.0 or anything newer that does not break functionality
 (up to, but not including, version 0.5.0). This is to ensure that the
 contract does not suddenly behave differently with a new compiler version. The keyword ``pragma`` is called that way because, in general,
 pragmas are instructions for the compiler about how to treat the
-source code (e.g. `pragma once <https://en.wikipedia.org/wiki/Pragma_once>`_).  .
+source code (e.g. `pragma once <https://en.wikipedia.org/wiki/Pragma_once>`_).
 
 A contract in the sense of Solidity is a collection of code (its *functions*) and
 data (its *state*) that resides at a specific address on the Ethereum


### PR DESCRIPTION
Fix a typo in the intro to smart contracts doc by removing extra period and unneeded spaces.