### PR TITLE
Allow `this.f.selector` to be pure.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Features:
    variables.
  * Syntax Checker: Deprecate the ``var`` keyword (and mark it an error as experimental 0.5.0 feature).
  * Type Checker: Issue warning for using ``public`` visibility for interface functions.
+ * Type Checker: Allow `this.f.selector` to be a pure expression.
 
 Bugfixes:
  * Parser: Disallow event declarations with no parameter list.

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -56,6 +56,7 @@ private:
 	virtual bool visit(ModifierDefinition const& _modifierDef) override;
 	virtual void endVisit(ModifierDefinition const& _modifierDef) override;
 	virtual void endVisit(Identifier const& _identifier) override;
+	virtual bool visit(MemberAccess const& _memberAccess) override;
 	virtual void endVisit(MemberAccess const& _memberAccess) override;
 	virtual void endVisit(IndexAccess const& _indexAccess) override;
 	virtual void endVisit(ModifierInvocation const& _modifier) override;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -10219,17 +10219,21 @@ BOOST_AUTO_TEST_CASE(function_types_sig)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f() returns (bytes4) {
+			uint public x;
+			function f() pure returns (bytes4) {
 				return this.f.selector;
 			}
 			function g() returns (bytes4) {
-				function () external returns (bytes4) fun = this.f;
+				function () pure external returns (bytes4) fun = this.f;
 				return fun.selector;
 			}
 			function h() returns (bytes4) {
-				function () external returns (bytes4) fun = this.f;
+				function () pure external returns (bytes4) fun = this.f;
 				var funvar = fun;
 				return funvar.selector;
+			}
+			function i() pure returns (bytes4) {
+				return this.x.selector;
 			}
 		}
 	)";
@@ -10237,6 +10241,7 @@ BOOST_AUTO_TEST_CASE(function_types_sig)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(asString(FixedHash<4>(dev::keccak256("f()")).asBytes())));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(asString(FixedHash<4>(dev::keccak256("f()")).asBytes())));
 	ABI_CHECK(callContractFunction("h()"), encodeArgs(asString(FixedHash<4>(dev::keccak256("f()")).asBytes())));
+	ABI_CHECK(callContractFunction("i()"), encodeArgs(asString(FixedHash<4>(dev::keccak256("x()")).asBytes())));
 }
 
 BOOST_AUTO_TEST_CASE(constant_string)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -6904,15 +6904,7 @@ BOOST_AUTO_TEST_CASE(function_types_sig)
 	CHECK_ERROR(text, TypeError, "Member \"selector\" not found");
 	text = R"(
 		contract C {
-			function f() view external returns (bytes4) {
-				return this.f.selector;
-			}
-		}
-	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
-	text = R"(
-		contract C {
-			function f() view external returns (bytes4) {
+			function f() pure external returns (bytes4) {
 				return this.f.selector;
 			}
 		}

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -330,10 +330,11 @@ BOOST_AUTO_TEST_CASE(selector)
 {
 	string text = R"(
 		contract C {
+			uint public x;
 			function f() payable public {
 			}
 			function g() pure public returns (bytes4) {
-				return this.f.selector;
+				return this.f.selector ^ this.x.selector;
 			}
 		}
 	)";

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -326,6 +326,52 @@ BOOST_AUTO_TEST_CASE(function_types)
 	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
+BOOST_AUTO_TEST_CASE(selector)
+{
+	string text = R"(
+		contract C {
+			function f() payable public {
+			}
+			function g() pure public returns (bytes4) {
+				return this.f.selector;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
+BOOST_AUTO_TEST_CASE(selector_complex)
+{
+	string text = R"(
+		contract C {
+			function f(C c) pure public returns (C) {
+				return c;
+			}
+			function g() pure public returns (bytes4) {
+				// By passing `this`, we read from the state, even if f itself is pure.
+				return f(this).f.selector;
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "reads from the environment or state and thus requires \"view\"");
+}
+
+BOOST_AUTO_TEST_CASE(selector_complex2)
+{
+	string text = R"(
+		contract C {
+				function f() payable public returns (C) {
+				return this;
+			}
+			function g() pure public returns (bytes4) {
+				C x = C(0x123);
+				return x.f.selector;
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
 BOOST_AUTO_TEST_CASE(creation)
 {
 	string text = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3494