### PR TITLE
Removed documentation reference to var for tuple variable assignment

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -284,10 +284,12 @@ Solidity internally allows tuple types, i.e. a list of objects of potentially di
         }
 
         function g() public {
-            // Declares and assigns the variables. Specifying the type explicitly is not possible.
-            var (x, b, y) = f();
-            // Assigns to a pre-existing variable.
-            (x, y) = (2, 7);
+            // Variables declared with type
+            uint x;
+            bool b;
+            uint y;
+            // These pre-existing variables can then be assigned to the tuple values
+            (x, b, y) = f();
             // Common trick to swap values -- does not work for non-value storage types.
             (x, y) = (y, x);
             // Components can be left out (also for variable declarations).

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -288,7 +288,7 @@ Solidity internally allows tuple types, i.e. a list of objects of potentially di
             uint x;
             bool b;
             uint y;
-            // These pre-existing variables can then be assigned to the tuple values
+            // Tuple values can be assigned to these pre-existing variables
             (x, b, y) = f();
             // Common trick to swap values -- does not work for non-value storage types.
             (x, y) = (y, x);


### PR DESCRIPTION
This is a fix for the documentation as mentioned in https://github.com/ethereum/solidity/issues/3669
The problem was that the documentation still referenced the now-depricated var way of assigning variables from tuples

This was brought to light in discussion here https://github.com/ethereum/solidity/issues/3301#issuecomment-372589186

My first contribution attempt here. Let me know if there's anything I should change.