### PR TITLE
Use double quotes for suggestion about hex literals and denominations.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2065,13 +2065,13 @@ void TypeChecker::endVisit(Literal const& _literal)
 			m_errorReporter.fatalTypeError(
 				_literal.location(),
 				"Hexadecimal numbers cannot be used with unit denominations. "
-				"You can use an expression of the form '0x1234 * 1 day' instead."
+				"You can use an expression of the form \"0x1234 * 1 day\" instead."
 			);
 		else
 			m_errorReporter.warning(
 				_literal.location(),
 				"Hexadecimal numbers with unit denominations are deprecated. "
-				"You can use an expression of the form '0x1234 * 1 day' instead."
+				"You can use an expression of the form \"0x1234 * 1 day\" instead."
 			);
 	}
 	if (!_literal.annotation().type)


### PR DESCRIPTION
Small fix as suggested in  #3628.