### PR TITLE
Case convention clarification

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -719,7 +719,7 @@ Events should be named using the CapWords style. Examples: ``Deposit``, ``Transf
 Function Names
 ==============
 
-Functions should use mixedCase. Examples: ``getBalance``, ``transfer``, ``verifyOwner``, ``addMember``, ``changeOwner``.
+Functions other than constructors should use mixedCase. Examples: ``getBalance``, ``transfer``, ``verifyOwner``, ``addMember``, ``changeOwner``.
 
 
 Function Argument Names


### PR DESCRIPTION
Constructors follow the contract naming convention, using CapWords, instead of mixedCase.