### PR TITLE
SMTChecker: computation of loop iterations and unrolling while and do-while

### DIFF
--- a/libsolidity/formal/SMTLib2Interface.cpp
+++ b/libsolidity/formal/SMTLib2Interface.cpp
@@ -117,6 +117,16 @@ pair<CheckResult, vector<string>> SMTLib2Interface::check(vector<Expression> con
 	return make_pair(result, values);
 }
 
+pair<CheckResult, string> SMTLib2Interface::maximize(Expression const&)
+{
+	return std::make_pair(CheckResult::UNKNOWN, "");
+}
+
+pair<CheckResult, string> SMTLib2Interface::minimize(Expression const&)
+{
+	return std::make_pair(CheckResult::UNKNOWN, "");
+}
+
 string SMTLib2Interface::toSExpr(Expression const& _expr)
 {
 	if (_expr.arguments.empty())

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -55,6 +55,9 @@ public:
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
+	std::pair<CheckResult, std::string> maximize(Expression const&);
+	std::pair<CheckResult, std::string> minimize(Expression const&);
+
 private:
 	std::string toSExpr(Expression const& _expr);
 

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -188,6 +188,13 @@ public:
 	/// is available. Throws SMTSolverError on error.
 	virtual std::pair<CheckResult, std::vector<std::string>>
 	check(std::vector<Expression> const& _expressionsToEvaluate) = 0;
+
+	/// Checks for satisfiability, maximize the equation if possible.
+	/// Throws SMTSolverError on error.
+	virtual std::pair<CheckResult, std::string> maximize(Expression const& _expressionToMaximize) = 0;
+	/// Checks for satisfiability, minimize the equation if possible.
+	/// Throws SMTSolverError on error.
+	virtual std::pair<CheckResult, std::string> minimize(Expression const& _expressionToMaximize) = 0;
 };
 
 

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -46,6 +46,8 @@ public:
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
+	std::pair<CheckResult, std::string> maximize(Expression const&);
+	std::pair<CheckResult, std::string> minimize(Expression const&);
 
 private:
 	z3::expr toZ3Expr(Expression const& _expr);
@@ -56,6 +58,7 @@ private:
 
 	z3::context m_context;
 	z3::solver m_solver;
+	z3::optimize* m_optimizer = nullptr;
 	std::map<std::string, z3::expr> m_constants;
 	std::map<std::string, z3::func_decl> m_functions;
 };

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -332,9 +332,28 @@ BOOST_AUTO_TEST_CASE(ways_to_merge_variables)
 	CHECK_WARNING(text, "Assertion violation happens here");
 }
 
+BOOST_AUTO_TEST_CASE(do_while_loop_simple)
+{
+	string text = R"(
+		contract C {
+			function f() public pure {
+				uint x;
+				uint y;
+				uint z = 7;
+				do {
+					++x;
+					++y;
+				} while (y < z);
+				assert(x == 7);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
 BOOST_AUTO_TEST_CASE(while_loop_simple)
 {
-	// Check that variables are cleared
+	// Check that assignment in loop works
 	string text = R"(
 		contract C {
 			function f(uint x) public pure {
@@ -346,7 +365,7 @@ BOOST_AUTO_TEST_CASE(while_loop_simple)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Assertion violation happens here");
+	CHECK_SUCCESS_NO_WARNINGS(text);
 	// Check that condition is assumed.
 	text = R"(
 		contract C {
@@ -357,7 +376,7 @@ BOOST_AUTO_TEST_CASE(while_loop_simple)
 			}
 		}
 	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
+	CHECK_WARNING(text, "Loop bound cannot yet be automatically computed for this comparison type");
 	// Check that condition is not assumed after the body anymore
 	text = R"(
 		contract C {
@@ -368,7 +387,8 @@ BOOST_AUTO_TEST_CASE(while_loop_simple)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Assertion violation happens here");
+	CHECK_WARNING_ALLOW_MULTI(text, "Loop bound cannot yet be automatically computed for this comparison type");
+	//CHECK_WARNING(text, "Assertion violation happens here");
 	// Check that negation of condition is not assumed after the body anymore
 	text = R"(
 		contract C {
@@ -379,7 +399,8 @@ BOOST_AUTO_TEST_CASE(while_loop_simple)
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Assertion violation happens here");
+	CHECK_WARNING_ALLOW_MULTI(text, "Loop bound cannot yet be automatically computed for this comparison type");
+	//CHECK_WARNING(text, "Assertion violation happens here");
 	// Check that side-effects of condition are taken into account
 	text = R"(
 		contract C {
@@ -388,6 +409,36 @@ BOOST_AUTO_TEST_CASE(while_loop_simple)
 				while ((x = y) > 0) {
 				}
 				assert(x == 7);
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Assertion violation happens here");
+	// Check that the variables are touched inside the loop
+	text = R"(
+		contract C {
+			function f() public pure {
+				uint x;
+				uint y;
+				while (y < 8) {
+					++x;
+					++y;
+				}
+				assert(x == 8);
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+	// Check that the variables are touched inside the loop
+	text = R"(
+		contract C {
+			function f() public pure {
+				uint x;
+				uint y;
+				while (y < 8) {
+					++x;
+					++y;
+				}
+				assert(x != 8);
 			}
 		}
 	)";


### PR DESCRIPTION
New code:
- Detects automatically the amount of times a loop runs, supports `<=`, `<`, `>` and `>=`. This is done by asking `z3` to maximize and minimize the equation, and checking whether the resulting value is the same. If yes, that is the constant difference between the `left` and `right` sides at that code point. **Assuming** (Assumption [1]) the difference decreases once every loop iteration, that is the loop bound.
- The loop is then unrolled that amount of times, and the touched variables merged after each iteration.
- If the loop runs less times than the computed bound the code is sound. If the loop runs more times, there are no guarantees.
- If a constant difference isn't found, the loop body is run once, as it was before.
- Added tests for `while` and `do-while`.

Main changes to existing code:
- Added the `maximize` and `minimize` functions to the solver interface.
- Since the loop condition and body may be visited several times, an `Expression` may now have many  `smt::Expression`. Method `expr` now points to the latest one.

Questions:
- Do we want to keep the check of whether a `do-while` condition is always true/false? I wonder how much help that would actually be to the user.
- In the `while` case, I kept the warning message only when the condition is `false` at the moment of the first condition check, that is, will never go in.
- Do we want a warning message stating that automatic loop bound detection does not support `==` and `!=`?
- I've added a note stating assumption [1] as a warning message. Do we want to keep it?

This PR depends on (or subsumes) https://github.com/ethereum/solidity/pull/3217.