### PR TITLE
Allow overriding external functions in interfaces with public in a child

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Features:
  * General: Support accessing dynamic return data in post-byzantium EVMs.
+ * Interfaces: Allow overriding external functions in interfaces with public in an implementing contract.
 
 Bugfixes:
  * Code Generator: Allow ``block.blockhash`` without being called.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -366,16 +366,6 @@ void TypeChecker::checkContractIllegalOverrides(ContractDefinition const& _contr
 	}
 }
 
-namespace {
-
-bool functionIsInInterface(FunctionDefinition const& _function)
-{
-	return dynamic_cast<ContractDefinition const*>(_function.scope()) &&
-		dynamic_cast<ContractDefinition const*>(_function.scope())->contractKind() == ContractDefinition::ContractKind::Interface;
-}
-
-}
-
 void TypeChecker::checkFunctionOverride(FunctionDefinition const& function, FunctionDefinition const& super)
 {
 	FunctionType functionType(function);
@@ -390,7 +380,11 @@ void TypeChecker::checkFunctionOverride(FunctionDefinition const& function, Func
 	if (function.visibility() != super.visibility())
 	{
 		// visibility is enforced to be external in interfaces, but a contract can override that with public
-		if (functionIsInInterface(super) && !functionIsInInterface(function) && function.visibility() == FunctionDefinition::Visibility::Public)
+		if (
+			super.inContractKind() == ContractDefinition::ContractKind::Interface &&
+			function.inContractKind() != ContractDefinition::ContractKind::Interface &&
+			function.visibility() == FunctionDefinition::Visibility::Public
+		)
 			return;
 		overrideError(function, super, "Overriding function visibility differs.");
 	}

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -290,6 +290,13 @@ TypeDeclarationAnnotation& EnumDefinition::annotation() const
 	return dynamic_cast<TypeDeclarationAnnotation&>(*m_annotation);
 }
 
+ContractDefinition::ContractKind FunctionDefinition::inContractKind() const
+{
+	auto contractDef = dynamic_cast<ContractDefinition const*>(scope());
+	solAssert(contractDef, "Enclosing Scope of FunctionDefinition was not set.");
+	return contractDef->contractKind();
+}
+
 shared_ptr<FunctionType> FunctionDefinition::functionType(bool _internal) const
 {
 	if (_internal)

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -624,6 +624,8 @@ public:
 	/// arguments separated by commas all enclosed in parentheses without any spaces.
 	std::string externalSignature() const;
 
+	ContractDefinition::ContractKind inContractKind() const;
+
 	virtual TypePointer type() const override;
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -6784,6 +6784,20 @@ BOOST_AUTO_TEST_CASE(using_interface_complex)
 	CHECK_SUCCESS(text);
 }
 
+BOOST_AUTO_TEST_CASE(interface_implement_public_contract)
+{
+	char const* text = R"(
+		interface I {
+			function f() external;
+		}
+		contract C is I {
+			function f() public {
+			}
+		}
+	)";
+	CHECK_SUCCESS_NO_WARNINGS(text);
+}
+
 BOOST_AUTO_TEST_CASE(warn_about_throw)
 {
 	char const* text = R"(


### PR DESCRIPTION
Fixes #3458.