### PR TITLE
Error when non-existent file is encountered 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-set(PROJECT_VERSION "0.4.21")
+set(PROJECT_VERSION "0.4.22")
 project(solidity VERSION ${PROJECT_VERSION})
 
 option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Features:
  * Code Generator: Assert that ``k != 0`` for ``mulmod(a, b, k)`` and ``addmod(a, b, k)`` as experimental 0.5.0 feature.
  * Code Generator: Do not retain any gas in calls (except if EVM version is set to homestead).
  * Code Generator: Use ``STATICCALL`` opcode for calling ``view`` and ``pure`` functions as experimenal 0.5.0 feature.
+ * Inline Assembly: Enforce strict mode as experimental 0.5.0 feature.
  * Interface: Provide ability to select target EVM version (homestead or byzantium, with byzantium being the default).
  * Standard JSON: Reject badly formatted invalid JSON inputs.
  * Type Checker: Disallow uninitialized storage pointers as experimental 0.5.0 feature.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,9 @@
 
 Features:
  * C99/C++-style scoping rules (instead of JavaScript function scoping) take effect as experimental v0.5.0 feature.
- * Code Generator: Assert that ``k != 0`` for ``molmod(a, b, k)`` and ``addmod(a, b, k)`` as experimental 0.5.0 feature.
+ * Code Generator: Assert that ``k != 0`` for ``mulmod(a, b, k)`` and ``addmod(a, b, k)`` as experimental 0.5.0 feature.
  * Code Generator: Do not retain any gas in calls (except if EVM version is set to homestead).
+ * Code Generator: Use ``STATICCALL`` opcode for calling ``view`` and ``pure`` functions as experimenal 0.5.0 feature.
  * Interface: Provide ability to select target EVM version (homestead or byzantium, with byzantium being the default).
  * Standard JSON: Reject badly formatted invalid JSON inputs.
  * Type Checker: Disallow uninitialized storage pointers as experimental 0.5.0 feature.

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ Features:
  * Type Checker: Disallow uninitialized storage pointers as experimental 0.5.0 feature.
  * Support and recommend using ``emit EventName();`` to call events explicitly.
  * Syntax Analyser: Do not warn about experimental features if they do not concern code generation.
- * Syntax Analyser: Do not warn about ``pragma experimental "v0.5.0"`` since it does not affect code generation.
+ * Syntax Analyser: Do not warn about ``pragma experimental "v0.5.0"`` and do not set the experimental flag in the bytecode for this.
  * Syntax Checker: Mark ``throw`` as an error as experimental 0.5.0 feature.
  * Syntax Checker: Issue error if no visibility is specified on contract functions as experimental 0.5.0 feature.
  * Syntax Checker: Issue warning when using overloads of ``address`` on contract instances.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,22 +1,22 @@
-### 0.4.21 (unreleased)
+### 0.4.21 (2018-03-07)
 
 Features:
- * C99/C++-style scoping rules (instead of JavaScript function scoping) take effect as experimental v0.5.0 feature.
  * Code Generator: Assert that ``k != 0`` for ``mulmod(a, b, k)`` and ``addmod(a, b, k)`` as experimental 0.5.0 feature.
  * Code Generator: Do not retain any gas in calls (except if EVM version is set to homestead).
  * Code Generator: Use ``STATICCALL`` opcode for calling ``view`` and ``pure`` functions as experimenal 0.5.0 feature.
+ * General: C99/C++-style scoping rules (instead of JavaScript function scoping) take effect as experimental v0.5.0 feature.
+ * General: Improved messaging when error spans multiple lines of a sourcefile
+ * General: Support and recommend using ``emit EventName();`` to call events explicitly.
  * Inline Assembly: Enforce strict mode as experimental 0.5.0 feature.
  * Interface: Provide ability to select target EVM version (homestead or byzantium, with byzantium being the default).
  * Standard JSON: Reject badly formatted invalid JSON inputs.
  * Type Checker: Disallow uninitialized storage pointers as experimental 0.5.0 feature.
- * Support and recommend using ``emit EventName();`` to call events explicitly.
  * Syntax Analyser: Do not warn about experimental features if they do not concern code generation.
  * Syntax Analyser: Do not warn about ``pragma experimental "v0.5.0"`` and do not set the experimental flag in the bytecode for this.
  * Syntax Checker: Mark ``throw`` as an error as experimental 0.5.0 feature.
  * Syntax Checker: Issue error if no visibility is specified on contract functions as experimental 0.5.0 feature.
  * Syntax Checker: Issue warning when using overloads of ``address`` on contract instances.
  * Type Checker: disallow combining hex numbers and unit denominations as experimental 0.5.0 feature.
- * Improved messaging when error spans multiple lines of a sourcefile 
 
 Bugfixes:
  * Assembly: Raise error on oversized number literals in assembly.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+### 0.4.22 (unreleased)
+
+Features:
+
+
+Bugfixes:
+
+
+
 ### 0.4.21 (2018-03-07)
 
 Features:

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ Bugfixes:
  * Standalone Assembly: Do not ignore input after closing brace of top level block.
  * Standard JSON: Catch errors properly when invalid "sources" are passed.
  * Standard JSON: Ensure that library addresses supplied are of correct length and hex prefixed.
+ * Type Checker: Properly detect which array and struct types are unsupported by the old ABI encoder.
  * Type Checker: Properly warn when using ``_offset`` and ``_slot`` for constants in inline assembly.
  * Commandline interface: throw error if option is unknown
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Features:
 
 
 Bugfixes:
+ * Code Generator: Properly skip unneeded storgae array cleanup when not reducing length.
 
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,11 @@
 ### 0.4.22 (unreleased)
 
 Features:
-
+ * Commandline interface:  Error when missing file detected. Support to suppress with missing error ``--ignore-missing`` flag.
 
 Bugfixes:
  * Code Generator: Properly skip unneeded storgae array cleanup when not reducing length.
+ 
 
 
 
@@ -28,7 +29,6 @@ Features:
  * Syntax Checker: Issue warning when using overloads of ``address`` on contract instances.
  * Type Checker: disallow combining hex numbers and unit denominations as experimental 0.5.0 feature.
  * Improved messaging when error spans multiple lines of a sourcefile 
- * Commandline interface:  Error when missing file detected. Support to suppress with missing error ``--ignore-missing`` flag.
 
 Bugfixes:
  * Assembly: Raise error on oversized number literals in assembly.

--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,8 @@ Features:
  * Syntax Checker: Issue error if no visibility is specified on contract functions as experimental 0.5.0 feature.
  * Syntax Checker: Issue warning when using overloads of ``address`` on contract instances.
  * Type Checker: disallow combining hex numbers and unit denominations as experimental 0.5.0 feature.
+ * Improved messaging when error spans multiple lines of a sourcefile 
+ * Commandline interface:  Error when missing file detected. Support to suppress with missing error ``--ignore-missing`` flag.
 
 Bugfixes:
  * Assembly: Raise error on oversized number literals in assembly.

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Features:
  * Syntax Analyser: Do not warn about ``pragma experimental "v0.5.0"`` since it does not affect code generation.
  * Syntax Checker: Mark ``throw`` as an error as experimental 0.5.0 feature.
  * Syntax Checker: Issue error if no visibility is specified on contract functions as experimental 0.5.0 feature.
+ * Syntax Checker: Issue warning when using overloads of ``address`` on contract instances.
  * Type Checker: disallow combining hex numbers and unit denominations as experimental 0.5.0 feature.
  * Improved messaging when error spans multiple lines of a sourcefile 
 

--- a/circle.yml
+++ b/circle.yml
@@ -102,7 +102,7 @@ jobs:
           key: ccache-{{ arch }}-
       - run:
           name: Configure ccache
-          command: ccache -M 80M && ccache -c && ccache -s && ccache -z
+          command: ccache -M 200M && ccache -c && ccache -s && ccache -z
       - run:
           name: Build
           command: |

--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -58,7 +58,7 @@ The following elementary types exist:
 
 - ``bytes<M>``: binary type of ``M`` bytes, ``0 < M <= 32``.
 
-- ``function``: an address (20 bytes) folled by a function selector (4 bytes). Encoded identical to ``bytes24``.
+- ``function``: an address (20 bytes) followed by a function selector (4 bytes). Encoded identical to ``bytes24``.
 
 The following (fixed-size) array type exists:
 

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -418,6 +418,10 @@
         "bugs": [], 
         "released": "2018-02-14"
     }, 
+    "0.4.21": {
+        "bugs": [], 
+        "released": "2018-03-07"
+    }, 
     "0.4.3": {
         "bugs": [
             "ZeroFunctionSelector", 

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -472,6 +472,13 @@ The following statements are considered modifying the state:
 .. note::
   Getter methods are marked ``view``.
 
+.. note::
+  If invalid explicit type conversions are used, state modifications are possible
+  even though a ``view`` function was called.
+  You can switch the compiler to use ``STATICCALL`` when calling such functions and thus
+  prevent modifications to the state on the level of the EVM by adding
+  ``pragma experimental "v0.5.0";``
+
 .. warning::
   The compiler does not enforce yet that a ``view`` method is not modifying state. It raises a warning though.
 
@@ -501,6 +508,18 @@ In addition to the list of state modifying statements explained above, the follo
             return a * (b + 42);
         }
     }
+
+.. note::
+  If invalid explicit type conversions are used, state modifications are possible
+  even though a ``pure`` function was called.
+  You can switch the compiler to use ``STATICCALL`` when calling such functions and thus
+  prevent modifications to the state on the level of the EVM by adding
+  ``pragma experimental "v0.5.0";``
+
+.. warning::
+  It is not possible to prevent functions from reading the state at the level
+  of the EVM, it is only possible to prevent them from writing to the state
+  (i.e. only ``view`` can be enforced at the EVM level, ``pure`` can not).
 
 .. warning::
   Before version 0.4.17 the compiler didn't enforce that ``pure`` is not reading the state.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,9 @@ crowdfunding, blind auctions, multi-signature wallets and more.
 .. note::
     The best way to try out Solidity right now is using
     `Remix <https://remix.ethereum.org/>`_
-    (it can take a while to load, please be patient).
+    (it can take a while to load, please be patient). Remix is a web browser
+    based IDE that allows you to write Solidity smart contracts, then deploy 
+    and run the smart contracts. 
 
 .. warning::
     Since software is written by humans, it can have bugs. Thus, also

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -80,7 +80,7 @@ registering with username and password - all you need is an Ethereum keypair.
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity ^0.4.21;
 
     contract Coin {
         // The keyword "public" makes those variables

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -219,7 +219,7 @@ activate themselves.
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity ^0.4.21;
 
     contract SimpleAuction {
         // Parameters of the auction. Times are either
@@ -376,7 +376,7 @@ high or low invalid bids.
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity ^0.4.21;
 
     contract BlindAuction {
         struct Bid {
@@ -529,7 +529,7 @@ Safe Remote Purchase
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity ^0.4.21;
 
     contract Purchase {
         uint public value;

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -86,7 +86,7 @@ Events are convenience interfaces with the EVM logging facilities.
 
 ::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity ^0.4.21;
 
     contract SimpleAuction {
         event HighestBidIncreased(address bidder, uint amount); // Event

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -470,7 +470,7 @@ Example that shows how to use internal function types::
 
 Another example that uses external function types::
 
-    pragma solidity ^0.4.20; // should actually be 0.4.21
+    pragma solidity ^0.4.21;
 
     contract Oracle {
       struct Request {

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -280,7 +280,8 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 	// Will be re-generated later with correct information
 	// We use the latest EVM version because we will re-run it anyway.
 	assembly::AsmAnalysisInfo analysisInfo;
-	assembly::AsmAnalyzer(analysisInfo, errorsIgnored, EVMVersion(), assembly::AsmFlavour::Loose, resolver).analyze(_inlineAssembly.operations());
+	boost::optional<Error::Type> errorTypeForLoose = m_experimental050Mode ? Error::Type::SyntaxError : Error::Type::Warning;
+	assembly::AsmAnalyzer(analysisInfo, errorsIgnored, EVMVersion(), errorTypeForLoose, assembly::AsmFlavour::Loose, resolver).analyze(_inlineAssembly.operations());
 	return false;
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -894,10 +894,15 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 	};
 	solAssert(!_inlineAssembly.annotation().analysisInfo, "");
 	_inlineAssembly.annotation().analysisInfo = make_shared<assembly::AsmAnalysisInfo>();
+	boost::optional<Error::Type> errorTypeForLoose =
+		m_scope->sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::V050) ?
+		Error::Type::SyntaxError :
+		Error::Type::Warning;
 	assembly::AsmAnalyzer analyzer(
 		*_inlineAssembly.annotation().analysisInfo,
 		m_errorReporter,
 		m_evmVersion,
+		errorTypeForLoose,
 		assembly::AsmFlavour::Loose,
 		identifierAccess
 	);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2084,13 +2084,13 @@ void TypeChecker::endVisit(Literal const& _literal)
 			m_errorReporter.fatalTypeError(
 				_literal.location(),
 				"Hexadecimal numbers cannot be used with unit denominations. "
-				"You can use an expression of the form '0x1234 * 1 day' instead."
+				"You can use an expression of the form \"0x1234 * 1 day\" instead."
 			);
 		else
 			m_errorReporter.warning(
 				_literal.location(),
 				"Hexadecimal numbers with unit denominations are deprecated. "
-				"You can use an expression of the form '0x1234 * 1 day' instead."
+				"You can use an expression of the form \"0x1234 * 1 day\" instead."
 			);
 	}
 	if (!_literal.annotation().type)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1853,6 +1853,16 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 
 	if (exprType->category() == Type::Category::Contract)
 	{
+		// Warn about using address members on contracts
+		for (auto const& addressMember: IntegerType(160, IntegerType::Modifier::Address).nativeMembers(nullptr))
+			if (addressMember.name == memberName && *annotation.type == *addressMember.type)
+				m_errorReporter.warning(
+					_memberAccess.location(),
+					"Using contract member \"" + memberName +"\" inherited from the address type is deprecated." +
+					" Convert the contract to \"address\" type to access the member."
+				);
+
+		// Warn about using send or transfer with a non-payable fallback function.
 		if (auto callType = dynamic_cast<FunctionType const*>(type(_memberAccess).get()))
 		{
 			auto kind = callType->kind();

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1854,13 +1854,17 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	if (exprType->category() == Type::Category::Contract)
 	{
 		// Warn about using address members on contracts
+		bool v050 = m_scope->sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::V050);
 		for (auto const& addressMember: IntegerType(160, IntegerType::Modifier::Address).nativeMembers(nullptr))
 			if (addressMember.name == memberName && *annotation.type == *addressMember.type)
+			{
+				solAssert(!v050, "Address member still present on contract in v0.5.0.");
 				m_errorReporter.warning(
 					_memberAccess.location(),
 					"Using contract member \"" + memberName +"\" inherited from the address type is deprecated." +
 					" Convert the contract to \"address\" type to access the member."
 				);
+			}
 
 		// Warn about using send or transfer with a non-payable fallback function.
 		if (auto callType = dynamic_cast<FunctionType const*>(type(_memberAccess).get()))

--- a/libsolidity/ast/ExperimentalFeatures.h
+++ b/libsolidity/ast/ExperimentalFeatures.h
@@ -29,8 +29,8 @@ namespace solidity
 
 enum class ExperimentalFeature
 {
-	SMTChecker,
 	ABIEncoderV2, // new ABI encoder that makes use of JULIA
+	SMTChecker,
 	V050, // v0.5.0 breaking changes
 	Test,
 	TestOnlyAnalysis
@@ -45,8 +45,8 @@ static const std::map<ExperimentalFeature, bool> ExperimentalFeatureOnlyAnalysis
 
 static const std::map<std::string, ExperimentalFeature> ExperimentalFeatureNames =
 {
-	{ "SMTChecker", ExperimentalFeature::SMTChecker },
 	{ "ABIEncoderV2", ExperimentalFeature::ABIEncoderV2 },
+	{ "SMTChecker", ExperimentalFeature::SMTChecker },
 	{ "v0.5.0", ExperimentalFeature::V050 },
 	{ "__test", ExperimentalFeature::Test },
 	{ "__testOnlyAnalysis", ExperimentalFeature::TestOnlyAnalysis },

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1589,8 +1589,6 @@ bool ArrayType::canBeUsedExternally(bool _inLibrary) const
 		return true;
 	else if (!m_baseType->canBeUsedExternally(_inLibrary))
 		return false;
-	else if (m_baseType->category() == Category::Array && m_baseType->isDynamicallySized())
-		return false;
 	else
 		return true;
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2344,6 +2344,7 @@ string FunctionType::richIdentifier() const
 	case Kind::Log2: id += "log2"; break;
 	case Kind::Log3: id += "log3"; break;
 	case Kind::Log4: id += "log4"; break;
+	case Kind::GasLeft: id += "gasleft"; break;
 	case Kind::Event: id += "event"; break;
 	case Kind::SetGas: id += "setgas"; break;
 	case Kind::SetValue: id += "setvalue"; break;

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -741,10 +741,10 @@ void ArrayUtils::resizeDynamicArray(ArrayType const& _typeIn) const
 			if (_type.isByteArray())
 				// For a "long" byte array, store length as 2*length+1
 				_context << Instruction::DUP1 << Instruction::ADD << u256(1) << Instruction::ADD;
-			_context<< Instruction::DUP4 << Instruction::SSTORE;
+			_context << Instruction::DUP4 << Instruction::SSTORE;
 			// skip if size is not reduced
 			_context << Instruction::DUP2 << Instruction::DUP2
-				<< Instruction::ISZERO << Instruction::GT;
+				<< Instruction::GT << Instruction::ISZERO;
 			_context.appendConditionalJumpTo(resizeEnd);
 
 			// size reduced, clear the end of the array

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -330,6 +330,7 @@ void CompilerContext::appendInlineAssembly(
 			analysisInfo,
 			errorReporter,
 			m_evmVersion,
+			boost::none,
 			assembly::AsmFlavour::Strict,
 			identifierAccess.resolve
 		).analyze(*parserResult);

--- a/libsolidity/inlineasm/AsmAnalysis.h
+++ b/libsolidity/inlineasm/AsmAnalysis.h
@@ -30,6 +30,7 @@
 #include <libsolidity/inlineasm/AsmDataForward.h>
 
 #include <boost/variant.hpp>
+#include <boost/optional.hpp>
 
 #include <functional>
 #include <memory>
@@ -56,9 +57,17 @@ public:
 		AsmAnalysisInfo& _analysisInfo,
 		ErrorReporter& _errorReporter,
 		EVMVersion _evmVersion,
+		boost::optional<Error::Type> _errorTypeForLoose,
 		AsmFlavour _flavour = AsmFlavour::Loose,
 		julia::ExternalIdentifierAccess::Resolver const& _resolver = julia::ExternalIdentifierAccess::Resolver()
-	): m_resolver(_resolver), m_info(_analysisInfo), m_errorReporter(_errorReporter), m_evmVersion(_evmVersion), m_flavour(_flavour) {}
+	):
+		m_resolver(_resolver),
+		m_info(_analysisInfo),
+		m_errorReporter(_errorReporter),
+		m_evmVersion(_evmVersion),
+		m_flavour(_flavour),
+		m_errorTypeForLoose(_errorTypeForLoose)
+	{}
 
 	bool analyze(assembly::Block const& _block);
 
@@ -91,6 +100,11 @@ private:
 	void expectValidType(std::string const& type, SourceLocation const& _location);
 	void warnOnInstructions(solidity::Instruction _instr, SourceLocation const& _location);
 
+	/// Depending on @a m_flavour and @a m_errorTypeForLoose, throws an internal compiler
+	/// exception (if the flavour is not Loose), reports an error/warning
+	/// (if m_errorTypeForLoose is set) or does nothing.
+	void checkLooseFeature(SourceLocation const& _location, std::string const& _description);
+
 	int m_stackHeight = 0;
 	julia::ExternalIdentifierAccess::Resolver m_resolver;
 	Scope* m_currentScope = nullptr;
@@ -101,6 +115,7 @@ private:
 	ErrorReporter& m_errorReporter;
 	EVMVersion m_evmVersion;
 	AsmFlavour m_flavour = AsmFlavour::Loose;
+	boost::optional<Error::Type> m_errorTypeForLoose;
 };
 
 }

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -91,7 +91,7 @@ bool AssemblyStack::analyze(assembly::Block const& _block, Scanner const* _scann
 bool AssemblyStack::analyzeParsed()
 {
 	m_analysisInfo = make_shared<assembly::AsmAnalysisInfo>();
-	assembly::AsmAnalyzer analyzer(*m_analysisInfo, m_errorReporter, m_evmVersion, languageToAsmFlavour(m_language));
+	assembly::AsmAnalyzer analyzer(*m_analysisInfo, m_errorReporter, m_evmVersion, boost::none, languageToAsmFlavour(m_language));
 	m_analysisSuccessful = analyzer.analyze(*m_parserResult);
 	return m_analysisSuccessful;
 }

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -59,12 +59,15 @@ function download_eth()
         ETH_PATH="eth"
     else
         mkdir -p /tmp/test
-        ETH_BINARY=eth_byzantium_artful
-        ETH_HASH="e527dd3e3dc17b983529dd7dcfb74a0d3a5aed4e"
         if grep -i trusty /etc/lsb-release >/dev/null 2>&1
         then
-            ETH_BINARY=eth_byzantium2
-            ETH_HASH="4dc3f208475f622be7c8e53bee720e14cd254c6f"
+            # built from 1ecff3cac12f0fbbeea3e645f331d5ac026b24d3 at 2018-03-06
+            ETH_BINARY=eth_byzantium_trusty
+            ETH_HASH="5432ea81c150e8a3547615bf597cd6dce9e1e27b"
+        else
+            # built from ?? at 2018-02-13 ?
+            ETH_BINARY=eth_byzantium_artful
+            ETH_HASH="e527dd3e3dc17b983529dd7dcfb74a0d3a5aed4e"
         fi
         wget -q -O /tmp/test/eth https://github.com/ethereum/cpp-ethereum/releases/download/solidityTester/$ETH_BINARY
         test "$(shasum /tmp/test/eth)" = "$ETH_HASH  /tmp/test/eth"

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -72,7 +72,7 @@ private:
 	void handleFormal();
 
 	/// Fills @a m_sourceCodes initially and @a m_redirects.
-	void readInputFilesAndConfigureRemappings();
+	bool readInputFilesAndConfigureRemappings();
 	/// Tries to read from the file @a _input or interprets _input literally if that fails.
 	/// It then tries to parse the contents and appends to m_libraries.
 	bool parseLibraryOption(std::string const& _input);

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -32,7 +32,7 @@ REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
 echo $REPO_ROOT
 SOLC="$REPO_ROOT/build/solc/solc"
 
-FULLARGS="--optimize --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
+FULLARGS="--optimize --ignore-missing --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
 
 echo "Checking that the bug list is up to date..."
 "$REPO_ROOT"/scripts/update_bugs_by_version.py

--- a/test/libjulia/Common.cpp
+++ b/test/libjulia/Common.cpp
@@ -67,6 +67,7 @@ pair<shared_ptr<Block>, shared_ptr<assembly::AsmAnalysisInfo>> dev::julia::test:
 			*analysisInfo,
 			errorReporter,
 			dev::test::Options::get().evmVersion(),
+			boost::none,
 			flavour
 		);
 		if (analyzer.analyze(*parserResult))

--- a/test/libjulia/Parser.cpp
+++ b/test/libjulia/Parser.cpp
@@ -60,6 +60,7 @@ bool parse(string const& _source, ErrorReporter& errorReporter)
 				analysisInfo,
 				errorReporter,
 				dev::test::Options::get().evmVersion(),
+				boost::none,
 				assembly::AsmFlavour::IULIA
 			)).analyze(*parserResult);
 		}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -978,6 +978,62 @@ BOOST_AUTO_TEST_CASE(functions_with_stucts_of_non_external_types_in_interface_ne
 	CHECK_ERROR(text, TypeError, "Internal or recursive type is not allowed for public or external functions.");
 }
 
+BOOST_AUTO_TEST_CASE(returning_multi_dimensional_arrays_new_abi)
+{
+	char const* text = R"(
+		pragma experimental ABIEncoderV2;
+
+		contract C {
+			function f() public pure returns (string[][]) {}
+		}
+	)";
+	CHECK_WARNING(text, "Experimental features");
+}
+
+BOOST_AUTO_TEST_CASE(returning_multi_dimensional_arrays)
+{
+	char const* text = R"(
+		contract C {
+			function f() public pure returns (string[][]) {}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "only supported in the new experimental ABI encoder");
+}
+
+BOOST_AUTO_TEST_CASE(returning_multi_dimensional_static_arrays)
+{
+	char const* text = R"(
+		contract C {
+			function f() public pure returns (uint[][2]) {}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "only supported in the new experimental ABI encoder");
+}
+
+BOOST_AUTO_TEST_CASE(returning_arrays_in_structs_new_abi)
+{
+	char const* text = R"(
+		pragma experimental ABIEncoderV2;
+
+		contract C {
+			struct S { string[] s; }
+			function f() public pure returns (S) {}
+		}
+	)";
+	CHECK_WARNING(text, "Experimental features");
+}
+
+BOOST_AUTO_TEST_CASE(returning_arrays_in_structs_arrays)
+{
+	char const* text = R"(
+		contract C {
+			struct S { string[] s; }
+			function f() public pure returns (S x) {}
+		}
+	)";
+	CHECK_ERROR(text, TypeError, "only supported in the new experimental ABI encoder");
+}
+
 BOOST_AUTO_TEST_CASE(function_external_call_allowed_conversion)
 {
 	char const* text = R"(

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -8491,7 +8491,7 @@ BOOST_AUTO_TEST_CASE(no_warning_for_using_members_that_look_like_address_members
 			}
 		}
 	)";
-	CHECK_WARNING(text, "Experimental features");
+	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
 BOOST_AUTO_TEST_CASE(emit_events)

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5946,10 +5946,11 @@ BOOST_AUTO_TEST_CASE(inline_assembly_unbalanced_negative_stack)
 BOOST_AUTO_TEST_CASE(inline_assembly_unbalanced_two_stack_load)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract c {
 			uint8 x;
 			function f() public {
-				assembly { x pop }
+				assembly { pop(x) }
 			}
 		}
 	)";
@@ -5959,6 +5960,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_unbalanced_two_stack_load)
 BOOST_AUTO_TEST_CASE(inline_assembly_in_modifier)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			modifier m {
 				uint a = 1;
@@ -5967,7 +5969,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_in_modifier)
 				}
 				_;
 			}
-			function f() m {
+			function f() public m {
 			}
 		}
 	)";
@@ -5977,6 +5979,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_in_modifier)
 BOOST_AUTO_TEST_CASE(inline_assembly_storage)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			uint x = 1;
 			function f() public {
@@ -5992,6 +5995,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_storage)
 BOOST_AUTO_TEST_CASE(inline_assembly_storage_in_modifiers)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			uint x = 1;
 			modifier m {
@@ -6000,7 +6004,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_storage_in_modifiers)
 				}
 				_;
 			}
-			function f() m {
+			function f() public m {
 			}
 		}
 	)";
@@ -6010,6 +6014,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_storage_in_modifiers)
 BOOST_AUTO_TEST_CASE(inline_assembly_constant_assign)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			uint constant x = 1;
 			function f() public {
@@ -6025,6 +6030,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_constant_assign)
 BOOST_AUTO_TEST_CASE(inline_assembly_constant_access)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			uint constant x = 1;
 			function f() public {
@@ -6040,6 +6046,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_constant_access)
 BOOST_AUTO_TEST_CASE(inline_assembly_local_variable_access_out_of_functions)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			function f() public {
 				uint a;
@@ -6055,6 +6062,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_local_variable_access_out_of_functions)
 BOOST_AUTO_TEST_CASE(inline_assembly_local_variable_access_out_of_functions_storage_ptr)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			uint[] r;
 			function f() public {
@@ -6071,6 +6079,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_local_variable_access_out_of_functions_stor
 BOOST_AUTO_TEST_CASE(inline_assembly_storage_variable_access_out_of_functions)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract test {
 			uint a;
 			function f() pure public {
@@ -6101,6 +6110,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_constant_variable_via_offset)
 BOOST_AUTO_TEST_CASE(inline_assembly_calldata_variables)
 {
 	char const* text = R"(
+		pragma experimental "v0.5.0";
 		contract C {
 			function f(bytes bytesAsCalldata) external {
 				assembly {
@@ -6110,6 +6120,182 @@ BOOST_AUTO_TEST_CASE(inline_assembly_calldata_variables)
 		}
 	)";
 	CHECK_ERROR(text, TypeError, "Call data elements cannot be accessed directly.");
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_050_literals_on_stack)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract C {
+			function f() pure public {
+				assembly {
+					1
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::SyntaxError, "are not supposed to return"},
+		{Error::Type::DeclarationError, "Unbalanced stack"},
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_literals_on_stack)
+{
+	char const* text = R"(
+		contract C {
+			function f() pure public {
+				assembly {
+					1
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "are not supposed to return"},
+		{Error::Type::DeclarationError, "Unbalanced stack"},
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_050_bare_instructions)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract C {
+			function f() view public {
+				assembly {
+					address
+					pop
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::SyntaxError, "The use of non-functional"},
+		{Error::Type::SyntaxError, "The use of non-functional"}
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_bare_instructions)
+{
+	char const* text = R"(
+		contract C {
+			function f() view public {
+				assembly {
+					address
+					pop
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "The use of non-functional"},
+		{Error::Type::Warning, "The use of non-functional"}
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_050_labels)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract C {
+			function f() pure public {
+				assembly {
+					label:
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::SyntaxError, "Jump instructions and labels are low-level"},
+		{Error::Type::SyntaxError, "The use of labels is deprecated"}
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_labels)
+{
+	char const* text = R"(
+		contract C {
+			function f() pure public {
+				assembly {
+					label:
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Jump instructions and labels are low-level"},
+		{Error::Type::Warning, "The use of labels is deprecated"}
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_050_jump)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract C {
+			function f() pure public {
+				assembly {
+					jump(2)
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::SyntaxError, "Jump instructions and labels are low-level"}
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_jump)
+{
+	char const* text = R"(
+		contract C {
+			function f() pure public {
+				assembly {
+					jump(2)
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::TypeError, "Function declared as pure"},
+		{Error::Type::Warning, "Jump instructions and labels are low-level"}
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_050_leave_items_on_stack)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract C {
+			function f() pure public {
+				assembly {
+					mload(0)
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::SyntaxError, "are not supposed to return"},
+		{Error::Type::DeclarationError, "Unbalanced stack"},
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(inline_assembly_leave_items_on_stack)
+{
+	char const* text = R"(
+		contract C {
+			function f() pure public {
+				assembly {
+					mload(0)
+				}
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "are not supposed to return"},
+		{Error::Type::DeclarationError, "Unbalanced stack"},
+	}));
 }
 
 BOOST_AUTO_TEST_CASE(invalid_mobile_type)
@@ -7174,6 +7360,7 @@ BOOST_AUTO_TEST_CASE(returndatacopy_as_variable)
 	)";
 	vector<pair<Error::Type, std::string>> expectations(vector<pair<Error::Type, std::string>>{
 		{Error::Type::Warning, "Variable is shadowed in inline assembly by an instruction of the same name"},
+		{Error::Type::Warning, "The use of non-functional instructions is deprecated."},
 		{Error::Type::DeclarationError, "Unbalanced stack"}
 	});
 	if (!dev::test::Options::get().evmVersion().supportsReturndata())
@@ -7189,7 +7376,8 @@ BOOST_AUTO_TEST_CASE(create2_as_variable)
 	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
 		{Error::Type::Warning, "Variable is shadowed in inline assembly by an instruction of the same name"},
 		{Error::Type::Warning, "The \"create2\" instruction is not supported by the VM version"},
-		{Error::Type::DeclarationError, "Unbalanced stack"}
+		{Error::Type::DeclarationError, "Unbalanced stack"},
+		{Error::Type::Warning, "not supposed to return values"}
 	}));
 }
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -7064,6 +7064,8 @@ BOOST_AUTO_TEST_CASE(callable_crash)
 
 BOOST_AUTO_TEST_CASE(error_transfer_non_payable_fallback)
 {
+	// This used to be a test for a.transfer to generate a warning
+	// because A's fallback function is not payable.
 	char const* text = R"(
 		contract A {
 			function() public {}
@@ -7077,12 +7079,17 @@ BOOST_AUTO_TEST_CASE(error_transfer_non_payable_fallback)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Value transfer to a contract without a payable fallback function.");
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"transfer\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
 }
 
 BOOST_AUTO_TEST_CASE(error_transfer_no_fallback)
 {
-	char const* text = R"(
+	// This used to be a test for a.transfer to generate a warning
+	// because A does not have a payable fallback function.
+	std::string text = R"(
 		contract A {}
 
 		contract B {
@@ -7093,12 +7100,17 @@ BOOST_AUTO_TEST_CASE(error_transfer_no_fallback)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Value transfer to a contract without a payable fallback function.");
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"transfer\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
 }
 
 BOOST_AUTO_TEST_CASE(error_send_non_payable_fallback)
 {
-	char const* text = R"(
+	// This used to be a test for a.send to generate a warning
+	// because A does not have a payable fallback function.
+	std::string text = R"(
 		contract A {
 			function() public {}
 		}
@@ -7111,11 +7123,16 @@ BOOST_AUTO_TEST_CASE(error_send_non_payable_fallback)
 			}
 		}
 	)";
-	CHECK_ERROR(text, TypeError, "Value transfer to a contract without a payable fallback function.");
+	CHECK_ALLOW_MULTI(text, (std::vector<std::pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"send\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
 }
 
 BOOST_AUTO_TEST_CASE(does_not_error_transfer_payable_fallback)
 {
+	// This used to be a test for a.transfer to generate a warning
+	// because A does not have a payable fallback function.
 	char const* text = R"(
 		contract A {
 			function() payable public {}
@@ -7129,7 +7146,7 @@ BOOST_AUTO_TEST_CASE(does_not_error_transfer_payable_fallback)
 			}
 		}
 	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
+	CHECK_WARNING(text, "Using contract member \"transfer\" inherited from the address type is deprecated.");
 }
 
 BOOST_AUTO_TEST_CASE(does_not_error_transfer_regular_function)
@@ -8089,6 +8106,134 @@ BOOST_AUTO_TEST_CASE(array_length_invalid_expression)
 	CHECK_ERROR(text, TypeError, "Operator / not compatible with types int_const 3 and int_const 0");
 }
 
+BOOST_AUTO_TEST_CASE(warn_about_address_members_on_contract)
+{
+	std::string text = R"(
+		contract C {
+			function f() view public {
+				this.balance;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Using contract member \"balance\" inherited from the address type is deprecated.");
+	text = R"(
+		contract C {
+			function f() view public {
+				this.transfer;
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (vector<pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"transfer\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
+	text = R"(
+		contract C {
+			function f() view public {
+				this.send;
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (vector<pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"send\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
+	text = R"(
+		contract C {
+			function f() view public {
+				this.call;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Using contract member \"call\" inherited from the address type is deprecated.");
+	text = R"(
+		contract C {
+			function f() view public {
+				this.callcode;
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (vector<pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"callcode\" inherited from the address type is deprecated"},
+		{Error::Type::Warning, "\"callcode\" has been deprecated in favour of \"delegatecall\""}
+	}));
+	text = R"(
+		contract C {
+			function f() view public {
+				this.delegatecall;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Using contract member \"delegatecall\" inherited from the address type is deprecated.");
+}
+
+BOOST_AUTO_TEST_CASE(warn_about_address_members_on_non_this_contract)
+{
+	std::string text = R"(
+		contract C {
+			function f() view public {
+				C c;
+				c.balance;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Using contract member \"balance\" inherited from the address type is deprecated");
+	text = R"(
+		contract C {
+			function f() view public {
+				C c;
+				c.transfer;
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (vector<pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"transfer\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
+	text = R"(
+		contract C {
+			function f() view public {
+				C c;
+				c.send;
+			}
+		}
+	)";
+	CHECK_ALLOW_MULTI(text, (vector<pair<Error::Type, std::string>>{
+		{Error::Type::Warning, "Using contract member \"send\" inherited from the address type is deprecated"},
+		{Error::Type::TypeError, "Value transfer to a contract without a payable fallback function"}
+	}));
+	text = R"(
+		contract C {
+			function f() pure public {
+				C c;
+				c.call;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Using contract member \"call\" inherited from the address type is deprecated");
+	text = R"(
+		contract C {
+			function f() pure public {
+				C c;
+				c.callcode;
+			}
+		}
+	)";
+	CHECK_WARNING_ALLOW_MULTI(text, (std::vector<std::string>{
+		"Using contract member \"callcode\" inherited from the address type is deprecated",
+		"\"callcode\" has been deprecated in favour of \"delegatecall\""
+	}));
+	text = R"(
+		contract C {
+			function f() pure public {
+				C c;
+				c.delegatecall;
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Using contract member \"delegatecall\" inherited from the address type is deprecated");
+}
+
 BOOST_AUTO_TEST_CASE(no_address_members_on_contract)
 {
 	char const* text = R"(
@@ -8145,6 +8290,20 @@ BOOST_AUTO_TEST_CASE(no_address_members_on_contract)
 		}
 	)";
 	CHECK_ERROR(text, TypeError, "Member \"delegatecall\" not found or not visible after argument-dependent lookup in contract");
+}
+
+BOOST_AUTO_TEST_CASE(no_warning_for_using_members_that_look_like_address_members)
+{
+	char const* text = R"(
+		pragma experimental "v0.5.0";
+		contract C {
+			function transfer(uint) public;
+			function f() public {
+				this.transfer(10);
+			}
+		}
+	)";
+	CHECK_WARNING(text, "Experimental features");
 }
 
 BOOST_AUTO_TEST_CASE(emit_events)

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -280,11 +280,11 @@ BOOST_AUTO_TEST_CASE(builtin_functions)
 	string text = R"(
 		contract C {
 			function f() public {
-				this.transfer(1);
-				require(this.send(2));
-				selfdestruct(this);
-				require(this.delegatecall());
-				require(this.call());
+				address(this).transfer(1);
+				require(address(this).send(2));
+				selfdestruct(address(this));
+				require(address(this).delegatecall());
+				require(address(this).call());
 			}
 			function g() pure public {
 				bytes32 x = keccak256("abc");


### PR DESCRIPTION
# PR for issue #3037 
This PR is now development complete and ready for review. 

## Decisions 
When implementing this feature I took the following approach 

1. Error and exit compilation if a non-existent file is encountered 
2. Create a new flag --ignore-missing that will continue compilation rather than error out when a missing file is encountered

## Questions 
Given I'm still fairly new to the codebase & Solidity in general I have the following questions 

1. In the method where I discover a missing file *and* the user hasn't passed in the `--ignore-missing` option I leverage `exit(1)` as a means to escape.  Primarily, it was the easiest path vs having to pass a boolean up the stack to inspect and then return 1/false further up the stack. 

2.  Please jump on my copy.  I don't have a feel for the prose throughout the code base for error message/communications within the compiler.  Open to any/all feedback. 

## Sample commands 
Here's a simple way to test it when compiling this branch.  This is executed from the ***build*** directory with the attached simple contract located in the same ***build*** directory 

*NO ERROR: * `./solc/solc --bin --ignore-missing test.sol missing-file.sol`
*ERROR* `./solc/solc --bin test.sol missing-file.sol`

## Sample contract 
Again, my above commands assume this is located in the *build* director 

```
pragma solidity ^0.4.17;

contract Test {

}
```