### PR TITLE
Deprecate the var keyword in SyntaxChecker

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Features:
  * Inline Assembly: Support some restricted tokens (return, byte, address) as identifiers in Julia mode.
  * SMT Checker: If-else branch conditions are taken into account in the SMT encoding of the program
    variables.
+ * Syntax Checker: Deprecate the ``var`` keyword (and mark it an error as experimental 0.5.0 feature).
  * Type Checker: Issue warning for using ``public`` visibility for interface functions.
 
 Bugfixes:

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -224,3 +224,17 @@ bool SyntaxChecker::visit(FunctionTypeName const& _node)
 
 	return true;
 }
+
+bool SyntaxChecker::visit(VariableDeclaration const& _declaration)
+{
+	bool const v050 = m_sourceUnit->annotation().experimentalFeatures.count(ExperimentalFeature::V050);
+
+	if (!_declaration.typeName())
+	{
+		if (v050)
+			m_errorReporter.syntaxError(_declaration.location(), "Use of the \"var\" keyword is deprecated.");
+		else
+			m_errorReporter.warning(_declaration.location(), "Use of the \"var\" keyword is deprecated.");
+	}
+	return true;
+}

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -69,6 +69,8 @@ private:
 	virtual bool visit(FunctionDefinition const& _function) override;
 	virtual bool visit(FunctionTypeName const& _node) override;
 
+	virtual bool visit(VariableDeclaration const& _declaration) override;
+
 	ErrorReporter& m_errorReporter;
 
 	/// Flag that indicates whether a function modifier actually contains '_'.

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7349,7 +7349,7 @@ BOOST_AUTO_TEST_CASE(warn_about_sha3)
 	char const* text = R"(
 		contract test {
 			function f() pure public {
-				var x = sha3(uint8(1));
+				bytes32 x = sha3(uint8(1));
 				x;
 			}
 		}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -1844,7 +1844,10 @@ BOOST_AUTO_TEST_CASE(warn_var_from_zero)
 			}
 		}
 	)";
-	CHECK_WARNING(sourceCode, "uint8, which can hold values between 0 and 255");
+	CHECK_WARNING_ALLOW_MULTI(sourceCode, (std::vector<std::string>{
+		"uint8, which can hold values between 0 and 255",
+		"Use of the \"var\" keyword is deprecated."
+	}));
 	sourceCode = R"(
 		contract test {
 			function f() pure public {
@@ -1853,7 +1856,10 @@ BOOST_AUTO_TEST_CASE(warn_var_from_zero)
 			}
 		}
 	)";
-	CHECK_WARNING(sourceCode, "uint256, which can hold values between 0 and 115792089237316195423570985008687907853269984665640564039457584007913129639935");
+	CHECK_WARNING_ALLOW_MULTI(sourceCode, (std::vector<std::string>{
+		"uint256, which can hold values between 0 and 115792089237316195423570985008687907853269984665640564039457584007913129639935",
+		"Use of the \"var\" keyword is deprecated."
+	}));
 	sourceCode = R"(
 		contract test {
 			function f() pure public {
@@ -1862,7 +1868,10 @@ BOOST_AUTO_TEST_CASE(warn_var_from_zero)
 			}
 		}
 	)";
-	CHECK_WARNING(sourceCode, "int8, which can hold values between -128 and 127");
+	CHECK_WARNING_ALLOW_MULTI(sourceCode, (std::vector<std::string>{
+		"int8, which can hold values between -128 and 127",
+		"Use of the \"var\" keyword is deprecated."
+	}));
 	sourceCode = R"(
 		 contract test {
 			 function f() pure public {
@@ -1870,7 +1879,10 @@ BOOST_AUTO_TEST_CASE(warn_var_from_zero)
 			 }
 		 }
 	)";
-	CHECK_WARNING(sourceCode, "uint8, which can hold");
+	CHECK_WARNING_ALLOW_MULTI(sourceCode, (std::vector<std::string>{
+		"uint8, which can hold",
+		"Use of the \"var\" keyword is deprecated."
+	}));
 }
 
 BOOST_AUTO_TEST_CASE(enum_member_access)
@@ -4887,8 +4899,7 @@ BOOST_AUTO_TEST_CASE(warn_about_callcode)
 	char const* text = R"(
 		contract test {
 			function f() pure public {
-				var x = address(0x12).callcode;
-				x;
+				address(0x12).callcode;
 			}
 		}
 	)";
@@ -4897,8 +4908,7 @@ BOOST_AUTO_TEST_CASE(warn_about_callcode)
 		pragma experimental "v0.5.0";
 		contract test {
 			function f() pure public {
-				var x = address(0x12).callcode;
-				x;
+				address(0x12).callcode;
 			}
 		}
 	)";
@@ -6918,7 +6928,7 @@ BOOST_AUTO_TEST_CASE(function_types_sig)
 			}
 		}
 	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
+	CHECK_WARNING(text, "Use of the \"var\" keyword is deprecated.");
 	text = R"(
 		contract C {
 			function h() pure external {
@@ -6941,7 +6951,7 @@ BOOST_AUTO_TEST_CASE(function_types_sig)
 			}
 		}
 	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
+	CHECK_WARNING(text, "Use of the \"var\" keyword is deprecated.");
 }
 
 BOOST_AUTO_TEST_CASE(using_this_in_constructor)

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -282,9 +282,9 @@ BOOST_AUTO_TEST_CASE(builtin_functions)
 				require(this.call());
 			}
 			function g() pure public {
-				var x = keccak256("abc");
-				var y = sha256("abc");
-				var z = ecrecover(1, 2, 3, 4);
+				bytes32 x = keccak256("abc");
+				bytes32 y = sha256("abc");
+				address z = ecrecover(1, 2, 3, 4);
 				require(true);
 				assert(true);
 				x; y; z;

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -136,10 +136,12 @@ BOOST_AUTO_TEST_CASE(environment_access)
 	}
 	for (string const& x: pure)
 	{
-		CHECK_WARNING(
+		CHECK_WARNING_ALLOW_MULTI(
 			"contract C { function f() view public { var x = " + x + "; x; } }",
-			"restricted to pure"
-		);
+			(std::vector<std::string>{
+				"Function state mutability can be restricted to pure",
+				"Use of the \"var\" keyword is deprecated."
+		}));
 	}
 }
 


### PR DESCRIPTION
Fix #3301 by extending `libsolidity/analysis/SyntaxChecker` with a visitor for `VariableDeclaration` where the `typeName` is empty (means "var"). The compiler emits a warning for such instances, unless the experimental mode V050 is turned on, in which case it emits an error. This addition causes 7 errors in SolidityTests due to their use of the `var` keyword.