### PR TITLE
Revert warning update about `view` modifier

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -473,7 +473,7 @@ The following statements are considered modifying the state:
   Getter methods are marked ``view``.
 
 .. warning::
-  Before version 0.4.17 the compiler didn't enforce that ``view`` is not modifying the state.
+  The compiler does not enforce yet that a ``view`` method is not modifying state. It raises a warning though.
 
 .. index:: ! pure function, function;pure
 


### PR DESCRIPTION
Based on the discussion: https://github.com/ethereum/solidity/commit/64eaff64200d166bdd48f81bceefec9bc83db72f#r27924503