### PR TITLE
Division and unary operators for SMT checker

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1060,7 +1060,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 						_statement.initialValue()->location(),
 						"Invalid rational " +
 						valueComponentType->toString() +
-						" (absolute value too large or divison by zero)."
+						" (absolute value too large or division by zero)."
 					);
 				else
 					solAssert(false, "");

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -57,6 +57,7 @@ private:
 	virtual void endVisit(ExpressionStatement const& _node) override;
 	virtual void endVisit(Assignment const& _node) override;
 	virtual void endVisit(TupleExpression const& _node) override;
+	virtual void endVisit(UnaryOperation const& _node) override;
 	virtual void endVisit(BinaryOperation const& _node) override;
 	virtual void endVisit(FunctionCall const& _node) override;
 	virtual void endVisit(Identifier const& _node) override;
@@ -66,7 +67,8 @@ private:
 	void compareOperation(BinaryOperation const& _op);
 	void booleanOperation(BinaryOperation const& _op);
 
-	void assignment(Declaration const& _variable, Expression const& _value);
+	void assignment(Declaration const& _variable, Expression const& _value, SourceLocation const& _location);
+	void assignment(Declaration const& _variable, smt::Expression const& _value, SourceLocation const& _location);
 
 	// Visits the branch given by the statement, pushes and pops the SMT checker.
 	// @param _condition if present, asserts that this condition is true within the branch.
@@ -88,6 +90,9 @@ private:
 		Expression const& _condition,
 		std::string const& _description
 	);
+	/// Checks that the value is in the range given by the type.
+	void checkUnderOverflow(smt::Expression _value, IntegerType const& _Type, SourceLocation const& _location);
+
 
 	std::pair<smt::CheckResult, std::vector<std::string>>
 	checkSatisifableAndGenerateModel(std::vector<smt::Expression> const& _expressionsToEvaluate);
@@ -126,9 +131,12 @@ private:
 
 	using VariableSequenceCounters = std::map<Declaration const*, int>;
 
-	/// Returns the expression corresponding to the AST node. Creates a new expression
-	/// if it does not exist yet.
+	/// Returns the expression corresponding to the AST node. Throws if the expression does not exist.
 	smt::Expression expr(Expression const& _e);
+	/// Creates the expression (value can be arbitrary)
+	void createExpr(Expression const& _e);
+	/// Creates the expression and sets its value.
+	void defineExpr(Expression const& _e, smt::Expression _value);
 	/// Returns the function declaration corresponding to the given variable.
 	/// The function takes one argument which is the "sequence number".
 	smt::Expression var(Declaration const& _decl);

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -67,6 +67,10 @@ private:
 	void compareOperation(BinaryOperation const& _op);
 	void booleanOperation(BinaryOperation const& _op);
 
+	/// Division expression in the given type. Requires special treatment because
+	/// of rounding for signed division.
+	smt::Expression division(smt::Expression _left, smt::Expression _right, IntegerType const& _type);
+
 	void assignment(Declaration const& _variable, Expression const& _value, SourceLocation const& _location);
 	void assignment(Declaration const& _variable, smt::Expression const& _value, SourceLocation const& _location);
 

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -120,6 +120,10 @@ public:
 	{
 		return Expression("*", std::move(_a), std::move(_b), Sort::Int);
 	}
+	friend Expression operator/(Expression _a, Expression _b)
+	{
+		return Expression("/", std::move(_a), std::move(_b), Sort::Int);
+	}
 	Expression operator()(Expression _a) const
 	{
 		solAssert(

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -127,7 +127,8 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 		{">=", 2},
 		{"+", 2},
 		{"-", 2},
-		{"*", 2}
+		{"*", 2},
+		{"/", 2}
 	};
 	string const& n = _expr.name;
 	if (m_functions.count(n))
@@ -173,6 +174,8 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 		return arguments[0] - arguments[1];
 	else if (n == "*")
 		return arguments[0] * arguments[1];
+	else if (n == "/")
+		return arguments[0] / arguments[1];
 	// Cannot reach here.
 	solAssert(false, "");
 	return arguments[0];

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -458,6 +458,91 @@ BOOST_AUTO_TEST_CASE(for_loop)
 	CHECK_WARNING(text, "Assertion violation");
 }
 
+BOOST_AUTO_TEST_CASE(division)
+{
+	string text = R"(
+		contract C {
+			function f(uint x, uint y) public pure returns (uint) {
+				return x / y;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Division by zero");
+	text = R"(
+		contract C {
+			function f(uint x, uint y) public pure returns (uint) {
+				require(y != 0);
+				return x / y;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(int x, int y) public pure returns (int) {
+				require(y != 0);
+				return x / y;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Overflow");
+	text = R"(
+		contract C {
+			function f(int x, int y) public pure returns (int) {
+				require(y != 0);
+				require(y != -1);
+				return x / y;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
+BOOST_AUTO_TEST_CASE(division_truncates_correctly)
+{
+	string text = R"(
+		contract C {
+			function f(uint x, uint y) public pure {
+				x = 7;
+				y = 2;
+				assert(x / y == 3);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(int x, int y) public pure {
+				x = 7;
+				y = 2;
+				assert(x / y == 3);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(int x, int y) public pure {
+				x = -7;
+				y = 2;
+				assert(x / y == -3);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(int x, int y) public pure {
+				x = -7;
+				y = -2;
+				int r = x / y;
+				assert(r == 3);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -533,6 +533,16 @@ BOOST_AUTO_TEST_CASE(division_truncates_correctly)
 	text = R"(
 		contract C {
 			function f(int x, int y) public pure {
+				x = 7;
+				y = -2;
+				assert(x / y == -3);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(int x, int y) public pure {
 				x = -7;
 				y = -2;
 				int r = x / y;

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -351,9 +351,9 @@ BOOST_AUTO_TEST_CASE(while_loop_simple)
 	// Check that side-effects of condition are taken into account
 	text = R"(
 		contract C {
-			function f(uint x) public pure {
+			function f(uint x, uint y) public pure {
 				x = 7;
-				while ((x = 5) > 0) {
+				while ((x = y) > 0) {
 				}
 				assert(x == 7);
 			}
@@ -545,8 +545,7 @@ BOOST_AUTO_TEST_CASE(division_truncates_correctly)
 			function f(int x, int y) public pure {
 				x = -7;
 				y = -2;
-				int r = x / y;
-				assert(r == 3);
+				assert(x / y == 3);
 			}
 		}
 	)";


### PR DESCRIPTION
Depends on https://github.com/ethereum/solidity/pull/2993

Fixes https://github.com/ethereum/solidity/issues/3021

It turns out, z3 implements truncation for signed division differently. It seems we have to add our own division.