### PR TITLE
Add gasleft to FunctionType::richIdentifier().

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2344,6 +2344,7 @@ string FunctionType::richIdentifier() const
 	case Kind::Log2: id += "log2"; break;
 	case Kind::Log3: id += "log3"; break;
 	case Kind::Log4: id += "log4"; break;
+	case Kind::GasLeft: id += "gasleft"; break;
 	case Kind::Event: id += "event"; break;
 	case Kind::SetGas: id += "setgas"; break;
 	case Kind::SetValue: id += "setvalue"; break;


### PR DESCRIPTION
Refs #3660.

This hopefully fixes the issue in #3660. This pr does not close the issue, since we may want to continue the discussion about how to avoid such problems using a test, if at all possible.