### PR TITLE
soltest: force the use of the --testpath option for soltest with an e…

### DIFF
--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -55,6 +55,10 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 {
 	master_test_suite_t& master = framework::master_test_suite();
 	master.p_name.value = "SolidityTests";
+	solAssert(
+		!dev::test::Options::get().testPath.empty(),
+		"No test path specified. The --testpath argument is required."
+	);
 	solAssert(dev::solidity::test::SyntaxTest::registerTests(
 		master,
 		dev::test::Options::get().testPath / "libsolidity",


### PR DESCRIPTION
…xplicit error.

The explicit check unfortunately seems to have gotten lost in a rebase, so we should merge this small amendment (otherwise there will be cryptic error messages, when no --testpath option is provided).