### PR TITLE
added formatting when source snippets is too long

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Features:
  * Type Checker: Do not add members of ``address`` to contracts as experimental 0.5.0 feature.
  * Type Checker: Force interface functions to be external as experimental 0.5.0 feature.
  * Type Checker: Require ``storage`` or ``memory`` keyword for local variables as experimental 0.5.0 feature.
+ * Compiler Interface: Better formatted error message for long source snippets
 
 Bugfixes:
  * Code Generator: Allocate one byte per memory byte array element instead of 32.

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -53,14 +53,14 @@ void SourceReferenceFormatter::printSourceLocation(
 		int locationLength = endColumn - startColumn;
 		if (locationLength > 150)
 		{
-			line = line.substr(0, startColumn) + line.substr(startColumn, 15) + "..." + line.substr(endColumn - 15, 15) + line.substr(endColumn, line.length() - endColumn);
-			endColumn = startColumn + 33;
-			locationLength = 33;
+			line = line.substr(0, startColumn + 75) + " ... " + line.substr(endColumn);
+			endColumn = startColumn + 80;
+			locationLength = 80;
 		}
 		if (line.length() > 150)
 		{
-			line = "..." + line.substr(startColumn, locationLength) + "...";
-			startColumn = 3;
+			line = " ... " + line.substr(startColumn, locationLength) + " ... ";
+			startColumn = 5;
 			endColumn = startColumn + locationLength;
 		}
 

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -49,6 +49,21 @@ void SourceReferenceFormatter::printSourceLocation(
 	if (startLine == endLine)
 	{
 		string line = scanner.lineAtPosition(_location->start);
+
+		int locationLength = endColumn - startColumn;
+		if (locationLength > 150)
+		{
+			line = line.substr(0, startColumn) + line.substr(startColumn, 15) + "..." + line.substr(endColumn - 15, 15) + line.substr(endColumn, line.length() - endColumn);
+			endColumn = startColumn + 33;
+			locationLength = 33;
+		}
+		if (line.length() > 150)
+		{
+			line = "..." + line.substr(startColumn, locationLength) + "...";
+			startColumn = 3;
+			endColumn = startColumn + locationLength;
+		}
+
 		_stream << line << endl;
 		for_each(
 			line.cbegin(),

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -53,9 +53,9 @@ void SourceReferenceFormatter::printSourceLocation(
 		int locationLength = endColumn - startColumn;
 		if (locationLength > 150)
 		{
-			line = line.substr(0, startColumn + 75) + " ... " + line.substr(endColumn);
-			endColumn = startColumn + 80;
-			locationLength = 80;
+			line = line.substr(0, startColumn + 35) + " ... " + line.substr(endColumn - 35);
+			endColumn = startColumn + 75;
+			locationLength = 75;
 		}
 		if (line.length() > 150)
 		{


### PR DESCRIPTION
reference #2885

the pointers are always display as ^--------^ for simplicity.