### PR TITLE
Use StaticAnalyzer to deprecate msg.gas instead of conditionally remo…

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3000,10 +3000,8 @@ bool MagicType::operator==(Type const& _other) const
 	return other.m_kind == m_kind;
 }
 
-MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const* _contract) const
+MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const*) const
 {
-	solAssert(_contract, "");
-	const bool v050 = _contract->sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::V050);
 	switch (m_kind)
 	{
 	case Kind::Block:
@@ -3016,17 +3014,13 @@ MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const* _contra
 			{"gaslimit", make_shared<IntegerType>(256)}
 		});
 	case Kind::Message:
-	{
-		std::vector<MemberList::Member> members = {
+		return MemberList::MemberMap({
 			{"sender", make_shared<IntegerType>(160, IntegerType::Modifier::Address)},
+			{"gas", make_shared<IntegerType>(256)},
 			{"value", make_shared<IntegerType>(256)},
 			{"data", make_shared<ArrayType>(DataLocation::CallData)},
 			{"sig", make_shared<FixedBytesType>(4)}
-		};
-		if (!v050)
-			members.emplace_back("gas", make_shared<IntegerType>(256));
-		return members;
-	}
+		});
 	case Kind::Transaction:
 		return MemberList::MemberMap({
 			{"origin", make_shared<IntegerType>(160, IntegerType::Modifier::Address)},

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -924,8 +924,6 @@ bool ExpressionCompiler::visit(NewExpression const&)
 
 bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 {
-	bool const v050 = m_context.experimentalFeatureActive(ExperimentalFeature::V050);
-
 	CompilerContext::LocationSetter locationSetter(m_context, _memberAccess);
 	// Check whether the member is a bound function.
 	ASTString const& member = _memberAccess.memberName();
@@ -1141,10 +1139,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		else if (member == "origin")
 			m_context << Instruction::ORIGIN;
 		else if (member == "gas")
-		{
-			solAssert(!v050, "");
 			m_context << Instruction::GAS;
-		}
 		else if (member == "gasprice")
 			m_context << Instruction::GASPRICE;
 		else if (member == "data")

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7416,7 +7416,7 @@ BOOST_AUTO_TEST_CASE(gasleft)
 			function f() public view returns (uint256 val) { return msg.gas; }
 		}
 	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
+	CHECK_WARNING(text, "\"msg.gas\" has been deprecated in favor of \"gasleft()\"");
 
 	text = R"(
 		contract C {
@@ -7431,7 +7431,7 @@ BOOST_AUTO_TEST_CASE(gasleft)
 			function f() public returns (uint256 val) { return msg.gas; }
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Member \"gas\" not found or not visible after argument-dependent lookup in msg");
+	CHECK_ERROR(text, TypeError, "\"msg.gas\" has been deprecated in favor of \"gasleft()\"");
 }
 
 BOOST_AUTO_TEST_CASE(gasleft_shadowing)


### PR DESCRIPTION
…ving it in MagicType.

Closes #3650.

In #3643 ``msg.gas`` was deprecated by conditionally removing it from the MagicType in Types.cpp, resulting in an error for experimental v0.5.0, but no warning was issued when using ``msg.gas`` pre-v0.5.0.

The only way to add such a warning I found is in the StaticAnalyzer (I realized this possibility only now - before I had not seen a good place to issue such a warning at all).

Comparing the case of ``msg.gas`` with, for instance, the deprecation of ``callcode`` in favour of ``delegatecall``, I now realize that the static analyzer may have been the better choice for deprecating ``msg.gas`` from the beginning. Therefore this pull request proposes to revert parts of the changes of #3643 and instead keeps ``msg.gas`` in MagicType, but issues a warning, resp. raises an error in the static analyzer.

I think this solution is more consistent with existing code than the original solution in #3643.

Alternatively, the changes of #3634 could be left untouched, and this pull request could be reduced to issuing the warning in the static analyzer only.