### PR TITLE
Enable travis tests when run by daily cron.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,8 +159,8 @@ cache:
 install:
     - test $SOLC_INSTALL_DEPS_TRAVIS != On || (scripts/install_deps.sh)
     - test "$TRAVIS_OS_NAME" != "linux" || (scripts/install_cmake.sh)
-#    - if [ "$TRAVIS_BRANCH" != release -a -z "$TRAVIS_TAG" ]; then SOLC_TESTS=Off; fi
-    - SOLC_TESTS=Off
+    # Disable tests unless run on the release branch, on tags or with daily cron
+    - if [ "$TRAVIS_BRANCH" != release -a -z "$TRAVIS_TAG" -a "$TRAVIS_EVENT_TYPE" != cron ]; then SOLC_TESTS=Off; fi
     - if [ "$TRAVIS_BRANCH" = release -o -n "$TRAVIS_TAG" ]; then echo -n > prerelease.txt; else date -u +"nightly.%Y.%-m.%-d" > prerelease.txt; fi
     - echo -n "$TRAVIS_COMMIT" > commit_hash.txt
 


### PR DESCRIPTION
Travis tests should run at least on the develop branch. Only running tests on release is no option.