### PR TITLE
Add gas forwarding details to address related functions in documentation

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -154,15 +154,15 @@ Address Related
 ``<address>.balance`` (``uint256``):
     balance of the :ref:`address` in Wei
 ``<address>.transfer(uint256 amount)``:
-    send given amount of Wei to :ref:`address`, throws on failure, forwards 2300 gas stipend
+    send given amount of Wei to :ref:`address`, throws on failure, forwards 2300 gas stipend, not adjustable
 ``<address>.send(uint256 amount) returns (bool)``:
-    send given amount of Wei to :ref:`address`, returns ``false`` on failure, forwards 2300 gas stipend
+    send given amount of Wei to :ref:`address`, returns ``false`` on failure, forwards 2300 gas stipend, not adjustable
 ``<address>.call(...) returns (bool)``:
-    issue low-level ``CALL``, returns ``false`` on failure, forwards all available gas
+    issue low-level ``CALL``, returns ``false`` on failure, forwards all available gas, adjustable
 ``<address>.callcode(...) returns (bool)``:
-    issue low-level ``CALLCODE``, returns ``false`` on failure, forwards all available gas
+    issue low-level ``CALLCODE``, returns ``false`` on failure, forwards all available gas, adjustable
 ``<address>.delegatecall(...) returns (bool)``:
-    issue low-level ``DELEGATECALL``, returns ``false`` on failure, forwards all available gas
+    issue low-level ``DELEGATECALL``, returns ``false`` on failure, forwards all available gas, adjustable
 
 For more information, see the section on :ref:`address`.
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -154,15 +154,15 @@ Address Related
 ``<address>.balance`` (``uint256``):
     balance of the :ref:`address` in Wei
 ``<address>.transfer(uint256 amount)``:
-    send given amount of Wei to :ref:`address`, throws on failure
+    send given amount of Wei to :ref:`address`, throws on failure, forwards 2300 gas stipend
 ``<address>.send(uint256 amount) returns (bool)``:
-    send given amount of Wei to :ref:`address`, returns ``false`` on failure
+    send given amount of Wei to :ref:`address`, returns ``false`` on failure, forwards 2300 gas stipend
 ``<address>.call(...) returns (bool)``:
-    issue low-level ``CALL``, returns ``false`` on failure
+    issue low-level ``CALL``, returns ``false`` on failure, forwards all available gas
 ``<address>.callcode(...) returns (bool)``:
-    issue low-level ``CALLCODE``, returns ``false`` on failure
+    issue low-level ``CALLCODE``, returns ``false`` on failure, forwards all available gas
 ``<address>.delegatecall(...) returns (bool)``:
-    issue low-level ``DELEGATECALL``, returns ``false`` on failure
+    issue low-level ``DELEGATECALL``, returns ``false`` on failure, forwards all available gas
 
 For more information, see the section on :ref:`address`.
 


### PR DESCRIPTION
For `transfer`, `send`, `call`, `callcode`, `delegatecall`, it's useful to know not only whether it returns `false` or throws on failure but also how much gas it forwards.
