### PR TITLE
Properly unlink unreachable source vertices from CFG

### DIFF
--- a/libevmasm/ControlFlowGraph.cpp
+++ b/libevmasm/ControlFlowGraph.cpp
@@ -312,13 +312,16 @@ void ControlFlowGraph::gatherKnowledge()
 	// never used for a JUMP.
 	// Note that this invalidates some contents of pushedTags
 	for (auto it = m_blocks.begin(); it != m_blocks.end();)
-		if (!it->second.startState) {
-			if (it->second.next != BlockId::invalid()) {
+		if (!it->second.startState)
+		{
+			if (it->second.next != BlockId::invalid())
+			{
 				BasicBlock& nextBlock = m_blocks.at(it->second.next);
 				nextBlock.prev = BlockId::invalid();
 			}
 			it = m_blocks.erase(it);
-		} else
+		}
+		else
 			it++;
 }
 

--- a/libevmasm/ControlFlowGraph.cpp
+++ b/libevmasm/ControlFlowGraph.cpp
@@ -312,9 +312,13 @@ void ControlFlowGraph::gatherKnowledge()
 	// never used for a JUMP.
 	// Note that this invalidates some contents of pushedTags
 	for (auto it = m_blocks.begin(); it != m_blocks.end();)
-		if (!it->second.startState)
+		if (!it->second.startState) {
+			if (it->second.next != BlockId::invalid()) {
+				BasicBlock& nextBlock = m_blocks.at(it->second.next);
+				nextBlock.prev = BlockId::invalid();
+			}
 			it = m_blocks.erase(it);
-		else
+		} else
 			it++;
 }
 


### PR DESCRIPTION
This properly unlinks unreachable source vertices from CFG.

Here goes a test case as I don't see where I should place it.

```
contract UnreachableSourceVertexTest {
    event Error(string message);

    function erroneous(bool condition, string message) public payable {
        if (!condition) {
            error(message);
        }
    }

    function error(string message) public payable {
        emit Error(message);
        revert();
    }
}
```

I would also suggest splitting the `gatherKnowledge` function into two smaller ones, one for gathering information and another one for unlinking unreachable basic blocks from the CFG, because I find it strange that a function with declared "gathering" semantics does a CFG modification. But it's up to you.