### PR TITLE
Set stack-size to 16MB for darwin clang.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -93,10 +93,15 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 		# testing on at least OS X and Ubuntu.
 		add_compile_options(-Wno-unused-function)
 		add_compile_options(-Wno-dangling-else)
-		
+
+		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+			# Set stack size to 16MB - by default Apple's clang defines a stack size of 8MB, some tests require more.
+			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-stack_size -Wl,0x1000000")
+		endif()
+
 		# Some Linux-specific Clang settings.  We don't want these for OS X.
 		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-		
+
 			# TODO - Is this even necessary?  Why?
 			# See http://stackoverflow.com/questions/19774778/when-is-it-necessary-to-use-use-the-flag-stdlib-libstdc.
 			add_compile_options(-stdlib=libstdc++)


### PR DESCRIPTION
By default Apple's clang defines a stack size of 8MB, some tests require more.

This is a very simple solution for issue #3460.

Somehow I would prefer to ensure that all supported toolchains will define a 16MB stack - this  change will just define the stack-size for darwin clang to be 16MB. It looks like that the stack-size definition for the gnu toolchains seem to be version dependent and need to be tested very well. So I decided just to focus on the darwin clang use-case.