### PR TITLE
Unary + now a synax error (experimental 0.5.0)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Features:
  * Parser: Better error message for unexpected trailing comma in parameter lists.
+ * Syntax Checker: Unary ``+`` is now a syntax error as experimental 0.5.0 feature.
 
 Bugfixes:
  * Parser: Fix source location of VariableDeclarationStatement.

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -182,8 +182,15 @@ bool SyntaxChecker::visit(Throw const& _throwStatement)
 
 bool SyntaxChecker::visit(UnaryOperation const& _operation)
 {
+	bool const v050 = m_sourceUnit->annotation().experimentalFeatures.count(ExperimentalFeature::V050);
+
 	if (_operation.getOperator() == Token::Add)
-		m_errorReporter.warning(_operation.location(), "Use of unary + is deprecated.");
+	{
+		if (v050)
+			m_errorReporter.syntaxError(_operation.location(), "Use of unary + is deprecated.");
+		else
+			m_errorReporter.warning(_operation.location(), "Use of unary + is deprecated.");
+	}
 	return true;
 }
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4135,6 +4135,8 @@ BOOST_AUTO_TEST_CASE(rational_unary_operation)
 		}
 	)";
 	CHECK_SUCCESS_NO_WARNINGS(text);
+
+	// Test deprecation warning under < 0.5.0
 	text = R"(
 		contract test {
 			function f() pure public {
@@ -4154,6 +4156,29 @@ BOOST_AUTO_TEST_CASE(rational_unary_operation)
 		}
 	)";
 	CHECK_WARNING(text,"Use of unary + is deprecated");
+
+	// Test syntax error under 0.5.0
+	text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
+				ufixed16x2 a = +3.25;
+				fixed16x2 b = -3.25;
+				a; b;
+			}
+		}
+	)";
+	CHECK_ERROR(text, SyntaxError, "Use of unary + is deprecated");
+	text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f(uint x) pure public {
+				uint y = +x;
+				y;
+			}
+		}
+	)";
+	CHECK_ERROR(text, SyntaxError, "Use of unary + is deprecated");
 }
 
 BOOST_AUTO_TEST_CASE(leading_zero_rationals_convert)


### PR DESCRIPTION
Fixes #1760.

The unary + was deprecated with a warning, but will be elevated to an
error in 0.5.0.  This adds the syntax error for the 0.5.0 pragma, and
for a true 0.5.0 release we should consider removing the operator from
the parser.