### PR TITLE
Correctly ignore costs of fallback for other functions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ Bugfixes:
  * Code Generator: Treat empty base constructor argument list as not provided.
  * Commandline interface: Support ``--evm-version constantinople`` properly.
  * DocString Parser: Fix error message for empty descriptions.
+ * Gas Estimator: Correctly ignore costs of fallback function for other functions.
  * Standard JSON: Support ``constantinople`` as ``evmVersion`` properly.
  * Type Checker: Fix detection of recursive structs.
  * Type Checker: Fix asymmetry bug when comparing with literal numbers.

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -294,6 +294,19 @@ BOOST_AUTO_TEST_CASE(extcodesize_gas)
 	testRunTimeGas("f()", vector<bytes>{encodeArgs()});
 }
 
+BOOST_AUTO_TEST_CASE(regular_functions_exclude_fallback)
+{
+	// A bug in the estimator caused the costs for a specific function
+	// to always include the costs for the fallback.
+	char const* sourceCode = R"(
+		contract A {
+			uint public x;
+			function() { x = 2; }
+		}
+	)";
+	testCreationTimeGas(sourceCode);
+	testRunTimeGas("x()", vector<bytes>{encodeArgs()});
+}
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3779

At some point we introduced the "calldata shorter than 4 bytes" shortcut but did not update the gas estimator accordingly.