### PR TITLE
Add soltest.sh script that invokes soltest with the correct --testpath.

### DIFF
--- a/scripts/soltest.sh
+++ b/scripts/soltest.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e
+
+REPO_ROOT="$(dirname "$0")"/..
+USE_DEBUGGER=0
+DEBUGGER="gdb --args"
+BOOST_OPTIONS=
+SOLTEST_OPTIONS=
+
+while [ $# -gt 0 ]
+do
+	case "$1" in
+		--debugger)
+			shift
+			DEBUGGER="$1"
+			USE_DEBUGGER=1
+			;;
+		--debug)
+			USE_DEBUGGER=1
+			;;
+		--boost-options)
+			shift
+			BOOST_OPTIONS="${BOOST_OPTIONS} $1"
+			;;
+		-t)
+			shift
+			BOOST_OPTIONS="${BOOST_OPTIONS} -t $1"
+			;;
+		--show-progress | -p)
+			BOOST_OPTIONS="${BOOST_OPTIONS} $1"
+			;;
+		*)
+			SOLTEST_OPTIONS="${SOLTEST_OPTIONS} $1"
+			;;
+	esac
+	shift
+done
+if [ "$USE_DEBUGGER" -ne "0" ]; then
+	DEBUG_PREFIX=${DEBUGGER}
+fi
+
+exec ${DEBUG_PREFIX} ${REPO_ROOT}/build/test/soltest ${BOOST_OPTIONS} -- --testpath ${REPO_ROOT}/test ${SOLTEST_OPTIONS}


### PR DESCRIPTION
The soltest.sh script uses exactly the same command line argument syntax as soltest itself, except that it automatically adds the correct --testpath and has an additional --debug "..." argument.
The debug argument can take a list of (quoted) arguments to be passed to gdb.

EDIT: the ``--debug`` option is now changed to a ``--debugger "gdb --args-to-gdb"`` option