### PR TITLE
Updated link for "try Solidity in your browser"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Useful links
 To get started you can find an introduction to the language in the [Solidity documentation](https://solidity.readthedocs.org). In the documentation, you can find [code examples](https://solidity.readthedocs.io/en/latest/solidity-by-example.html) as well as [a reference](https://solidity.readthedocs.io/en/latest/solidity-in-depth.html) of the syntax and details on how to write smart contracts.
 
-You can start using [Solidity in your browser](https://ethereum.github.io/browser-solidity/) with no need to download or compile anything.
+You can start using [Solidity in your browser](http://remix.ethereum.org) with no need to download or compile anything.
 
 The changelog for this project can be found [here](https://github.com/ethereum/solidity/blob/develop/Changelog.md).
 


### PR DESCRIPTION
Previous link leads to a page with a model warning:
_The Remix IDE has moved to http://remix.ethereum.org. This instance of Remix you are visiting WILL NOT BE UPDATED. Please make a backup of your contracts and start using http://remix.ethereum.org_

Updated link to point to http://remix.ethereum.org