### PR TITLE
hash256 -> bytes32 fix in misleading note

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -803,7 +803,7 @@ as topics. The event call above can be performed in the same way as
     }
 
 where the long hexadecimal number is equal to
-``keccak256("Deposit(address,hash256,uint256)")``, the signature of the event.
+``keccak256("Deposit(address,bytes32,uint256)")``, the signature of the event.
 
 Additional Resources for Understanding Events
 ==============================================


### PR DESCRIPTION
Fixes #3815 

As it was described here: https://ethereum.stackexchange.com/questions/44628/understanding-low-level-interface-to-logs/44629?noredirect=1#comment52316_44629