### PR TITLE
Allow constant integer variables as array lengths. Closes #716

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.19 (unreleased)
 
 Features:
+ * Allow constant variables to be used as array length
  * Syntax Checker: Turn the usage of ``callcode`` into an error as experimental 0.5.0 feature.
  * Type Checker: Improve address checksum warning.
  * Type Checker: More detailed errors for invalid array lengths (such as division by zero).

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -74,3 +74,21 @@ void ConstantEvaluator::endVisit(Literal const& _literal)
 	if (!_literal.annotation().type)
 		m_errorReporter.fatalTypeError(_literal.location(), "Invalid literal value.");
 }
+
+void ConstantEvaluator::endVisit(Identifier const& _identifier)
+{
+	VariableDeclaration const *variableDeclaration = dynamic_cast<VariableDeclaration const *>(_identifier.annotation().referencedDeclaration);
+	if (!variableDeclaration)
+		return;
+	if (!variableDeclaration->isConstant())
+		m_errorReporter.fatalTypeError(_identifier.location(), "Identifier must be declared constant.");
+
+	ASTPointer<Expression> value = variableDeclaration->value();
+	if (value)
+	{
+		if (!value->annotation().type)
+			ConstantEvaluator e(*value, m_errorReporter);
+
+		_identifier.annotation().type = value->annotation().type;
+	}
+}

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -90,7 +90,7 @@ void ConstantEvaluator::endVisit(Identifier const& _identifier)
 	if (!value->annotation().type)
 	{
 		if (m_depth > 32)
-			m_errorReporter.fatalTypeError(_identifier.location(), "Cyclic constant definition.");
+			m_errorReporter.fatalTypeError(_identifier.location(), "Cyclic constant definition (or maximum recursion depth exhausted).");
 		ConstantEvaluator e(*value, m_errorReporter, m_depth + 1);
 	}
 

--- a/libsolidity/analysis/ConstantEvaluator.h
+++ b/libsolidity/analysis/ConstantEvaluator.h
@@ -48,6 +48,7 @@ private:
 	virtual void endVisit(BinaryOperation const& _operation);
 	virtual void endVisit(UnaryOperation const& _operation);
 	virtual void endVisit(Literal const& _literal);
+	virtual void endVisit(Identifier const& _identifier);
 
 	ErrorReporter& m_errorReporter;
 };

--- a/libsolidity/analysis/ConstantEvaluator.h
+++ b/libsolidity/analysis/ConstantEvaluator.h
@@ -38,8 +38,9 @@ class TypeChecker;
 class ConstantEvaluator: private ASTConstVisitor
 {
 public:
-	ConstantEvaluator(Expression const& _expr, ErrorReporter& _errorReporter):
-		m_errorReporter(_errorReporter)
+	ConstantEvaluator(Expression const& _expr, ErrorReporter& _errorReporter, size_t _newDepth = 0):
+		m_errorReporter(_errorReporter),
+		m_depth(_newDepth)
 	{
 		_expr.accept(*this);
 	}
@@ -51,6 +52,8 @@ private:
 	virtual void endVisit(Identifier const& _identifier);
 
 	ErrorReporter& m_errorReporter;
+	/// Current recursion depth.
+	size_t m_depth;
 };
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2345,6 +2345,24 @@ BOOST_AUTO_TEST_CASE(constructor_static_array_argument)
 	ABI_CHECK(callContractFunction("b(uint256)", u256(2)), encodeArgs(u256(4)));
 }
 
+BOOST_AUTO_TEST_CASE(constant_var_as_array_length)
+{
+	char const* sourceCode = R"(
+		contract C {
+			uint constant LEN = 3;
+			uint[LEN] public a;
+
+			function C(uint[LEN] _a) {
+				a = _a;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C", encodeArgs(u256(1), u256(2), u256(3)));
+	ABI_CHECK(callContractFunction("a(uint256)", u256(0)), encodeArgs(u256(1)));
+	ABI_CHECK(callContractFunction("a(uint256)", u256(1)), encodeArgs(u256(2)));
+	ABI_CHECK(callContractFunction("a(uint256)", u256(2)), encodeArgs(u256(3)));
+}
+
 BOOST_AUTO_TEST_CASE(functions_called_by_constructor)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7366,7 +7366,35 @@ BOOST_AUTO_TEST_CASE(array_length_cannot_be_constant_function_parameter)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Constant identifier declaration must have a constant value.");
+}
+
+BOOST_AUTO_TEST_CASE(array_length_with_cyclic_constant)
+{
+	char const* text = R"(
+		contract C {
+			uint constant LEN = LEN;
+			function f() {
+				uint[LEN] a;
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Cyclic constant definition.");
+}
+
+BOOST_AUTO_TEST_CASE(array_length_with_complex_cyclic_constant)
+{
+	char const* text = R"(
+		contract C {
+			uint constant L2 = LEN - 10;
+			uint constant L1 = L2 / 10;
+			uint constant LEN = 10 + L1 * 5;
+			function f() {
+				uint[LEN] a;
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Cyclic constant definition.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_with_pure_functions)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7379,7 +7379,7 @@ BOOST_AUTO_TEST_CASE(array_length_with_cyclic_constant)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Cyclic constant definition.");
+	CHECK_ERROR(text, TypeError, "Cyclic constant definition (or maximum recursion depth exhausted).");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_with_complex_cyclic_constant)
@@ -7394,7 +7394,7 @@ BOOST_AUTO_TEST_CASE(array_length_with_complex_cyclic_constant)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Cyclic constant definition.");
+	CHECK_ERROR(text, TypeError, "Cyclic constant definition (or maximum recursion depth exhausted).");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_with_pure_functions)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2107,7 +2107,7 @@ BOOST_AUTO_TEST_CASE(array_with_nonconstant_length)
 			function f(uint a) public { uint8[a] x; }
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Identifier must be declared constant");
 }
 
 BOOST_AUTO_TEST_CASE(array_with_negative_length)
@@ -7258,6 +7258,28 @@ BOOST_AUTO_TEST_CASE(array_length_not_convertible_to_integer)
 	char const* text = R"(
 		contract C {
 			uint[true] ids;
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+}
+
+BOOST_AUTO_TEST_CASE(array_length_constant_var)
+{
+	char const* text = R"(
+		contract C {
+			uint constant LEN = 10;
+			uint[LEN] ids;
+		}
+	)";
+	CHECK_SUCCESS(text);
+}
+
+BOOST_AUTO_TEST_CASE(array_length_non_integer_constant_var)
+{
+	char const* text = R"(
+		contract C {
+			bool constant LEN = true;
+			uint[LEN] ids;
 		}
 	)";
 	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");


### PR DESCRIPTION
Fixes #716.

I have extended ConstantEvaluator to support identifiers. It also recursively calls in case of more constant references. 