### PR TITLE
Convert static SourceReferenceFormatter functions to member ones

### DIFF
--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -31,15 +31,11 @@ namespace dev
 namespace solidity
 {
 
-void SourceReferenceFormatter::printSourceLocation(
-	ostream& _stream,
-	SourceLocation const* _location,
-	function<Scanner const&(string const&)> const& _scannerFromSourceName
-)
+void SourceReferenceFormatter::printSourceLocation(SourceLocation const* _location)
 {
 	if (!_location || !_location->sourceName)
 		return; // Nothing we can print here
-	auto const& scanner = _scannerFromSourceName(*_location->sourceName);
+	auto const& scanner = m_scannerFromSourceName(*_location->sourceName);
 	int startLine;
 	int startColumn;
 	tie(startLine, startColumn) = scanner.translatePositionToLineColumn(_location->start);
@@ -64,21 +60,22 @@ void SourceReferenceFormatter::printSourceLocation(
 			endColumn = startColumn + locationLength;
 		}
 
-		_stream << line << endl;
+		m_stream << line << endl;
+
 		for_each(
 			line.cbegin(),
 			line.cbegin() + startColumn,
-			[&_stream](char const& ch) { _stream << (ch == '\t' ? '\t' : ' '); }
+			[this](char const& ch) { m_stream << (ch == '\t' ? '\t' : ' '); }
 		);
-		_stream << "^";
+		m_stream << "^";
 		if (endColumn > startColumn + 2)
-			_stream << string(endColumn - startColumn - 2, '-');
+			m_stream << string(endColumn - startColumn - 2, '-');
 		if (endColumn > startColumn + 1)
-			_stream << "^";
-		_stream << endl;
+			m_stream << "^";
+		m_stream << endl;
 	}
 	else
-		_stream <<
+		m_stream <<
 			scanner.lineAtPosition(_location->start) <<
 			endl <<
 			string(startColumn, ' ') <<
@@ -86,50 +83,44 @@ void SourceReferenceFormatter::printSourceLocation(
 			"Spanning multiple lines.\n";
 }
 
-void SourceReferenceFormatter::printSourceName(
-	ostream& _stream,
-	SourceLocation const* _location,
-	function<Scanner const&(string const&)> const& _scannerFromSourceName
-)
+void SourceReferenceFormatter::printSourceName(SourceLocation const* _location)
 {
 	if (!_location || !_location->sourceName)
 		return; // Nothing we can print here
-	auto const& scanner = _scannerFromSourceName(*_location->sourceName);
+	auto const& scanner = m_scannerFromSourceName(*_location->sourceName);
 	int startLine;
 	int startColumn;
 	tie(startLine, startColumn) = scanner.translatePositionToLineColumn(_location->start);
-	_stream << *_location->sourceName << ":" << (startLine + 1) << ":" << (startColumn + 1) << ": ";
+	m_stream << *_location->sourceName << ":" << (startLine + 1) << ":" << (startColumn + 1) << ": ";
 }
 
 void SourceReferenceFormatter::printExceptionInformation(
-	ostream& _stream,
 	Exception const& _exception,
-	string const& _name,
-	function<Scanner const&(string const&)> const& _scannerFromSourceName
+	string const& _name
 )
 {
 	SourceLocation const* location = boost::get_error_info<errinfo_sourceLocation>(_exception);
 	auto secondarylocation = boost::get_error_info<errinfo_secondarySourceLocation>(_exception);
 
-	printSourceName(_stream, location, _scannerFromSourceName);
+	printSourceName(location);
 
-	_stream << _name;
+	m_stream << _name;
 	if (string const* description = boost::get_error_info<errinfo_comment>(_exception))
-		_stream << ": " << *description << endl;
+		m_stream << ": " << *description << endl;
 	else
-		_stream << endl;
+		m_stream << endl;
 
-	printSourceLocation(_stream, location, _scannerFromSourceName);
+	printSourceLocation(location);
 
 	if (secondarylocation && !secondarylocation->infos.empty())
 	{
 		for (auto info: secondarylocation->infos)
 		{
-			printSourceName(_stream, &info.second, _scannerFromSourceName);
-			_stream << info.first << endl;
-			printSourceLocation(_stream, &info.second, _scannerFromSourceName);
+			printSourceName(&info.second);
+			m_stream << info.first << endl;
+			printSourceLocation(&info.second);
 		}
-		_stream << endl;
+		m_stream << endl;
 	}
 }
 

--- a/libsolidity/interface/SourceReferenceFormatter.h
+++ b/libsolidity/interface/SourceReferenceFormatter.h
@@ -45,10 +45,10 @@ public:
 
 	explicit SourceReferenceFormatter(
 		std::ostream& _stream,
-		ScannerFromSourceNameFun const& _scannerFromSourceName
+		ScannerFromSourceNameFun _scannerFromSourceName
 	):
 		m_stream(_stream),
-		m_scannerFromSourceName(_scannerFromSourceName)
+		m_scannerFromSourceName(std::move(_scannerFromSourceName))
 	{}
 
 	/// Prints source location if it is given.
@@ -72,7 +72,7 @@ private:
 	void printSourceName(SourceLocation const* _location);
 
 	std::ostream& m_stream;
-	ScannerFromSourceNameFun const& m_scannerFromSourceName;
+	ScannerFromSourceNameFun m_scannerFromSourceName;
 };
 
 }

--- a/libsolidity/interface/SourceReferenceFormatter.h
+++ b/libsolidity/interface/SourceReferenceFormatter.h
@@ -38,22 +38,23 @@ namespace solidity
 class Scanner; // forward
 class CompilerStack; // forward
 
-struct SourceReferenceFormatter
+class SourceReferenceFormatter
 {
 public:
 	using ScannerFromSourceNameFun = std::function<Scanner const&(std::string const&)>;
+
+	explicit SourceReferenceFormatter(
+		std::ostream& _stream,
+		ScannerFromSourceNameFun const& _scannerFromSourceName
+	):
+		m_stream(_stream),
+		m_scannerFromSourceName(_scannerFromSourceName)
+	{}
+
 	/// Prints source location if it is given.
-	static void printSourceLocation(
-		std::ostream& _stream,
-		SourceLocation const* _location,
-		ScannerFromSourceNameFun const& _scannerFromSourceName
-	);
-	static void printExceptionInformation(
-		std::ostream& _stream,
-		Exception const& _exception,
-		std::string const& _name,
-		ScannerFromSourceNameFun const& _scannerFromSourceName
-	);
+	void printSourceLocation(SourceLocation const* _location);
+	void printExceptionInformation(Exception const& _exception, std::string const& _name);
+
 	static std::string formatExceptionInformation(
 		Exception const& _exception,
 		std::string const& _name,
@@ -61,16 +62,17 @@ public:
 	)
 	{
 		std::ostringstream errorOutput;
-		printExceptionInformation(errorOutput, _exception, _name, _scannerFromSourceName);
+
+		SourceReferenceFormatter formatter(errorOutput, _scannerFromSourceName);
+		formatter.printExceptionInformation(_exception, _name);
 		return errorOutput.str();
 	}
 private:
 	/// Prints source name if location is given.
-	static void printSourceName(
-		std::ostream& _stream,
-		SourceLocation const* _location,
-		ScannerFromSourceNameFun const& _scannerFromSourceName
-	);
+	void printSourceName(SourceLocation const* _location);
+
+	std::ostream& m_stream;
+	ScannerFromSourceNameFun const& m_scannerFromSourceName;
 };
 
 }

--- a/test/libjulia/Common.cpp
+++ b/test/libjulia/Common.cpp
@@ -40,12 +40,12 @@ using namespace dev::solidity;
 
 void dev::julia::test::printErrors(ErrorList const& _errors, Scanner const& _scanner)
 {
+	SourceReferenceFormatter formatter(cout, [&](std::string const&) -> Scanner const& { return _scanner; });
+
 	for (auto const& error: _errors)
-		SourceReferenceFormatter::printExceptionInformation(
-			cout,
+		formatter.printExceptionInformation(
 			*error,
-			(error->type() == Error::Type::Warning) ? "Warning" : "Error",
-			[&](std::string const&) -> Scanner const& { return _scanner; }
+			(error->type() == Error::Type::Warning) ? "Warning" : "Error"
 		);
 }
 

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -136,8 +136,10 @@ BOOST_AUTO_TEST_CASE(non_overlapping_filtered_costs)
 			{
 				BOOST_CHECK_MESSAGE(false, "Source locations should not overlap!");
 				auto scannerFromSource = [&](string const& _sourceName) -> Scanner const& { return m_compiler.scanner(_sourceName); };
-				SourceReferenceFormatter::printSourceLocation(cout, &first->first->location(), scannerFromSource);
-				SourceReferenceFormatter::printSourceLocation(cout, &second->first->location(), scannerFromSource);
+				SourceReferenceFormatter formatter(cout, scannerFromSource);
+
+				formatter.printSourceLocation(&first->first->location());
+				formatter.printSourceLocation(&second->first->location());
 			}
 	}
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -60,12 +60,13 @@ public:
 		m_compiler.setOptimiserSettings(m_optimize, m_optimizeRuns);
 		if (!m_compiler.compile())
 		{
+			auto scannerFromSourceName = [&](std::string const& _sourceName) -> solidity::Scanner const& { return m_compiler.scanner(_sourceName); };
+			SourceReferenceFormatter formatter(std::cerr, scannerFromSourceName);
+
 			for (auto const& error: m_compiler.errors())
-				SourceReferenceFormatter::printExceptionInformation(
-					std::cerr,
+				formatter.printExceptionInformation(
 					*error,
-					(error->type() == Error::Type::Warning) ? "Warning" : "Error",
-					[&](std::string const& _sourceName) -> solidity::Scanner const& { return m_compiler.scanner(_sourceName); }
+					(error->type() == Error::Type::Warning) ? "Warning" : "Error"
 				);
 			BOOST_ERROR("Compiling contract failed");
 		}


### PR DESCRIPTION
This cleans up the method signatures and also opens the door to configuring and even replacing the formatter implementations.