### PR TITLE
Constructors are defined using the ``constructor`` keyword.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Features:
  * Interfaces: Allow overriding external functions in interfaces with public in an implementing contract.
  * Optimizer: Optimize across ``mload`` if ``msize()`` is not used.
  * Syntax Checker: Issue warning for empty structs (or error as experimental 0.5.0 feature).
+ * General: Introduce new constructor syntax using the ``constructor`` keyword as experimental 0.5.0 feature.
 
 Bugfixes:
  * Code Generator: Allow ``block.blockhash`` without being called.

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -40,7 +40,7 @@ This means that cyclic creation dependencies are impossible.
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity >0.4.21;
 
     contract OwnedToken {
         // TokenCreator is a contract type that is defined below.
@@ -981,7 +981,7 @@ Constructor functions can be either ``public`` or ``internal``.
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity >0.4.21;
 
     contract A {
         uint public a;
@@ -998,7 +998,7 @@ Constructor functions can be either ``public`` or ``internal``.
 A constructor set as ``internal`` causes the contract to be marked as :ref:`abstract <abstract-contract>`.
 
 .. note ::
-    Prior to version 0.4.21, constructors were defined as functions with the same name as the contract. This syntax is now deprecated.
+    Prior to version 0.4.22, constructors were defined as functions with the same name as the contract. This syntax is now deprecated.
 
 ::
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -977,7 +977,9 @@ virtual method lookup.
 Constructors
 ============
 A constructor is an optional function declared with the ``constructor`` keyword which is executed upon contract creation. 
-Constructor functions can be either ``public`` or ``internal``.
+Constructor functions can be either ``public`` or ``internal``. If there is no constructor, the contract will assume the
+default constructor: ``contructor() public {}``.
+
 
 ::
 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -40,7 +40,7 @@ This means that cyclic creation dependencies are impossible.
 
 ::
 
-    pragma solidity ^0.4.16;
+    pragma solidity ^0.4.20; // should actually be 0.4.21
 
     contract OwnedToken {
         // TokenCreator is a contract type that is defined below.
@@ -52,7 +52,7 @@ This means that cyclic creation dependencies are impossible.
 
         // This is the constructor which registers the
         // creator and the assigned name.
-        function OwnedToken(bytes32 _name) public {
+        constructor(bytes32 _name) public {
             // State variables are accessed via their name
             // and not via e.g. this.owner. This also applies
             // to functions and especially in the constructors,
@@ -976,8 +976,29 @@ virtual method lookup.
 
 Constructors
 ============
-A constructor is an optional function with the same name as the contract which is executed upon contract creation. 
+A constructor is an optional function declared with the ``constructor`` keyword which is executed upon contract creation. 
 Constructor functions can be either ``public`` or ``internal``.
+
+::
+
+    pragma solidity ^0.4.20; // should actually be 0.4.21
+
+    contract A {
+        uint public a;
+
+        constructor(uint _a) internal {
+            a = _a;
+        }
+    }
+
+    contract B is A(1) {
+        constructor() public {}
+    }
+
+A constructor set as ``internal`` causes the contract to be marked as :ref:`abstract <abstract-contract>`.
+
+.. note ::
+    Prior to version 0.4.21, constructors were defined as functions with the same name as the contract. This syntax is now deprecated.
 
 ::
 
@@ -995,7 +1016,6 @@ Constructor functions can be either ``public`` or ``internal``.
         function B() public {}
     }
 
-A constructor set as ``internal`` causes the contract to be marked as :ref:`abstract <abstract-contract>`.
 
 .. index:: ! base;constructor
 
@@ -1009,11 +1029,11 @@ the base constructors. This can be done in two ways::
 
     contract Base {
         uint x;
-        function Base(uint _x) public { x = _x; }
+        constructor(uint _x) public { x = _x; }
     }
 
     contract Derived is Base(7) {
-        function Derived(uint _y) Base(_y * _y) public {
+        constructor(uint _y) Base(_y * _y) public {
         }
     }
 

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -216,7 +216,22 @@ bool SyntaxChecker::visit(FunctionDefinition const& _function)
 
 	if (v050 && _function.noVisibilitySpecified())
 		m_errorReporter.syntaxError(_function.location(), "No visibility specified.");
-			
+
+	if (_function.isOldStyleConstructor())
+	{
+		if (v050)
+			m_errorReporter.syntaxError(
+				_function.location(),
+				"Functions are not allowed to have the same name as the contract. "
+				"If you intend this to be a constructor, use \"constructor(...) { ... }\" to define it."
+			);
+		else
+			m_errorReporter.warning(
+				_function.location(),
+				"Defining constructors as functions with the same name as the contract is deprecated. "
+				"Use \"constructor(...) { ... }\" instead."
+			);
+	}
 	return true;
 }
 

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -607,7 +607,8 @@ public:
 
 	StateMutability stateMutability() const { return m_stateMutability; }
 	bool isConstructor() const { return m_isConstructor; }
-	bool isFallback() const { return name().empty(); }
+	bool isOldStyleConstructor() const { return m_isConstructor && !name().empty(); }
+	bool isFallback() const { return !m_isConstructor && name().empty(); }
 	bool isPayable() const { return m_stateMutability == StateMutability::Payable; }
 	std::vector<ASTPointer<ModifierInvocation>> const& modifiers() const { return m_functionModifiers; }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameters() const { return m_returnParameters->parameters(); }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -341,13 +341,11 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(
 	RecursionGuard recursionGuard(*this);
 	FunctionHeaderParserResult result;
 
-	if (m_scanner->currentToken() == Token::Function)
-		// In case of old style constructors, i.e. functions with the same name as the contract,
-		// this is set to true below.
-		result.isConstructor = false;
-	else if (m_scanner->currentToken() == Token::Identifier && m_scanner->currentLiteral() == "constructor")
+	result.isConstructor = false;
+
+	if (m_scanner->currentToken() == Token::Identifier && m_scanner->currentLiteral() == "constructor")
 		result.isConstructor = true;
-	else
+	else if (m_scanner->currentToken() != Token::Function)
 		solAssert(false, "Function or constructor expected.");
 	m_scanner->next();
 

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -74,7 +74,11 @@ private:
 	ASTPointer<InheritanceSpecifier> parseInheritanceSpecifier();
 	Declaration::Visibility parseVisibilitySpecifier(Token::Value _token);
 	StateMutability parseStateMutability(Token::Value _token);
-	FunctionHeaderParserResult parseFunctionHeader(bool _forceEmptyName, bool _allowModifiers);
+	FunctionHeaderParserResult parseFunctionHeader(
+		bool _forceEmptyName,
+		bool _allowModifiers,
+		ASTString const* _contractName = nullptr
+	);
 	ASTPointer<ASTNode> parseFunctionDefinitionOrFunctionTypeStateVariable(ASTString const* _contractName);
 	ASTPointer<FunctionDefinition> parseFunctionDefinition(ASTString const* _contractName);
 	ASTPointer<StructDefinition> parseStructDefinition();

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -56,6 +56,7 @@ private:
 	/// This struct is shared for parsing a function header and a function type.
 	struct FunctionHeaderParserResult
 	{
+		bool isConstructor;
 		ASTPointer<ASTString> name;
 		ASTPointer<ParameterList> parameters;
 		ASTPointer<ParameterList> returnParameters;

--- a/std/StandardToken.sol
+++ b/std/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity >0.4.21;
 
 import "./Token.sol";
 
@@ -8,7 +8,7 @@ contract StandardToken is Token {
 	mapping (address =>
 		mapping (address => uint256)) m_allowance;
 
-	function StandardToken(address _initialOwner, uint256 _supply) public {
+	constructor(address _initialOwner, uint256 _supply) public {
 		supply = _supply;
 		balance[_initialOwner] = _supply;
 	}

--- a/std/owned.sol
+++ b/std/owned.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity >0.4.21;
 
 contract owned {
     address owner;
@@ -9,7 +9,7 @@ contract owned {
         }
     }
 
-    function owned() public {
+    constructor() public {
         owner = msg.sender;
     }
 }

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -967,13 +967,7 @@ BOOST_AUTO_TEST_CASE(new_constructor_syntax)
 	char const* text = R"(
 		contract A { constructor() public {} }
 	)";
-	CHECK_SUCCESS(text);
-
-	text = R"(
-		pragma experimental "v0.5.0";
-		contract A { constructor() public {} }
-	)";
-	CHECK_SUCCESS(text);
+	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
 BOOST_AUTO_TEST_CASE(old_constructor_syntax)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -962,6 +962,41 @@ BOOST_AUTO_TEST_CASE(base_constructor_arguments_override)
 	CHECK_SUCCESS(text);
 }
 
+BOOST_AUTO_TEST_CASE(new_constructor_syntax)
+{
+	char const* text = R"(
+		contract A { constructor() public {} }
+	)";
+	CHECK_SUCCESS(text);
+
+	text = R"(
+		pragma experimental "v0.5.0";
+		contract A { constructor() public {} }
+	)";
+	CHECK_SUCCESS(text);
+}
+
+BOOST_AUTO_TEST_CASE(old_constructor_syntax)
+{
+	char const* text = R"(
+		contract A { function A() public {} }
+	)";
+	CHECK_WARNING(
+		text,
+		"Defining constructors as functions with the same name as the contract is deprecated."
+	);
+
+	text = R"(
+		pragma experimental "v0.5.0";
+		contract A { function A() public {} }
+	)";
+	CHECK_ERROR(
+		text,
+		SyntaxError,
+		"Functions are not allowed to have the same name as the contract."
+	);
+}
+
 BOOST_AUTO_TEST_CASE(implicit_derived_to_base_conversion)
 {
 	char const* text = R"(
@@ -6916,7 +6951,7 @@ BOOST_AUTO_TEST_CASE(shadowing_builtins_ignores_constructor)
 {
 	char const* text = R"(
 		contract C {
-			function C() public {}
+			constructor() public {}
 		}
 	)";
 	CHECK_SUCCESS_NO_WARNINGS(text);
@@ -7328,7 +7363,7 @@ BOOST_AUTO_TEST_CASE(using_this_in_constructor)
 {
 	char const* text = R"(
 		contract C {
-			function C() public {
+			constructor() public {
 				this.f();
 			}
 			function f() pure public {

--- a/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses.sol
+++ b/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses.sol
@@ -1,5 +1,5 @@
 contract Base {
-  function Base(uint) public {}
+  constructor(uint) public {}
 }
 contract Derived is Base(2) { }
 contract Derived2 is Base(), Derived() { }

--- a/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
+++ b/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
@@ -1,9 +1,9 @@
 contract Base {
-  function Base(uint, uint) public {}
+  constructor(uint, uint) public {}
 }
 contract Derived is Base(2) { }
 contract Derived2 is Base {
-  function Derived2() Base(2) public { }
+  constructor() Base(2) public { }
 }
 // ----
 // TypeError: Wrong argument count for constructor call: 1 arguments given but expected 2.


### PR DESCRIPTION
Closes #3196.

These changes do not contain adjustments of unit test that are using the old constructors. Should we change them once 0.5.0 has been released or earlier?