### PR TITLE
Do not run emscripten tests on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ before_script:
       && scripts/create_source_tarball.sh)
 
 script:
-    - test $SOLC_EMSCRIPTEN != On || (scripts/test_emscripten.sh)
+    - test $SOLC_EMSCRIPTEN != On -o $SOLC_TESTS != On || (scripts/test_emscripten.sh)
     - test $SOLC_TESTS != On || (cd $TRAVIS_BUILD_DIR && scripts/tests.sh)
     - test $SOLC_STOREBYTECODE != On || (cd $TRAVIS_BUILD_DIR && scripts/bytecodecompare/storebytecode.sh)
 


### PR DESCRIPTION
External tests are run which have sporadic failures and prevent creation of artefacts otherwise.