### PR TITLE
Split inline assembly into loose and strict flavour.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.20 (unreleased)
 
 Features:
+ * Commandline interface: Support strict mode of assembly with the ``--strict--assembly`` switch.
  * Limit the number of warnings raised for creating abstract contracts.
  * Inline Assembly: Issue warning for using jump labels (already existed for jump instructions).
  * Inline Assembly: Support some restricted tokens (return, byte, address) as identifiers in Julia mode.

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -207,7 +207,7 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 
 	// Will be re-generated later with correct information
 	assembly::AsmAnalysisInfo analysisInfo;
-	assembly::AsmAnalyzer(analysisInfo, errorsIgnored, false, resolver).analyze(_inlineAssembly.operations());
+	assembly::AsmAnalyzer(analysisInfo, errorsIgnored, assembly::AsmFlavour::Loose, resolver).analyze(_inlineAssembly.operations());
 	return false;
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -873,7 +873,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 	assembly::AsmAnalyzer analyzer(
 		*_inlineAssembly.annotation().analysisInfo,
 		m_errorReporter,
-		false,
+		assembly::AsmFlavour::Loose,
 		identifierAccess
 	);
 	if (!analyzer.analyze(_inlineAssembly.operations()))

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -319,14 +319,19 @@ void CompilerContext::appendInlineAssembly(
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	auto scanner = make_shared<Scanner>(CharStream(_assembly), "--CODEGEN--");
-	auto parserResult = assembly::Parser(errorReporter).parse(scanner);
+	auto parserResult = assembly::Parser(errorReporter, assembly::AsmFlavour::Strict).parse(scanner);
 #ifdef SOL_OUTPUT_ASM
 	cout << assembly::AsmPrinter()(*parserResult) << endl;
 #endif
 	assembly::AsmAnalysisInfo analysisInfo;
 	bool analyzerResult = false;
 	if (parserResult)
-		analyzerResult = assembly::AsmAnalyzer(analysisInfo, errorReporter, false, identifierAccess.resolve).analyze(*parserResult);
+		analyzerResult = assembly::AsmAnalyzer(
+			analysisInfo,
+			errorReporter,
+			assembly::AsmFlavour::Strict,
+			identifierAccess.resolve
+		).analyze(*parserResult);
 	if (!parserResult || !errorReporter.errors().empty() || !analyzerResult)
 	{
 		string message =

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -187,8 +187,8 @@ public:
 	CompilerContext& operator<<(u256 const& _value) { m_asm->append(_value); return *this; }
 	CompilerContext& operator<<(bytes const& _data) { m_asm->append(_data); return *this; }
 
-	/// Appends inline assembly. @a _replacements are string-matching replacements that are performed
-	/// prior to parsing the inline assembly.
+	/// Appends inline assembly (strict mode).
+	/// @a _replacements are string-matching replacements that are performed prior to parsing the inline assembly.
 	/// @param _localVariables assigns stack positions to variables with the last one being the stack top
 	/// @param _system if true, this is a "system-level" assembly where all functions use named labels.
 	void appendInlineAssembly(

--- a/libsolidity/inlineasm/AsmAnalysis.h
+++ b/libsolidity/inlineasm/AsmAnalysis.h
@@ -54,9 +54,9 @@ public:
 	explicit AsmAnalyzer(
 		AsmAnalysisInfo& _analysisInfo,
 		ErrorReporter& _errorReporter,
-		bool _julia = false,
+		AsmFlavour _flavour = AsmFlavour::Loose,
 		julia::ExternalIdentifierAccess::Resolver const& _resolver = julia::ExternalIdentifierAccess::Resolver()
-	): m_resolver(_resolver), m_info(_analysisInfo), m_errorReporter(_errorReporter), m_julia(_julia) {}
+	): m_resolver(_resolver), m_info(_analysisInfo), m_errorReporter(_errorReporter), m_flavour(_flavour) {}
 
 	bool analyze(assembly::Block const& _block);
 
@@ -97,7 +97,7 @@ private:
 	std::set<Scope::Variable const*> m_activeVariables;
 	AsmAnalysisInfo& m_info;
 	ErrorReporter& m_errorReporter;
-	bool m_julia = false;
+	AsmFlavour m_flavour = AsmFlavour::Loose;
 };
 
 }

--- a/libsolidity/inlineasm/AsmDataForward.h
+++ b/libsolidity/inlineasm/AsmDataForward.h
@@ -53,6 +53,13 @@ struct TypedName;
 using Expression = boost::variant<FunctionalInstruction, FunctionCall, Identifier, Literal>;
 using Statement = boost::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Block>;
 
+enum class AsmFlavour
+{
+	Loose,  // no types, EVM instructions as function, jumps and direct stack manipulations
+	Strict, // no types, EVM instructions as functions, but no jumps and no direct stack manipulations
+	IULIA   // same as Strict mode with types
+};
+
 }
 }
 }

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -254,17 +254,6 @@ assembly::Expression Parser::parseExpression()
 	if (operation.type() == typeid(Instruction))
 	{
 		Instruction const& instr = boost::get<Instruction>(operation);
-		// Enforce functional notation for instructions requiring multiple arguments.
-		int args = instructionInfo(instr.instruction).args;
-		bool requireFunctionalNotation = (args > 0 || m_flavour != AsmFlavour::Loose);
-		if (requireFunctionalNotation && currentToken() != Token::LParen)
-			fatalParserError(string(
-				"Expected token \"(\" (\"" +
-				instructionNames().at(instr.instruction) +
-				"\" expects " +
-				boost::lexical_cast<string>(args) +
-				" arguments)"
-			));
 		// Disallow instructions returning multiple values (and DUP/SWAP) as expression.
 		if (
 			instructionInfo(instr.instruction).ret != 1 ||
@@ -276,6 +265,17 @@ assembly::Expression Parser::parseExpression()
 				instructionNames().at(instr.instruction) +
 				"\" not allowed in this context."
 			);
+		// Enforce functional notation for instructions requiring multiple arguments.
+		int args = instructionInfo(instr.instruction).args;
+		bool requireFunctionalNotation = (args > 0 || m_flavour != AsmFlavour::Loose);
+		if (requireFunctionalNotation && currentToken() != Token::LParen)
+			fatalParserError(string(
+				"Expected token \"(\" (\"" +
+				instructionNames().at(instr.instruction) +
+				"\" expects " +
+				boost::lexical_cast<string>(args) +
+				" arguments)"
+			));
 	}
 	if (currentToken() == Token::LParen)
 		return parseCall(std::move(operation));

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -103,14 +103,14 @@ assembly::Statement Parser::parseStatement()
 		return parseForLoop();
 	case Token::Assign:
 	{
-		if (m_julia)
+		if (m_flavour != AsmFlavour::Loose)
 			break;
 		assembly::StackAssignment assignment = createWithLocation<assembly::StackAssignment>();
 		advance();
 		expectToken(Token::Colon);
 		assignment.variableName.location = location();
 		assignment.variableName.name = currentLiteral();
-		if (!m_julia && instructions().count(assignment.variableName.name))
+		if (instructions().count(assignment.variableName.name))
 			fatalParserError("Identifier expected, got instruction name.");
 		assignment.location.end = endPosition();
 		expectToken(Token::Identifier);
@@ -170,7 +170,7 @@ assembly::Statement Parser::parseStatement()
 		if (currentToken() == Token::Assign && peekNextToken() != Token::Colon)
 		{
 			assembly::Assignment assignment = createWithLocation<assembly::Assignment>(identifier.location);
-			if (!m_julia && instructions().count(identifier.name))
+			if (m_flavour != AsmFlavour::IULIA && instructions().count(identifier.name))
 				fatalParserError("Cannot use instruction names for identifier names.");
 			advance();
 			assignment.variableNames.emplace_back(identifier);
@@ -181,7 +181,7 @@ assembly::Statement Parser::parseStatement()
 		else
 		{
 			// label
-			if (m_julia)
+			if (m_flavour != AsmFlavour::Loose)
 				fatalParserError("Labels are not supported.");
 			Label label = createWithLocation<Label>(identifier.location);
 			label.name = identifier.name;
@@ -189,7 +189,7 @@ assembly::Statement Parser::parseStatement()
 		}
 	}
 	default:
-		if (m_julia)
+		if (m_flavour != AsmFlavour::Loose)
 			fatalParserError("Call or assignment expected.");
 		break;
 	}
@@ -247,13 +247,17 @@ assembly::ForLoop Parser::parseForLoop()
 assembly::Expression Parser::parseExpression()
 {
 	RecursionGuard recursionGuard(*this);
+	// In strict mode, this might parse a plain Instruction, but
+	// it will be converted to a FunctionalInstruction inside
+	// parseCall below.
 	ElementaryOperation operation = parseElementaryOperation();
 	if (operation.type() == typeid(Instruction))
 	{
 		Instruction const& instr = boost::get<Instruction>(operation);
 		// Enforce functional notation for instructions requiring multiple arguments.
 		int args = instructionInfo(instr.instruction).args;
-		if (args > 0 && currentToken() != Token::LParen)
+		bool requireFunctionalNotation = (args > 0 || m_flavour != AsmFlavour::Loose);
+		if (requireFunctionalNotation && currentToken() != Token::LParen)
 			fatalParserError(string(
 				"Expected token \"(\" (\"" +
 				instructionNames().at(instr.instruction) +
@@ -278,6 +282,7 @@ assembly::Expression Parser::parseExpression()
 	else if (operation.type() == typeid(Instruction))
 	{
 		// Instructions not taking arguments are allowed as expressions.
+		solAssert(m_flavour == AsmFlavour::Loose, "");
 		Instruction& instr = boost::get<Instruction>(operation);
 		return FunctionalInstruction{std::move(instr.location), instr.instruction, {}};
 	}
@@ -351,7 +356,7 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 		else
 			literal = currentLiteral();
 		// first search the set of instructions.
-		if (!m_julia && instructions().count(literal))
+		if (m_flavour != AsmFlavour::IULIA && instructions().count(literal))
 		{
 			dev::solidity::Instruction const& instr = instructions().at(literal);
 			ret = Instruction{location(), instr};
@@ -392,7 +397,7 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 			""
 		};
 		advance();
-		if (m_julia)
+		if (m_flavour == AsmFlavour::IULIA)
 		{
 			expectToken(Token::Colon);
 			literal.location.end = endPosition();
@@ -405,7 +410,7 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 	}
 	default:
 		fatalParserError(
-			m_julia ?
+			m_flavour == AsmFlavour::IULIA ?
 			"Literal or identifier expected." :
 			"Literal, identifier or instruction expected."
 		);
@@ -475,7 +480,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 	RecursionGuard recursionGuard(*this);
 	if (_initialOp.type() == typeid(Instruction))
 	{
-		solAssert(!m_julia, "Instructions are invalid in JULIA");
+		solAssert(m_flavour != AsmFlavour::IULIA, "Instructions are invalid in JULIA");
 		Instruction& instruction = boost::get<Instruction>(_initialOp);
 		FunctionalInstruction ret;
 		ret.instruction = instruction.instruction;
@@ -546,7 +551,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 	}
 	else
 		fatalParserError(
-			m_julia ?
+			m_flavour == AsmFlavour::IULIA ?
 			"Function name expected." :
 			"Assembly instruction or function name required in front of \"(\")"
 		);
@@ -559,7 +564,7 @@ TypedName Parser::parseTypedName()
 	RecursionGuard recursionGuard(*this);
 	TypedName typedName = createWithLocation<TypedName>();
 	typedName.name = expectAsmIdentifier();
-	if (m_julia)
+	if (m_flavour == AsmFlavour::IULIA)
 	{
 		expectToken(Token::Colon);
 		typedName.location.end = endPosition();
@@ -571,7 +576,7 @@ TypedName Parser::parseTypedName()
 string Parser::expectAsmIdentifier()
 {
 	string name = currentLiteral();
-	if (m_julia)
+	if (m_flavour == AsmFlavour::IULIA)
 	{
 		switch (currentToken())
 		{

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -265,10 +265,13 @@ assembly::Expression Parser::parseExpression()
 				instructionNames().at(instr.instruction) +
 				"\" not allowed in this context."
 			);
+		if (m_flavour != AsmFlavour::Loose && currentToken() != Token::LParen)
+			fatalParserError(
+				"Non-functional instructions are not allowed in this context."
+			);
 		// Enforce functional notation for instructions requiring multiple arguments.
 		int args = instructionInfo(instr.instruction).args;
-		bool requireFunctionalNotation = (args > 0 || m_flavour != AsmFlavour::Loose);
-		if (requireFunctionalNotation && currentToken() != Token::LParen)
+		if (args > 0 && currentToken() != Token::LParen)
 			fatalParserError(string(
 				"Expected token \"(\" (\"" +
 				instructionNames().at(instr.instruction) +

--- a/libsolidity/inlineasm/AsmParser.h
+++ b/libsolidity/inlineasm/AsmParser.h
@@ -37,7 +37,8 @@ namespace assembly
 class Parser: public ParserBase
 {
 public:
-	explicit Parser(ErrorReporter& _errorReporter, bool _julia = false): ParserBase(_errorReporter), m_julia(_julia) {}
+	explicit Parser(ErrorReporter& _errorReporter, AsmFlavour _flavour = AsmFlavour::Loose):
+		ParserBase(_errorReporter), m_flavour(_flavour) {}
 
 	/// Parses an inline assembly block starting with `{` and ending with `}`.
 	/// @returns an empty shared pointer on error.
@@ -70,6 +71,9 @@ protected:
 	assembly::Expression parseExpression();
 	static std::map<std::string, dev::solidity::Instruction> const& instructions();
 	static std::map<dev::solidity::Instruction, std::string> const& instructionNames();
+	/// Parses an elementary operation, i.e. a literal, identifier or instruction.
+	/// This will parse instructions even in strict mode as part of the full parser
+	/// for FunctionalInstruction.
 	ElementaryOperation parseElementaryOperation();
 	VariableDeclaration parseVariableDeclaration();
 	FunctionDefinition parseFunctionDefinition();
@@ -80,7 +84,7 @@ protected:
 	static bool isValidNumberLiteral(std::string const& _literal);
 
 private:
-	bool m_julia = false;
+	AsmFlavour m_flavour = AsmFlavour::Loose;
 };
 
 }

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -38,6 +38,23 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
+namespace
+{
+assembly::AsmFlavour languageToAsmFlavour(AssemblyStack::Language _language)
+{
+	switch (_language)
+	{
+	case AssemblyStack::Language::Assembly:
+		return assembly::AsmFlavour::Loose;
+	case AssemblyStack::Language::JULIA:
+		return assembly::AsmFlavour::IULIA;
+	}
+	solAssert(false, "");
+	return assembly::AsmFlavour::IULIA;
+}
+
+}
+
 
 Scanner const& AssemblyStack::scanner() const
 {
@@ -50,7 +67,7 @@ bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string 
 	m_errors.clear();
 	m_analysisSuccessful = false;
 	m_scanner = make_shared<Scanner>(CharStream(_source), _sourceName);
-	m_parserResult = assembly::Parser(m_errorReporter, m_language == Language::JULIA).parse(m_scanner);
+	m_parserResult = assembly::Parser(m_errorReporter, languageToAsmFlavour(m_language)).parse(m_scanner);
 	if (!m_errorReporter.errors().empty())
 		return false;
 	solAssert(m_parserResult, "");
@@ -72,7 +89,7 @@ bool AssemblyStack::analyze(assembly::Block const& _block, Scanner const* _scann
 bool AssemblyStack::analyzeParsed()
 {
 	m_analysisInfo = make_shared<assembly::AsmAnalysisInfo>();
-	assembly::AsmAnalyzer analyzer(*m_analysisInfo, m_errorReporter, m_language == Language::JULIA);
+	assembly::AsmAnalyzer analyzer(*m_analysisInfo, m_errorReporter, languageToAsmFlavour(m_language));
 	m_analysisSuccessful = analyzer.analyze(*m_parserResult);
 	return m_analysisSuccessful;
 }

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -46,6 +46,8 @@ assembly::AsmFlavour languageToAsmFlavour(AssemblyStack::Language _language)
 	{
 	case AssemblyStack::Language::Assembly:
 		return assembly::AsmFlavour::Loose;
+	case AssemblyStack::Language::StrictAssembly:
+		return assembly::AsmFlavour::Strict;
 	case AssemblyStack::Language::JULIA:
 		return assembly::AsmFlavour::IULIA;
 	}

--- a/libsolidity/interface/AssemblyStack.h
+++ b/libsolidity/interface/AssemblyStack.h
@@ -51,7 +51,7 @@ struct MachineAssemblyObject
 class AssemblyStack
 {
 public:
-	enum class Language { JULIA, Assembly };
+	enum class Language { JULIA, Assembly, StrictAssembly };
 	enum class Machine { EVM, EVM15, eWasm };
 
 	explicit AssemblyStack(Language _language = Language::Assembly):

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -97,6 +97,7 @@ static string const g_strJulia = "julia";
 static string const g_strLicense = "license";
 static string const g_strLibraries = "libraries";
 static string const g_strLink = "link";
+static string const g_strMachine = "machine";
 static string const g_strMetadata = "metadata";
 static string const g_strMetadataLiteral = "metadata-literal";
 static string const g_strNatspecDev = "devdoc";
@@ -112,6 +113,7 @@ static string const g_strSourceList = "sourceList";
 static string const g_strSrcMap = "srcmap";
 static string const g_strSrcMapRuntime = "srcmap-runtime";
 static string const g_strStandardJSON = "standard-json";
+static string const g_strStrictAssembly = "strict-assembly";
 static string const g_strPrettyJson = "pretty-json";
 static string const g_strVersion = "version";
 
@@ -134,10 +136,10 @@ static string const g_argFormal = g_strFormal;
 static string const g_argGas = g_strGas;
 static string const g_argHelp = g_strHelp;
 static string const g_argInputFile = g_strInputFile;
-static string const g_argJulia = "julia";
+static string const g_argJulia = g_strJulia;
 static string const g_argLibraries = g_strLibraries;
 static string const g_argLink = g_strLink;
-static string const g_argMachine = "machine";
+static string const g_argMachine = g_strMachine;
 static string const g_argMetadata = g_strMetadata;
 static string const g_argMetadataLiteral = g_strMetadataLiteral;
 static string const g_argNatspecDev = g_strNatspecDev;
@@ -148,6 +150,7 @@ static string const g_argOptimizeRuns = g_strOptimizeRuns;
 static string const g_argOutputDir = g_strOutputDir;
 static string const g_argSignatureHashes = g_strSignatureHashes;
 static string const g_argStandardJSON = g_strStandardJSON;
+static string const g_argStrictAssembly = g_strStrictAssembly;
 static string const g_argVersion = g_strVersion;
 static string const g_stdinFileName = g_stdinFileNameStr;
 
@@ -575,6 +578,10 @@ Allowed options)",
 			"Switch to JULIA mode, ignoring all options except --machine and assumes input is JULIA."
 		)
 		(
+			g_argStrictAssembly.c_str(),
+			"Switch to strict assembly mode, ignoring all options except --machine and assumes input is strict assembly."
+		)
+		(
 			g_argMachine.c_str(),
 			po::value<string>()->value_name(boost::join(g_machineArgs, ",")),
 			"Target machine in assembly or JULIA mode."
@@ -737,13 +744,13 @@ bool CommandLineInterface::processInput()
 			if (!parseLibraryOption(library))
 				return false;
 
-	if (m_args.count(g_argAssemble) || m_args.count(g_argJulia))
+	if (m_args.count(g_argAssemble) || m_args.count(g_argStrictAssembly) || m_args.count(g_argJulia))
 	{
 		// switch to assembly mode
 		m_onlyAssemble = true;
 		using Input = AssemblyStack::Language;
 		using Machine = AssemblyStack::Machine;
-		Input inputLanguage = m_args.count(g_argJulia) ? Input::JULIA : Input::Assembly;
+		Input inputLanguage = m_args.count(g_argJulia) ? Input::JULIA : (m_args.count(g_argStrictAssembly) ? Input::StrictAssembly : Input::Assembly);
 		Machine targetMachine = Machine::EVM;
 		if (m_args.count(g_argMachine))
 		{

--- a/test/libjulia/Common.cpp
+++ b/test/libjulia/Common.cpp
@@ -52,15 +52,16 @@ void dev::julia::test::printErrors(ErrorList const& _errors, Scanner const& _sca
 
 pair<shared_ptr<Block>, shared_ptr<assembly::AsmAnalysisInfo>> dev::julia::test::parse(string const& _source, bool _julia)
 {
+	auto flavour = _julia ? assembly::AsmFlavour::IULIA : assembly::AsmFlavour::Strict;
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	auto scanner = make_shared<Scanner>(CharStream(_source), "");
-	auto parserResult = assembly::Parser(errorReporter, _julia).parse(scanner);
+	auto parserResult = assembly::Parser(errorReporter, flavour).parse(scanner);
 	if (parserResult)
 	{
 		BOOST_REQUIRE(errorReporter.errors().empty());
 		auto analysisInfo = make_shared<assembly::AsmAnalysisInfo>();
-		assembly::AsmAnalyzer analyzer(*analysisInfo, errorReporter, _julia);
+		assembly::AsmAnalyzer analyzer(*analysisInfo, errorReporter, flavour);
 		if (analyzer.analyze(*parserResult))
 		{
 			BOOST_REQUIRE(errorReporter.errors().empty());

--- a/test/libjulia/Parser.cpp
+++ b/test/libjulia/Parser.cpp
@@ -52,11 +52,11 @@ bool parse(string const& _source, ErrorReporter& errorReporter)
 	try
 	{
 		auto scanner = make_shared<Scanner>(CharStream(_source));
-		auto parserResult = assembly::Parser(errorReporter, true).parse(scanner);
+		auto parserResult = assembly::Parser(errorReporter, assembly::AsmFlavour::IULIA).parse(scanner);
 		if (parserResult)
 		{
 			assembly::AsmAnalysisInfo analysisInfo;
-			return (assembly::AsmAnalyzer(analysisInfo, errorReporter, true)).analyze(*parserResult);
+			return (assembly::AsmAnalyzer(analysisInfo, errorReporter, assembly::AsmFlavour::IULIA)).analyze(*parserResult);
 		}
 	}
 	catch (FatalError const&)

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -480,11 +480,11 @@ BOOST_AUTO_TEST_CASE(no_opcodes_in_strict)
 {
 	BOOST_CHECK(successParse("{ pop(callvalue) }"));
 	BOOST_CHECK(successParse("{ callvalue pop }"));
-	CHECK_STRICT_ERROR("{ pop(callvalue) }", ParserError, "Expected token \"(\" (\"callvalue\" expects 0 arguments)");
+	CHECK_STRICT_ERROR("{ pop(callvalue) }", ParserError, "Instruction \"callvalue\" not allowed in this context");
 	CHECK_STRICT_ERROR("{ callvalue pop }", ParserError, "Call or assignment expected");
 	SUCCESS_STRICT("{ pop(callvalue()) }");
 	BOOST_CHECK(successParse("{ switch callvalue case 0 {} }"));
-	CHECK_STRICT_ERROR("{ switch callvalue case 0 {} }", ParserError, "Expected token \"(\" (\"callvalue\" expects 0 arguments)");
+	CHECK_STRICT_ERROR("{ switch callvalue case 0 {} }", ParserError, "Instruction \"callvalue\" not allowed in this context");
 }
 
 BOOST_AUTO_TEST_CASE(no_labels_in_strict)
@@ -509,8 +509,8 @@ BOOST_AUTO_TEST_CASE(no_dup_swap_in_strict)
 	CHECK_STRICT_ERROR("{ swap2 }", ParserError, "Call or assignment expected.");
 	BOOST_CHECK(successParse("{ dup2 pop }"));
 	CHECK_STRICT_ERROR("{ dup2 pop }", ParserError, "Call or assignment expected.");
-	CHECK_PARSE_ERROR("{ switch dup1 case 0 {} }", ParserError, "Expected token \"(\" (\"dup1\" expects 1 arguments)");
-	CHECK_STRICT_ERROR("{ switch dup1 case 0 {} }", ParserError, "Expected token \"(\" (\"dup1\" expects 1 arguments)");
+	CHECK_PARSE_ERROR("{ switch dup1 case 0 {} }", ParserError, "Instruction \"dup1\" not allowed in this context");
+	CHECK_STRICT_ERROR("{ switch dup1 case 0 {} }", ParserError, "Instruction \"dup1\" not allowed in this context");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -51,10 +51,11 @@ boost::optional<Error> parseAndReturnFirstError(
 	string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,
+	AssemblyStack::Language _language = AssemblyStack::Language::Assembly,
 	AssemblyStack::Machine _machine = AssemblyStack::Machine::EVM
 )
 {
-	AssemblyStack stack;
+	AssemblyStack stack(_language);
 	bool success = false;
 	try
 	{
@@ -87,22 +88,29 @@ bool successParse(
 	string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,
+	AssemblyStack::Language _language = AssemblyStack::Language::Assembly,
 	AssemblyStack::Machine _machine = AssemblyStack::Machine::EVM
 )
 {
-	return !parseAndReturnFirstError(_source, _assemble, _allowWarnings, _machine);
+	return !parseAndReturnFirstError(_source, _assemble, _allowWarnings, _language, _machine);
 }
 
-bool successAssemble(string const& _source, bool _allowWarnings = true)
+bool successAssemble(string const& _source, bool _allowWarnings = true, AssemblyStack::Language _language = AssemblyStack::Language::Assembly)
 {
-	return successParse(_source, true, _allowWarnings, AssemblyStack::Machine::EVM) &&
-		successParse(_source, true, _allowWarnings, AssemblyStack::Machine::EVM15);
+	return
+		successParse(_source, true, _allowWarnings, _language, AssemblyStack::Machine::EVM) &&
+		successParse(_source, true, _allowWarnings, _language, AssemblyStack::Machine::EVM15);
 }
 
-Error expectError(std::string const& _source, bool _assemble, bool _allowWarnings = false)
+Error expectError(
+	std::string const& _source,
+	bool _assemble,
+	bool _allowWarnings = false,
+	AssemblyStack::Language _language = AssemblyStack::Language::Assembly
+)
 {
 
-	auto error = parseAndReturnFirstError(_source, _assemble, _allowWarnings);
+	auto error = parseAndReturnFirstError(_source, _assemble, _allowWarnings, _language);
 	BOOST_REQUIRE(error);
 	return *error;
 }
@@ -120,13 +128,16 @@ void parsePrintCompare(string const& _source, bool _canWarn = false)
 
 }
 
-#define CHECK_ERROR(text, assemble, typ, substring, warnings) \
+#define CHECK_ERROR_LANG(text, assemble, typ, substring, warnings, language) \
 do \
 { \
-	Error err = expectError((text), (assemble), warnings); \
+	Error err = expectError((text), (assemble), warnings, (language)); \
 	BOOST_CHECK(err.type() == (Error::Type::typ)); \
 	BOOST_CHECK(searchErrorMessage(err, (substring))); \
 } while(0)
+
+#define CHECK_ERROR(text, assemble, typ, substring, warnings) \
+CHECK_ERROR_LANG(text, assemble, typ, substring, warnings, AssemblyStack::Language::Assembly)
 
 #define CHECK_PARSE_ERROR(text, type, substring) \
 CHECK_ERROR(text, false, type, substring, false)
@@ -137,6 +148,14 @@ CHECK_ERROR(text, false, type, substring, false)
 #define CHECK_ASSEMBLE_ERROR(text, type, substring) \
 CHECK_ERROR(text, true, type, substring, false)
 
+#define CHECK_STRICT_ERROR(text, type, substring) \
+CHECK_ERROR_LANG(text, false, type, substring, false, AssemblyStack::Language::StrictAssembly)
+
+#define CHECK_STRICT_WARNING(text, type, substring) \
+CHECK_ERROR(text, false, type, substring, false, AssemblyStack::Language::StrictAssembly)
+
+#define SUCCESS_STRICT(text) \
+do { successParse((text), false, false, AssemblyStack::Language::StrictAssembly); } while (false)
 
 
 BOOST_AUTO_TEST_SUITE(SolidityInlineAssembly)
@@ -451,6 +470,47 @@ BOOST_AUTO_TEST_CASE(multiple_assignment)
 	}
 	)";
 	BOOST_CHECK(successParse(text));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(LooseStrictMode)
+
+BOOST_AUTO_TEST_CASE(no_opcodes_in_strict)
+{
+	BOOST_CHECK(successParse("{ pop(callvalue) }"));
+	BOOST_CHECK(successParse("{ callvalue pop }"));
+	CHECK_STRICT_ERROR("{ pop(callvalue) }", ParserError, "Expected token \"(\" (\"callvalue\" expects 0 arguments)");
+	CHECK_STRICT_ERROR("{ callvalue pop }", ParserError, "Call or assignment expected");
+	SUCCESS_STRICT("{ pop(callvalue()) }");
+	BOOST_CHECK(successParse("{ switch callvalue case 0 {} }"));
+	CHECK_STRICT_ERROR("{ switch callvalue case 0 {} }", ParserError, "Expected token \"(\" (\"callvalue\" expects 0 arguments)");
+}
+
+BOOST_AUTO_TEST_CASE(no_labels_in_strict)
+{
+	BOOST_CHECK(successParse("{ a: }"));
+	CHECK_STRICT_ERROR("{ a: }", ParserError, "Labels are not supported");
+}
+
+BOOST_AUTO_TEST_CASE(no_stack_assign_in_strict)
+{
+	BOOST_CHECK(successParse("{ let x 4 =: x }"));
+	CHECK_STRICT_ERROR("{ let x 4 =: x }", ParserError, "Call or assignment expected.");
+}
+
+BOOST_AUTO_TEST_CASE(no_dup_swap_in_strict)
+{
+	BOOST_CHECK(successParse("{ swap1 }"));
+	CHECK_STRICT_ERROR("{ swap1 }", ParserError, "Call or assignment expected.");
+	BOOST_CHECK(successParse("{ dup1 pop }"));
+	CHECK_STRICT_ERROR("{ dup1 pop }", ParserError, "Call or assignment expected.");
+	BOOST_CHECK(successParse("{ swap2 }"));
+	CHECK_STRICT_ERROR("{ swap2 }", ParserError, "Call or assignment expected.");
+	BOOST_CHECK(successParse("{ dup2 pop }"));
+	CHECK_STRICT_ERROR("{ dup2 pop }", ParserError, "Call or assignment expected.");
+	CHECK_PARSE_ERROR("{ switch dup1 case 0 {} }", ParserError, "Expected token \"(\" (\"dup1\" expects 1 arguments)");
+	CHECK_STRICT_ERROR("{ switch dup1 case 0 {} }", ParserError, "Expected token \"(\" (\"dup1\" expects 1 arguments)");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -480,11 +480,11 @@ BOOST_AUTO_TEST_CASE(no_opcodes_in_strict)
 {
 	BOOST_CHECK(successParse("{ pop(callvalue) }"));
 	BOOST_CHECK(successParse("{ callvalue pop }"));
-	CHECK_STRICT_ERROR("{ pop(callvalue) }", ParserError, "Instruction \"callvalue\" not allowed in this context");
+	CHECK_STRICT_ERROR("{ pop(callvalue) }", ParserError, "Non-functional instructions are not allowed in this context.");
 	CHECK_STRICT_ERROR("{ callvalue pop }", ParserError, "Call or assignment expected");
 	SUCCESS_STRICT("{ pop(callvalue()) }");
 	BOOST_CHECK(successParse("{ switch callvalue case 0 {} }"));
-	CHECK_STRICT_ERROR("{ switch callvalue case 0 {} }", ParserError, "Instruction \"callvalue\" not allowed in this context");
+	CHECK_STRICT_ERROR("{ switch callvalue case 0 {} }", ParserError, "Non-functional instructions are not allowed in this context.");
 }
 
 BOOST_AUTO_TEST_CASE(no_labels_in_strict)


### PR DESCRIPTION
Fixes #1820. Depends on #3297.