### PR TITLE
Edit function name 'send' in Coin contract

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -95,7 +95,7 @@ registering with username and password - all you need is an Ethereum keypair.
             balances[receiver] += amount;
         }
 
-        function send(address receiver, uint amount) {
+        function sendCoins(address receiver, uint amount) {
             if (balances[msg.sender] < amount) return;
             balances[msg.sender] -= amount;
             balances[receiver] += amount;


### PR DESCRIPTION
Edit in function name of Coin contract (from 'send' to 'sendCoins'), 'send' interferes with the reserved function 'send', rendering this function call to result in Error, viz. 'Sender doesn't have enough funds', most times.