### PR TITLE
Add abi.encode and abi.encodePacked

### DIFF
--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -35,6 +35,7 @@ namespace solidity
 
 GlobalContext::GlobalContext():
 m_magicVariables(vector<shared_ptr<MagicVariableDeclaration const>>{
+	make_shared<MagicVariableDeclaration>("abi", make_shared<MagicType>(MagicType::Kind::ABI)),
 	make_shared<MagicVariableDeclaration>("addmod", make_shared<FunctionType>(strings{"uint256", "uint256", "uint256"}, strings{"uint256"}, FunctionType::Kind::AddMod, false, StateMutability::Pure)),
 	make_shared<MagicVariableDeclaration>("assert", make_shared<FunctionType>(strings{"bool"}, strings{}, FunctionType::Kind::Assert, false, StateMutability::Pure)),
 	make_shared<MagicVariableDeclaration>("block", make_shared<MagicType>(MagicType::Kind::Block)),

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -305,10 +305,15 @@ void ViewPureChecker::endVisit(MemberAccess const& _memberAccess)
 			mutability = StateMutability::View;
 		break;
 	case Type::Category::Magic:
+	{
 		// we can ignore the kind of magic and only look at the name of the member
-		if (member != "data" && member != "sig" && member != "blockhash")
+		set<string> static const pureMembers{
+			"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "data", "sig", "blockhash"
+		};
+		if (!pureMembers.count(member))
 			mutability = StateMutability::View;
 		break;
+	}
 	case Type::Category::Struct:
 	{
 		if (_memberAccess.expression().annotation().type->dataStoredIn(DataLocation::Storage))

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2375,7 +2375,11 @@ string FunctionType::richIdentifier() const
 	case Kind::ByteArrayPush: id += "bytearraypush"; break;
 	case Kind::ObjectCreation: id += "objectcreation"; break;
 	case Kind::Assert: id += "assert"; break;
-	case Kind::Require: id += "require";break;
+	case Kind::Require: id += "require"; break;
+	case Kind::ABIEncode: id += "abiencode"; break;
+	case Kind::ABIEncodePacked: id += "abiencodepacked"; break;
+	case Kind::ABIEncodeWithSelector: id += "abiencodewithselector"; break;
+	case Kind::ABIEncodeWithSignature: id += "abiencodewithsignature"; break;
 	default: solAssert(false, "Unknown function location."); break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
@@ -2996,6 +3000,8 @@ string MagicType::richIdentifier() const
 		return "t_magic_message";
 	case Kind::Transaction:
 		return "t_magic_transaction";
+	case Kind::ABI:
+		return "t_magic_abi";
 	default:
 		solAssert(false, "Unknown kind of magic");
 	}
@@ -3036,6 +3042,45 @@ MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const*) const
 			{"origin", make_shared<IntegerType>(160, IntegerType::Modifier::Address)},
 			{"gasprice", make_shared<IntegerType>(256)}
 		});
+	case Kind::ABI:
+		return MemberList::MemberMap({
+			{"encode", make_shared<FunctionType>(
+				TypePointers(),
+				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+				strings{},
+				strings{},
+				FunctionType::Kind::ABIEncode,
+				true,
+				StateMutability::Pure
+			)},
+			{"encodePacked", make_shared<FunctionType>(
+				TypePointers(),
+				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+				strings{},
+				strings{},
+				FunctionType::Kind::ABIEncodePacked,
+				true,
+				StateMutability::Pure
+			)},
+			{"encodeWithSelector", make_shared<FunctionType>(
+				TypePointers{make_shared<FixedBytesType>(4)},
+				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+				strings{},
+				strings{},
+				FunctionType::Kind::ABIEncodeWithSelector,
+				true,
+				StateMutability::Pure
+			)},
+			{"encodeWithSignature", make_shared<FunctionType>(
+				TypePointers{make_shared<ArrayType>(DataLocation::Memory, true)},
+				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+				strings{},
+				strings{},
+				FunctionType::Kind::ABIEncodeWithSignature,
+				true,
+				StateMutability::Pure
+			)}
+		});
 	default:
 		solAssert(false, "Unknown kind of magic.");
 	}
@@ -3051,6 +3096,8 @@ string MagicType::toString(bool) const
 		return "msg";
 	case Kind::Transaction:
 		return "tx";
+	case Kind::ABI:
+		return "abi";
 	default:
 		solAssert(false, "Unknown kind of magic.");
 	}

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -914,6 +914,10 @@ public:
 		ObjectCreation, ///< array creation using new
 		Assert, ///< assert()
 		Require, ///< require()
+		ABIEncode,
+		ABIEncodePacked,
+		ABIEncodeWithSelector,
+		ABIEncodeWithSignature,
 		GasLeft ///< gasleft()
 	};
 
@@ -1049,7 +1053,7 @@ public:
 	ASTPointer<ASTString> documentation() const;
 
 	/// true iff arguments are to be padded to multiples of 32 bytes for external calls
-	bool padArguments() const { return !(m_kind == Kind::SHA3 || m_kind == Kind::SHA256 || m_kind == Kind::RIPEMD160); }
+	bool padArguments() const { return !(m_kind == Kind::SHA3 || m_kind == Kind::SHA256 || m_kind == Kind::RIPEMD160 || m_kind == Kind::ABIEncodePacked); }
 	bool takesArbitraryParameters() const { return m_arbitraryParameters; }
 	bool gasSet() const { return m_gasSet; }
 	bool valueSet() const { return m_valueSet; }
@@ -1207,7 +1211,7 @@ private:
 class MagicType: public Type
 {
 public:
-	enum class Kind { Block, Message, Transaction };
+	enum class Kind { Block, Message, Transaction, ABI };
 	virtual Category category() const override { return Category::Magic; }
 
 	explicit MagicType(Kind _kind): m_kind(_kind) {}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -11095,69 +11095,212 @@ BOOST_AUTO_TEST_CASE(abi_encode)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f() returns (bytes) {
+			function f0() returns (bytes) {
+				return abi.encode();
+			}
+			function f1() returns (bytes) {
 				return abi.encode(1, 2);
 			}
-			function g() returns (bytes) {
-				return abi.encodePacked(uint256(1), uint256(2));
+			function f2() returns (bytes) {
+				string memory x = "abc";
+				return abi.encode(1, x, 2);
+			}
+			function f3() returns (bytes r) {
+				// test that memory is properly allocated
+				string memory x = "abc";
+				r = abi.encode(1, x, 2);
+				bytes memory y = "def";
+				require(y[0] == "d");
+				y[0] = "e";
+				require(y[0] == "e");
 			}
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
-	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(0x20), u256(0x40), u256(1), u256(2)));
-	ABI_CHECK(callContractFunction("g()"), encodeArgs(u256(0x20), u256(0x40), u256(1), u256(2)));
+	ABI_CHECK(callContractFunction("f0()"), encodeArgs(0x20, 0));
+	ABI_CHECK(callContractFunction("f1()"), encodeArgs(0x20, 0x40, 1, 2));
+	ABI_CHECK(callContractFunction("f2()"), encodeArgs(0x20, 0xa0, 1, 0x60, 2, 3, "abc"));
+	ABI_CHECK(callContractFunction("f3()"), encodeArgs(0x20, 0xa0, 1, 0x60, 2, 3, "abc"));
 }
 
-BOOST_AUTO_TEST_CASE(abi_encode_complex_call)
+BOOST_AUTO_TEST_CASE(abi_encode_v2)
+{
+	char const* sourceCode = R"(
+		pragma experimental ABIEncoderV2;
+		contract C {
+			struct S { uint a; uint[] b; }
+			function f0() public pure returns (bytes) {
+				return abi.encode();
+			}
+			function f1() public pure returns (bytes) {
+				return abi.encode(1, 2);
+			}
+			function f2() public pure returns (bytes) {
+				string memory x = "abc";
+				return abi.encode(1, x, 2);
+			}
+			function f3() public pure returns (bytes r) {
+				// test that memory is properly allocated
+				string memory x = "abc";
+				r = abi.encode(1, x, 2);
+				bytes memory y = "def";
+				require(y[0] == "d");
+				y[0] = "e";
+				require(y[0] == "e");
+			}
+			S s;
+			function f4() public view returns (bytes r) {
+				string memory x = "abc";
+				s.a = 7;
+				s.b.push(2);
+				s.b.push(3);
+				r = abi.encode(1, x, s, 2);
+				bytes memory y = "def";
+				require(y[0] == "d");
+				y[0] = "e";
+				require(y[0] == "e");
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("f0()"), encodeArgs(0x20, 0));
+	ABI_CHECK(callContractFunction("f1()"), encodeArgs(0x20, 0x40, 1, 2));
+	ABI_CHECK(callContractFunction("f2()"), encodeArgs(0x20, 0xa0, 1, 0x60, 2, 3, "abc"));
+	ABI_CHECK(callContractFunction("f3()"), encodeArgs(0x20, 0xa0, 1, 0x60, 2, 3, "abc"));
+	ABI_CHECK(callContractFunction("f4()"), encodeArgs(0x20, 0x160, 1, 0x80, 0xc0, 2, 3, "abc", 7, 0x40, 2, 2, 3));
+}
+
+
+BOOST_AUTO_TEST_CASE(abi_encodePacked)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f0() public pure returns (bytes) {
+				return abi.encodePacked();
+			}
+			function f1() public pure returns (bytes) {
+				return abi.encodePacked(uint8(1), uint8(2));
+			}
+			function f2() public pure returns (bytes) {
+				string memory x = "abc";
+				return abi.encodePacked(uint8(1), x, uint8(2));
+			}
+			function f3() public pure returns (bytes r) {
+				// test that memory is properly allocated
+				string memory x = "abc";
+				r = abi.encodePacked(uint8(1), x, uint8(2));
+				bytes memory y = "def";
+				require(y[0] == "d");
+				y[0] = "e";
+				require(y[0] == "e");
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("f0()"), encodeArgs(0x20, 0));
+	ABI_CHECK(callContractFunction("f1()"), encodeArgs(0x20, 2, "\x01\x02"));
+	ABI_CHECK(callContractFunction("f2()"), encodeArgs(0x20, 5, "\x01" "abc" "\x02"));
+	ABI_CHECK(callContractFunction("f3()"), encodeArgs(0x20, 5, "\x01" "abc" "\x02"));
+}
+
+BOOST_AUTO_TEST_CASE(abi_encode_with_selector)
+{
+	char const* sourceCode = R"(
+		contract C {
+			function f0() public pure returns (bytes) {
+				return abi.encodeWithSelector(0x12345678);
+			}
+			function f1() public pure returns (bytes) {
+				return abi.encodeWithSelector(0x12345678, "abc");
+			}
+			function f2() public pure returns (bytes) {
+				bytes4 x = 0x12345678;
+				return abi.encodeWithSelector(x, "abc");
+			}
+			function f3() public pure returns (bytes) {
+				bytes4 x = 0x12345678;
+				return abi.encodeWithSelector(x, uint(-1));
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("f0()"), encodeArgs(0x20, 4, "\x12\x34\x56\x78"));
+	bytes expectation;
+	expectation = encodeArgs(0x20, 4 + 0x60) + bytes{0x12, 0x34, 0x56, 0x78} + encodeArgs(0x20, 3, "abc") + bytes(0x20 - 4);
+	ABI_CHECK(callContractFunction("f1()"), expectation);
+	expectation = encodeArgs(0x20, 4 + 0x60) + bytes{0x12, 0x34, 0x56, 0x78} + encodeArgs(0x20, 3, "abc") + bytes(0x20 - 4);
+	ABI_CHECK(callContractFunction("f2()"), expectation);
+	expectation = encodeArgs(0x20, 4 + 0x20) + bytes{0x12, 0x34, 0x56, 0x78} + encodeArgs(u256(-1)) + bytes(0x20 - 4);
+	ABI_CHECK(callContractFunction("f3()"), expectation);
+}
+
+BOOST_AUTO_TEST_CASE(abi_encode_with_signature)
 {
 	char const* sourceCode = R"T(
 		contract C {
-			function f(uint8 a, string b, string c) {
-				require(a == 42);
-				require(bytes(b).length == 2);
-				require(bytes(b)[0] == 72); // 'H'
-				require(bytes(b)[1] == 101); // 'e'
-				require(keccak256(b) == keccak256(c));
+			function f0() public pure returns (bytes) {
+				return abi.encodeWithSignature("f(uint256)");
 			}
-			function g(uint8 a, string b) returns (bool) {
-				bytes request = abi.encode(
-					bytes4(keccak256(abi.encodePacked("f(uint8,string)"))),
-					a,
-					b,
-					"He"
-				);
-				return this.call(request);
+			function f1() public pure returns (bytes) {
+				string memory x = "f(uint256)";
+				return abi.encodeWithSignature(x, "abc");
+			}
+			string xstor;
+			function f1s() public returns (bytes) {
+				xstor = "f(uint256)";
+				return abi.encodeWithSignature(xstor, "abc");
+			}
+			function f2() public pure returns (bytes r, uint[] ar) {
+				string memory x = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+				uint[] memory y = new uint[](4);
+				y[0] = uint(-1);
+				y[1] = uint(-2);
+				y[2] = uint(-3);
+				y[3] = uint(-4);
+				r = abi.encodeWithSignature(x, y);
+				// The hash uses temporary memory. This allocation re-uses the memory
+				// and should initialize it properly.
+				ar = new uint[](2);
 			}
 		}
 	)T";
 	compileAndRun(sourceCode, 0, "C");
-	ABI_CHECK(callContractFunction("g(uint8,string)", u256(42), u256(0x40), u256(2), string("He")), encodeArgs(u256(1)));
+	ABI_CHECK(callContractFunction("f0()"), encodeArgs(0x20, 4, "\xb3\xde\x64\x8b"));
+	bytes expectation;
+	expectation = encodeArgs(0x20, 4 + 0x60) + bytes{0xb3, 0xde, 0x64, 0x8b} + encodeArgs(0x20, 3, "abc") + bytes(0x20 - 4);
+	ABI_CHECK(callContractFunction("f1()"), expectation);
+	ABI_CHECK(callContractFunction("f1s()"), expectation);
+	expectation =
+		encodeArgs(0x40, 0x140, 4 + 0xc0) +
+		(bytes{0xe9, 0xc9, 0x21, 0xcd} + encodeArgs(0x20, 4, u256(-1), u256(-2), u256(-3), u256(-4)) + bytes(0x20 - 4)) +
+		encodeArgs(2, 0, 0);
+	ABI_CHECK(callContractFunction("f2()"), expectation);
 }
 
-BOOST_AUTO_TEST_CASE(abi_encodewithselector_complex_call)
+BOOST_AUTO_TEST_CASE(abi_encode_call)
 {
 	char const* sourceCode = R"T(
 		contract C {
-			function f(uint8 a, string b, string c) {
-				require(a == 42);
-				require(bytes(b).length == 2);
-				require(bytes(b)[0] == 72); // 'H'
-				require(bytes(b)[1] == 101); // 'e'
-				require(keccak256(b) == keccak256(c));
+			bool x;
+			function c(uint a, uint[] b) public {
+				require(a == 5);
+				require(b.length == 2);
+				require(b[0] == 6);
+				require(b[1] == 7);
+				x = true;
 			}
-			function g(uint8 a, string b) returns (bool) {
-				bytes request = abi.encodeWithSignature(
-					"f(uint8,string)",
-					a,
-					b,
-					"He"
-				);
-				return this.call(request);
+			function f() public returns (bool) {
+				uint a = 5;
+				uint[] memory b = new uint[](2);
+				b[0] = 6;
+				b[1] = 7;
+				require(this.call(abi.encodeWithSignature("c(uint256,uint256[])", a, b)));
+				return x;
 			}
 		}
 	)T";
 	compileAndRun(sourceCode, 0, "C");
-	ABI_CHECK(callContractFunction("g(uint8,string)", u256(42), u256(0x40), u256(2), string("He")), encodeArgs(u256(1)));
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(true));
 }
 
 BOOST_AUTO_TEST_CASE(staticcall_for_view_and_pure)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7120,6 +7120,22 @@ BOOST_AUTO_TEST_CASE(tight_packing_literals)
 		}
 	)";
 	CHECK_WARNING(text, "The type of \"int_const 1\" was inferred as uint8.");
+	text = R"(
+		contract C {
+			function f() pure public returns (bytes) {
+				return abi.encode(1);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f() pure public returns (bytes) {
+				return abi.encodePacked(1);
+			}
+		}
+	)";
+	CHECK_WARNING(text, "The type of \"int_const 1\" was inferred as uint8.");
 }
 
 BOOST_AUTO_TEST_CASE(non_external_fallback)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7075,69 +7075,6 @@ BOOST_AUTO_TEST_CASE(reject_interface_constructors)
 	CHECK_ERROR(text, TypeError, "Wrong argument count for constructor call: 1 arguments given but expected 0.");
 }
 
-BOOST_AUTO_TEST_CASE(tight_packing_literals)
-{
-	char const* text = R"(
-		contract C {
-			function f() pure public returns (bytes32) {
-				return keccak256(1);
-			}
-		}
-	)";
-	CHECK_WARNING(text, "The type of \"int_const 1\" was inferred as uint8.");
-	text = R"(
-		contract C {
-			function f() pure public returns (bytes32) {
-				return keccak256(uint8(1));
-			}
-		}
-	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
-	text = R"(
-		contract C {
-			function f() pure public returns (bytes32) {
-				return sha3(1);
-			}
-		}
-	)";
-	CHECK_WARNING_ALLOW_MULTI(text, (std::vector<std::string>{
-		"The type of \"int_const 1\" was inferred as uint8.",
-		"\"sha3\" has been deprecated in favour of \"keccak256\""
-	}));
-	text = R"(
-		contract C {
-			function f() pure public returns (bytes32) {
-				return sha256(1);
-			}
-		}
-	)";
-	CHECK_WARNING(text, "The type of \"int_const 1\" was inferred as uint8.");
-	text = R"(
-		contract C {
-			function f() pure public returns (bytes32) {
-				return ripemd160(1);
-			}
-		}
-	)";
-	CHECK_WARNING(text, "The type of \"int_const 1\" was inferred as uint8.");
-	text = R"(
-		contract C {
-			function f() pure public returns (bytes) {
-				return abi.encode(1);
-			}
-		}
-	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
-	text = R"(
-		contract C {
-			function f() pure public returns (bytes) {
-				return abi.encodePacked(1);
-			}
-		}
-	)";
-	CHECK_WARNING(text, "The type of \"int_const 1\" was inferred as uint8.");
-}
-
 BOOST_AUTO_TEST_CASE(non_external_fallback)
 {
 	char const* text = R"(

--- a/test/libsolidity/syntaxTests/functionCalls/arbitrary_parameters_but_restricted_first_type.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/arbitrary_parameters_but_restricted_first_type.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f() pure public {
+        abi.encodeWithSelector();
+        abi.encodeWithSignature();
+        abi.encodeWithSelector(uint(2), 2);
+        abi.encodeWithSignature(uint(2), 2);
+    }
+}
+// ----
+// TypeError: (52-76): Need at least 1 arguments for function call, but provided only 0.
+// TypeError: (86-111): Need at least 1 arguments for function call, but provided only 0.
+// TypeError: (144-151): Invalid type for argument in function call. Invalid implicit conversion from uint256 to bytes4 requested.
+// TypeError: (189-196): Invalid type for argument in function call. Invalid implicit conversion from uint256 to string memory requested.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs.sol
@@ -1,0 +1,17 @@
+contract C {
+    struct S { uint x; }
+    S s;
+    struct T { uint y; }
+    T t;
+    function f() public view {
+        abi.encode(s, t);
+    }
+    function g() public view {
+        abi.encodePacked(s, t);
+    }
+}
+// ----
+// TypeError: (131-132): This type cannot be encoded.
+// TypeError: (134-135): This type cannot be encoded.
+// TypeError: (200-201): This type cannot be encoded.
+// TypeError: (203-204): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs_abiv2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs_abiv2.sol
@@ -1,0 +1,18 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    struct S { uint x; }
+    S s;
+    struct T { uint y; }
+    T t;
+    function f() public view {
+        abi.encode(s, t);
+    }
+    function g() public view {
+        abi.encodePacked(s, t);
+    }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (235-236): This type cannot be encoded.
+// TypeError: (238-239): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
@@ -1,14 +1,13 @@
 contract C {
     struct S { uint x; }
     S s;
-    struct T { }
+    struct T { uint y; }
     T t;
-    function f() public pure {
+    function f() public view {
         bytes32 a = sha256(s, t);
         a;
     }
 }
 // ----
-// Warning: (51-63): Defining empty structs is deprecated.
-// TypeError: (131-132): This type cannot be encoded.
-// TypeError: (134-135): This type cannot be encoded.
+// TypeError: (139-140): This type cannot be encoded.
+// TypeError: (142-143): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs_abiv2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs_abiv2.sol
@@ -1,0 +1,16 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    struct S { uint x; }
+    S s;
+    struct T { uint y; }
+    T t;
+    function f() public view {
+        bytes32 a = sha256(s, t);
+        a;
+    }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (174-175): This type cannot be encoded.
+// TypeError: (177-178): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/tight_packing_literals.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals.sol
@@ -1,0 +1,25 @@
+contract C {
+    function f() pure public returns (bytes32) {
+        return keccak256(1);
+    }
+    function g() pure public returns (bytes32) {
+        return sha3(1);
+    }
+    function h() pure public returns (bytes32) {
+        return sha256(1);
+    }
+    function j() pure public returns (bytes32) {
+        return ripemd160(1);
+    }
+    function k() pure public returns (bytes) {
+        return abi.encodePacked(1);
+    }
+}
+
+// ----
+// Warning: (87-88): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.
+// Warning: (161-168): "sha3" has been deprecated in favour of "keccak256"
+// Warning: (166-167): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.
+// Warning: (247-248): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.
+// Warning: (331-332): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.
+// Warning: (420-421): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.

--- a/test/libsolidity/syntaxTests/tight_packing_literals_fine.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals_fine.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() pure public returns (bytes32) {
+        return keccak256(uint8(1));
+    }
+    function g() pure public returns (bytes) {
+        return abi.encode(1);
+    }
+    function h() pure public returns (bytes) {
+        return abi.encodePacked(uint8(1));
+    }
+}

--- a/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode.sol
+++ b/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() pure public returns (bytes r) {
+        r = abi.encode(1, 2);
+        r = abi.encodePacked(f());
+        r = abi.encodeWithSelector(0x12345678, 1);
+        r = abi.encodeWithSignature("f(uint256)", 4);
+    }
+}

--- a/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode_arguments.sol
+++ b/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode_arguments.sol
@@ -1,0 +1,36 @@
+contract C {
+    uint x;
+    function gView() public view returns (uint) { return x; }
+    function gNonPayable() public returns (uint) { x = 4; return 0; }
+
+    function f1() view public returns (bytes) {
+        return abi.encode(gView());
+    }
+    function f2() view public returns (bytes) {
+        return abi.encodePacked(gView());
+    }
+    function f3() view public returns (bytes) {
+        return abi.encodeWithSelector(0x12345678, gView());
+    }
+    function f4() view public returns (bytes) {
+        return abi.encodeWithSignature("f(uint256)", gView());
+    }
+    function g1() public returns (bytes) {
+        return abi.encode(gNonPayable());
+    }
+    function g2() public returns (bytes) {
+        return abi.encodePacked(gNonPayable());
+    }
+    function g3() public returns (bytes) {
+        return abi.encodeWithSelector(0x12345678, gNonPayable());
+    }
+    function g4() public returns (bytes) {
+        return abi.encodeWithSignature("f(uint256)", gNonPayable());
+    }
+    // This will generate the only warning.
+    function check() public returns (bytes) {
+        return abi.encode(2);
+    }
+}
+// ----
+// Warning: (1044-1121): Function state mutability can be restricted to pure


### PR DESCRIPTION
Fixes #1707. Continuation of #2851 (managed to overwrite that branch with something else)

Add the global `abi` with the following four functions:

- `abi.encode(...) -> bytes`
- `abi.encodePacked(...) -> bytes`
- `abi.encodeWithSelector(bytes4, ...) -> bytes`
- `abi.encodeWithSignature(string, ...) -> bytes`

`abi.encode` ABI-encodes the provided arguments according to their types. `abi.encodePacked` performs packed encoding. `abi.encodeWithSelector(a, x, ...)` acts like `abi.encode(x, ...)` but prepends the four bytes in `a`. `abi.encodeWithSignature(a, x, ...)` is identical to `abi.encode(bytes4(keccak256(a)), x, ...)`.

TODO:

 - [x] test that the selector functions properly type check the first parameter
 - [x] test encoding interleaved with other memory operations
 - [x] test that encoding functions are non-pure if they arguments are non-pure