### PR TITLE
Update Delegatecall Description in Docs

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -169,6 +169,13 @@ For more information, see the section on :ref:`address`.
     Use a pattern where the recipient withdraws the money.
 
 .. note::
+   If storage variables are accessed via a low-level delegatecall, the storage layout of the two contracts
+   must align in order for the called contract to correctly access the storage variables of the calling contract by name.
+   This is of course not the case if storage pointers are passed as function arguments as in the case for
+   the high-level libraries.
+   
+    
+.. note::
     The use of ``callcode`` is discouraged and will be removed in the future.
 
 .. index:: this, selfdestruct


### PR DESCRIPTION
The previous description did not include the fact that the storage locations of the two contracts must align up until the storage variable(s) affected in order for the called contract to successfully write to the caller's storage. If they are misaligned, delegatecall will silently fail. This is difficult to debug without underlying knowledge of how delegatecall works, and clarity in the docs would certainly be helpful.