### PR TITLE
Error on non existing or irregular files 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.22 (unreleased)
 
 Features:
+ * Commandline interface: Error when missing or inaccessible file detected. Suppress it with the ``--ignore-missing`` flag.
  * General: Support accessing dynamic return data in post-byzantium EVMs.
  * Interfaces: Allow overriding external functions in interfaces with public in an implementing contract.
 

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -72,7 +72,7 @@ private:
 	void handleFormal();
 
 	/// Fills @a m_sourceCodes initially and @a m_redirects.
-	void readInputFilesAndConfigureRemappings();
+	bool readInputFilesAndConfigureRemappings();
 	/// Tries to read from the file @a _input or interprets _input literally if that fails.
 	/// It then tries to parse the contents and appends to m_libraries.
 	bool parseLibraryOption(std::string const& _input);

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -32,7 +32,7 @@ REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
 echo $REPO_ROOT
 SOLC="$REPO_ROOT/build/solc/solc"
 
-FULLARGS="--optimize --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
+FULLARGS="--optimize --ignore-missing --combined-json abi,asm,ast,bin,bin-runtime,clone-bin,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
 
 echo "Checking that the bug list is up to date..."
 "$REPO_ROOT"/scripts/update_bugs_by_version.py


### PR DESCRIPTION
Fixes #3037.

## Decisions 
When implementing this feature I took the following approach 

1. Error and exit compilation if a non-existent or irregular file is encountered (per request in issue #3037)
2. Create a new flag --ignore-missing that will continue compilation rather than error out when a missing or irregular file is encountered

## Sample commands 
Here's a simple way to test it when compiling this branch.  This is executed from the ***build*** directory with the attached simple contract located in the same ***build*** directory 

*NO ERROR: * `./solc/solc --bin --ignore-missing test.sol missing-file.sol`
*ERROR* `./solc/solc --bin test.sol missing-file.sol`

## Sample contract 
Again, my above commands assume this is located in the *build* director 

```
pragma solidity ^0.4.17;

contract Test {

}
```