### PR TITLE
Add modifier areas

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -12,7 +12,7 @@ ContractDefinition = ( 'contract' | 'library' | 'interface' ) Identifier
                      '{' ContractPart* '}'
 
 ContractPart = StateVariableDeclaration | UsingForDeclaration
-             | StructDefinition | ModifierDefinition | FunctionDefinition | EventDefinition | EnumDefinition
+             | StructDefinition | ModifierDefinition | FunctionDefinition | EventDefinition | EnumDefinition | ModifierArea
 
 InheritanceSpecifier = UserDefinedTypeName ( '(' Expression ( ',' Expression )* ')' )?
 
@@ -24,13 +24,17 @@ StructDefinition = 'struct' Identifier '{'
 ModifierDefinition = 'modifier' Identifier ParameterList? Block
 ModifierInvocation = Identifier ( '(' ExpressionList? ')' )?
 
+FunctionModifier = ModifierInvocation | StateMutability | Visibility
 FunctionDefinition = 'function' Identifier? ParameterList
-                     ( ModifierInvocation | StateMutability | 'external' | 'public' | 'internal' | 'private' )*
+                     FunctionModifier*
                      ( 'returns' ParameterList )? ( ';' | Block )
 EventDefinition = 'event' Identifier EventParameterList 'anonymous'? ';'
 
 EnumValue = Identifier
 EnumDefinition = 'enum' Identifier '{' EnumValue? (',' EnumValue)* '}'
+
+ModifierArea = 'using modifier' FunctionModifier FunctionModifier*
+               '{' (ModifierArea | FunctionDefinition)* '}'
 
 ParameterList = '(' ( Parameter (',' Parameter)* )? ')'
 Parameter = TypeName StorageLocation? Identifier?
@@ -59,6 +63,7 @@ FunctionTypeName = 'function' FunctionTypeParameterList ( 'internal' | 'external
                    ( 'returns' FunctionTypeParameterList )?
 StorageLocation = 'memory' | 'storage' | 'calldata'
 StateMutability = 'pure' | 'view' | 'payable'
+Visibility = 'public' | 'external' | 'internal' | 'private'
 
 Block = '{' Statement* '}'
 Statement = IfStatement | WhileStatement | ForStatement | Block | InlineAssemblyStatement |

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -139,3 +139,100 @@ Enums can be used to create custom types with a finite set of 'constant values' 
     contract Purchase {
         enum State { Created, Locked, Inactive } // Enum
     }
+
+
+.. _structure-modifier-areas:
+
+Modifier Areas
+==============
+
+Modifier areas can be used to apply modifier invocations,
+a visibility specifier, or a mutability specifier to an
+entire group of functions. They take the following syntax:
+
+::
+
+    pragma soliditiy [TBD];
+
+    contract Purchase {
+        private State currentState = Created;
+
+        enum State { Created, Locked, Inactive } // Enum
+
+        modifier inState(State requiredState) { require(currentState = requiredState); }
+
+        using modifier inState(State.Created) {
+            function lock() { currentState = State.Locked; }
+
+            // Other functions only callable in state Created
+        }
+
+        using modifier inState(State.Locked) {
+            function inactivate() { currentState = State.Inactive; }
+
+            // Other functions only callable in state Locked
+        }
+
+        using modifier inState(State.Inactive) {
+            // Functions only callable in state Inactive
+        }
+    }
+
+Multiple modifier invocations can be used in a single modifier area:
+`using modifier A, B { /* ... */ }` declares a modifier area
+where both modifiers `A` and `B` are used on every function.
+
+Modifier areas can be nested by declaring a modifier area
+inside the scope of another. Inside the nested modifier area,
+all modifiers from all parents apply in addition to those
+declared on that modifier area.
+
+::
+
+    contract C {
+        modifier A { /* ... */ }
+        modifier B { /* ... */ }
+
+        using modifier A {
+            // Functions where only A applies
+
+            using modifier B {
+                // Functions where A and B apply
+            }
+        }
+    }
+
+Modifier areas can also apply a mutability or visiblity specifier to
+a group of functions.
+
+::
+
+    contract C {
+        using modifier public {
+            // Functions that are public
+        }
+        
+        using modifier payable {
+            // Functions that are payable
+        }
+    }
+
+State and mutability specifiers also nest, just like modifiers.
+
+::
+
+    contract C {
+        using modifier public {
+            // Functions that are public
+            
+            using modifier payable {
+                // Functions that are public and payable
+            }
+        }
+    }
+
+It is **not** permissible to do any of the following:
+1. Declare a nested modifier area with a different visibility or
+mutability than any of its parents
+2. Declare a function within a modifier area with a different
+visibility or mutability than any of its parents.

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -122,6 +122,22 @@ bool SyntaxChecker::visit(PragmaDirective const& _pragma)
 	return true;
 }
 
+bool SyntaxChecker::visit(ModifierArea const& _modifierArea)
+{
+	if (_modifierArea.parent())
+	{
+		auto parent = _modifierArea.parent();
+
+		if (parent->visibility() != Declaration::Visibility::Default && _modifierArea.visibility() != parent->visibility())
+			m_errorReporter.syntaxError(_modifierArea.location(), "Cannot override parent modifier area's visibility.");
+
+		if (parent->stateMutability() != StateMutability::NonPayable && _modifierArea.stateMutability() != parent->stateMutability())
+			m_errorReporter.syntaxError(_modifierArea.location(), "Cannot override parent modifier area's state mutability.");
+	}
+
+	return true;
+}
+
 bool SyntaxChecker::visit(ModifierDefinition const&)
 {
 	m_placeholderFound = false;
@@ -220,6 +236,17 @@ bool SyntaxChecker::visit(FunctionDefinition const& _function)
 			_function.location(),
 			"No visibility specified. Did you intend to add \"" + suggestedVisibility + "\"?"
 		);
+	}
+
+	if (_function.modifierArea())
+	{
+		auto modifierArea = _function.modifierArea();
+
+		if (modifierArea->visibility() != Declaration::Visibility::Default && _function.visibility() != modifierArea->visibility())
+			m_errorReporter.syntaxError(_function.location(), "Cannot override modifier area's visibility.");
+
+		if (modifierArea->stateMutability() != StateMutability::NonPayable && _function.stateMutability() != modifierArea->stateMutability())
+			m_errorReporter.syntaxError(_function.location(), "Cannot override modifier area's state mutability.");
 	}
 
 	if (!_function.isImplemented() && !_function.modifiers().empty())

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -49,6 +49,8 @@ private:
 	virtual void endVisit(SourceUnit const& _sourceUnit) override;
 	virtual bool visit(PragmaDirective const& _pragma) override;
 
+	virtual bool visit(ModifierArea const& _modifierArea) override;
+
 	virtual bool visit(ModifierDefinition const& _modifier) override;
 	virtual void endVisit(ModifierDefinition const& _modifier) override;
 

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -614,7 +614,7 @@ public:
 	std::vector<ASTPointer<ModifierInvocation>> const& modifiers() const { return m_functionModifiers; }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameters() const { return m_returnParameters->parameters(); }
 	Block const& body() const { solAssert(m_body, ""); return *m_body; }
-	ModifierArea* modifierArea() { return m_modifierArea; }
+	ModifierArea* modifierArea() const { return m_modifierArea; }
 
 	virtual bool isVisibleInContract() const override
 	{
@@ -744,7 +744,7 @@ public:
 	StateMutability const& stateMutability() const { return m_mutability; }
 	std::vector<ASTPointer<FunctionDefinition>> const& definedFunctions() const { return *m_functions; }
 	std::vector<ASTPointer<ModifierArea>> const& subAreas() const { return *m_subAreas; }
-	ModifierArea const& parent() const { return *m_parent; }
+	ModifierArea const* parent() const { return m_parent; }
 
 private:
 	std::vector<ASTPointer<ModifierInvocation>> m_declaredModifiers;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -616,7 +616,6 @@ public:
 	Block const& body() const { solAssert(m_body, ""); return *m_body; }
 	ModifierArea* modifierArea() { return m_modifierArea; }
 
-	std::string fullyQualifiedName() const;
 	virtual bool isVisibleInContract() const override
 	{
 		return Declaration::isVisibleInContract() && !isConstructor() && !isFallback();

--- a/libsolidity/ast/ASTForward.h
+++ b/libsolidity/ast/ASTForward.h
@@ -47,6 +47,7 @@ class EnumValue;
 class ParameterList;
 class FunctionDefinition;
 class VariableDeclaration;
+class ModifierArea;
 class ModifierDefinition;
 class ModifierInvocation;
 class EventDefinition;

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -359,6 +359,16 @@ bool ASTJsonConverter::visit(VariableDeclaration const& _node)
 	return false;
 }
 
+bool ASTJsonConverter::visit(ModifierArea const& _node)
+{
+	setJsonNode(_node, "ModifierArea", {
+		make_pair("modifiers", toJson(_node.declaredModifiers())),
+		make_pair("functions", toJson(_node.definedFunctions())),
+		make_pair("subAreas", toJson(_node.subAreas()))
+	});
+	return false;
+}
+
 bool ASTJsonConverter::visit(ModifierDefinition const& _node)
 {
 	setJsonNode(_node, "ModifierDefinition", {

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -73,6 +73,7 @@ public:
 	bool visit(ParameterList const& _node) override;
 	bool visit(FunctionDefinition const& _node) override;
 	bool visit(VariableDeclaration const& _node) override;
+	bool visit(ModifierArea const& _node) override;
 	bool visit(ModifierDefinition const& _node) override;
 	bool visit(ModifierInvocation const& _node) override;
 	bool visit(EventDefinition const& _node) override;

--- a/libsolidity/ast/ASTPrinter.cpp
+++ b/libsolidity/ast/ASTPrinter.cpp
@@ -132,6 +132,13 @@ bool ASTPrinter::visit(VariableDeclaration const& _node)
 	return goDeeper();
 }
 
+bool ASTPrinter::visit(ModifierArea const& _node)
+{
+	writeLine("ModifierArea");
+	printSourcePart(_node);
+	return goDeeper();
+}
+
 bool ASTPrinter::visit(ModifierDefinition const& _node)
 {
 	writeLine("ModifierDefinition \"" + _node.name() + "\"");
@@ -430,6 +437,11 @@ void ASTPrinter::endVisit(FunctionDefinition const&)
 }
 
 void ASTPrinter::endVisit(VariableDeclaration const&)
+{
+	m_indentation--;
+}
+
+void ASTPrinter::endVisit(ModifierArea const&)
 {
 	m_indentation--;
 }

--- a/libsolidity/ast/ASTPrinter.h
+++ b/libsolidity/ast/ASTPrinter.h
@@ -58,6 +58,7 @@ public:
 	bool visit(ParameterList const& _node) override;
 	bool visit(FunctionDefinition const& _node) override;
 	bool visit(VariableDeclaration const& _node) override;
+	bool visit(ModifierArea const& _node) override;
 	bool visit(ModifierDefinition const& _node) override;
 	bool visit(ModifierInvocation const& _node) override;
 	bool visit(EventDefinition const& _node) override;
@@ -103,6 +104,7 @@ public:
 	void endVisit(ParameterList const&) override;
 	void endVisit(FunctionDefinition const&) override;
 	void endVisit(VariableDeclaration const&) override;
+	void endVisit(ModifierArea const&) override;
 	void endVisit(ModifierDefinition const&) override;
 	void endVisit(ModifierInvocation const&) override;
 	void endVisit(EventDefinition const&) override;

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -56,6 +56,7 @@ public:
 	virtual bool visit(ParameterList& _node) { return visitNode(_node); }
 	virtual bool visit(FunctionDefinition& _node) { return visitNode(_node); }
 	virtual bool visit(VariableDeclaration& _node) { return visitNode(_node); }
+	virtual bool visit(ModifierArea& _node) { return visitNode(_node); }
 	virtual bool visit(ModifierDefinition& _node) { return visitNode(_node); }
 	virtual bool visit(ModifierInvocation& _node) { return visitNode(_node); }
 	virtual bool visit(EventDefinition& _node) { return visitNode(_node); }
@@ -102,6 +103,7 @@ public:
 	virtual void endVisit(ParameterList& _node) { endVisitNode(_node); }
 	virtual void endVisit(FunctionDefinition& _node) { endVisitNode(_node); }
 	virtual void endVisit(VariableDeclaration& _node) { endVisitNode(_node); }
+	virtual void endVisit(ModifierArea& _node) { endVisitNode(_node); }
 	virtual void endVisit(ModifierDefinition& _node) { endVisitNode(_node); }
 	virtual void endVisit(ModifierInvocation& _node) { endVisitNode(_node); }
 	virtual void endVisit(EventDefinition& _node) { endVisitNode(_node); }
@@ -161,6 +163,7 @@ public:
 	virtual bool visit(ParameterList const& _node) { return visitNode(_node); }
 	virtual bool visit(FunctionDefinition const& _node) { return visitNode(_node); }
 	virtual bool visit(VariableDeclaration const& _node) { return visitNode(_node); }
+	virtual bool visit(ModifierArea const& _node) { return visitNode(_node); }
 	virtual bool visit(ModifierDefinition const& _node) { return visitNode(_node); }
 	virtual bool visit(ModifierInvocation const& _node) { return visitNode(_node); }
 	virtual bool visit(EventDefinition const& _node) { return visitNode(_node); }
@@ -207,6 +210,7 @@ public:
 	virtual void endVisit(ParameterList const& _node) { endVisitNode(_node); }
 	virtual void endVisit(FunctionDefinition const& _node) { endVisitNode(_node); }
 	virtual void endVisit(VariableDeclaration const& _node) { endVisitNode(_node); }
+	virtual void endVisit(ModifierArea const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ModifierDefinition const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ModifierInvocation const& _node) { endVisitNode(_node); }
 	virtual void endVisit(EventDefinition const& _node) { endVisitNode(_node); }

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -239,6 +239,28 @@ void VariableDeclaration::accept(ASTConstVisitor& _visitor) const
 	_visitor.endVisit(*this);
 }
 
+void ModifierArea::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+	{
+		listAccept(m_declaredModifiers, _visitor);
+		listAccept(*m_functions, _visitor);
+		listAccept(*m_subAreas, _visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void ModifierArea::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+	{
+		listAccept(m_declaredModifiers, _visitor);
+		listAccept(*m_functions, _visitor);
+		listAccept(*m_subAreas, _visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
 void ModifierDefinition::accept(ASTVisitor& _visitor)
 {
 	if (_visitor.visit(*this))

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -266,7 +266,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition(Token::Value _exp
 		else if (currentTokenValue == Token::Using)
 			subNodes.push_back(parseUsingDirective());
 		else if (currentTokenValue == Token::Apply)
-			subNodes.push_back(parseModifierArea(name.get()));
+			subNodes.push_back(parseModifierArea());
 		else
 			fatalParserError(string("Function, variable, struct or modifier declaration expected."));
 	}
@@ -482,8 +482,14 @@ ASTPointer<ASTNode> Parser::parseFunctionDefinitionOrFunctionTypeStateVariable(
 
 		if (_modifierArea)
 		{
-			header.visibility = _modifierArea->visibility();
-			header.stateMutability = _modifierArea->stateMutability();
+			auto const modifierAreaVisibility = _modifierArea->visibility();
+			auto const modifierAreaStateMutability = _modifierArea->stateMutability();
+
+			if (modifierAreaVisibility != Declaration::Visibility::Default)
+				header.visibility = _modifierArea->visibility();
+
+			if (modifierAreaStateMutability != StateMutability::NonPayable)
+				header.stateMutability = _modifierArea->stateMutability();
 		}
 
 		return nodeFactory.createNode<FunctionDefinition>(
@@ -752,7 +758,7 @@ ASTPointer<UsingForDirective> Parser::parseUsingDirective()
 	return nodeFactory.createNode<UsingForDirective>(library, typeName);
 }
 
-ASTPointer<ModifierArea> Parser::parseModifierArea(ASTString const* _contractName, ModifierArea* const& _parent)
+ASTPointer<ModifierArea> Parser::parseModifierArea(ModifierArea* const& _parent)
 {
 	RecursionGuard recursionGuard(*this);
 	ASTNodeFactory nodeFactory(*this);
@@ -820,7 +826,7 @@ ASTPointer<ModifierArea> Parser::parseModifierArea(ASTString const* _contractNam
 		}
 		else if (currentToken == Token::Apply)
 		{
-			subAreas->push_back(parseModifierArea(_contractName, modifierArea.get()));
+			subAreas->push_back(parseModifierArea(modifierArea.get()));
 		}
 		else
 			fatalParserError(string("Expected modifier area declaration, function definition, or right brace."));

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -74,11 +74,7 @@ private:
 	ASTPointer<InheritanceSpecifier> parseInheritanceSpecifier();
 	Declaration::Visibility parseVisibilitySpecifier(Token::Value _token);
 	StateMutability parseStateMutability(Token::Value _token);
-	FunctionHeaderParserResult parseFunctionHeader(
-		bool _forceEmptyName,
-		bool _allowModifiers,
-		ModifierArea const* _modifierArea = nullptr
-	);
+	FunctionHeaderParserResult parseFunctionHeader(bool _forceEmptyName, bool _allowModifiers);
 	ASTPointer<ASTNode> parseFunctionDefinitionOrFunctionTypeStateVariable(
 		ModifierArea* const& _modifierArea = nullptr
 	);

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -74,8 +74,14 @@ private:
 	ASTPointer<InheritanceSpecifier> parseInheritanceSpecifier();
 	Declaration::Visibility parseVisibilitySpecifier(Token::Value _token);
 	StateMutability parseStateMutability(Token::Value _token);
-	FunctionHeaderParserResult parseFunctionHeader(bool _forceEmptyName, bool _allowModifiers);
-	ASTPointer<ASTNode> parseFunctionDefinitionOrFunctionTypeStateVariable();
+	FunctionHeaderParserResult parseFunctionHeader(
+		bool _forceEmptyName,
+		bool _allowModifiers,
+		ModifierArea const* _modifierArea = nullptr
+	);
+	ASTPointer<ASTNode> parseFunctionDefinitionOrFunctionTypeStateVariable(
+		ModifierArea* const& _modifierArea = nullptr
+	);
 	ASTPointer<FunctionDefinition> parseFunctionDefinition(ASTString const* _contractName);
 	ASTPointer<StructDefinition> parseStructDefinition();
 	ASTPointer<EnumDefinition> parseEnumDefinition();
@@ -86,7 +92,12 @@ private:
 	);
 	ASTPointer<ModifierDefinition> parseModifierDefinition();
 	ASTPointer<EventDefinition> parseEventDefinition();
+
 	ASTPointer<UsingForDirective> parseUsingDirective();
+	ASTPointer<ModifierArea> parseModifierArea(
+		ASTString const* _contractName,
+		ModifierArea* const& _parent = nullptr
+	);
 	ASTPointer<ModifierInvocation> parseModifierInvocation();
 	ASTPointer<Identifier> parseIdentifier();
 	ASTPointer<UserDefinedTypeName> parseUserDefinedTypeName();

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -94,10 +94,7 @@ private:
 	ASTPointer<EventDefinition> parseEventDefinition();
 
 	ASTPointer<UsingForDirective> parseUsingDirective();
-	ASTPointer<ModifierArea> parseModifierArea(
-		ASTString const* _contractName,
-		ModifierArea* const& _parent = nullptr
-	);
+	ASTPointer<ModifierArea> parseModifierArea(ModifierArea* const& _parent = nullptr);
 	ASTPointer<ModifierInvocation> parseModifierInvocation();
 	ASTPointer<Identifier> parseIdentifier();
 	ASTPointer<UserDefinedTypeName> parseUserDefinedTypeName();

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -182,6 +182,7 @@ namespace solidity
 	K(Var, "var", 0)                                                   \
 	K(View, "view", 0)                                                 \
 	K(While, "while", 0)                                               \
+	K(Apply, "apply", 0)                                               \
 	\
 	/* Ether subdenominations */                                       \
 	K(SubWei, "wei", 0)                                                \
@@ -225,7 +226,6 @@ namespace solidity
 	K(Abstract, "abstract", 0)                                         \
 	K(After, "after", 0)                                               \
 	K(Alias, "alias", 0)                                               \
-	K(Apply, "apply", 0)                                               \
 	K(Auto, "auto", 0)                                                 \
 	K(Case, "case", 0)                                                 \
 	K(Catch, "catch", 0)                                               \

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -139,6 +139,7 @@ namespace solidity
 	K(Delete, "delete", 0)                                             \
 	\
 	/* Keywords */                                                     \
+	K(Apply, "apply", 0)                                               \
 	K(Anonymous, "anonymous", 0)                                       \
 	K(As, "as", 0)                                                     \
 	K(Assembly, "assembly", 0)                                         \
@@ -182,7 +183,6 @@ namespace solidity
 	K(Var, "var", 0)                                                   \
 	K(View, "view", 0)                                                 \
 	K(While, "while", 0)                                               \
-	K(Apply, "apply", 0)                                               \
 	\
 	/* Ether subdenominations */                                       \
 	K(SubWei, "wei", 0)                                                \

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -12925,7 +12925,7 @@ BOOST_AUTO_TEST_CASE(modifier_area_mutability)
 	char const* sourceCode = R"(
 		contract C {
 			apply payable {
-				function f() returns (uint256) {
+				function f() public returns (uint256) {
 					return msg.value;
 				}
 			}
@@ -12933,6 +12933,21 @@ BOOST_AUTO_TEST_CASE(modifier_area_mutability)
 	)";
 	compileAndRun(sourceCode);
 	ABI_CHECK(callContractFunctionWithValue("f()", 1337), encodeArgs(1337));
+}
+
+BOOST_AUTO_TEST_CASE(modifier_area_visibility)
+{
+	char const* sourceCode = R"(
+		contract C {
+			apply public {
+				function f() returns (uint256) {
+					return 87;
+				}
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(87));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -492,7 +492,6 @@ BOOST_AUTO_TEST_CASE(keyword_is_reserved)
 		"abstract",
 		"after",
 		"alias",
-		"apply",
 		"auto",
 		"case",
 		"catch",

--- a/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/empty.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/empty.sol
@@ -1,0 +1,5 @@
+contract C {
+    modifier A { _; }
+    apply A {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/many_functions.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/many_functions.sol
@@ -1,0 +1,12 @@
+contract C {
+    modifier A { _; }
+    apply A {
+        function f() {}
+        function g() {}
+    }
+}
+// ----
+// Warning: (57-72): No visibility specified. Defaulting to "public". 
+// Warning: (81-96): No visibility specified. Defaulting to "public". 
+// Warning: (57-72): Function state mutability can be restricted to pure
+// Warning: (81-96): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/many_functions.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/many_functions.sol
@@ -1,12 +1,7 @@
 contract C {
     modifier A { _; }
     apply A {
-        function f() {}
-        function g() {}
+        function f() public pure {}
+        function g() public pure {}
     }
 }
-// ----
-// Warning: (57-72): No visibility specified. Defaulting to "public". 
-// Warning: (81-96): No visibility specified. Defaulting to "public". 
-// Warning: (57-72): Function state mutability can be restricted to pure
-// Warning: (81-96): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/one_function.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/one_function.sol
@@ -1,9 +1,6 @@
 contract C {
     modifier A { _; }
     apply A {
-        function f() {}
+        function f() public pure {}
     }
 }
-// ----
-// Warning: (57-72): No visibility specified. Defaulting to "public". 
-// Warning: (57-72): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/one_function.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/modifiers/valid/one_function.sol
@@ -1,0 +1,9 @@
+contract C {
+    modifier A { _; }
+    apply A {
+        function f() {}
+    }
+}
+// ----
+// Warning: (57-72): No visibility specified. Defaulting to "public". 
+// Warning: (57-72): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/function_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/function_discrepancy.sol
@@ -1,7 +1,7 @@
 contract C {
     apply pure {
-        function f() view {}
+        function f() public view {}
     }
 }
 // ----
-// ParserError: (51-55): Cannot override modifier area's state mutability.
+// SyntaxError: (38-65): Cannot override modifier area's state mutability.

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/function_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/function_discrepancy.sol
@@ -1,0 +1,7 @@
+contract C {
+    apply pure {
+        function f() view {}
+    }
+}
+// ----
+// ParserError: (51-55): Cannot override modifier area's state mutability.

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/nested_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/nested_discrepancy.sol
@@ -1,0 +1,7 @@
+contract C {
+    apply pure {
+        apply payable {}
+    }
+}
+// ----
+// ParserError: (44-51): Cannot override parent modifier area's state mutability of "pure".

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/nested_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/nested_discrepancy.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// ParserError: (44-51): Cannot override parent modifier area's state mutability of "pure".
+// SyntaxError: (38-54): Cannot override parent modifier area's state mutability.

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/redeclataion.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/invalid/redeclataion.sol
@@ -1,0 +1,6 @@
+contract A {
+    apply pure payable {}
+}
+
+// ----
+// ParserError: (28-35): State mutability already specified as "pure".

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/empty.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/empty.sol
@@ -1,0 +1,4 @@
+contract C {
+    apply payable {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/many_functions.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/many_functions.sol
@@ -1,0 +1,9 @@
+contract C {
+    apply pure {
+        function f() {}
+        function g() {}
+    }
+}
+// ----
+// Warning: (38-53): No visibility specified. Defaulting to "public". 
+// Warning: (62-77): No visibility specified. Defaulting to "public". 

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/many_functions.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/many_functions.sol
@@ -1,9 +1,6 @@
 contract C {
     apply pure {
-        function f() {}
-        function g() {}
+        function f() public {}
+        function g() public {}
     }
 }
-// ----
-// Warning: (38-53): No visibility specified. Defaulting to "public". 
-// Warning: (62-77): No visibility specified. Defaulting to "public". 

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/one_function.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/one_function.sol
@@ -1,7 +1,5 @@
 contract C {
     apply pure {
-        function f() {}
+        function f() public {}
     }
 }
-// ----
-// Warning: (38-53): No visibility specified. Defaulting to "public". 

--- a/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/one_function.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/mutability/valid/one_function.sol
@@ -1,0 +1,7 @@
+contract C {
+    apply pure {
+        function f() {}
+    }
+}
+// ----
+// Warning: (38-53): No visibility specified. Defaulting to "public". 

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/function_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/function_discrepancy.sol
@@ -3,5 +3,6 @@ contract C {
         function f() private {}
     }
 }
+
 // ----
-// ParserError: (53-60): Cannot override modifier area's visibility.
+// SyntaxError: (40-63): Cannot override modifier area's visibility.

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/function_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/function_discrepancy.sol
@@ -1,0 +1,7 @@
+contract C {
+    apply public {
+        function f() private {}
+    }
+}
+// ----
+// ParserError: (53-60): Cannot override modifier area's visibility.

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/nested_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/nested_discrepancy.sol
@@ -1,0 +1,7 @@
+contract C {
+    apply public {
+        apply private {}
+    }
+}
+// ----
+// ParserError: (46-53): Cannot override parent modifier area's visibility of "public".

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/nested_discrepancy.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/nested_discrepancy.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// ParserError: (46-53): Cannot override parent modifier area's visibility of "public".
+// SyntaxError: (40-56): Cannot override parent modifier area's visibility.

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/redeclaration.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/invalid/redeclaration.sol
@@ -1,0 +1,6 @@
+contract A {
+    apply public private {}
+}
+
+// ----
+// ParserError: (30-37): Visibility already specified as "public".

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/valid/empty.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/valid/empty.sol
@@ -1,0 +1,4 @@
+contract C {
+    apply public {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/valid/many_functions.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/valid/many_functions.sol
@@ -1,0 +1,9 @@
+contract C {
+    apply internal {
+        function f() {}
+        function g() {}
+    }
+}
+// ----
+// Warning: (42-57): Function state mutability can be restricted to pure
+// Warning: (66-81): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/modifierAreas/visibility/valid/one_function.sol
+++ b/test/libsolidity/syntaxTests/modifierAreas/visibility/valid/one_function.sol
@@ -1,0 +1,7 @@
+contract C {
+    apply private {
+        function f() {}
+    }
+}
+// ----
+// Warning: (41-56): Function state mutability can be restricted to pure


### PR DESCRIPTION
Closes #623.

Yes, the code here is pretty sloppy. Feedback (from maintainers and others) is welcome and encouraged!
I'm especially interested in hearing suggestions people have for syntax.

Syntax:
```
apply ... { ... }
```

The ellipsis after apply can contain any modifier invocations, a state mutability specifier, and a visibility mutability specifier, or any combination of the above. Inside the area there can be more modifier areas (modifier invocations are cumulative) and function declarations. Nested modifier areas and function declarations cannot have a different visibility or mutability than their modifier areas.

- [x] Modifier areas
- [x] Nested modifier areas
- [x] Visibility areas
- [x] Mutability areas
- [x] Some tests
- [ ] Lots of tests