### PR TITLE
A couple of ABI spec improvements

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -77,7 +77,7 @@ of them inside parentheses, separated by commas:
 
 - ``(T1,T2,...,Tn)``: tuple consisting of the types ``T1``, ..., ``Tn``, ``n >= 0``
 
-It is possible to form tuples of tuples, arrays of tuples and so on.
+It is possible to form tuples of tuples, arrays of tuples and so on.  It is also possible to form zero-tuples (where ``n == 0``).
 
 .. note::
     Solidity supports all the types presented above with the same names with the exception of tuples. The ABI tuple type is utilised for encoding Solidity ``structs``.

--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -117,7 +117,7 @@ on the type of ``X`` being
 
 - ``(T1,...,Tk)`` for ``k >= 0`` and any types ``T1``, ..., ``Tk``
 
-  ``enc(X) = head(X(1)) ... head(X(k-1)) tail(X(0)) ... tail(X(k-1))``
+  ``enc(X) = head(X(1)) ... head(X(k)) tail(X(1)) ... tail(X(k))``
 
   where ``X(i)`` is the ``ith`` component of the value, and
   ``head`` and ``tail`` are defined for ``Ti`` being a static type as
@@ -126,7 +126,7 @@ on the type of ``X`` being
 
   and as
 
-    ``head(X(i)) = enc(len(head(X(0)) ... head(X(k-1)) tail(X(0)) ... tail(X(i-1))))``
+    ``head(X(i)) = enc(len( head(X(1)) ... head(X(k)) tail(X(1)) ... tail(X(i-1)) ))``
     ``tail(X(i)) = enc(X(i))``
 
   otherwise, i.e. if ``Ti`` is a dynamic type.
@@ -137,7 +137,7 @@ on the type of ``X`` being
 
 - ``T[k]`` for any ``T`` and ``k``:
 
-  ``enc(X) = enc((X[0], ..., X[k-1]))``
+  ``enc(X) = enc((X[1], ..., X[k]))``
 
   i.e. it is encoded as if it were a tuple with ``k`` elements
   of the same type.


### PR DESCRIPTION
This PR does two things:

1. Adds a note to clarify that zero-tuples are an intended feature of the specification
2. Fixes apparent typos or inconsistencies in the choice of index notation used in the spec

#### For item 2:

The ABI spec begins by using 1-indexing.  I assume this is because 1-indexing is more common in mathematical expositions and the ABI spec seems to follow that style.  For that reason, it seemed appropriate to correct occurrences of 0-indexing to use 1-indexing and not the other way around.

Of course, if all that notation was chosen intentionally and there's something I'm just not understanding, please ignore me 🙂 .