### PR TITLE
cmake/jsoncpp.cmake: update to jsoncpp v1.8.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.24 (unreleased)
 
 Features:
+ * Build System: Update internal dependency of jsoncpp to 1.8.4, which introduces more strictness and reduces memory usage.
  * Optimizer: Remove unnecessary masking of the result of known short instructions (``ADDRESS``, ``CALLER``, ``ORIGIN`` and ``COINBASE``).
  * Type Checker: Make literals (without explicit type casting) an error for tight packing as experimental 0.5.0 feature.
 

--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -6,15 +6,9 @@ else()
     set(JSONCPP_CMAKE_COMMAND ${CMAKE_COMMAND})
 endif()
 
-# Disable implicit fallthrough warning in jsoncpp for gcc >= 7 until the upstream handles it properly
-if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
-    set(JSONCCP_EXTRA_FLAGS -Wno-implicit-fallthrough)
-else()
-    set(JSONCCP_EXTRA_FLAGS "")
-endif()
-
+include(GNUInstallDirs)
 set(prefix "${CMAKE_BINARY_DIR}/deps")
-set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(JSONCPP_LIBRARY "${prefix}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(JSONCPP_INCLUDE_DIR "${prefix}/include")
 
 set(byproducts "")
@@ -25,9 +19,9 @@ endif()
 ExternalProject_Add(jsoncpp-project
     PREFIX "${prefix}"
     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
-    DOWNLOAD_NAME jsoncpp-1.7.7.tar.gz
-    URL https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz
-    URL_HASH SHA256=087640ebcf7fbcfe8e2717a0b9528fff89c52fcf69fa2a18cc2b538008098f97
+    DOWNLOAD_NAME jsoncpp-1.8.4.tar.gz
+    URL https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz
+    URL_HASH SHA256=c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6
     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}

--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -11,6 +11,10 @@ set(prefix "${CMAKE_BINARY_DIR}/deps")
 set(JSONCPP_LIBRARY "${prefix}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(JSONCPP_INCLUDE_DIR "${prefix}/include")
 
+if(NOT MSVC)
+    set(JSONCPP_EXTRA_FLAGS "-std=c++11")
+endif()
+
 set(byproducts "")
 if(CMAKE_VERSION VERSION_GREATER 3.1)
     set(byproducts BUILD_BYPRODUCTS "${JSONCPP_LIBRARY}")
@@ -30,7 +34,7 @@ ExternalProject_Add(jsoncpp-project
                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
                -DJSONCPP_WITH_TESTS=OFF
                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
-               -DCMAKE_CXX_FLAGS=${JSONCCP_EXTRA_FLAGS}
+               -DCMAKE_CXX_FLAGS=${JSONCPP_EXTRA_FLAGS}
     # Overwrite build and install commands to force Release build on MSVC.
     BUILD_COMMAND cmake --build <BINARY_DIR> --config Release
     INSTALL_COMMAND cmake --build <BINARY_DIR> --config Release --target install

--- a/libdevcore/JSON.cpp
+++ b/libdevcore/JSON.cpp
@@ -28,8 +28,8 @@
 using namespace std;
 
 static_assert(
-	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 7) && (JSONCPP_VERSION_PATCH == 7),
-	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.7.7."
+	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 8) && (JSONCPP_VERSION_PATCH == 4),
+	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.8.4."
 );
 
 namespace dev

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -32,7 +32,7 @@ REPO_ROOT="$(dirname "$0")"/..
     fi
     # Add dependencies
     mkdir -p "$SOLDIR/deps/downloads/" 2>/dev/null || true
-    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.7.7.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz
+    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.8.4.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz
     mkdir -p "$REPO_ROOT/upload"
     tar czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
     rm -r "$TEMPDIR"

--- a/scripts/install_cmake.sh
+++ b/scripts/install_cmake.sh
@@ -18,6 +18,8 @@ esac
 
 BIN=$PREFIX/bin
 
+PATH=$PREFIX/bin:$PATH
+
 if test -f $BIN/cmake && ($BIN/cmake --version | grep -q "$VERSION"); then
     echo "CMake $VERSION already installed in $BIN"
 else

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -76,7 +76,7 @@ mv solidity solc
 
 # Fetch jsoncpp dependency
 mkdir -p ./solc/deps/downloads/ 2>/dev/null || true
-wget -O ./solc/deps/downloads/jsoncpp-1.7.7.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz
+wget -O ./solc/deps/downloads/jsoncpp-1.8.4.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz
 
 # Determine version
 cd solc

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -40,6 +40,12 @@ if ! type git &>/dev/null; then
     apt-get -y install git-core
 fi
 
+if ! type wget &>/dev/null; then
+    # We need wget to install cmake
+    apt-get update
+    apt-get -y install wget
+fi
+
 WORKSPACE=/root/project
 
 # Increase nodejs stack size
@@ -66,6 +72,10 @@ find . -name 'libboost*.a' -exec cp {} . \;
 rm -rf b2 libs doc tools more bin.v2 status
 )
 echo -en 'travis_fold:end:compiling_boost\\r'
+
+echo -en 'travis_fold:start:install_cmake.sh\\r'
+source $WORKSPACE/scripts/install_cmake.sh
+echo -en 'travis_fold:end:install_cmake.sh\\r'
 
 # Build dependent components and solidity itself
 echo -en 'travis_fold:start:compiling_solidity\\r'


### PR DESCRIPTION
Fixes #2829.

To get version 1.8.4 to work, we need to get rid of the usage of deprecated API. PR #3532 (libdevcore/JSON.h - new API) will remove the deprecated API calls.

Remember, that `scripts/travis-emscripten/build_emscripten.sh` is currently using the systems `cmake`, that is shipped with `trzeci/emscripten:sdk`, it is not using the one that is installed with `scripts/install_cmake.sh`.

The new `jsoncpp` (at least version 1.8.4) needs a minimum `cmake` version of 3.1, that is currently not provided by `trzeci/emscripten:sdk`, at least not with version `1.37.33-64bit`. So minor changes on the build scripts are needed. 