### PR TITLE
Update tests for empty structs

### DIFF
--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
@@ -9,5 +9,6 @@ contract C {
     }
 }
 // ----
+// Warning: Defining empty structs is deprecated.
 // TypeError: This type cannot be encoded.
 // TypeError: This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_types.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_types.sol
@@ -9,6 +9,7 @@ contract C {
     }
 }
 // ----
+// Warning: Defining empty structs is deprecated.
 // TypeError: This type cannot be encoded.
 // TypeError: This type cannot be encoded.
 // TypeError: This type cannot be encoded.


### PR DESCRIPTION
Fixes #3790. Should have been rebased after #3753 was merged.