### PR TITLE
Remove use of solAssert in Jumpdest optimization

### DIFF
--- a/libevmasm/JumpdestRemover.cpp
+++ b/libevmasm/JumpdestRemover.cpp
@@ -21,8 +21,6 @@
 
 #include "JumpdestRemover.h"
 
-#include <libsolidity/interface/Exceptions.h>
-
 #include <libevmasm/AssemblyItem.h>
 
 using namespace std;
@@ -45,7 +43,7 @@ bool JumpdestRemover::optimise(set<size_t> const& _tagsReferencedFromOutside)
 			if (_item.type() != Tag)
 				return false;
 			auto asmIdAndTag = _item.splitForeignPushTag();
-			solAssert(asmIdAndTag.first == size_t(-1), "Sub-assembly tag used as label.");
+			assertThrow(asmIdAndTag.first == size_t(-1), OptimizerException, "Sub-assembly tag used as label.");
 			size_t tag = asmIdAndTag.second;
 			return !references.count(tag);
 		}


### PR DESCRIPTION
#### Background

I was looking into existing LLL implementations, and Solidity's one is nearly perfect enough to use as a standalone library. There is one problem - you can't currently build it without `libsolidity`, because of one line of code.

## Changes

Replaced a use of `solAssert` with an `assertThrow(..., OptimizerException, ...)`.
Removed the inclusion of a `libsolidity` header.

### Reasoning

There's no reason for this to be a `solAssert` - it's not directly in `libsolidity` or `solc`, `libevmasm` is otherwise totally decoupled from Solidity proper, and there's no justification for why this represents a Solidity compiler error instead of a problem with the assembly optimizer directly.

There's not really an explanation for why this illegal state is checked here at all, but I didn't wan't to remove the Exception entirely, because presumably it was motivated by something.