### PR TITLE
Build documentation on CircleCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ env:
     global:
         - ENCRYPTION_LABEL="6d4541b72666"
         - SOLC_BUILD_TYPE=RelWithDebInfo
-        - SOLC_DOCS=Off
         - SOLC_EMSCRIPTEN=Off
         - SOLC_INSTALL_DEPS_TRAVIS=On
         - SOLC_RELEASE=On
@@ -64,18 +63,6 @@ matrix:
           env:
               - ZIP_SUFFIX=ubuntu-trusty-clang
               - SOLC_STOREBYTECODE=On
-
-        # Documentation target, which generates documentation using Phoenix / ReadTheDocs.
-        - os: linux
-          dist: trusty
-          sudo: required
-          compiler: gcc
-          before_install:
-            - sudo apt-get -y install python-sphinx 
-          env:
-              - SOLC_DOCS=On
-              - SOLC_RELEASE=Off
-              - SOLC_TESTS=Off
 
         # Docker target, which generates a statically linked alpine image
         - os: linux
@@ -184,7 +171,6 @@ before_script:
 
 script:
     - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh)
-    - test $SOLC_DOCS != On || (scripts/docs.sh)
     - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh)
     - test $SOLC_STOREBYTECODE != On || (cd $TRAVIS_BUILD_DIR && scripts/bytecodecompare/storebytecode.sh)
 

--- a/circle.yml
+++ b/circle.yml
@@ -101,7 +101,7 @@ jobs:
       - run:
           name: Store commit hash and prerelease
           command: |
-            date -u +"nightly.%Y.%-m.%-d" > prerelease.txt
+            if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" ]; then echo -n > prerelease.txt; else date -u +"nightly.%Y.%-m.%-d" > prerelease.txt; fi
             echo -n "$CIRCLE_SHA1" > commit_hash.txt
       - restore_cache:
           key: ccache-{{ arch }}-{{ .Branch }}
@@ -130,6 +130,28 @@ jobs:
           path: build/solc/solc
           destination: solc
 
+  docs:
+    docker:
+      - image: buildpack-deps:artful
+    steps:
+      - checkout
+      - run:
+          name: Install build dependencies
+          command: |
+            apt-get -qq update
+            apt-get -qy install python-sphinx
+      - run:
+          name: Store commit hash and prerelease
+          command: |
+            if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" ]; then echo -n > prerelease.txt; else date -u +"nightly.%Y.%-m.%-d" > prerelease.txt; fi
+            echo -n "$CIRCLE_SHA1" > commit_hash.txt
+      - run:
+          name: Build documentation
+          command: ./scripts/docs.sh
+      - store_artifacts:
+          path: docs/_build/html/
+          destination: docs-html
+
 workflows:
   version: 2
   build_all:
@@ -142,3 +164,4 @@ workflows:
           requires:
             - build_emscripten
       - build_x86
+      - docs


### PR DESCRIPTION
This builds the documentation on CircleCI and not on travis anymore, i.e. it removes workload from travis.

You can actually inspect the generated documentation: https://1970-40892817-gh.circle-artifacts.com/0/docs-html/index.html