### PR TITLE
Update using-the-compiler.rst

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -147,11 +147,11 @@ Input Description
           },
           // Enable the abi and opcodes output of MyContract defined in file def.
           "def": {
-            "MyContract": [ "abi", "evm.opcodes" ]
+            "MyContract": [ "abi", "evm.bytecode.opcodes" ]
           },
           // Enable the source map output of every single contract.
           "*": {
-            "*": [ "evm.sourceMap" ]
+            "*": [ "evm.bytecode.sourceMap" ]
           },
           // Enable the legacy AST output of every single file.
           "*": {


### PR DESCRIPTION
 in outputSelection section of Compiler Input and Output JSON Description:
"evm.sourceMap" should be "evm.bytecode.sourceMap"
"evm.opcodes"  should be "evm.bytecode.opcodes"