### PR TITLE
Simplify ConstantEvaluator.

### DIFF
--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -56,7 +56,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 			_operation,
 			Token::isCompareOp(_operation.getOperator()) ?
 			make_shared<BoolType>() :
-			left->binaryOperatorResult(_operation.getOperator(), right)
+			commonType
 		);
 	}
 }

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -33,7 +33,7 @@ void ConstantEvaluator::endVisit(UnaryOperation const& _operation)
 {
 	TypePointer const& subType = _operation.subExpression().annotation().type;
 	if (!dynamic_cast<RationalNumberType const*>(subType.get()))
-		m_errorReporter.fatalTypeError(_operation.subExpression().location(), "Invalid constant expression.");
+		return;
 	TypePointer t = subType->unaryOperatorResult(_operation.getOperator());
 	_operation.annotation().type = t;
 }
@@ -44,9 +44,9 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 	TypePointer const& leftType = _operation.leftExpression().annotation().type;
 	TypePointer const& rightType = _operation.rightExpression().annotation().type;
 	if (!dynamic_cast<RationalNumberType const*>(leftType.get()))
-		m_errorReporter.fatalTypeError(_operation.leftExpression().location(), "Invalid constant expression.");
+		return;
 	if (!dynamic_cast<RationalNumberType const*>(rightType.get()))
-		m_errorReporter.fatalTypeError(_operation.rightExpression().location(), "Invalid constant expression.");
+		return;
 	TypePointer commonType = leftType->binaryOperatorResult(_operation.getOperator(), rightType);
 	if (!commonType)
 	{
@@ -71,8 +71,6 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 void ConstantEvaluator::endVisit(Literal const& _literal)
 {
 	_literal.annotation().type = Type::forLiteral(_literal);
-	if (!_literal.annotation().type)
-		m_errorReporter.fatalTypeError(_literal.location(), "Invalid literal value.");
 }
 
 void ConstantEvaluator::endVisit(Identifier const& _identifier)
@@ -81,11 +79,11 @@ void ConstantEvaluator::endVisit(Identifier const& _identifier)
 	if (!variableDeclaration)
 		return;
 	if (!variableDeclaration->isConstant())
-		m_errorReporter.fatalTypeError(_identifier.location(), "Identifier must be declared constant.");
+		return;
 
-	ASTPointer<Expression> value = variableDeclaration->value();
+	ASTPointer<Expression> const& value = variableDeclaration->value();
 	if (!value)
-		m_errorReporter.fatalTypeError(_identifier.location(), "Constant identifier declaration must have a constant value.");
+		return;
 
 	if (!value->annotation().type)
 	{

--- a/libsolidity/analysis/ConstantEvaluator.h
+++ b/libsolidity/analysis/ConstantEvaluator.h
@@ -38,12 +38,18 @@ class TypeChecker;
 class ConstantEvaluator: private ASTConstVisitor
 {
 public:
-	ConstantEvaluator(Expression const& _expr, ErrorReporter& _errorReporter, size_t _newDepth = 0):
+	ConstantEvaluator(
+		ErrorReporter& _errorReporter,
+		size_t _newDepth = 0,
+		std::shared_ptr<std::map<ASTNode const*, TypePointer>> _types = std::make_shared<std::map<ASTNode const*, TypePointer>>()
+	):
 		m_errorReporter(_errorReporter),
-		m_depth(_newDepth)
+		m_depth(_newDepth),
+		m_types(_types)
 	{
-		_expr.accept(*this);
 	}
+
+	TypePointer evaluate(Expression const& _expr);
 
 private:
 	virtual void endVisit(BinaryOperation const& _operation);
@@ -51,9 +57,13 @@ private:
 	virtual void endVisit(Literal const& _literal);
 	virtual void endVisit(Identifier const& _identifier);
 
+	void setType(ASTNode const& _node, TypePointer const& _type);
+	TypePointer type(ASTNode const& _node);
+
 	ErrorReporter& m_errorReporter;
 	/// Current recursion depth.
-	size_t m_depth;
+	size_t m_depth = 0;
+	std::shared_ptr<std::map<ASTNode const*, TypePointer>> m_types;
 };
 
 }

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -150,7 +150,7 @@ void ReferencesResolver::endVisit(ArrayTypeName const& _typeName)
 			ConstantEvaluator e(*length, m_errorReporter);
 		auto const* lengthType = dynamic_cast<RationalNumberType const*>(length->annotation().type.get());
 		if (!lengthType || !lengthType->mobileType())
-			fatalTypeError(length->location(), "Invalid array length, expected integer literal.");
+			fatalTypeError(length->location(), "Invalid array length, expected integer literal or constant expression.");
 		else if (lengthType->isFractional())
 			fatalTypeError(length->location(), "Array with fractional length specified.");
 		else if (lengthType->isNegative())

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -146,9 +146,10 @@ void ReferencesResolver::endVisit(ArrayTypeName const& _typeName)
 		fatalTypeError(_typeName.baseType().location(), "Illegal base type of storage size zero for array.");
 	if (Expression const* length = _typeName.length())
 	{
-		if (!length->annotation().type)
-			ConstantEvaluator e(*length, m_errorReporter);
-		auto const* lengthType = dynamic_cast<RationalNumberType const*>(length->annotation().type.get());
+		TypePointer lengthTypeGeneric = length->annotation().type;
+		if (!lengthTypeGeneric)
+			lengthTypeGeneric = ConstantEvaluator(m_errorReporter).evaluate(*length);
+		RationalNumberType const* lengthType = dynamic_cast<RationalNumberType const*>(lengthTypeGeneric.get());
 		if (!lengthType || !lengthType->mobileType())
 			fatalTypeError(length->location(), "Invalid array length, expected integer literal or constant expression.");
 		else if (lengthType->isFractional())

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -257,7 +257,7 @@ public:
 	}
 	virtual u256 literalValue(Literal const*) const
 	{
-		solAssert(false, "Literal value requested for type without literals.");
+		solAssert(false, "Literal value requested for type without literals: " + toString(false));
 	}
 
 	/// @returns a (simpler) type that is encoded in the same way for external function calls.

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7370,7 +7370,7 @@ BOOST_AUTO_TEST_CASE(array_length_cannot_be_constant_function_parameter)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Constant identifier declaration must have a constant value.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_with_cyclic_constant)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -2109,7 +2109,7 @@ BOOST_AUTO_TEST_CASE(array_with_nonconstant_length)
 			function f(uint a) public { uint8[a] x; }
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Identifier must be declared constant.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_with_negative_length)
@@ -4398,7 +4398,7 @@ BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_signed_fixed_type)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_unsigned_fixed_type)
@@ -4410,7 +4410,7 @@ BOOST_AUTO_TEST_CASE(invalid_array_declaration_with_unsigned_fixed_type)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(rational_to_bytes_implicit_conversion)
@@ -7254,7 +7254,7 @@ BOOST_AUTO_TEST_CASE(array_length_too_large)
 			uint[8**90] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_not_convertible_to_integer)
@@ -7264,7 +7264,7 @@ BOOST_AUTO_TEST_CASE(array_length_not_convertible_to_integer)
 			uint[true] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_constant_var)
@@ -7286,7 +7286,7 @@ BOOST_AUTO_TEST_CASE(array_length_non_integer_constant_var)
 			uint[LEN] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_cannot_be_function)
@@ -7297,7 +7297,7 @@ BOOST_AUTO_TEST_CASE(array_length_cannot_be_function)
 			uint[f] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_can_be_recursive_constant)
@@ -7321,7 +7321,7 @@ BOOST_AUTO_TEST_CASE(array_length_cannot_be_function_call)
 			uint[LEN] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_const_cannot_be_fractional)
@@ -7409,7 +7409,7 @@ BOOST_AUTO_TEST_CASE(array_length_with_pure_functions)
 			uint[LEN] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 }
 
 BOOST_AUTO_TEST_CASE(array_length_invalid_expression)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7419,25 +7419,25 @@ BOOST_AUTO_TEST_CASE(array_length_invalid_expression)
 			uint[-true] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid constant expression.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 	text = R"(
 		contract C {
 			uint[true/1] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid constant expression.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 	text = R"(
 		contract C {
 			uint[1/true] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid constant expression.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 	text = R"(
 		contract C {
 			uint[1.111111E1111111111111] ids;
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Invalid literal value.");
+	CHECK_ERROR(text, TypeError, "Invalid array length, expected integer literal or constant expression.");
 	text = R"(
 		contract C {
 			uint[3/0] ids;


### PR DESCRIPTION
I was increasingly uneasy with ConstantEvaluator setting the `type` property of the annotations. This should only be done by the TypeChecker, and not already in the reference resolution stage.