### PR TITLE
SMTChecker: A little refactoring on SSA vars (preparation for Bool)

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -370,7 +370,7 @@ void SMTChecker::endVisit(Identifier const& _identifier)
 	{
 		// Will be translated as part of the node that requested the lvalue.
 	}
-	else if (dynamic_cast<IntegerType const*>(_identifier.annotation().type.get()))
+	else if (SSAVariable::supportedType(_identifier.annotation().type.get()))
 		defineExpr(_identifier, currentValue(*decl));
 	else if (FunctionType const* fun = dynamic_cast<FunctionType const*>(_identifier.annotation().type.get()))
 	{
@@ -728,7 +728,7 @@ void SMTChecker::mergeVariables(vector<Declaration const*> const& _variables, sm
 
 bool SMTChecker::createVariable(VariableDeclaration const& _varDecl)
 {
-	if (dynamic_cast<IntegerType const*>(_varDecl.type().get()))
+	if (SSAVariable::supportedType(_varDecl.type().get()))
 	{
 		solAssert(m_variables.count(&_varDecl) == 0, "");
 		m_variables.emplace(&_varDecl, SSAVariable(&_varDecl, *m_interface));

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include <libsolidity/formal/SSAVariable.h>
+#include <libsolidity/formal/SymbolicIntVariable.h>
 #include <libsolidity/formal/VariableUsage.h>
 
 #include <libsolidity/interface/ErrorReporter.h>
@@ -244,14 +245,14 @@ void SMTChecker::endVisit(TupleExpression const& _tuple)
 void SMTChecker::checkUnderOverflow(smt::Expression _value, IntegerType const& _type, SourceLocation const& _location)
 {
 	checkCondition(
-		_value < minValue(_type),
+		_value < SymbolicIntVariable::minValue(_type),
 		_location,
 		"Underflow (resulting value less than " + formatNumber(_type.minValue()) + ")",
 		"value",
 		&_value
 	);
 	checkCondition(
-		_value > maxValue(_type),
+		_value > SymbolicIntVariable::maxValue(_type),
 		_location,
 		"Overflow (resulting value larger than " + formatNumber(_type.maxValue()) + ")",
 		"value",
@@ -828,15 +829,6 @@ void SMTChecker::defineExpr(Expression const& _e, smt::Expression _value)
 	m_interface->addAssertion(expr(_e) == _value);
 }
 
-smt::Expression SMTChecker::minValue(IntegerType const& _t)
-{
-	return smt::Expression(_t.minValue());
-}
-
-smt::Expression SMTChecker::maxValue(IntegerType const& _t)
-{
-	return smt::Expression(_t.maxValue());
-}
 void SMTChecker::popPathCondition()
 {
 	solAssert(m_pathConditions.size() > 0, "Cannot pop path condition, empty.");

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -140,9 +140,6 @@ private:
 	/// Resets the variable to an unknown value (in its range).
 	void setUnknownValue(Declaration const& decl);
 
-	static smt::Expression minValue(IntegerType const& _t);
-	static smt::Expression maxValue(IntegerType const& _t);
-
 	/// Returns the expression corresponding to the AST node. Throws if the expression does not exist.
 	smt::Expression expr(Expression const& _e);
 	/// Creates the expression (value can be arbitrary)

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -20,6 +20,8 @@
 
 #include <libsolidity/formal/SolverInterface.h>
 
+#include <libsolidity/formal/SSAVariable.h>
+
 #include <libsolidity/ast/ASTVisitor.h>
 
 #include <libsolidity/interface/ReadFile.h>
@@ -76,7 +78,7 @@ private:
 	void assignment(Declaration const& _variable, smt::Expression const& _value, SourceLocation const& _location);
 
 	/// Maps a variable to an SSA index.
-	using VariableSequenceCounters = std::map<Declaration const*, int>;
+	using VariableSequenceCounters = std::map<Declaration const*, SSAVariable>;
 
 	/// Visits the branch given by the statement, pushes and pops the current path conditions.
 	/// @param _condition if present, asserts that this condition is true within the branch.
@@ -118,7 +120,6 @@ private:
 	/// This fails if the type is not supported.
 	bool createVariable(VariableDeclaration const& _varDecl);
 
-	static std::string uniqueSymbol(Declaration const& _decl);
 	static std::string uniqueSymbol(Expression const& _expr);
 
 	/// @returns true if _delc is a variable that is known at the current point, i.e.
@@ -148,9 +149,6 @@ private:
 	void createExpr(Expression const& _e);
 	/// Creates the expression and sets its value.
 	void defineExpr(Expression const& _e, smt::Expression _value);
-	/// Returns the function declaration corresponding to the given variable.
-	/// The function takes one argument which is the "sequence number".
-	smt::Expression var(Declaration const& _decl);
 
 	/// Adds a new path condition
 	void pushPathCondition(smt::Expression const& _e);
@@ -166,10 +164,8 @@ private:
 	std::shared_ptr<smt::SolverInterface> m_interface;
 	std::shared_ptr<VariableUsage> m_variableUsage;
 	bool m_conditionalExecutionHappened = false;
-	std::map<Declaration const*, int> m_currentSequenceCounter;
-	std::map<Declaration const*, int> m_nextFreeSequenceCounter;
 	std::map<Expression const*, smt::Expression> m_expressions;
-	std::map<Declaration const*, smt::Expression> m_variables;
+	std::map<Declaration const*, SSAVariable> m_variables;
 	std::vector<smt::Expression> m_pathConditions;
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -1,0 +1,66 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/formal/SSAVariable.h>
+
+#include <libsolidity/formal/SymbolicIntVariable.h>
+
+#include <libsolidity/ast/AST.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+SSAVariable::SSAVariable(Declaration const* _decl,
+	smt::SolverInterface& _interface)
+{
+	resetIndex();
+
+	if (dynamic_cast<IntegerType const*>(_decl->type().get()))
+		m_symbVar = make_shared<SymbolicIntVariable>(_decl, _interface);
+	else
+	{
+		//solAssert(false, "");
+	}
+}
+
+void SSAVariable::resetIndex()
+{
+	m_currentSequenceCounter = 0;
+	m_nextFreeSequenceCounter.reset (new int);
+	*m_nextFreeSequenceCounter = 1;
+}
+
+int SSAVariable::index() const
+{
+	return m_currentSequenceCounter;
+}
+
+int SSAVariable::next() const
+{
+	return *m_nextFreeSequenceCounter;
+}
+
+void SSAVariable::setZeroValue()
+{
+	m_symbVar->setZeroValue(index());
+}
+
+void SSAVariable::setUnknownValue()
+{
+	m_symbVar->setUnknownValue(index());
+}

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -34,8 +34,13 @@ SSAVariable::SSAVariable(Declaration const* _decl,
 		m_symbVar = make_shared<SymbolicIntVariable>(_decl, _interface);
 	else
 	{
-		//solAssert(false, "");
+		solAssert(false, "");
 	}
+}
+
+bool SSAVariable::supportedType(Type const* _decl)
+{
+	return dynamic_cast<IntegerType const*>(_decl);
 }
 
 void SSAVariable::resetIndex()

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -25,13 +25,15 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-SSAVariable::SSAVariable(Declaration const* _decl,
-	smt::SolverInterface& _interface)
+SSAVariable::SSAVariable(
+	Declaration const* _decl,
+	smt::SolverInterface& _interface
+)
 {
 	resetIndex();
 
 	if (dynamic_cast<IntegerType const*>(_decl->type().get()))
-		m_symbVar = make_shared<SymbolicIntVariable>(_decl, _interface);
+		m_symbolicVar = make_shared<SymbolicIntVariable>(_decl, _interface);
 	else
 	{
 		solAssert(false, "");
@@ -62,10 +64,10 @@ int SSAVariable::next() const
 
 void SSAVariable::setZeroValue()
 {
-	m_symbVar->setZeroValue(index());
+	m_symbolicVar->setZeroValue(index());
 }
 
 void SSAVariable::setUnknownValue()
 {
-	m_symbVar->setUnknownValue(index());
+	m_symbolicVar->setUnknownValue(index());
 }

--- a/libsolidity/formal/SSAVariable.h
+++ b/libsolidity/formal/SSAVariable.h
@@ -36,8 +36,10 @@ class SSAVariable
 public:
 	/// @param _decl Used to determine the type and forwarded to the symbolic var.
 	/// @param _interface Forwarded to the symbolic var such that it can give constraints to the solver.
-	explicit SSAVariable(Declaration const* _decl,
-		smt::SolverInterface& _interface);
+	SSAVariable(
+		Declaration const* _decl,
+		smt::SolverInterface& _interface
+	);
 	SSAVariable(SSAVariable const&) = default;
 	SSAVariable(SSAVariable&&) = default;
 	SSAVariable& operator=(SSAVariable const&) = default;
@@ -45,7 +47,9 @@ public:
 
 	void resetIndex();
 
+	/// This function returns the current index of this SSA variable.
 	int index() const;
+	/// This function returns the next free index of this SSA variable.
 	int next() const;
 
 	int operator++()
@@ -74,10 +78,10 @@ public:
 private:
 	smt::Expression valueAtSequence(int _seq) const
 	{
-		return (*m_symbVar)(_seq);
+		return (*m_symbolicVar)(_seq);
 	}
 
-	std::shared_ptr<SymbolicVariable> m_symbVar = nullptr;
+	std::shared_ptr<SymbolicVariable> m_symbolicVar = nullptr;
 	int m_currentSequenceCounter;
 	/// The next free sequence counter is a shared pointer because we want
 	/// the copy and the copied to share it.

--- a/libsolidity/formal/SSAVariable.h
+++ b/libsolidity/formal/SSAVariable.h
@@ -40,10 +40,6 @@ public:
 		Declaration const* _decl,
 		smt::SolverInterface& _interface
 	);
-	SSAVariable(SSAVariable const&) = default;
-	SSAVariable(SSAVariable&&) = default;
-	SSAVariable& operator=(SSAVariable const&) = default;
-	SSAVariable& operator=(SSAVariable&&) = default;
 
 	void resetIndex();
 

--- a/libsolidity/formal/SSAVariable.h
+++ b/libsolidity/formal/SSAVariable.h
@@ -1,0 +1,79 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolidity/formal/SymbolicVariable.h>
+
+#include <memory>
+
+namespace dev
+{
+namespace solidity
+{
+
+class Declaration;
+
+/**
+ * This class represents the SSA representation of a program variable.
+ */
+class SSAVariable
+{
+public:
+	explicit SSAVariable(Declaration const* _decl,
+		smt::SolverInterface& _interface);
+	SSAVariable(SSAVariable const&) = default;
+	SSAVariable(SSAVariable&&) = default;
+	SSAVariable& operator=(SSAVariable const&) = default;
+	SSAVariable& operator=(SSAVariable&&) = default;
+
+	void resetIndex();
+
+	int index() const;
+	int next() const;
+
+	int operator++()
+	{
+		return m_currentSequenceCounter = (*m_nextFreeSequenceCounter)++;
+	}
+
+	smt::Expression operator()() const
+	{
+		return valueAtSequence(index());
+	}
+
+	smt::Expression operator()(int _seq) const
+	{
+		return valueAtSequence(_seq);
+	}
+
+	void setZeroValue();
+	void setUnknownValue();
+
+private:
+	smt::Expression valueAtSequence(int _seq) const
+	{
+		return (*m_symbVar)(_seq);
+	}
+
+	std::shared_ptr<SymbolicVariable> m_symbVar = nullptr;
+	int m_currentSequenceCounter;
+	std::shared_ptr<int> m_nextFreeSequenceCounter;
+};
+
+}
+}

--- a/libsolidity/formal/SSAVariable.h
+++ b/libsolidity/formal/SSAVariable.h
@@ -34,6 +34,8 @@ class Declaration;
 class SSAVariable
 {
 public:
+	/// @param _decl Used to determine the type and forwarded to the symbolic var.
+	/// @param _interface Forwarded to the symbolic var such that it can give constraints to the solver.
 	explicit SSAVariable(Declaration const* _decl,
 		smt::SolverInterface& _interface);
 	SSAVariable(SSAVariable const&) = default;
@@ -61,8 +63,13 @@ public:
 		return valueAtSequence(_seq);
 	}
 
+	/// These two functions forward the call to the symbolic var
+	/// which generates the constraints according to the type.
 	void setZeroValue();
 	void setUnknownValue();
+
+	/// So far Int is supported.
+	static bool supportedType(Type const* _decl);
 
 private:
 	smt::Expression valueAtSequence(int _seq) const
@@ -72,6 +79,8 @@ private:
 
 	std::shared_ptr<SymbolicVariable> m_symbVar = nullptr;
 	int m_currentSequenceCounter;
+	/// The next free sequence counter is a shared pointer because we want
+	/// the copy and the copied to share it.
 	std::shared_ptr<int> m_nextFreeSequenceCounter;
 };
 

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -23,9 +23,11 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-SymbolicIntVariable::SymbolicIntVariable(Declaration const* _decl,
-	smt::SolverInterface&_interface)
-	: SymbolicVariable(_decl, _interface)
+SymbolicIntVariable::SymbolicIntVariable(
+	Declaration const* _decl,
+	smt::SolverInterface& _interface
+):
+	SymbolicVariable(_decl, _interface)
 {
 	solAssert(m_declaration->type()->category() == Type::Category::Integer, "");
 	m_expression = make_shared<smt::Expression>(m_interface.newFunction(uniqueSymbol(), smt::Sort::Int, smt::Sort::Int));

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -43,12 +43,12 @@ void SymbolicIntVariable::setUnknownValue(int _seq)
 	m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(intType));
 }
 
-smt::Expression SymbolicIntVariable::minValue(IntegerType const& _t) const
+smt::Expression SymbolicIntVariable::minValue(IntegerType const& _t)
 {
 	return smt::Expression(_t.minValue());
 }
 
-smt::Expression SymbolicIntVariable::maxValue(IntegerType const& _t) const
+smt::Expression SymbolicIntVariable::maxValue(IntegerType const& _t)
 {
 	return smt::Expression(_t.maxValue());
 }

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -1,0 +1,54 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/formal/SymbolicIntVariable.h>
+
+#include <libsolidity/ast/AST.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+SymbolicIntVariable::SymbolicIntVariable(Declaration const* _decl,
+	smt::SolverInterface&_interface)
+	: SymbolicVariable(_decl, _interface)
+{
+	solAssert(m_declaration->type()->category() == Type::Category::Integer, "");
+	m_expression = make_shared<smt::Expression>(m_interface.newFunction(uniqueSymbol(), smt::Sort::Int, smt::Sort::Int));
+}
+
+void SymbolicIntVariable::setZeroValue(int _seq)
+{
+	m_interface.addAssertion(valueAtSequence(_seq) == 0);
+}
+
+void SymbolicIntVariable::setUnknownValue(int _seq)
+{
+	auto const& intType = dynamic_cast<IntegerType const&>(*m_declaration->type());
+	m_interface.addAssertion(valueAtSequence(_seq) >= minValue(intType));
+	m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(intType));
+}
+
+smt::Expression SymbolicIntVariable::minValue(IntegerType const& _t) const
+{
+	return smt::Expression(_t.minValue());
+}
+
+smt::Expression SymbolicIntVariable::maxValue(IntegerType const& _t) const
+{
+	return smt::Expression(_t.maxValue());
+}

--- a/libsolidity/formal/SymbolicIntVariable.h
+++ b/libsolidity/formal/SymbolicIntVariable.h
@@ -29,11 +29,13 @@ namespace solidity
 /**
  * Specialization of SymbolicVariable for Integers
  */
-class SymbolicIntVariable : public SymbolicVariable
+class SymbolicIntVariable: public SymbolicVariable
 {
 public:
-	explicit SymbolicIntVariable(Declaration const* _decl,
-		smt::SolverInterface& _interface);
+	SymbolicIntVariable(
+		Declaration const* _decl,
+		smt::SolverInterface& _interface
+	);
 	SymbolicIntVariable(SymbolicIntVariable const&) = default;
 	SymbolicIntVariable(SymbolicIntVariable&&) = default;
 	SymbolicIntVariable& operator=(SymbolicIntVariable const&) = default;
@@ -41,7 +43,7 @@ public:
 
 	/// Sets the var to 0.
 	void setZeroValue(int _seq);
-	/// Sets the valid interval for the var.
+	/// Sets the variable to the full valid value range.
 	void setUnknownValue(int _seq);
 
 	static smt::Expression minValue(IntegerType const& _t);

--- a/libsolidity/formal/SymbolicIntVariable.h
+++ b/libsolidity/formal/SymbolicIntVariable.h
@@ -36,10 +36,6 @@ public:
 		Declaration const* _decl,
 		smt::SolverInterface& _interface
 	);
-	SymbolicIntVariable(SymbolicIntVariable const&) = default;
-	SymbolicIntVariable(SymbolicIntVariable&&) = default;
-	SymbolicIntVariable& operator=(SymbolicIntVariable const&) = default;
-	SymbolicIntVariable& operator=(SymbolicIntVariable&&) = default;
 
 	/// Sets the var to 0.
 	void setZeroValue(int _seq);

--- a/libsolidity/formal/SymbolicIntVariable.h
+++ b/libsolidity/formal/SymbolicIntVariable.h
@@ -1,0 +1,51 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolidity/formal/SymbolicVariable.h>
+
+#include <libsolidity/ast/Types.h>
+
+namespace dev
+{
+namespace solidity
+{
+
+/**
+ * Specialization of SymbolicVariable for Integers
+ */
+class SymbolicIntVariable : public SymbolicVariable
+{
+public:
+	explicit SymbolicIntVariable(Declaration const* _decl,
+		smt::SolverInterface& _interface);
+	SymbolicIntVariable(SymbolicIntVariable const&) = default;
+	SymbolicIntVariable(SymbolicIntVariable&&) = default;
+	SymbolicIntVariable& operator=(SymbolicIntVariable const&) = default;
+	SymbolicIntVariable& operator=(SymbolicIntVariable&&) = default;
+
+	void setZeroValue(int _seq);
+	void setUnknownValue(int _seq);
+
+private:
+	smt::Expression minValue(IntegerType const& _t) const;
+	smt::Expression maxValue(IntegerType const& _t) const;
+};
+
+}
+}

--- a/libsolidity/formal/SymbolicIntVariable.h
+++ b/libsolidity/formal/SymbolicIntVariable.h
@@ -39,12 +39,13 @@ public:
 	SymbolicIntVariable& operator=(SymbolicIntVariable const&) = default;
 	SymbolicIntVariable& operator=(SymbolicIntVariable&&) = default;
 
+	/// Sets the var to 0.
 	void setZeroValue(int _seq);
+	/// Sets the valid interval for the var.
 	void setUnknownValue(int _seq);
 
-private:
-	smt::Expression minValue(IntegerType const& _t) const;
-	smt::Expression maxValue(IntegerType const& _t) const;
+	static smt::Expression minValue(IntegerType const& _t);
+	static smt::Expression maxValue(IntegerType const& _t);
 };
 
 }

--- a/libsolidity/formal/SymbolicVariable.cpp
+++ b/libsolidity/formal/SymbolicVariable.cpp
@@ -1,0 +1,38 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/formal/SymbolicVariable.h>
+
+#include <libsolidity/ast/AST.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+SymbolicVariable::SymbolicVariable(Declaration const* _decl,
+	smt::SolverInterface& _interface)
+	: m_declaration(_decl),
+	m_interface(_interface)
+{
+}
+
+string SymbolicVariable::uniqueSymbol() const
+{
+	return m_declaration->name() + "_" + to_string(m_declaration->id());
+}
+
+

--- a/libsolidity/formal/SymbolicVariable.cpp
+++ b/libsolidity/formal/SymbolicVariable.cpp
@@ -23,9 +23,11 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-SymbolicVariable::SymbolicVariable(Declaration const* _decl,
-	smt::SolverInterface& _interface)
-	: m_declaration(_decl),
+SymbolicVariable::SymbolicVariable(
+	Declaration const* _decl,
+	smt::SolverInterface& _interface
+):
+	m_declaration(_decl),
 	m_interface(_interface)
 {
 }

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -36,8 +36,10 @@ class Declaration;
 class SymbolicVariable
 {
 public:
-	explicit SymbolicVariable(Declaration const* _decl,
-		smt::SolverInterface& _interface);
+	SymbolicVariable(
+		Declaration const* _decl,
+		smt::SolverInterface& _interface
+	);
 	SymbolicVariable(SymbolicVariable const&) = default;
 	SymbolicVariable(SymbolicVariable&&) = default;
 	SymbolicVariable& operator=(SymbolicVariable const&) = default;
@@ -52,8 +54,8 @@ public:
 
 	/// Sets the var to the default value of its type.
 	virtual void setZeroValue(int _seq) = 0;
-	/// The unknown value depends on the type. For example, an interval is set for Integers.
-	/// This is decided by the subclasses.
+	/// The unknown value is the full range of valid values,
+	/// and that's sub-type dependent.
 	virtual void setUnknownValue(int _seq) = 0;
 
 protected:

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -1,0 +1,68 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolidity/formal/SolverInterface.h>
+
+#include <libsolidity/ast/AST.h>
+
+#include <memory>
+
+namespace dev
+{
+namespace solidity
+{
+
+class Declaration;
+
+/**
+ * This class represents the symbolic version of a program variable.
+ */
+class SymbolicVariable
+{
+public:
+	explicit SymbolicVariable(Declaration const* _decl,
+		smt::SolverInterface& _interface);
+	SymbolicVariable(SymbolicVariable const&) = default;
+	SymbolicVariable(SymbolicVariable&&) = default;
+	SymbolicVariable& operator=(SymbolicVariable const&) = default;
+	SymbolicVariable& operator=(SymbolicVariable&&) = default;
+
+	smt::Expression operator()(int _seq) const
+	{
+		return valueAtSequence(_seq);
+	}
+
+	std::string uniqueSymbol() const;
+
+	virtual void setZeroValue(int _seq) = 0;
+	virtual void setUnknownValue(int _seq) = 0;
+
+protected:
+	smt::Expression valueAtSequence(int _seq) const
+	{
+		return (*m_expression)(_seq);
+	}
+
+	Declaration const* m_declaration;
+	std::shared_ptr<smt::Expression> m_expression = nullptr;
+	smt::SolverInterface& m_interface;
+};
+
+}
+}

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -40,10 +40,6 @@ public:
 		Declaration const* _decl,
 		smt::SolverInterface& _interface
 	);
-	SymbolicVariable(SymbolicVariable const&) = default;
-	SymbolicVariable(SymbolicVariable&&) = default;
-	SymbolicVariable& operator=(SymbolicVariable const&) = default;
-	SymbolicVariable& operator=(SymbolicVariable&&) = default;
 
 	smt::Expression operator()(int _seq) const
 	{

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -50,7 +50,10 @@ public:
 
 	std::string uniqueSymbol() const;
 
+	/// Sets the var to the default value of its type.
 	virtual void setZeroValue(int _seq) = 0;
+	/// The unknown value depends on the type. For example, an interval is set for Integers.
+	/// This is decided by the subclasses.
 	virtual void setUnknownValue(int _seq) = 0;
 
 protected:


### PR DESCRIPTION
The idea is to remove the SSA reasoning from the SMTChecker class and do it somewhere else, in this case, symbolic vars of each type have their own classes.

The code isn't ready to merge (still not fully documented, debug, etc), but I wanted to start a discussion. Some points:

- Is the code separation reasonable? :+1: 
- Where should functions `minValue` and `maxValue` stay?
- A pointer to the solver (`m_interface`) is passed to the var. :+1: (reference)
- Variables are now pushed and popped inside branches. :x: (copy instead)
- Zero and default unknown values are now defined in the specific var type class. :+1: 
- The addition of support to `Bool` should be easier now.