### PR TITLE
Add Korean to Translations

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ This documentation is translated into several languages by community volunteers,
 * `Simplified Chinese <http://solidity-cn.readthedocs.io>`_ (in progress)
 * `Spanish <https://solidity-es.readthedocs.io>`_
 * `Russian <https://github.com/ethereum/wiki/wiki/%5BRussian%5D-%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE-Solidity>`_ (rather outdated)
+* `Korean <http://solidity-kr.readthedocs.io>`_ (in progress)
 
 
 Useful links


### PR DESCRIPTION
Hi, we are [Solidity Korea](http://github.com/solidity-korea)
and Solidity docs translation is in progress from [solidity-docs-kr](https://github.com/solidity-korea/solidity-docs-kr) repo

could we add Korean to Translations list for more contributions and participations?

Thanks