### PR TITLE
[SMTChecker] Remove 'information is erase' message for if-else

### DIFF
--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -160,7 +160,7 @@ private:
 
 	std::shared_ptr<smt::SolverInterface> m_interface;
 	std::shared_ptr<VariableUsage> m_variableUsage;
-	bool m_conditionalExecutionHappened = false;
+	bool m_loopExecutionHappened = false;
 	std::map<Expression const*, smt::Expression> m_expressions;
 	std::map<Declaration const*, SSAVariable> m_variables;
 	std::vector<smt::Expression> m_pathConditions;


### PR DESCRIPTION
Since branching is supported we don't reset the variables anymore, so we should remove the message
`Note that some information is erased after the execution of loops.
You can re-introduce information using require().`
for that case. I kept it for loops.