### PR TITLE
[WIP] documentation: overflow rules in 'solidity in depth -> misc'

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -306,7 +306,7 @@ The following is the order of precedence for operators, listed in order of evalu
 Overflow and underflow rules for operators
 ==========================================
 
-Integers in Solidity have a fixed size. When an (arithmetic) operation attempts to
+Integers in Solidity have a fixed size. When an arithmetic operation attempts to
 create a number that is greater than the maximum value it results in an *overflow*,
 and if it tries to create number is less than the minimum value allowed it results
 in an *underflow*.

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -317,7 +317,7 @@ Signed integers are represented in `two's complement <https://en.wikipedia.org/w
 which means they have the range ``[-2**(N - 1), 2**(N - 1) - 1]``, where ``N`` is the bitsize.
 
 .. warning::
-Solidity does not automatically detect over/underflow.
+    Solidity does not automatically detect over/underflow.
 
 Overflow and underflow in signed and unsigned integers are generally handled by
 reducing the value ``modulo N``, where ``N`` is the bitsize of the integer in question.
@@ -331,9 +331,9 @@ where ``N`` is the bitsize of the new type.
 
 ``uint8 x = 255; x + 2 == 1``
 
-``uint8 x = 2; = 2 - 5 == 253``
+``uint8 x = 2; x - 5 == 253``
 
-``int8 x = -128; == x - 1 == 127``
+``int8 x = -128; x - 1 == 127``
 
 ``var x = uint8(258); x == 2``
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -318,13 +318,13 @@ Additionally, the EVM has its own overflow semantics for results that exceed 256
 
 **Truncation**
 
-Some operations will simply discard certain bits of the result rather then doing a modulo computation. This is referred to as *truncation*. Examples of truncating operators is the left and right arithmetic shifts.
+Some operations will discard certain bits of the result instead of doing a modulo computation. This is referred to as *truncation*. Examples of truncating operators are the left and right arithmetic shifts.
 
 **Examples**
 
-``uint8(257) == 257 % 2**8 == 1``
+``uint8(257) == 257 mod 2**8 == 1``
 
-``uint8(2 - 5) == -5 % 2**8 == 256 - 5 == 251``
+``uint8(2 - 5) == -3 mod 2**8 == 256 - 3 == 253``
 
 ``int8(-129) == -129 mod 256 == 127``
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -309,7 +309,9 @@ Overflow and underflow rules for operators
 Integers in Solidity have a fixed size. When an arithmetic operation attempts to
 create a number that is greater than the maximum value it results in an *overflow*,
 and if it tries to create number is less than the minimum value allowed it results
-in an *underflow*.
+in an *underflow*. Overflow and underflow in signed and unsigned integers are generally
+handled by reducing the value ``modulo N``, where ``N`` is the bitsize of the integer
+in question.
 
 Unsigned integers are restricted to the range ``[0, 2**N - 1]``, where ``N`` is the bitsize.
 
@@ -318,9 +320,6 @@ which means they have the range ``[-2**(N - 1), 2**(N - 1) - 1]``, where ``N`` i
 
 .. warning::
     Solidity does not automatically detect over/underflow.
-
-Overflow and underflow in signed and unsigned integers are generally handled by
-reducing the value ``modulo N``, where ``N`` is the bitsize of the integer in question.
 
 **Casting and demotion**
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -318,7 +318,7 @@ Unsigned integers are restricted to the range ``[0, 2**N - 1]``, where ``N`` is 
 +------------+----------+-----------+---------+
 | \+ (unary) | N/A      | N/A       | 1       |
 +------------+----------+-----------+---------+
-| \-, --, -= |          | x         |         |
+| -, --, -=  |          | x         |         |
 +------------+----------+-----------+---------+
 | \- (unary) |          |           | 2       |
 +------------+----------+-----------+---------+
@@ -344,7 +344,7 @@ Unsigned integers are restricted to the range ``[0, 2**N - 1]``, where ``N`` is 
 +------------+----------+-----------+---------+
 
 1) Unary ``+`` has been deprecated.
-2) Note that unary ``-`` works on ``uints``, e.g. ``-uint(1) == ~uint(0) (> 1)``, although this is technically not an over/underflow.
+2) Unary ``-`` works on ``uints``, e.g. ``-uint(1) == ~uint(0)``.
 3) Arithmetic left shift, implemented as truncated multiplication ``n << m == n * 2**m`` (overflowing bits are removed). The bitsize of the shifted value is that of ``n``.
 4) Arithmetic right shift, implemented as division ``n >> m == n / 2**m``. The bitsize of the shifted value is that of ``n``.
 
@@ -370,11 +370,11 @@ Signed integers are represented in two's complement, and are restricted to the r
 +------------+----------+-----------+---------+
 | /, /=      |          |           | 2       |
 +------------+----------+-----------+---------+
-| %, %=      |          | x         |         |
+| %, %=      |          |           | 4       |
 +------------+----------+-----------+---------+
-| <<, <<=    | x        |           | 4       |
+| <<, <<=    | x        | x         | 5       |
 +------------+----------+-----------+---------+
-| >>, >>=    |          |           | 5       |
+| >>, >>=    |          |           | 6       |
 +------------+----------+-----------+---------+
 | &, &=      |          |           |         |
 +------------+----------+-----------+---------+
@@ -386,10 +386,11 @@ Signed integers are represented in two's complement, and are restricted to the r
 +------------+----------+-----------+---------+
 
 1) Unary ``+`` has been deprecated.
-2) Due to the overflow protection for ``INT_MIN = 2**255``, which is built into the EVM, we have the following relation ``-INT_MIN == INT_MIN``. This affects a numer of arithmetic operations. See: `The Ethereum Yellow Paper <http://gavwood.com/paper>`_, ``SDIV``, Appendix H, Section 2 (Instruction set).
+2) Due to the overflow protection for ``INT_MIN = -2**255``, which is built into the EVM, we have the following relation ``-INT_MIN == INT_MIN``. This affects a number of arithmetic operations. See: `The Ethereum Yellow Paper <https://ethereum.github.io/yellowpaper>`_, ``SDIV``, Appendix H, Section 2 (Instruction set).
 3) The exponent must be signed.
-4) Arithmetic left shift, implemented as truncated multiplication ``n << m == n * 2**m`` (overflowing bits are removed). The bitsize of the shifted value is that of ``n``.
-5) Arithmetic right shift, implemented as signed division ``n >> m := n / 2**m``. The bitsize of the shifted value is that of ``n``.
+4) Implemented as ``a % b = sign(a)*(|a| mod |b|)``. See: `The Ethereum Yellow Paper <https://ethereum.github.io/yellowpaper>`_, ``SMOD``, Appendix H, Section 2 (Instruction set).
+5) Arithmetic left shift, implemented as truncated multiplication ``n << m == n * 2**m`` (overflowing bits are removed). The bitsize of the shifted value is that of ``n``.
+6) Arithmetic right shift, implemented as signed division ``n >> m == n / 2**m``. The bitsize of the shifted value is that of ``n``.
 
 
 Global Variables

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -303,6 +303,95 @@ The following is the order of precedence for operators, listed in order of evalu
 
 .. index:: assert, block, coinbase, difficulty, number, block;number, timestamp, block;timestamp, msg, data, gas, sender, value, now, gas price, origin, revert, require, keccak256, ripemd160, sha256, ecrecover, addmod, mulmod, cryptography, this, super, selfdestruct, balance, send
 
+Overflow rules
+==============
+
+Unsigned Integers
+-----------------
+
+Unsigned integers are restricted to the range ``[0, 2**N - 1]``, where ``N`` is the bitsize.
+
++------------+----------+-----------+---------+
+|  Operator  | Overflow | Underflow | Notes   |
++============+==========+===========+=========+
+| +, ++, +=  | x        |           |         |
++------------+----------+-----------+---------+
+| \+ (unary) | N/A      | N/A       | 1       |
++------------+----------+-----------+---------+
+| \-, --, -= |          | x         |         |
++------------+----------+-----------+---------+
+| \- (unary) |          |           | 2       |
++------------+----------+-----------+---------+
+| \*, \*=    | x        |           |         |
++------------+----------+-----------+---------+
+| \*\*       | x        |           |         |
++------------+----------+-----------+---------+
+| /, /=      |          |           |         |
++------------+----------+-----------+---------+
+| %, %=      |          |           |         |
++------------+----------+-----------+---------+
+| <<, <<=    |          |           | 3       |
++------------+----------+-----------+---------+
+| >>, >>=    |          |           | 4       |
++------------+----------+-----------+---------+
+| &, &=      |          |           |         |
++------------+----------+-----------+---------+
+| \|, \|=    |          |           |         |
++------------+----------+-----------+---------+
+| ^, ^=      |          |           |         |
++------------+----------+-----------+---------+
+| ~, ~=      |          |           |         |
++------------+----------+-----------+---------+
+
+1) Unary ``+`` has been deprecated.
+2) Note that unary ``-`` works on ``uints``, e.g. ``-uint(1) == ~uint(0) (> 1)``, although this is technically not an over/underflow.
+3) Arithmetic left shift, implemented as truncated multiplication ``n << m == n * 2**m`` (overflowing bits are removed). The bitsize of the shifted value is that of ``n``.
+4) Arithmetic right shift, implemented as division ``n >> m == n / 2**m``. The bitsize of the shifted value is that of ``n``.
+
+Signed Integers
+---------------
+
+Signed integers are represented in two's complement, and are restricted to the range ``[-2**(N - 1), 2**(N - 1) - 1]``, , where ``N`` is the bitsize.
+
++------------+----------+-----------+---------+
+|  Operator  | Overflow | Underflow | Notes   |
++============+==========+===========+=========+
+| +, ++, +=  | x        | x         |         |
++------------+----------+-----------+---------+
+| \+ (unary) | N/A      | N/A       | 1       |
++------------+----------+-----------+---------+
+| -, --, -=  | x        | x         |         |
++------------+----------+-----------+---------+
+| \- (unary) | x        | x         | 2       |
++------------+----------+-----------+---------+
+| \*, \*=    | x        | x         | 2       |
++------------+----------+-----------+---------+
+| \*\*       | x        | x         | 3       |
++------------+----------+-----------+---------+
+| /, /=      |          |           | 2       |
++------------+----------+-----------+---------+
+| %, %=      |          | x         |         |
++------------+----------+-----------+---------+
+| <<, <<=    | x        |           | 4       |
++------------+----------+-----------+---------+
+| >>, >>=    |          |           | 5       |
++------------+----------+-----------+---------+
+| &, &=      |          |           |         |
++------------+----------+-----------+---------+
+| \|, \|=    |          |           |         |
++------------+----------+-----------+---------+
+| ^, ^=      |          |           |         |
++------------+----------+-----------+---------+
+| ~, ~=      |          |           |         |
++------------+----------+-----------+---------+
+
+1) Unary ``+`` has been deprecated.
+2) Due to the overflow protection for ``INT_MIN = 2**255``, which is built into the EVM, we have the following relation ``-INT_MIN == INT_MIN``. This affects a numer of arithmetic operations. See: `The Ethereum Yellow Paper <http://gavwood.com/paper>`_, ``SDIV``, Appendix H, Section 2 (Instruction set).
+3) The exponent must be signed.
+4) Arithmetic left shift, implemented as truncated multiplication ``n << m == n * 2**m`` (overflowing bits are removed). The bitsize of the shifted value is that of ``n``.
+5) Arithmetic right shift, implemented as signed division ``n >> m := n / 2**m``. The bitsize of the shifted value is that of ``n``.
+
+
 Global Variables
 ================
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -306,38 +306,36 @@ The following is the order of precedence for operators, listed in order of evalu
 Overflow and underflow rules for operators
 ==========================================
 
-Integers in Solidity have a fixed range of possible values, and that range is defined by their bit-size. When an (arithmetic) operation attempts to create a number that is greater than the maximum value it results in an *overflow*. If it attempts to create a number that is less than the minimum value allowed then it is called an *underflow*.
+Integers in Solidity have a fixed size. When an (arithmetic) operation attempts to
+create a number that is greater than the maximum value it results in an *overflow*,
+and if it tries to create number is less than the minimum value allowed it results
+in an *underflow*.
 
 Unsigned integers are restricted to the range ``[0, 2**N - 1]``, where ``N`` is the bitsize.
 
-Signed integers are represented in two's complement, and are restricted to the range ``[-2**(N - 1), 2**(N - 1) - 1]``, , where ``N`` is the bitsize.
-
-Overflow and underflow in signed and unsigned integers are generally handled by reducing the value ``modulo N``, where ``N`` is the bitsize of the integer in question, although there are some important exceptions (see the **special cases** section below).
+Signed integers are represented in `two's complement <https://en.wikipedia.org/wiki/Two%27s_complement>`_,
+which means they have the range ``[-2**(N - 1), 2**(N - 1) - 1]``, where ``N`` is the bitsize.
 
 .. warning::
-    Solidity does not automatically detect over/underflow.
+Solidity does not automatically detect over/underflow.
 
-Additionally, the EVM has its own overflow semantics for results that exceed 256 bits. See: `The Ethereum Yellow Paper <https://ethereum.github.io/yellowpaper>`_, Appendix H, Section 2 (Instruction set).
-
-Examples:
-
-``uint8(257) == 257 mod 2**8 == 1``
-
-``uint8(2 - 5) == -3 mod 2**8 == 256 - 3 == 253``
-
-``int8(-129) == -129 mod 256 == 127``
+Overflow and underflow in signed and unsigned integers are generally handled by
+reducing the value ``modulo N``, where ``N`` is the bitsize of the integer in question.
 
 **Casting and demotion**
 
-When casting a value into an integer type, the result is always reduced `modulo N`, where `N` is the bit-size of that integer type. This is important to remember when demoting an integer to a new type with a smaller bit-size.
+When a value is casted to an integer type, the result is always reduced ``modulo N``,
+where ``N`` is the bitsize of the new type.
 
-Example: ``uint8(257) = 1``;
+**Examples**
 
-**Special cases**
+``uint8 x = 255; x + 2 == 1``
 
-The range of signed integer types, i.e. ``[-2**(N - 1), 2**(N - 1) - 1]``, is asymmetric around 0. As a result of this, inverting the minimum value will result in a value that is ``1`` greater then the maximum value, making it wrap around back to itself:
+``uint8 x = 2; = 2 - 5 == 253``
 
-``-INT_MIN = -(-2**(N - 1)) = 2**(N - 1) = 2**(N - 1) - 1 + 1 = INT_MAX + 1 = INT_MIN``
+``int8 x = -128; == x - 1 == 127``
+
+``var x = uint8(258); x == 2``
 
 Table I: Rules for operators and unsigned Integers
 --------------------------------------------------
@@ -375,7 +373,7 @@ Table I: Rules for operators and unsigned Integers
 +------------+----------+-----------+---------+
 
 1) Unary ``+`` has been deprecated.
-2) Unary ``-`` works on ``uints``, e.g. ``-uint(1) == ~uint(0)``.
+2) Unary ``-`` also works on ``uints``, e.g. ``-uint(1) == ~uint(0)``.
 3) ``0**0 := 1``
 4) Arithmetic left shift, implemented as clamped multiplication ``n << m == n * 2**m`` (overflowing bits are removed). The bitsize of the shifted value is that of ``n``.
 5) Arithmetic right shift, implemented as division ``n >> m == n / 2**m``. The bitsize of the shifted value is that of ``n``.

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -303,8 +303,8 @@ The following is the order of precedence for operators, listed in order of evalu
 
 .. index:: assert, block, coinbase, difficulty, number, block;number, timestamp, block;timestamp, msg, data, gas, sender, value, now, gas price, origin, revert, require, keccak256, ripemd160, sha256, ecrecover, addmod, mulmod, cryptography, this, super, selfdestruct, balance, send
 
-Overflow rules
-==============
+Overflow and underflow rules for operators
+==========================================
 
 Unsigned Integers
 -----------------

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -315,7 +315,7 @@ Signed integers are represented in two's complement, and are restricted to the r
 Overflow and underflow in signed and unsigned integers are generally handled by reducing the value ``modulo N``, where ``N`` is the bitsize of the integer in question, although there are some important exceptions (see the **special cases** section below).
 
 .. warning::
-Solidity does not automatically detect over/underflow.
+    Solidity does not automatically detect over/underflow.
 
 Additionally, the EVM has its own overflow semantics for results that exceed 256 bits. See: `The Ethereum Yellow Paper <https://ethereum.github.io/yellowpaper>`_, Appendix H, Section 2 (Instruction set).
 


### PR DESCRIPTION
A short section on overflow rules by the different operators, for signed and unsigned integers.