### PR TITLE
Properly warn when using ``_offset`` and ``_slot`` for constants in inline assembly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Features:
 Bugfixes:
  * JSON-AST: Add "documentation" property to function, event and modifier definition.
  * Standard JSON: catch errors properly when invalid "sources" are passed
+ * Type Checker: Properly warn when using ``_offset`` and ``_slot`` for constants in inline assembly.
 
 ### 0.4.20 (2018-02-14)
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -804,7 +804,12 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 		solAssert(!!declaration, "");
 		if (auto var = dynamic_cast<VariableDeclaration const*>(declaration))
 		{
-			if (ref->second.isSlot || ref->second.isOffset)
+			if (var->isConstant())
+			{
+				m_errorReporter.typeError(_identifier.location, "Constant variables not supported by inline assembly.");
+				return size_t(-1);
+			}
+			else if (ref->second.isSlot || ref->second.isOffset)
 			{
 				if (!var->isStateVariable() && !var->type()->dataStoredIn(DataLocation::Storage))
 				{
@@ -816,11 +821,6 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 					m_errorReporter.typeError(_identifier.location, "Storage variables cannot be assigned to.");
 					return size_t(-1);
 				}
-			}
-			else if (var->isConstant())
-			{
-				m_errorReporter.typeError(_identifier.location, "Constant variables not supported by inline assembly.");
-				return size_t(-1);
 			}
 			else if (!var->isLocalVariable())
 			{

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5776,6 +5776,21 @@ BOOST_AUTO_TEST_CASE(inline_assembly_storage_variable_access_out_of_functions)
 	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
+BOOST_AUTO_TEST_CASE(inline_assembly_constant_variable_via_offset)
+{
+	char const* text = R"(
+		contract test {
+			uint constant x = 2;
+			function f() pure public {
+				assembly {
+					let r := x_offset
+				}
+			}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "Constant variables not supported by inline assembly.");
+}
+
 BOOST_AUTO_TEST_CASE(inline_assembly_calldata_variables)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3547