### PR TITLE
Fix internal compiler error when parsing ``var`` declaration without …

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@ Bugfixes:
  * Commandline interface: Support ``--evm-version constantinople`` properly.
  * DocString Parser: Fix error message for empty descriptions.
  * Gas Estimator: Correctly ignore costs of fallback function for other functions.
+ * Parser: Fix internal compiler error when parsing ``var`` declaration without identifier.
  * Parser: Fix parsing of getters for function type variables.
  * Standard JSON: Support ``constantinople`` as ``evmVersion`` properly.
  * Type Checker: Fix detection of recursive structs.

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -607,8 +607,10 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 	if (_options.allowEmptyName && m_scanner->currentToken() != Token::Identifier)
 	{
 		identifier = make_shared<ASTString>("");
-		solAssert(type != nullptr, "");
-		nodeFactory.setEndPositionFromNode(type);
+		solAssert(!_options.allowVar, ""); // allowEmptyName && allowVar makes no sense
+		if (type)
+			nodeFactory.setEndPositionFromNode(type);
+		// if type is null this has already caused an error
 	}
 	else
 		identifier = expectIdentifierToken();

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -557,16 +557,6 @@ BOOST_AUTO_TEST_CASE(variable_definition_with_initialization)
 	BOOST_CHECK(successParse(text));
 }
 
-BOOST_AUTO_TEST_CASE(variable_definition_in_function_parameter)
-{
-	char const* text = R"(
-		contract test {
-			function fun(var a) {}
-		}
-	)";
-	CHECK_PARSE_ERROR(text, "Expected explicit type name");
-}
-
 BOOST_AUTO_TEST_CASE(variable_definition_in_mapping)
 {
 	char const* text = R"(
@@ -577,18 +567,6 @@ BOOST_AUTO_TEST_CASE(variable_definition_in_mapping)
 		}
 	)";
 	CHECK_PARSE_ERROR(text, "Expected elementary type name for mapping key type");
-}
-
-BOOST_AUTO_TEST_CASE(variable_definition_in_function_return)
-{
-	char const* text = R"(
-		contract test {
-			function fun() returns(var d) {
-				return 1;
-			}
-		}
-	)";
-	CHECK_PARSE_ERROR(text, "Expected explicit type name");
 }
 
 BOOST_AUTO_TEST_CASE(operator_expression)

--- a/test/libsolidity/syntaxTests/parsing/return_var.sol
+++ b/test/libsolidity/syntaxTests/parsing/return_var.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f() returns(var) {}
+    function f() returns(var x) {}
+    function f() public pure returns (var storage) {}
+    function f() public pure returns (var storage x) {}
+}
+// ----
+// ParserError: (38-38): Expected explicit type name.
+// ParserError: (71-71): Expected explicit type name.
+// ParserError: (119-119): Expected explicit type name.
+// ParserError: (123-123): Location specifier needs explicit type name.
+// ParserError: (173-173): Expected explicit type name.
+// ParserError: (177-177): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/return_var.sol
+++ b/test/libsolidity/syntaxTests/parsing/return_var.sol
@@ -1,13 +1,25 @@
 contract C {
     function f() returns(var) {}
     function f() returns(var x) {}
+    function f() returns(var x, uint y) {}
+    function f() returns(uint x, var y) {}
+    function f() returns(var x, var y) {}
     function f() public pure returns (var storage) {}
     function f() public pure returns (var storage x) {}
+    function f() public pure returns (var storage x, var storage y) {}
 }
 // ----
 // ParserError: (38-38): Expected explicit type name.
 // ParserError: (71-71): Expected explicit type name.
-// ParserError: (119-119): Expected explicit type name.
-// ParserError: (123-123): Location specifier needs explicit type name.
-// ParserError: (173-173): Expected explicit type name.
-// ParserError: (177-177): Location specifier needs explicit type name.
+// ParserError: (106-106): Expected explicit type name.
+// ParserError: (157-157): Expected explicit type name.
+// ParserError: (192-192): Expected explicit type name.
+// ParserError: (199-199): Expected explicit type name.
+// ParserError: (247-247): Expected explicit type name.
+// ParserError: (251-251): Location specifier needs explicit type name.
+// ParserError: (301-301): Expected explicit type name.
+// ParserError: (305-305): Location specifier needs explicit type name.
+// ParserError: (357-357): Expected explicit type name.
+// ParserError: (361-361): Location specifier needs explicit type name.
+// ParserError: (372-372): Expected explicit type name.
+// ParserError: (376-376): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/var_in_function_arguments.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_in_function_arguments.sol
@@ -1,13 +1,25 @@
 contract C {
     function f(var) public pure {}
     function f(var x) public pure {}
+    function f(var x, var y) public pure {}
+    function f(uint x, var y) public pure {}
+    function f(var x, uint y) public pure {}
     function f(var storage) public pure {}
     function f(var storage x) public pure {}
+    function f(var storage x, var storage y) public pure {}
 }
 // ----
 // ParserError: (28-28): Expected explicit type name.
 // ParserError: (63-63): Expected explicit type name.
 // ParserError: (100-100): Expected explicit type name.
-// ParserError: (104-104): Location specifier needs explicit type name.
-// ParserError: (143-143): Expected explicit type name.
-// ParserError: (147-147): Location specifier needs explicit type name.
+// ParserError: (107-107): Expected explicit type name.
+// ParserError: (152-152): Expected explicit type name.
+// ParserError: (189-189): Expected explicit type name.
+// ParserError: (234-234): Expected explicit type name.
+// ParserError: (238-238): Location specifier needs explicit type name.
+// ParserError: (277-277): Expected explicit type name.
+// ParserError: (281-281): Location specifier needs explicit type name.
+// ParserError: (322-322): Expected explicit type name.
+// ParserError: (326-326): Location specifier needs explicit type name.
+// ParserError: (337-337): Expected explicit type name.
+// ParserError: (341-341): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/var_in_function_arguments.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_in_function_arguments.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f(var) public pure {}
+    function f(var x) public pure {}
+    function f(var storage) public pure {}
+    function f(var storage x) public pure {}
+}
+// ----
+// ParserError: (28-28): Expected explicit type name.
+// ParserError: (63-63): Expected explicit type name.
+// ParserError: (100-100): Expected explicit type name.
+// ParserError: (104-104): Location specifier needs explicit type name.
+// ParserError: (143-143): Expected explicit type name.
+// ParserError: (147-147): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/var_storage_var.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_storage_var.sol
@@ -1,0 +1,5 @@
+contract C {
+    var a;
+}
+// ----
+// ParserError: (17-17): Function, variable, struct or modifier declaration expected.


### PR DESCRIPTION
…identifier.

Fixes #3039.

Arguably instead parsing ``var`` with ``_options.allowVar == false`` could be a fatal parser error, but the plan was to get away from those and try to continue parsing gracefully whenever possible.