### PR TITLE
 Turn deprecated warnings for sha3/suicide into errors (experimental 0.5.0)

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1652,10 +1652,18 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 
 	if (auto functionName = dynamic_cast<Identifier const*>(&_functionCall.expression()))
 	{
+		string msg;
 		if (functionName->name() == "sha3" && functionType->kind() == FunctionType::Kind::SHA3)
-			m_errorReporter.warning(_functionCall.location(), "\"sha3\" has been deprecated in favour of \"keccak256\"");
+			msg = "\"sha3\" has been deprecated in favour of \"keccak256\"";
 		else if (functionName->name() == "suicide" && functionType->kind() == FunctionType::Kind::Selfdestruct)
-			m_errorReporter.warning(_functionCall.location(), "\"suicide\" has been deprecated in favour of \"selfdestruct\"");
+			msg = "\"suicide\" has been deprecated in favour of \"selfdestruct\"";
+		if (!msg.empty())
+		{
+			if (v050)
+				m_errorReporter.typeError(_functionCall.location(), msg);
+			else
+				m_errorReporter.warning(_functionCall.location(), msg);
+		}
 	}
 	if (!m_insideEmitStatement && functionType->kind() == FunctionType::Kind::Event)
 	{

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -5823,7 +5823,7 @@ BOOST_AUTO_TEST_CASE(bare_others)
 	CHECK_WARNING("contract C { function f() pure public { assert; } }", "Statement has no effect.");
 	// This is different because it does have overloads.
 	CHECK_ERROR("contract C { function f() pure public { require; } }", TypeError, "No matching declaration found after variable lookup.");
-	CHECK_WARNING("contract C { function f() pure public { suicide; } }", "Statement has no effect.");
+	CHECK_WARNING("contract C { function f() pure public { selfdestruct; } }", "Statement has no effect.");
 }
 
 BOOST_AUTO_TEST_CASE(pure_statement_in_for_loop)
@@ -6956,31 +6956,6 @@ BOOST_AUTO_TEST_CASE(invalid_literal_in_tuple)
 		}
 	)";
 	CHECK_SUCCESS(text);
-}
-
-BOOST_AUTO_TEST_CASE(warn_about_sha3)
-{
-	char const* text = R"(
-		contract test {
-			function f() pure public {
-				bytes32 x = sha3(uint8(1));
-				x;
-			}
-		}
-	)";
-	CHECK_WARNING(text, "\"sha3\" has been deprecated in favour of \"keccak256\"");
-}
-
-BOOST_AUTO_TEST_CASE(warn_about_suicide)
-{
-	char const* text = R"(
-		contract test {
-			function f() public {
-				suicide(1);
-			}
-		}
-	)";
-	CHECK_WARNING(text, "\"suicide\" has been deprecated in favour of \"selfdestruct\"");
 }
 
 BOOST_AUTO_TEST_CASE(address_overload_resolution)

--- a/test/libsolidity/syntaxTests/deprecated_functions.sol
+++ b/test/libsolidity/syntaxTests/deprecated_functions.sol
@@ -1,0 +1,12 @@
+contract test {
+	function f() pure public {
+		bytes32 x = sha3(uint8(1));
+		x;
+	}
+	function g() public {
+		suicide(1);
+	}
+}
+// ----
+// Warning: (58-72): "sha3" has been deprecated in favour of "keccak256"
+// Warning: (107-117): "suicide" has been deprecated in favour of "selfdestruct"

--- a/test/libsolidity/syntaxTests/deprecated_functions_050.sol
+++ b/test/libsolidity/syntaxTests/deprecated_functions_050.sol
@@ -1,0 +1,13 @@
+pragma experimental "v0.5.0";
+contract test {
+	function f() pure public {
+		bytes32 x = sha3(uint8(1));
+		x;
+	}
+	function g() public {
+		suicide(1);
+	}
+}
+// ----
+// TypeError: (88-102): "sha3" has been deprecated in favour of "keccak256"
+// TypeError: (137-147): "suicide" has been deprecated in favour of "selfdestruct"

--- a/test/libsolidity/syntaxTests/tight_packing_literals_050.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals_050.sol
@@ -19,7 +19,7 @@ contract C {
 
 // ----
 // TypeError: (117-118): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.
-// Warning: (191-198): "sha3" has been deprecated in favour of "keccak256"
+// TypeError: (191-198): "sha3" has been deprecated in favour of "keccak256"
 // TypeError: (196-197): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.
 // TypeError: (277-278): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.
 // TypeError: (361-362): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.


### PR DESCRIPTION
Depends on #3956.