### PR TITLE
Properly force-clean for shortening bytesXX conversions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@ Bugfixes:
  * Code Generator: Bugfix in modifier lookup in libraries.
  * Code Generator: Implement packed encoding of external function types.
  * Code Generator: Treat empty base constructor argument list as not provided.
+ * Code Generator: Properly force-clean bytesXX types for shortening conversions.
  * Commandline interface: Fix error messages for imported files that do not exist.
  * Commandline interface: Support ``--evm-version constantinople`` properly.
  * DocString Parser: Fix error message for empty descriptions.

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -405,6 +405,16 @@ changes during the call, and thus references to local variables will be wrong.
         }
     }
 
+.. note::
+    If you access variables of a type that spans less than 256 bits
+    (for example ``uint64``, ``address``, ``bytes16`` or ``byte``),
+    you cannot make any assumptions about bits not part of the
+    encoding of the type. Especially, do not assume them to be zero.
+    To be safe, always clear the data properly before you use it
+    in a context where this is important:
+    ``uint32 x = f(); assembly { x := and(x, 0xffffffff) /* now use x */ }``
+    To clean signed types, you can use the ``signextend`` opcode.
+
 Labels
 ------
 

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -684,19 +684,17 @@ void CompilerUtils::convertType(
 			// clear for conversion to longer bytes
 			solAssert(targetTypeCategory == Type::Category::FixedBytes, "Invalid type conversion requested.");
 			FixedBytesType const& targetType = dynamic_cast<FixedBytesType const&>(_targetType);
-			if (targetType.numBytes() > typeOnStack.numBytes() || _cleanupNeeded)
+			if (typeOnStack.numBytes() == 0 || targetType.numBytes() == 0)
+				m_context << Instruction::POP << u256(0);
+			else if (targetType.numBytes() > typeOnStack.numBytes() || _cleanupNeeded)
 			{
-				if (typeOnStack.numBytes() == 0)
-					m_context << Instruction::POP << u256(0);
-				else
-				{
-					m_context << ((u256(1) << (256 - typeOnStack.numBytes() * 8)) - 1);
-					m_context << Instruction::NOT << Instruction::AND;
-				}
+				int bytes = min(typeOnStack.numBytes(), targetType.numBytes());
+				m_context << ((u256(1) << (256 - bytes * 8)) - 1);
+				m_context << Instruction::NOT << Instruction::AND;
 			}
 		}
-	}
 		break;
+	}
 	case Type::Category::Enum:
 		solAssert(_targetType == _typeOnStack || targetTypeCategory == Type::Category::Integer, "");
 		if (enumOverflowCheckPending)
@@ -798,8 +796,9 @@ void CompilerUtils::convertType(
 		bytesConstRef data(value);
 		if (targetTypeCategory == Type::Category::FixedBytes)
 		{
+			int const numBytes = dynamic_cast<FixedBytesType const&>(_targetType).numBytes();
 			solAssert(data.size() <= 32, "");
-			m_context << h256::Arith(h256(data, h256::AlignLeft));
+			m_context << (h256::Arith(h256(data, h256::AlignLeft)) & (~(u256(-1) >> (8 * numBytes))));
 		}
 		else if (targetTypeCategory == Type::Category::Array)
 		{

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1023,7 +1023,6 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 					solAssert(function.kind() == FunctionType::Kind::ABIEncodeWithSelector, "");
 				}
 
-				// Cleanup actually does not clean on shrinking the type.
 				utils().convertType(*dataOnStack, FixedBytesType(4), true);
 
 				// stack: <memory pointer> <selector>
@@ -1034,7 +1033,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 					let data_start := add(mem_ptr, 0x20)
 					let data := mload(data_start)
 					let mask := )" + mask + R"(
-					mstore(data_start, or(and(data, mask), and(selector, not(mask))))
+					mstore(data_start, or(and(data, mask), selector))
 				})", {"mem_ptr", "selector"});
 				m_context << Instruction::POP;
 			}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3867

It seems like the proper thing is done for integers, but not for bytesXX types.