### PR TITLE
Fix file missing error message on imports.

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -676,7 +676,13 @@ bool CommandLineInterface::processInput()
 		try
 		{
 			auto path = boost::filesystem::path(_path);
+			if (!boost::filesystem::exists(path))
+				return ReadCallback::Result{false, "File not found."};
+
 			auto canonicalPath = boost::filesystem::canonical(path);
+			if (!boost::filesystem::is_regular_file(canonicalPath))
+				return ReadCallback::Result{false, "Not a valid file."};
+
 			bool isAllowed = false;
 			for (auto const& allowedDir: m_allowedDirectories)
 			{
@@ -692,16 +698,10 @@ bool CommandLineInterface::processInput()
 			}
 			if (!isAllowed)
 				return ReadCallback::Result{false, "File outside of allowed directories."};
-			else if (!boost::filesystem::exists(path))
-				return ReadCallback::Result{false, "File not found."};
-			else if (!boost::filesystem::is_regular_file(canonicalPath))
-				return ReadCallback::Result{false, "Not a valid file."};
-			else
-			{
-				auto contents = dev::contentsString(canonicalPath.string());
-				m_sourceCodes[path.string()] = contents;
-				return ReadCallback::Result{true, contents};
-			}
+
+			auto contents = dev::contentsString(canonicalPath.string());
+			m_sourceCodes[path.string()] = contents;
+			return ReadCallback::Result{true, contents};
 		}
 		catch (Exception const& _exception)
 		{


### PR DESCRIPTION
Trying to convert an import path into a Boost canonical path causes
boost to throw an exception if the given file does not exist. Thus,
instead of geting to the 'File not found' error, we instead got into the
cath-all handler for 'Unknown exception in read callback'.

This change rearranges the file checks to happen before we create a
canonical Boost path. It also drive-by removes the unnecessary 'else'
block, as the body of the if is a guard-like return block.