### PR TITLE
Properly support library file names containing a colon (such as URLs).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ Features:
 Bugfixes:
  * Parser: Disallow event declarations with no parameter list.
  * Standard JSON: Populate the ``sourceLocation`` field in the error list.
- * Standard JSON: Properly support file names containing a colon (such as URLs).
+ * Standard JSON: Properly support contract and library file names containing a colon (such as URLs).
  * Type Checker: Suggest the experimental ABI encoder if using ``struct``s as function parameters
    (instead of an internal compiler error).
  * Type Checker: Improve error message for wrong struct initialization.

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -193,7 +193,7 @@ Json::Value formatLinkReferences(std::map<size_t, std::string> const& linkRefere
 	for (auto const& ref: linkReferences)
 	{
 		string const& fullname = ref.second;
-		size_t colon = fullname.find(':');
+		size_t colon = fullname.rfind(':');
 		solAssert(colon != string::npos, "");
 		string file = fullname.substr(0, colon);
 		string name = fullname.substr(colon + 1);


### PR DESCRIPTION
Missed in #3369.