### PR TITLE
docs: clarify the maximum line length style

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -117,7 +117,7 @@ No::
 Maximum Line Length 
 ===================
 
-Keeping lines under the `PEP 8 recommendation <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_ of 79 (or 99) 
+Keeping lines under the `PEP 8 recommendation <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_ to a maximum of 79 (or 99) 
 characters helps readers easily parse the code.
 
 Wrapped lines should conform to the following guidelines.


### PR DESCRIPTION
when I read this first, I thought it meant to keep the lines under 79, i.e, a maximum of 78.