### PR TITLE
SyntaxTests: extend syntax tests and isoltest to support parser error…

### DIFF
--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -57,14 +57,17 @@ protected:
 	bool success(std::string const& _source);
 	ErrorList expectError(std::string const& _source, bool _warning = false, bool _allowMultiple = false);
 
-	std::string formatErrors();
-	std::string formatError(Error const& _error);
+	std::string formatErrors() const;
+	std::string formatError(Error const& _error) const;
 
 	static ContractDefinition const* retrieveContractByName(SourceUnit const& _source, std::string const& _name);
 	static FunctionTypePointer retrieveFunctionBySignature(
 		ContractDefinition const& _contract,
 		std::string const& _signature
 	);
+
+	// filter out the warnings in m_warningsToFilter or all warnings if _includeWarnings is false
+	ErrorList filterErrors(ErrorList const& _errorList, bool _includeWarnings) const;
 
 	std::vector<std::string> m_warningsToFilter = {"This is a pre-release compiler version"};
 	dev::solidity::CompilerStack m_compiler;

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -112,26 +112,6 @@ while(0)
 
 BOOST_AUTO_TEST_SUITE(SolidityParser)
 
-BOOST_AUTO_TEST_CASE(smoke_test)
-{
-	char const* text = R"(
-		contract test {
-			uint256 stateVariable1;
-		}
-	)";
-	BOOST_CHECK(successParse(text));
-}
-
-BOOST_AUTO_TEST_CASE(missing_variable_name_in_declaration)
-{
-	char const* text = R"(
-		contract test {
-			uint256 ;
-		}
-	)";
-	CHECK_PARSE_ERROR(text, "Expected identifier");
-}
-
 BOOST_AUTO_TEST_CASE(empty_function)
 {
 	char const* text = R"(

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -36,10 +36,14 @@ namespace solidity
 namespace test
 {
 
-struct SyntaxTestExpectation
+struct SyntaxTestError
 {
 	std::string type;
 	std::string message;
+	bool operator==(SyntaxTestError const& _rhs) const
+	{
+		return type == _rhs.type && message == _rhs.message;
+	}
 };
 
 
@@ -50,21 +54,16 @@ public:
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false);
 
-	std::vector<SyntaxTestExpectation> const& expectations() const { return m_expectations; }
+	std::vector<SyntaxTestError> const& expectations() const { return m_expectations; }
 	std::string const& source() const { return m_source; }
-	ErrorList const& errorList() const { return m_errorList; }
-	ErrorList const& compilerErrors() const { return m_compiler.errors(); }
+	std::vector<SyntaxTestError> const& errorList() const { return m_errorList; }
 
-	void printExpected(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted = false) const;
-
-	void printErrorList(
+	static void printErrorList(
 		std::ostream& _stream,
-		ErrorList const& _errors,
+		std::vector<SyntaxTestError> const& _errors,
 		std::string const& _linePrefix,
-		bool const _ignoreWarnings,
-		bool const _lineNumbers,
 		bool const _formatted = false
-	) const;
+	);
 
 	static int registerTests(
 		boost::unit_test::test_suite& _suite,
@@ -72,16 +71,14 @@ public:
 		boost::filesystem::path const& _path
 	);
 	static bool isTestFilename(boost::filesystem::path const& _filename);
+	static std::string errorMessage(Exception const& _e);
 private:
-	bool matchesExpectations(ErrorList const& _errors) const;
-	static std::string errorMessage(Error const& _e);
 	static std::string parseSource(std::istream& _stream);
-	static std::vector<SyntaxTestExpectation> parseExpectations(std::istream& _stream);
-	int offsetToLineNumber(int _location) const;
+	static std::vector<SyntaxTestError> parseExpectations(std::istream& _stream);
 
 	std::string m_source;
-	std::vector<SyntaxTestExpectation> m_expectations;
-	ErrorList m_errorList;
+	std::vector<SyntaxTestError> m_expectations;
+	std::vector<SyntaxTestError> m_errorList;
 };
 
 }

--- a/test/libsolidity/syntaxTests/parsing/missing_variable_name_in_declaration.sol
+++ b/test/libsolidity/syntaxTests/parsing/missing_variable_name_in_declaration.sol
@@ -1,0 +1,5 @@
+contract test {
+    uint256 ;
+}
+// ----
+// ParserError: Expected identifier, got 'Semicolon'

--- a/test/libsolidity/syntaxTests/parsing/smoke_test.sol
+++ b/test/libsolidity/syntaxTests/parsing/smoke_test.sol
@@ -1,0 +1,4 @@
+contract test {
+    uint256 stateVariable1;
+}
+// ----


### PR DESCRIPTION
…s and compiler exceptions.

Came up in #3039.