### PR TITLE
Handle git release tag properly

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ "$(git tag --points-at HEAD 2>/dev/null)"=="v*" ]]; then
-	touch prerelease.txt
-fi
-
 if [ -z "$1" ]; then
     BUILD_TYPE=Release
 else
@@ -11,6 +7,11 @@ else
 fi
 
 cd $(dirname "$0")/.. &&
+
+if [[ "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]; then
+	touch prerelease.txt
+fi
+
 mkdir -p build &&
 cd build &&
 cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE" &&

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [[ "$(git tag --points-at HEAD 2>/dev/null)"=="v*" ]]; then
+	touch prerelease.txt
+fi
+
 if [ -z "$1" ]; then
     BUILD_TYPE=Release
 else


### PR DESCRIPTION
Build process will check current commit and if it is tagged
starting with a `v` then it will create `prerelease.txt` file in
the top directory.