### PR TITLE
 Added JSON property 'documentation' to Function, Event, and Modifier defs.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Features:
 
 
 Bugfixes:
+ * JSON-AST: Add "documentation" property to function, event and modifier definition.
  * Standard JSON: catch errors properly when invalid "sources" are passed
 
 ### 0.4.20 (2018-02-14)

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -324,6 +324,7 @@ bool ASTJsonConverter::visit(FunctionDefinition const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("name", _node.name()),
+		make_pair("documentation", _node.documentation() ? Json::Value(*_node.documentation()) : Json::nullValue),
 		// FIXME: remove with next breaking release
 		make_pair(m_legacy ? "constant" : "isDeclaredConst", _node.stateMutability() <= StateMutability::View),
 		make_pair("payable", _node.isPayable()),
@@ -365,6 +366,7 @@ bool ASTJsonConverter::visit(ModifierDefinition const& _node)
 {
 	setJsonNode(_node, "ModifierDefinition", {
 		make_pair("name", _node.name()),
+		make_pair("documentation", _node.documentation() ? Json::Value(*_node.documentation()) : Json::nullValue),
 		make_pair("visibility", Declaration::visibilityToString(_node.visibility())),
 		make_pair("parameters", toJson(_node.parameterList())),
 		make_pair("body", toJson(_node.body()))
@@ -386,6 +388,7 @@ bool ASTJsonConverter::visit(EventDefinition const& _node)
 	m_inEvent = true;
 	setJsonNode(_node, "EventDefinition", {
 		make_pair("name", _node.name()),
+		make_pair("documentation", _node.documentation() ? Json::Value(*_node.documentation()) : Json::nullValue),
 		make_pair("parameters", toJson(_node.parameterList())),
 		make_pair("anonymous", _node.isAnonymous())
 	});

--- a/test/libsolidity/ASTJSON.cpp
+++ b/test/libsolidity/ASTJSON.cpp
@@ -237,16 +237,31 @@ BOOST_AUTO_TEST_CASE(documentation)
 		" and has a line-breaking comment.*/"
 		"contract C {}"
 	);
+	c.addSource("c",
+		"contract C {"
+    "  /** Some comment on Evt.*/ event Evt();"
+    "  /** Some comment on mod.*/ modifier mod() { _; }"
+    "  /** Some comment on fn.*/ function fn() public {}"
+		"}"
+	);
 	c.parseAndAnalyze();
 	map<string, unsigned> sourceIndices;
 	sourceIndices["a"] = 0;
 	sourceIndices["b"] = 1;
+	sourceIndices["c"] = 2;
 	Json::Value astJsonA = ASTJsonConverter(true, sourceIndices).toJson(c.ast("a"));
 	Json::Value documentationA = astJsonA["children"][0]["attributes"]["documentation"];
 	BOOST_CHECK_EQUAL(documentationA, "This contract is empty");
 	Json::Value astJsonB = ASTJsonConverter(true, sourceIndices).toJson(c.ast("b"));
 	Json::Value documentationB = astJsonB["children"][0]["attributes"]["documentation"];
 	BOOST_CHECK_EQUAL(documentationB, "This contract is empty and has a line-breaking comment.");
+	Json::Value astJsonC = ASTJsonConverter(true, sourceIndices).toJson(c.ast("c"));
+	Json::Value documentationC0 = astJsonC["children"][0]["children"][0]["attributes"]["documentation"];
+	Json::Value documentationC1 = astJsonC["children"][0]["children"][1]["attributes"]["documentation"];
+	Json::Value documentationC2 = astJsonC["children"][0]["children"][2]["attributes"]["documentation"];
+	BOOST_CHECK_EQUAL(documentationC0, "Some comment on Evt.");
+	BOOST_CHECK_EQUAL(documentationC1, "Some comment on mod.");
+	BOOST_CHECK_EQUAL(documentationC2, "Some comment on fn.");
 	//same tests for non-legacy mode
 	astJsonA = ASTJsonConverter(false, sourceIndices).toJson(c.ast("a"));
 	documentationA = astJsonA["nodes"][0]["documentation"];
@@ -254,7 +269,13 @@ BOOST_AUTO_TEST_CASE(documentation)
 	astJsonB = ASTJsonConverter(false, sourceIndices).toJson(c.ast("b"));
 	documentationB = astJsonB["nodes"][0]["documentation"];
 	BOOST_CHECK_EQUAL(documentationB, "This contract is empty and has a line-breaking comment.");
-
+	astJsonC = ASTJsonConverter(false, sourceIndices).toJson(c.ast("c"));
+	documentationC0 = astJsonC["nodes"][0]["nodes"][0]["documentation"];
+	documentationC1 = astJsonC["nodes"][0]["nodes"][1]["documentation"];
+	documentationC2 = astJsonC["nodes"][0]["nodes"][2]["documentation"];
+	BOOST_CHECK_EQUAL(documentationC0, "Some comment on Evt.");
+	BOOST_CHECK_EQUAL(documentationC1, "Some comment on mod.");
+	BOOST_CHECK_EQUAL(documentationC2, "Some comment on fn.");
 }
 
 

--- a/test/libsolidity/ASTJSON.cpp
+++ b/test/libsolidity/ASTJSON.cpp
@@ -239,9 +239,9 @@ BOOST_AUTO_TEST_CASE(documentation)
 	);
 	c.addSource("c",
 		"contract C {"
-    "  /** Some comment on Evt.*/ event Evt();"
-    "  /** Some comment on mod.*/ modifier mod() { _; }"
-    "  /** Some comment on fn.*/ function fn() public {}"
+		"  /** Some comment on Evt.*/ event Evt();"
+		"  /** Some comment on mod.*/ modifier mod() { _; }"
+		"  /** Some comment on fn.*/ function fn() public {}"
 		"}"
 	);
 	c.parseAndAnalyze();


### PR DESCRIPTION
Fixes #3537.

Added 'documentation' property to JSON output of `FunctionDefinition`, `EventDefinition`, and `ModifierDefinition` classes.

Extended unit tests with cases that would have failed before the fix.