### PR TITLE
Truncate linkerObject at the beginning, not end

### DIFF
--- a/libevmasm/LinkerObject.cpp
+++ b/libevmasm/LinkerObject.cpp
@@ -51,9 +51,12 @@ string LinkerObject::toHex() const
 	{
 		size_t pos = ref.first * 2;
 		string const& name = ref.second;
+		// truncate the beginning of fully qualified library path, so
+		// we keep the library name
+		size_t from = name.size() > 36 ? name.size() - 36 : 0;
 		hex[pos] = hex[pos + 1] = hex[pos + 38] = hex[pos + 39] = '_';
 		for (size_t i = 0; i < 36; ++i)
-			hex[pos + 2 + i] = i < name.size() ? name[i] : '_';
+			hex[pos + 2 + i] = i < name.size() ? name[i + from] : '_';
 	}
 	return hex;
 }

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1057,9 +1057,12 @@ bool CommandLineInterface::link()
 		// Library placeholders are 40 hex digits (20 bytes) that start and end with '__'.
 		// This leaves 36 characters for the library name, while too short library names are
 		// padded on the right with '_' and too long names are truncated.
+		// Truncate the beginning of fully qualified library path, so
+		// we keep the library name
 		string replacement = "__";
+		size_t from = name.size() > 36 ? name.size() - 36 : 0;
 		for (size_t i = 0; i < placeholderSize - 4; ++i)
-			replacement.push_back(i < name.size() ? name[i] : '_');
+			replacement.push_back(i < name.size() ? name[i + from] : '_');
 		replacement += "__";
 		librariesReplacements[replacement] = library.second;
 	}


### PR DESCRIPTION
When a importing a library with a long path, the unresolved name in the bin file gets truncated at tail end, and contract name is lost. This makes it impossible to link against.

**Before this PR:**
```
[sean@hamalech yours]$ pwd
/home/sean/solidity/my/path/is/longer/than/yours
[sean@hamalech yours]$ cat bar.sol 

library bar {
	function number() returns (uint) {
		return 1;
	}
}
[sean@hamalech yours]$ cat foo.sol 

import "/home/sean/solidity/my/path/is/longer/than/yours/bar.sol";

contract foo {
	function func1() returns (uint)
	{
		return bar.number();
	}
}
[sean@hamalech yours]$ ~/git/solidity/build/solc/solc --bin -o . foo.sol 
Warning: This is a pre-release compiler version, please do not use it in production.
/home/sean/solidity/my/path/is/longer/than/yours/bar.sol:2:1: Warning: Source file does not specify required compiler version!
library bar {
^ (Relevant source part starts here and spans across multiple lines).
foo.sol:2:1: Warning: Source file does not specify required compiler version!
import "/home/sean/solidity/my/path/is/longer/than/yours/bar.sol";
^ (Relevant source part starts here and spans across multiple lines).
/home/sean/solidity/my/path/is/longer/than/yours/bar.sol:3:2: Warning: No visibility specified. Defaulting to "public". 
	function number() returns (uint) {
 ^ (Relevant source part starts here and spans across multiple lines).
foo.sol:5:2: Warning: No visibility specified. Defaulting to "public". 
	function func1() returns (uint)
 ^ (Relevant source part starts here and spans across multiple lines).
/home/sean/solidity/my/path/is/longer/than/yours/bar.sol:3:2: Warning: Function state mutability can be restricted to pure
	function number() returns (uint) {
 ^ (Relevant source part starts here and spans across multiple lines).
[sean@hamalech yours]$ cat foo.bin 
608060405234801561001057600080fd5b5061013f806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680637413515414610046575b600080fd5b34801561005257600080fd5b5061005b610071565b6040518082815260200191505060405180910390f35b600073__/home/sean/solidity/my/path/is/longe__638381f58a6040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100d357600080fd5b505af41580156100e7573d6000803e3d6000fd5b505050506040513d60208110156100fd57600080fd5b81019080805190602001909291905050509050905600a165627a7a723058200dd3284d826f7d529da5e65ea2e7c789eeb00daa4b0c05b4c277ed84c0442dfd0029[sean@hamalech yours]$ 
[sean@hamalech yours]$  ~/git/solidity/build/solc/solc --link --libraries bar:0xE68EB21C15974808648B0C145E91C7C3BB10F292 < foo.bin
Reference "__/home/sean/solidity/my/path/is/longe__" in file "<stdin>" still unresolved.
608060405234801561001057600080fd5b5061013f806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680637413515414610046575b600080fd5b34801561005257600080fd5b5061005b610071565b6040518082815260200191505060405180910390f35b600073__/home/sean/solidity/my/path/is/longe__638381f58a6040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100d357600080fd5b505af41580156100e7573d6000803e3d6000fd5b505050506040513d60208110156100fd57600080fd5b81019080805190602001909291905050509050905600a165627a7a723058200dd3284d826f7d529da5e65ea2e7c789eeb00daa4b0c05b4c277ed84c0442dfd0029
```

**After this PR:**
```
[sean@hamalech yours]$ pwd
/home/sean/solidity/my/path/is/longer/than/yours
[sean@hamalech yours]$ cat bar.sol

library bar {
	function number() returns (uint) {
		return 1;
	}
}
[sean@hamalech yours]$ cat foo.sol 
import "/home/sean/solidity/my/path/is/longer/than/yours/bar.sol";

contract foo {
	function func1() returns (uint)
	{
		return bar.number();
	}
}
[sean@hamalech yours]$ ~/git/solidity/build/solc/solc --bin -o . foo.sol 
Warning: This is a pre-release compiler version, please do not use it in production.
/home/sean/solidity/my/path/is/longer/than/yours/bar.sol:2:1: Warning: Source file does not specify required compiler version!
library bar {
^ (Relevant source part starts here and spans across multiple lines).
foo.sol:2:1: Warning: Source file does not specify required compiler version!
import "/home/sean/solidity/my/path/is/longer/than/yours/bar.sol";
^ (Relevant source part starts here and spans across multiple lines).
/home/sean/solidity/my/path/is/longer/than/yours/bar.sol:3:2: Warning: No visibility specified. Defaulting to "public". 
	function number() returns (uint) {
 ^ (Relevant source part starts here and spans across multiple lines).
foo.sol:5:2: Warning: No visibility specified. Defaulting to "public". 
	function func1() returns (uint)
 ^ (Relevant source part starts here and spans across multiple lines).
/home/sean/solidity/my/path/is/longer/than/yours/bar.sol:3:2: Warning: Function state mutability can be restricted to pure
	function number() returns (uint) {
 ^ (Relevant source part starts here and spans across multiple lines).
[sean@hamalech yours]$ cat foo.bin
608060405234801561001057600080fd5b5061013f806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680637413515414610046575b600080fd5b34801561005257600080fd5b5061005b610071565b6040518082815260200191505060405180910390f35b600073__ath/is/longer/than/yours/bar.sol:bar__638381f58a6040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100d357600080fd5b505af41580156100e7573d6000803e3d6000fd5b505050506040513d60208110156100fd57600080fd5b81019080805190602001909291905050509050905600a165627a7a72305820bff2bc2b6f9cbf78dd880a28c9b24dd513053dc5dff6aca76b72e8da400ca4fb0029[sean@hamalech yours]$ 
[sean@hamalech yours]$  ~/git/solidity/build/solc/solc --link --libraries /home/sean/solidity/my/path/is/longer/than/yours/bar.sol:bar:0xE68EB21C15974808648B0C145E91C7C3BB10F292 < foo.bin
608060405234801561001057600080fd5b5061013f806100206000396000f300608060405260043610610041576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680637413515414610046575b600080fd5b34801561005257600080fd5b5061005b610071565b6040518082815260200191505060405180910390f35b600073e68eb21c15974808648b0c145e91c7c3bb10f292638381f58a6040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100d357600080fd5b505af41580156100e7573d6000803e3d6000fd5b505050506040513d60208110156100fd57600080fd5b81019080805190602001909291905050509050905600a165627a7a72305820bff2bc2b6f9cbf78dd880a28c9b24dd513053dc5dff6aca76b72e8da400ca4fb0029
```
