### PR TITLE
Fixes jsoncpp compilation when it is also installed system-wide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ include(EthCcache)
 # Let's find our dependencies
 include(EthDependencies)
 include(jsoncpp)
+include_directories(${JSONCPP_INCLUDE_DIR})
 
 find_package(Threads)
 

--- a/libevmasm/CMakeLists.txt
+++ b/libevmasm/CMakeLists.txt
@@ -2,4 +2,4 @@ file(GLOB sources "*.cpp")
 file(GLOB headers "*.h")
 
 add_library(evmasm ${sources} ${headers})
-target_link_libraries(evmasm PUBLIC jsoncpp devcore)
+target_link_libraries(evmasm PUBLIC devcore)


### PR DESCRIPTION
Fixes https://github.com/ethereum/homebrew-ethereum/issues/163 and https://github.com/ethereum/homebrew-ethereum/issues/164