### PR TITLE
Update create token factory to comment

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -95,7 +95,8 @@ This means that cyclic creation dependencies are impossible.
             // Create a new Token contract and return its address.
             // From the JavaScript side, the return type is simply
             // "address", as this is the closest type available in
-            // the ABI.
+            // the ABI. Address is only returned in javascript
+            // on calls not transactions.
             return new OwnedToken(name);
         }
 


### PR DESCRIPTION
Updated the comment for create token factory to make it clear that returns don't work on transactions but only on calls. Which is an issue in using factories as a design pattern without storing the resulting address somewhere to be retrieved later.