### PR TITLE
clarify 2300 gas stipend in fallback function section

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -523,7 +523,12 @@ Ether (without data). Additionally, in order to receive Ether, the fallback func
 must be marked ``payable``. If no such function exists, the contract cannot receive
 Ether through regular transactions.
 
-It is worth nothing that the "send" or "transfer" function only has a 2300 gas stipend. If the fallback function is called by another contract account using the send/transfer function (eg address.transfer(1 ether)), then the fallback function only has 2300 gas to spend, meaning that it cannot do much other than basic logging.
+In the worst case, the fallback function can only rely on 2300 gas being available (for example when send or transfer is used), leaving not much room to perform other operations except basic logging. The following operations will consume more gas than the 2300 gas stipend:
+
+- Writing to storage
+- Creating a contract
+- Calling an external function which consumes a large amount of gas
+- Sending Ether
 
 Like any function, the fallback function can execute complex operations as long as there is enough gas passed on to it.
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -523,16 +523,9 @@ Ether (without data). Additionally, in order to receive Ether, the fallback func
 must be marked ``payable``. If no such function exists, the contract cannot receive
 Ether through regular transactions.
 
-In such a context, there is usually very little gas available to the function call (to be precise, 2300 gas), so it is important to make fallback functions as cheap as possible. Note that the gas required by a transaction (as opposed to an internal call) that invokes the fallback function is much higher, because each transaction charges an additional amount of 21000 gas or more for things like signature checking.
+It is worth nothing that the "send" or "transfer" function only has a 2300 gas stipend. If the fallback function is called by another contract account using the send/transfer function (eg address.transfer(1 ether)), then the fallback function only has 2300 gas to spend, meaning that it cannot do much other than basic logging.
 
-In particular, the following operations will consume more gas than the stipend provided to a fallback function:
-
-- Writing to storage
-- Creating a contract
-- Calling an external function which consumes a large amount of gas
-- Sending Ether
-
-Please ensure you test your fallback function thoroughly to ensure the execution cost is less than 2300 gas before deploying a contract.
+Like any function, the fallback function can execute complex operations as long as there is enough gas passed on to it.
 
 .. note::
     Even though the fallback function cannot have arguments, one can still use ``msg.data`` to retrieve


### PR DESCRIPTION
The fallback function documentation on gas stipend is confusing. It didn't mention anything about EOA or CA and is giving people the impression that it cannot use more than 2300 gas.