### PR TITLE
C99/C++ scoping rules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.21 (unreleased)
 
 Features:
+ * C99/C++-style scoping rules (instead of JavaScript function scoping) take effect as experimental v0.5.0 feature.
  * Code Generator: Assert that ``k != 0`` for ``molmod(a, b, k)`` and ``addmod(a, b, k)`` as experimental 0.5.0 feature.
  * Standard JSON: Reject badly formatted invalid JSON inputs.
  * Type Checker: Disallow uninitialized storage pointers as experimental 0.5.0 feature.

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -79,6 +79,17 @@ Declaration const* DeclarationContainer::conflictingDeclaration(
 	return nullptr;
 }
 
+void DeclarationContainer::activateVariable(ASTString const& _name)
+{
+	solAssert(
+		m_invisibleDeclarations.count(_name) && m_invisibleDeclarations.at(_name).size() == 1,
+		"Tried to activate a non-inactive variable or multiple inactive variables with the same name."
+	);
+	solAssert(m_declarations.count(_name) == 0 || m_declarations.at(_name).empty(), "");
+	m_declarations[_name].emplace_back(m_invisibleDeclarations.at(_name).front());
+	m_invisibleDeclarations.erase(_name);
+}
+
 bool DeclarationContainer::registerDeclaration(
 	Declaration const& _declaration,
 	ASTString const* _name,
@@ -106,15 +117,17 @@ bool DeclarationContainer::registerDeclaration(
 	return true;
 }
 
-vector<Declaration const*> DeclarationContainer::resolveName(ASTString const& _name, bool _recursive) const
+vector<Declaration const*> DeclarationContainer::resolveName(ASTString const& _name, bool _recursive, bool _alsoInvisible) const
 {
 	solAssert(!_name.empty(), "Attempt to resolve empty name.");
-	auto result = m_declarations.find(_name);
-	if (result != m_declarations.end())
-		return result->second;
-	if (_recursive && m_enclosingContainer)
-		return m_enclosingContainer->resolveName(_name, true);
-	return vector<Declaration const*>({});
+	vector<Declaration const*> result;
+	if (m_declarations.count(_name))
+		result = m_declarations.at(_name);
+	if (_alsoInvisible && m_invisibleDeclarations.count(_name))
+		result += m_invisibleDeclarations.at(_name);
+	if (result.empty() && _recursive && m_enclosingContainer)
+		result = m_enclosingContainer->resolveName(_name, true, _alsoInvisible);
+	return result;
 }
 
 vector<ASTString> DeclarationContainer::similarNames(ASTString const& _name) const
@@ -124,6 +137,12 @@ vector<ASTString> DeclarationContainer::similarNames(ASTString const& _name) con
 	vector<ASTString> similar;
 
 	for (auto const& declaration: m_declarations)
+	{
+		string const& declarationName = declaration.first;
+		if (stringWithinDistance(_name, declarationName, MAXIMUM_EDIT_DISTANCE))
+			similar.push_back(declarationName);
+	}
+	for (auto const& declaration: m_invisibleDeclarations)
 	{
 		string const& declarationName = declaration.first;
 		if (stringWithinDistance(_name, declarationName, MAXIMUM_EDIT_DISTANCE))

--- a/libsolidity/analysis/DeclarationContainer.h
+++ b/libsolidity/analysis/DeclarationContainer.h
@@ -51,12 +51,16 @@ public:
 	/// @param _update if true, replaces a potential declaration that is already present
 	/// @returns false if the name was already declared.
 	bool registerDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr, bool _invisible = false, bool _update = false);
-	std::vector<Declaration const*> resolveName(ASTString const& _name, bool _recursive = false) const;
+	std::vector<Declaration const*> resolveName(ASTString const& _name, bool _recursive = false, bool _alsoInvisible = false) const;
 	ASTNode const* enclosingNode() const { return m_enclosingNode; }
 	DeclarationContainer const* enclosingContainer() const { return m_enclosingContainer; }
 	std::map<ASTString, std::vector<Declaration const*>> const& declarations() const { return m_declarations; }
 	/// @returns whether declaration is valid, and if not also returns previous declaration.
 	Declaration const* conflictingDeclaration(Declaration const& _declaration, ASTString const* _name = nullptr) const;
+
+	/// Activates a previously inactive (invisible) variable. To be used in C99 scpoing for
+	/// VariableDeclarationStatements.
+	void activateVariable(ASTString const& _name);
 
 	/// @returns existing declaration names similar to @a _name.
 	/// Searches this and all parent containers.

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -159,15 +159,15 @@ vector<Declaration const*> NameAndTypeResolver::resolveName(ASTString const& _na
 	return iterator->second->resolveName(_name, false);
 }
 
-vector<Declaration const*> NameAndTypeResolver::nameFromCurrentScope(ASTString const& _name, bool _recursive) const
+vector<Declaration const*> NameAndTypeResolver::nameFromCurrentScope(ASTString const& _name) const
 {
-	return m_currentScope->resolveName(_name, _recursive);
+	return m_currentScope->resolveName(_name, true);
 }
 
-Declaration const* NameAndTypeResolver::pathFromCurrentScope(vector<ASTString> const& _path, bool _recursive) const
+Declaration const* NameAndTypeResolver::pathFromCurrentScope(vector<ASTString> const& _path) const
 {
 	solAssert(!_path.empty(), "");
-	vector<Declaration const*> candidates = m_currentScope->resolveName(_path.front(), _recursive);
+	vector<Declaration const*> candidates = m_currentScope->resolveName(_path.front(), true);
 	for (size_t i = 1; i < _path.size() && candidates.size() == 1; i++)
 	{
 		if (!m_scopes.count(candidates.front()))

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -610,6 +610,30 @@ void DeclarationRegistrationHelper::endVisit(ModifierDefinition&)
 	closeCurrentScope();
 }
 
+bool DeclarationRegistrationHelper::visit(Block& _block)
+{
+	enterNewSubScope(_block);
+	return true;
+}
+
+void DeclarationRegistrationHelper::endVisit(Block&)
+{
+	closeCurrentScope();
+}
+
+bool DeclarationRegistrationHelper::visit(ForStatement& _for)
+{
+	// TODO special scoping rules for the init statement - if it is a block, then it should
+	// not open its own scope.
+	enterNewSubScope(_for);
+	return true;
+}
+
+void DeclarationRegistrationHelper::endVisit(ForStatement&)
+{
+	closeCurrentScope();
+}
+
 void DeclarationRegistrationHelper::endVisit(VariableDeclarationStatement& _variableDeclarationStatement)
 {
 	// Register the local variables with the function

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -97,6 +97,9 @@ public:
 	/// @returns a list of similar identifiers in the current and enclosing scopes. May return empty string if no suggestions.
 	std::string similarNameSuggestions(ASTString const& _name) const;
 
+	/// Sets the current scope.
+	void setScope(ASTNode const* _node);
+
 private:
 	/// Internal version of @a resolveNamesAndTypes (called from there) throws exceptions on fatal errors.
 	bool resolveNamesAndTypesInternal(ASTNode& _node, bool _resolveInsideCode = true);
@@ -169,7 +172,7 @@ private:
 	bool visit(EventDefinition& _event) override;
 	void endVisit(EventDefinition& _event) override;
 
-	void enterNewSubScope(Declaration const& _declaration);
+	void enterNewSubScope(ASTNode& _subScope);
 	void closeCurrentScope();
 	void registerDeclaration(Declaration& _declaration, bool _opensScope);
 

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -73,16 +73,17 @@ public:
 	/// Resolves the given @a _name inside the scope @a _scope. If @a _scope is omitted,
 	/// the global scope is used (i.e. the one containing only the pre-defined global variables).
 	/// @returns a pointer to the declaration on success or nullptr on failure.
+	/// SHOULD only be used for testing.
 	std::vector<Declaration const*> resolveName(ASTString const& _name, ASTNode const* _scope = nullptr) const;
 
-	/// Resolves a name in the "current" scope. Should only be called during the initial
-	/// resolving phase.
-	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name, bool _recursive = true) const;
+	/// Resolves a name in the "current" scope, but also searches parent scopes.
+	/// Should only be called during the initial resolving phase.
+	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name) const;
 
-	/// Resolves a path starting from the "current" scope. Should only be called during the initial
-	/// resolving phase.
+	/// Resolves a path starting from the "current" scope, but also searches parent scopes.
+	/// Should only be called during the initial resolving phase.
 	/// @note Returns a null pointer if any component in the path was not unique or not found.
-	Declaration const* pathFromCurrentScope(std::vector<ASTString> const& _path, bool _recursive = true) const;
+	Declaration const* pathFromCurrentScope(std::vector<ASTString> const& _path) const;
 
 	/// returns the vector of declarations without repetitions
 	std::vector<Declaration const*> cleanedDeclarations(

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -167,6 +167,10 @@ private:
 	void endVisit(FunctionDefinition& _function) override;
 	bool visit(ModifierDefinition& _modifier) override;
 	void endVisit(ModifierDefinition& _modifier) override;
+	bool visit(Block& _block) override;
+	void endVisit(Block& _block) override;
+	bool visit(ForStatement& _forLoop) override;
+	void endVisit(ForStatement& _forLoop) override;
 	void endVisit(VariableDeclarationStatement& _variableDeclarationStatement) override;
 	bool visit(VariableDeclaration& _declaration) override;
 	bool visit(EventDefinition& _event) override;

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -56,7 +56,7 @@ public:
 	/// @returns false in case of error.
 	/// @param _currentScope should be nullptr but can be used to inject new declarations into
 	/// existing scopes, used by the snippets feature.
-	bool registerDeclarations(ASTNode& _sourceUnit, ASTNode const* _currentScope = nullptr);
+	bool registerDeclarations(SourceUnit& _sourceUnit, ASTNode const* _currentScope = nullptr);
 	/// Applies the effect of import directives.
 	bool performImports(SourceUnit& _sourceUnit, std::map<std::string, SourceUnit const*> const& _sourceUnits);
 	/// Resolves all names and types referenced from the given AST Node.
@@ -69,6 +69,9 @@ public:
 	/// that create their own scope.
 	/// @returns false in case of error.
 	bool updateDeclaration(Declaration const& _declaration);
+	/// Activates a previously inactive (invisible) variable. To be used in C99 scpoing for
+	/// VariableDeclarationStatements.
+	void activateVariable(std::string const& _name);
 
 	/// Resolves the given @a _name inside the scope @a _scope. If @a _scope is omitted,
 	/// the global scope is used (i.e. the one containing only the pre-defined global variables).
@@ -78,7 +81,7 @@ public:
 
 	/// Resolves a name in the "current" scope, but also searches parent scopes.
 	/// Should only be called during the initial resolving phase.
-	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name) const;
+	std::vector<Declaration const*> nameFromCurrentScope(ASTString const& _name, bool _includeInvisibles = false) const;
 
 	/// Resolves a path starting from the "current" scope, but also searches parent scopes.
 	/// Should only be called during the initial resolving phase.
@@ -139,6 +142,7 @@ public:
 	DeclarationRegistrationHelper(
 		std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& _scopes,
 		ASTNode& _astRoot,
+		bool _useC99Scoping,
 		ErrorReporter& _errorReporter,
 		ASTNode const* _currentScope = nullptr
 	);
@@ -149,6 +153,7 @@ public:
 		std::string const* _name,
 		SourceLocation const* _errorLocation,
 		bool _warnOnShadow,
+		bool _inactive,
 		ErrorReporter& _errorReporter
 	);
 
@@ -185,6 +190,7 @@ private:
 	/// @returns the canonical name of the current scope.
 	std::string currentCanonicalName() const;
 
+	bool m_useC99Scoping = false;
 	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>>& m_scopes;
 	ASTNode const* m_currentScope = nullptr;
 	VariableScope* m_currentFunction = nullptr;

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -47,7 +47,10 @@ bool ReferencesResolver::visit(Block const& _block)
 {
 	if (!m_resolveInsideCode)
 		return false;
-	m_resolver.setScope(&_block);
+	m_experimental050Mode = _block.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::V050);
+	// C99-scoped variables
+	if (m_experimental050Mode)
+		m_resolver.setScope(&_block);
 	return true;
 }
 
@@ -56,14 +59,19 @@ void ReferencesResolver::endVisit(Block const& _block)
 	if (!m_resolveInsideCode)
 		return;
 
-	m_resolver.setScope(_block.scope());
+	// C99-scoped variables
+	if (m_experimental050Mode)
+		m_resolver.setScope(_block.scope());
 }
 
 bool ReferencesResolver::visit(ForStatement const& _for)
 {
 	if (!m_resolveInsideCode)
 		return false;
-	m_resolver.setScope(&_for);
+	m_experimental050Mode = _for.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::V050);
+	// C99-scoped variables
+	if (m_experimental050Mode)
+		m_resolver.setScope(&_for);
 	return true;
 }
 
@@ -71,7 +79,8 @@ void ReferencesResolver::endVisit(ForStatement const& _for)
 {
 	if (!m_resolveInsideCode)
 		return;
-	m_resolver.setScope(_for.scope());
+	if (m_experimental050Mode)
+		m_resolver.setScope(_for.scope());
 }
 
 bool ReferencesResolver::visit(Identifier const& _identifier)

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -83,6 +83,16 @@ void ReferencesResolver::endVisit(ForStatement const& _for)
 		m_resolver.setScope(_for.scope());
 }
 
+void ReferencesResolver::endVisit(VariableDeclarationStatement const& _varDeclStatement)
+{
+	if (!m_resolveInsideCode)
+		return;
+	if (m_experimental050Mode)
+		for (auto const& var: _varDeclStatement.declarations())
+			if (var)
+				m_resolver.activateVariable(var->name());
+}
+
 bool ReferencesResolver::visit(Identifier const& _identifier)
 {
 	auto declarations = m_resolver.nameFromCurrentScope(_identifier.name());

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -43,6 +43,37 @@ bool ReferencesResolver::resolve(ASTNode const& _root)
 	return !m_errorOccurred;
 }
 
+bool ReferencesResolver::visit(Block const& _block)
+{
+	if (!m_resolveInsideCode)
+		return false;
+	m_resolver.setScope(&_block);
+	return true;
+}
+
+void ReferencesResolver::endVisit(Block const& _block)
+{
+	if (!m_resolveInsideCode)
+		return;
+
+	m_resolver.setScope(_block.scope());
+}
+
+bool ReferencesResolver::visit(ForStatement const& _for)
+{
+	if (!m_resolveInsideCode)
+		return false;
+	m_resolver.setScope(&_for);
+	return true;
+}
+
+void ReferencesResolver::endVisit(ForStatement const& _for)
+{
+	if (!m_resolveInsideCode)
+		return;
+	m_resolver.setScope(_for.scope());
+}
+
 bool ReferencesResolver::visit(Identifier const& _identifier)
 {
 	auto declarations = m_resolver.nameFromCurrentScope(_identifier.name());

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -93,6 +93,7 @@ private:
 	std::vector<ParameterList const*> m_returnParameters;
 	bool const m_resolveInsideCode;
 	bool m_errorOccurred = false;
+	bool m_experimental050Mode = false;
 };
 
 }

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -61,6 +61,7 @@ private:
 	virtual void endVisit(Block const& _block) override;
 	virtual bool visit(ForStatement const& _for) override;
 	virtual void endVisit(ForStatement const& _for) override;
+	virtual void endVisit(VariableDeclarationStatement const& _varDeclStatement) override;
 	virtual bool visit(Identifier const& _identifier) override;
 	virtual bool visit(ElementaryTypeName const& _typeName) override;
 	virtual bool visit(FunctionDefinition const& _functionDefinition) override;

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -57,7 +57,10 @@ public:
 	bool resolve(ASTNode const& _root);
 
 private:
-	virtual bool visit(Block const&) override { return m_resolveInsideCode; }
+	virtual bool visit(Block const& _block) override;
+	virtual void endVisit(Block const& _block) override;
+	virtual bool visit(ForStatement const& _for) override;
+	virtual void endVisit(ForStatement const& _for) override;
 	virtual bool visit(Identifier const& _identifier) override;
 	virtual bool visit(ElementaryTypeName const& _typeName) override;
 	virtual bool visit(FunctionDefinition const& _functionDefinition) override;

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -415,6 +415,15 @@ bool VariableDeclaration::isLValue() const
 	return !isExternalCallableParameter() && !m_isConstant;
 }
 
+bool VariableDeclaration::isLocalVariable() const
+{
+	auto s = scope();
+	return
+		dynamic_cast<CallableDeclaration const*>(s) ||
+		dynamic_cast<Block const*>(s) ||
+		dynamic_cast<ForStatement const*>(s);
+}
+
 bool VariableDeclaration::isCallableParameter() const
 {
 	auto const* callable = dynamic_cast<CallableDeclaration const*>(scope());
@@ -460,8 +469,7 @@ bool VariableDeclaration::isExternalCallableParameter() const
 
 bool VariableDeclaration::canHaveAutoType() const
 {
-	auto const* callable = dynamic_cast<CallableDeclaration const*>(scope());
-	return (!!callable && !isCallableParameter());
+	return isLocalVariable() && !isCallableParameter();
 }
 
 TypePointer VariableDeclaration::type() const

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -98,11 +98,12 @@ set<SourceUnit const*> SourceUnit::referencedSourceUnits(bool _recurse, set<Sour
 
 SourceUnit const& Declaration::sourceUnit() const
 {
-	solAssert(!!m_scope, "");
-	ASTNode const* scope = m_scope;
-	while (dynamic_cast<Declaration const*>(scope) && dynamic_cast<Declaration const*>(scope)->m_scope)
-		scope = dynamic_cast<Declaration const*>(scope)->m_scope;
-	return dynamic_cast<SourceUnit const&>(*scope);
+	ASTNode const* s = scope();
+	solAssert(s, "");
+	// will not always be a declaratoion
+	while (dynamic_cast<Scopable const*>(s) && dynamic_cast<Scopable const*>(s)->scope())
+		s = dynamic_cast<Scopable const*>(s)->scope();
+	return dynamic_cast<SourceUnit const&>(*s);
 }
 
 string Declaration::sourceUnitName() const

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -96,21 +96,6 @@ set<SourceUnit const*> SourceUnit::referencedSourceUnits(bool _recurse, set<Sour
 	return sourceUnits;
 }
 
-SourceUnit const& Declaration::sourceUnit() const
-{
-	ASTNode const* s = scope();
-	solAssert(s, "");
-	// will not always be a declaratoion
-	while (dynamic_cast<Scopable const*>(s) && dynamic_cast<Scopable const*>(s)->scope())
-		s = dynamic_cast<Scopable const*>(s)->scope();
-	return dynamic_cast<SourceUnit const&>(*s);
-}
-
-string Declaration::sourceUnitName() const
-{
-	return sourceUnit().annotation().path;
-}
-
 ImportAnnotation& ImportDirective::annotation() const
 {
 	if (!m_annotation)
@@ -407,6 +392,21 @@ UserDefinedTypeNameAnnotation& UserDefinedTypeName::annotation() const
 	if (!m_annotation)
 		m_annotation = new UserDefinedTypeNameAnnotation();
 	return dynamic_cast<UserDefinedTypeNameAnnotation&>(*m_annotation);
+}
+
+SourceUnit const& Scopable::sourceUnit() const
+{
+	ASTNode const* s = scope();
+	solAssert(s, "");
+	// will not always be a declaratoion
+	while (dynamic_cast<Scopable const*>(s) && dynamic_cast<Scopable const*>(s)->scope())
+		s = dynamic_cast<Scopable const*>(s)->scope();
+	return dynamic_cast<SourceUnit const&>(*s);
+}
+
+string Scopable::sourceUnitName() const
+{
+	return sourceUnit().annotation().path;
 }
 
 bool VariableDeclaration::isLValue() const

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -151,6 +151,13 @@ public:
 	ASTNode const* scope() const { return m_scope; }
 	void setScope(ASTNode const* _scope) { m_scope = _scope; }
 
+	/// @returns the source unit this scopable is present in.
+	SourceUnit const& sourceUnit() const;
+
+	/// @returns the source name this scopable is present in.
+	/// Can be combined with annotation().canonicalName (if present) to form a globally unique name.
+	std::string sourceUnitName() const;
+
 protected:
 	ASTNode const* m_scope = nullptr;
 };
@@ -197,12 +204,6 @@ public:
 	virtual bool isVisibleInContract() const { return visibility() != Visibility::External; }
 	bool isVisibleInDerivedContracts() const { return isVisibleInContract() && visibility() >= Visibility::Internal; }
 
-	/// @returns the source unit this declaration is present in.
-	SourceUnit const& sourceUnit() const;
-
-	/// @returns the source name this declaration is present in.
-	/// Can be combined with annotation().canonicalName to form a globally unique name.
-	std::string sourceUnitName() const;
 	std::string fullyQualifiedName() const { return sourceUnitName() + ":" + name(); }
 
 	virtual bool isLValue() const { return false; }

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -140,9 +140,25 @@ private:
 };
 
 /**
+ * Abstract class that is added to each AST node that is stored inside a scope
+ * (including scopes).
+ */
+class Scopable
+{
+public:
+	/// @returns the scope this declaration resides in. Can be nullptr if it is the global scope.
+	/// Available only after name and type resolution step.
+	ASTNode const* scope() const { return m_scope; }
+	void setScope(ASTNode const* _scope) { m_scope = _scope; }
+
+protected:
+	ASTNode const* m_scope = nullptr;
+};
+
+/**
  * Abstract AST class for a declaration (contract, function, struct, variable, import directive).
  */
-class Declaration: public ASTNode
+class Declaration: public ASTNode, public Scopable
 {
 public:
 	/// Visibility ordered from restricted to unrestricted.
@@ -171,7 +187,7 @@ public:
 		ASTPointer<ASTString> const& _name,
 		Visibility _visibility = Visibility::Default
 	):
-		ASTNode(_location), m_name(_name), m_visibility(_visibility), m_scope(nullptr) {}
+		ASTNode(_location), m_name(_name), m_visibility(_visibility) {}
 
 	/// @returns the declared name.
 	ASTString const& name() const { return *m_name; }
@@ -180,11 +196,6 @@ public:
 	bool isPublic() const { return visibility() >= Visibility::Public; }
 	virtual bool isVisibleInContract() const { return visibility() != Visibility::External; }
 	bool isVisibleInDerivedContracts() const { return isVisibleInContract() && visibility() >= Visibility::Internal; }
-
-	/// @returns the scope this declaration resides in. Can be nullptr if it is the global scope.
-	/// Available only after name and type resolution step.
-	ASTNode const* scope() const { return m_scope; }
-	void setScope(ASTNode const* _scope) { m_scope = _scope; }
 
 	/// @returns the source unit this declaration is present in.
 	SourceUnit const& sourceUnit() const;
@@ -213,7 +224,6 @@ protected:
 private:
 	ASTPointer<ASTString> m_name;
 	Visibility m_visibility;
-	ASTNode const* m_scope;
 };
 
 /**

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -299,6 +299,8 @@ private:
 
 /**
  * Abstract class that is added to each AST node that can store local variables.
+ * Local variables in functions are always added to functions, even though they are not
+ * in scope for the whole function.
  */
 class VariableScope
 {
@@ -672,7 +674,7 @@ public:
 	virtual bool isLValue() const override;
 	virtual bool isPartOfExternalInterface() const override { return isPublic(); }
 
-	bool isLocalVariable() const { return !!dynamic_cast<CallableDeclaration const*>(scope()); }
+	bool isLocalVariable() const;
 	/// @returns true if this variable is a parameter or return parameter of a function.
 	bool isCallableParameter() const;
 	/// @returns true if this variable is a return parameter of a function.
@@ -1014,7 +1016,7 @@ private:
 /**
  * Brace-enclosed block containing zero or more statements.
  */
-class Block: public Statement
+class Block: public Statement, public Scopable
 {
 public:
 	Block(
@@ -1121,7 +1123,7 @@ private:
 /**
  * For loop statement
  */
-class ForStatement: public BreakableStatement
+class ForStatement: public BreakableStatement, public Scopable
 {
 public:
 	ForStatement(

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -466,7 +466,8 @@ BOOST_AUTO_TEST_CASE(for_loop)
 	text = R"(
 		contract C {
 			function f(uint x) public pure {
-				for (uint y = 2; x < 10; ) {
+				uint y;
+				for (y = 2; x < 10; ) {
 					y = 3;
 				}
 				assert(y == 3);
@@ -477,7 +478,8 @@ BOOST_AUTO_TEST_CASE(for_loop)
 	text = R"(
 		contract C {
 			function f(uint x) public pure {
-				for (uint y = 2; x < 10; ) {
+				uint y;
+				for (y = 2; x < 10; ) {
 					y = 3;
 				}
 				assert(y == 2);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -284,6 +284,26 @@ BOOST_AUTO_TEST_CASE(conditional_expression_functions)
 	ABI_CHECK(callContractFunction("f(bool)", false), encodeArgs(u256(2)));
 }
 
+BOOST_AUTO_TEST_CASE(C99_scoping_activation)
+{
+	char const* sourceCode = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public returns (uint) {
+				uint x = 7;
+				{
+					x = 3; // This should still assign to the outer variable
+					uint x;
+					x = 4; // This should assign to the new one
+				}
+				return x;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(3));
+}
+
 BOOST_AUTO_TEST_CASE(recursive_calls)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -298,10 +298,38 @@ BOOST_AUTO_TEST_CASE(C99_scoping_activation)
 				}
 				return x;
 			}
+			function g() pure public returns (uint x) {
+				x = 7;
+				{
+					x = 3;
+					uint x;
+					return x; // This returns the new variable, i.e. 0
+				}
+			}
+			function h() pure public returns (uint x, uint a, uint b) {
+				x = 7;
+				{
+					x = 3;
+					a = x; // This should read from the outer
+					uint x = 4;
+					b = x;
+				}
+			}
+			function i() pure public returns (uint x, uint a) {
+				x = 7;
+				{
+					x = 3;
+					uint x = x; // This should read from the outer and assign to the inner
+					a = x;
+				}
+			}
 		}
 	)";
 	compileAndRun(sourceCode);
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(3));
+	ABI_CHECK(callContractFunction("g()"), encodeArgs(0));
+	ABI_CHECK(callContractFunction("h()"), encodeArgs(3, 3, 4));
+	ABI_CHECK(callContractFunction("i()"), encodeArgs(3, 3));
 }
 
 BOOST_AUTO_TEST_CASE(recursive_calls)

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -322,10 +322,10 @@ BOOST_AUTO_TEST_CASE(arithmetics)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f(uint y) { var x = ((((((((y ^ 8) & 7) | 6) - 5) + 4) % 3) / 2) * 1); }
+			function f(uint y) { ((((((((y ^ 8) & 7) | 6) - 5) + 4) % 3) / 2) * 1); }
 		}
 	)";
-	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}, {"test", "f", "x"}});
+	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}});
 	bytes expectation({byte(Instruction::PUSH1), 0x1,
 					   byte(Instruction::PUSH1), 0x2,
 					   byte(Instruction::PUSH1), 0x3,
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(arithmetics)
 					   byte(Instruction::PUSH1), 0x6,
 					   byte(Instruction::PUSH1), 0x7,
 					   byte(Instruction::PUSH1), 0x8,
-					   byte(Instruction::DUP10),
+					   byte(Instruction::DUP9),
 					   byte(Instruction::XOR),
 					   byte(Instruction::AND),
 					   byte(Instruction::OR),
@@ -364,13 +364,13 @@ BOOST_AUTO_TEST_CASE(unary_operators)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f(int y) { var x = !(~+- y == 2); }
+			function f(int y) { !(~+- y == 2); }
 		}
 	)";
-	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}, {"test", "f", "x"}});
+	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}});
 
 	bytes expectation({byte(Instruction::PUSH1), 0x2,
-					   byte(Instruction::DUP3),
+					   byte(Instruction::DUP2),
 					   byte(Instruction::PUSH1), 0x0,
 					   byte(Instruction::SUB),
 					   byte(Instruction::NOT),
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(unary_inc_dec)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f(uint a) { var x = --a ^ (a-- ^ (++a ^ a++)); }
+			function f(uint a) returns (uint x) { x = --a ^ (a-- ^ (++a ^ a++)); }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "a"}, {"test", "f", "x"}});
@@ -426,7 +426,10 @@ BOOST_AUTO_TEST_CASE(unary_inc_dec)
 					   byte(Instruction::POP), // second ++
 					   // Stack here: a x a^(a+2)^(a+2)
 					   byte(Instruction::DUP3), // will change
-					   byte(Instruction::XOR)});
+					   byte(Instruction::XOR),
+					   byte(Instruction::SWAP1),
+					   byte(Instruction::POP),
+					   byte(Instruction::DUP1)});
 					   // Stack here: a x a^(a+2)^(a+2)^a
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -76,15 +76,19 @@ BOOST_AUTO_TEST_CASE(double_function_declaration)
 
 BOOST_AUTO_TEST_CASE(double_variable_declaration)
 {
-	char const* text = R"(
+	string text = R"(
 		contract test {
-			function f() public {
+			function f() pure public {
 				uint256 x;
 				if (true) { uint256 x; }
 			}
 		}
 	)";
-	CHECK_ERROR(text, DeclarationError, "Identifier already declared.");
+	CHECK_WARNING_ALLOW_MULTI(text, (vector<string>{
+		"This declaration shadows an existing declaration.",
+		"Unused local variable",
+		"Unused local variable"
+	}));
 }
 
 BOOST_AUTO_TEST_CASE(name_shadowing)
@@ -1043,7 +1047,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_invocation_local_variables)
 			modifier mod(uint a) { if (a > 0) _; }
 		}
 	)";
-	CHECK_SUCCESS(text);
+	CHECK_ERROR(text, DeclarationError, "Undeclared identifier.");
 }
 
 BOOST_AUTO_TEST_CASE(function_modifier_double_invocation)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -84,16 +84,45 @@ BOOST_AUTO_TEST_CASE(double_variable_declaration)
 			}
 		}
 	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier already declared");
+}
+
+BOOST_AUTO_TEST_CASE(double_variable_declaration_050)
+{
+	string text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
+				uint256 x;
+				if (true) { uint256 x; }
+			}
+		}
+	)";
 	CHECK_WARNING_ALLOW_MULTI(text, (vector<string>{
 		"This declaration shadows an existing declaration.",
+		"Experimental features",
 		"Unused local variable",
 		"Unused local variable"
 	}));
 }
 
+BOOST_AUTO_TEST_CASE(scoping_old)
+{
+	char const* text = R"(
+		contract test {
+			function f() pure public {
+				x = 4;
+				uint256 x = 2;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
 BOOST_AUTO_TEST_CASE(scoping)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			function f() public {
 				{
@@ -109,6 +138,7 @@ BOOST_AUTO_TEST_CASE(scoping)
 BOOST_AUTO_TEST_CASE(scoping_for)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			function f() public {
 				for (uint x = 0; x < 10; x ++){
@@ -123,6 +153,7 @@ BOOST_AUTO_TEST_CASE(scoping_for)
 BOOST_AUTO_TEST_CASE(scoping_for2)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			function f() public {
 				for (uint x = 0; x < 10; x ++){
@@ -1052,7 +1083,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_invocation)
 {
 	char const* text = R"(
 		contract B {
-			function f() mod1(2, true) mod2("0123456") public { }
+			function f() mod1(2, true) mod2("0123456") pure public { }
 			modifier mod1(uint a, bool b) { if (b) _; }
 			modifier mod2(bytes7 a) { while (a == "1234567") _; }
 		}
@@ -1087,7 +1118,19 @@ BOOST_AUTO_TEST_CASE(function_modifier_invocation_local_variables)
 {
 	char const* text = R"(
 		contract B {
-			function f() mod(x) public { uint x = 7; }
+			function f() mod(x) pure public { uint x = 7; }
+			modifier mod(uint a) { if (a > 0) _; }
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
+BOOST_AUTO_TEST_CASE(function_modifier_invocation_local_variables050)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract B {
+			function f() mod(x) pure public { uint x = 7; }
 			modifier mod(uint a) { if (a > 0) _; }
 		}
 	)";

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -135,19 +135,59 @@ BOOST_AUTO_TEST_CASE(scoping)
 	CHECK_ERROR(text, DeclarationError, "Undeclared identifier");
 }
 
-BOOST_AUTO_TEST_CASE(scoping_for)
+BOOST_AUTO_TEST_CASE(scoping_activation_old)
+{
+	char const* text = R"(
+		contract test {
+			function f() pure public {
+				x = 3;
+				uint x;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
+BOOST_AUTO_TEST_CASE(scoping_activation)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
+				x = 3;
+				uint x;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Undeclared identifier");
+}
+
+BOOST_AUTO_TEST_CASE(scoping_self_use)
 {
 	char const* text = R"(
 		pragma experimental "v0.5.0";
 		contract test {
 			function f() public {
+				uint a = a;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Undeclared identifier");
+}
+
+BOOST_AUTO_TEST_CASE(scoping_for)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
 				for (uint x = 0; x < 10; x ++){
 					x = 2;
 				}
 			}
 		}
 	)";
-	CHECK_SUCCESS(text);
+	CHECK_WARNING(text, "Experimental features");
 }
 
 BOOST_AUTO_TEST_CASE(scoping_for2)
@@ -155,11 +195,40 @@ BOOST_AUTO_TEST_CASE(scoping_for2)
 	char const* text = R"(
 		pragma experimental "v0.5.0";
 		contract test {
-			function f() public {
+			function f() pure public {
+				for (uint x = 0; x < 10; x ++)
+					x = 2;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Experimental features");
+}
+
+BOOST_AUTO_TEST_CASE(scoping_for3)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
 				for (uint x = 0; x < 10; x ++){
 					x = 2;
 				}
 				x = 4;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Undeclared identifier");
+}
+
+BOOST_AUTO_TEST_CASE(scoping_for_decl_in_body)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
+				for (;; y++){
+					uint y = 3;
+				}
 			}
 		}
 	)";

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -91,6 +91,50 @@ BOOST_AUTO_TEST_CASE(double_variable_declaration)
 	}));
 }
 
+BOOST_AUTO_TEST_CASE(scoping)
+{
+	char const* text = R"(
+		contract test {
+			function f() public {
+				{
+					uint256 x;
+				}
+				x = 2;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Undeclared identifier");
+}
+
+BOOST_AUTO_TEST_CASE(scoping_for)
+{
+	char const* text = R"(
+		contract test {
+			function f() public {
+				for (uint x = 0; x < 10; x ++){
+					x = 2;
+				}
+			}
+		}
+	)";
+	CHECK_SUCCESS(text);
+}
+
+BOOST_AUTO_TEST_CASE(scoping_for2)
+{
+	char const* text = R"(
+		contract test {
+			function f() public {
+				for (uint x = 0; x < 10; x ++){
+					x = 2;
+				}
+				x = 4;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Undeclared identifier");
+}
+
 BOOST_AUTO_TEST_CASE(name_shadowing)
 {
 	char const* text = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -106,6 +106,67 @@ BOOST_AUTO_TEST_CASE(double_variable_declaration_050)
 	}));
 }
 
+BOOST_AUTO_TEST_CASE(double_variable_declaration_disjoint_scope)
+{
+	string text = R"(
+		contract test {
+			function f() pure public {
+				{ uint x; }
+				{ uint x; }
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier already declared");
+}
+
+BOOST_AUTO_TEST_CASE(double_variable_declaration_disjoint_scope_050)
+{
+	string text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
+				{ uint x; }
+				{ uint x; }
+			}
+		}
+	)";
+	CHECK_WARNING_ALLOW_MULTI(text, (vector<string>{
+		"Experimental features",
+		"Unused local variable",
+		"Unused local variable"
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(double_variable_declaration_disjoint_scope_activation)
+{
+	string text = R"(
+		contract test {
+			function f() pure public {
+				{ uint x; }
+				uint x;
+			}
+		}
+	)";
+	CHECK_ERROR(text, DeclarationError, "Identifier already declared");
+}
+
+BOOST_AUTO_TEST_CASE(double_variable_declaration_disjoint_scope_activation_050)
+{
+	string text = R"(
+		pragma experimental "v0.5.0";
+		contract test {
+			function f() pure public {
+				{ uint x; }
+				uint x;
+			}
+		}
+	)";
+	CHECK_WARNING_ALLOW_MULTI(text, (vector<string>{
+		"Experimental features",
+		"Unused local variable",
+		"Unused local variable"
+	}));
+}
 BOOST_AUTO_TEST_CASE(scoping_old)
 {
 	char const* text = R"(
@@ -165,9 +226,21 @@ BOOST_AUTO_TEST_CASE(scoping_activation)
 BOOST_AUTO_TEST_CASE(scoping_self_use)
 {
 	char const* text = R"(
+		contract test {
+			function f() pure public {
+				uint a = a;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
+BOOST_AUTO_TEST_CASE(scoping_self_use_050)
+{
+	char const* text = R"(
 		pragma experimental "v0.5.0";
 		contract test {
-			function f() public {
+			function f() pure public {
 				uint a = a;
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/1679 and #2495.

Still to do:

 - [x] update ExpressionCompiler tests
 - [x] only activate new rules for 0.5.0
 - [x] for loops: make body and post-expression sub-scope of init statement
 - [x] documentation
 - [x] check that `int a = a` is impossible. (https://github.com/ethereum/solidity/issues/2495)
 - [x] check that `{ a = 7; uint a;}` is impossible.