### PR TITLE
Simplify struct definition.

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -18,8 +18,7 @@ InheritanceSpecifier = UserDefinedTypeName ( '(' Expression ( ',' Expression )* 
 
 StateVariableDeclaration = TypeName ( 'public' | 'internal' | 'private' | 'constant' )? Identifier ('=' Expression)? ';'
 UsingForDeclaration = 'using' Identifier 'for' ('*' | TypeName) ';'
-StructDefinition = 'struct' Identifier '{'
-                     ( VariableDeclaration ';' (VariableDeclaration ';')* )? '}'
+StructDefinition = 'struct' Identifier '{' (VariableDeclaration ';')* '}'
 
 ModifierDefinition = 'modifier' Identifier ParameterList? Block
 ModifierInvocation = Identifier ( '(' ExpressionList? ')' )?


### PR DESCRIPTION
```
'struct' Identifier '{' ( VariableDeclaration ';' (VariableDeclaration ';')* )? '}'
```
is equivalent to
```
'struct' Identifier '{' (VariableDeclaration ';')* '}'
```

I just simplified it.