### PR TITLE
BREAKING: Bool variables should not allow arithmetic comparison

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### 0.5.0 (unreleased)
+Features:
+ * Type Checker: Disallow arithmetic operations for Boolean variables.
+
+
 ### 0.4.24 (unreleased)
 
 Features:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1374,7 +1374,7 @@ TypePointer BoolType::binaryOperatorResult(Token::Value _operator, TypePointer c
 {
 	if (category() != _other->category())
 		return TypePointer();
-	if (Token::isCompareOp(_operator) || _operator == Token::And || _operator == Token::Or)
+	if (_operator == Token::Equal || _operator == Token::NotEqual || _operator == Token::And || _operator == Token::Or)
 		return _other;
 	else
 		return TypePointer();

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -472,11 +472,7 @@ void SMTChecker::compareOperation(BinaryOperation const& _op)
 			solUnimplementedAssert(SSAVariable::isBool(_op.annotation().commonType->category()), "Operation not yet supported");
 			value = make_shared<smt::Expression>(
 				op == Token::Equal ? (left == right) :
-				op == Token::NotEqual ? (left != right) :
-				op == Token::LessThan ? (!left && right) :
-				op == Token::LessThanOrEqual ? (!left || right) :
-				op == Token::GreaterThan ? (left && !right) :
-				/*op == Token::GreaterThanOrEqual*/ (left || !right)
+				/*op == Token::NotEqual*/ (left != right)
 			);
 		}
 		// TODO: check that other values for op are not possible.

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -388,35 +388,6 @@ BOOST_AUTO_TEST_CASE(bool_simple)
 		}
 	)";
 	CHECK_SUCCESS_NO_WARNINGS(text);
-	text = R"(
-		contract C {
-			function f(bool x) public pure {
-				bool y;
-				assert(x <= y);
-			}
-		}
-	)";
-	CHECK_WARNING(text, "Assertion violation happens here");
-	text = R"(
-		contract C {
-			function f(bool x) public pure {
-				bool y;
-				assert(x >= y);
-			}
-		}
-	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
-	text = R"(
-		contract C {
-			function f(bool x) public pure {
-				require(x);
-				bool y;
-				assert(x > y);
-				assert(y < x);
-			}
-		}
-	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
 }
 
 BOOST_AUTO_TEST_CASE(bool_int_mixed)

--- a/test/libsolidity/syntaxTests/types/bool_ops.sol
+++ b/test/libsolidity/syntaxTests/types/bool_ops.sol
@@ -1,0 +1,53 @@
+contract C {
+    function f(bool a, bool b) public pure {
+        bool c;
+        // OK
+        c = !a;
+        c = !b;
+        c = a == b;
+        c = a != b;
+        c = a || b;
+        c = a && b;
+
+        // Not OK
+        c = a > b;
+        c = a < b;
+        c = a >= b;
+        c = a <= b;
+        c = a & b;
+        c = a | b;
+        c = a ^ b;
+        c = ~a;
+        c = ~b;
+        c = a + b;
+        c = a - b;
+        c = -a;
+        c = -b;
+        c = a * b;
+        c = a / b;
+        c = a ** b;
+        c = a % b;
+        c = a << b;
+        c = a >> b;
+    }
+}
+// ----
+// TypeError: (231-236): Operator > not compatible with types bool and bool
+// TypeError: (250-255): Operator < not compatible with types bool and bool
+// TypeError: (269-275): Operator >= not compatible with types bool and bool
+// TypeError: (289-295): Operator <= not compatible with types bool and bool
+// TypeError: (309-314): Operator & not compatible with types bool and bool
+// TypeError: (328-333): Operator | not compatible with types bool and bool
+// TypeError: (347-352): Operator ^ not compatible with types bool and bool
+// TypeError: (366-368): Unary operator ~ cannot be applied to type bool
+// TypeError: (382-384): Unary operator ~ cannot be applied to type bool
+// TypeError: (398-403): Operator + not compatible with types bool and bool
+// TypeError: (417-422): Operator - not compatible with types bool and bool
+// TypeError: (436-438): Unary operator - cannot be applied to type bool
+// TypeError: (452-454): Unary operator - cannot be applied to type bool
+// TypeError: (468-473): Operator * not compatible with types bool and bool
+// TypeError: (487-492): Operator / not compatible with types bool and bool
+// TypeError: (506-512): Operator ** not compatible with types bool and bool
+// TypeError: (526-531): Operator % not compatible with types bool and bool
+// TypeError: (545-551): Operator << not compatible with types bool and bool
+// TypeError: (565-571): Operator >> not compatible with types bool and bool


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3811