### PR TITLE
Add another example with call to demonstrate Re-Entrancy

### DIFF
--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -69,8 +69,8 @@ complete contract):
     }
 
 The problem is not too serious here because of the limited gas as part
-of ``send``, but it still exposes a weakness: Ether transfer always
-includes code execution, so the recipient could be a contract that calls
+of ``send``, but it still exposes a weakness: Ether transfer can always
+include code execution, so the recipient could be a contract that calls
 back into ``withdraw``. This would let it get multiple refunds and
 basically retrieve all the Ether in the contract. In particular, the
 following contract will allow an attacker to refund multiple times

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -72,7 +72,24 @@ The problem is not too serious here because of the limited gas as part
 of ``send``, but it still exposes a weakness: Ether transfer always
 includes code execution, so the recipient could be a contract that calls
 back into ``withdraw``. This would let it get multiple refunds and
-basically retrieve all the Ether in the contract.
+basically retrieve all the Ether in the contract. In particular, the
+following contract will allow an attacker to refund multiple times
+as it uses ``call`` which forwards all remaining gas by default:
+
+::
+
+    pragma solidity ^0.4.0;
+
+    // THIS CONTRACT CONTAINS A BUG - DO NOT USE
+    contract Fund {
+        /// Mapping of ether shares of the contract.
+        mapping(address => uint) shares;
+        /// Withdraw your share.
+        function withdraw() {
+            if (msg.sender.call.value(shares[msg.sender])())
+                shares[msg.sender] = 0;
+        }
+    }
 
 To avoid re-entrancy, you can use the Checks-Effects-Interactions pattern as
 outlined further below:


### PR DESCRIPTION
Add another example with ``call`` to demonstrate Re-Entrancy. Since ``send`` explicitly sets gas to 2300 by default according to this commit https://github.com/ethereum/solidity/commit/9ca7472089a9f4d8bfec20e9e55c4f7ed2fb502e which makes it impossible to "get multiple refunds" because a non-zero CALL costs at least 9700 gas. This issue is discussed on Ethereum StackExchange https://ethereum.stackexchange.com/questions/30371/send-ether-reentrancy-attack-in-reality-how-could-fallback-function-make-a-mes/30616#30616