### PR TITLE
Adds better error message for fractional array size expressions

### DIFF
--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -149,8 +149,10 @@ void ReferencesResolver::endVisit(ArrayTypeName const& _typeName)
 		if (!length->annotation().type)
 			ConstantEvaluator e(*length);
 		auto const* lengthType = dynamic_cast<RationalNumberType const*>(length->annotation().type.get());
-		if (!lengthType || lengthType->isFractional() || !lengthType->mobileType())
+		if (!lengthType || !lengthType->mobileType())
 			fatalTypeError(length->location(), "Invalid array length, expected integer literal.");
+		else if (lengthType->isFractional())
+			fatalTypeError(length->location(), "Array with fractional length specified.");
 		else if (lengthType->isNegative())
 			fatalTypeError(length->location(), "Array with negative length specified.");
 		else
@@ -347,4 +349,3 @@ void ReferencesResolver::fatalDeclarationError(SourceLocation const& _location, 
 	m_errorOccurred = true;
 	m_errorReporter.fatalDeclarationError(_location, _description);
 }
-

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4354,7 +4354,7 @@ BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_rational)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal");
+	CHECK_ERROR(text, TypeError, "Array with fractional length specified.");
 }
 
 BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_signed_fixed_type)
@@ -4366,7 +4366,7 @@ BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_signed_fixed_type)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
 }
 
 BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_unsigned_fixed_type)
@@ -4378,7 +4378,7 @@ BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_unsigned_fixed_type)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
 }
 
 BOOST_AUTO_TEST_CASE(rational_to_bytes_implicit_conversion)


### PR DESCRIPTION
Part of #1259. For array size expressions like [3/0], the compiler now displays the message "Operator / not compatible with types int_const 3 and int_const 0". In addition, for array size expressions like [3.5], the error was changed to "Array with fractional length specified."