### PR TITLE
Better message for unexpected trailing commas in parameter lists

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.18 (unreleased)
 
 Features:
+ * Parser: Better error message for unexpected trailing comma in parameter lists.
 
 Bugfixes:
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -828,6 +828,8 @@ ASTPointer<ParameterList> Parser::parseParameterList(
 		parameters.push_back(parseVariableDeclaration(options));
 		while (m_scanner->currentToken() != Token::RParen)
 		{
+			if (m_scanner->currentToken() == Token::Comma && m_scanner->peekNextToken() == Token::RParen)
+				fatalParserError("Unexpected trailing comma in parameter list.");
 			expectToken(Token::Comma);
 			parameters.push_back(parseVariableDeclaration(options));
 		}

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -167,6 +167,90 @@ BOOST_AUTO_TEST_CASE(single_function_param)
 	BOOST_CHECK(successParse(text));
 }
 
+BOOST_AUTO_TEST_CASE(single_function_param_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			function(uint a,) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(single_return_param_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			function() returns (uint a,) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(single_modifier_arg_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			modifier modTest(uint a,) { _; }
+			function(uint a) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(single_event_arg_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			event Test(uint a,);
+			function(uint a) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(multiple_function_param_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			function(uint a, uint b,) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(multiple_return_param_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			function() returns (uint a, uint b,) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(multiple_modifier_arg_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			modifier modTest(uint a, uint b,) { _; }
+			function(uint a) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
+BOOST_AUTO_TEST_CASE(multiple_event_arg_trailing_comma)
+{
+	char const* text = R"(
+		contract test {
+			event Test(uint a, uint b,);
+			function(uint a) {}
+		}
+	)";
+	CHECK_PARSE_ERROR(text, "Unexpected trailing comma in parameter list.");
+}
+
 BOOST_AUTO_TEST_CASE(function_no_body)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes #2579.

Improve error message for trailing commas in function signatures -

Trailing commas in function arguments, return parameters, event arguments, and modifier arguments now display the error message "Unexpected trailing comma in arguments"