### PR TITLE
Avoid 'delegated voting rights' being 'misused' for different proposal.

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -110,7 +110,7 @@ of votes.
         }
 
         /// Delegate your vote to the voter `to`.
-        function delegate(address to) public {
+        function delegate(address to, uint proposalChoice) public {
             // assigns reference
             Voter storage sender = voters[msg.sender];
             require(!sender.voted, "You already voted.");
@@ -137,6 +137,14 @@ of votes.
             sender.voted = true;
             sender.delegate = to;
             Voter storage delegate_ = voters[to];
+
+            //Check if the delegate will vote for the 'same proposal' 
+            //as requested by the sender - otherwise, the number of votes
+            //will be added to the delegate's choice of proposal, 
+            //instead of the sender's choice of proposal.
+            
+            require(delegate_.vote == proposalChoice, "Delegate is voting for a 'different proposal'");
+
             if (delegate_.voted) {
                 // If the delegate already voted,
                 // directly add to the number of votes


### PR DESCRIPTION
While delegating 'voting right', add checks to makes sure that the 'weight (number of votes)'  is added to the 'proposal originally intended' by the sender.
**It's possible that the 'delegate' has a 'different interest'**, than that of the 'sender'. So, **make sure**, before assigning the 'voting right', that **the delegate's choice of proposal is SAME as the sender's choice of proposal**. **Otherwise**, the **sender's voting rights could be misused** towards the delegate's choice of proposal.