### PR TITLE
Add source locations to syntax test expectations.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Features:
  * Optimizer: Optimize across ``mload`` if ``msize()`` is not used.
  * Static Analyzer: Error on duplicated super constructor calls as experimental 0.5.0 feature.
  * Syntax Checker: Issue warning for empty structs (or error as experimental 0.5.0 feature).
+ * Syntax Tests: Add source locations to syntax test expectations.
  * General: Introduce new constructor syntax using the ``constructor`` keyword as experimental 0.5.0 feature.
  * Inheritance: Error when using empty parentheses for base class constructors that require arguments as experimental 0.5.0 feature.
  * Inheritance: Error when using no parentheses in modifier-style constructor calls as experimental 0.5.0 feature.

--- a/test/libsolidity/FormattedScope.h
+++ b/test/libsolidity/FormattedScope.h
@@ -38,6 +38,8 @@ static constexpr char const* GREEN = "\033[1;32m";
 static constexpr char const* YELLOW = "\033[1;33m";
 static constexpr char const* CYAN = "\033[1;36m";
 static constexpr char const* BOLD = "\033[1m";
+static constexpr char const* RED_BACKGROUND  = "\033[48;5;160m";
+static constexpr char const* ORANGE_BACKGROUND  = "\033[48;5;166m";
 static constexpr char const* INVERSE = "\033[7m";
 
 }

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -40,9 +40,14 @@ struct SyntaxTestError
 {
 	std::string type;
 	std::string message;
+	int locationStart;
+	int locationEnd;
 	bool operator==(SyntaxTestError const& _rhs) const
 	{
-		return type == _rhs.type && message == _rhs.message;
+		return type == _rhs.type &&
+			message == _rhs.message &&
+			locationStart == _rhs.locationStart &&
+			locationEnd == _rhs.locationEnd;
 	}
 };
 

--- a/test/libsolidity/syntaxTests/constants/cyclic_dependency_1.sol
+++ b/test/libsolidity/syntaxTests/constants/cyclic_dependency_1.sol
@@ -2,4 +2,4 @@ contract C {
     uint constant a = a;
 }
 // ----
-// TypeError: The value of the constant a has a cyclic dependency via a.
+// TypeError: (17-36): The value of the constant a has a cyclic dependency via a.

--- a/test/libsolidity/syntaxTests/constants/cyclic_dependency_2.sol
+++ b/test/libsolidity/syntaxTests/constants/cyclic_dependency_2.sol
@@ -5,6 +5,6 @@ contract C {
     uint constant d = 2 + a;
 }
 // ----
-// TypeError: The value of the constant a has a cyclic dependency via c.
-// TypeError: The value of the constant c has a cyclic dependency via d.
-// TypeError: The value of the constant d has a cyclic dependency via a.
+// TypeError: (17-40): The value of the constant a has a cyclic dependency via c.
+// TypeError: (71-111): The value of the constant c has a cyclic dependency via d.
+// TypeError: (117-140): The value of the constant d has a cyclic dependency via a.

--- a/test/libsolidity/syntaxTests/constants/cyclic_dependency_3.sol
+++ b/test/libsolidity/syntaxTests/constants/cyclic_dependency_3.sol
@@ -5,7 +5,7 @@ contract C {
     uint constant c = b;
 }
 // ----
-// TypeError: The value of the constant x has a cyclic dependency via a.
-// TypeError: The value of the constant a has a cyclic dependency via b.
-// TypeError: The value of the constant b has a cyclic dependency via c.
-// TypeError: The value of the constant c has a cyclic dependency via b.
+// TypeError: (17-36): The value of the constant x has a cyclic dependency via a.
+// TypeError: (42-65): The value of the constant a has a cyclic dependency via b.
+// TypeError: (71-90): The value of the constant b has a cyclic dependency via c.
+// TypeError: (96-115): The value of the constant c has a cyclic dependency via b.

--- a/test/libsolidity/syntaxTests/double_stateVariable_declaration.sol
+++ b/test/libsolidity/syntaxTests/double_stateVariable_declaration.sol
@@ -3,4 +3,4 @@ contract test {
 	uint128 variable;
 }
 // ----
-// DeclarationError: Identifier already declared.
+// DeclarationError: (36-52): Identifier already declared.

--- a/test/libsolidity/syntaxTests/double_variable_declaration.sol
+++ b/test/libsolidity/syntaxTests/double_variable_declaration.sol
@@ -5,4 +5,4 @@ contract test {
 	}
 }
 // ----
-// DeclarationError: Identifier already declared.
+// DeclarationError: (71-80): Identifier already declared.

--- a/test/libsolidity/syntaxTests/double_variable_declaration_050.sol
+++ b/test/libsolidity/syntaxTests/double_variable_declaration_050.sol
@@ -6,6 +6,6 @@ contract test {
 	}
 }
 // ----
-// Warning: This declaration shadows an existing declaration.
-// Warning: Unused local variable.
-// Warning: Unused local variable.
+// Warning: (101-110): This declaration shadows an existing declaration.
+// Warning: (76-85): Unused local variable.
+// Warning: (101-110): Unused local variable.

--- a/test/libsolidity/syntaxTests/empty_struct.sol
+++ b/test/libsolidity/syntaxTests/empty_struct.sol
@@ -2,4 +2,4 @@ contract test {
 	struct A {}
 }
 // ----
-// Warning: Defining empty structs is deprecated.
+// Warning: (17-28): Defining empty structs is deprecated.

--- a/test/libsolidity/syntaxTests/empty_struct_050.sol
+++ b/test/libsolidity/syntaxTests/empty_struct_050.sol
@@ -3,4 +3,4 @@ contract test {
 	struct A {}
 }
 // ----
-// SyntaxError: Defining empty structs is disallowed.
+// SyntaxError: (47-58): Defining empty structs is disallowed.

--- a/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses.sol
+++ b/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses.sol
@@ -4,4 +4,4 @@ contract Base {
 contract Derived is Base(2) { }
 contract Derived2 is Base(), Derived() { }
 // ----
-// Warning: Wrong argument count for constructor call: 0 arguments given but expected 1.
+// Warning: (101-107): Wrong argument count for constructor call: 0 arguments given but expected 1.

--- a/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses_V050.sol
+++ b/test/libsolidity/syntaxTests/inheritance/base_arguments_empty_parentheses_V050.sol
@@ -6,4 +6,4 @@ contract Base {
 contract Derived is Base(2) { }
 contract Derived2 is Base(), Derived() { }
 // ----
-// TypeError: Wrong argument count for constructor call: 0 arguments given but expected 1.
+// TypeError: (132-138): Wrong argument count for constructor call: 0 arguments given but expected 1.

--- a/test/libsolidity/syntaxTests/inheritance/base_arguments_multiple_inheritance.sol
+++ b/test/libsolidity/syntaxTests/inheritance/base_arguments_multiple_inheritance.sol
@@ -6,4 +6,4 @@ contract Derived is Base, Base1 {
     constructor(uint i) Base(i) public {}
 }
 // ----
-// Warning: Base constructor arguments given twice.
+// Warning: (138-145): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/disallow_modifier_style_without_parentheses.sol
+++ b/test/libsolidity/syntaxTests/inheritance/disallow_modifier_style_without_parentheses.sol
@@ -1,4 +1,4 @@
 contract A { constructor() public { } }
 contract B is A { constructor() A public {  } }
 // ----
-// Warning: Modifier-style base constructor call without arguments.
+// Warning: (72-73): Modifier-style base constructor call without arguments.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/ancestor.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/ancestor.sol
@@ -2,4 +2,4 @@ contract A { constructor(uint) public { } }
 contract B is A(2) { constructor() public {  } }
 contract C is B { constructor() A(3) public {  } }
 // ----
-// Warning: Base constructor arguments given twice.
+// Warning: (125-129): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/ancestor_V050.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/ancestor_V050.sol
@@ -4,4 +4,4 @@ contract A { constructor(uint) public { } }
 contract B is A(2) { constructor() public {  } }
 contract C is B { constructor() A(3) public {  } }
 // ----
-// DeclarationError: Base constructor arguments given twice.
+// DeclarationError: (156-160): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base.sol
@@ -1,4 +1,4 @@
 contract A { constructor(uint) public { } }
 contract B is A(2) { constructor() A(3) public {  } }
 // ----
-// Warning: Base constructor arguments given twice.
+// Warning: (79-83): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_V050.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_V050.sol
@@ -3,4 +3,4 @@ pragma experimental "v0.5.0";
 contract A { constructor(uint) public { } }
 contract B is A(2) { constructor() A(3) public {  } }
 // ----
-// DeclarationError: Base constructor arguments given twice.
+// DeclarationError: (110-114): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_multi.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_multi.sol
@@ -3,5 +3,5 @@ contract A is C(2) {}
 contract B is C(2) {}
 contract D is A, B { constructor() C(3) public {} }
 // ----
-// Warning: Base constructor arguments given twice.
-// Warning: Base constructor arguments given twice.
+// Warning: (122-126): Base constructor arguments given twice.
+// Warning: (122-126): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_multi_no_constructor.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_multi_no_constructor.sol
@@ -3,4 +3,4 @@ contract A is C(2) {}
 contract B is C(2) {}
 contract D is A, B {}
 // ----
-// Warning: Base constructor arguments given twice.
+// Warning: (87-108): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_multi_no_constructor_modifier_style.sol
+++ b/test/libsolidity/syntaxTests/inheritance/duplicated_constructor_call/base_multi_no_constructor_modifier_style.sol
@@ -3,4 +3,4 @@ contract A is C { constructor() C(2) public {} }
 contract B is C { constructor() C(2) public {} }
 contract D is A, B { }
 // ----
-// Warning: Base constructor arguments given twice.
+// Warning: (141-163): Base constructor arguments given twice.

--- a/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
+++ b/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
@@ -6,5 +6,5 @@ contract Derived2 is Base {
   constructor() Base(2) public { }
 }
 // ----
-// TypeError: Wrong argument count for constructor call: 1 arguments given but expected 2.
-// TypeError: Wrong argument count for modifier invocation: 1 arguments given but expected 2.
+// TypeError: (74-81): Wrong argument count for constructor call: 1 arguments given but expected 2.
+// TypeError: (130-137): Wrong argument count for modifier invocation: 1 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/parsing/missing_variable_name_in_declaration.sol
+++ b/test/libsolidity/syntaxTests/parsing/missing_variable_name_in_declaration.sol
@@ -2,4 +2,4 @@ contract test {
     uint256 ;
 }
 // ----
-// ParserError: Expected identifier, got 'Semicolon'
+// ParserError: (28-28): Expected identifier, got 'Semicolon'

--- a/test/libsolidity/syntaxTests/scoping/double_function_declaration.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_function_declaration.sol
@@ -3,4 +3,4 @@ contract test {
     function fun() public { }
 }
 // ----
-// DeclarationError: Function with same name and arguments defined twice.
+// DeclarationError: (20-45): Function with same name and arguments defined twice.

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Identifier already declared.
+// DeclarationError: (77-83): Identifier already declared.

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_050.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_050.sol
@@ -6,5 +6,5 @@ contract test {
     }
 }
 // ----
-// Warning: Unused local variable.
-// Warning: Unused local variable.
+// Warning: (87-93): Unused local variable.
+// Warning: (107-113): Unused local variable.

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_activation.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_activation.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Identifier already declared.
+// DeclarationError: (75-81): Identifier already declared.

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_activation_050.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_activation_050.sol
@@ -6,5 +6,5 @@ contract test {
     }
 }
 // ----
-// Warning: Unused local variable.
-// Warning: Unused local variable.
+// Warning: (87-93): Unused local variable.
+// Warning: (105-111): Unused local variable.

--- a/test/libsolidity/syntaxTests/scoping/name_shadowing.sol
+++ b/test/libsolidity/syntaxTests/scoping/name_shadowing.sol
@@ -3,5 +3,4 @@ contract test {
     function f() pure public { uint32 variable; variable = 2; }
 }
 // ----
-// Warning: This declaration shadows an existing declaration.
-
+// Warning: (69-84): This declaration shadows an existing declaration.

--- a/test/libsolidity/syntaxTests/scoping/scoping.sol
+++ b/test/libsolidity/syntaxTests/scoping/scoping.sol
@@ -8,4 +8,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Undeclared identifier.
+// DeclarationError: (123-124): Undeclared identifier.

--- a/test/libsolidity/syntaxTests/scoping/scoping_activation.sol
+++ b/test/libsolidity/syntaxTests/scoping/scoping_activation.sol
@@ -6,4 +6,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Undeclared identifier. Did you mean "x"?
+// DeclarationError: (85-86): Undeclared identifier. Did you mean "x"?

--- a/test/libsolidity/syntaxTests/scoping/scoping_for3.sol
+++ b/test/libsolidity/syntaxTests/scoping/scoping_for3.sol
@@ -8,4 +8,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Undeclared identifier.
+// DeclarationError: (154-155): Undeclared identifier.

--- a/test/libsolidity/syntaxTests/scoping/scoping_for_decl_in_body.sol
+++ b/test/libsolidity/syntaxTests/scoping/scoping_for_decl_in_body.sol
@@ -7,4 +7,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Undeclared identifier.
+// DeclarationError: (93-94): Undeclared identifier.

--- a/test/libsolidity/syntaxTests/scoping/scoping_self_use_050.sol
+++ b/test/libsolidity/syntaxTests/scoping/scoping_self_use_050.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// DeclarationError: Undeclared identifier. Did you mean "a"?
+// DeclarationError: (94-95): Undeclared identifier. Did you mean "a"?

--- a/test/libsolidity/syntaxTests/smoke_test.sol
+++ b/test/libsolidity/syntaxTests/smoke_test.sol
@@ -3,4 +3,4 @@ contract test {
 	function fun(uint256 arg1) public { uint256 y; y = arg1; }
 }
 // ----
-// Warning: Function state mutability can be restricted to pure
+// Warning: (42-100): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_internal_functions.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_internal_functions.sol
@@ -5,7 +5,7 @@ contract C {
     }
 }
 // ----
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
+// TypeError: (74-83): This type cannot be encoded.
+// TypeError: (85-86): This type cannot be encoded.
+// TypeError: (88-98): This type cannot be encoded.
+// TypeError: (100-115): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_special_types.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_special_types.sol
@@ -6,8 +6,8 @@ contract C {
     }
 }
 // ----
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
+// TypeError: (80-106): This type cannot be encoded.
+// TypeError: (108-113): This type cannot be encoded.
+// TypeError: (160-164): This type cannot be encoded.
+// TypeError: (166-168): This type cannot be encoded.
+// TypeError: (170-176): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
@@ -9,6 +9,6 @@ contract C {
     }
 }
 // ----
-// Warning: Defining empty structs is deprecated.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
+// Warning: (51-63): Defining empty structs is deprecated.
+// TypeError: (131-132): This type cannot be encoded.
+// TypeError: (134-135): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_types.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_types.sol
@@ -9,9 +9,9 @@ contract C {
     }
 }
 // ----
-// Warning: Defining empty structs is deprecated.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
-// TypeError: This type cannot be encoded.
+// Warning: (51-63): Defining empty structs is deprecated.
+// TypeError: (168-169): This type cannot be encoded.
+// TypeError: (171-172): This type cannot be encoded.
+// TypeError: (179-180): This type cannot be encoded.
+// TypeError: (182-186): This type cannot be encoded.
+// TypeError: (188-194): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/structs/recursion/multi_struct_composition.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/multi_struct_composition.sol
@@ -12,4 +12,4 @@ contract C {
   function f(T) public pure { }
 }
 // ----
-// Warning: Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/recursion/parallel_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/parallel_structs.sol
@@ -12,4 +12,4 @@ contract TestContract
     function addTestStruct(TestStruct) public pure {}
 }
 // ----
-// Warning: Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: Internal or recursive type is not allowed for public or external functions.
+// TypeError: (91-92): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: Internal or recursive type is not allowed for public or external functions.
+// TypeError: (94-95): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// TypeError: Internal or recursive type is not allowed for public or external functions.
+// TypeError: (119-122): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_directly_recursive.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_directly_recursive.sol
@@ -5,4 +5,4 @@ contract Test {
     }
 }
 // ----
-// TypeError: Recursive struct definition.
+// TypeError: (20-93): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive.sol
@@ -9,4 +9,4 @@ contract Test {
     }
 }
 // ----
-// TypeError: Recursive struct definition.
+// TypeError: (20-118): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_default.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_default.sol
@@ -2,5 +2,5 @@ interface I {
 	function f();
 }
 // ----
-// Warning: Functions in interfaces should be declared external.
-// Warning: No visibility specified. Defaulting to "public". In interfaces it defaults to external.
+// Warning: (15-28): Functions in interfaces should be declared external.
+// Warning: (15-28): No visibility specified. Defaulting to "public". In interfaces it defaults to external.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_default050.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_default050.sol
@@ -3,5 +3,5 @@ interface I {
 	function f();
 }
 // ----
-// SyntaxError: No visibility specified.
-// TypeError: Functions in interfaces must be declared external.
+// SyntaxError: (45-58): No visibility specified.
+// TypeError: (45-58): Functions in interfaces must be declared external.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_internal.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_internal.sol
@@ -2,4 +2,4 @@ interface I {
 	function f() internal;
 }
 // ----
-// TypeError: Functions in interfaces cannot be internal or private.
+// TypeError: (15-37): Functions in interfaces cannot be internal or private.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_private.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_private.sol
@@ -2,4 +2,4 @@ interface I {
 	function f() private;
 }
 // ----
-// TypeError: Functions in interfaces cannot be internal or private.
+// TypeError: (15-36): Functions in interfaces cannot be internal or private.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_public.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_public.sol
@@ -2,4 +2,4 @@ interface I {
 	function f() public;
 }
 // ----
-// Warning: Functions in interfaces should be declared external.
+// Warning: (15-35): Functions in interfaces should be declared external.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_public050.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_public050.sol
@@ -3,4 +3,4 @@ interface I {
 	function f() public;
 }
 // ----
-// TypeError: Functions in interfaces must be declared external.
+// TypeError: (45-65): Functions in interfaces must be declared external.


### PR DESCRIPTION
Also uses colored background to indicate warnings and errors when printing the contract in isoltest.

Closes #3810.