### PR TITLE
Fix: Missing payable at function forceOwnerChange

### DIFF
--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -194,6 +194,7 @@ restrictions highly readable.
 
         function forceOwnerChange(address _newOwner)
             public
+            payable
             costs(200 ether)
         {
             owner = _newOwner;


### PR DESCRIPTION
forceOwnerChange expects ether, and does not have the payable keyword.