### PR TITLE
stop allow_guessing for command line option parser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * Standalone Assembly: Do not ignore input after closing brace of top level block.
  * Standard JSON: catch errors properly when invalid "sources" are passed
  * Type Checker: Properly warn when using ``_offset`` and ``_slot`` for constants in inline assembly.
+ * Commandline interface: throw error if option is unknown
 
 ### 0.4.20 (2018-02-14)
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -627,6 +627,7 @@ Allowed options)",
 	try
 	{
 		po::command_line_parser cmdLineParser(_argc, _argv);
+		cmdLineParser.style(po::command_line_style::default_style & (~po::command_line_style::allow_guessing));
 		cmdLineParser.options(allOptions).positional(filesPositions);
 		po::store(cmdLineParser.run(), m_args);
 	}

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -83,6 +83,21 @@ function compileWithoutWarning()
     test -z "$output" -a "$failed" -eq 0
 }
 
+printTask "Testing unknown options..."
+(
+    set +e
+    output=$("$SOLC" --allow=test 2>&1)
+    failed=$?
+    set -e
+
+    if [ "$output" == "unrecognised option '--allow=test'" ] && [ $failed -ne 0 ] ; then
+	echo "Passed"
+    else
+	printError "Incorrect response to unknown options: $STDERR"
+	exit 1
+    fi
+)
+
 printTask "Compiling various other contracts and libraries..."
 (
 cd "$REPO_ROOT"/test/compilationTests/


### PR DESCRIPTION
this fixes https://github.com/ethereum/solidity/issues/2148