### PR TITLE
Docs: Update solidity version for revert with reason

### DIFF
--- a/docs/common-patterns.rst
+++ b/docs/common-patterns.rst
@@ -130,7 +130,7 @@ restrictions highly readable.
 
 ::
 
-    pragma solidity ^0.4.11;
+    pragma solidity ^0.4.22;
 
     contract AccessRestriction {
         // These will be assigned at the construction
@@ -282,7 +282,7 @@ function finishes.
 
 ::
 
-    pragma solidity ^0.4.11;
+    pragma solidity ^0.4.22;
 
     contract StateMachine {
         enum Stages {

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -301,7 +301,7 @@ inheritable properties of contracts and may be overridden by derived contracts.
 
 ::
 
-    pragma solidity ^0.4.11;
+    pragma solidity ^0.4.22;
 
     contract owned {
         function owned() public { owner = msg.sender; }
@@ -1215,7 +1215,7 @@ more advanced example to implement a set).
 
 ::
 
-    pragma solidity ^0.4.16;
+    pragma solidity ^0.4.22;
 
     library Set {
       // We define a new struct datatype that will be used to

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -477,7 +477,7 @@ a message string for ``require``, but not for ``assert``.
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.22;
 
     contract Sharer {
         function sendHalf(address addr) public payable returns (uint balance) {
@@ -524,7 +524,7 @@ The following example shows how an error string can be used together with revert
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.22;
 
     contract VendingMachine {
         function buy(uint amount) payable {

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -36,7 +36,7 @@ of votes.
 
 ::
 
-    pragma solidity ^0.4.16;
+    pragma solidity ^0.4.22;
 
     /// @title Voting with delegation.
     contract Ballot {
@@ -225,7 +225,7 @@ activate themselves.
 
 ::
 
-    pragma solidity ^0.4.21;
+    pragma solidity ^0.4.22;
 
     contract SimpleAuction {
         // Parameters of the auction. Times are either
@@ -388,7 +388,7 @@ high or low invalid bids.
 
 ::
 
-    pragma solidity ^0.4.21;
+    pragma solidity ^0.4.22;
 
     contract BlindAuction {
         struct Bid {
@@ -541,7 +541,7 @@ Safe Remote Purchase
 
 ::
 
-    pragma solidity ^0.4.21;
+    pragma solidity ^0.4.22;
 
     contract Purchase {
         uint public value;

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -62,7 +62,7 @@ Function modifiers can be used to amend the semantics of functions in a declarat
 
 ::
 
-    pragma solidity ^0.4.11;
+    pragma solidity ^0.4.22;
 
     contract Purchase {
         address public seller;

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -470,7 +470,7 @@ Example that shows how to use internal function types::
 
 Another example that uses external function types::
 
-    pragma solidity ^0.4.21;
+    pragma solidity ^0.4.22;
 
     contract Oracle {
       struct Request {


### PR DESCRIPTION
Updated the version pragma in the docs wherever a revert/require with error message was utilized.