### PR TITLE
Add comment to clarify example

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -939,6 +939,8 @@ derived override, but this function will bypass
         function kill() public { /* do cleanup 2 */ super.kill(); }
     }
 
+    // note that the ordering of inherited contracts has been reversed from the above example to ensure that 
+    // 'do cleanup 1' is run before 'do cleanup 2'
     contract Final is Base2, Base1 {
     }
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -939,9 +939,7 @@ derived override, but this function will bypass
         function kill() public { /* do cleanup 2 */ super.kill(); }
     }
 
-    // note that the ordering of inherited contracts has been reversed from the above example to ensure that 
-    // 'do cleanup 1' is run before 'do cleanup 2'
-    contract Final is Base2, Base1 {
+    contract Final is Base1, Base2 {
     }
 
 If ``Base1`` calls a function of ``super``, it does not simply


### PR DESCRIPTION
It's quite subtle and confusing that the ordering of the inheritance declaration changes between the first and second examples in these docs. 

I've added a comment which guesses at the reason for this, but it might not be the right approach, and the author's intent might be something different, or not to have reversed them at all. It's not clear to me that the different functions are meant to run in a specific order.