### PR TITLE
Require 0.4.16 for view/pure in docs examples

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -293,9 +293,9 @@ The JSON format for a contract's interface is given by an array of function and/
   * `name`: the name of the parameter;
   * `type`: the canonical type of the parameter.
 - `outputs`: an array of objects similar to `inputs`, can be omitted if function doesn't return anything;
-- `constant`: `true` if function is :ref:`specified to not modify blockchain state <view-functions>`);
 - `payable`: `true` if function accepts ether, defaults to `false`;
-- `stateMutability`: a string with one of the following values: `pure` (:ref:`specified to not read blockchain state <pure-functions>`), `view` (same as `constant` above), `nonpayable` and `payable` (same as `payable` above).
+- `stateMutability`: a string with one of the following values: `pure` (:ref:`specified to not read blockchain state <pure-functions>`), `view` (:ref:`specified to not modify the blockchain state <view-functions>`), `nonpayable` and `payable` (same as `payable` above).
+- `constant`: `true` if function is either `pure` or `view`
 
 `type` can be omitted, defaulting to `"function"`.
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -469,6 +469,17 @@ View Functions
 
 Functions can be declared ``view`` in which case they promise not to modify the state.
 
+The following statements are considered modifying the state:
+
+#. Writing to state variables.
+#. :ref:`Emitting events. <events>`.
+#. :ref:`Creating other contracts <creating-contracts>`.
+#. Using ``selfdestruct``.
+#. Sending Ether via calls.
+#. Calling any function not marked ``view`` or ``pure``.
+#. Using low-level calls.
+#. Using inline assembly that contains certain opcodes.
+
 ::
 
     pragma solidity ^0.4.16;
@@ -495,6 +506,13 @@ Pure Functions
 **************
 
 Functions can be declared ``pure`` in which case they promise not to read from or modify the state.
+
+In addition to the list of state modifying statements explained above, the following are considered reading from the state:
+#. Reading from state variables.
+#. Accessing ``this.balance`` or ``<address>.balance``.
+#. Accessing any of the members of ``block``, ``tx``, ``msg`` (with the exception of ``msg.sig`` and ``msg.data``).
+#. Calling any function not marked ``pure``.
+#. Using inline assembly that contains certain opcodes.
 
 ::
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -471,7 +471,7 @@ Functions can be declared ``view`` in which case they promise not to modify the 
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
         function f(uint a, uint b) view returns (uint) {
@@ -498,7 +498,7 @@ Functions can be declared ``pure`` in which case they promise not to read from o
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
         function f(uint a, uint b) pure returns (uint) {


### PR DESCRIPTION
Depends on #2745. To be merged after the release.