### PR TITLE
Minor improvement: Check sources

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Features:
 
 
 Bugfixes:
-
+ * Standard JSON: catch errors properly when invalid "sources" are passed
 
 ### 0.4.20 (2018-02-14)
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -236,7 +236,11 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		return formatFatalError("JSONError", "Only \"Solidity\" is supported as a language.");
 
 	Json::Value const& sources = _input["sources"];
-	if (!sources)
+
+	if (!sources.isObject() && !sources.isNull())
+		return formatFatalError("JSONError", "\"sources\" is not a JSON object.");
+
+	if (sources.empty())
 		return formatFatalError("JSONError", "No input sources specified.");
 
 	Json::Value errors = Json::arrayValue;

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -154,6 +154,42 @@ BOOST_AUTO_TEST_CASE(no_sources)
 	BOOST_CHECK(containsError(result, "JSONError", "No input sources specified."));
 }
 
+BOOST_AUTO_TEST_CASE(no_sources_empty_object)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"sources": {}
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "No input sources specified."));
+}
+
+BOOST_AUTO_TEST_CASE(no_sources_empty_array)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"sources": []
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "\"sources\" is not a JSON object."));
+}
+
+BOOST_AUTO_TEST_CASE(sources_is_array)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"sources": ["aa", "bb"]
+	}
+	)";
+	Json::Value result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "\"sources\" is not a JSON object."));
+}
+
 BOOST_AUTO_TEST_CASE(smoke_test)
 {
 	char const* input = R"(


### PR DESCRIPTION
- returns error, if "sources" is an array, an empty object or not defined
- Added new test-cases in test/libsolidity/StandardCompiler.cpp