### PR TITLE
Correct notice about which macOS versions are supported

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -86,7 +86,7 @@ case $(uname -s) in
                 ;;
             *)
                 echo "Unsupported macOS version."
-                echo "We only support Mavericks, Yosemite and El Capitan, with work-in-progress on Sierra."
+                echo "We only support Mavericks, Yosemite and El Capitan, with work-in-progress on High Sierra."
                 exit 1
                 ;;
         esac

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -86,7 +86,7 @@ case $(uname -s) in
                 ;;
             *)
                 echo "Unsupported macOS version."
-                echo "We only support Mavericks, Yosemite and El Capitan, with work-in-progress on High Sierra."
+                echo "We only support Mavericks, Yosemite, El Capitan and Sierra, with work-in-progress on High Sierra."
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
This PR does not change any code. The code already shows Sierra is supported. I have changed just the message to show that the unsupported version is High Sierra (aka macOS 10.13, the next version after Sierra).