### PR TITLE
moved spanning multi lines message to appear on some lane vs new line…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Features:
  * Syntax Checker: Mark ``throw`` as an error as experimental 0.5.0 feature.
  * Syntax Checker: Issue error if no visibility is specified on contract functions as experimental 0.5.0 feature.
  * Type Checker: disallow combining hex numbers and unit denominations as experimental 0.5.0 feature.
+ * Improved messaging when error spans multiple lines of a sourcefile 
 
 Bugfixes:
  * Assembly: Raise error on oversized number literals in assembly.

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -79,8 +79,8 @@ void SourceReferenceFormatter::printSourceLocation(SourceLocation const* _locati
 			scanner.lineAtPosition(_location->start) <<
 			endl <<
 			string(startColumn, ' ') <<
-			"^\n" <<
-			"Spanning multiple lines.\n";
+			"^ (Relevant source part starts here and spans across multiple lines)." <<
+			endl;
 }
 
 void SourceReferenceFormatter::printSourceName(SourceLocation const* _location)


### PR DESCRIPTION
Fixes #3620.  I moved the message to be on the same line per the direction in the issue.  

I didn't add any tests for this, but open to that if we think that is needed.  

Let me know what feedback exists and what you would like to see changed. 

Cheers.