### PR TITLE
Made install_deps.sh safe to use on Arch Linux

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -137,7 +137,7 @@ case $(uname -s) in
                 # All our dependencies can be found in the Arch Linux official repositories.
                 # See https://wiki.archlinux.org/index.php/Official_repositories
                 # Also adding ethereum-git to allow for testing with the `eth` client
-                sudo pacman -Sy \
+                sudo pacman -Syu \
                     base-devel \
                     boost \
                     cmake \


### PR DESCRIPTION
After cloning the repo, I saw that in `scripts/install_deps.sh` installing dependencies  in Arch Linux is done with `pacman -Sy ...` which is discouraged in the [official Wiki](https://wiki.archlinux.org/index.php/pacman#Installing_packages) as it can lead to dependency issues and break the system.