### PR TITLE
Close IPC socket on connect failure

### DIFF
--- a/test/RPCSession.cpp
+++ b/test/RPCSession.cpp
@@ -74,7 +74,10 @@ IPCSocket::IPCSocket(string const& _path): m_path(_path)
 		BOOST_FAIL("Error creating IPC socket object");
 
 	if (connect(m_socket, reinterpret_cast<struct sockaddr const*>(&saun), sizeof(struct sockaddr_un)) < 0)
+	{
+		close(m_socket);
 		BOOST_FAIL("Error connecting to IPC socket: " << _path);
+	}
 #endif
 }
 


### PR DESCRIPTION
Without this two different error messages are displayed if cannot connect to IPC and number of sockets is exhausted:
```
/Users/alex/Projects/solidity/test/RPCSession.cpp:77: fatal error: in "SolidityEndToEndTest/base_constructor_arguments": Error connecting to IPC socket: /invalid
/Users/alex/Projects/solidity/test/RPCSession.cpp:74: fatal error: in "SolidityEndToEndTest/function_usage_in_constructor_arguments": Error creating IPC socket object
```