### PR TITLE
Assume peephole optimizer was successful if number of pops increased.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Features:
  * Type Checker: Require ``storage`` or ``memory`` keyword for local variables as experimental 0.5.0 feature.
 
 Bugfixes:
+ * Optimizer: Remove unused stack computation results.
  * Parser: Fix source location of VariableDeclarationStatement.
  * Type Checker: Properly check array length and don't rely on an assertion in code generation.
  * Type Checker: Properly support overwriting members inherited from ``address`` in a contract

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -407,8 +407,11 @@ map<u256, u256> Assembly::optimiseInternal(
 		if (_settings.runPeephole)
 		{
 			PeepholeOptimiser peepOpt(m_items);
-			while (peepOpt.optimise() && count < 0xffffff)
+			while (peepOpt.optimise())
+			{
 				count++;
+				assertThrow(count < 64000, OptimizerException, "Peephole optimizer seems to be stuck.");
+			}
 		}
 
 		// This only modifies PushTags, we have to run again to actually remove code.

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -407,7 +407,7 @@ map<u256, u256> Assembly::optimiseInternal(
 		if (_settings.runPeephole)
 		{
 			PeepholeOptimiser peepOpt(m_items);
-			while (peepOpt.optimise())
+			while (peepOpt.optimise() && count < 0xffffff)
 				count++;
 		}
 

--- a/libevmasm/PeepholeOptimiser.cpp
+++ b/libevmasm/PeepholeOptimiser.cpp
@@ -249,6 +249,11 @@ void applyMethods(OptimiserState& _state, Method, OtherMethods... _other)
 		applyMethods(_state, _other...);
 }
 
+size_t numberOfPops(AssemblyItems const& _items)
+{
+	return std::count(_items.begin(), _items.end(), Instruction::POP);
+}
+
 }
 
 bool PeepholeOptimiser::optimise()
@@ -257,8 +262,10 @@ bool PeepholeOptimiser::optimise()
 	while (state.i < m_items.size())
 		applyMethods(state, PushPop(), OpPop(), DoublePush(), DoubleSwap(), JumpToNext(), UnreachableCode(), TagConjunctions(), Identity());
 	if (m_optimisedItems.size() < m_items.size() || (
-		m_optimisedItems.size() == m_items.size() &&
-		eth::bytesRequired(m_optimisedItems, 3) < eth::bytesRequired(m_items, 3)
+		m_optimisedItems.size() == m_items.size() && (
+			eth::bytesRequired(m_optimisedItems, 3) < eth::bytesRequired(m_items, 3) ||
+			numberOfPops(m_optimisedItems) > numberOfPops(m_items)
+		)
 	))
 	{
 		m_items = std::move(m_optimisedItems);

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -841,6 +841,20 @@ BOOST_AUTO_TEST_CASE(peephole_double_push)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(peephole_pop_calldatasize)
+{
+	AssemblyItems items{
+		u256(4),
+		Instruction::CALLDATASIZE,
+		Instruction::LT,
+		Instruction::POP
+	};
+	PeepholeOptimiser peepOpt(items);
+	for (size_t i = 0; i < 3; i++)
+		BOOST_CHECK(peepOpt.optimise());
+	BOOST_CHECK(items.empty());
+}
+
 BOOST_AUTO_TEST_CASE(jumpdest_removal)
 {
 	AssemblyItems items{


### PR DESCRIPTION
Without this change, the "OpPop" method is not really effective, because it just replaces an operation by a pop and does not decrease the number of operations.

I vaguely remember having implemented that before, but either it got lost in a merge or was removed deliberately...