### PR TITLE
DocStringParser: Fix error message for empty parameter description.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Bugfixes:
  * Code Generator: Properly skip unneeded storgae array cleanup when not reducing length.
  * Commandline interface: Support ``--evm-version constantinople`` properly.
  * Standard JSON: Support ``constantinople`` as ``evmVersion`` properly.
+ * DocString Parser: Fix error message for empty descriptions.
 
 ### 0.4.21 (2018-03-07)
 

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -119,21 +119,17 @@ DocStringParser::iter DocStringParser::parseDocTagParam(iter _pos, iter _end)
 		return _end;
 	}
 	auto nameEndPos = firstSpaceOrTab(nameStartPos, _end);
-	if (nameEndPos == _end)
-	{
-		appendError("End of param name not found: " + string(nameStartPos, _end));
-		return _end;
-	}
 	auto paramName = string(nameStartPos, nameEndPos);
 
 	auto descStartPos = skipWhitespace(nameEndPos, _end);
-	if (descStartPos == _end)
+	auto nlPos = find(descStartPos, _end, '\n');
+
+	if (descStartPos == nlPos)
 	{
 		appendError("No description given for param " + paramName);
 		return _end;
 	}
 
-	auto nlPos = find(descStartPos, _end, '\n');
 	auto paramDesc = string(descStartPos, nlPos);
 	newTag("param");
 	m_lastTag->paramName = paramName;

--- a/test/libsolidity/syntaxTests/docstring_empty_description.sol
+++ b/test/libsolidity/syntaxTests/docstring_empty_description.sol
@@ -1,0 +1,6 @@
+contract C {
+    /// @param id
+    function vote(uint id) public;
+}
+// ----
+// DocstringParsingError: No description given for param id


### PR DESCRIPTION
Fixes #3728.

