### PR TITLE
 Noted `suicide` is deprecated 

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -341,7 +341,7 @@ Global Variables
 - ``this`` (current contract's type): the current contract, explicitly convertible to ``address``
 - ``super``: the contract one level higher in the inheritance hierarchy
 - ``selfdestruct(address recipient)``: destroy the current contract, sending its funds to the given address
-- ``suicide(address recipient)``: an alias to ``selfdestruct``
+- ``suicide(address recipient)``: a deprecated alias to ``selfdestruct``
 - ``<address>.balance`` (``uint256``): balance of the :ref:`address` in Wei
 - ``<address>.send(uint256 amount) returns (bool)``: send given amount of Wei to :ref:`address`, returns ``false`` on failure
 - ``<address>.transfer(uint256 amount)``: send given amount of Wei to :ref:`address`, throws on failure

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -183,7 +183,7 @@ Contract Related
     destroy the current contract, sending its funds to the given :ref:`address`
 
 ``suicide(address recipient)``:
-    alias to ``selfdestruct``
+    deprecated alias to ``selfdestruct``
 
 Furthermore, all functions of the current contract are callable directly including the current function.
 


### PR DESCRIPTION
According to the [changelog](https://github.com/ethereum/solidity/blob/b5e804b8caba0cc84514898323df91a025705177/Changelog.md), `suicide` was deprecated before 0.4.3 (after 0.2.0) and warning by 0.4.17.
This PR puts that in the official documentation. 