### PR TITLE
Only consider files ending with .sol and not starting with ~ in synta…

### DIFF
--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -205,6 +205,13 @@ test_case *make_test_case(
 }
 #endif
 
+bool SyntaxTest::isTestFilename(boost::filesystem::path const& _filename)
+{
+	return _filename.extension().string() == ".sol" &&
+		!boost::starts_with(_filename.string(), "~") &&
+		!boost::starts_with(_filename.string(), ".");
+}
+
 int SyntaxTest::registerTests(
 	boost::unit_test::test_suite& _suite,
 	boost::filesystem::path const& _basepath,
@@ -220,7 +227,8 @@ int SyntaxTest::registerTests(
 			fs::directory_iterator(fullpath),
 			fs::directory_iterator()
 		))
-			numTestsAdded += registerTests(*sub_suite, _basepath, _path / entry.path().filename());
+			if (fs::is_directory(entry.path()) || isTestFilename(entry.path().filename()))
+				numTestsAdded += registerTests(*sub_suite, _basepath, _path / entry.path().filename());
 		_suite.add(sub_suite);
 	}
 	else

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -71,6 +71,7 @@ public:
 		boost::filesystem::path const& _basepath,
 		boost::filesystem::path const& _path
 	);
+	static bool isTestFilename(boost::filesystem::path const& _filename);
 private:
 	bool matchesExpectations(ErrorList const& _errors) const;
 	static std::string errorMessage(Error const& _e);

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -19,6 +19,7 @@
 #include <test/libsolidity/AnalysisFramework.h>
 #include <test/libsolidity/SyntaxTest.h>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
@@ -218,7 +219,8 @@ SyntaxTestStats SyntaxTestTool::processPath(
 				fs::directory_iterator(fullpath),
 				fs::directory_iterator()
 			))
-				paths.push(currentPath / entry.path().filename());
+				if (fs::is_directory(entry.path()) || SyntaxTest::isTestFilename(entry.path().filename()))
+					paths.push(currentPath / entry.path().filename());
 		}
 		else
 		{


### PR DESCRIPTION
…x tests.

Fixes #3742.

Are there any other naming schemes for temporary files that will still result in temporary files being considered valid tests?