### PR TITLE
[BREAKING] Throw error if function parameters (return) use default data location.

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -193,9 +193,9 @@ Given the contract:
     pragma solidity ^0.4.16;
 
     contract Foo {
-      function bar(bytes3[2]) public pure {}
+      function bar(bytes3[2] memory) public pure {}
       function baz(uint32 x, bool y) public pure returns (bool r) { r = x > 32 || y; }
-      function sam(bytes, bool, uint[]) public pure {}
+      function sam(bytes memory, bool, uint[] memory) public pure {}
     }
 
 
@@ -490,8 +490,8 @@ As an example, the code
     contract Test {
       struct S { uint a; uint[] b; T[] c; }
       struct T { uint x; uint y; }
-      function f(S s, T t, uint a) public { }
-      function g() public returns (S s, T t, uint a) {}
+      function f(S memory s, T memory t, uint a) public { }
+      function g() public returns (S memory s, T memory t, uint a) {}
     }
 
 would result in the JSON:

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -54,7 +54,7 @@ idea is that assembly libraries will be used to enhance the language in such way
     pragma solidity ^0.4.0;
 
     library GetCode {
-        function at(address _addr) public view returns (bytes o_code) {
+        function at(address _addr) public view returns (bytes memory o_code) {
             assembly {
                 // retrieve the size of the code, this needs assembly
                 let size := extcodesize(_addr)
@@ -83,7 +83,7 @@ you really know what you are doing.
     library VectorSum {
         // This function is less efficient because the optimizer currently fails to
         // remove the bounds checks in array access.
-        function sumSolidity(uint[] _data) public view returns (uint o_sum) {
+        function sumSolidity(uint[] memory _data) public view returns (uint o_sum) {
             for (uint i = 0; i < _data.length; ++i)
                 o_sum += _data[i];
         }
@@ -91,7 +91,7 @@ you really know what you are doing.
         // We know that we only access the array in bounds, so we can avoid the check.
         // 0x20 needs to be added to an array because the first slot contains the
         // array length.
-        function sumAsm(uint[] _data) public view returns (uint o_sum) {
+        function sumAsm(uint[] memory _data) public view returns (uint o_sum) {
             for (uint i = 0; i < _data.length; ++i) {
                 assembly {
                     o_sum := add(o_sum, mload(add(add(_data, 0x20), mul(i, 0x20))))
@@ -100,7 +100,7 @@ you really know what you are doing.
         }
 
         // Same as above, but accomplish the entire code within inline assembly.
-        function sumPureAsm(uint[] _data) public view returns (uint o_sum) {
+        function sumPureAsm(uint[] memory _data) public view returns (uint o_sum) {
             assembly {
                // Load the length (first 32 bytes)
                let len := mload(_data)

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -1287,12 +1287,12 @@ custom types without the overhead of external function calls:
             uint[] limbs;
         }
 
-        function fromUint(uint x) internal pure returns (bigint r) {
+        function fromUint(uint x) internal pure returns (bigint memory r) {
             r.limbs = new uint[](1);
             r.limbs[0] = x;
         }
 
-        function add(bigint _a, bigint _b) internal pure returns (bigint r) {
+        function add(bigint memory _a, bigint memory _b) internal pure returns (bigint memory r) {
             r.limbs = new uint[](max(_a.limbs.length, _b.limbs.length));
             uint carry = 0;
             for (uint i = 0; i < r.limbs.length; ++i) {
@@ -1315,7 +1315,7 @@ custom types without the overhead of external function calls:
             }
         }
 
-        function limb(bigint _a, uint _limb) internal pure returns (uint) {
+        function limb(bigint memory _a, uint _limb) internal pure returns (uint) {
             return _limb < _a.limbs.length ? _a.limbs[_limb] : 0;
         }
 

--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -85,7 +85,7 @@ Example::
     pragma solidity ^0.4.16;
 
     contract C {
-        function f() public pure returns (uint8[5]) {
+        function f() public pure returns (uint8[5] memory) {
             string[4] memory adaArr = ["This", "is", "an", "array"];
             return ([1, 2, 3, 4, 5]);
         }
@@ -479,7 +479,7 @@ independent copies will be created::
             h(x);
         }
 
-        function g(uint[20] y) internal pure {
+        function g(uint[20] memory y) internal pure {
             y[2] = 3;
         }
 
@@ -489,10 +489,9 @@ independent copies will be created::
     }
 
 The call to ``g(x)`` will not have an effect on ``x`` because it needs
-to create an independent copy of the storage value in memory
-(the default storage location is memory). On the other hand,
-``h(x)`` successfully modifies ``x`` because only a reference
-and not a copy is passed.
+to create an independent copy of the storage value in memory.
+On the other hand, ``h(x)`` successfully modifies ``x`` because only
+a reference and not a copy is passed.
 
 Sometimes, when I try to change the length of an array with ex: ``arrayname.length = 7;`` I get a compiler error ``Value must be an lvalue``. Why?
 ==================================================================================================================================================

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -66,7 +66,7 @@ of votes.
         Proposal[] public proposals;
 
         /// Create a new ballot to choose one of `proposalNames`.
-        constructor(bytes32[] proposalNames) public {
+        constructor(bytes32[] memory proposalNames) public {
             chairperson = msg.sender;
             voters[chairperson].weight = 1;
 
@@ -452,9 +452,9 @@ high or low invalid bids.
         /// correctly blinded invalid bids and for all bids except for
         /// the totally highest.
         function reveal(
-            uint[] _values,
-            bool[] _fake,
-            bytes32[] _secret
+            uint[] memory _values,
+            bool[] memory _fake,
+            bytes32[] memory _secret
         )
             public
             onlyAfter(biddingEnd)

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -475,11 +475,11 @@ Another example that uses external function types::
       }
       Request[] requests;
       event NewRequest(uint);
-      function query(bytes data, function(bytes memory) external callback) public {
+      function query(bytes memory data, function(bytes memory) external callback) public {
         requests.push(Request(data, callback));
         emit NewRequest(requests.length - 1);
       }
-      function reply(uint requestID, bytes response) public {
+      function reply(uint requestID, bytes memory response) public {
         // Here goes the check that the reply comes from a trusted source
         requests[requestID].callback(response);
       }
@@ -490,7 +490,7 @@ Another example that uses external function types::
       function buySomething() {
         oracle.query("USD", this.oracleResponse);
       }
-      function oracleResponse(bytes response) public {
+      function oracleResponse(bytes memory response) public {
         require(
             msg.sender == address(oracle),
             "Only oracle can call this."
@@ -544,7 +544,7 @@ memory-stored reference type do not create a copy.
         uint[] x; // the data location of x is storage
 
         // the data location of memoryArray is memory
-        function f(uint[] memoryArray) public {
+        function f(uint[] memory memoryArray) public {
             x = memoryArray; // works, copies the whole array to storage
             uint[] storage y = x; // works, assigns a pointer, data location of y is storage
             y[7]; // fine, returns the 8th element
@@ -561,7 +561,7 @@ memory-stored reference type do not create a copy.
         }
 
         function g(uint[] storage storageArray) internal {}
-        function h(uint[] memoryArray) public {}
+        function h(uint[] memory memoryArray) public {}
     }
 
 Summary
@@ -650,7 +650,7 @@ assigned to a variable right away.
         function f() public pure {
             g([uint(1), 2, 3]);
         }
-        function g(uint[3] _data) public pure {
+        function g(uint[3] memory _data) public pure {
             // ...
         }
     }
@@ -717,7 +717,7 @@ Members
         bool[2][] m_pairsOfFlags;
         // newPairs is stored in memory - the default for function arguments
 
-        function setAllFlagPairs(bool[2][] newPairs) public {
+        function setAllFlagPairs(bool[2][] memory newPairs) public {
             // assignment to a storage array replaces the complete array
             m_pairsOfFlags = newPairs;
         }
@@ -743,7 +743,7 @@ Members
 
         bytes m_byteData;
 
-        function byteArrays(bytes data) public {
+        function byteArrays(bytes memory data) public {
             // byte arrays ("bytes") are different as they are stored without padding,
             // but can be treated identical to "uint8[]"
             m_byteData = data;
@@ -752,11 +752,11 @@ Members
             delete m_byteData[2];
         }
 
-        function addFlag(bool[2] flag) public returns (uint) {
+        function addFlag(bool[2] memory flag) public returns (uint) {
             return m_pairsOfFlags.push(flag);
         }
 
-        function createMemoryArray(uint size) public pure returns (bytes) {
+        function createMemoryArray(uint size) public pure returns (bytes memory) {
             // Dynamic memory arrays are created using `new`:
             uint[2][] memory arrayOfPairs = new uint[2][](size);
             // Create a dynamic byte array:

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -520,7 +520,8 @@ Every complex type, i.e. *arrays* and *structs*, has an additional
 annotation, the "data location", about whether it is stored in memory or in storage. Depending on the
 context, there is always a default, but it can be overridden by appending
 either ``storage`` or ``memory`` to the type. The default for function parameters (including return parameters) is ``memory``, the default for local variables is ``storage`` and the location is forced
-to ``storage`` for state variables (obviously).
+to ``storage`` for state variables (obviously). As of version 0.5.0, data locations for function parameters and function return parameters no longer have a default location, and ``memory`` or ``storage``
+must be provided, with the exception being parameters (not return parameters) for external functions which are talked about below.
 
 There is also a third data location, ``calldata``, which is a non-modifiable,
 non-persistent area where function arguments are stored. Function parameters
@@ -572,7 +573,7 @@ Forced data location:
  - state variables: storage
 
 Default data location:
- - parameters (also return) of functions: memory
+ - parameters (also return) of functions: data location must be provided
  - all other local variables: storage
 
 .. index:: ! array

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -480,6 +480,11 @@ bool VariableDeclaration::canHaveAutoType() const
 	return isLocalVariable() && !isCallableParameter();
 }
 
+bool VariableDeclaration::isEventParameter() const
+{
+	return dynamic_cast<EventDefinition const*>(scope()) != nullptr;
+}
+
 TypePointer VariableDeclaration::type() const
 {
 	return annotation().type;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -698,6 +698,8 @@ public:
 	/// @returns true if the type of the variable does not need to be specified, i.e. it is declared
 	/// in the body of a function or modifier.
 	bool canHaveAutoType() const;
+	/// @returns true if this variable is a parameter from an event.
+	bool isEventParameter() const;
 	bool isStateVariable() const { return m_isStateVariable; }
 	bool isIndexed() const { return m_isIndexed; }
 	bool isConstant() const { return m_isConstant; }

--- a/test/compilationTests/MultiSigWallet/MultiSigWallet.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWallet.sol
@@ -103,7 +103,7 @@ contract MultiSigWallet {
     /// @dev Contract constructor sets initial owners and required number of confirmations.
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
-    constructor(address[] _owners, uint _required)
+    constructor(address[] memory _owners, uint _required)
         public
         validRequirement(_owners.length, _required)
     {
@@ -185,7 +185,7 @@ contract MultiSigWallet {
     /// @param value Transaction ether value.
     /// @param data Transaction data payload.
     /// @return Returns transaction ID.
-    function submitTransaction(address destination, uint value, bytes data)
+    function submitTransaction(address destination, uint value, bytes memory data)
         public
         returns (uint transactionId)
     {
@@ -261,7 +261,7 @@ contract MultiSigWallet {
     /// @param value Transaction ether value.
     /// @param data Transaction data payload.
     /// @return Returns transaction ID.
-    function addTransaction(address destination, uint value, bytes data)
+    function addTransaction(address destination, uint value, bytes memory data)
         internal
         notNull(destination)
         returns (uint transactionId)
@@ -313,7 +313,7 @@ contract MultiSigWallet {
     function getOwners()
         public
         view
-        returns (address[])
+        returns (address[] memory)
     {
         return owners;
     }
@@ -324,7 +324,7 @@ contract MultiSigWallet {
     function getConfirmations(uint transactionId)
         public
         view
-        returns (address[] _confirmations)
+        returns (address[] memory _confirmations)
     {
         address[] memory confirmationsTemp = new address[](owners.length);
         uint count = 0;
@@ -348,7 +348,7 @@ contract MultiSigWallet {
     function getTransactionIds(uint from, uint to, bool pending, bool executed)
         public
         view
-        returns (uint[] _transactionIds)
+        returns (uint[] memory _transactionIds)
     {
         uint[] memory transactionIdsTemp = new uint[](transactionCount);
         uint count = 0;

--- a/test/compilationTests/MultiSigWallet/MultiSigWalletFactory.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWalletFactory.sol
@@ -11,7 +11,7 @@ contract MultiSigWalletFactory is Factory {
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
     /// @return Returns wallet address.
-    function create(address[] _owners, uint _required)
+    function create(address[] memory _owners, uint _required)
         public
         returns (address wallet)
     {

--- a/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimit.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimit.sol
@@ -19,7 +19,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
     /// @param _dailyLimit Amount in wei, which can be withdrawn without confirmations on a daily basis.
-    constructor(address[] _owners, uint _required, uint _dailyLimit)
+    constructor(address[] memory _owners, uint _required, uint _dailyLimit)
         public
         MultiSigWallet(_owners, _required)
     {

--- a/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimitFactory.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimitFactory.sol
@@ -12,7 +12,7 @@ contract MultiSigWalletWithDailyLimitFactory is Factory {
     /// @param _required Number of required confirmations.
     /// @param _dailyLimit Amount in wei, which can be withdrawn without confirmations on a daily basis.
     /// @return Returns wallet address.
-    function create(address[] _owners, uint _required, uint _dailyLimit)
+    function create(address[] memory _owners, uint _required, uint _dailyLimit)
         public
         returns (address wallet)
     {

--- a/test/compilationTests/corion/ico.sol
+++ b/test/compilationTests/corion/ico.sol
@@ -50,7 +50,7 @@ contract ico is safeMath {
     uint256 public totalMint;
     uint256 public totalPremiumMint;
     
-    constructor(address foundation, address priceSet, uint256 exchangeRate, uint256 startBlockNum, address[] genesisAddr, uint256[] genesisValue) {
+    constructor(address foundation, address priceSet, uint256 exchangeRate, uint256 startBlockNum, address[] memory genesisAddr, uint256[] memory genesisValue) {
         /*
             Installation function.
             

--- a/test/compilationTests/corion/moduleHandler.sol
+++ b/test/compilationTests/corion/moduleHandler.sol
@@ -34,9 +34,9 @@ contract moduleHandler is multiOwner, announcementTypes {
     modules_s[] public modules;
     address public foundationAddress;
     uint256 debugModeUntil = block.number + 1000000;
+
     
-    
-    constructor(address[] newOwners) multiOwner(newOwners) {}
+    constructor(address[] memory newOwners) multiOwner(newOwners) {}
     function load(address foundation, bool forReplace, address Token, address Premium, address Publisher, address Schelling, address Provider) {
         /*
             Loading modulest to ModuleHandler.
@@ -60,7 +60,7 @@ contract moduleHandler is multiOwner, announcementTypes {
         addModule( modules_s(Schelling,  keccak256('Schelling'),  false, true),   ! forReplace);
         addModule( modules_s(Provider,   keccak256('Provider'),   true, true),    ! forReplace);
     }
-    function addModule(modules_s input, bool call) internal {
+    function addModule(modules_s memory input, bool call) internal {
         /*
             Inside function for registration of the modules in the database.
             If the call is false, wont happen any direct call.
@@ -81,7 +81,7 @@ contract moduleHandler is multiOwner, announcementTypes {
         }
         modules[id] = input;
     }
-    function getModuleAddressByName(string name) public view returns( bool success, bool found, address addr ) {
+    function getModuleAddressByName(string memory name) public view returns( bool success, bool found, address addr ) {
         /*
             Search by name for module. The result is an Ethereum address.
             
@@ -109,7 +109,7 @@ contract moduleHandler is multiOwner, announcementTypes {
         }
         return (true, false, 0);
     }
-    function getModuleIDByName(string name) public view returns( bool success, bool found, uint256 id ) {
+    function getModuleIDByName(string memory name) public view returns( bool success, bool found, uint256 id ) {
         /*
             Search by name for module. The result is an index array.
             
@@ -177,7 +177,7 @@ contract moduleHandler is multiOwner, announcementTypes {
         require( abstractModule(modules[_id].addr).replaceModule(newModule) );
         return true;
     }
-    
+
     function newModule(string name, address addr, bool schellingEvent, bool transferEvent) external returns (bool success) {
         /*
             Adding new module to the database. Can be called only by the Publisher contract.

--- a/test/compilationTests/corion/multiOwner.sol
+++ b/test/compilationTests/corion/multiOwner.sol
@@ -12,7 +12,7 @@ contract multiOwner is safeMath {
     /*
         Constructor
     */
-    constructor(address[] newOwners) {
+    constructor(address[] memory newOwners) {
         for ( uint256 a=0 ; a<newOwners.length ; a++ ) {
             _addOwner(newOwners[a]);
         }
@@ -41,7 +41,7 @@ contract multiOwner is safeMath {
     function ownersForChange() public view returns (uint256 owners) {
         return ownerCount * 75 / 100;
     }
-    function calcDoHash(string job, bytes32 data) public pure returns (bytes32 hash) {
+    function calcDoHash(string memory job, bytes32 data) public pure returns (bytes32 hash) {
         return keccak256(abi.encodePacked(job, data));
     }
     function validDoHash(bytes32 doHash) public view returns (bool valid) {

--- a/test/compilationTests/corion/premium.sol
+++ b/test/compilationTests/corion/premium.sol
@@ -40,7 +40,7 @@ contract premium is module, safeMath {
     
     mapping(address => bool) public genesis;
     
-    constructor(bool forReplace, address moduleHandler, address dbAddress, address icoContractAddr, address[] genesisAddr, uint256[] genesisValue) {
+    constructor(bool forReplace, address moduleHandler, address dbAddress, address icoContractAddr, address[] memory genesisAddr, uint256[] memory genesisValue) {
         /*
             Setup function.
             If an ICOaddress is defined then the balance of the genesis addresses will be set as well.
@@ -246,7 +246,7 @@ contract premium is module, safeMath {
         return true;
     }
     
-    function transferToContract(address from, address to, uint256 amount, bytes extraData) internal {
+    function transferToContract(address from, address to, uint256 amount, bytes memory extraData) internal {
         /*
             Inner function in order to transact a contract.
             

--- a/test/compilationTests/corion/provider.sol
+++ b/test/compilationTests/corion/provider.sol
@@ -299,7 +299,7 @@ contract provider is module, safeMath, announcementTypes {
         providers[addr].data[currHeight].currentRate     = rate;
         emit EProviderDetailsChanged(addr, currHeight, website, country, info, rate, admin);
     }
-    function getProviderInfo(address addr, uint256 height) public view returns (string name, string website, string country, string info, uint256 create) {
+    function getProviderInfo(address addr, uint256 height) public view returns (string memory name, string memory website, string memory country, string memory info, uint256 create) {
         /*
             for the infos of the provider.
             In case the height is unknown then the system will use the last known height.

--- a/test/compilationTests/corion/publisher.sol
+++ b/test/compilationTests/corion/publisher.sol
@@ -70,7 +70,7 @@ contract publisher is announcementTypes, module, safeMath {
         super.registerModuleHandler(moduleHandler);
     }
     
-    function Announcements(uint256 id) public view returns (uint256 Type, uint256 Start, uint256 End, bool Closed, string Announcement, string Link, bool Opposited, string _str, uint256 _uint, address _addr) {
+    function Announcements(uint256 id) public view returns (uint256 Type, uint256 Start, uint256 End, bool Closed, string memory Announcement, string memory Link, bool Opposited, string memory _str, uint256 _uint, address _addr) {
         /*
             Announcement data query
             

--- a/test/compilationTests/corion/schelling.sol
+++ b/test/compilationTests/corion/schelling.sol
@@ -174,7 +174,7 @@ contract schelling is module, announcementTypes, schellingVars {
     function setFunds(address addr, uint256 amount) internal {
         require( db.setFunds(addr, amount) );
     }
-    function setVoter(address owner, _voter voter) internal {
+    function setVoter(address owner, _voter memory voter) internal {
         require( db.setVoter(owner, 
             voter.roundID,
             voter.hash,
@@ -182,13 +182,13 @@ contract schelling is module, announcementTypes, schellingVars {
             voter.voteResult,
             voter.rewards
             ) );
-    }    
-    function getVoter(address addr) internal view returns (_voter) {
+    }
+    function getVoter(address addr) internal view returns (_voter memory) {
         (bool a, uint256 b, bytes32 c, schellingVars.voterStatus d, bool e, uint256 f) = db.getVoter(addr);
         require( a );
         return _voter(b, c, d, e, f);
     }
-    function setRound(uint256 id, _rounds round) internal {
+    function setRound(uint256 id, _rounds memory round) internal {
         require( db.setRound(id, 
             round.totalAboveWeight,
             round.totalBelowWeight,
@@ -197,8 +197,8 @@ contract schelling is module, announcementTypes, schellingVars {
             round.voted
             ) );
     }
-    function pushRound(_rounds round) internal returns (uint256) {
-        (bool a, uint256 b) = db.pushRound( 
+    function pushRound(_rounds memory round) internal returns (uint256) {
+        (bool a, uint256 b) = db.pushRound(
             round.totalAboveWeight,
             round.totalBelowWeight,
             round.reward,
@@ -208,7 +208,7 @@ contract schelling is module, announcementTypes, schellingVars {
         require( a );
         return b;
     }
-    function getRound(uint256 id) internal returns (_rounds) {
+    function getRound(uint256 id) internal returns (_rounds memory) {
         (bool a, uint256 b, uint256 c, uint256 d, uint256 e, bool f) = db.getRound(id);
         require( a );
         return _rounds(b, c, d, e, f);
@@ -529,7 +529,7 @@ contract schelling is module, announcementTypes, schellingVars {
             return belowW;
         }
     }
-    function isWinner(_rounds round, bool aboveVote) internal returns (bool) {
+    function isWinner(_rounds memory round, bool aboveVote) internal returns (bool) {
         /*
             Inside function for calculating the result of the game.
             

--- a/test/compilationTests/corion/token.sol
+++ b/test/compilationTests/corion/token.sol
@@ -48,7 +48,7 @@ contract token is safeMath, module, announcementTypes {
     
     mapping(address => bool) public genesis;
     
-    constructor(bool forReplace, address moduleHandler, address dbAddr, address icoContractAddr, address exchangeContractAddress, address[] genesisAddr, uint256[] genesisValue) payable {
+    constructor(bool forReplace, address moduleHandler, address dbAddr, address icoContractAddr, address exchangeContractAddress, address[] memory genesisAddr, uint256[] memory genesisValue) payable {
         /*
             Installation function
             
@@ -288,7 +288,7 @@ contract token is safeMath, module, announcementTypes {
         return true;
     }
     
-    function _transferToContract(address from, address to, uint256 amount, bytes extraData) internal {
+    function _transferToContract(address from, address to, uint256 amount, bytes memory extraData) internal {
         /*
             Internal function to start transactions to a contract
             

--- a/test/compilationTests/gnosis/Events/Event.sol
+++ b/test/compilationTests/gnosis/Events/Event.sol
@@ -101,7 +101,7 @@ contract Event {
     function getOutcomeTokens()
         public
         view
-        returns (OutcomeToken[])
+        returns (OutcomeToken[] memory)
     {
         return outcomeTokens;
     }
@@ -111,7 +111,7 @@ contract Event {
     function getOutcomeTokenDistribution(address owner)
         public
         view
-        returns (uint[] outcomeTokenDistribution)
+        returns (uint[] memory outcomeTokenDistribution)
     {
         outcomeTokenDistribution = new uint[](outcomeTokens.length);
         for (uint8 i = 0; i < outcomeTokenDistribution.length; i++)

--- a/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
+++ b/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
@@ -108,7 +108,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param netOutcomeTokensSold Net outcome tokens sold by market
     /// @param funding Initial funding for market
     /// @return Cost level
-    function calcCostLevel(int logN, int[] netOutcomeTokensSold, uint funding)
+    function calcCostLevel(int logN, int[] memory netOutcomeTokensSold, uint funding)
         private
         view
         returns(int costLevel)
@@ -129,7 +129,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param funding Initial funding for market
     /// @param outcomeIndex Index of exponential term to extract (for use by marginal price function)
     /// @return A result structure composed of the sum, the offset used, and the summand associated with the supplied index
-    function sumExpOffset(int logN, int[] netOutcomeTokensSold, uint funding, uint8 outcomeIndex)
+    function sumExpOffset(int logN, int[] memory netOutcomeTokensSold, uint funding, uint8 outcomeIndex)
         private
         view
         returns (uint sum, int offset, uint outcomeExpTerm)
@@ -171,7 +171,7 @@ contract LMSRMarketMaker is MarketMaker {
     function getNetOutcomeTokensSold(Market market)
         private
         view
-        returns (int[] quantities)
+        returns (int[] memory quantities)
     {
         quantities = new int[](market.eventContract().getOutcomeCount());
         for (uint8 i = 0; i < quantities.length; i++)

--- a/test/compilationTests/gnosis/Oracles/CentralizedOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/CentralizedOracle.sol
@@ -34,7 +34,7 @@ contract CentralizedOracle is Oracle {
      */
     /// @dev Constructor sets owner address and IPFS hash
     /// @param _ipfsHash Hash identifying off chain event description
-    constructor(address _owner, bytes _ipfsHash)
+    constructor(address _owner, bytes memory _ipfsHash)
         public
     {
         // Description hash cannot be null

--- a/test/compilationTests/gnosis/Oracles/CentralizedOracleFactory.sol
+++ b/test/compilationTests/gnosis/Oracles/CentralizedOracleFactory.sol
@@ -17,7 +17,7 @@ contract CentralizedOracleFactory {
     /// @dev Creates a new centralized oracle contract
     /// @param ipfsHash Hash identifying off chain event description
     /// @return Oracle contract
-    function createCentralizedOracle(bytes ipfsHash)
+    function createCentralizedOracle(bytes memory ipfsHash)
         public
         returns (CentralizedOracle centralizedOracle)
     {

--- a/test/compilationTests/gnosis/Oracles/MajorityOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/MajorityOracle.sol
@@ -16,7 +16,7 @@ contract MajorityOracle is Oracle {
      */
     /// @dev Allows to create an oracle for a majority vote based on other oracles
     /// @param _oracles List of oracles taking part in the majority vote
-    constructor(Oracle[] _oracles)
+    constructor(Oracle[] memory _oracles)
         public
     {
         // At least 2 oracles should be defined

--- a/test/compilationTests/gnosis/Oracles/MajorityOracleFactory.sol
+++ b/test/compilationTests/gnosis/Oracles/MajorityOracleFactory.sol
@@ -17,7 +17,7 @@ contract MajorityOracleFactory {
     /// @dev Creates a new majority oracle contract
     /// @param oracles List of oracles taking part in the majority vote
     /// @return Oracle contract
-    function createMajorityOracle(Oracle[] oracles)
+    function createMajorityOracle(Oracle[] memory oracles)
         public
         returns (MajorityOracle majorityOracle)
     {

--- a/test/compilationTests/gnosis/Utils/Math.sol
+++ b/test/compilationTests/gnosis/Utils/Math.sol
@@ -176,7 +176,7 @@ library Math {
     /// @dev Returns maximum of an array
     /// @param nums Numbers to look through
     /// @return Maximum number
-    function max(int[] nums)
+    function max(int[] memory nums)
         public
         pure
         returns (int max)

--- a/test/compilationTests/milestonetracker/MilestoneTracker.sol
+++ b/test/compilationTests/milestonetracker/MilestoneTracker.sol
@@ -175,7 +175,7 @@ contract MilestoneTracker {
     ///       uint reviewTime
     ///       address paymentSource,
     ///       bytes payData,
-    function proposeMilestones(bytes _newMilestones
+    function proposeMilestones(bytes memory _newMilestones
     ) onlyRecipient campaignNotCanceled {
         proposedMilestones = _newMilestones;
         changingMilestones = true;

--- a/test/compilationTests/stringutils/strings.sol
+++ b/test/compilationTests/stringutils/strings.sol
@@ -63,7 +63,7 @@ library strings {
      * @param self The string to make a slice from.
      * @return A newly allocated slice containing the entire string.
      */
-    function toSlice(string self) internal returns (slice) {
+    function toSlice(string memory self) internal returns (slice memory) {
         uint ptr;
         assembly {
             ptr := add(self, 0x20)
@@ -109,7 +109,7 @@ library strings {
      * @return A new slice containing the value of the input argument up to the
      *         first null.
      */
-    function toSliceB32(bytes32 self) internal returns (slice ret) {
+    function toSliceB32(bytes32 self) internal returns (slice memory ret) {
         // Allocate space for `self` in memory, copy it there, and point ret at it
         assembly {
             let ptr := mload(0x40)
@@ -125,7 +125,7 @@ library strings {
      * @param self The slice to copy.
      * @return A new slice containing the same data as `self`.
      */
-    function copy(slice self) internal returns (slice) {
+    function copy(slice memory self) internal returns (slice memory) {
         return slice(self._len, self._ptr);
     }
 
@@ -134,7 +134,7 @@ library strings {
      * @param self The slice to copy.
      * @return A newly allocated string containing the slice's text.
      */
-    function toString(slice self) internal returns (string) {
+    function toString(slice memory self) internal returns (string memory) {
         string memory ret = new string(self._len);
         uint retptr;
         assembly { retptr := add(ret, 32) }
@@ -151,7 +151,7 @@ library strings {
      * @param self The slice to operate on.
      * @return The length of the slice in runes.
      */
-    function len(slice self) internal returns (uint) {
+    function len(slice memory self) internal returns (uint) {
         // Starting at ptr-31 means the LSB will be the byte we care about
         uint ptr = self._ptr - 31;
         uint end = ptr + self._len;
@@ -181,7 +181,7 @@ library strings {
      * @param self The slice to operate on.
      * @return True if the slice is empty, False otherwise.
      */
-    function empty(slice self) internal returns (bool) {
+    function empty(slice memory self) internal returns (bool) {
         return self._len == 0;
     }
 
@@ -194,7 +194,7 @@ library strings {
      * @param other The second slice to compare.
      * @return The result of the comparison.
      */
-    function compare(slice self, slice other) internal returns (int) {
+    function compare(slice memory self, slice memory other) internal returns (int) {
         uint shortest = self._len;
         if (other._len < self._len)
             shortest = other._len;
@@ -227,7 +227,7 @@ library strings {
      * @param self The second slice to compare.
      * @return True if the slices are equal, false otherwise.
      */
-    function equals(slice self, slice other) internal returns (bool) {
+    function equals(slice memory self, slice memory other) internal returns (bool) {
         return compare(self, other) == 0;
     }
 
@@ -238,7 +238,7 @@ library strings {
      * @param rune The slice that will contain the first rune.
      * @return `rune`.
      */
-    function nextRune(slice self, slice rune) internal returns (slice) {
+    function nextRune(slice memory self, slice memory rune) internal returns (slice memory) {
         rune._ptr = self._ptr;
 
         if (self._len == 0) {
@@ -280,7 +280,7 @@ library strings {
      * @param self The slice to operate on.
      * @return A slice containing only the first rune from `self`.
      */
-    function nextRune(slice self) internal returns (slice ret) {
+    function nextRune(slice memory self) internal returns (slice memory ret) {
         nextRune(self, ret);
     }
 
@@ -289,7 +289,7 @@ library strings {
      * @param self The slice to operate on.
      * @return The number of the first codepoint in the slice.
      */
-    function ord(slice self) internal returns (uint ret) {
+    function ord(slice memory self) internal returns (uint ret) {
         if (self._len == 0) {
             return 0;
         }
@@ -338,7 +338,7 @@ library strings {
      * @param self The slice to hash.
      * @return The hash of the slice.
      */
-    function keccak(slice self) internal returns (bytes32 ret) {
+    function keccak(slice memory self) internal returns (bytes32 ret) {
         assembly {
             ret := keccak256(mload(add(self, 32)), mload(self))
         }
@@ -350,7 +350,7 @@ library strings {
      * @param needle The slice to search for.
      * @return True if the slice starts with the provided text, false otherwise.
      */
-    function startsWith(slice self, slice needle) internal returns (bool) {
+    function startsWith(slice memory self, slice memory needle) internal returns (bool) {
         if (self._len < needle._len) {
             return false;
         }
@@ -376,7 +376,7 @@ library strings {
      * @param needle The slice to search for.
      * @return `self`
      */
-    function beyond(slice self, slice needle) internal returns (slice) {
+    function beyond(slice memory self, slice memory needle) internal returns (slice memory) {
         if (self._len < needle._len) {
             return self;
         }
@@ -405,7 +405,7 @@ library strings {
      * @param needle The slice to search for.
      * @return True if the slice starts with the provided text, false otherwise.
      */
-    function endsWith(slice self, slice needle) internal returns (bool) {
+    function endsWith(slice memory self, slice memory needle) internal returns (bool) {
         if (self._len < needle._len) {
             return false;
         }
@@ -433,7 +433,7 @@ library strings {
      * @param needle The slice to search for.
      * @return `self`
      */
-    function until(slice self, slice needle) internal returns (slice) {
+    function until(slice memory self, slice memory needle) internal returns (slice memory) {
         if (self._len < needle._len) {
             return self;
         }
@@ -542,7 +542,7 @@ library strings {
      * @param needle The text to search for.
      * @return `self`.
      */
-    function find(slice self, slice needle) internal returns (slice) {
+    function find(slice memory self, slice memory needle) internal returns (slice memory) {
         uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
         self._len -= ptr - self._ptr;
         self._ptr = ptr;
@@ -557,7 +557,7 @@ library strings {
      * @param needle The text to search for.
      * @return `self`.
      */
-    function rfind(slice self, slice needle) internal returns (slice) {
+    function rfind(slice memory self, slice memory needle) internal returns (slice memory) {
         uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
         self._len = ptr - self._ptr;
         return self;
@@ -573,7 +573,7 @@ library strings {
      * @param token An output parameter to which the first token is written.
      * @return `token`.
      */
-    function split(slice self, slice needle, slice token) internal returns (slice) {
+    function split(slice memory self, slice memory needle, slice memory token) internal returns (slice memory) {
         uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
         token._ptr = self._ptr;
         token._len = ptr - self._ptr;
@@ -596,7 +596,7 @@ library strings {
      * @param needle The text to search for in `self`.
      * @return The part of `self` up to the first occurrence of `delim`.
      */
-    function split(slice self, slice needle) internal returns (slice token) {
+    function split(slice memory self, slice memory needle) internal returns (slice memory token) {
         split(self, needle, token);
     }
 
@@ -610,7 +610,7 @@ library strings {
      * @param token An output parameter to which the first token is written.
      * @return `token`.
      */
-    function rsplit(slice self, slice needle, slice token) internal returns (slice) {
+    function rsplit(slice memory self, slice memory needle, slice memory token) internal returns (slice memory) {
         uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
         token._ptr = ptr;
         token._len = self._len - (ptr - self._ptr);
@@ -632,7 +632,7 @@ library strings {
      * @param needle The text to search for in `self`.
      * @return The part of `self` after the last occurrence of `delim`.
      */
-    function rsplit(slice self, slice needle) internal returns (slice token) {
+    function rsplit(slice memory self, slice memory needle) internal returns (slice memory token) {
         rsplit(self, needle, token);
     }
 
@@ -642,7 +642,7 @@ library strings {
      * @param needle The text to search for in `self`.
      * @return The number of occurrences of `needle` found in `self`.
      */
-    function count(slice self, slice needle) internal returns (uint count) {
+    function count(slice memory self, slice memory needle) internal returns (uint count) {
         uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) + needle._len;
         while (ptr <= self._ptr + self._len) {
             count++;
@@ -656,7 +656,7 @@ library strings {
      * @param needle The text to search for in `self`.
      * @return True if `needle` is found in `self`, false otherwise.
      */
-    function contains(slice self, slice needle) internal returns (bool) {
+    function contains(slice memory self, slice memory needle) internal returns (bool) {
         return rfindPtr(self._len, self._ptr, needle._len, needle._ptr) != self._ptr;
     }
 
@@ -667,7 +667,7 @@ library strings {
      * @param other The second slice to concatenate.
      * @return The concatenation of the two strings.
      */
-    function concat(slice self, slice other) internal returns (string) {
+    function concat(slice memory self, slice memory other) internal returns (string memory) {
         string memory ret = new string(self._len + other._len);
         uint retptr;
         assembly { retptr := add(ret, 32) }
@@ -684,7 +684,7 @@ library strings {
      * @return A newly allocated string containing all the slices in `parts`,
      *         joined with `self`.
      */
-    function join(slice self, slice[] parts) internal returns (string) {
+    function join(slice memory self, slice[] memory parts) internal returns (string memory) {
         if (parts.length == 0)
             return "";
 

--- a/test/compilationTests/zeppelin/MultisigWallet.sol
+++ b/test/compilationTests/zeppelin/MultisigWallet.sol
@@ -25,7 +25,7 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
    * @param _owners A list of owners.
    * @param _required The amount required for a transaction to be approved.
    */
-  constructor(address[] _owners, uint256 _required, uint256 _daylimit)       
+  constructor(address[] memory _owners, uint256 _required, uint256 _daylimit)
     Shareable(_owners, _required)
     DayLimit(_daylimit) { }
 

--- a/test/compilationTests/zeppelin/lifecycle/TokenDestructible.sol
+++ b/test/compilationTests/zeppelin/lifecycle/TokenDestructible.sol
@@ -21,7 +21,7 @@ contract TokenDestructible is Ownable {
    * @notice The called token contracts could try to re-enter this contract. Only
    supply token contracts you trust.
    */
-  function destroy(address[] tokens) onlyOwner {
+  function destroy(address[] memory tokens) onlyOwner {
 
     // Transfer tokens to owner
     for(uint256 i = 0; i < tokens.length; i++) {

--- a/test/compilationTests/zeppelin/ownership/Contactable.sol
+++ b/test/compilationTests/zeppelin/ownership/Contactable.sol
@@ -15,7 +15,7 @@ contract Contactable is Ownable{
      * @dev Allows the owner to set a string with their contact information.
      * @param info The contact information to attach to the contract.
      */
-    function setContactInformation(string info) onlyOwner{
+    function setContactInformation(string memory info) onlyOwner{
          contactInformation = info;
      }
 }

--- a/test/compilationTests/zeppelin/ownership/Shareable.sol
+++ b/test/compilationTests/zeppelin/ownership/Shareable.sol
@@ -59,7 +59,7 @@ contract Shareable {
    * @param _owners A list of owners.
    * @param _required The amount required for a transaction to be approved.
    */
-  constructor(address[] _owners, uint256 _required) {
+  constructor(address[] memory _owners, uint256 _required) {
     owners[1] = msg.sender;
     ownerIndex[msg.sender] = 1;
     for (uint256 i = 0; i < _owners.length; ++i) {

--- a/test/compilationTests/zeppelin/token/VestedToken.sol
+++ b/test/compilationTests/zeppelin/token/VestedToken.sol
@@ -212,7 +212,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    * @param time The time to be checked
    * @return An uint256 representing the amount of vested tokens of a specific grant at a specific time.
    */
-  function vestedTokens(TokenGrant grant, uint64 time) private view returns (uint256) {
+  function vestedTokens(TokenGrant memory grant, uint64 time) private view returns (uint256) {
     return calculateVestedTokens(
       grant.value,
       uint256(time),
@@ -229,7 +229,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    * @return An uint256 representing the amount of non vested tokens of a specifc grant on the 
    * passed time frame.
    */
-  function nonVestedTokens(TokenGrant grant, uint64 time) private view returns (uint256) {
+  function nonVestedTokens(TokenGrant memory grant, uint64 time) private view returns (uint256) {
     return grant.value.sub(vestedTokens(grant, time));
   }
 

--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -43,20 +43,20 @@ static char const* registrarCode = R"DELIMITER(
 pragma solidity ^0.4.0;
 
 contract NameRegister {
-	function addr(string _name) view returns (address o_owner);
-	function name(address _owner) view returns (string o_name);
+	function addr(string memory _name) view returns (address o_owner);
+	function name(address _owner) view returns (string memory o_name);
 }
 
 contract Registrar is NameRegister {
 	event Changed(string indexed name);
 	event PrimaryChanged(string indexed name, address indexed addr);
 
-	function owner(string _name) view returns (address o_owner);
-	function addr(string _name) view returns (address o_address);
-	function subRegistrar(string _name) view returns (address o_subRegistrar);
-	function content(string _name) view returns (bytes32 o_content);
+	function owner(string memory _name) view returns (address o_owner);
+	function addr(string memory _name) view returns (address o_address);
+	function subRegistrar(string memory _name) view returns (address o_subRegistrar);
+	function content(string memory _name) view returns (bytes32 o_content);
 
-	function name(address _owner) view returns (string o_name);
+	function name(address _owner) view returns (string memory o_name);
 }
 
 contract AuctionSystem {
@@ -64,9 +64,9 @@ contract AuctionSystem {
 	event NewBid(string indexed _name, address _bidder, uint _value);
 
 	/// Function that is called once an auction ends.
-	function onAuctionEnd(string _name) internal;
+	function onAuctionEnd(string memory _name) internal;
 
-	function bid(string _name, address _bidder, uint _value) internal {
+	function bid(string memory _name, address _bidder, uint _value) internal {
 		Auction storage auction = m_auctions[_name];
 		if (auction.endDate > 0 && now > auction.endDate)
 		{
@@ -116,7 +116,7 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		// TODO: Populate with hall-of-fame.
 	}
 
-	function onAuctionEnd(string _name) internal {
+	function onAuctionEnd(string memory _name) internal {
 		Auction storage auction = m_auctions[_name];
 		Record storage record = m_toRecord[_name];
 		address previousOwner = record.owner;
@@ -150,18 +150,18 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		}
 	}
 
-	function requiresAuction(string _name) internal returns (bool) {
+	function requiresAuction(string memory _name) internal returns (bool) {
 		return bytes(_name).length < c_freeBytes;
 	}
 
-	modifier onlyrecordowner(string _name) { if (m_toRecord[_name].owner == msg.sender) _; }
+	modifier onlyrecordowner(string memory _name) { if (m_toRecord[_name].owner == msg.sender) _; }
 
-	function transfer(string _name, address _newOwner) onlyrecordowner(_name) {
+	function transfer(string memory _name, address _newOwner) onlyrecordowner(_name) {
 		m_toRecord[_name].owner = _newOwner;
 		emit Changed(_name);
 	}
 
-	function disown(string _name) onlyrecordowner(_name) {
+	function disown(string memory _name) onlyrecordowner(_name) {
 		if (stringsEqual(m_toName[m_toRecord[_name].primary], _name))
 		{
 			emit PrimaryChanged(_name, m_toRecord[_name].primary);
@@ -171,7 +171,7 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		emit Changed(_name);
 	}
 
-	function setAddress(string _name, address _a, bool _primary) onlyrecordowner(_name) {
+	function setAddress(string memory _name, address _a, bool _primary) onlyrecordowner(_name) {
 		m_toRecord[_name].primary = _a;
 		if (_primary)
 		{
@@ -180,11 +180,11 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		}
 		emit Changed(_name);
 	}
-	function setSubRegistrar(string _name, address _registrar) onlyrecordowner(_name) {
+	function setSubRegistrar(string memory _name, address _registrar) onlyrecordowner(_name) {
 		m_toRecord[_name].subRegistrar = _registrar;
 		emit Changed(_name);
 	}
-	function setContent(string _name, bytes32 _content) onlyrecordowner(_name) {
+	function setContent(string memory _name, bytes32 _content) onlyrecordowner(_name) {
 		m_toRecord[_name].content = _content;
 		emit Changed(_name);
 	}
@@ -201,11 +201,11 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 		return true;
 	}
 
-	function owner(string _name) view returns (address) { return m_toRecord[_name].owner; }
-	function addr(string _name) view returns (address) { return m_toRecord[_name].primary; }
-	function subRegistrar(string _name) view returns (address) { return m_toRecord[_name].subRegistrar; }
-	function content(string _name) view returns (bytes32) { return m_toRecord[_name].content; }
-	function name(address _addr) view returns (string o_name) { return m_toName[_addr]; }
+	function owner(string memory _name) view returns (address) { return m_toRecord[_name].owner; }
+	function addr(string memory _name) view returns (address) { return m_toRecord[_name].primary; }
+	function subRegistrar(string memory _name) view returns (address) { return m_toRecord[_name].subRegistrar; }
+	function content(string memory _name) view returns (bytes32) { return m_toRecord[_name].content; }
+	function name(address _addr) view returns (string memory o_name) { return m_toName[_addr]; }
 
 	mapping (address => string) m_toName;
 	mapping (string => Record) m_toRecord;

--- a/test/contracts/FixedFeeRegistrar.cpp
+++ b/test/contracts/FixedFeeRegistrar.cpp
@@ -58,10 +58,10 @@ pragma solidity ^0.4.0;
 contract Registrar {
 	event Changed(string indexed name);
 
-	function owner(string _name) view returns (address o_owner);
-	function addr(string _name) view returns (address o_address);
-	function subRegistrar(string _name) view returns (address o_subRegistrar);
-	function content(string _name) view returns (bytes32 o_content);
+	function owner(string memory _name) view returns (address o_owner);
+	function addr(string memory _name) view returns (address o_address);
+	function subRegistrar(string memory _name) view returns (address o_subRegistrar);
+	function content(string memory _name) view returns (bytes32 o_content);
 }
 
 contract FixedFeeRegistrar is Registrar {
@@ -72,52 +72,52 @@ contract FixedFeeRegistrar is Registrar {
 		address owner;
 	}
 
-	modifier onlyrecordowner(string _name) { if (m_record(_name).owner == msg.sender) _; }
+	modifier onlyrecordowner(string memory _name) { if (m_record(_name).owner == msg.sender) _; }
 
-	function reserve(string _name) payable {
+	function reserve(string memory _name) payable {
 		Record rec = m_record(_name);
 		if (rec.owner == 0x0000000000000000000000000000000000000000 && msg.value >= c_fee) {
 			rec.owner = msg.sender;
 			emit Changed(_name);
 		}
 	}
-	function disown(string _name, address _refund) onlyrecordowner(_name) {
+	function disown(string memory _name, address _refund) onlyrecordowner(_name) {
 		delete m_recordData[uint(keccak256(bytes(_name))) / 8];
 		if (!_refund.send(c_fee))
 			throw;
 		emit Changed(_name);
 	}
-	function transfer(string _name, address _newOwner) onlyrecordowner(_name) {
+	function transfer(string memory _name, address _newOwner) onlyrecordowner(_name) {
 		m_record(_name).owner = _newOwner;
 		emit Changed(_name);
 	}
-	function setAddr(string _name, address _a) onlyrecordowner(_name) {
+	function setAddr(string memory _name, address _a) onlyrecordowner(_name) {
 		m_record(_name).addr = _a;
 		emit Changed(_name);
 	}
-	function setSubRegistrar(string _name, address _registrar) onlyrecordowner(_name) {
+	function setSubRegistrar(string memory _name, address _registrar) onlyrecordowner(_name) {
 		m_record(_name).subRegistrar = _registrar;
 		emit Changed(_name);
 	}
-	function setContent(string _name, bytes32 _content) onlyrecordowner(_name) {
+	function setContent(string memory _name, bytes32 _content) onlyrecordowner(_name) {
 		m_record(_name).content = _content;
 		emit Changed(_name);
 	}
 
-	function record(string _name) view returns (address o_addr, address o_subRegistrar, bytes32 o_content, address o_owner) {
+	function record(string memory _name) view returns (address o_addr, address o_subRegistrar, bytes32 o_content, address o_owner) {
 		Record rec = m_record(_name);
 		o_addr = rec.addr;
 		o_subRegistrar = rec.subRegistrar;
 		o_content = rec.content;
 		o_owner = rec.owner;
 	}
-	function addr(string _name) view returns (address) { return m_record(_name).addr; }
-	function subRegistrar(string _name) view returns (address) { return m_record(_name).subRegistrar; }
-	function content(string _name) view returns (bytes32) { return m_record(_name).content; }
-	function owner(string _name) view returns (address) { return m_record(_name).owner; }
+	function addr(string memory _name) view returns (address) { return m_record(_name).addr; }
+	function subRegistrar(string memory _name) view returns (address) { return m_record(_name).subRegistrar; }
+	function content(string memory _name) view returns (bytes32) { return m_record(_name).content; }
+	function owner(string memory _name) view returns (address) { return m_record(_name).owner; }
 
 	Record[2**253] m_recordData;
-	function m_record(string _name) view internal returns (Record storage o_record) {
+	function m_record(string memory _name) view internal returns (Record storage o_record) {
 		return m_recordData[uint(keccak256(bytes(_name))) / 8];
 	}
 	uint constant c_fee = 69 ether;

--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -101,7 +101,7 @@ contract multiowned {
 
 	// constructor is given number of sigs required to do protected "onlymanyowners" transactions
 	// as well as the selection of addresses capable of confirming them.
-	constructor(address[] _owners, uint _required) {
+	constructor(address[] memory _owners, uint _required) {
 		m_numOwners = _owners.length + 1;
 		m_owners[1] = uint(msg.sender);
 		m_ownerIndex[uint(msg.sender)] = 1;
@@ -369,7 +369,7 @@ contract Wallet is multisig, multiowned, daylimit {
 
 	// constructor - just pass on the owner array to the multiowned and
 	// the limit to daylimit
-	constructor(address[] _owners, uint _required, uint _daylimit) payable
+	constructor(address[] memory _owners, uint _required, uint _daylimit) payable
 			multiowned(_owners, _required) daylimit(_daylimit) {
 	}
 

--- a/test/libsolidity/ABIDecoderTests.cpp
+++ b/test/libsolidity/ABIDecoderTests.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(fixed_arrays)
 {
 	string sourceCode = R"(
 		contract C {
-			function f(uint16[3] a, uint16[2][3] b, uint i, uint j, uint k)
+			function f(uint16[3] memory a, uint16[2][3] memory b, uint i, uint j, uint k)
 					public pure returns (uint, uint) {
 				return (a[i], b[j][k]);
 			}
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(dynamic_arrays)
 {
 	string sourceCode = R"(
 		contract C {
-			function f(uint a, uint16[] b, uint c)
+			function f(uint a, uint16[] memory b, uint c)
 					public pure returns (uint, uint, uint) {
 				return (b.length, b[a], c);
 			}
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(dynamic_nested_arrays)
 {
 	string sourceCode = R"(
 		contract C {
-			function f(uint a, uint16[][] b, uint[2][][3] c, uint d)
+			function f(uint a, uint16[][] memory b, uint[2][][3] memory c, uint d)
 					public pure returns (uint, uint, uint, uint, uint, uint, uint) {
 				return (a, b.length, b[1].length, b[1][1], c[1].length, c[1][1][1], d);
 			}
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(byte_arrays)
 {
 	string sourceCode = R"(
 		contract C {
-			function f(uint a, bytes b, uint c)
+			function f(uint a, bytes memory b, uint c)
 					public pure returns (uint, uint, byte, uint) {
 				return (a, b.length, b[3], c);
 			}
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(decode_from_memory_simple)
 		contract C {
 			uint public _a;
 			uint[] public _b;
-			constructor(uint a, uint[] b) public {
+			constructor(uint a, uint[] memory b) public {
 				_a = a;
 				_b = b;
 			}
@@ -344,13 +344,13 @@ BOOST_AUTO_TEST_CASE(decode_function_type_array)
 	string sourceCode = R"(
 		contract D {
 			function () external returns (uint)[] public _a;
-			constructor(function () external returns (uint)[] a) public {
+			constructor(function () external returns (uint)[] memory a) public {
 				_a = a;
 			}
 		}
 		contract E {
 			function () external returns (uint)[3] public _a;
-			constructor(function () external returns (uint)[3] a) public {
+			constructor(function () external returns (uint)[3] memory a) public {
 				_a = a;
 			}
 		}
@@ -364,10 +364,10 @@ BOOST_AUTO_TEST_CASE(decode_function_type_array)
 			function f3() public returns (uint) {
 				return 3;
 			}
-			function g(function () external returns (uint)[] _f, uint i) public returns (uint) {
+			function g(function () external returns (uint)[] memory _f, uint i) public returns (uint) {
 				return _f[i]();
 			}
-			function h(function () external returns (uint)[3] _f, uint i) public returns (uint) {
+			function h(function () external returns (uint)[3] memory _f, uint i) public returns (uint) {
 				return _f[i]();
 			}
 			// uses "decode from memory"
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(decode_from_memory_complex)
 			uint public _a;
 			uint[] public _b;
 			bytes[2] public _c;
-			constructor(uint a, uint[] b, bytes[2] c) public {
+			constructor(uint a, uint[] memory b, bytes[2] memory c) public {
 				_a = a;
 				_b = b;
 				_c = c;
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(short_input_array)
 {
 	string sourceCode = R"(
 		contract C {
-			function f(uint[] a) public pure returns (uint) { return 7; }
+			function f(uint[] memory a) public pure returns (uint) { return 7; }
 		}
 	)";
 	BOTH_ENCODERS(
@@ -476,7 +476,7 @@ BOOST_AUTO_TEST_CASE(short_dynamic_input_array)
 {
 	string sourceCode = R"(
 		contract C {
-			function f(bytes[1] a) public pure returns (uint) { return 7; }
+			function f(bytes[1] memory a) public pure returns (uint) { return 7; }
 		}
 	)";
 	NEW_ENCODER(
@@ -489,8 +489,8 @@ BOOST_AUTO_TEST_CASE(short_input_bytes)
 {
 	string sourceCode = R"(
 		contract C {
-			function e(bytes a) public pure returns (uint) { return 7; }
-			function f(bytes[] a) public pure returns (uint) { return 7; }
+			function e(bytes memory a) public pure returns (uint) { return 7; }
+			function f(bytes[] memory a) public pure returns (uint) { return 7; }
 		}
 	)";
 	NEW_ENCODER(
@@ -511,9 +511,9 @@ BOOST_AUTO_TEST_CASE(cleanup_int_inside_arrays)
 	string sourceCode = R"(
 		contract C {
 			enum E { A, B }
-			function f(uint16[] a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
-			function g(int16[] a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
-			function h(E[] a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
+			function f(uint16[] memory a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
+			function g(int16[] memory a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
+			function h(E[] memory a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
 		}
 	)";
 	NEW_ENCODER(
@@ -569,7 +569,7 @@ BOOST_AUTO_TEST_CASE(struct_simple)
 	string sourceCode = R"(
 		contract C {
 			struct S { uint a; uint8 b; uint8 c; bytes2 d; }
-			function f(S s) public pure returns (uint a, uint b, uint c, uint d) {
+			function f(S memory s) public pure returns (uint a, uint b, uint c, uint d) {
 				a = s.a;
 				b = s.b;
 				c = s.c;
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(struct_cleanup)
 	string sourceCode = R"(
 		contract C {
 			struct S { int16 a; uint8 b; bytes2 c; }
-			function f(S s) public pure returns (uint a, uint b, uint c) {
+			function f(S memory s) public pure returns (uint a, uint b, uint c) {
 				assembly {
 					a := mload(s)
 					b := mload(add(s, 0x20))
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(struct_short)
 	string sourceCode = R"(
 		contract C {
 			struct S { int a; uint b; bytes16 c; }
-			function f(S s) public pure returns (S q) {
+			function f(S memory s) public pure returns (S memory q) {
 				q = s;
 			}
 		}
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE(struct_function)
 	string sourceCode = R"(
 		contract C {
 			struct S { function () external returns (uint) f; uint b; }
-			function f(S s) public returns (uint, uint) {
+			function f(S memory s) public returns (uint, uint) {
 				return (s.f(), s.b);
 			}
 			function test() public returns (uint, uint) {
@@ -658,7 +658,7 @@ BOOST_AUTO_TEST_CASE(mediocre_struct)
 	string sourceCode = R"(
 		contract C {
 			struct S { C c; }
-			function f(uint a, S[2] s1, uint b) public returns (uint r1, C r2, uint r3) {
+			function f(uint a, S[2] memory s1, uint b) public returns (uint r1, C r2, uint r3) {
 				r1 = a;
 				r2 = s1[0].c;
 				r3 = b;
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE(mediocre2_struct)
 	string sourceCode = R"(
 		contract C {
 			struct S { C c; uint[] x; }
-			function f(uint a, S[2] s1, uint b) public returns (uint r1, C r2, uint r3) {
+			function f(uint a, S[2] memory s1, uint b) public returns (uint r1, C r2, uint r3) {
 				r1 = a;
 				r2 = s1[0].c;
 				r3 = b;
@@ -707,7 +707,7 @@ BOOST_AUTO_TEST_CASE(complex_struct)
 			enum E {A, B, C}
 			struct T { uint x; E e; uint8 y; }
 			struct S { C c; T[] t;}
-			function f(uint a, S[2] s1, S[] s2, uint b) public returns
+			function f(uint a, S[2] memory s1, S[] memory s2, uint b) public returns
 					(uint r1, C r2, uint r3, uint r4, C r5, uint r6, E r7, uint8 r8) {
 				r1 = a;
 				r2 = s1[0].c;
@@ -767,10 +767,10 @@ BOOST_AUTO_TEST_CASE(return_dynamic_types_cross_call_simple)
 
 	string sourceCode = R"(
 		contract C {
-			function dyn() public returns (bytes) {
+			function dyn() public returns (bytes memory) {
 				return "1234567890123456789012345678901234567890";
 			}
-			function f() public returns (bytes) {
+			function f() public returns (bytes memory) {
 				return this.dyn();
 			}
 		}
@@ -788,7 +788,7 @@ BOOST_AUTO_TEST_CASE(return_dynamic_types_cross_call_advanced)
 
 	string sourceCode = R"(
 		contract C {
-			function dyn() public returns (bytes a, uint b, bytes20[] c, uint d) {
+			function dyn() public returns (bytes memory a, uint b, bytes20[] memory c, uint d) {
 				a = "1234567890123456789012345678901234567890";
 				b = uint(-1);
 				c = new bytes20[](4);
@@ -796,7 +796,7 @@ BOOST_AUTO_TEST_CASE(return_dynamic_types_cross_call_advanced)
 				c[3] = bytes20(6789);
 				d = 0x1234;
 			}
-			function f() public returns (bytes, uint, bytes20[], uint) {
+			function f() public returns (bytes memory, uint, bytes20[] memory, uint) {
 				return this.dyn();
 			}
 		}
@@ -815,7 +815,7 @@ BOOST_AUTO_TEST_CASE(return_dynamic_types_cross_call_out_of_range)
 {
 	string sourceCode = R"(
 		contract C {
-			function dyn(uint x) public returns (bytes a) {
+			function dyn(uint x) public returns (bytes memory a) {
 				assembly {
 					mstore(0, 0x20)
 					mstore(0x20, 0x21)

--- a/test/libsolidity/ABIEncoderTests.cpp
+++ b/test/libsolidity/ABIEncoderTests.cpp
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_CASE(structs)
 			struct T { uint64[2] x; }
 			S s;
 			event e(uint16, S);
-			function f() public returns (uint, S) {
+			function f() public returns (uint, S memory) {
 				uint16 x = 7;
 				s.a = 8;
 				s.b = 9;
@@ -454,7 +454,7 @@ BOOST_AUTO_TEST_CASE(structs2)
 			enum E {A, B, C}
 			struct T { uint x; E e; uint8 y; }
 			struct S { C c; T[] t;}
-			function f() public returns (uint a, S[2] s1, S[] s2, uint b) {
+			function f() public returns (uint a, S[2] memory s1, S[] memory s2, uint b) {
 				a = 7;
 				b = 8;
 				s1[0].c = this;

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(complex_import)
 	CompilerStack c;
 	c.addSource("a", "contract A {} contract B {} contract C { struct S { uint a; } } pragma solidity >=0.0;");
 	c.addSource("b", "import \"a\" as x; import {B as b, C as c, C} from \"a\"; "
-				"contract D is b { function f(c.S var1, x.C.S var2, C.S var3) internal {} } pragma solidity >=0.0;");
+				"contract D is b { function f(c.S memory var1, x.C.S memory var2, C.S memory var3) internal {} } pragma solidity >=0.0;");
 	c.setEVMVersion(dev::test::Options::get().evmVersion());
 	BOOST_CHECK(c.compile());
 }

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(warn_on_struct)
 		pragma experimental ABIEncoderV2;
 		contract C {
 			struct A { uint a; uint b; }
-			function f() public pure returns (A) {
+			function f() public pure returns (A memory) {
 				return A({ a: 1, b: 2 });
 			}
 		}

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE(library_function)
 	char const* sourceCode = R"(
 		library test {
 			struct StructType { uint a; }
-			function f(StructType storage b, uint[] storage c, test d) public returns (uint[] e, StructType storage f) {}
+			function f(StructType storage b, uint[] storage c, test d) public returns (uint[] memory e, StructType storage f) {}
 		}
 	)";
 
@@ -891,7 +891,7 @@ BOOST_AUTO_TEST_CASE(return_structs)
 		contract C {
 			struct S { uint a; T[] sub; }
 			struct T { uint[2] x; }
-			function f() public returns (uint x, S s) {
+			function f() public returns (uint x, S memory s) {
 			}
 		}
 	)";
@@ -940,7 +940,7 @@ BOOST_AUTO_TEST_CASE(return_structs_with_contracts)
 		pragma experimental ABIEncoderV2;
 		contract C {
 			struct S { C[] x; C y; }
-			function f() public returns (S s, C c) {
+			function f() public returns (S memory s, C c) {
 			}
 		}
 	)";
@@ -1042,7 +1042,7 @@ BOOST_AUTO_TEST_CASE(structs_in_libraries)
 			struct S { uint a; T[] sub; bytes b; }
 			struct T { uint[2] x; }
 			function f(L.S storage s) {}
-			function g(L.S s) {}
+			function g(L.S memory s) {}
 		}
 	)";
 	char const* interface = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2444,7 +2444,7 @@ BOOST_AUTO_TEST_CASE(constructor_with_long_arguments)
 			string public a;
 			string public b;
 
-			constructor(string _a, string _b) public {
+			constructor(string memory _a, string memory _b) public {
 				a = _a;
 				b = _b;
 			}
@@ -2472,7 +2472,7 @@ BOOST_AUTO_TEST_CASE(constructor_static_array_argument)
 			uint public a;
 			uint[3] public b;
 
-			constructor(uint _a, uint[3] _b) public {
+			constructor(uint _a, uint[3] memory _b) public {
 				a = _a;
 				b = _b;
 			}
@@ -2492,7 +2492,7 @@ BOOST_AUTO_TEST_CASE(constant_var_as_array_length)
 			uint constant LEN = 3;
 			uint[LEN] public a;
 
-			constructor(uint[LEN] _a) public {
+			constructor(uint[LEN] memory _a) public {
 				a = _a;
 			}
 		}
@@ -4760,22 +4760,22 @@ BOOST_AUTO_TEST_CASE(array_copy_storage_abi)
 			uint16[] y;
 			uint24[] z;
 			uint24[][] w;
-			function test1() public returns (uint8[]) {
+			function test1() public returns (uint8[] memory) {
 				for (uint i = 0; i < 101; ++i)
 					x.push(uint8(i));
 				return x;
 			}
-			function test2() public returns (uint16[]) {
+			function test2() public returns (uint16[] memory) {
 				for (uint i = 0; i < 101; ++i)
 					y.push(uint16(i));
 				return y;
 			}
-			function test3() public returns (uint24[]) {
+			function test3() public returns (uint24[] memory) {
 				for (uint i = 0; i < 101; ++i)
 					z.push(uint24(i));
 				return z;
 			}
-			function test4() public returns (uint24[][]) {
+			function test4() public returns (uint24[][] memory) {
 				w.length = 5;
 				for (uint i = 0; i < 5; ++i)
 					for (uint j = 0; j < 101; ++j)
@@ -4808,7 +4808,7 @@ BOOST_AUTO_TEST_CASE(array_copy_storage_abi_signed)
 	char const* sourceCode = R"(
 		contract c {
 			int16[] x;
-			function test() public returns (int16[]) {
+			function test() public returns (int16[] memory) {
 				x.push(int16(-1));
 				x.push(int16(-1));
 				x.push(int16(8));
@@ -5186,7 +5186,7 @@ BOOST_AUTO_TEST_CASE(byte_array_pop_masking_long)
 	char const* sourceCode = R"(
 		contract c {
 			bytes data;
-			function test() public returns (bytes) {
+			function test() public returns (bytes memory) {
 				for (uint i = 0; i < 34; i++)
 					data.push(3);
 				data.pop();
@@ -5208,7 +5208,7 @@ BOOST_AUTO_TEST_CASE(byte_array_pop_copy_long)
 	char const* sourceCode = R"(
 		contract c {
 			bytes data;
-			function test() public returns (bytes) {
+			function test() public returns (bytes memory) {
 				for (uint i = 0; i < 33; i++)
 					data.push(3);
 				for (uint j = 0; j < 4; j++)
@@ -6339,10 +6339,10 @@ BOOST_AUTO_TEST_CASE(return_string)
 			function set(string _s) external {
 				s = _s;
 			}
-			function get1() public returns (string r) {
+			function get1() public returns (string memory r) {
 				return s;
 			}
-			function get2() public returns (string r) {
+			function get2() public returns (string memory r) {
 				r = s;
 			}
 		}
@@ -6367,7 +6367,7 @@ BOOST_AUTO_TEST_CASE(return_multiple_strings_of_various_sizes)
 				s2 = _s2;
 				return x;
 			}
-			function get() public returns (string r1, string r2) {
+			function get() public returns (string memory r1, string memory r2) {
 				r1 = s1;
 				r2 = s2;
 			}
@@ -6440,12 +6440,12 @@ BOOST_AUTO_TEST_CASE(bytes_in_function_calls)
 		contract Main {
 			string public s1;
 			string public s2;
-			function set(string _s1, uint x, string _s2) public returns (uint) {
+			function set(string memory _s1, uint x, string memory _s2) public returns (uint) {
 				s1 = _s1;
 				s2 = _s2;
 				return x;
 			}
-			function setIndirectFromMemory(string _s1, uint x, string _s2) public returns (uint) {
+			function setIndirectFromMemory(string memory _s1, uint x, string memory _s2) public returns (uint) {
 				return this.set(_s1, x, _s2);
 			}
 			function setIndirectFromCalldata(string _s1, uint x, string _s2) external returns (uint) {
@@ -6485,11 +6485,11 @@ BOOST_AUTO_TEST_CASE(return_bytes_internal)
 	char const* sourceCode = R"(
 		contract Main {
 			bytes s1;
-			function doSet(bytes _s1) public returns (bytes _r1) {
+			function doSet(bytes memory _s1) public returns (bytes memory _r1) {
 				s1 = _s1;
 				_r1 = s1;
 			}
-			function set(bytes _s1) external returns (uint _r, bytes _r1) {
+			function set(bytes _s1) external returns (uint _r, bytes memory _r1) {
 				_r1 = doSet(_s1);
 				_r = _r1.length;
 			}
@@ -6513,15 +6513,15 @@ BOOST_AUTO_TEST_CASE(bytes_index_access_memory)
 {
 	char const* sourceCode = R"(
 		contract Main {
-			function f(bytes _s1, uint i1, uint i2, uint i3) public returns (byte c1, byte c2, byte c3) {
+			function f(bytes memory _s1, uint i1, uint i2, uint i3) public returns (byte c1, byte c2, byte c3) {
 				c1 = _s1[i1];
 				c2 = intern(_s1, i2);
 				c3 = internIndirect(_s1)[i3];
 			}
-			function intern(bytes _s1, uint i) public returns (byte c) {
+			function intern(bytes memory _s1, uint i) public returns (byte c) {
 				return _s1[i];
 			}
-			function internIndirect(bytes _s1) public returns (bytes) {
+			function internIndirect(bytes memory _s1) public returns (bytes memory) {
 				return _s1;
 			}
 		}
@@ -6542,7 +6542,7 @@ BOOST_AUTO_TEST_CASE(bytes_in_constructors_unpacker)
 		contract Test {
 			uint public m_x;
 			bytes public m_s;
-			constructor(uint x, bytes s) public {
+			constructor(uint x, bytes memory s) public {
 				m_x = x;
 				m_s = s;
 			}
@@ -6563,7 +6563,7 @@ BOOST_AUTO_TEST_CASE(bytes_in_constructors_packer)
 		contract Base {
 			uint public m_x;
 			bytes m_s;
-			constructor(uint x, bytes s) public {
+			constructor(uint x, bytes memory s) public {
 				m_x = x;
 				m_s = s;
 			}
@@ -6572,13 +6572,13 @@ BOOST_AUTO_TEST_CASE(bytes_in_constructors_packer)
 			}
 		}
 		contract Main is Base {
-			constructor(bytes s, uint x) Base(x, f(s)) public {}
-			function f(bytes s) public returns (bytes) {
+			constructor(bytes memory s, uint x) Base(x, f(s)) {}
+			function f(bytes memory s) public returns (bytes memory) {
 				return s;
 			}
 		}
 		contract Creator {
-			function f(uint x, bytes s) public returns (uint r, byte ch) {
+			function f(uint x, bytes memory s) public returns (uint r, byte ch) {
 				Main c = new Main(s, x);
 				r = c.m_x();
 				ch = c.part(x);
@@ -6602,7 +6602,7 @@ BOOST_AUTO_TEST_CASE(arrays_in_constructors)
 		contract Base {
 			uint public m_x;
 			address[] m_s;
-			constructor(uint x, address[] s) public {
+			constructor(uint x, address[] memory s) public {
 				m_x = x;
 				m_s = s;
 			}
@@ -6611,13 +6611,13 @@ BOOST_AUTO_TEST_CASE(arrays_in_constructors)
 			}
 		}
 		contract Main is Base {
-			constructor(address[] s, uint x) Base(x, f(s)) public {}
-			function f(address[] s) public returns (address[]) {
+			constructor(address[] memory s, uint x) Base(x, f(s)) public {}
+			function f(address[] memory s) public returns (address[] memory) {
 				return s;
 			}
 		}
 		contract Creator {
-			function f(uint x, address[] s) public returns (uint r, address ch) {
+			function f(uint x, address[] memory s) public returns (uint r, address ch) {
 				Main c = new Main(s, x);
 				r = c.m_x();
 				ch = c.part(x);
@@ -6641,7 +6641,7 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_in_constructors)
 		contract Creator {
 			uint public r;
 			address public ch;
-			constructor(address[3] s, uint x) public {
+			constructor(address[3] memory s, uint x) public {
 				r = x;
 				ch = s[2];
 			}
@@ -6657,11 +6657,11 @@ BOOST_AUTO_TEST_CASE(arrays_from_and_to_storage)
 	char const* sourceCode = R"(
 		contract Test {
 			uint24[] public data;
-			function set(uint24[] _data) public returns (uint) {
+			function set(uint24[] memory _data) public returns (uint) {
 				data = _data;
 				return data.length;
 			}
-			function get() public returns (uint24[]) {
+			function get() public returns (uint24[] memory) {
 				return data;
 			}
 		}
@@ -6684,11 +6684,11 @@ BOOST_AUTO_TEST_CASE(arrays_complex_from_and_to_storage)
 	char const* sourceCode = R"(
 		contract Test {
 			uint24[3][] public data;
-			function set(uint24[3][] _data) public returns (uint) {
+			function set(uint24[3][] memory _data) public returns (uint) {
 				data = _data;
 				return data.length;
 			}
-			function get() public returns (uint24[3][]) {
+			function get() public returns (uint24[3][] memory) {
 				return data;
 			}
 		}
@@ -6710,7 +6710,7 @@ BOOST_AUTO_TEST_CASE(arrays_complex_memory_index_access)
 {
 	char const* sourceCode = R"(
 		contract Test {
-			function set(uint24[3][] _data, uint a, uint b) public returns (uint l, uint e) {
+			function set(uint24[3][] memory _data, uint a, uint b) public returns (uint l, uint e) {
 				l = _data.length;
 				e = _data[a][b];
 			}
@@ -6733,7 +6733,7 @@ BOOST_AUTO_TEST_CASE(bytes_memory_index_access)
 {
 	char const* sourceCode = R"(
 		contract Test {
-			function set(bytes _data, uint i) public returns (uint l, byte c) {
+			function set(bytes memory _data, uint i) public returns (uint l, byte c) {
 				l = _data.length;
 				c = _data[i];
 			}
@@ -6809,13 +6809,13 @@ BOOST_AUTO_TEST_CASE(memory_types_initialisation)
 	char const* sourceCode = R"(
 		contract Test {
 			mapping(uint=>uint) data;
-			function stat() public returns (uint[5])
+			function stat() public returns (uint[5] memory)
 			{
 				data[2] = 3; // make sure to use some memory
 			}
-			function dyn() public returns (uint[]) { stat(); }
-			function nested() public returns (uint[3][]) { stat(); }
-			function nestedStat() public returns (uint[3][7]) { stat(); }
+			function dyn() public returns (uint[] memory) { stat(); }
+			function nested() public returns (uint[3][] memory) { stat(); }
+			function nestedStat() public returns (uint[3][7] memory) { stat(); }
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Test");
@@ -6830,7 +6830,7 @@ BOOST_AUTO_TEST_CASE(memory_arrays_delete)
 {
 	char const* sourceCode = R"(
 		contract Test {
-			function del() public returns (uint24[3][4]) {
+			function del() public returns (uint24[3][4] memory) {
 				uint24[3][4] memory x;
 				for (uint24 i = 0; i < x.length; i ++)
 					for (uint24 j = 0; j < x[i].length; j ++)
@@ -6859,11 +6859,11 @@ BOOST_AUTO_TEST_CASE(memory_arrays_index_access_write)
 {
 	char const* sourceCode = R"(
 		contract Test {
-			function set(uint24[3][4] x) {
+			function set(uint24[3][4] memory x) {
 				x[2][2] = 1;
 				x[3][2] = 7;
 			}
-			function f() public returns (uint24[3][4]){
+			function f() public returns (uint24[3][4] memory){
 				uint24[3][4] memory data;
 				set(data);
 				return data;
@@ -6883,12 +6883,12 @@ BOOST_AUTO_TEST_CASE(memory_arrays_dynamic_index_access_write)
 	char const* sourceCode = R"(
 		contract Test {
 			uint24[3][][4] data;
-			function set(uint24[3][][4] x) internal returns (uint24[3][][4]) {
+			function set(uint24[3][][4] memory x) internal returns (uint24[3][][4] memory) {
 				x[1][2][2] = 1;
 				x[1][3][2] = 7;
 				return x;
 			}
-			function f() public returns (uint24[3][]) {
+			function f() public returns (uint24[3][] memory) {
 				data[1].length = 4;
 				return set(data)[1];
 			}
@@ -6958,12 +6958,12 @@ BOOST_AUTO_TEST_CASE(memory_structs_as_function_args)
 				y = extract(data, 1);
 				z = extract(data, 2);
 			}
-			function extract(S s, uint which) internal returns (uint x) {
+			function extract(S memory s, uint which) internal returns (uint x) {
 				if (which == 0) return s.x;
 				else if (which == 1) return s.y;
 				else return s.z;
 			}
-			function combine(uint8 x, uint16 y, uint z) internal returns (S s) {
+			function combine(uint8 x, uint16 y, uint z) internal returns (S memory s) {
 				s.x = x;
 				s.y = y;
 				s.z = z;
@@ -6988,13 +6988,13 @@ BOOST_AUTO_TEST_CASE(memory_structs_nested)
 				y = extract(d, 2);
 				z = extract(d, 3);
 			}
-			function extract(X s, uint which) internal returns (uint x) {
+			function extract(X memory s, uint which) internal returns (uint x) {
 				if (which == 0) return s.x;
 				else if (which == 1) return s.s.x;
 				else if (which == 2) return s.s.y;
 				else return s.s.z;
 			}
-			function combine(uint8 a, uint8 x, uint16 y, uint z) internal returns (X s) {
+			function combine(uint8 a, uint8 x, uint16 y, uint z) internal returns (X memory s) {
 				s.x = a;
 				s.s.x = x;
 				s.s.y = y;
@@ -7066,7 +7066,7 @@ BOOST_AUTO_TEST_CASE(struct_constructor_nested)
 				s2[1] = 9;
 				s = S(1, s2, X(4, 5));
 			}
-			function get() public returns (uint s1, uint[3] s2, uint x1, uint x2)
+			function get() public returns (uint s1, uint[3] memory s2, uint x1, uint x2)
 			{
 				s1 = s.s1;
 				s2 = s.s2;
@@ -7105,7 +7105,7 @@ BOOST_AUTO_TEST_CASE(literal_strings)
 			string public medium;
 			string public short;
 			string public empty;
-			function f() public returns (string) {
+			function f() public returns (string memory) {
 				long = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
 				medium = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
 				short = "123";
@@ -7172,7 +7172,7 @@ BOOST_AUTO_TEST_CASE(string_bytes_conversion)
 		contract Test {
 			string s;
 			bytes b;
-			function f(string _s, uint n) public returns (byte) {
+			function f(string memory _s, uint n) public returns (byte) {
 				b = bytes(_s);
 				s = string(b);
 				return bytes(s)[n];
@@ -7196,8 +7196,8 @@ BOOST_AUTO_TEST_CASE(string_as_mapping_key)
 	char const* sourceCode = R"(
 		contract Test {
 			mapping(string => uint) data;
-			function set(string _s, uint _v) { data[_s] = _v; }
-			function get(string _s) public returns (uint) { return data[_s]; }
+			function set(string memory _s, uint _v) { data[_s] = _v; }
+			function get(string memory _s) public returns (uint) { return data[_s]; }
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Test");
@@ -7374,8 +7374,8 @@ BOOST_AUTO_TEST_CASE(constant_string_literal)
 				bytes32 bb = b;
 			}
 			function getB() public returns (bytes32) { return b; }
-			function getX() public returns (string) { return x; }
-			function getX2() public returns (string r) { r = x; }
+			function getX() public returns (string memory) { return x; }
+			function getX2() public returns (string memory r) { r = x; }
 			function unused() public returns (uint) {
 				"unusedunusedunusedunusedunusedunusedunusedunusedunusedunusedunusedunused";
 				return 2;
@@ -7429,7 +7429,7 @@ BOOST_AUTO_TEST_CASE(library_function_external)
 	char const* sourceCode = R"(
 		library Lib { function m(bytes b) external pure returns (byte) { return b[2]; } }
 		contract Test {
-			function f(bytes b) public pure returns (byte) {
+			function f(bytes memory b) public pure returns (byte) {
 				return Lib.m(b);
 			}
 		}
@@ -7517,7 +7517,7 @@ BOOST_AUTO_TEST_CASE(strings_in_struct)
 			{
 				return bug.third;
 			}
-			function getLast() public returns (string)
+			function getLast() public returns (string memory)
 			{
 				return bug.last;
 			}
@@ -7535,7 +7535,7 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_as_return_type)
 {
 	char const* sourceCode = R"(
 		contract A {
-			function f(uint16 input) public pure returns (uint16[5] arr)
+			function f(uint16 input) public pure returns (uint16[5] memory arr)
 			{
 				arr[0] = input;
 				arr[1] = ++input;
@@ -7545,7 +7545,7 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_as_return_type)
 			}
 		}
 		contract B {
-			function f() public returns (uint16[5] res, uint16[5] res2)
+			function f() public returns (uint16[5] memory res, uint16[5] memory res2)
 			{
 				A a = new A();
 				res = a.f(2);
@@ -7777,7 +7777,7 @@ BOOST_AUTO_TEST_CASE(calldata_offset)
 		{
 			address[] _arr;
 			string public last = "nd";
-			constructor(address[] guardians)
+			constructor(address[] memory guardians)
 			{
 				_arr = guardians;
 			}
@@ -7908,13 +7908,13 @@ BOOST_AUTO_TEST_CASE(string_tuples)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f() public returns (string, uint) {
+			function f() public returns (string memory, uint) {
 				return ("abc", 8);
 			}
-			function g() public returns (string, string) {
+			function g() public returns (string memory, string memory) {
 				return (h(), "def");
 			}
-			function h() public returns (string) {
+			function h() public returns (string memory) {
 				return ("abc",);
 			}
 		}
@@ -7961,13 +7961,13 @@ BOOST_AUTO_TEST_CASE(destructuring_assignment)
 			bytes data;
 			uint[] y;
 			uint[] arrayData;
-			function returnsArray() public returns (uint[]) {
+			function returnsArray() public returns (uint[] memory) {
 				arrayData.length = 9;
 				arrayData[2] = 5;
 				arrayData[7] = 4;
 				return arrayData;
 			}
-			function f(bytes s) public returns (uint) {
+			function f(bytes memory s) public returns (uint) {
 				uint loc;
 				uint[] memory memArray;
 				(loc, x, y, data, arrayData[3]) = (8, 4, returnsArray(), s, 2);
@@ -8139,7 +8139,7 @@ BOOST_AUTO_TEST_CASE(memory_overwrite)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f() public returns (bytes x) {
+			function f() public returns (bytes memory x) {
 				x = "12345";
 				x[3] = 0x61;
 				x[0] = 0x62;
@@ -8371,7 +8371,7 @@ BOOST_AUTO_TEST_CASE(inline_array_storage_to_memory_conversion_strings)
 	char const* sourceCode = R"(
 		contract C {
 			string s = "doh";
-			function f() public returns (string, string) {
+			function f() public returns (string memory, string memory) {
 				string memory t = "ray";
 				string[3] memory x = [s, t, "mi"];
 				return (x[1], x[2]);
@@ -8386,7 +8386,7 @@ BOOST_AUTO_TEST_CASE(inline_array_strings_from_document)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f(uint i) public returns (string) {
+			function f(uint i) public returns (string memory) {
 				string[4] memory x = ["This", "is", "an", "array"];
 				return (x[i]);
 			}
@@ -8433,7 +8433,7 @@ BOOST_AUTO_TEST_CASE(inline_array_index_access_strings)
 	char const* sourceCode = R"(
 		contract C {
 			string public tester;
-			function f() public returns (string) {
+			function f() public returns (string memory) {
 				return (["abc", "def", "g"][0]);
 			}
 			function test() public {
@@ -8451,7 +8451,7 @@ BOOST_AUTO_TEST_CASE(inline_array_return)
 	char const* sourceCode = R"(
 		contract C {
 			uint8[] tester;
-			function f() public returns (uint8[5]) {
+			function f() public returns (uint8[5] memory) {
 				return ([1,2,3,4,5]);
 			}
 			function test() public returns (uint8, uint8, uint8, uint8, uint8) {
@@ -8483,7 +8483,7 @@ BOOST_AUTO_TEST_CASE(inline_long_string_return)
 {
 		char const* sourceCode = R"(
 		contract C {
-			function f() public returns (string) {
+			function f() public returns (string memory) {
 				return (["somethingShort", "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"][1]);
 			}
 		}
@@ -8560,7 +8560,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_memory_access)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function test() public returns (bytes) {
+			function test() public returns (bytes memory) {
 				bytes memory x = new bytes(5);
 				for (uint i = 0; i < x.length; ++i)
 					x[i] = byte(uint8(i + 1));
@@ -8919,7 +8919,7 @@ BOOST_AUTO_TEST_CASE(index_access_with_type_conversion)
 	// Test for a bug where higher order bits cleanup was not done for array index access.
 	char const* sourceCode = R"(
 			contract C {
-				function f(uint x) public returns (uint[256] r){
+				function f(uint x) public returns (uint[256] memory r){
 					r[uint8(x)] = 2;
 				}
 			}
@@ -8959,7 +8959,7 @@ BOOST_AUTO_TEST_CASE(internal_library_function)
 	// and retain the same memory context (i.e. are pulled into the caller's code)
 	char const* sourceCode = R"(
 		library L {
-			function f(uint[] _data) internal {
+			function f(uint[] memory _data) internal {
 				_data[3] = 2;
 			}
 		}
@@ -8984,10 +8984,10 @@ BOOST_AUTO_TEST_CASE(internal_library_function_calling_private)
 	// also has to be pulled into the caller's code)
 	char const* sourceCode = R"(
 		library L {
-			function g(uint[] _data) private {
+			function g(uint[] memory _data) private {
 				_data[3] = 2;
 			}
-			function f(uint[] _data) internal {
+			function f(uint[] memory _data) internal {
 				g(_data);
 			}
 		}
@@ -9010,7 +9010,7 @@ BOOST_AUTO_TEST_CASE(internal_library_function_bound)
 	char const* sourceCode = R"(
 		library L {
 			struct S { uint[] data; }
-			function f(S _s) internal {
+			function f(S memory _s) internal {
 				_s.data[3] = 2;
 			}
 		}
@@ -9035,7 +9035,7 @@ BOOST_AUTO_TEST_CASE(internal_library_function_return_var_size)
 	char const* sourceCode = R"(
 		library L {
 			struct S { uint[] data; }
-			function f(S _s) internal returns (uint[]) {
+			function f(S memory _s) internal returns (uint[] memory) {
 				_s.data[3] = 2;
 				return _s.data;
 			}
@@ -9116,7 +9116,7 @@ BOOST_AUTO_TEST_CASE(skip_dynamic_types)
 	// The EVM cannot provide access to dynamically-sized return values, so we have to skip them.
 	char const* sourceCode = R"(
 		contract C {
-			function f() public returns (uint, uint[], uint) {
+			function f() public returns (uint, uint[] memory, uint) {
 				return (7, new uint[](2), 8);
 			}
 			function g() public returns (uint, uint) {
@@ -9543,7 +9543,7 @@ BOOST_AUTO_TEST_CASE(mem_resize_is_not_paid_at_call)
 	// Tests that this also survives the optimizer.
 	char const* sourceCode = R"(
 		contract C {
-			function f() public returns (uint[200]) {}
+			function f() public returns (uint[200] memory) {}
 		}
 		contract D {
 			function f(C c) public returns (uint) { c.f(); return 7; }
@@ -9848,7 +9848,7 @@ BOOST_AUTO_TEST_CASE(function_type_library_internal)
 			}
 		}
 		contract C {
-			function f(uint[] x) public returns (uint) {
+			function f(uint[] memory x) public returns (uint) {
 				return Utils.reduce(x, Utils.sum, 0);
 			}
 		}
@@ -10077,8 +10077,8 @@ BOOST_AUTO_TEST_CASE(function_array_cross_calls)
 {
 	char const* sourceCode = R"(
 		contract D {
-			function f(function() external returns (function() external returns (uint))[] x)
-				public returns (function() external returns (uint)[3] r)
+			function f(function() external returns (function() external returns (uint))[] memory x)
+				public returns (function() external returns (uint)[3] memory r)
 			{
 				r[0] = x[0]();
 				r[1] = x[1]();
@@ -11035,7 +11035,7 @@ BOOST_AUTO_TEST_CASE(revert_with_cause)
 		}
 		contract C {
 			D d = new D();
-			function forward(address target, bytes data) internal returns (bool success, bytes retval) {
+			function forward(address target, bytes memory data) internal returns (bool success, bytes memory retval) {
 				uint retsize;
 				assembly {
 					success := call(not(0), target, 0, add(data, 0x20), mload(data), 0, 0)
@@ -11046,19 +11046,19 @@ BOOST_AUTO_TEST_CASE(revert_with_cause)
 					returndatacopy(add(retval, 0x20), 0, returndatasize())
 				}
 			}
-			function f() public returns (bool, bytes) {
+			function f() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function g() public returns (bool, bytes) {
+			function g() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function h() public returns (bool, bytes) {
+			function h() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function i() public returns (bool, bytes) {
+			function i() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function j() public returns (bool, bytes) {
+			function j() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
 		}
@@ -11090,7 +11090,7 @@ BOOST_AUTO_TEST_CASE(require_with_message)
 				bool flagCopy = flag;
 				require(flagCopy == false, internalFun());
 			}
-			function internalFun() public returns (string) {
+			function internalFun() public returns (string memory) {
 				flag = true;
 				return "only on second run";
 			}
@@ -11107,7 +11107,7 @@ BOOST_AUTO_TEST_CASE(require_with_message)
 		}
 		contract C {
 			D d = new D();
-			function forward(address target, bytes data) internal returns (bool success, bytes retval) {
+			function forward(address target, bytes memory data) internal returns (bool success, bytes memory retval) {
 				uint retsize;
 				assembly {
 					success := call(not(0), target, 0, add(data, 0x20), mload(data), 0, 0)
@@ -11118,19 +11118,19 @@ BOOST_AUTO_TEST_CASE(require_with_message)
 					returndatacopy(add(retval, 0x20), 0, returndatasize())
 				}
 			}
-			function f(uint x) public returns (bool, bytes) {
+			function f(uint x) public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function g() public returns (bool, bytes) {
+			function g() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function h() public returns (bool, bytes) {
+			function h() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function i() public returns (bool, bytes) {
+			function i() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function j() public returns (bool, bytes) {
+			function j() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
 		}
@@ -11160,7 +11160,7 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages)
 		}
 		contract C {
 			D d = new D();
-			function forward(address target, bytes data) internal returns (bool success, bytes retval) {
+			function forward(address target, bytes memory data) internal returns (bool success, bytes memory retval) {
 				uint retsize;
 				assembly {
 					success := call(not(0), target, 0, add(data, 0x20), mload(data), 0, 0)
@@ -11171,10 +11171,10 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages)
 					returndatacopy(add(retval, 0x20), 0, returndatasize())
 				}
 			}
-			function f() public returns (bool, bytes) {
+			function f() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
-			function g() public returns (bool, bytes) {
+			function g() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
 		}
@@ -11199,7 +11199,7 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages_through_transfer)
 		}
 		contract C {
 			D d = new D();
-			function forward(address target, bytes data) internal returns (bool success, bytes retval) {
+			function forward(address target, bytes memory data) internal returns (bool success, bytes memory retval) {
 				uint retsize;
 				assembly {
 					success := call(not(0), target, 0, add(data, 0x20), mload(data), 0, 0)
@@ -11210,7 +11210,7 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages_through_transfer)
 					returndatacopy(add(retval, 0x20), 0, returndatasize())
 				}
 			}
-			function f() public returns (bool, bytes) {
+			function f() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
 		}
@@ -11236,7 +11236,7 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages_through_create)
 		}
 		contract C {
 			D d = new D();
-			function forward(address target, bytes data) internal returns (bool success, bytes retval) {
+			function forward(address target, bytes memory data) internal returns (bool success, bytes memory retval) {
 				uint retsize;
 				assembly {
 					success := call(not(0), target, 0, add(data, 0x20), mload(data), 0, 0)
@@ -11247,7 +11247,7 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages_through_create)
 					returndatacopy(add(retval, 0x20), 0, returndatasize())
 				}
 			}
-			function f() public returns (bool, bytes) {
+			function f() public returns (bool, bytes memory) {
 				return forward(address(d), msg.data);
 			}
 		}
@@ -11271,9 +11271,9 @@ BOOST_AUTO_TEST_CASE(negative_stack_height)
 				bool Aboolc;
 				bool exists;
 			}
-			function nredit(uint startindex) public pure returns(uint[500] CIDs, uint[500] dates, uint[500] RIDs, bool[500] Cboolas, uint[500] amounts){}
-			function return500InvoicesByDates(uint begindate, uint enddate, uint startindex) public view returns(uint[500] AIDs, bool[500] Aboolas, uint[500] dates, bytes32[3][500] Abytesas, bytes32[3][500] bytesbs, bytes32[2][500] bytescs, uint[500] amounts, bool[500] Aboolbs, bool[500] Aboolcs){}
-			function return500PaymentsByDates(uint begindate, uint enddate, uint startindex) public view returns(uint[500] BIDs, uint[500] dates, uint[500] RIDs, bool[500] Bboolas, bytes32[3][500] bytesbs,bytes32[2][500] bytescs, uint[500] amounts, bool[500] Bboolbs){}
+			function nredit(uint startindex) public pure returns(uint[500] memory CIDs, uint[500] memory dates, uint[500] memory RIDs, bool[500] memory Cboolas, uint[500] memory amounts){}
+			function return500InvoicesByDates(uint begindate, uint enddate, uint startindex) public view returns(uint[500] memory AIDs, bool[500] memory Aboolas, uint[500] memory dates, bytes32[3][500] memory Abytesas, bytes32[3][500] memory bytesbs, bytes32[2][500] memory bytescs, uint[500] memory amounts, bool[500] memory Aboolbs, bool[500] memory Aboolcs){}
+			function return500PaymentsByDates(uint begindate, uint enddate, uint startindex) public view returns(uint[500] memory BIDs, uint[500] memory dates, uint[500] memory RIDs, bool[500] memory Bboolas, bytes32[3][500] memory bytesbs,bytes32[2][500] memory bytescs, uint[500] memory amounts, bool[500] memory Bboolbs){}
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
@@ -11528,13 +11528,13 @@ BOOST_AUTO_TEST_CASE(constant_string)
 			bytes constant a = "\x03\x01\x02";
 			bytes constant b = hex"030102";
 			string constant c = "hello";
-			function f() public returns (bytes) {
+			function f() public returns (bytes memory) {
 				return a;
 			}
-			function g() public returns (bytes) {
+			function g() public returns (bytes memory) {
 				return b;
 			}
-			function h() public returns (bytes) {
+			function h() public returns (bytes memory) {
 				return bytes(c);
 			}
 		}
@@ -11585,12 +11585,12 @@ BOOST_AUTO_TEST_CASE(snark)
 		}
 
 		/// @return the generator of G1
-		function P1() internal returns (G1Point) {
+		function P1() internal returns (G1Point memory) {
 			return G1Point(1, 2);
 		}
 
 		/// @return the generator of G2
-		function P2() internal returns (G2Point) {
+		function P2() internal returns (G2Point memory) {
 			return G2Point(
 				[11559732032986387107991004021392285783925812861821192530917403151452391805634,
 				 10857046999023057135944570762232829481370756359578518086990519993285655852781],
@@ -11600,7 +11600,7 @@ BOOST_AUTO_TEST_CASE(snark)
 		}
 
 		/// @return the negation of p, i.e. p.add(p.negate()) should be zero.
-		function negate(G1Point p) internal returns (G1Point) {
+		function negate(G1Point memory p) internal returns (G1Point memory) {
 			// The prime q in the base field F_q for G1
 			uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
 			if (p.X == 0 && p.Y == 0)
@@ -11609,7 +11609,7 @@ BOOST_AUTO_TEST_CASE(snark)
 		}
 
 		/// @return the sum of two points of G1
-		function add(G1Point p1, G1Point p2) internal returns (G1Point r) {
+		function add(G1Point memory p1, G1Point memory p2) internal returns (G1Point memory r) {
 			uint[4] memory input;
 			input[0] = p1.X;
 			input[1] = p1.Y;
@@ -11626,7 +11626,7 @@ BOOST_AUTO_TEST_CASE(snark)
 
 		/// @return the product of a point on G1 and a scalar, i.e.
 		/// p == p.mul(1) and p.add(p) == p.mul(2) for all points p.
-		function mul(G1Point p, uint s) internal returns (G1Point r) {
+		function mul(G1Point memory p, uint s) internal returns (G1Point memory r) {
 			uint[3] memory input;
 			input[0] = p.X;
 			input[1] = p.Y;
@@ -11644,7 +11644,7 @@ BOOST_AUTO_TEST_CASE(snark)
 		/// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
 		/// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
 		/// return true.
-		function pairing(G1Point[] p1, G2Point[] p2) internal returns (bool) {
+		function pairing(G1Point[] memory p1, G2Point[] memory p2) internal returns (bool) {
 			require(p1.length == p2.length);
 			uint elements = p1.length;
 			uint inputSize = p1.length * 6;
@@ -11668,7 +11668,7 @@ BOOST_AUTO_TEST_CASE(snark)
 			require(success);
 			return out[0] != 0;
 		}
-		function pairingProd2(G1Point a1, G2Point a2, G1Point b1, G2Point b2) internal returns (bool) {
+		function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal returns (bool) {
 			G1Point[] memory p1 = new G1Point[](2);
 			G2Point[] memory p2 = new G2Point[](2);
 			p1[0] = a1;
@@ -11678,9 +11678,9 @@ BOOST_AUTO_TEST_CASE(snark)
 			return pairing(p1, p2);
 		}
 		function pairingProd3(
-				G1Point a1, G2Point a2,
-				G1Point b1, G2Point b2,
-				G1Point c1, G2Point c2
+				G1Point memory a1, G2Point memory a2,
+				G1Point memory b1, G2Point memory b2,
+				G1Point memory c1, G2Point memory c2
 		) internal returns (bool) {
 			G1Point[] memory p1 = new G1Point[](3);
 			G2Point[] memory p2 = new G2Point[](3);
@@ -11693,10 +11693,10 @@ BOOST_AUTO_TEST_CASE(snark)
 			return pairing(p1, p2);
 		}
 		function pairingProd4(
-				G1Point a1, G2Point a2,
-				G1Point b1, G2Point b2,
-				G1Point c1, G2Point c2,
-				G1Point d1, G2Point d2
+				G1Point memory a1, G2Point memory a2,
+				G1Point memory b1, G2Point memory b2,
+				G1Point memory c1, G2Point memory c2,
+				G1Point memory d1, G2Point memory d2
 		) internal returns (bool) {
 			G1Point[] memory p1 = new G1Point[](4);
 			G2Point[] memory p2 = new G2Point[](4);
@@ -11785,7 +11785,7 @@ BOOST_AUTO_TEST_CASE(snark)
 				return false;
 			return true;
 		}
-		function verifyingKey() internal returns (VerifyingKey vk) {
+		function verifyingKey() internal returns (VerifyingKey memory vk) {
 			vk.A = Pairing.G2Point([0x209dd15ebff5d46c4bd888e51a93cf99a7329636c63514396b4a452003a35bf7, 0x04bf11ca01483bfa8b34b43561848d28905960114c8ac04049af4b6315a41678], [0x2bb8324af6cfc93537a2ad1a445cfd0ca2a71acd7ac41fadbf933c2a51be344d, 0x120a2a4cf30c1bf9845f20c6fe39e07ea2cce61f0c9bb048165fe5e4de877550]);
 			vk.B = Pairing.G1Point(0x2eca0c7238bf16e83e7a1e6c5d49540685ff51380f309842a98561558019fc02, 0x03d3260361bb8451de5ff5ecd17f010ff22f5c31cdf184e9020b06fa5997db84);
 			vk.C = Pairing.G2Point([0x2e89718ad33c8bed92e210e81d1853435399a271913a6520736a4729cf0d51eb, 0x01a9e2ffa2e92599b68e44de5bcf354fa2642bd4f26b259daa6f7ce3ed57aeb3], [0x14a9a87b789a58af499b314e13c3d65bede56c07ea2d418d6874857b70763713, 0x178fb49a2d6cd347dc58973ff49613a20757d0fcc22079f9abd10c3baee24590]);
@@ -11805,7 +11805,7 @@ BOOST_AUTO_TEST_CASE(snark)
 			vk.IC[8] = Pairing.G1Point(0x0a6de0e2240aa253f46ce0da883b61976e3588146e01c9d8976548c145fe6e4a, 0x04fbaa3a4aed4bb77f30ebb07a3ec1c7d77a7f2edd75636babfeff97b1ea686e);
 			vk.IC[9] = Pairing.G1Point(0x111e2e2a5f8828f80ddad08f9f74db56dac1cc16c1cb278036f79a84cf7a116f, 0x1d7d62e192b219b9808faa906c5ced871788f6339e8d91b83ac1343e20a16b30);
 		}
-		function verify(uint[] input, Proof proof) internal returns (uint) {
+		function verify(uint[] memory input, Proof memory proof) internal returns (uint) {
 			VerifyingKey memory vk = verifyingKey();
 			require(input.length + 1 == vk.IC.length);
 			// Compute the linear combination vk_x
@@ -11875,17 +11875,17 @@ BOOST_AUTO_TEST_CASE(abi_encode)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f0() public returns (bytes) {
+			function f0() public returns (bytes memory) {
 				return abi.encode();
 			}
-			function f1() public returns (bytes) {
+			function f1() public returns (bytes memory) {
 				return abi.encode(1, 2);
 			}
-			function f2() public returns (bytes) {
+			function f2() public returns (bytes memory) {
 				string memory x = "abc";
 				return abi.encode(1, x, 2);
 			}
-			function f3() public returns (bytes r) {
+			function f3() public returns (bytes memory r) {
 				// test that memory is properly allocated
 				string memory x = "abc";
 				r = abi.encode(1, x, 2);
@@ -11894,7 +11894,7 @@ BOOST_AUTO_TEST_CASE(abi_encode)
 				y[0] = "e";
 				require(y[0] == "e");
 			}
-			function f4() public returns (bytes) {
+			function f4() public returns (bytes memory) {
 				bytes4 x = "abcd";
 				return abi.encode(bytes2(x));
 			}
@@ -11914,17 +11914,17 @@ BOOST_AUTO_TEST_CASE(abi_encode_v2)
 		pragma experimental ABIEncoderV2;
 		contract C {
 			struct S { uint a; uint[] b; }
-			function f0() public pure returns (bytes) {
+			function f0() public pure returns (bytes memory) {
 				return abi.encode();
 			}
-			function f1() public pure returns (bytes) {
+			function f1() public pure returns (bytes memory) {
 				return abi.encode(1, 2);
 			}
-			function f2() public pure returns (bytes) {
+			function f2() public pure returns (bytes memory) {
 				string memory x = "abc";
 				return abi.encode(1, x, 2);
 			}
-			function f3() public pure returns (bytes r) {
+			function f3() public pure returns (bytes memory r) {
 				// test that memory is properly allocated
 				string memory x = "abc";
 				r = abi.encode(1, x, 2);
@@ -11934,7 +11934,7 @@ BOOST_AUTO_TEST_CASE(abi_encode_v2)
 				require(y[0] == "e");
 			}
 			S s;
-			function f4() public returns (bytes r) {
+			function f4() public returns (bytes memory r) {
 				string memory x = "abc";
 				s.a = 7;
 				s.b.push(2);
@@ -11960,17 +11960,17 @@ BOOST_AUTO_TEST_CASE(abi_encodePacked)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f0() public pure returns (bytes) {
+			function f0() public pure returns (bytes memory) {
 				return abi.encodePacked();
 			}
-			function f1() public pure returns (bytes) {
+			function f1() public pure returns (bytes memory) {
 				return abi.encodePacked(uint8(1), uint8(2));
 			}
-			function f2() public pure returns (bytes) {
+			function f2() public pure returns (bytes memory) {
 				string memory x = "abc";
 				return abi.encodePacked(uint8(1), x, uint8(2));
 			}
-			function f3() public pure returns (bytes r) {
+			function f3() public pure returns (bytes memory r) {
 				// test that memory is properly allocated
 				string memory x = "abc";
 				r = abi.encodePacked(uint8(1), x, uint8(2));
@@ -11992,17 +11992,17 @@ BOOST_AUTO_TEST_CASE(abi_encode_with_selector)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f0() public pure returns (bytes) {
+			function f0() public pure returns (bytes memory) {
 				return abi.encodeWithSelector(0x12345678);
 			}
-			function f1() public pure returns (bytes) {
+			function f1() public pure returns (bytes memory) {
 				return abi.encodeWithSelector(0x12345678, "abc");
 			}
-			function f2() public pure returns (bytes) {
+			function f2() public pure returns (bytes memory) {
 				bytes4 x = 0x12345678;
 				return abi.encodeWithSelector(x, "abc");
 			}
-			function f3() public pure returns (bytes) {
+			function f3() public pure returns (bytes memory) {
 				bytes4 x = 0x12345678;
 				return abi.encodeWithSelector(x, uint(-1));
 			}
@@ -12024,22 +12024,22 @@ BOOST_AUTO_TEST_CASE(abi_encode_with_selectorv2)
 	char const* sourceCode = R"(
 		pragma experimental ABIEncoderV2;
 		contract C {
-			function f0() public pure returns (bytes) {
+			function f0() public pure returns (bytes memory) {
 				return abi.encodeWithSelector(0x12345678);
 			}
-			function f1() public pure returns (bytes) {
+			function f1() public pure returns (bytes memory) {
 				return abi.encodeWithSelector(0x12345678, "abc");
 			}
-			function f2() public pure returns (bytes) {
+			function f2() public pure returns (bytes memory) {
 				bytes4 x = 0x12345678;
 				return abi.encodeWithSelector(x, "abc");
 			}
-			function f3() public pure returns (bytes) {
+			function f3() public pure returns (bytes memory) {
 				bytes4 x = 0x12345678;
 				return abi.encodeWithSelector(x, uint(-1));
 			}
 			struct S { uint a; string b; uint16 c; }
-			function f4() public pure returns (bytes) {
+			function f4() public pure returns (bytes memory) {
 				bytes4 x = 0x12345678;
 				S memory s;
 				s.a = 0x1234567;
@@ -12070,19 +12070,19 @@ BOOST_AUTO_TEST_CASE(abi_encode_with_signature)
 {
 	char const* sourceCode = R"T(
 		contract C {
-			function f0() public pure returns (bytes) {
+			function f0() public pure returns (bytes memory) {
 				return abi.encodeWithSignature("f(uint256)");
 			}
-			function f1() public pure returns (bytes) {
+			function f1() public pure returns (bytes memory) {
 				string memory x = "f(uint256)";
 				return abi.encodeWithSignature(x, "abc");
 			}
 			string xstor;
-			function f1s() public returns (bytes) {
+			function f1s() public returns (bytes memory) {
 				xstor = "f(uint256)";
 				return abi.encodeWithSignature(xstor, "abc");
 			}
-			function f2() public pure returns (bytes r, uint[] ar) {
+			function f2() public pure returns (bytes memory r, uint[] memory ar) {
 				string memory x = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 				uint[] memory y = new uint[](4);
 				y[0] = uint(-1);
@@ -12114,19 +12114,19 @@ BOOST_AUTO_TEST_CASE(abi_encode_with_signaturev2)
 	char const* sourceCode = R"T(
 		pragma experimental ABIEncoderV2;
 		contract C {
-			function f0() public pure returns (bytes) {
+			function f0() public pure returns (bytes memory) {
 				return abi.encodeWithSignature("f(uint256)");
 			}
-			function f1() public pure returns (bytes) {
+			function f1() public pure returns (bytes memory) {
 				string memory x = "f(uint256)";
 				return abi.encodeWithSignature(x, "abc");
 			}
 			string xstor;
-			function f1s() public returns (bytes) {
+			function f1s() public returns (bytes memory) {
 				xstor = "f(uint256)";
 				return abi.encodeWithSignature(xstor, "abc");
 			}
-			function f2() public pure returns (bytes r, uint[] ar) {
+			function f2() public pure returns (bytes memory r, uint[] memory ar) {
 				string memory x = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 				uint[] memory y = new uint[](4);
 				y[0] = uint(-1);
@@ -12139,7 +12139,7 @@ BOOST_AUTO_TEST_CASE(abi_encode_with_signaturev2)
 				ar = new uint[](2);
 			}
 			struct S { uint a; string b; uint16 c; }
-			function f4() public pure returns (bytes) {
+			function f4() public pure returns (bytes memory) {
 				bytes4 x = 0x12345678;
 				S memory s;
 				s.a = 0x1234567;
@@ -12173,7 +12173,7 @@ BOOST_AUTO_TEST_CASE(abi_encode_call)
 	char const* sourceCode = R"T(
 		contract C {
 			bool x;
-			function c(uint a, uint[] b) public {
+			function c(uint a, uint[] memory b) public {
 				require(a == 5);
 				require(b.length == 2);
 				require(b[0] == 6);

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(dynamic_return_types_not_possible)
 {
 	char const* sourceCode = R"(
 		contract C {
-			function f(uint) public returns (string);
+			function f(uint) public returns (string memory);
 			function g() public {
 				string memory x = this.f(2);
 				// we can assign to x but it is not usable.

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(sequence_number_for_calls)
 	// to storage), so the sequence number should be incremented.
 	char const* sourceCode = R"(
 		contract test {
-			function f(string a, string b) public returns (bool) { return sha256(bytes(a)) == sha256(bytes(b)); }
+			function f(string memory a, string memory b) public returns (bool) { return sha256(bytes(a)) == sha256(bytes(b)); }
 		}
 	)";
 	compileBothVersions(sourceCode);
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE(optimise_multi_stores)
 			struct S { uint16 a; uint16 b; uint16[3] c; uint[] dyn; }
 			uint padding;
 			S[] s;
-			function f() public returns (uint16, uint16, uint16[3], uint) {
+			function f() public returns (uint16, uint16, uint16[3] memory, uint) {
 				uint16[3] memory c;
 				c[0] = 7;
 				c[1] = 8;

--- a/test/libsolidity/syntaxTests/constructor/constructor_visibility_new.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_visibility_new.sol
@@ -1,5 +1,5 @@
 // The constructor of a base class should not be visible in the derived class
-contract A { constructor(string) public { } }
+contract A { constructor(string memory) public { } }
 contract B is A {
   function f() pure public {
     A x = A(0); // convert from address
@@ -9,4 +9,4 @@ contract B is A {
   }
 }
 // ----
-// TypeError: (243-247): Explicit type conversion not allowed from "string memory" to "contract A".
+// TypeError: (250-254): Explicit type conversion not allowed from "string memory" to "contract A".

--- a/test/libsolidity/syntaxTests/constructor/constructor_visibility_old.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_visibility_old.sol
@@ -1,5 +1,5 @@
 // The constructor of a base class should not be visible in the derived class
-contract A { function A(string s) public { } }
+contract A { function A(string memory s) public { } }
 contract B is A {
   function f() pure public {
     A x = A(0); // convert from address
@@ -9,5 +9,5 @@ contract B is A {
   }
 }
 // ----
-// Warning: (91-122): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
-// TypeError: (244-248): Explicit type conversion not allowed from "string memory" to "contract A".
+// Warning: (91-129): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
+// TypeError: (251-255): Explicit type conversion not allowed from "string memory" to "contract A".

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/default_location.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/default_location.sol
@@ -1,18 +1,18 @@
 contract C {
     struct S { bool f; }
     S s;
-    function f() internal view returns (S c) {
+    function f() internal view returns (S memory c) {
         c = s;
     }
-    function g() internal view returns (S) {
+    function g() internal view returns (S memory) {
         return s;
     }
-    function h() internal pure returns (S) {
+    function h() internal pure returns (S memory) {
     }
-    function i(bool flag) internal view returns (S c) {
+    function i(bool flag) internal view returns (S memory c) {
         if (flag) c = s;
     }
-    function j(bool flag) internal view returns (S) {
+    function j(bool flag) internal view returns (S memory) {
         if (flag) return s;
     }
 }

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/external_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/external_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    function i() external pure returns(uint[]) {}
+}
+// ----
+// TypeError: (52-58): Location must be specified as "memory" for parameters in publicly visible functions.

--- a/test/libsolidity/syntaxTests/dataLocations/function_parameters_with_data_location_fine.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_parameters_with_data_location_fine.sol
@@ -1,0 +1,8 @@
+contract C {
+    // Warning for no data location provided can be silenced with storage or memory.
+    function f(uint[] memory, uint[] storage) private pure {}
+    function g(uint[] memory, uint[] storage) internal pure {}
+    function h(uint[] memory) public pure {}
+    // No warning on external functions, because of default to calldata.
+    function i(uint[]) external pure {}
+}

--- a/test/libsolidity/syntaxTests/dataLocations/function_parameters_with_data_location_fine.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_parameters_with_data_location_fine.sol
@@ -5,4 +5,6 @@ contract C {
     function h(uint[] memory) public pure {}
     // No warning on external functions, because of default to calldata.
     function i(uint[]) external pure {}
+    // No warning for events.
+    event e(uint[]);
 }

--- a/test/libsolidity/syntaxTests/dataLocations/function_return_parameters_with_data_location_fine.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_return_parameters_with_data_location_fine.sol
@@ -1,0 +1,7 @@
+contract C {
+    // Shows that the warning for no data location provided can be silenced with storage or memory.
+    function f() private pure returns(uint[] memory, uint[] storage) {}
+    function g() internal pure returns(uint[] memory, uint[] storage) {}
+    function h() public pure returns(uint[] memory) {}
+    function i() external pure returns(uint[] memory) {}
+}

--- a/test/libsolidity/syntaxTests/dataLocations/function_return_parameters_with_data_location_fine.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_return_parameters_with_data_location_fine.sol
@@ -1,7 +1,7 @@
 contract C {
     // Shows that the warning for no data location provided can be silenced with storage or memory.
-    function f() private pure returns(uint[] memory, uint[] storage) {}
-    function g() internal pure returns(uint[] memory, uint[] storage) {}
+    function f() private pure returns(uint[] memory, uint[] storage b) { b = b; }
+    function g() internal pure returns(uint[] memory, uint[] storage b) { b = b; }
     function h() public pure returns(uint[] memory) {}
     function i() external pure returns(uint[] memory) {}
 }

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    function g(uint[]) internal pure {}
+}
+// ----
+// TypeError: (28-34): Location must be specified as either "memory" or "storage" for parameters.

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    function g() internal pure returns(uint[]) {}
+}
+// ----
+// TypeError: (52-58): Location must be specified as either "memory" or "storage" for parameters.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_function_parameters_with_data_location_fine.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_function_parameters_with_data_location_fine.sol
@@ -1,0 +1,8 @@
+library L {
+    // Warning for no data location provided can be silenced with storage or memory.
+    function f(uint[] memory, uint[] storage) private pure {}
+    function g(uint[] memory, uint[] storage) internal pure {}
+    function h(uint[] memory) public pure {}
+    // No warning on external functions, because of default to calldata.
+    function i(uint[]) external pure {}
+}

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_internal_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_internal_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+library L {
+    function g(uint[]) internal pure {}
+}
+// ----
+// TypeError: (27-33): Location must be specified as either "memory" or "storage" for parameters.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_private_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_private_function_parameters_no_data_location.sol
@@ -1,0 +1,7 @@
+library L {
+    function f(uint[]) private pure {}
+    function g(uint[]) internal pure {}
+    function h(uint[]) public pure {}
+}
+// ----
+// TypeError: (27-33): Location must be specified as either "memory" or "storage" for parameters.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_public_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_public_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+library L {
+    function h(uint[]) public pure {}
+}
+// ----
+// TypeError: (27-33): Location must be specified as "memory" for parameters in publicly visible functions.

--- a/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_parameters_no_data_location.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(uint[]) private pure {}
+    function g(uint[]) internal pure {}
+    function h(uint[]) public pure {}
+}
+// ----
+// TypeError: (28-34): Location must be specified as either "memory" or "storage" for parameters.

--- a/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() private pure returns(uint[]) {}
+}
+// ----
+// TypeError: (51-57): Location must be specified as either "memory" or "storage" for parameters.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    function h(uint[]) public pure {}
+}
+// ----
+// TypeError: (28-34): Location must be specified as "memory" for parameters in publicly visible functions.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    function h() public pure returns(uint[]) {}
+}
+// ----
+// TypeError: (50-56): Location must be specified as "memory" for parameters in publicly visible functions.

--- a/test/libsolidity/syntaxTests/functionTypes/warn_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/warn_function_parameters_no_data_location.sol
@@ -1,5 +1,0 @@
-library C {
-    function f(uint[]) private pure {}
-}
-// ----
-// Warning: (27-33): Parameter is declared as memory. Use an explicit "memory" keyword to silence this warning.

--- a/test/libsolidity/syntaxTests/functionTypes/warn_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/warn_function_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+library C {
+    function f(uint[]) private pure {}
+}
+// ----
+// Warning: (27-33): Parameter is declared as memory. Use an explicit "memory" keyword to silence this warning.

--- a/test/libsolidity/syntaxTests/functionTypes/warn_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/warn_function_return_parameters_no_data_location.sol
@@ -1,5 +1,0 @@
-library C {
-    function f() private pure returns(uint[]) {}
-}
-// ----
-// Warning: (50-56): Parameter is declared as memory. Use an explicit "memory" keyword to silence this warning.

--- a/test/libsolidity/syntaxTests/functionTypes/warn_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/warn_function_return_parameters_no_data_location.sol
@@ -1,0 +1,5 @@
+library C {
+    function f() private pure returns(uint[]) {}
+}
+// ----
+// Warning: (50-56): Parameter is declared as memory. Use an explicit "memory" keyword to silence this warning.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/039_functions_with_identical_structs_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/039_functions_with_identical_structs_in_interface.sol
@@ -3,9 +3,9 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct S1 { int i; }
     struct S2 { int i; }
-    function f(S1) pure {}
-    function f(S2) pure {}
+    function f(S1 memory) pure {}
+    function f(S2 memory) pure {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (129-151): Function overload clash during conversion to external types for arguments.
+// TypeError: (136-165): Function overload clash during conversion to external types for arguments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/040_functions_with_different_structs_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/040_functions_with_different_structs_in_interface.sol
@@ -3,8 +3,8 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct S1 { function() external a; }
     struct S2 { bytes24 a; }
-    function f(S1) public pure {}
-    function f(S2) public pure {}
+    function f(S1 memory) public pure {}
+    function f(S2 memory) public pure {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
@@ -2,7 +2,7 @@ pragma experimental ABIEncoderV2;
 
 contract C {
     struct S { function() internal a; }
-    function f(S) {}
+    function f(S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
@@ -2,7 +2,7 @@ pragma experimental ABIEncoderV2;
 
 contract C {
     struct S { mapping(uint => uint) a; }
-    function f(S) {}
+    function f(S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
@@ -3,7 +3,7 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct T { mapping(uint => uint) a; }
     struct S { T[][2] b; }
-    function f(S) {}
+    function f(S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/044_returning_multi_dimensional_arrays_new_abi.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/044_returning_multi_dimensional_arrays_new_abi.sol
@@ -1,7 +1,7 @@
 pragma experimental ABIEncoderV2;
 
 contract C {
-    function f() public pure returns (string[][]) {}
+    function f() public pure returns (string[][] memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() public pure returns (string[][]) {}
+    function f() public pure returns (string[][] memory) {}
 }
 // ----
 // TypeError: (51-61): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() public pure returns (uint[][2]) {}
+    function f() public pure returns (uint[][2] memory) {}
 }
 // ----
 // TypeError: (51-60): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/047_returning_arrays_in_structs_new_abi.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/047_returning_arrays_in_structs_new_abi.sol
@@ -2,7 +2,7 @@ pragma experimental ABIEncoderV2;
 
 contract C {
     struct S { string[] s; }
-    function f() public pure returns (S) {}
+    function f() public pure returns (S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/048_returning_arrays_in_structs_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/048_returning_arrays_in_structs_arrays.sol
@@ -1,6 +1,6 @@
 contract C {
     struct S { string[] s; }
-    function f() public pure returns (S x) {}
+    function f() public pure returns (S memory x) {}
 }
 // ----
-// TypeError: (80-83): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
+// TypeError: (80-90): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
@@ -1,7 +1,7 @@
 contract test {
-    function f(uint[] constant a) public { }
+    function f(uint[] memory constant a) public { }
 }
 // ----
-// TypeError: (31-48): Illegal use of "constant" specifier.
-// TypeError: (31-48): Constants of non-value type not yet implemented.
-// TypeError: (31-48): Uninitialized "constant" variable.
+// TypeError: (31-55): Illegal use of "constant" specifier.
+// TypeError: (31-55): Constants of non-value type not yet implemented.
+// TypeError: (31-55): Uninitialized "constant" variable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/208_assignment_mem_to_local_storage_variable.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/208_assignment_mem_to_local_storage_variable.sol
@@ -1,9 +1,9 @@
 contract C {
     uint[] data;
-    function f(uint[] x) public {
+    function f(uint[] memory x) public {
         uint[] storage dataRef = data;
         dataRef = x;
     }
 }
 // ----
-// TypeError: (121-122): Type uint256[] memory is not implicitly convertible to expected type uint256[] storage pointer.
+// TypeError: (128-129): Type uint256[] memory is not implicitly convertible to expected type uint256[] storage pointer.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/214_assignment_mem_storage_variable_directly.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/214_assignment_mem_storage_variable_directly.sol
@@ -1,6 +1,6 @@
 contract C {
     uint[] data;
-    function f(uint[] x) public {
+    function f(uint[] memory x) public {
         data = x;
     }
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/215_function_argument_mem_to_storage.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/215_function_argument_mem_to_storage.sol
@@ -1,9 +1,9 @@
 contract C {
     function f(uint[] storage x) private {
     }
-    function g(uint[] x) public {
+    function g(uint[] memory x) public {
         f(x);
     }
 }
 // ----
-// TypeError: (106-107): Invalid type for argument in function call. Invalid implicit conversion from uint256[] memory to uint256[] storage pointer requested.
+// TypeError: (113-114): Invalid type for argument in function call. Invalid implicit conversion from uint256[] memory to uint256[] storage pointer requested.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/216_function_argument_storage_to_mem.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/216_function_argument_storage_to_mem.sol
@@ -2,9 +2,9 @@ contract C {
     function f(uint[] storage x) private {
         g(x);
     }
-    function g(uint[] x) public {
+    function g(uint[] memory x) public {
     }
 }
 // ----
-// Warning: (91-99): Unused function parameter. Remove or comment out the variable name to silence this warning.
-// Warning: (80-115): Function state mutability can be restricted to pure
+// Warning: (91-106): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (80-122): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/224_string_bytes_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/224_string_bytes_conversion.sol
@@ -2,16 +2,16 @@ contract Test {
     string s;
     bytes b;
     function h(string _s) external { bytes(_s).length; }
-    function i(string _s) internal { bytes(_s).length; }
+    function i(string memory _s) internal { bytes(_s).length; }
     function j() internal { bytes(s).length; }
     function k(bytes _b) external { string(_b); }
-    function l(bytes _b) internal { string(_b); }
+    function l(bytes memory _b) internal { string(_b); }
     function m() internal { string(b); }
 }
 // ----
 // Warning: (47-99): Function state mutability can be restricted to pure
-// Warning: (104-156): Function state mutability can be restricted to pure
-// Warning: (161-203): Function state mutability can be restricted to view
-// Warning: (208-253): Function state mutability can be restricted to pure
-// Warning: (258-303): Function state mutability can be restricted to pure
-// Warning: (308-344): Function state mutability can be restricted to view
+// Warning: (104-163): Function state mutability can be restricted to pure
+// Warning: (168-210): Function state mutability can be restricted to view
+// Warning: (215-260): Function state mutability can be restricted to pure
+// Warning: (265-317): Function state mutability can be restricted to pure
+// Warning: (322-358): Function state mutability can be restricted to view

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/260_library_memory_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/260_library_memory_struct.sol
@@ -1,8 +1,8 @@
 pragma experimental ABIEncoderV2;
 library c {
     struct S { uint x; }
-    function f() public returns (S ) {}
+    function f() public returns (S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// Warning: (75-110): Function state mutability can be restricted to pure
+// Warning: (75-116): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/268_function_overload_array_type.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/268_function_overload_array_type.sol
@@ -1,4 +1,4 @@
 contract M {
-    function f(uint[]) public;
-    function f(int[]) public;
+    function f(uint[] memory) public;
+    function f(int[] memory) public;
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/270_inline_array_declaration_and_passing_implicit_conversion_strings.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/270_inline_array_declaration_and_passing_implicit_conversion_strings.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() public returns (string) {
+    function f() public returns (string memory) {
         string memory x = "Hello";
         string memory y = "World";
         string[2] memory z = [x, y];
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// Warning: (17-191): Function state mutability can be restricted to pure
+// Warning: (17-198): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/272_inline_array_declaration_const_string_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/272_inline_array_declaration_const_string_conversion.sol
@@ -1,8 +1,8 @@
 contract C {
-    function f() public returns (string) {
+    function f() public returns (string memory) {
         string[2] memory z = ["Hello", "World"];
         return (z[0]);
     }
 }
 // ----
-// Warning: (17-133): Function state mutability can be restricted to pure
+// Warning: (17-140): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/274_inline_array_declaration_no_type_strings.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/274_inline_array_declaration_no_type_strings.sol
@@ -1,7 +1,7 @@
 contract C {
-    function f() public returns (string) {
+    function f() public returns (string memory) {
         return (["foo", "man", "choo"][1]);
     }
 }
 // ----
-// Warning: (17-105): Function state mutability can be restricted to pure
+// Warning: (17-112): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/403_return_structs.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/403_return_structs.sol
@@ -2,9 +2,9 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct S { uint a; T[] sub; }
     struct T { uint[] x; }
-    function f() public returns (uint, S) {
+    function f() public returns (uint, S memory) {
     }
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// Warning: (112-157): Function state mutability can be restricted to pure
+// Warning: (112-164): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/404_read_returned_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/404_read_returned_struct.sol
@@ -4,7 +4,7 @@ contract A {
         int x;
         int y;
     }
-    function g() public returns (T) {
+    function g() public returns (T memory) {
         return this.g();
     }
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/477_too_large_arrays_for_calldata_internal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/477_too_large_arrays_for_calldata_internal.sol
@@ -1,6 +1,6 @@
 contract C {
-    function f(uint[85678901234] a) pure internal {
+    function f(uint[85678901234] memory a) pure internal {
     }
 }
 // ----
-// TypeError: (28-47): Array is too large to be encoded.
+// TypeError: (28-54): Array is too large to be encoded.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/478_too_large_arrays_for_calldata_public.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/478_too_large_arrays_for_calldata_public.sol
@@ -1,6 +1,6 @@
 contract C {
-    function f(uint[85678901234] a) pure public {
+    function f(uint[85678901234] memory a) pure public {
     }
 }
 // ----
-// TypeError: (28-47): Array is too large to be encoded.
+// TypeError: (28-54): Array is too large to be encoded.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/514_using_for_with_non_library.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/514_using_for_with_non_library.sol
@@ -2,7 +2,7 @@
 library L {
     struct S { uint d; }
     using S for S;
-    function f(S _s) internal {
+    function f(S memory _s) internal {
         _s.d = 1;
     }
 }

--- a/test/libsolidity/syntaxTests/structs/recursion/multi_struct_composition.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/multi_struct_composition.sol
@@ -9,7 +9,7 @@ contract C {
 
   struct W { uint x; }
 
-  function f(T) public pure { }
+  function f(T memory) public pure { }
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/recursion/parallel_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/parallel_structs.sol
@@ -9,7 +9,7 @@ contract TestContract
         SubStruct subStruct1;
         SubStruct subStruct2;
     }
-    function addTestStruct(TestStruct) public pure {}
+    function addTestStruct(TestStruct memory) public pure {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
@@ -1,6 +1,6 @@
 contract C {
     struct S { uint a; S[] sub; }
-    function f() public pure returns (uint, S) {
+    function f() public pure returns (uint, S memory) {
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
@@ -1,6 +1,6 @@
 contract C {
     struct S { uint a; S[2][] sub; }
-    function f() public pure returns (uint, S) {
+    function f() public pure returns (uint, S memory) {
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
@@ -1,8 +1,8 @@
 contract C {
     struct S { uint a; S[][][] sub; }
     struct T { S s; }
-    function f() public pure returns (uint x, T t) {
+    function f() public pure returns (uint x, T memory t) {
     }
 }
 // ----
-// TypeError: (119-122): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (119-129): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/tight_packing_literals.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals.sol
@@ -1,8 +1,8 @@
 contract C {
-    function k() pure public returns (bytes) {
+    function k() pure public returns (bytes memory) {
         return abi.encodePacked(1);
     }
 }
 
 // ----
-// Warning: (92-93): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.
+// Warning: (99-100): The type of "int_const 1" was inferred as uint8. This is probably not desired. Use an explicit type to silence this warning.

--- a/test/libsolidity/syntaxTests/tight_packing_literals_050.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals_050.sol
@@ -1,9 +1,9 @@
 pragma experimental "v0.5.0";
 contract C {
-    function k() pure public returns (bytes) {
+    function k() pure public returns (bytes memory) {
         return abi.encodePacked(1);
     }
 }
 
 // ----
-// TypeError: (122-123): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.
+// TypeError: (129-130): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.

--- a/test/libsolidity/syntaxTests/tight_packing_literals_fine.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals_fine.sol
@@ -1,8 +1,8 @@
 contract C {
-    function k() pure public returns (bytes) {
+    function k() pure public returns (bytes memory) {
         return abi.encodePacked(uint8(1));
     }
-    function l() pure public returns (bytes) {
+    function l() pure public returns (bytes memory) {
         return abi.encode(1);
     }
 }

--- a/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode.sol
+++ b/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() pure public returns (bytes r) {
+    function f() pure public returns (bytes memory r) {
         r = abi.encode(1, 2);
         r = abi.encodePacked(f());
         r = abi.encodeWithSelector(0x12345678, 1);

--- a/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode_arguments.sol
+++ b/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode_arguments.sol
@@ -3,34 +3,34 @@ contract C {
     function gView() public view returns (uint) { return x; }
     function gNonPayable() public returns (uint) { x = 4; return 0; }
 
-    function f1() view public returns (bytes) {
+    function f1() view public returns (bytes memory) {
         return abi.encode(gView());
     }
-    function f2() view public returns (bytes) {
+    function f2() view public returns (bytes memory) {
         return abi.encodePacked(gView());
     }
-    function f3() view public returns (bytes) {
+    function f3() view public returns (bytes memory) {
         return abi.encodeWithSelector(0x12345678, gView());
     }
-    function f4() view public returns (bytes) {
+    function f4() view public returns (bytes memory) {
         return abi.encodeWithSignature("f(uint256)", gView());
     }
-    function g1() public returns (bytes) {
+    function g1() public returns (bytes memory) {
         return abi.encode(gNonPayable());
     }
-    function g2() public returns (bytes) {
+    function g2() public returns (bytes memory) {
         return abi.encodePacked(gNonPayable());
     }
-    function g3() public returns (bytes) {
+    function g3() public returns (bytes memory) {
         return abi.encodeWithSelector(0x12345678, gNonPayable());
     }
-    function g4() public returns (bytes) {
+    function g4() public returns (bytes memory) {
         return abi.encodeWithSignature("f(uint256)", gNonPayable());
     }
     // This will generate the only warning.
-    function check() public returns (bytes) {
+    function check() public returns (bytes memory) {
         return abi.encode(2);
     }
 }
 // ----
-// Warning: (1044-1121): Function state mutability can be restricted to pure
+// Warning: (1100-1184): Function state mutability can be restricted to pure


### PR DESCRIPTION
Fixes #3402 

Only warns if the contract is a library, but can be changed to all contracts if needed.
Throws Type Error for 0.5.0.