### PR TITLE
Avoid output messages size blow-up using huge bignums literals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Features:
  * Type Checker: Issue warning for using ``public`` visibility for interface functions.
 
 Bugfixes:
+ * Error Output: Truncate huge number literals in the middle to avoid output blow-up.
  * Parser: Disallow event declarations with no parameter list.
  * Standard JSON: Populate the ``sourceLocation`` field in the error list.
  * Standard JSON: Properly support contract and library file names containing a colon (such as URLs).

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -949,25 +949,25 @@ bool RationalNumberType::operator==(Type const& _other) const
 	return m_value == other.m_value;
 }
 
-string RationalNumberType::bigintToString(dev::bigint const& _num, bool _short)
+string RationalNumberType::bigintToReadableString(dev::bigint const& _num)
 {
 	string str = _num.str();
-	if (_short && str.size() > 32)
+	if (str.size() > 32)
 	{
 		int omitted = str.size() - 8;
-		return str.substr(0, 4) + "...(" + to_string(omitted) + " digits omitted)..." + str.substr(str.size() - 4, 4);
+		str = str.substr(0, 4) + "...(" + to_string(omitted) + " digits omitted)..." + str.substr(str.size() - 4, 4);
 	}
 	return str;
 }
 
-string RationalNumberType::toString(bool _short) const
+string RationalNumberType::toString(bool) const
 {
 	if (!isFractional())
-		return "int_const " + bigintToString(m_value.numerator(), _short);
+		return "int_const " + bigintToReadableString(m_value.numerator());
 
-	string numerator = bigintToString(m_value.numerator(), _short);
-	string denominator = bigintToString(m_value.denominator(), _short);
-	return "rational_const " + numerator + '/' + denominator;
+	string numerator = bigintToReadableString(m_value.numerator());
+	string denominator = bigintToReadableString(m_value.denominator());
+	return "rational_const " + numerator + " / " + denominator;
 }
 
 u256 RationalNumberType::literalValue(Literal const*) const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -949,11 +949,25 @@ bool RationalNumberType::operator==(Type const& _other) const
 	return m_value == other.m_value;
 }
 
-string RationalNumberType::toString(bool) const
+string RationalNumberType::bigintToString(dev::bigint const& _num, bool _short)
+{
+	string str = _num.str();
+	if (_short && str.size() > 32)
+	{
+		int omitted = str.size() - 8;
+		return str.substr(0, 4) + "...(" + to_string(omitted) + " digits omitted)..." + str.substr(str.size() - 4, 4);
+	}
+	return str;
+}
+
+string RationalNumberType::toString(bool _short) const
 {
 	if (!isFractional())
-		return "int_const " + m_value.numerator().str();
-	return "rational_const " + m_value.numerator().str() + '/' + m_value.denominator().str();
+		return "int_const " + bigintToString(m_value.numerator(), _short);
+
+	string numerator = bigintToString(m_value.numerator(), _short);
+	string denominator = bigintToString(m_value.denominator(), _short);
+	return "rational_const " + numerator + '/' + denominator;
 }
 
 u256 RationalNumberType::literalValue(Literal const*) const

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -440,7 +440,7 @@ private:
 
 	/// @returns a truncated readable representation of the bigint keeping only
 	/// up to 4 leading and 4 trailing digits.
-	static std::string bigintToString(dev::bigint const& num, bool _short);
+	static std::string bigintToReadableString(dev::bigint const& num);
 };
 
 /**

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -437,6 +437,10 @@ private:
 
 	/// @returns true if the literal is a valid rational number.
 	static std::tuple<bool, rational> parseRational(std::string const& _value);
+
+	/// @returns a truncated readable representation of the bigint keeping only
+	/// up to 4 leading and 4 trailing digits.
+	static std::string bigintToString(dev::bigint const& num, bool _short);
 };
 
 /**

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1752,7 +1752,7 @@ BOOST_AUTO_TEST_CASE(overflow_caused_by_ether_units)
 			uint256 a;
 		}
 	)";
-	CHECK_ERROR(sourceCode, TypeError, "Type int_const 115792089237316195423570985008687907853269984665640564039458000000000000000000 is not implicitly convertible to expected type uint256.");
+	CHECK_ERROR(sourceCode, TypeError, "Type int_const 1157...(70 digits omitted)...0000 is not implicitly convertible to expected type uint256.");
 }
 
 BOOST_AUTO_TEST_CASE(exp_operator_exponent_too_big)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -4574,7 +4574,7 @@ BOOST_AUTO_TEST_CASE(rational_index_access)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "rational_const 1/2 is not implicitly convertible to expected type uint256");
+	CHECK_ERROR(text, TypeError, "rational_const 1 / 2 is not implicitly convertible to expected type uint256");
 }
 
 BOOST_AUTO_TEST_CASE(rational_to_fixed_literal_expression)


### PR DESCRIPTION
Fixes #3328 

Example output:
```
test.sol:4:5: Error: Operator + not compatible with types int_const 1000...(93 digits omitted)...0000 and literal_string "foo"
    1e100 + "foo";
    ^-----------^
``` 