### PR TITLE
Update on the example for BlindAction

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -467,7 +467,7 @@ high or low invalid bids.
                 }
                 // Make it impossible for the sender to re-claim
                 // the same deposit.
-                bid.blindedBid = 0;
+                bid.blindedBid = bytes32(0);
             }
             msg.sender.transfer(refund);
         }


### PR DESCRIPTION
In the Mist app, the Blind Action contract cannot compile because it cannot accept implicit conversion of integer to byte32. I just added the conversion method byte32 in line 470 for bid.blindedBid.