### PR TITLE
Use returndatacopy for retrieving dynamically sized outputs.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.22 (unreleased)
 
 Features:
+ * General: Support accessing dynamic return data in post-byzantium EVMs.
 
 Bugfixes:
  * Code Generator: Allow ``block.blockhash`` without being called.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1551,7 +1551,7 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 			_functionCall.expression().annotation().isPure &&
 			functionType->isPure();
 
-	bool allowDynamicTypes = false; // @TODO
+	bool allowDynamicTypes = m_evmVersion.supportsReturndata();
 	if (!functionType)
 	{
 		m_errorReporter.typeError(_functionCall.location(), "Type is not callable");

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1551,16 +1551,22 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 			_functionCall.expression().annotation().isPure &&
 			functionType->isPure();
 
+	bool allowDynamicTypes = false; // @TODO
 	if (!functionType)
 	{
 		m_errorReporter.typeError(_functionCall.location(), "Type is not callable");
 		_functionCall.annotation().type = make_shared<TupleType>();
 		return false;
 	}
-	else if (functionType->returnParameterTypes().size() == 1)
-		_functionCall.annotation().type = functionType->returnParameterTypes().front();
+
+	auto returnTypes =
+		allowDynamicTypes ?
+		functionType->returnParameterTypes() :
+		functionType->returnParameterTypesWithoutDynamicTypes();
+	if (returnTypes.size() == 1)
+		_functionCall.annotation().type = returnTypes.front();
 	else
-		_functionCall.annotation().type = make_shared<TupleType>(functionType->returnParameterTypes());
+		_functionCall.annotation().type = make_shared<TupleType>(returnTypes);
 
 	if (auto functionName = dynamic_cast<Identifier const*>(&_functionCall.expression()))
 	{

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -973,6 +973,9 @@ public:
 	TypePointers parameterTypes() const;
 	std::vector<std::string> parameterNames() const;
 	TypePointers const& returnParameterTypes() const { return m_returnParameterTypes; }
+	/// @returns the list of return parameter types. All dynamically-sized types (this excludes
+	/// storage pointers) are replaced by InaccessibleDynamicType instances.
+	TypePointers returnParameterTypesWithoutDynamicTypes() const;
 	std::vector<std::string> const& returnParameterNames() const { return m_returnParameterNames; }
 	/// @returns the "self" parameter type for a bound function
 	TypePointer const& selfType() const;

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -253,6 +253,9 @@ string ABIFunctions::cleanupFunction(Type const& _type, bool _revertOnFailure)
 			templ("body", w.render());
 			break;
 		}
+		case Type::Category::InaccessibleDynamic:
+			templ("body", "cleaned := 0");
+			break;
 		default:
 			solAssert(false, "Cleanup of type " + _type.identifier() + " requested.");
 		}

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -198,7 +198,7 @@ void CompilerUtils::abiDecode(TypePointers const& _typeParameters, bool _fromMem
 		if (type->category() == Type::Category::Array)
 		{
 			auto const& arrayType = dynamic_cast<ArrayType const&>(*type);
-			solUnimplementedAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
+			solUnimplementedAssert(!arrayType.baseType()->isDynamicallyEncoded(), "Nested arrays not yet implemented.");
 			if (_fromMemory)
 			{
 				solUnimplementedAssert(
@@ -308,7 +308,7 @@ void CompilerUtils::abiDecode(TypePointers const& _typeParameters, bool _fromMem
 		}
 		else
 		{
-			solAssert(!type->isDynamicallySized(), "Unknown dynamically sized type: " + type->toString());
+			solAssert(!type->isDynamicallyEncoded(), "Unknown dynamically sized type: " + type->toString());
 			loadFromMemoryDynamic(*type, !_fromMemory, true);
 			// stack: v1 v2 ... v(k-1) input_end base_offset v(k) mem_offset
 			moveToStackTop(1, type->sizeOnStack());

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -88,6 +88,11 @@ public:
 	/// Stack post: (memory_offset+length)
 	void storeInMemoryDynamic(Type const& _type, bool _padToWords = true);
 
+	/// Creates code that unpacks the arguments according to their types specified by a vector of TypePointers.
+	/// From memory if @a _fromMemory is true, otherwise from call data.
+	/// Expects source offset on the stack, which is removed.
+	void abiDecode(TypePointers const& _typeParameters, bool _fromMemory = false);
+
 	/// Copies values (of types @a _givenTypes) given on the stack to a location in memory given
 	/// at the stack top, encoding them according to the ABI as the given types @a _targetTypes.
 	/// Removes the values from the stack and leaves the updated memory pointer.

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -90,8 +90,12 @@ public:
 
 	/// Creates code that unpacks the arguments according to their types specified by a vector of TypePointers.
 	/// From memory if @a _fromMemory is true, otherwise from call data.
-	/// Expects source offset on the stack, which is removed.
-	void abiDecode(TypePointers const& _typeParameters, bool _fromMemory = false);
+	/// Calls revert if @a _revertOnOutOfBounds is true and the supplied size is shorter
+	/// than the static data requirements or if dynamic data pointers reach outside of the
+	/// area. Also has a hard cap of 0x100000000 for any given length/offset field.
+	/// Stack pre: <source_offset> <length>
+	/// Stack post: <value0> <value1> ... <valuen>
+	void abiDecode(TypePointers const& _typeParameters, bool _fromMemory = false, bool _revertOnOutOfBounds = false);
 
 	/// Copies values (of types @a _givenTypes) given on the stack to a location in memory given
 	/// at the stack top, encoding them according to the ABI as the given types @a _targetTypes.
@@ -154,7 +158,7 @@ public:
 	/// Decodes data from ABI encoding into internal encoding. If @a _fromMemory is set to true,
 	/// the data is taken from memory instead of from calldata.
 	/// Can allocate memory.
-	/// Stack pre: <source_offset>
+	/// Stack pre: <source_offset> <length>
 	/// Stack post: <value0> <value1> ... <valuen>
 	void abiDecodeV2(TypePointers const& _parameterTypes, bool _fromMemory = false);
 

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -280,7 +280,7 @@ void ContractCompiler::appendConstructor(FunctionDefinition const& _constructor)
 		m_context << Instruction::DUP2 << Instruction::ADD;
 		CompilerUtils(m_context).storeFreeMemoryPointer();
 		// stack: <memptr>
-		appendCalldataUnpacker(FunctionType(_constructor).parameterTypes(), true);
+		CompilerUtils(m_context).abiDecode(FunctionType(_constructor).parameterTypes(), true);
 	}
 	_constructor.accept(*this);
 }
@@ -367,7 +367,7 @@ void ContractCompiler::appendFunctionSelector(ContractDefinition const& _contrac
 		{
 			// Parameter for calldataUnpacker
 			m_context << CompilerUtils::dataStartOffset;
-			appendCalldataUnpacker(functionType->parameterTypes());
+			CompilerUtils(m_context).abiDecode(functionType->parameterTypes());
 		}
 		m_context.appendJumpTo(m_context.functionEntryLabel(functionType->declaration()));
 		m_context << returnTag;
@@ -380,105 +380,6 @@ void ContractCompiler::appendFunctionSelector(ContractDefinition const& _contrac
 		// Consumes the return parameters.
 		appendReturnValuePacker(functionType->returnParameterTypes(), _contract.isLibrary());
 	}
-}
-
-void ContractCompiler::appendCalldataUnpacker(TypePointers const& _typeParameters, bool _fromMemory)
-{
-	// We do not check the calldata size, everything is zero-padded
-
-	if (m_context.experimentalFeatureActive(ExperimentalFeature::ABIEncoderV2))
-	{
-		// Use the new JULIA-based decoding function
-		auto stackHeightBefore = m_context.stackHeight();
-		CompilerUtils(m_context).abiDecodeV2(_typeParameters, _fromMemory);
-		solAssert(m_context.stackHeight() - stackHeightBefore == CompilerUtils(m_context).sizeOnStack(_typeParameters) - 1, "");
-		return;
-	}
-
-	//@todo this does not yet support nested dynamic arrays
-
-	// Retain the offset pointer as base_offset, the point from which the data offsets are computed.
-	m_context << Instruction::DUP1;
-	for (TypePointer const& parameterType: _typeParameters)
-	{
-		// stack: v1 v2 ... v(k-1) base_offset current_offset
-		TypePointer type = parameterType->decodingType();
-		solUnimplementedAssert(type, "No decoding type found.");
-		if (type->category() == Type::Category::Array)
-		{
-			auto const& arrayType = dynamic_cast<ArrayType const&>(*type);
-			solUnimplementedAssert(!arrayType.baseType()->isDynamicallySized(), "Nested arrays not yet implemented.");
-			if (_fromMemory)
-			{
-				solUnimplementedAssert(
-					arrayType.baseType()->isValueType(),
-					"Nested memory arrays not yet implemented here."
-				);
-				// @todo If base type is an array or struct, it is still calldata-style encoded, so
-				// we would have to convert it like below.
-				solAssert(arrayType.location() == DataLocation::Memory, "");
-				if (arrayType.isDynamicallySized())
-				{
-					// compute data pointer
-					m_context << Instruction::DUP1 << Instruction::MLOAD;
-					m_context << Instruction::DUP3 << Instruction::ADD;
-					m_context << Instruction::SWAP2 << Instruction::SWAP1;
-					m_context << u256(0x20) << Instruction::ADD;
-				}
-				else
-				{
-					m_context << Instruction::SWAP1 << Instruction::DUP2;
-					m_context << u256(arrayType.calldataEncodedSize(true)) << Instruction::ADD;
-				}
-			}
-			else
-			{
-				// first load from calldata and potentially convert to memory if arrayType is memory
-				TypePointer calldataType = arrayType.copyForLocation(DataLocation::CallData, false);
-				if (calldataType->isDynamicallySized())
-				{
-					// put on stack: data_pointer length
-					CompilerUtils(m_context).loadFromMemoryDynamic(IntegerType(256), !_fromMemory);
-					// stack: base_offset data_offset next_pointer
-					m_context << Instruction::SWAP1 << Instruction::DUP3 << Instruction::ADD;
-					// stack: base_offset next_pointer data_pointer
-					// retrieve length
-					CompilerUtils(m_context).loadFromMemoryDynamic(IntegerType(256), !_fromMemory, true);
-					// stack: base_offset next_pointer length data_pointer
-					m_context << Instruction::SWAP2;
-					// stack: base_offset data_pointer length next_pointer
-				}
-				else
-				{
-					// leave the pointer on the stack
-					m_context << Instruction::DUP1;
-					m_context << u256(calldataType->calldataEncodedSize()) << Instruction::ADD;
-				}
-				if (arrayType.location() == DataLocation::Memory)
-				{
-					// stack: base_offset calldata_ref [length] next_calldata
-					// copy to memory
-					// move calldata type up again
-					CompilerUtils(m_context).moveIntoStack(calldataType->sizeOnStack());
-					CompilerUtils(m_context).convertType(*calldataType, arrayType, false, false, true);
-					// fetch next pointer again
-					CompilerUtils(m_context).moveToStackTop(arrayType.sizeOnStack());
-				}
-				// move base_offset up
-				CompilerUtils(m_context).moveToStackTop(1 + arrayType.sizeOnStack());
-				m_context << Instruction::SWAP1;
-			}
-		}
-		else
-		{
-			solAssert(!type->isDynamicallySized(), "Unknown dynamically sized type: " + type->toString());
-			CompilerUtils(m_context).loadFromMemoryDynamic(*type, !_fromMemory, true);
-			CompilerUtils(m_context).moveToStackTop(1 + type->sizeOnStack());
-			m_context << Instruction::SWAP1;
-		}
-		// stack: v1 v2 ... v(k-1) v(k) base_offset mem_offset
-	}
-	m_context << Instruction::POP << Instruction::POP;
 }
 
 void ContractCompiler::appendReturnValuePacker(TypePointers const& _typeParameters, bool _isLibrary)

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -278,6 +278,7 @@ void ContractCompiler::appendConstructor(FunctionDefinition const& _constructor)
 		m_context.appendProgramSize();
 		m_context << Instruction::DUP4 << Instruction::CODECOPY;
 		m_context << Instruction::DUP2 << Instruction::ADD;
+		m_context << Instruction::DUP1;
 		CompilerUtils(m_context).storeFreeMemoryPointer();
 		// stack: <memptr>
 		CompilerUtils(m_context).abiDecode(FunctionType(_constructor).parameterTypes(), true);
@@ -367,6 +368,7 @@ void ContractCompiler::appendFunctionSelector(ContractDefinition const& _contrac
 		{
 			// Parameter for calldataUnpacker
 			m_context << CompilerUtils::dataStartOffset;
+			m_context << Instruction::DUP1 << Instruction::CALLDATASIZE << Instruction::SUB;
 			CompilerUtils(m_context).abiDecode(functionType->parameterTypes());
 		}
 		m_context.appendJumpTo(m_context.functionEntryLabel(functionType->declaration()));

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -90,10 +90,6 @@ private:
 	void appendDelegatecallCheck();
 	void appendFunctionSelector(ContractDefinition const& _contract);
 	void appendCallValueCheck();
-	/// Creates code that unpacks the arguments for the given function represented by a vector of TypePointers.
-	/// From memory if @a _fromMemory is true, otherwise from call data.
-	/// Expects source offset on the stack, which is removed.
-	void appendCalldataUnpacker(TypePointers const& _typeParameters, bool _fromMemory = false);
 	void appendReturnValuePacker(TypePointers const& _typeParameters, bool _isLibrary);
 
 	void registerStateVariables(ContractDefinition const& _contract);

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -3372,6 +3372,11 @@ BOOST_AUTO_TEST_CASE(dynamic_return_types_not_possible)
 			}
 		}
 	)";
+	m_compiler.setEVMVersion(EVMVersion{});
+	CHECK_WARNING(sourceCode, "Use of the \"var\" keyword is deprecated");
+	m_compiler.setEVMVersion(*EVMVersion::fromString("byzantium"));
+	CHECK_WARNING(sourceCode, "Use of the \"var\" keyword is deprecated");
+	m_compiler.setEVMVersion(*EVMVersion::fromString("homestead"));
 	CHECK_ERROR(sourceCode, TypeError, "Explicit type conversion not allowed from \"inaccessible dynamic type\" to \"bytes storage pointer\".");
 }
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3270
Fixes https://github.com/ethereum/solidity/issues/2964
Fixes https://github.com/ethereum/solidity/issues/3273 
Fixes https://github.com/ethereum/solidity/issues/3516

 - [x] add out of bounds checks for the old decoder, but only use it for decoding dynamic return data
 - [x] use evm target selection
 - [x] even if we use the current EVM, do not use the new abi decoder by default
 - [x] add a test case for https://github.com/ethereum/solidity/issues/3516

Depends on https://github.com/ethereum/solidity/pull/3569