### PR TITLE
add clarity to destructuring assignments with leading comma

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -295,6 +295,7 @@ Solidity internally allows tuple types, i.e. a list of objects of potentially di
             // the rest of the values are discarded.
             (data.length,) = f(); // Sets the length to 7
             // The same can be done on the left side.
+            // If the tuple begins in an empty component, the beginning values are discarded.
             (,data[3]) = f(); // Sets data[3] to 2
             // Components can only be left out at the left-hand-side of assignments, with
             // one exception:


### PR DESCRIPTION
Coming from Javascript, destructuring in Solidity with a leading comma confused me because I initially thought `(,data[3]) = f();` meant discard the first value and get the second value, which would be `true` in this example.  (Which would fail because `data` is a `uint`).

But this doesn't seem to be the case because destructuring in Solidity with a leading comma tells the compiler to destructure from the right side.