### PR TITLE
Better specify the fall function gas cost in the docs.

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -519,8 +519,7 @@ Ether (without data). Additionally, in order to receive Ether, the fallback func
 must be marked ``payable``. If no such function exists, the contract cannot receive
 Ether through regular transactions.
 
-In such a context, there is usually very little gas available to the function call (to be precise, 2300 gas),
-so it is important to make fallback functions as cheap as possible.
+In such a context, there is usually very little gas available to the function call (to be precise, 2300 gas), so it is important to make fallback functions as cheap as possible. Note that the gas required by a transaction (as opposed to an internal call) that invokes the fallback function is much higher, because each transaction charges an additional amount of 21000 gas or more for things like signature checking.
 
 In particular, the following operations will consume more gas than the stipend provided to a fallback function:
 


### PR DESCRIPTION
Better specify the fall function gas cost in the docs.