### PR TITLE
No bytecodecompare if tests failed (issue #2300)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,10 +184,10 @@ before_script:
 
 script:
     - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh)
-    - [[ $? == 0 ]] || SOLC_STOREBYTECODE=Off
+    - test $? == 0 || SOLC_STOREBYTECODE=Off
     - test $SOLC_DOCS != On || (scripts/docs.sh)
     - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh)
-    - [[ $? == 0 ]] || SOLC_STOREBYTECODE=Off
+    - test $? == 0 || SOLC_STOREBYTECODE=Off
     - test $SOLC_STOREBYTECODE != On || (cd $TRAVIS_BUILD_DIR && scripts/bytecodecompare/storebytecode.sh)
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,9 +183,11 @@ before_script:
       && scripts/create_source_tarball.sh)
 
 script:
-    - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh) || SOLC_STOREBYTECODE=Off
+    - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh)
+    - [[ $? == 0 ]] || SOLC_STOREBYTECODE=Off
     - test $SOLC_DOCS != On || (scripts/docs.sh)
-    - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh) || SOLC_STOREBYTECODE=Off
+    - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh)
+    - [[ $? == 0 ]] || SOLC_STOREBYTECODE=Off
     - test $SOLC_STOREBYTECODE != On || (cd $TRAVIS_BUILD_DIR && scripts/bytecodecompare/storebytecode.sh)
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,9 +183,9 @@ before_script:
       && scripts/create_source_tarball.sh)
 
 script:
-    - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh)
+    - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh) || SOLC_STOREBYTECODE=Off
     - test $SOLC_DOCS != On || (scripts/docs.sh)
-    - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh)
+    - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh) || SOLC_STOREBYTECODE=Off
     - test $SOLC_STOREBYTECODE != On || (cd $TRAVIS_BUILD_DIR && scripts/bytecodecompare/storebytecode.sh)
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,15 +68,14 @@ build_script:
     - cd %APPVEYOR_BUILD_FOLDER%
     - scripts\release.bat %CONFIGURATION%
     - ps: $bytecodedir = git show -s --format="%cd-%H" --date=short
+
+test_script:
+    - cd %APPVEYOR_BUILD_FOLDER%\build\test\%CONFIGURATION%
+    - soltest.exe --show-progress -- --no-ipc --no-smt
 # Skip bytecode compare if private key is not available
     - ps: if ($env:priv_key) {
         scripts\bytecodecompare\storebytecode.bat $Env:CONFIGURATION $bytecodedir
         }
-
-test_script:
-    - cd %APPVEYOR_BUILD_FOLDER%
-    - cd %APPVEYOR_BUILD_FOLDER%\build\test\%CONFIGURATION%
-    - soltest.exe --show-progress -- --no-ipc --no-smt
 
 artifacts:
     - path: solidity-windows.zip


### PR DESCRIPTION
AppVeyor stops tests at first failure. This is opposite to Travis behavior.
