### PR TITLE
Warn about duplicated super constructor calls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Bugfixes:
  * Parser: Disallow event declarations with no parameter list.
  * Standard JSON: Populate the ``sourceLocation`` field in the error list.
  * Standard JSON: Properly support contract and library file names containing a colon (such as URLs).
+ * Static Analyzer: Error on duplicated super constructor calls.
  * Type Checker: Suggest the experimental ABI encoder if using ``struct``s as function parameters
    (instead of an internal compiler error).
  * Type Checker: Improve error message for wrong struct initialization.

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -968,9 +968,12 @@ the base constructors. This can be done in two ways::
         function Base(uint _x) public { x = _x; }
     }
 
-    contract Derived is Base(7) {
-        function Derived(uint _y) Base(_y * _y) public {
-        }
+    contract Derived1 is Base(7) {
+        function Derived1(uint _y) public {}
+    }
+
+    contract Derived2 is Base {
+        function Derived2(uint _y) Base(_y * _y) public {}
     }
 
 One way is directly in the inheritance list (``is Base(7)``).  The other is in

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -80,6 +80,37 @@ void StaticAnalyzer::endVisit(FunctionDefinition const&)
 	m_localVarUseCount.clear();
 }
 
+bool modifierOverridesInheritanceSpecifier(
+		ContractDefinition const* _contract,
+		ModifierInvocation const& _modifier,
+		InheritanceSpecifier const& _specifier)
+{
+	auto parent = _specifier.name().annotation().referencedDeclaration;
+	return _contract == parent && (!_specifier.arguments().empty() || _modifier.arguments().empty());
+}
+
+bool StaticAnalyzer::visit(ModifierInvocation const& _modifier)
+{
+	if (!m_constructor)
+		return true;
+
+	if (auto contract = dynamic_cast<ContractDefinition const*>(_modifier.name()->annotation().referencedDeclaration))
+		for (auto const& specifier: m_currentContract->baseContracts())
+			if (modifierOverridesInheritanceSpecifier(contract, _modifier, *specifier))
+			{
+				SecondarySourceLocation ssl;
+				ssl.append("Overriden constructor call is here:", specifier->location());
+
+				m_errorReporter.declarationError(
+					_modifier.location(),
+					ssl,
+					"Duplicated super constructor call."
+				);
+			}
+
+	return true;
+}
+
 bool StaticAnalyzer::visit(Identifier const& _identifier)
 {
 	if (m_currentFunction)

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -57,6 +57,7 @@ private:
 
 	virtual bool visit(FunctionDefinition const& _function) override;
 	virtual void endVisit(FunctionDefinition const& _function) override;
+	virtual bool visit(ModifierInvocation const& _modifier) override;
 
 	virtual bool visit(ExpressionStatement const& _statement) override;
 	virtual bool visit(VariableDeclaration const& _variable) override;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -4835,7 +4835,7 @@ BOOST_AUTO_TEST_CASE(pass_dynamic_arguments_to_the_base)
 			}
 			uint public m_i;
 		}
-		contract Derived is Base(2) {
+		contract Derived is Base {
 			function Derived(uint i) Base(i)
 			{}
 		}
@@ -4855,10 +4855,10 @@ BOOST_AUTO_TEST_CASE(pass_dynamic_arguments_to_the_base_base)
 			}
 			uint public m_i;
 		}
-		contract Base1 is Base(3) {
+		contract Base1 is Base {
 			function Base1(uint k) Base(k*k) {}
 		}
-		contract Derived is Base(3), Base1(2) {
+		contract Derived is Base, Base1 {
 			function Derived(uint i) Base(i) Base1(i)
 			{}
 		}
@@ -4879,7 +4879,7 @@ BOOST_AUTO_TEST_CASE(pass_dynamic_arguments_to_the_base_base_with_gap)
 			uint public m_i;
 		}
 		contract Base1 is Base(3) {}
-		contract Derived is Base(2), Base1 {
+		contract Derived is Base, Base1 {
 			function Derived(uint i) Base(i) {}
 		}
 		contract Final is Derived(4) {

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -947,6 +947,21 @@ BOOST_AUTO_TEST_CASE(base_constructor_arguments_override)
 	CHECK_SUCCESS(text);
 }
 
+BOOST_AUTO_TEST_CASE(duplicated_super_constructor_call)
+{
+	char const* text = R"(
+		contract A { function A(uint) public { } }
+		contract B is A(2) { function B() A(3) public {  } }
+	)";
+	CHECK_ERROR(text, DeclarationError, "Duplicated super constructor call.");
+
+	text = R"(
+		contract A { function A() public { } }
+		contract B is A { function B() A() public {  } }
+	)";
+	CHECK_ERROR(text, DeclarationError, "Duplicated super constructor call.");
+}
+
 BOOST_AUTO_TEST_CASE(implicit_derived_to_base_conversion)
 {
 	char const* text = R"(


### PR DESCRIPTION
Mentioned in the audit report from Coinspect available [here](https://github.com/AugurProject/augur-audits/blob/master/solidity-compiler/Coinspect%20-%20Solidity%20Compiler%20Audit%20v1.0.pdf).

I think I saw an issue related to this, but I couldn't find it.

FIxes https://github.com/ethereum/solidity/issues/3325