### PR TITLE
 Allow ``block.blockhash`` without it being called. 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Features:
 
 Bugfixes:
+ * Code Generator: Allow ``block.blockhash`` without being called.
  * Code Generator: Properly skip unneeded storgae array cleanup when not reducing length.
  * Commandline interface: Support ``--evm-version constantinople`` properly.
  * Standard JSON: Support ``constantinople`` as ``evmVersion`` properly.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1147,6 +1147,9 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		else if (member == "sig")
 			m_context << u256(0) << Instruction::CALLDATALOAD
 				<< (u256(0xffffffff) << (256 - 32)) << Instruction::AND;
+		else if (member == "blockhash")
+		{
+		}
 		else
 			solAssert(false, "Unknown magic member.");
 		break;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -1788,6 +1788,23 @@ BOOST_AUTO_TEST_CASE(transfer_ether)
 	ABI_CHECK(callContractFunction("b(address,uint256)", oogRecipient, 10), encodeArgs());
 }
 
+BOOST_AUTO_TEST_CASE(uncalled_blockhash)
+{
+	char const* code = R"(
+		contract C {
+			function f() public view returns (bytes32)
+			{
+				var x = block.blockhash;
+				return x(block.number - 1);
+			}
+		}
+	)";
+	compileAndRun(code, 0, "C");
+	bytes result = callContractFunction("f()");
+	BOOST_REQUIRE_EQUAL(result.size(), 32);
+	BOOST_CHECK(result[0] != 0 || result[1] != 0 || result[2] != 0);
+}
+
 BOOST_AUTO_TEST_CASE(log0)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/2977