### PR TITLE
Allow visibility modifier for both function type and variable declaration. Fixes #1805.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ Features:
  * Type Checker: More detailed errors for invalid array lengths (such as division by zero).
 
 Bugfixes:
- * Allow visibility modifier for both function type and variable declaration.
+ * Parser: Allow visibility modifier for both function type and variable declaration.
 
 ### 0.4.18 (2017-10-18)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
  * Type Checker: More detailed errors for invalid array lengths (such as division by zero).
 
 Bugfixes:
+ * Allow visibility modifier for both function type and variable declaration.
 
 ### 0.4.18 (2017-10-18)
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -352,8 +352,7 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(bool _forceEmptyN
 				m_scanner->peekNextToken() == Token::Semicolon ||
 				m_scanner->peekNextToken() == Token::Assign
 			)
-				// Variable declaration, break here.
-				break;
+				break; // Variable declaration, break here.
 			else
 				result.modifiers.push_back(parseModifierInvocation());
 		}
@@ -361,12 +360,21 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(bool _forceEmptyN
 		{
 			if (result.visibility != Declaration::Visibility::Default)
 			{
-				parserError(string(
-					"Visibility already specified as \"" +
-					Declaration::visibilityToString(result.visibility) +
-					"\"."
-				));
-				m_scanner->next();
+				// Is it part of function definition? Only a heuristic; will fail for more than 2 visibility modifiers
+				if (
+					m_scanner->peekNextToken() == Token::LBrace ||
+					Token::isStateMutabilitySpecifier(m_scanner->peekNextToken())
+				)
+				{
+					parserError(string(
+						"Visibility already specified as \"" +
+						Declaration::visibilityToString(result.visibility) +
+						"\"."
+					));
+					m_scanner->next();
+				}
+				else
+					break; // Part of function type, so make this token a part of variable declaration.
 			}
 			else
 				result.visibility = parseVisibilitySpecifier(token);

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -352,7 +352,8 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(bool _forceEmptyN
 				m_scanner->peekNextToken() == Token::Semicolon ||
 				m_scanner->peekNextToken() == Token::Assign
 			)
-				break; // Variable declaration, break here.
+				// Variable declaration, break here.
+				break;
 			else
 				result.modifiers.push_back(parseModifierInvocation());
 		}
@@ -374,7 +375,8 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(bool _forceEmptyN
 					m_scanner->next();
 				}
 				else
-					break; // Part of function type, so make this token a part of variable declaration.
+					// Part of function type, so make this token a part of variable declaration.
+					break;
 			}
 			else
 				result.visibility = parseVisibilitySpecifier(token);

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7342,6 +7342,19 @@ BOOST_AUTO_TEST_CASE(no_address_members_on_contract)
 	CHECK_ERROR(text, TypeError, "Member \"delegatecall\" not found or not visible after argument-dependent lookup in contract");
 }
 
+BOOST_AUTO_TEST_CASE(incorrect_function_type_specifiers)
+{
+	char const* text = R"(
+		contract test {
+			function fa(bytes memory) { }
+			function(bytes memory) external internal a = fa;
+
+		}
+	)";
+
+	CHECK_ERROR(text, TypeError, "Type function (bytes memory) is not implicitly convertible to expected type function (bytes memory) external.");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1702,14 +1702,23 @@ BOOST_AUTO_TEST_CASE(valid_function_type_variables)
 {
 	char const* text = R"(
 		contract test {
-			function(bytes memory) a;
-			function(bytes memory) internal b; // (explicit internal applies to the function type)
-			function(bytes memory) internal internal c;
-			function(bytes memory) external d;
-			function(bytes memory) external internal e;
-			function(bytes memory) internal public f;
-			function(bytes memory) internal pure public g;
-			function(bytes memory) pure internal public h;
+			function(bytes memory) fa {}
+			function(bytes memory) fb internal {}
+			function(bytes memory) fc internal {}
+			function(bytes memory) fd external {}
+			function(bytes memory) fe external {}
+			function(bytes memory) ff internal {}
+			function(bytes memory) fg internal pure {}
+			function(bytes memory) fh pure internal {}
+
+			function(bytes memory) a = fa;
+			function(bytes memory) internal b = fb; // (explicit internal applies to the function type)
+			function(bytes memory) internal internal c = fc;
+			function(bytes memory) external d = fd;
+			function(bytes memory) external internal e = fd;
+			function(bytes memory) internal public f = ff;
+			function(bytes memory) internal pure public g = fg;
+			function(bytes memory) pure internal public h = fh;
 		}
 	)";
 	BOOST_CHECK(successParse(text));
@@ -1723,7 +1732,6 @@ BOOST_AUTO_TEST_CASE(incorrect_function_type_specifiers)
 
 		}
 	)";
-	//BOOST_CHECK(successParse(text));
 	CHECK_PARSE_ERROR(text, "Expected identifier, got 'External'");
 }
 

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -1698,6 +1698,46 @@ BOOST_AUTO_TEST_CASE(newInvalidTypeName)
 	CHECK_PARSE_ERROR(text, "Expected explicit type name");
 }
 
+BOOST_AUTO_TEST_CASE(valid_function_type_variables)
+{
+	char const* text = R"(
+		contract test {
+			function(bytes memory) a;
+			function(bytes memory) internal b; // (explicit internal applies to the function type)
+			function(bytes memory) internal internal c;
+			function(bytes memory) external d;
+			function(bytes memory) external internal e;
+			function(bytes memory) internal public f;
+			function(bytes memory) internal pure public g;
+			function(bytes memory) pure internal public h;
+		}
+	)";
+	BOOST_CHECK(successParse(text));
+}
+
+BOOST_AUTO_TEST_CASE(incorrect_function_type_specifiers)
+{
+	char const* text = R"(
+		contract test {
+			function(bytes memory) internal external a;
+
+		}
+	)";
+	//BOOST_CHECK(successParse(text));
+	CHECK_PARSE_ERROR(text, "Expected identifier, got 'External'");
+}
+
+BOOST_AUTO_TEST_CASE(more_than_2_visibility_specivier)
+{
+	char const* text = R"(
+		contract c {
+			function f() private external public {}
+		})";
+	CHECK_PARSE_ERROR(text, "Expected token LBrace got 'External'");
+}
+
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1805.
When parsing function header, if we encounter another visibility modifier, we break the parsing of function header.
For better error message, we see if next token is of a function definition and emit a more useful error message in that case.