### PR TITLE
Optimize across MLOAD if MSIZE is not used.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,11 @@
 ### 0.4.22 (unreleased)
 
 Features:
+ * Code Generator: Initialize arrays without using ``msize()``.
  * Commandline interface: Error when missing or inaccessible file detected. Suppress it with the ``--ignore-missing`` flag.
  * General: Support accessing dynamic return data in post-byzantium EVMs.
  * Interfaces: Allow overriding external functions in interfaces with public in an implementing contract.
+ * Optimizer: Optimize across ``mload`` if ``msize()`` is not used.
  * Syntax Checker: Issue warning for empty structs (or error as experimental 0.5.0 feature).
 
 Bugfixes:

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -438,13 +438,15 @@ map<u256, u256> Assembly::optimiseInternal(
 			// function types that can be stored in storage.
 			AssemblyItems optimisedItems;
 
+			bool usesMSize = (find(m_items.begin(), m_items.end(), AssemblyItem(Instruction::MSIZE)) != m_items.end());
+
 			auto iter = m_items.begin();
 			while (iter != m_items.end())
 			{
 				KnownState emptyState;
 				CommonSubexpressionEliminator eliminator(emptyState);
 				auto orig = iter;
-				iter = eliminator.feedItems(iter, m_items.end());
+				iter = eliminator.feedItems(iter, m_items.end(), usesMSize);
 				bool shouldReplace = false;
 				AssemblyItems optimisedChunk;
 				try

--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -65,8 +65,9 @@ public:
 
 	/// Feeds AssemblyItems into the eliminator and @returns the iterator pointing at the first
 	/// item that must be fed into a new instance of the eliminator.
+	/// @param _msizeImportant if false, do not consider modification of MSIZE a side-effect
 	template <class _AssemblyItemIterator>
-	_AssemblyItemIterator feedItems(_AssemblyItemIterator _iterator, _AssemblyItemIterator _end);
+	_AssemblyItemIterator feedItems(_AssemblyItemIterator _iterator, _AssemblyItemIterator _end, bool _msizeImportant);
 
 	/// @returns the resulting items after optimization.
 	AssemblyItems getOptimizedItems();
@@ -168,11 +169,12 @@ private:
 template <class _AssemblyItemIterator>
 _AssemblyItemIterator CommonSubexpressionEliminator::feedItems(
 	_AssemblyItemIterator _iterator,
-	_AssemblyItemIterator _end
+	_AssemblyItemIterator _end,
+	bool _msizeImportant
 )
 {
 	assertThrow(!m_breakingItem, OptimizerException, "Invalid use of CommonSubexpressionEliminator.");
-	for (; _iterator != _end && !SemanticInformation::breaksCSEAnalysisBlock(*_iterator); ++_iterator)
+	for (; _iterator != _end && !SemanticInformation::breaksCSEAnalysisBlock(*_iterator, _msizeImportant); ++_iterator)
 		feedItem(*_iterator);
 	if (_iterator != _end)
 		m_breakingItem = &(*_iterator++);

--- a/libevmasm/Instruction.cpp
+++ b/libevmasm/Instruction.cpp
@@ -199,7 +199,7 @@ static const std::map<Instruction, InstructionInfo> c_instructionInfo =
 	{ Instruction::ADDMOD,		{ "ADDMOD",			0, 3, 1, false, Tier::Mid } },
 	{ Instruction::MULMOD,		{ "MULMOD",			0, 3, 1, false, Tier::Mid } },
 	{ Instruction::SIGNEXTEND,	{ "SIGNEXTEND",		0, 2, 1, false, Tier::Low } },
-	{ Instruction::KECCAK256,	{ "KECCAK256",			0, 2, 1, false, Tier::Special } },
+	{ Instruction::KECCAK256,	{ "KECCAK256",			0, 2, 1, true, Tier::Special } },
 	{ Instruction::ADDRESS,		{ "ADDRESS",		0, 0, 1, false, Tier::Base } },
 	{ Instruction::BALANCE,		{ "BALANCE",		0, 1, 1, false, Tier::Balance } },
 	{ Instruction::ORIGIN,		{ "ORIGIN",			0, 0, 1, false, Tier::Base } },

--- a/libevmasm/SemanticInformation.cpp
+++ b/libevmasm/SemanticInformation.cpp
@@ -28,7 +28,7 @@ using namespace std;
 using namespace dev;
 using namespace dev::eth;
 
-bool SemanticInformation::breaksCSEAnalysisBlock(AssemblyItem const& _item)
+bool SemanticInformation::breaksCSEAnalysisBlock(AssemblyItem const& _item, bool _msizeImportant)
 {
 	switch (_item.type())
 	{
@@ -58,6 +58,11 @@ bool SemanticInformation::breaksCSEAnalysisBlock(AssemblyItem const& _item)
 		if (_item.instruction() == Instruction::SSTORE)
 			return false;
 		if (_item.instruction() == Instruction::MSTORE)
+			return false;
+		if (!_msizeImportant && (
+			_item.instruction() == Instruction::MLOAD ||
+			_item.instruction() == Instruction::KECCAK256
+		))
 			return false;
 		//@todo: We do not handle the following memory instructions for now:
 		// calldatacopy, codecopy, extcodecopy, mstore8,

--- a/libevmasm/SemanticInformation.h
+++ b/libevmasm/SemanticInformation.h
@@ -38,7 +38,8 @@ class AssemblyItem;
 struct SemanticInformation
 {
 	/// @returns true if the given items starts a new block for common subexpression analysis.
-	static bool breaksCSEAnalysisBlock(AssemblyItem const& _item);
+	/// @param _msizeImportant if false, consider an operation non-breaking if its only side-effect is that it modifies msize.
+	static bool breaksCSEAnalysisBlock(AssemblyItem const& _item, bool _msizeImportant);
 	/// @returns true if the item is a two-argument operation whose value does not depend on the
 	/// order of its arguments.
 	static bool isCommutativeOperation(AssemblyItem const& _item);

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -229,6 +229,9 @@ public:
 	/// i.e. it behaves differently in lvalue context and in value context.
 	virtual bool isValueType() const { return false; }
 	virtual unsigned sizeOnStack() const { return 1; }
+	/// If it is possible to initialize such a value in memory by just writing zeros
+	/// of the size memoryHeadSize().
+	virtual bool hasSimpleZeroValueInMemory() const { return true; }
 	/// @returns the mobile (in contrast to static) type corresponding to the given type.
 	/// This returns the corresponding IntegerType or FixedPointType for RationalNumberType
 	/// and the pointer type for storage reference types.
@@ -568,6 +571,7 @@ public:
 
 	virtual TypePointer mobileType() const override { return copyForLocation(m_location, true); }
 	virtual bool dataStoredIn(DataLocation _location) const override { return m_location == _location; }
+	virtual bool hasSimpleZeroValueInMemory() const override { return false; }
 
 	/// Storage references can be pointers or bound references. In general, local variables are of
 	/// pointer type, state variables are bound references. Assignments to pointers or deleting
@@ -855,6 +859,7 @@ public:
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override;
+	virtual bool hasSimpleZeroValueInMemory() const override { return false; }
 	virtual TypePointer mobileType() const override;
 	/// Converts components to their temporary types and performs some wildcard matching.
 	virtual TypePointer closestTemporaryType(TypePointer const& _targetType) const override;
@@ -999,6 +1004,7 @@ public:
 	virtual bool isValueType() const override { return true; }
 	virtual bool canLiveOutsideStorage() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
 	virtual unsigned sizeOnStack() const override;
+	virtual bool hasSimpleZeroValueInMemory() const override { return false; }
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 	virtual TypePointer encodingType() const override;
 	virtual TypePointer interfaceType(bool _inLibrary) const override;
@@ -1104,6 +1110,8 @@ public:
 		return _inLibrary ? shared_from_this() : TypePointer();
 	}
 	virtual bool dataStoredIn(DataLocation _location) const override { return _location == DataLocation::Storage; }
+	/// Cannot be stored in memory, but just in case.
+	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 
 	TypePointer const& keyType() const { return m_keyType; }
 	TypePointer const& valueType() const { return m_valueType; }
@@ -1132,6 +1140,7 @@ public:
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override;
+	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 	virtual std::string toString(bool _short) const override { return "type(" + m_actualType->toString(_short) + ")"; }
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 
@@ -1154,6 +1163,7 @@ public:
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override { return 0; }
+	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual std::string toString(bool _short) const override;
@@ -1179,6 +1189,7 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
+	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 	virtual unsigned sizeOnStack() const override { return 0; }
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
 
@@ -1209,6 +1220,7 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
+	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 	virtual unsigned sizeOnStack() const override { return 0; }
 	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
 
@@ -1238,6 +1250,7 @@ public:
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual bool isValueType() const override { return true; }
 	virtual unsigned sizeOnStack() const override { return 1; }
+	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 	virtual std::string toString(bool) const override { return "inaccessible dynamic type"; }
 	virtual TypePointer decodingType() const override { return std::make_shared<IntegerType>(256); }
 };

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -69,8 +69,9 @@ namespace
 	{
 		AssemblyItems input = addDummyLocations(_input);
 
+		bool usesMsize = (find(_input.begin(), _input.end(), AssemblyItem{Instruction::MSIZE}) != _input.end());
 		eth::CommonSubexpressionEliminator cse(_state);
-		BOOST_REQUIRE(cse.feedItems(input.begin(), input.end()) == input.end());
+		BOOST_REQUIRE(cse.feedItems(input.begin(), input.end(), usesMsize) == input.end());
 		AssemblyItems output = cse.getOptimizedItems();
 
 		for (AssemblyItem const& item: output)
@@ -124,7 +125,7 @@ BOOST_AUTO_TEST_CASE(cse_intermediate_swap)
 		Instruction::SLOAD, Instruction::SWAP1, u256(100), Instruction::EXP, Instruction::SWAP1,
 		Instruction::DIV, u256(0xff), Instruction::AND
 	};
-	BOOST_REQUIRE(cse.feedItems(input.begin(), input.end()) == input.end());
+	BOOST_REQUIRE(cse.feedItems(input.begin(), input.end(), false) == input.end());
 	AssemblyItems output = cse.getOptimizedItems();
 	BOOST_CHECK(!output.empty());
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8756,6 +8756,32 @@ BOOST_AUTO_TEST_CASE(create_dynamic_array_with_zero_length)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(7)));
 }
 
+BOOST_AUTO_TEST_CASE(correctly_initialize_memory_array_in_constructor)
+{
+	// Memory arrays are initialized using codecopy past the size of the code.
+	// This test checks that it also works in the constructor context.
+	char const* sourceCode = R"(
+		contract C {
+			bool public success;
+			function C() public {
+				// Make memory dirty.
+				assembly {
+					for { let i := 0 } lt(i, 64) { i := add(i, 1) } {
+						mstore(msize, not(0))
+					}
+				}
+				uint16[3] memory c;
+				require(c[0] == 0 && c[1] == 0 && c[2] == 0);
+				uint16[] memory x = new uint16[](3);
+				require(x[0] == 0 && x[1] == 0 && x[2] == 0);
+				success = true;
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("success()"), encodeArgs(u256(1)));
+}
+
 BOOST_AUTO_TEST_CASE(return_does_not_skip_modifier)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Fixes #3691 and #3688 

Thanks to @figs999 for noticing these problems with the optimizer!

TODO:

 - [x] tests
 - [x] ~~create multidimensional arrays more efficiently~~ (will do in separate PR)
 - [x] change `calldatacopy` to `codecopy` (add a test that checks that it also works in a constructor)