### PR TITLE
Added boost-static to Fedora dependencies

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -231,6 +231,7 @@ case $(uname -s) in
                     autoconf \
                     automake \
                     boost-devel \
+                    boost-static \
                     cmake \
                     gcc \
                     gcc-c++ \


### PR DESCRIPTION
This fixes potential failure of _cmake_ stage of the build, as documented here https://github.com/ethereum/solidity/issues/3071#issuecomment-336477742 .