### PR TITLE
Correct warning message in Pure Functions doc

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -503,7 +503,7 @@ In addition to the list of state modifying statements explained above, the follo
     }
 
 .. warning::
-  Before version 0.4.17 the compiler didn't enforce that ``view`` is not reading the state.
+  Before version 0.4.17 the compiler didn't enforce that ``pure`` is not reading the state.
 
 .. index:: ! fallback function, function;fallback
 


### PR DESCRIPTION
wrong commit that caused this: (https://github.com/ethereum/solidity/commit/64eaff64200d166bdd48f81bceefec9bc83db72f#diff-754689a291c0a19b500c31eb6c1d30c7R506)