### PR TITLE
docs: Update configuration from 2017 to 2018

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Solidity'
-copyright = '2016-2017, Ethereum'
+copyright = '2016-2018, Ethereum'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Change date from 2017 to 2018 in conf.py.

Resulting in « © Copyright 2016-2017, Ethereum. » to « © Copyright 2016-2018, Ethereum. » in generated documentation.