### PR TITLE
Fix: Treat empty base constructor argument list as not provided.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Bugfixes:
  * Code Generator: Properly skip unneeded storage array cleanup when not reducing length.
  * Code Generator: Bugfix in modifier lookup in libraries.
  * Code Generator: Implement packed encoding of external function types.
+ * Code Generator: Treat empty base constructor argument list as not provided.
  * Commandline interface: Support ``--evm-version constantinople`` properly.
  * DocString Parser: Fix error message for empty descriptions.
  * Standard JSON: Support ``constantinople`` as ``evmVersion`` properly.

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -143,8 +143,9 @@ void ContractCompiler::appendInitAndConstructorCode(ContractDefinition const& _c
 			for (auto const& modifier: constructor->modifiers())
 			{
 				auto baseContract = dynamic_cast<ContractDefinition const*>(
-					modifier->name()->annotation().referencedDeclaration);
-				if (baseContract)
+					modifier->name()->annotation().referencedDeclaration
+				);
+				if (baseContract && !modifier->arguments().empty())
 					if (m_baseArguments.count(baseContract->constructor()) == 0)
 						m_baseArguments[baseContract->constructor()] = &modifier->arguments();
 			}
@@ -156,7 +157,7 @@ void ContractCompiler::appendInitAndConstructorCode(ContractDefinition const& _c
 			);
 			solAssert(baseContract, "");
 
-			if (m_baseArguments.count(baseContract->constructor()) == 0)
+			if (!m_baseArguments.count(baseContract->constructor()) && !base->arguments().empty())
 				m_baseArguments[baseContract->constructor()] = &base->arguments();
 		}
 	}
@@ -238,6 +239,7 @@ void ContractCompiler::appendBaseConstructor(FunctionDefinition const& _construc
 		solAssert(m_baseArguments.count(&_constructor), "");
 		std::vector<ASTPointer<Expression>> const* arguments = m_baseArguments[&_constructor];
 		solAssert(arguments, "");
+		solAssert(arguments->size() == constructorType.parameterTypes().size(), "");
 		for (unsigned i = 0; i < arguments->size(); ++i)
 			compileExpression(*(arguments->at(i)), constructorType.parameterTypes()[i]);
 	}

--- a/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses.sol
+++ b/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses.sol
@@ -1,0 +1,6 @@
+contract Base {
+  function Base(uint) public {}
+}
+contract Derived is Base(2) { }
+contract Derived2 is Base(), Derived() { }
+contract Derived3 is Base, Derived {}

--- a/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
+++ b/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
@@ -1,0 +1,10 @@
+contract Base {
+  function Base(uint, uint) public {}
+}
+contract Derived is Base(2) { }
+contract Derived2 is Base {
+  function Derived2() Base(2) public { }
+}
+// ----
+// TypeError: Wrong argument count for constructor call: 1 arguments given but expected 2.
+// TypeError: Wrong argument count for modifier invocation: 1 arguments given but expected 2.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/2912