### PR TITLE
Add z3 performance option

### DIFF
--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -28,6 +28,7 @@ using namespace dev::solidity::smt;
 Z3Interface::Z3Interface():
 	m_solver(m_context)
 {
+	z3::set_param("rewriter.pull_cheap_ite", true);
 }
 
 void Z3Interface::reset()


### PR DESCRIPTION
This code is necessary to guarantee good solving time since we use a lot of `ite`s.
It also partially fixes https://github.com/ethereum/solidity/issues/3625. Partially because that bug required code changes in `z3`, plus the use of this option.