### PR TITLE
Adding storage into the pointer for Voter delegate

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -126,7 +126,7 @@ of votes.
             // modifies `voters[msg.sender].voted`
             sender.voted = true;
             sender.delegate = to;
-            Voter delegate = voters[to];
+            Voter storage delegate = voters[to];
             if (delegate.voted) {
                 // If the delegate already voted,
                 // directly add to the number of votes


### PR DESCRIPTION
Hi,

The example from https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst is not working. 

It keeps giving this error in the Mist program:

     Could not compile source code. 

     Variable is declared as a storage pointer. Use an explicit "storage" keyword to silence this warning.
            Voter delegate = voters[to];
            ^------------^

The solution is just to add the keyword "storage" and then the example works again.