### PR TITLE
CMake: abort if linking results in undefined symbols with emscripten

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -140,6 +140,9 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NO_DYNAMIC_EXECUTION=1")
 			# Disable greedy exception catcher
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s NODEJS_CATCH_EXIT=0")
+			# Abort if linking results in any undefined symbols
+			# Note: this is on by default in the CMake Emscripten module which we aren't using
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s ERROR_ON_UNDEFINED_SYMBOLS=1")
 			add_definitions(-DETH_EMSCRIPTEN=1)
 		endif()
 	endif()


### PR DESCRIPTION
Fixes #3558.