### PR TITLE
Add the link for Solidity documentation in Simplified Chinese

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Translations
 
 This documentation is translated into several languages by community volunteers, but the English version stands as a reference.
 
-* `Simplified Chinese <http://solidity-cn.readthedocs.io>`_
+* `Simplified Chinese <http://solidity-cn.readthedocs.io>`_ (in progress)
 * `Spanish <https://solidity-es.readthedocs.io>`_
 * `Russian <https://github.com/ethereum/wiki/wiki/%5BRussian%5D-%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE-Solidity>`_ (rather outdated)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Translations
 
 This documentation is translated into several languages by community volunteers, but the English version stands as a reference.
 
+* `Simplified Chinese <http://solidity-cn.readthedocs.io>`_
 * `Spanish <https://solidity-es.readthedocs.io>`_
 * `Russian <https://github.com/ethereum/wiki/wiki/%5BRussian%5D-%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE-Solidity>`_ (rather outdated)
 


### PR DESCRIPTION
Talked with Chris and Matt, in order to develop stronger ethereum community in China, we decided to initiate the activity to translate Solidity documentation into Simplified Chinese version. We have invited over 10 experienced translators as a team to contribute on this effort.

What you did:
I finished translation of index.rst into Simplified Chinese and wanted it to be added into main doc index.