### PR TITLE
Replace biddingTime with auctionEnd in auction example

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -222,7 +222,6 @@ activate themselves.
         // or time periods in seconds.
         address public beneficiary;
         uint public auctionEnd;
-        uint public biddingTime;
 
         // Current state of the auction.
         address public highestBidder;
@@ -251,8 +250,7 @@ activate themselves.
             address _beneficiary
         ) {
             beneficiary = _beneficiary;
-            auctionEnd = now + biddingTime;
-            biddingTime = _biddingTime;
+            auctionEnd = now + _biddingTime;
         }
 
         /// Bid on the auction with the value sent

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -221,7 +221,7 @@ activate themselves.
         // absolute unix timestamps (seconds since 1970-01-01)
         // or time periods in seconds.
         address public beneficiary;
-        uint public auctionStart;
+        uint public auctionEnd;
         uint public biddingTime;
 
         // Current state of the auction.
@@ -251,7 +251,7 @@ activate themselves.
             address _beneficiary
         ) {
             beneficiary = _beneficiary;
-            auctionStart = now;
+            auctionEnd = now + biddingTime;
             biddingTime = _biddingTime;
         }
 
@@ -268,7 +268,7 @@ activate themselves.
 
             // Revert the call if the bidding
             // period is over.
-            require(now <= (auctionStart + biddingTime));
+            require(now <= auctionEnd);
 
             // If the bid is not higher, send the
             // money back.
@@ -322,7 +322,7 @@ activate themselves.
             // external contracts.
 
             // 1. Conditions
-            require(now >= (auctionStart + biddingTime)); // auction did not yet end
+            require(now >= auctionEnd); // auction did not yet end
             require(!ended); // this function has already been called
 
             // 2. Effects
@@ -382,7 +382,6 @@ high or low invalid bids.
         }
 
         address public beneficiary;
-        uint public auctionStart;
         uint public biddingEnd;
         uint public revealEnd;
         bool public ended;
@@ -410,7 +409,6 @@ high or low invalid bids.
             address _beneficiary
         ) {
             beneficiary = _beneficiary;
-            auctionStart = now;
             biddingEnd = now + _biddingTime;
             revealEnd = biddingEnd + _revealTime;
         }


### PR DESCRIPTION
#### Rationale
It is better to compute the auctionEnd once during contract creation than to compute it every time someone bids. It is also better to not store unnecessary information on the blockchain. I found these issues distracting while learning Solidity.

#### Change
SimpleAuction does less computing for each bid by retaining the more-relevant auctionEnd instead of auctionStart.
SimpleAuction drops its now-unused biddingTime variable.
BlindAuction drops its already-unused auctionStart variable.