### PR TITLE
Fix warning checking in test framework.

### DIFF
--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -59,7 +59,7 @@ AnalysisFramework::parseAnalyseAndReturnError(
 		if (currentError->comment()->find("This is a pre-release compiler version") == 0)
 			continue;
 
-		if (_reportWarnings == (currentError->type() == Error::Type::Warning))
+		if (_reportWarnings || (currentError->type() != Error::Type::Warning))
 		{
 			if (firstError && !_allowMultipleErrors)
 			{

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4528,12 +4528,12 @@ BOOST_AUTO_TEST_CASE(warn_about_callcode)
 	CHECK_WARNING(text, "\"callcode\" has been deprecated in favour");
 }
 
-BOOST_AUTO_TEST_CASE(no_warn_about_callcode_as_local)
+BOOST_AUTO_TEST_CASE(no_warn_about_callcode_as_function)
 {
 	char const* text = R"(
 		contract test {
 			function callcode() {
-				var x = this.callcode;
+				test.callcode();
 			}
 		}
 	)";
@@ -6140,14 +6140,14 @@ BOOST_AUTO_TEST_CASE(does_not_error_transfer_regular_function)
 {
 	char const* text = R"(
 		contract A {
-			function transfer(uint) {}
+			function transfer() {}
 		}
 
 		contract B {
 			A a;
 
 			function() {
-				a.transfer(100);
+				a.transfer();
 			}
 		}
 	)";


### PR DESCRIPTION
Previously, checks for "success no warning" would succeed if there is an error and no warning, now there has to be neither an error nor a warning.