### PR TITLE
Remove warnings in examples

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -190,9 +190,9 @@ Given the contract:
     pragma solidity ^0.4.0;
 
     contract Foo {
-      function bar(bytes3[2] xy) {}
-      function baz(uint32 x, bool y) returns (bool r) { r = x > 32 || y; }
-      function sam(bytes name, bool z, uint[] data) {}
+      function bar(bytes3[2] xy) public {}
+      function baz(uint32 x, bool y) public returns (bool r) { r = x > 32 || y; }
+      function sam(bytes name, bool z, uint[] data) public {}
     }
 
 
@@ -333,10 +333,10 @@ For example,
     pragma solidity ^0.4.0;
 
     contract Test {
-      function Test(){ b = 0x12345678901234567890123456789012; }
+      function Test() public { b = 0x12345678901234567890123456789012; }
       event Event(uint indexed a, bytes32 b);
       event Event2(uint indexed a, bytes32 b);
-      function foo(uint a) { Event(a, b); }
+      function foo(uint a) public { Event(a, b); }
       bytes32 b;
     }
 
@@ -383,8 +383,8 @@ As an example, the code
     contract Test {
       struct S { uint a; uint[] b; T[] c; }
       struct T { uint x; uint y; }
-      function f(S s, T t, uint a) { }
-      function g() returns (S s, T t, uint a) {}
+      function f(S s, T t, uint a) public { }
+      function g() public returns (S s, T t, uint a) {}
     }
 
 would result in the JSON:

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -23,7 +23,7 @@ arising when writing manual assembly by the following features:
 
 * functional-style opcodes: ``mul(1, add(2, 3))`` instead of ``push1 3 push1 2 add push1 1 mul``
 * assembly-local variables: ``let x := add(2, 3)  let y := mload(0x40)  x := add(x, y)``
-* access to external variables: ``function f(uint x) { assembly { x := sub(x, 1) } }``
+* access to external variables: ``function f(uint x) public { assembly { x := sub(x, 1) } }``
 * labels: ``let x := 10  repeat: x := sub(x, 1) jumpi(repeat, eq(x, 0))``
 * loops: ``for { let i := 0 } lt(i, x) { i := add(i, 1) } { y := mul(2, y) }``
 * if statements: ``if slt(x, 0) { x := sub(0, x) }``
@@ -54,7 +54,7 @@ idea is that assembly libraries will be used to enhance the language in such way
     pragma solidity ^0.4.0;
 
     library GetCode {
-        function at(address _addr) returns (bytes o_code) {
+        function at(address _addr) public returns (bytes o_code) {
             assembly {
                 // retrieve the size of the code, this needs assembly
                 let size := extcodesize(_addr)
@@ -83,7 +83,7 @@ you really know what you are doing.
     library VectorSum {
         // This function is less efficient because the optimizer currently fails to
         // remove the bounds checks in array access.
-        function sumSolidity(uint[] _data) returns (uint o_sum) {
+        function sumSolidity(uint[] _data) public returns (uint o_sum) {
             for (uint i = 0; i < _data.length; ++i)
                 o_sum += _data[i];
         }
@@ -91,7 +91,7 @@ you really know what you are doing.
         // We know that we only access the array in bounds, so we can avoid the check.
         // 0x20 needs to be added to an array because the first slot contains the
         // array length.
-        function sumAsm(uint[] _data) returns (uint o_sum) {
+        function sumAsm(uint[] _data) returns (uint o_sum) public {
             for (uint i = 0; i < _data.length; ++i) {
                 assembly {
                     o_sum := add(o_sum, mload(add(add(_data, 0x20), mul(i, 0x20))))
@@ -100,7 +100,7 @@ you really know what you are doing.
         }
 
         // Same as above, but accomplish the entire code within inline assembly.
-        function sumPureAsm(uint[] _data) returns (uint o_sum) {
+        function sumPureAsm(uint[] _data) returns (uint o_sum) public {
             assembly {
                // Load the length (first 32 bytes)
                let len := mload(_data)
@@ -388,7 +388,7 @@ changes during the call, and thus references to local variables will be wrong.
 
     contract C {
         uint b;
-        function f(uint x) returns (uint r) {
+        function f(uint x) public returns (uint r) {
             assembly {
                 r := mul(x, sload(b_slot)) // ignore the offset, we know it is zero
             }
@@ -462,7 +462,7 @@ be just ``0``, but it can also be a complex functional-style expression.
     pragma solidity ^0.4.0;
 
     contract C {
-        function f(uint x) returns (uint b) {
+        function f(uint x) public returns (uint b) {
             assembly {
                 let v := add(x, 1)
                 mstore(0x80, v)
@@ -574,7 +574,7 @@ Simply leave the initialization and post-iteration parts empty.
             x := add(x, mload(i))
             i := add(i, 0x20)
         }
-    } 
+    }
 
 Functions
 ---------
@@ -713,7 +713,7 @@ We consider the runtime bytecode of the following Solidity program::
     pragma solidity ^0.4.0;
 
     contract C {
-      function f(uint x) returns (uint y) {
+      function f(uint x) public returns (uint y) {
         y = 1;
         for (uint i = 0; i < x; i++)
           y = 2 * y;

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -91,7 +91,7 @@ you really know what you are doing.
         // We know that we only access the array in bounds, so we can avoid the check.
         // 0x20 needs to be added to an array because the first slot contains the
         // array length.
-        function sumAsm(uint[] _data) returns (uint o_sum) public {
+        function sumAsm(uint[] _data) public returns (uint o_sum) {
             for (uint i = 0; i < _data.length; ++i) {
                 assembly {
                     o_sum := add(o_sum, mload(add(add(_data, 0x20), mul(i, 0x20))))
@@ -100,7 +100,7 @@ you really know what you are doing.
         }
 
         // Same as above, but accomplish the entire code within inline assembly.
-        function sumPureAsm(uint[] _data) returns (uint o_sum) public {
+        function sumPureAsm(uint[] _data) public returns (uint o_sum) {
             assembly {
                // Load the length (first 32 bytes)
                let len := mload(_data)

--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -36,12 +36,12 @@ become the new richest.
 
         mapping (address => uint) pendingWithdrawals;
 
-        function WithdrawalContract() payable {
+        function WithdrawalContract() public payable {
             richest = msg.sender;
             mostSent = msg.value;
         }
 
-        function becomeRichest() payable returns (bool) {
+        function becomeRichest() public payable returns (bool) {
             if (msg.value > mostSent) {
                 pendingWithdrawals[richest] += msg.value;
                 richest = msg.sender;
@@ -52,7 +52,7 @@ become the new richest.
             }
         }
 
-        function withdraw() {
+        function withdraw() public {
             uint amount = pendingWithdrawals[msg.sender];
             // Remember to zero the pending refund before
             // sending to prevent re-entrancy attacks
@@ -71,12 +71,12 @@ This is as opposed to the more intuitive sending pattern:
         address public richest;
         uint public mostSent;
 
-        function SendContract() payable {
+        function SendContract() public payable {
             richest = msg.sender;
             mostSent = msg.value;
         }
 
-        function becomeRichest() payable returns (bool) {
+        function becomeRichest() public payable returns (bool) {
             if (msg.value > mostSent) {
                 // This line can cause problems (explained below).
                 richest.transfer(msg.value);
@@ -157,6 +157,7 @@ restrictions highly readable.
         /// Make `_newOwner` the new owner of this
         /// contract.
         function changeOwner(address _newOwner)
+            public
             onlyBy(owner)
         {
             owner = _newOwner;
@@ -171,6 +172,7 @@ restrictions highly readable.
         /// May only be called 6 weeks after
         /// the contract has been created.
         function disown()
+            public
             onlyBy(owner)
             onlyAfter(creationTime + 6 weeks)
         {
@@ -191,6 +193,7 @@ restrictions highly readable.
         }
 
         function forceOwnerChange(address _newOwner)
+            public
             costs(200 ether)
         {
             owner = _newOwner;
@@ -310,6 +313,7 @@ function finishes.
 
         // Order of the modifiers matters here!
         function bid()
+            public
             payable
             timedTransitions
             atStage(Stages.AcceptingBlindedBids)
@@ -318,6 +322,7 @@ function finishes.
         }
 
         function reveal()
+            public
             timedTransitions
             atStage(Stages.RevealBids)
         {
@@ -332,6 +337,7 @@ function finishes.
         }
 
         function g()
+            public
             timedTransitions
             atStage(Stages.AnotherStage)
             transitionNext
@@ -339,6 +345,7 @@ function finishes.
         }
 
         function h()
+            public
             timedTransitions
             atStage(Stages.AreWeDoneYet)
             transitionNext
@@ -346,6 +353,7 @@ function finishes.
         }
 
         function i()
+            public
             timedTransitions
             atStage(Stages.Finished)
         {

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -135,7 +135,7 @@ the gas can be specified with special options ``.value()`` and ``.gas()``, respe
     contract Consumer {
         InfoFeed feed;
         function setFeed(address addr) public { feed = InfoFeed(addr); }
-        function public callFeed() { feed.info.value(10).gas(800)(); }
+        function callFeed() public { feed.info.value(10).gas(800)(); }
     }
 
 The modifier ``payable`` has to be used for ``info``, because otherwise, the `.value()`

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -20,10 +20,10 @@ For example, suppose we want our contract to
 accept one kind of external calls with two integers, we would write
 something like::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract Simple {
-        function taker(uint _a, uint _b) {
+        function taker(uint _a, uint _b) public pure {
             // do something with _a and _b.
         }
     }
@@ -36,10 +36,14 @@ The output parameters can be declared with the same syntax after the
 the sum and the product of the two given integers, then we would
 write::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract Simple {
-        function arithmetics(uint _a, uint _b) returns (uint o_sum, uint o_product) {
+        function arithmetics(uint _a, uint _b)
+            public
+            pure
+            returns (uint o_sum, uint o_product)
+        {
             o_sum = _a + _b;
             o_product = _a * _b;
         }
@@ -95,11 +99,11 @@ Internal Function Calls
 Functions of the current contract can be called directly ("internally"), also recursively, as seen in
 this nonsensical example::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
-        function g(uint a) returns (uint ret) { return f(); }
-        function f() returns (uint ret) { return g(7) + f(); }
+        function g(uint a) public pure returns (uint ret) { return f(); }
+        function f() internal pure returns (uint ret) { return g(7) + f(); }
     }
 
 These function calls are translated into simple jumps inside the EVM. This has
@@ -125,13 +129,13 @@ the gas can be specified with special options ``.value()`` and ``.gas()``, respe
     pragma solidity ^0.4.0;
 
     contract InfoFeed {
-        function info() payable returns (uint ret) { return 42; }
+        function info() public payable returns (uint ret) { return 42; }
     }
 
     contract Consumer {
         InfoFeed feed;
-        function setFeed(address addr) { feed = InfoFeed(addr); }
-        function callFeed() { feed.info.value(10).gas(800)(); }
+        function setFeed(address addr) public { feed = InfoFeed(addr); }
+        function public callFeed() { feed.info.value(10).gas(800)(); }
     }
 
 The modifier ``payable`` has to be used for ``info``, because otherwise, the `.value()`
@@ -180,11 +184,11 @@ parameters from the function declaration, but can be in arbitrary order.
     pragma solidity ^0.4.0;
 
     contract C {
-        function f(uint key, uint value) {
+        function f(uint key, uint value) public {
             // ...
         }
 
-        function g() {
+        function g() public {
             // named arguments
             f({value: 2, key: 3});
         }
@@ -198,11 +202,11 @@ Those parameters will still be present on the stack, but they are inaccessible.
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
         // omitted name for parameter
-        function func(uint k, uint) returns(uint) {
+        function func(uint k, uint) public pure returns(uint) {
             return k;
         }
     }
@@ -225,7 +229,7 @@ creation-dependencies are not possible.
 
     contract D {
         uint x;
-        function D(uint a) payable {
+        function D(uint a) public payable {
             x = a;
         }
     }
@@ -233,11 +237,11 @@ creation-dependencies are not possible.
     contract C {
         D d = new D(4); // will be executed as part of C's constructor
 
-        function createD(uint arg) {
+        function createD(uint arg) public {
             D newD = new D(arg);
         }
 
-        function createAndEndowD(uint arg, uint amount) payable {
+        function createAndEndowD(uint arg, uint amount) public payable {
             // Send ether along with the creation
             D newD = (new D).value(amount)(arg);
         }
@@ -270,16 +274,16 @@ Destructuring Assignments and Returning Multiple Values
 
 Solidity internally allows tuple types, i.e. a list of objects of potentially different types whose size is a constant at compile-time. Those tuples can be used to return multiple values at the same time and also assign them to multiple variables (or LValues in general) at the same time::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
         uint[] data;
 
-        function f() returns (uint, bool, uint) {
+        function f() public pure returns (uint, bool, uint) {
             return (7, true, 2);
         }
 
-        function g() {
+        function g() public {
             // Declares and assigns the variables. Specifying the type explicitly is not possible.
             var (x, b, y) = f();
             // Assigns to a pre-existing variable.
@@ -326,10 +330,10 @@ As a result, the following code is illegal and cause the compiler to throw an er
 
     // This will not compile
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract ScopingErrors {
-        function scoping() {
+        function scoping() public {
             uint i = 0;
 
             while (i++ < 1) {
@@ -341,7 +345,7 @@ As a result, the following code is illegal and cause the compiler to throw an er
             }
         }
 
-        function minimalScoping() {
+        function minimalScoping() public {
             {
                 uint same2 = 0;
             }
@@ -351,7 +355,7 @@ As a result, the following code is illegal and cause the compiler to throw an er
             }
         }
 
-        function forLoopScoping() {
+        function forLoopScoping() public {
             for (uint same3 = 0; same3 < 1; same3++) {
             }
 
@@ -364,9 +368,9 @@ In addition to this, if a variable is declared, it will be initialized at the be
 As a result, the following code is legal, despite being poorly written::
 
     pragma solidity ^0.4.0;
-    
+
     contract C {
-        function foo() returns (uint) {
+        function foo() public pure returns (uint) {
             // baz is implicitly initialized as 0
             uint bar = 5;
             if (true) {
@@ -412,7 +416,7 @@ and how ``assert`` can be used for internal error checking::
     pragma solidity ^0.4.0;
 
     contract Sharer {
-        function sendHalf(address addr) payable returns (uint balance) {
+        function sendHalf(address addr) public payable returns (uint balance) {
             require(msg.value % 2 == 0); // Only allow even numbers
             uint balanceBeforeTransfer = this.balance;
             addr.transfer(msg.value / 2);

--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -111,10 +111,10 @@ array in the return statement. Pretty cool, huh?
 
 Example::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
-        function f() returns (uint8[5]) {
+        function f() public pure returns (uint8[5]) {
             string[4] memory adaArr = ["This", "is", "an", "array"];
             return ([1, 2, 3, 4, 5]);
         }
@@ -190,11 +190,11 @@ you should always convert it to a ``bytes`` first::
     contract C {
         string s;
 
-        function append(byte c) {
+        function append(byte c) public {
             bytes(s).push(c);
         }
 
-        function set(uint i, byte c) {
+        function set(uint i, byte c) public {
             bytes(s)[i] = c;
         }
     }
@@ -232,12 +232,14 @@ situation.
 
 If you do not want to throw, you can return a pair::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
         uint[] counters;
 
         function getCounter(uint index)
+            public
+            view
             returns (uint counter, bool error) {
                 if (index >= counters.length)
                     return (0, true);
@@ -245,7 +247,7 @@ If you do not want to throw, you can return a pair::
                     return (counters[index], false);
         }
 
-        function checkCounter(uint index) {
+        function checkCounter(uint index) public view {
             var (counter, error) = getCounter(index);
             if (error) {
                 // ...
@@ -316,11 +318,11 @@ Example::
         uint[] data1;
         uint[] data2;
 
-        function appendOne() {
+        function appendOne() public {
             append(data1);
         }
 
-        function appendTwo() {
+        function appendTwo() public {
             append(data2);
         }
 
@@ -349,7 +351,7 @@ be created in memory, although it will be created in storage::
         uint someVariable;
         uint[] data;
 
-        function f() {
+        function f() public {
             uint[] x;
             x.push(2);
             data = x;
@@ -375,7 +377,7 @@ The correct way to do this is the following::
         uint someVariable;
         uint[] data;
 
-        function f() {
+        function f() public {
             uint[] x = data;
             x.push(2);
         }
@@ -435,7 +437,7 @@ This is a very interesting question. Suppose that we have a contract field set u
         mapping(string => string) comments;
     }
 
-    function somefunction {
+    function somefunction public {
        user user1;
        user1.comments["Hello"] = "World";
        user user2 = user1;
@@ -456,13 +458,13 @@ In this example::
     pragma solidity ^0.4.0;
 
     contract B {
-        function B() payable {}
+        function B() public payable {}
     }
 
     contract A {
         address child;
 
-        function test() {
+        function test() public {
             child = (new B).value(10)(); //construct a new B with 10 wei
         }
     }
@@ -501,17 +503,17 @@ Can a contract pass an array (static size) or string or ``bytes`` (dynamic size)
 Sure. Take care that if you cross the memory / storage boundary,
 independent copies will be created::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
         uint[20] x;
 
-        function f() {
+        function f() public {
             g(x);
             h(x);
         }
 
-        function g(uint[20] y) internal {
+        function g(uint[20] y) internal pure {
             y[2] = 3;
         }
 

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -21,11 +21,11 @@ Storage
     contract SimpleStorage {
         uint storedData;
 
-        function set(uint x) {
+        function set(uint x) public {
             storedData = x;
         }
 
-        function get() constant returns (uint) {
+        function get() public constant returns (uint) {
             return storedData;
         }
     }
@@ -94,16 +94,16 @@ registering with username and password - all you need is an Ethereum keypair.
 
         // This is the constructor whose code is
         // run only when the contract is created.
-        function Coin() {
+        function Coin() public {
             minter = msg.sender;
         }
 
-        function mint(address receiver, uint amount) {
+        function mint(address receiver, uint amount) public {
             if (msg.sender != minter) return;
             balances[receiver] += amount;
         }
 
-        function send(address receiver, uint amount) {
+        function send(address receiver, uint amount) public {
             if (balances[msg.sender] < amount) return;
             balances[msg.sender] -= amount;
             balances[receiver] += amount;
@@ -145,7 +145,7 @@ like this one. The :ref:`getter function<getter-functions>` created by the ``pub
 is a bit more complex in this case. It roughly looks like the
 following::
 
-    function balances(address _account) returns (uint) {
+    function balances(address _account) public view returns (uint) {
         return balances[_account];
     }
 

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -62,7 +62,7 @@ complete contract):
         /// Mapping of ether shares of the contract.
         mapping(address => uint) shares;
         /// Withdraw your share.
-        function withdraw() {
+        function withdraw() public {
             if (msg.sender.send(shares[msg.sender]))
                 shares[msg.sender] = 0;
         }
@@ -85,7 +85,7 @@ as it uses ``call`` which forwards all remaining gas by default:
         /// Mapping of ether shares of the contract.
         mapping(address => uint) shares;
         /// Withdraw your share.
-        function withdraw() {
+        function withdraw() public {
             if (msg.sender.call.value(shares[msg.sender])())
                 shares[msg.sender] = 0;
         }
@@ -102,7 +102,7 @@ outlined further below:
         /// Mapping of ether shares of the contract.
         mapping(address => uint) shares;
         /// Withdraw your share.
-        function withdraw() {
+        function withdraw() public {
             var share = shares[msg.sender];
             shares[msg.sender] = 0;
             msg.sender.transfer(share);
@@ -130,7 +130,7 @@ Sending and Receiving Ether
 - Neither contracts nor "external accounts" are currently able to prevent that someone sends them Ether.
   Contracts can react on and reject a regular transfer, but there are ways
   to move Ether without creating a message call. One way is to simply "mine to"
-  the contract address and the second way is using ``selfdestruct(x)``. 
+  the contract address and the second way is using ``selfdestruct(x)``.
 
 - If a contract receives Ether (without a function being called), the fallback function is executed.
   If it does not have a fallback function, the Ether will be rejected (by throwing an exception).
@@ -186,11 +186,11 @@ Never use tx.origin for authorization. Let's say you have a wallet contract like
     contract TxUserWallet {
         address owner;
 
-        function TxUserWallet() {
+        function TxUserWallet() public {
             owner = msg.sender;
         }
 
-        function transferTo(address dest, uint amount) {
+        function transferTo(address dest, uint amount) public {
             require(tx.origin == owner);
             dest.transfer(amount);
         }
@@ -203,17 +203,17 @@ Now someone tricks you into sending ether to the address of this attack wallet:
     pragma solidity ^0.4.11;
 
     interface TxUserWallet {
-        function transferTo(address dest, uint amount);
+        function transferTo(address dest, uint amount) public;
     }
 
     contract TxAttackWallet {
         address owner;
 
-        function TxAttackWallet() {
+        function TxAttackWallet() public {
             owner = msg.sender;
         }
 
-        function() {
+        function() public {
             TxUserWallet(msg.sender).transferTo(owner, msg.sender.balance);
         }
     }

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -158,9 +158,9 @@ of votes.
                 returns (uint winningProposal)
         {
             uint winningVoteCount = 0;
-            for (uint p = 0; p < winningProposals.length; p++) {
-                if (winningProposals[p].voteCount > winningVoteCount) {
-                    winningVoteCount = winningProposals[p].voteCount;
+            for (uint p = 0; p < proposals.length; p++) {
+                if (proposals[p].voteCount > winningVoteCount) {
+                    winningVoteCount = proposals[p].voteCount;
                     winningProposal = p;
                 }
             }
@@ -172,7 +172,7 @@ of votes.
         function winnerName() public view
                 returns (bytes32 winnerName)
         {
-            name = proposals[winningProposal()].name;
+            winnerName = proposals[winningProposal()].name;
         }
     }
 

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -36,7 +36,7 @@ of votes.
 
 ::
 
-    pragma solidity ^0.4.11;
+    pragma solidity ^0.4.16;
 
     /// @title Voting with delegation.
     contract Ballot {
@@ -66,7 +66,7 @@ of votes.
         Proposal[] public proposals;
 
         /// Create a new ballot to choose one of `proposalNames`.
-        function Ballot(bytes32[] proposalNames) {
+        function Ballot(bytes32[] proposalNames) public {
             chairperson = msg.sender;
             voters[chairperson].weight = 1;
 
@@ -86,7 +86,7 @@ of votes.
 
         // Give `voter` the right to vote on this ballot.
         // May only be called by `chairperson`.
-        function giveRightToVote(address voter) {
+        function giveRightToVote(address voter) public {
             // If the argument of `require` evaluates to `false`,
             // it terminates and reverts all changes to
             // the state and to Ether balances. It is often
@@ -99,7 +99,7 @@ of votes.
         }
 
         /// Delegate your vote to the voter `to`.
-        function delegate(address to) {
+        function delegate(address to) public {
             // assigns reference
             Voter storage sender = voters[msg.sender];
             require(!sender.voted);
@@ -140,7 +140,7 @@ of votes.
 
         /// Give your vote (including votes delegated to you)
         /// to proposal `proposals[proposal].name`.
-        function vote(uint proposal) {
+        function vote(uint proposal) public {
             Voter storage sender = voters[msg.sender];
             require(!sender.voted);
             sender.voted = true;
@@ -154,13 +154,13 @@ of votes.
 
         /// @dev Computes the winning proposal taking all
         /// previous votes into account.
-        function winningProposal() constant
+        function winningProposal() public view
                 returns (uint winningProposal)
         {
             uint winningVoteCount = 0;
-            for (uint p = 0; p < proposals.length; p++) {
-                if (proposals[p].voteCount > winningVoteCount) {
-                    winningVoteCount = proposals[p].voteCount;
+            for (uint p = 0; p < winningProposals.length; p++) {
+                if (winningProposals[p].voteCount > winningVoteCount) {
+                    winningVoteCount = winningProposals[p].voteCount;
                     winningProposal = p;
                 }
             }
@@ -169,10 +169,10 @@ of votes.
         // Calls winningProposal() function to get the index
         // of the winner contained in the proposals array and then
         // returns the name of the winner
-        function winnerName() constant
+        function winnerName() public view
                 returns (bytes32 winnerName)
         {
-            winnerName = proposals[winningProposal()].name;
+            name = proposals[winningProposal()].name;
         }
     }
 
@@ -248,7 +248,7 @@ activate themselves.
         function SimpleAuction(
             uint _biddingTime,
             address _beneficiary
-        ) {
+        ) public {
             beneficiary = _beneficiary;
             auctionEnd = now + _biddingTime;
         }
@@ -257,7 +257,7 @@ activate themselves.
         /// together with this transaction.
         /// The value will only be refunded if the
         /// auction is not won.
-        function bid() payable {
+        function bid() public payable {
             // No arguments are necessary, all
             // information is already part of
             // the transaction. The keyword payable
@@ -286,7 +286,7 @@ activate themselves.
         }
 
         /// Withdraw a bid that was overbid.
-        function withdraw() returns (bool) {
+        function withdraw() public returns (bool) {
             uint amount = pendingReturns[msg.sender];
             if (amount > 0) {
                 // It is important to set this to zero because the recipient
@@ -305,7 +305,7 @@ activate themselves.
 
         /// End the auction and send the highest bid
         /// to the beneficiary.
-        function auctionEnd() {
+        function auctionEnd() public {
             // It is a good guideline to structure functions that interact
             // with other contracts (i.e. they call functions or send Ether)
             // into three phases:
@@ -405,7 +405,7 @@ high or low invalid bids.
             uint _biddingTime,
             uint _revealTime,
             address _beneficiary
-        ) {
+        ) public {
             beneficiary = _beneficiary;
             biddingEnd = now + _biddingTime;
             revealEnd = biddingEnd + _revealTime;
@@ -421,6 +421,7 @@ high or low invalid bids.
         /// still make the required deposit. The same address can
         /// place multiple bids.
         function bid(bytes32 _blindedBid)
+            public
             payable
             onlyBefore(biddingEnd)
         {
@@ -438,6 +439,7 @@ high or low invalid bids.
             bool[] _fake,
             bytes32[] _secret
         )
+            public
             onlyAfter(biddingEnd)
             onlyBefore(revealEnd)
         {
@@ -487,7 +489,7 @@ high or low invalid bids.
         }
 
         /// Withdraw a bid that was overbid.
-        function withdraw() {
+        function withdraw() public {
             uint amount = pendingReturns[msg.sender];
             if (amount > 0) {
                 // It is important to set this to zero because the recipient
@@ -503,6 +505,7 @@ high or low invalid bids.
         /// End the auction and send the highest bid
         /// to the beneficiary.
         function auctionEnd()
+            public
             onlyAfter(revealEnd)
         {
             require(!ended);
@@ -533,7 +536,7 @@ Safe Remote Purchase
         // Ensure that `msg.value` is an even number.
         // Division will truncate if it is an odd number.
         // Check via multiplication that it wasn't an odd number.
-        function Purchase() payable {
+        function Purchase() public payable {
             seller = msg.sender;
             value = msg.value / 2;
             require((2 * value) == msg.value);
@@ -567,6 +570,7 @@ Safe Remote Purchase
         /// Can only be called by the seller before
         /// the contract is locked.
         function abort()
+            public
             onlySeller
             inState(State.Created)
         {
@@ -580,6 +584,7 @@ Safe Remote Purchase
         /// The ether will be locked until confirmReceived
         /// is called.
         function confirmPurchase()
+            public
             inState(State.Created)
             condition(msg.value == (2 * value))
             payable
@@ -592,6 +597,7 @@ Safe Remote Purchase
         /// Confirm that you (the buyer) received the item.
         /// This will release the locked ether.
         function confirmReceived()
+            public
             onlyBuyer
             inState(State.Locked)
         {

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -43,7 +43,7 @@ Functions are the executable units of code within a contract.
     pragma solidity ^0.4.0;
 
     contract SimpleAuction {
-        function bid() payable { // Function
+        function bid() public payable { // Function
             // ...
         }
     }
@@ -72,7 +72,7 @@ Function modifiers can be used to amend the semantics of functions in a declarat
             _;
         }
 
-        function abort() onlySeller { // Modifier usage
+        function abort() public onlySeller { // Modifier usage
             // ...
         }
     }
@@ -91,7 +91,7 @@ Events are convenience interfaces with the EVM logging facilities.
     contract SimpleAuction {
         event HighestBidIncreased(address bidder, uint amount); // Event
 
-        function bid() payable {
+        function bid() public payable {
             // ...
             HighestBidIncreased(msg.sender, msg.value); // Triggering event
         }

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -86,17 +86,17 @@ Blank lines may be omitted between groups of related one-liners (such as stub fu
 Yes::
 
     contract A {
-        function spam();
-        function ham();
+        function spam() public;
+        function ham() public;
     }
 
 
     contract B is A {
-        function spam() {
+        function spam() public {
             ...
         }
 
-        function ham() {
+        function ham() public {
             ...
         }
     }
@@ -104,10 +104,10 @@ Yes::
 No::
 
     contract A {
-        function spam() {
+        function spam() public {
             ...
         }
-        function ham() {
+        function ham() public {
             ...
         }
     }
@@ -169,26 +169,26 @@ Within a grouping, place the ``constant`` functions last.
 Yes::
 
     contract A {
-        function A() {
+        function A() public {
             ...
         }
-        
-        function() {
+
+        function() public {
             ...
         }
-        
+
         // External functions
         // ...
-        
+
         // External functions that are constant
         // ...
-        
+
         // Public functions
         // ...
-        
+
         // Internal functions
         // ...
-        
+
         // Private functions
         // ...
     }
@@ -196,7 +196,7 @@ Yes::
 No::
 
     contract A {
-        
+
         // External functions
         // ...
 
@@ -206,16 +206,16 @@ No::
         // Public functions
         // ...
 
-        function A() {
+        function A() public {
             ...
         }
-        
-        function() {
+
+        function() public {
             ...
         }
 
         // Internal functions
-        // ...       
+        // ...
     }
 
 Whitespace in Expressions
@@ -235,17 +235,17 @@ No::
 
 Exception::
 
-    function singleLine() { spam(); }
+    function singleLine() public { spam(); }
 
 Immediately before a comma, semicolon:
 
 Yes::
 
-    function spam(uint i, Coin coin);
+    function spam(uint i, Coin coin) public;
 
 No::
 
-    function spam(uint i , Coin coin) ;
+    function spam(uint i , Coin coin) public ;
 
 More than one space around an assignment or other operator to align with
   another:
@@ -266,13 +266,13 @@ Don't include a whitespace in the fallback function:
 
 Yes::
 
-    function() {
+    function() public {
         ...
     }
 
 No::
-   
-    function () {
+
+    function () public {
         ...
     }
 
@@ -395,30 +395,30 @@ The opening brace should be preceeded by a single space.
 
 Yes::
 
-    function increment(uint x) returns (uint) {
+    function increment(uint x) public pure returns (uint) {
         return x + 1;
     }
 
-    function increment(uint x) public onlyowner returns (uint) {
+    function increment(uint x) public pure onlyowner returns (uint) {
         return x + 1;
     }
 
 No::
 
-    function increment(uint x) returns (uint)
+    function increment(uint x) public pure returns (uint)
     {
         return x + 1;
     }
 
-    function increment(uint x) returns (uint){
+    function increment(uint x) public pure returns (uint){
         return x + 1;
     }
 
-    function increment(uint x) returns (uint) {
+    function increment(uint x) public pure returns (uint) {
         return x + 1;
         }
 
-    function increment(uint x) returns (uint) {
+    function increment(uint x) public pure returns (uint) {
         return x + 1;}
 
 The visibility modifiers for a function should come before any custom
@@ -450,14 +450,16 @@ Yes::
         address d,
         address e,
         address f
-    ) {
+    )
+        public
+    {
         doSomething();
     }
 
 No::
 
     function thisFunctionHasLotsOfArguments(address a, address b, address c,
-        address d, address e, address f) {
+        address d, address e, address f) public {
         doSomething();
     }
 
@@ -466,7 +468,7 @@ No::
                                             address c,
                                             address d,
                                             address e,
-                                            address f) {
+                                            address f) public {
         doSomething();
     }
 
@@ -476,12 +478,12 @@ No::
         address c,
         address d,
         address e,
-        address f) {
+        address f) public {
         doSomething();
     }
 
 If a long function declaration has modifiers, then each modifier should be
-dropped to it's own line.
+dropped to its own line.
 
 Yes::
 
@@ -542,6 +544,7 @@ Yes::
             B(param1)
             C(param2, param3)
             D(param4)
+            public
         {
             // do something with param5
         }
@@ -554,6 +557,7 @@ No::
         B(param1)
         C(param2, param3)
         D(param4)
+        public
         {
             // do something with param5
         }
@@ -563,7 +567,8 @@ No::
         function A(uint param1, uint param2, uint param3, uint param4, uint param5)
             B(param1)
             C(param2, param3)
-            D(param4) {
+            D(param4)
+            public {
             // do something with param5
         }
     }
@@ -572,7 +577,7 @@ When declaring short functions with a single statement, it is permissible to do 
 
 Permissible::
 
-    function shortFunction() { doSomething(); }
+    function shortFunction() public { doSomething(); }
 
 These guidelines for function declarations are intended to improve readability.
 Authors should use their best judgement as this guide does not try to cover all

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -649,7 +649,7 @@ assigned to a variable right away.
         function f() public pure {
             g([uint(1), 2, 3]);
         }
-        function g(uint[3] _data) public {
+        function g(uint[3] _data) public pure {
             // ...
         }
     }

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -79,8 +79,8 @@ Fixed Point Numbers
     Fixed point numbers are not fully supported by Solidity yet. They can be declared, but
     cannot be assigned to or from.
 
-``fixed`` / ``ufixed``: Signed and unsigned fixed point number of various sizes. Keywords ``ufixedMxN`` and ``fixedMxN``, where ``M`` represent the number of bits taken by 
-the type and ``N`` represent how many decimal points are available. ``M`` must be divisible by 8 and goes from 8 to 256 bits. ``N`` must be between 0 and 80, inclusive.
+``fixed`` / ``ufixed``: Signed and unsigned fixed point number of various sizes. Keywords ``ufixedMxN`` and ``fixedMxN``, where ``M`` represents the number of bits taken by
+the type and ``N`` represents how many decimal points are available. ``M`` must be divisible by 8 and goes from 8 to 256 bits. ``N`` must be between 0 and 80, inclusive.
 ``ufixed`` and ``fixed`` are aliases for ``ufixed128x19`` and ``fixed128x19``, respectively.
 
 Operators:
@@ -331,14 +331,14 @@ check the value ranges at runtime and a failure causes an exception.  Enums need
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract test {
         enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
         ActionChoices choice;
         ActionChoices constant defaultChoice = ActionChoices.GoStraight;
 
-        function setGoStraight() {
+        function setGoStraight() public {
             choice = ActionChoices.GoStraight;
         }
 
@@ -347,11 +347,11 @@ check the value ranges at runtime and a failure causes an exception.  Enums need
         // for all matters external to Solidity. The integer type used is just
         // large enough to hold all enum values, i.e. if you have more values,
         // `uint16` will be used and so on.
-        function getChoice() returns (ActionChoices) {
+        function getChoice() public view returns (ActionChoices) {
             return choice;
         }
 
-        function getDefaultChoice() returns (uint) {
+        function getDefaultChoice() public pure returns (uint) {
             return uint(defaultChoice);
         }
     }
@@ -409,23 +409,24 @@ just use ``f``, if you want to use its external form, use ``this.f``.
 Additionally, public (or external) functions also have a special member called ``selector``,
 which returns the :ref:`ABI function selector <abi_function_selector>`::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract Selector {
-      function f() returns (bytes4) {
+      function f() public view returns (bytes4) {
         return this.f.selector;
       }
     }
 
 Example that shows how to use internal function types::
 
-    pragma solidity ^0.4.5;
+    pragma solidity ^0.4.16;
 
     library ArrayUtils {
       // internal functions can be used in internal library functions because
       // they will be part of the same code context
-      function map(uint[] memory self, function (uint) returns (uint) f)
+      function map(uint[] memory self, function (uint) pure returns (uint) f)
         internal
+        pure
         returns (uint[] memory r)
       {
         r = new uint[](self.length);
@@ -435,9 +436,10 @@ Example that shows how to use internal function types::
       }
       function reduce(
         uint[] memory self,
-        function (uint, uint) returns (uint) f
+        function (uint, uint) pure returns (uint) f
       )
         internal
+        pure
         returns (uint r)
       {
         r = self[0];
@@ -445,23 +447,23 @@ Example that shows how to use internal function types::
           r = f(r, self[i]);
         }
       }
-      function range(uint length) internal returns (uint[] memory r) {
+      function range(uint length) internal pure returns (uint[] memory r) {
         r = new uint[](length);
         for (uint i = 0; i < r.length; i++) {
           r[i] = i;
         }
       }
     }
-    
+
     contract Pyramid {
       using ArrayUtils for *;
-      function pyramid(uint l) returns (uint) {
+      function pyramid(uint l) public pure returns (uint) {
         return ArrayUtils.range(l).map(square).reduce(sum);
       }
-      function square(uint x) internal returns (uint) {
+      function square(uint x) internal pure returns (uint) {
         return x * x;
       }
-      function sum(uint x, uint y) internal returns (uint) {
+      function sum(uint x, uint y) internal pure returns (uint) {
         return x + y;
       }
     }
@@ -477,11 +479,11 @@ Another example that uses external function types::
       }
       Request[] requests;
       event NewRequest(uint);
-      function query(bytes data, function(bytes memory) external callback) {
+      function query(bytes data, function(bytes memory) external callback) public {
         requests.push(Request(data, callback));
         NewRequest(requests.length - 1);
       }
-      function reply(uint requestID, bytes response) {
+      function reply(uint requestID, bytes response) public {
         // Here goes the check that the reply comes from a trusted source
         requests[requestID].callback(response);
       }
@@ -492,7 +494,7 @@ Another example that uses external function types::
       function buySomething() {
         oracle.query("USD", this.oracleResponse);
       }
-      function oracleResponse(bytes response) {
+      function oracleResponse(bytes response) public {
         require(msg.sender == address(oracle));
         // Use the data
       }
@@ -543,7 +545,7 @@ memory-stored reference type do not create a copy.
         uint[] x; // the data location of x is storage
 
         // the data location of memoryArray is memory
-        function f(uint[] memoryArray) {
+        function f(uint[] memoryArray) public {
             x = memoryArray; // works, copies the whole array to storage
             var y = x; // works, assigns a pointer, data location of y is storage
             y[7]; // fine, returns the 8th element
@@ -560,7 +562,7 @@ memory-stored reference type do not create a copy.
         }
 
         function g(uint[] storage storageArray) internal {}
-        function h(uint[] memoryArray) {}
+        function h(uint[] memoryArray) public {}
     }
 
 Summary
@@ -620,10 +622,10 @@ the ``.length`` member.
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
-        function f(uint len) {
+        function f(uint len) public pure {
             uint[] memory a = new uint[](7);
             bytes memory b = new bytes(len);
             // Here we have a.length == 7 and b.length == len
@@ -641,13 +643,13 @@ assigned to a variable right away.
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract C {
-        function f() {
+        function f() public pure {
             g([uint(1), 2, 3]);
         }
-        function g(uint[3] _data) {
+        function g(uint[3] _data) public {
             // ...
         }
     }
@@ -667,7 +669,7 @@ possible:
     pragma solidity ^0.4.0;
 
     contract C {
-        function f() {
+        function f() public {
             // The next line creates a type error because uint[3] memory
             // cannot be converted to uint[] memory.
             uint[] x = [uint(1), 3, 4];
@@ -703,7 +705,7 @@ Members
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.16;
 
     contract ArrayContract {
         uint[2**20] m_aLotOfIntegers;
@@ -712,23 +714,23 @@ Members
         bool[2][] m_pairsOfFlags;
         // newPairs is stored in memory - the default for function arguments
 
-        function setAllFlagPairs(bool[2][] newPairs) {
+        function setAllFlagPairs(bool[2][] newPairs) public {
             // assignment to a storage array replaces the complete array
             m_pairsOfFlags = newPairs;
         }
 
-        function setFlagPair(uint index, bool flagA, bool flagB) {
+        function setFlagPair(uint index, bool flagA, bool flagB) public {
             // access to a non-existing index will throw an exception
             m_pairsOfFlags[index][0] = flagA;
             m_pairsOfFlags[index][1] = flagB;
         }
 
-        function changeFlagArraySize(uint newSize) {
+        function changeFlagArraySize(uint newSize) public {
             // if the new size is smaller, removed array elements will be cleared
             m_pairsOfFlags.length = newSize;
         }
 
-        function clear() {
+        function clear() public {
             // these clear the arrays completely
             delete m_pairsOfFlags;
             delete m_aLotOfIntegers;
@@ -738,20 +740,20 @@ Members
 
         bytes m_byteData;
 
-        function byteArrays(bytes data) {
+        function byteArrays(bytes data) public {
             // byte arrays ("bytes") are different as they are stored without padding,
             // but can be treated identical to "uint8[]"
             m_byteData = data;
             m_byteData.length += 7;
-            m_byteData[3] = 8;
+            m_byteData[3] = byte(8);
             delete m_byteData[2];
         }
 
-        function addFlag(bool[2] flag) returns (uint) {
+        function addFlag(bool[2] flag) public returns (uint) {
             return m_pairsOfFlags.push(flag);
         }
 
-        function createMemoryArray(uint size) returns (bytes) {
+        function createMemoryArray(uint size) public pure returns (bytes) {
             // Dynamic memory arrays are created using `new`:
             uint[2][] memory arrayOfPairs = new uint[2][](size);
             // Create a dynamic byte array:
@@ -795,13 +797,13 @@ shown in the following example:
         uint numCampaigns;
         mapping (uint => Campaign) campaigns;
 
-        function newCampaign(address beneficiary, uint goal) returns (uint campaignID) {
+        function newCampaign(address beneficiary, uint goal) public returns (uint campaignID) {
             campaignID = numCampaigns++; // campaignID is return variable
             // Creates new struct and saves in storage. We leave out the mapping type.
             campaigns[campaignID] = Campaign(beneficiary, goal, 0, 0);
         }
 
-        function contribute(uint campaignID) payable {
+        function contribute(uint campaignID) public payable {
             Campaign storage c = campaigns[campaignID];
             // Creates a new temporary memory struct, initialised with the given values
             // and copies it over to storage.
@@ -810,7 +812,7 @@ shown in the following example:
             c.amount += msg.value;
         }
 
-        function checkGoalReached(uint campaignID) returns (bool reached) {
+        function checkGoalReached(uint campaignID) public returns (bool reached) {
             Campaign storage c = campaigns[campaignID];
             if (c.amount < c.fundingGoal)
                 return false;
@@ -872,13 +874,13 @@ for each ``_KeyType``, recursively.
     contract MappingExample {
         mapping(address => uint) public balances;
 
-        function update(uint newBalance) {
+        function update(uint newBalance) public {
             balances[msg.sender] = newBalance;
         }
     }
 
     contract MappingUser {
-        function f() returns (uint) {
+        function f() public returns (uint) {
             MappingExample m = new MappingExample();
             m.update(100);
             return m.balances(this);
@@ -916,11 +918,11 @@ It is important to note that ``delete a`` really behaves like an assignment to `
         uint data;
         uint[] dataArray;
 
-        function f() {
+        function f() public {
             uint x = data;
             delete x; // sets x to 0, does not affect data
             delete data; // sets data to 0, does not affect x which still holds a copy
-            uint[] y = dataArray;
+            uint[] storage y = dataArray;
             delete dataArray; // this sets dataArray.length to zero, but as uint[] is a complex object, also
             // y is affected which is an alias to the storage object
             // On the other hand: "delete y" is not valid, as assignments to local variables

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -34,7 +34,7 @@ library has to be updated by an external oracle.
 These suffixes cannot be applied to variables. If you want to
 interpret some input variable in e.g. days, you can do it in the following way::
 
-    function f(uint start, uint daysAfter) {
+    function f(uint start, uint daysAfter) public {
         if (now >= start + daysAfter * 1 days) {
           // ...
         }


### PR DESCRIPTION
Solidity has moved on since many of the examples in the documentation were written.  This causes problems where users cut and paste the examples in to Remix and it spits out what they see as errors (generally warnings but very confusing for new users).

This PR fixes up the various code samples in the documentation so that they don't give spurious examples when pasted in to the current Remix.

Note that this does not update the Solidity version in the relevant pragmas; this could be done in a new PR if required.