### PR TITLE
test: Rename test/TestHelper.* to test/Options.* and add Options::val…

### DIFF
--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 #include <test/RPCSession.h>
 
 #include <libsolidity/interface/EVMVersion.h>

--- a/test/Options.cpp
+++ b/test/Options.cpp
@@ -19,9 +19,10 @@
 * @date 2014
 */
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/interface/EVMVersion.h>
+#include <libsolidity/interface/Exceptions.h>
 
 #include <boost/test/framework.hpp>
 
@@ -69,6 +70,19 @@ Options::Options()
 	if (testPath.empty())
 		if (auto path = getenv("ETH_TEST_PATH"))
 			testPath = path;
+}
+
+void Options::validate() const
+{
+	solAssert(
+		!dev::test::Options::get().testPath.empty(),
+		"No test path specified. The --testpath argument is required."
+	);
+	if (!disableIPC)
+		solAssert(
+			!dev::test::Options::get().ipcPath.empty(),
+			"No ipc path specified. The --ipcpath argument is required, unless --no-ipc is used."
+		);
 }
 
 dev::solidity::EVMVersion Options::evmVersion() const

--- a/test/Options.h
+++ b/test/Options.h
@@ -41,6 +41,7 @@ struct Options: boost::noncopyable
 	bool disableIPC = false;
 	bool disableSMT = false;
 
+	void validate() const;
 	solidity::EVMVersion evmVersion() const;
 
 	static Options const& get();

--- a/test/RPCSession.cpp
+++ b/test/RPCSession.cpp
@@ -21,7 +21,7 @@
 
 #include <test/RPCSession.h>
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/interface/EVMVersion.h>
 

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -35,7 +35,7 @@
 
 #pragma GCC diagnostic pop
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 #include <test/libsolidity/SyntaxTest.h>
 
 using namespace boost::unit_test;
@@ -55,10 +55,7 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 {
 	master_test_suite_t& master = framework::master_test_suite();
 	master.p_name.value = "SolidityTests";
-	solAssert(
-		!dev::test::Options::get().testPath.empty(),
-		"No test path specified. The --testpath argument is required."
-	);
+	dev::test::Options::get().validate();
 	solAssert(dev::solidity::test::SyntaxTest::registerTests(
 		master,
 		dev::test::Options::get().testPath / "libsolidity",

--- a/test/libdevcore/Checksum.cpp
+++ b/test/libdevcore/Checksum.cpp
@@ -22,7 +22,7 @@
 #include <libdevcore/Exceptions.h>
 
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libdevcore/IndentedWriter.cpp
+++ b/test/libdevcore/IndentedWriter.cpp
@@ -20,7 +20,7 @@
 
 #include <libdevcore/IndentedWriter.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libdevcore/JSON.cpp
+++ b/test/libdevcore/JSON.cpp
@@ -21,7 +21,7 @@
 
 #include <libdevcore/JSON.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libdevcore/StringUtils.cpp
+++ b/test/libdevcore/StringUtils.cpp
@@ -20,7 +20,7 @@
 
 #include <libdevcore/StringUtils.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libdevcore/SwarmHash.cpp
+++ b/test/libdevcore/SwarmHash.cpp
@@ -20,7 +20,7 @@
 
 #include <libdevcore/SwarmHash.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libdevcore/UTF8.cpp
+++ b/test/libdevcore/UTF8.cpp
@@ -21,7 +21,7 @@
 #include <libdevcore/CommonData.h>
 #include <libdevcore/UTF8.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libdevcore/Whiskers.cpp
+++ b/test/libdevcore/Whiskers.cpp
@@ -20,7 +20,7 @@
 
 #include <libdevcore/Whiskers.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -20,7 +20,7 @@
  * Tests for the Solidity optimizer.
  */
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libevmasm/CommonSubexpressionEliminator.h>
 #include <libevmasm/PeepholeOptimiser.h>

--- a/test/libevmasm/SourceLocation.cpp
+++ b/test/libevmasm/SourceLocation.cpp
@@ -22,7 +22,7 @@
 
 #include <libevmasm/SourceLocation.h>
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 namespace dev
 {

--- a/test/libjulia/Common.cpp
+++ b/test/libjulia/Common.cpp
@@ -21,7 +21,7 @@
 
 #include <test/libjulia/Common.h>
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libjulia/optimiser/Disambiguator.h>
 

--- a/test/libjulia/Parser.cpp
+++ b/test/libjulia/Parser.cpp
@@ -19,7 +19,7 @@
  * Unit tests for parsing Julia.
  */
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 #include <test/libsolidity/ErrorCheck.h>
 

--- a/test/liblll/Compiler.cpp
+++ b/test/liblll/Compiler.cpp
@@ -20,7 +20,7 @@
  * Unit tests for the LLL compiler.
  */
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libdevcore/FixedHash.h>
 

--- a/test/liblll/EndToEndTest.cpp
+++ b/test/liblll/EndToEndTest.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <test/liblll/ExecutionFramework.h>
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/libsolidity/ASTJSON.cpp
+++ b/test/libsolidity/ASTJSON.cpp
@@ -20,7 +20,7 @@
  * Tests for the json ast output.
  */
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/interface/CompilerStack.h>

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -20,7 +20,7 @@
 
 #include <test/libsolidity/AnalysisFramework.h>
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/SourceReferenceFormatter.h>

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -20,7 +20,7 @@
  * Unit tests for Assembly Items from evmasm/Assembly.h
  */
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libevmasm/SourceLocation.h>
 #include <libevmasm/Assembly.h>

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <test/libsolidity/ErrorCheck.h>
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/interface/CompilerStack.h>

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -20,7 +20,7 @@
  * Unit tests for inline assembly.
  */
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 #include <libsolidity/interface/AssemblyStack.h>
 #include <libsolidity/parsing/Scanner.h>

--- a/test/libsolidity/JSONCompiler.cpp
+++ b/test/libsolidity/JSONCompiler.cpp
@@ -25,8 +25,8 @@
 #include <libsolidity/interface/Version.h>
 #include <libsolc/libsolc.h>
 
-#include "../Metadata.h"
-#include "../TestHelper.h"
+#include <test/Metadata.h>
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -19,8 +19,8 @@
  * Unit tests for the metadata output.
  */
 
-#include "../Metadata.h"
-#include "../TestHelper.h"
+#include <test/Metadata.h>
+#include <test/Options.h>
 #include <libsolidity/interface/CompilerStack.h>
 #include <libdevcore/SwarmHash.h>
 #include <libdevcore/JSON.h>

--- a/test/libsolidity/SemVerMatcher.cpp
+++ b/test/libsolidity/SemVerMatcher.cpp
@@ -25,7 +25,7 @@
 #include <tuple>
 #include <libsolidity/parsing/Scanner.h>
 #include <libsolidity/analysis/SemVerHandler.h>
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -20,7 +20,7 @@
  * Unit tests for the solidity compiler JSON Interface output.
  */
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 #include <libsolidity/interface/CompilerStack.h>
 
 #include <libdevcore/Exceptions.h>

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -23,7 +23,7 @@
 
 #include <test/libsolidity/SolidityExecutionFramework.h>
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/interface/EVMVersion.h>

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -30,7 +30,7 @@
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/analysis/TypeChecker.h>
 #include <libsolidity/interface/ErrorReporter.h>
-#include "../TestHelper.h"
+#include <test/Options.h>
 
 using namespace std;
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -22,7 +22,7 @@
 
 #include <test/libsolidity/AnalysisFramework.h>
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <libsolidity/ast/AST.h>
 

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -20,7 +20,7 @@
  * Unit tests for the solidity compiler JSON Interface output.
  */
 
-#include "../TestHelper.h"
+#include <test/Options.h>
 #include <string>
 #include <libdevcore/JSON.h>
 #include <libsolidity/interface/CompilerStack.h>

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -25,8 +25,8 @@
 #include <libsolidity/parsing/Scanner.h>
 #include <libsolidity/parsing/Parser.h>
 #include <libsolidity/interface/ErrorReporter.h>
-#include "../TestHelper.h"
-#include "ErrorCheck.h"
+#include <test/Options.h>
+#include <test/libsolidity/ErrorCheck.h>
 
 using namespace std;
 

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -20,7 +20,7 @@
 
 #include <test/libsolidity/AnalysisFramework.h>
 
-#include <test/TestHelper.h>
+#include <test/Options.h>
 
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
…idate().

Came up in #3731.

Some questions about proper procedure:
- Should I always first create an issue even for quick changes such as this one?
- This pull request also fixes some includes throughout the tests to use absolute paths - strictly speaking this would have to be a separate commit and pull request - are you OK with such small and harmless side-changes if they come up during a commit?

To be discussed:
- Should test/TestHelper.* actually be renamed to test/Options.*? Since TestHelper only contained the Options class I would say this makes sense - one may want to add another TestHelper.h header that includes Options.h, though, if one expects further test helpers in the future.