### PR TITLE
This commit will display warning when there is unused function parameter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Features:
  * Optimizer: Add new optimization step to remove unused ``JUMPDEST``s.
+ * Type Checker: Display helpful warning for unused function arguments/return parameters.
  * Type Checker: Do not show the same error multiple times for events.
  * Type Checker: Warn on using literals as tight packing parameters in ``keccak256``, ``sha3``, ``sha256`` and ``ripemd160``.
 

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -69,7 +69,16 @@ void StaticAnalyzer::endVisit(FunctionDefinition const&)
 	m_constructor = false;
 	for (auto const& var: m_localVarUseCount)
 		if (var.second == 0)
-			m_errorReporter.warning(var.first->location(), "Unused local variable");
+		{
+			if (var.first->isCallableParameter())
+				m_errorReporter.warning(
+					var.first->location(),
+					"Unused function parameter. Remove or comment out the variable name to silence this warning."
+				);
+			else
+				m_errorReporter.warning(var.first->location(), "Unused local variable.");
+		}
+
 	m_localVarUseCount.clear();
 }
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5816,7 +5816,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_local)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Unused");
+	CHECK_WARNING(text, "Unused local variable.");
 }
 
 BOOST_AUTO_TEST_CASE(warn_unused_local_assigned)
@@ -5828,10 +5828,10 @@ BOOST_AUTO_TEST_CASE(warn_unused_local_assigned)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Unused");
+	CHECK_WARNING(text, "Unused local variable.");
 }
 
-BOOST_AUTO_TEST_CASE(warn_unused_param)
+BOOST_AUTO_TEST_CASE(warn_unused_function_parameter)
 {
 	char const* text = R"(
 		contract C {
@@ -5839,7 +5839,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_param)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Unused");
+	CHECK_WARNING(text, "Unused function parameter. Remove or comment out the variable name to silence this warning.");
 	text = R"(
 		contract C {
 			function f(uint a) {
@@ -5849,7 +5849,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_param)
 	success(text);
 }
 
-BOOST_AUTO_TEST_CASE(warn_unused_return_param)
+BOOST_AUTO_TEST_CASE(warn_unused_return_parameter)
 {
 	char const* text = R"(
 		contract C {
@@ -5857,7 +5857,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Unused");
+	CHECK_WARNING(text, "Unused function parameter. Remove or comment out the variable name to silence this warning.");
 	text = R"(
 		contract C {
 			function f() returns (uint a) {
@@ -5865,7 +5865,7 @@ BOOST_AUTO_TEST_CASE(warn_unused_return_param)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Unused");
+	CHECK_WARNING(text, "Unused function parameter. Remove or comment out the variable name to silence this warning.");
 	text = R"(
 		contract C {
 			function f() returns (uint) {


### PR DESCRIPTION
Fixes #2830.  If we have a function parameter then the following warning will be displayed. "Warning: Unused variable. Remove or comment out the variable name to silence this warning"