### PR TITLE
Update Delegatecall Description in Docs

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -429,6 +429,9 @@ There exists a special variant of a message call, named **delegatecall**
 which is identical to a message call apart from the fact that
 the code at the target address is executed in the context of the calling
 contract and ``msg.sender`` and ``msg.value`` do not change their values.
+The storage locations of the calling and called contract need to match 
+in order for the called contract to successfully write to the caller's
+storage.
 
 This means that a contract can dynamically load code from a different
 address at runtime. Storage, current address and balance still


### PR DESCRIPTION
The previous description did not include the fact that the storage locations of the two contracts must align up until the storage variable(s) affected in order for the called contract to successfully write to the caller's storage. If they are misaligned, delegatecall will silently fail. This is difficult to debug without underlying knowledge of how delegatecall works, and clarity in the docs would certainly be helpful.