### PR TITLE
Use emscripten 1.37.21 on Travis (same as on Circleci)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ matrix:
           before_install:
               - nvm install 8
               - nvm use 8
-              - docker pull trzeci/emscripten:sdk-tag-1.35.4-64bit
+              - docker pull trzeci/emscripten:sdk-tag-1.37.21-64bit
           env:
               - SOLC_EMSCRIPTEN=On
               - SOLC_INSTALL_DEPS_TRAVIS=Off

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ matrix:
               - nvm use 8
               - docker pull trzeci/emscripten:sdk-tag-1.37.21-64bit
           env:
+              - EMCC_DEBUG=1
               - SOLC_EMSCRIPTEN=On
               - SOLC_INSTALL_DEPS_TRAVIS=Off
               - SOLC_RELEASE=Off

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ matrix:
           before_install:
               - nvm install 8
               - nvm use 8
-              - docker pull trzeci/emscripten:sdk-tag-1.37.21-64bit
+              - docker pull trzeci/emscripten:sdk-tag-1.37.37-64bit
           env:
               - EMCC_DEBUG=1
               - SOLC_EMSCRIPTEN=On

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ version: 2
 jobs:
   build_emscripten:
     docker:
-      - image: trzeci/emscripten:sdk-tag-1.37.21-64bit
+      - image: trzeci/emscripten:sdk-tag-1.37.37-64bit
     steps:
       - checkout
       - restore_cache:
@@ -41,7 +41,7 @@ jobs:
             - version.txt
   test_emscripten_solcjs:
     docker:
-      - image: trzeci/emscripten:sdk-tag-1.37.21-64bit
+      - image: trzeci/emscripten:sdk-tag-1.37.37-64bit
     steps:
       - checkout
       - attach_workspace:
@@ -65,7 +65,7 @@ jobs:
             test/solcjsTests.sh /tmp/workspace/soljson.js $(cat /tmp/workspace/version.txt)
   test_emscripten_external:
     docker:
-      - image: trzeci/emscripten:sdk-tag-1.37.21-64bit
+      - image: trzeci/emscripten:sdk-tag-1.37.37-64bit
     steps:
       - checkout
       - attach_workspace:

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -111,6 +111,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			# Note: this is on by default in the CMake Emscripten module which we aren't using
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s ERROR_ON_UNDEFINED_SYMBOLS=1")
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s VERBOSE=1")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s STRICT=1")
 			add_definitions(-DETH_EMSCRIPTEN=1)
 		endif()
 	endif()

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -110,6 +110,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			# Abort if linking results in any undefined symbols
 			# Note: this is on by default in the CMake Emscripten module which we aren't using
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s ERROR_ON_UNDEFINED_SYMBOLS=1")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s VERBOSE=1")
 			add_definitions(-DETH_EMSCRIPTEN=1)
 		endif()
 	endif()

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -30,5 +30,5 @@ set -e
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
     ./scripts/travis-emscripten/install_deps.sh
-    docker run -v $(pwd):/root/project -w /root/project trzeci/emscripten:sdk-tag-1.35.4-64bit ./scripts/travis-emscripten/build_emscripten.sh
+    docker run -v $(pwd):/root/project -w /root/project trzeci/emscripten:sdk-tag-1.37.21-64bit ./scripts/travis-emscripten/build_emscripten.sh
 fi

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -30,5 +30,5 @@ set -e
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
     ./scripts/travis-emscripten/install_deps.sh
-    docker run -v $(pwd):/root/project -w /root/project trzeci/emscripten:sdk-tag-1.37.21-64bit ./scripts/travis-emscripten/build_emscripten.sh
+    docker run -v $(pwd):/root/project -w /root/project trzeci/emscripten:sdk-tag-1.37.37-64bit ./scripts/travis-emscripten/build_emscripten.sh
 fi

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -47,10 +47,10 @@ WORKSPACE=/root/project
 if [ -e ~/.emscripten ]
 then
     cat ~/.emscripten
-    sed -i -e 's/NODE_JS="nodejs"/NODE_JS=["nodejs", "--stack_size=8192"]/' ~/.emscripten
+    sed -i -e 's/NODE_JS="nodejs"/NODE_JS=["nodejs", "--stack_size=16384"]/' ~/.emscripten
 else
     nodejs --version
-    echo 'NODE_JS=["nodejs", "--stack_size=8192"]' > ~/.emscripten
+    echo 'NODE_JS=["nodejs", "--stack_size=16384"]' > ~/.emscripten
 fi
 
 

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -43,10 +43,15 @@ fi
 WORKSPACE=/root/project
 
 
+ls -laR /emsdk_portable
+
+ls -laR ~/
+
 # Increase nodejs stack size
 if [ -e ~/.emscripten ]
 then
     cat ~/.emscripten
+    # /emsdk_portable/node/bin/node
     sed -i -e 's/NODE_JS="nodejs"/NODE_JS=["nodejs", "--stack_size=16384"]/' ~/.emscripten
 else
     nodejs --version

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -40,12 +40,6 @@ if ! type git &>/dev/null; then
     apt-get -y install git-core
 fi
 
-if ! type wget &>/dev/null; then
-    # We need wget to install cmake
-    apt-get update
-    apt-get -y install wget
-fi
-
 WORKSPACE=/root/project
 
 # Increase nodejs stack size

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -42,11 +42,14 @@ fi
 
 WORKSPACE=/root/project
 
+
 # Increase nodejs stack size
 if [ -e ~/.emscripten ]
 then
+    cat ~/.emscripten
     sed -i -e 's/NODE_JS="nodejs"/NODE_JS=["nodejs", "--stack_size=8192"]/' ~/.emscripten
 else
+    nodejs --version
     echo 'NODE_JS=["nodejs", "--stack_size=8192"]' > ~/.emscripten
 fi
 


### PR DESCRIPTION
The same version used by the circleci target.

Fixes #3558.

This results in:
- Travis: emscripten changed (1.37.37), boost unchanged (1.57)
- Circleci: emscripten changed (1.37.37), boost unchanged (1.57)

But it fails on cirlceci.