### PR TITLE
SMTChecker: new ite vars and conditions path used for assert checks

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -707,7 +707,6 @@ void SMTChecker::mergeVariables(vector<Declaration const*> const& _variables, sm
 {
 	for (auto const* decl: _variables)
 	{
-		newValue(*decl);
 		int trueCounter = _countersEndTrue.at(decl);
 		int falseCounter = _countersEndFalse.at(decl);
 		m_interface->addAssertion(newValue(*decl) == smt::Expression::ite(

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -527,7 +527,7 @@ SMTChecker::VariableSequenceCounters SMTChecker::visitBranch(Statement const& _s
 
 	m_conditionalExecutionHappened = true;
 	std::swap(sequenceCountersStart, m_currentSequenceCounter);
-	return sequenceCountersStart;
+	return std::move(sequenceCountersStart);
 }
 
 void SMTChecker::checkCondition(

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -75,6 +75,7 @@ private:
 	void assignment(Declaration const& _variable, Expression const& _value, SourceLocation const& _location);
 	void assignment(Declaration const& _variable, smt::Expression const& _value, SourceLocation const& _location);
 
+	/// Maps a variable to an SSA index.
 	using VariableSequenceCounters = std::map<Declaration const*, int>;
 
 	// Visits the branch given by the statement, pushes and pops the SMT checker.
@@ -109,7 +110,10 @@ private:
 
 	void initializeLocalVariables(FunctionDefinition const& _function);
 	void resetVariables(std::vector<Declaration const*> _variables);
-	void mergeVariables(std::vector<Declaration const*> _variables, smt::Expression _condition, VariableSequenceCounters& _countersEndTrue, VariableSequenceCounters& _countersEndFalse);
+	/// Given two different branches and the touched variables,
+	/// merge the touched variables into after-branch ite variables
+	/// using the branch condition as guard.
+	void mergeVariables(std::vector<Declaration const*> const& _variables, smt::Expression const& _condition, VariableSequenceCounters const& _countersEndTrue, VariableSequenceCounters const& _countersEndFalse);
 	/// Tries to create an uninitialized variable and returns true on success.
 	/// This fails if the type is not supported.
 	bool createVariable(VariableDeclaration const& _varDecl);

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -77,16 +77,6 @@ public:
 		return !std::move(_a) || std::move(_b);
 	}
 
-	static Expression lTrue()
-	{
-		return Expression(std::string("true"));
-	}
-
-	static Expression lFalse()
-	{
-		return Expression(std::string("false"));
-	}
-
 	friend Expression operator!(Expression _a)
 	{
 		return Expression("not", std::move(_a), Sort::Bool);

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -72,6 +72,21 @@ public:
 		}, _trueValue.sort);
 	}
 
+	static Expression implies(Expression _a, Expression _b)
+	{
+		return !std::move(_a) || std::move(_b);
+	}
+
+	static Expression lTrue()
+	{
+		return Expression(std::string("true"));
+	}
+
+	static Expression lFalse()
+	{
+		return Expression(std::string("false"));
+	}
+
 	friend Expression operator!(Expression _a)
 	{
 		return Expression("not", std::move(_a), Sort::Bool);

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -117,8 +117,6 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 
 	static map<string, unsigned> arity{
 		{"ite", 3},
-		{"true", 0},
-		{"false", 0},
 		{"not", 1},
 		{"and", 2},
 		{"or", 2},
@@ -133,11 +131,7 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 		{"/", 2}
 	};
 	string const& n = _expr.name;
-	if (n == "true")
-		return m_context.bool_val(true);
-	else if (n == "false")
-		return m_context.bool_val(false);
-	else  if (m_functions.count(n))
+	if (m_functions.count(n))
 		return m_functions.at(n)(arguments);
 	else if (m_constants.count(n))
 	{

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -117,6 +117,8 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 
 	static map<string, unsigned> arity{
 		{"ite", 3},
+		{"true", 0},
+		{"false", 0},
 		{"not", 1},
 		{"and", 2},
 		{"or", 2},
@@ -131,7 +133,11 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 		{"/", 2}
 	};
 	string const& n = _expr.name;
-	if (m_functions.count(n))
+	if (n == "true")
+		return m_context.bool_val(true);
+	else if (n == "false")
+		return m_context.bool_val(false);
+	else  if (m_functions.count(n))
 		return m_functions.at(n)(arguments);
 	else if (m_constants.count(n))
 	{

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(function_call_does_not_clear_local_vars)
 
 BOOST_AUTO_TEST_CASE(branches_clear_variables)
 {
-	// Only clears accessed variables
+	// Branch does not touch variable a
 	string text = R"(
 		contract C {
 			function f(uint x) public pure {
@@ -193,8 +193,8 @@ BOOST_AUTO_TEST_CASE(branches_clear_variables)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Assertion violation happens here");
-	// Clear also works on the else branch
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	// Variable a is touched, but assertion should hold
 	text = R"(
 		contract C {
 			function f(uint x) public pure {
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(branches_clear_variables)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Assertion violation happens here");
+	CHECK_SUCCESS_NO_WARNINGS(text);
 	// Variable is not cleared, if it is only read.
 	text = R"(
 		contract C {
@@ -217,6 +217,20 @@ BOOST_AUTO_TEST_CASE(branches_clear_variables)
 					assert(a == 3);
 				} else {
 					assert(a == 3);
+				}
+				assert(a == 3);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(uint x) public pure {
+				uint a = 2;
+				if (x > 10) {
+					a = 3;
+				} else {
+					a = 3;
 				}
 				assert(a == 3);
 			}
@@ -274,6 +288,7 @@ BOOST_AUTO_TEST_CASE(ways_to_clear_variables)
 			}
 		}
 	)";
+	CHECK_WARNING(text, "Assertion violation happens here");
 	text = R"(
 		contract C {
 			function f(uint x) public pure {

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -237,6 +237,24 @@ BOOST_AUTO_TEST_CASE(branches_clear_variables)
 		}
 	)";
 	CHECK_SUCCESS_NO_WARNINGS(text);
+	text = R"(
+		contract C {
+			function f(uint x) public pure {
+				uint a;
+				if (x == 0) {
+					a = 1;
+				} else {
+					if (x == 1)
+						a = 2;
+					else
+						a = 3;
+				}
+				assert(a < 4);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+
 }
 
 BOOST_AUTO_TEST_CASE(branches_assert_condition)


### PR DESCRIPTION
This PR contains:
-  variables that are touched inside branches are merged afterwards, in `ite` variables
- `assert` checks use the current path of conditions
- Adjusted/added tests

This PR subsumes https://github.com/ethereum/solidity/pull/3216