### PR TITLE
Make tuple components optional in documented grammar

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -129,8 +129,8 @@ Identifier = [a-zA-Z_$] [a-zA-Z_$0-9]*
 HexNumber = '0x' [0-9a-fA-F]+
 DecimalNumber = [0-9]+
 
-TupleExpression = '(' ( Expression ( ',' Expression )*  )? ')'
-                | '[' ( Expression ( ',' Expression )*  )? ']'
+TupleExpression = '(' ( Expression? ( ',' Expression? )*  )? ')'
+                | '[' ( Expression  ( ',' Expression  )*  )? ']'
 
 ElementaryTypeNameExpression = ElementaryTypeName
 


### PR DESCRIPTION
The following wasn't documented as valid grammar.
```
uint a;
(a,) = foo();
```

Fixes #3156.

