### PR TITLE
Add option to output storage layout info for a contract

### DIFF
--- a/libsolidity/codegen/Compiler.h
+++ b/libsolidity/codegen/Compiler.h
@@ -81,6 +81,9 @@ public:
 	/// UndefinedItem if it does not exist yet.
 	eth::AssemblyItem functionEntryLabel(FunctionDefinition const& _function) const;
 
+	/// @returns all state variables along with their storage slot and byte offset of the value inside the slot.
+	std::map<Declaration const*, std::pair<u256, unsigned>> const& stateVariables() const { return m_context.stateVariables(); }
+
 private:
 	bool const m_optimize;
 	unsigned const m_optimizeRuns;

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -141,6 +141,8 @@ public:
 	unsigned currentToBaseStackOffset(unsigned _offset) const;
 	/// @returns pair of slot and byte offset of the value inside this slot.
 	std::pair<u256, unsigned> storageLocationOfVariable(Declaration const& _declaration) const;
+	/// @returns all state variables along with their storage slot and byte offset of the value inside the slot.
+	std::map<Declaration const*, std::pair<u256, unsigned>> const& stateVariables() const { return m_stateVariables; }
 
 	/// Appends a JUMPI instruction to a new tag and @returns the tag
 	eth::AssemblyItem appendConditionalJump() { return m_asm->appendJumpI().tag(); }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -40,6 +40,7 @@
 #include <libsolidity/codegen/Compiler.h>
 #include <libsolidity/formal/SMTChecker.h>
 #include <libsolidity/interface/ABI.h>
+#include <libsolidity/interface/StorageInfo.h>
 #include <libsolidity/interface/Natspec.h>
 #include <libsolidity/interface/GasEstimator.h>
 
@@ -475,6 +476,24 @@ Json::Value const& CompilerStack::natspecDev(Contract const& _contract) const
 		_contract.devDocumentation.reset(new Json::Value(Natspec::devDocumentation(*_contract.contract)));
 
 	return *_contract.devDocumentation;
+}
+
+Json::Value const& CompilerStack::storageInfo(string const& _contractName) const
+{
+	return storageInfo(contract(_contractName));
+}
+
+Json::Value const& CompilerStack::storageInfo(Contract const& _contract) const
+{
+	if (m_stackState < CompilationSuccessful)
+		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+
+	solAssert(_contract.contract, "");
+
+	// caches the result
+	if (!_contract.storageInfo)
+		_contract.storageInfo.reset(new Json::Value(StorageInfo::generate(*_contract.compiler)));
+	return *_contract.storageInfo;
 }
 
 Json::Value CompilerStack::methodIdentifiers(string const& _contractName) const

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -492,7 +492,7 @@ Json::Value const& CompilerStack::storageInfo(Contract const& _contract) const
 
 	// caches the result
 	if (!_contract.storageInfo)
-		_contract.storageInfo.reset(new Json::Value(StorageInfo::generate(*_contract.compiler)));
+		_contract.storageInfo.reset(new Json::Value(StorageInfo::generate(_contract.compiler.get())));
 	return *_contract.storageInfo;
 }
 

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -239,6 +239,10 @@ public:
 	/// @returns a JSON representing the estimated gas usage for contract creation, internal and external functions
 	Json::Value gasEstimates(std::string const& _contractName) const;
 
+	/// @returns a JSON representing the internal storage layout of the contract.
+	/// Prerequisite: Successful call to compile.
+	Json::Value const& storageInfo(std::string const& _contractName) const;
+
 private:
 	/**
 	 * Information pertaining to one source unit, filled gradually during parsing and compilation.
@@ -262,6 +266,7 @@ private:
 		mutable std::unique_ptr<Json::Value const> abi;
 		mutable std::unique_ptr<Json::Value const> userDocumentation;
 		mutable std::unique_ptr<Json::Value const> devDocumentation;
+		mutable std::unique_ptr<Json::Value const> storageInfo;
 		mutable std::unique_ptr<std::string const> sourceMapping;
 		mutable std::unique_ptr<std::string const> runtimeSourceMapping;
 	};
@@ -299,6 +304,7 @@ private:
 	Json::Value const& contractABI(Contract const&) const;
 	Json::Value const& natspecUser(Contract const&) const;
 	Json::Value const& natspecDev(Contract const&) const;
+	Json::Value const& storageInfo(Contract const&) const;
 
 	/// @returns the offset of the entry point of the given function into the list of assembly items
 	/// or zero if it is not found or does not exist.

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -520,8 +520,8 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 			contractData["userdoc"] = m_compilerStack.natspecUser(contractName);
 		if (isArtifactRequested(outputSelection, file, name, "devdoc"))
 			contractData["devdoc"] = m_compilerStack.natspecDev(contractName);
-		if (isArtifactRequested(outputSelection, file, name, "storage"))
-			contractData["storage"] = m_compilerStack.storageInfo(contractName);
+		if (isArtifactRequested(outputSelection, file, name, "storageLayoutMap"))
+			contractData["storageLayoutMap"] = m_compilerStack.storageInfo(contractName);
 
 		// EVM
 		Json::Value evmData(Json::objectValue);

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -510,7 +510,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 		string file = contractName.substr(0, colon);
 		string name = contractName.substr(colon + 1);
 
-		// ABI, documentation and metadata
+		// ABI, documentation, storage and metadata
 		Json::Value contractData(Json::objectValue);
 		if (isArtifactRequested(outputSelection, file, name, "abi"))
 			contractData["abi"] = m_compilerStack.contractABI(contractName);
@@ -520,6 +520,8 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 			contractData["userdoc"] = m_compilerStack.natspecUser(contractName);
 		if (isArtifactRequested(outputSelection, file, name, "devdoc"))
 			contractData["devdoc"] = m_compilerStack.natspecDev(contractName);
+		if (isArtifactRequested(outputSelection, file, name, "storage"))
+			contractData["storage"] = m_compilerStack.storageInfo(contractName);
 
 		// EVM
 		Json::Value evmData(Json::objectValue);

--- a/libsolidity/interface/StorageInfo.cpp
+++ b/libsolidity/interface/StorageInfo.cpp
@@ -34,28 +34,30 @@ Json::Value StorageInfo::generate(Compiler const& _compiler)
 
 	for (auto it: _compiler.stateVariables())
 	{
-		auto decl = (VariableDeclaration*)it.first;
-		auto location = it.second;
-		
-		Json::Value variable;
-		variable["name"] = decl->name();
-		variable["slot"] = location.first.str();
-		variable["offset"] = to_string(location.second);
-		variable["type"] = decl->type()->canonicalName();
-		variable["size"] = decl->type()->storageSize().str();
+		if (auto decl = dynamic_cast<VariableDeclaration const*>(it.first)) 
+		{
+			auto location = it.second;	
+			
+			Json::Value variable;
+			variable["name"] = decl->name();
+			variable["slot"] = location.first.str();
+			variable["offset"] = to_string(location.second);
+			variable["type"] = decl->type()->canonicalName();
+			variable["size"] = decl->type()->storageSize().str();
 
-		// Only include storageBytes if storageSize is 1, otherwise it always returns 32
-		if (decl->type()->storageSize() == 1) {
-			variable["bytes"] = to_string(decl->type()->storageBytes());
+			// Only include storageBytes if storageSize is 1, otherwise it always returns 32
+			if (decl->type()->storageSize() == 1) {
+				variable["bytes"] = to_string(decl->type()->storageBytes());
+			}
+			
+			// Assume that the parent scope of a state variable is a contract
+			auto parent = ((Declaration*)decl->scope());
+			if (parent != NULL) {
+				variable["contract"] = parent->name();
+			}
+			
+			storage.append(variable);
 		}
-		
-		// Assume that the parent scope of a state variable is a contract
-		auto parent = ((Declaration*)decl->scope());
-		if (parent != NULL) {
-			variable["contract"] = parent->name();
-		}
-		
-		storage.append(variable);
 	}
 
 	return storage;

--- a/libsolidity/interface/StorageInfo.cpp
+++ b/libsolidity/interface/StorageInfo.cpp
@@ -1,0 +1,62 @@
+/*
+        This file is part of solidity.
+
+        solidity is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+
+        solidity is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Santiago Palladino <spalladino@gmail.com>
+ * @date 2018
+ * Outputs contract storage layout information
+ */
+
+#include <libsolidity/interface/StorageInfo.h>
+#include <libsolidity/codegen/Compiler.h>
+#include <libsolidity/ast/AST.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+Json::Value StorageInfo::generate(Compiler const& _compiler)
+{
+	Json::Value storage(Json::arrayValue);
+
+	for (auto it: _compiler.stateVariables())
+	{
+		auto decl = (VariableDeclaration*)it.first;
+		auto location = it.second;
+		
+		Json::Value variable;
+		variable["name"] = decl->name();
+		variable["slot"] = location.first.str();
+		variable["offset"] = to_string(location.second);
+		variable["type"] = decl->type()->canonicalName();
+		variable["size"] = decl->type()->storageSize().str();
+
+		// Only include storageBytes if storageSize is 1, otherwise it always returns 32
+		if (decl->type()->storageSize() == 1) {
+			variable["bytes"] = to_string(decl->type()->storageBytes());
+		}
+		
+		// Assume that the parent scope of a state variable is a contract
+		auto parent = ((Declaration*)decl->scope());
+		if (parent != NULL) {
+			variable["contract"] = parent->name();
+		}
+		
+		storage.append(variable);
+	}
+
+	return storage;
+}

--- a/libsolidity/interface/StorageInfo.cpp
+++ b/libsolidity/interface/StorageInfo.cpp
@@ -28,11 +28,15 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity;
 
-Json::Value StorageInfo::generate(Compiler const& _compiler)
+Json::Value StorageInfo::generate(Compiler const* _compiler)
 {
 	Json::Value storage(Json::arrayValue);
+	
+	if(_compiler == NULL) {
+		return storage;
+	}
 
-	for (auto it: _compiler.stateVariables())
+	for (auto it: _compiler->stateVariables())
 	{
 		if (auto decl = dynamic_cast<VariableDeclaration const*>(it.first)) 
 		{

--- a/libsolidity/interface/StorageInfo.cpp
+++ b/libsolidity/interface/StorageInfo.cpp
@@ -59,6 +59,32 @@ Json::Value StorageInfo::generate(Compiler const* _compiler)
 			if (parent != NULL) {
 				variable["contract"] = parent->name();
 			}
+
+			// If this is a struct, visit its members
+			if (decl->type()->category() == Type::Category::Struct) 
+			{
+				auto structType = static_pointer_cast<const StructType>(decl->type());
+				Json::Value members(Json::arrayValue);
+				
+				for(auto member: structType->members(nullptr)) 
+				{
+					Json::Value memberData;
+					
+					auto offsets = structType->storageOffsetsOfMember(member.name);
+					memberData["name"] = member.name;
+					memberData["slot"] = offsets.first.str();
+					memberData["offset"] = to_string(offsets.second);
+					memberData["type"] = member.type->canonicalName();
+					memberData["size"] = member.type->storageSize().str();
+					if (member.type->storageSize() == 1) {
+						memberData["bytes"] = to_string(member.type->storageBytes());
+					}
+
+					members.append(memberData);
+				}
+
+				variable["storage"] = members;
+			}
 			
 			storage.append(variable);
 		}

--- a/libsolidity/interface/StorageInfo.h
+++ b/libsolidity/interface/StorageInfo.h
@@ -42,6 +42,9 @@ public:
 	/// @param _compiler The compiler used for the contract
 	/// @return          A JSON representation of the contract's storage layout
 	static Json::Value generate(Compiler const* _compiler);
+
+private:
+	static Json::Value processStructMembers(StructType const& structType);
 };
 }
 }

--- a/libsolidity/interface/StorageInfo.h
+++ b/libsolidity/interface/StorageInfo.h
@@ -45,6 +45,7 @@ public:
 
 private:
 	static Json::Value processStructMembers(StructType const& structType);
+	static Json::Value processMember(MemberList::Member const& member, std::pair<u256, unsigned> const& location);
 };
 }
 }

--- a/libsolidity/interface/StorageInfo.h
+++ b/libsolidity/interface/StorageInfo.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @author Santiago Palladino <spalladino@gmail.com>
+ * @date 2018
+ * Outputs contract storage layout information
+ */
+
+#pragma once
+
+#include <string>
+#include <memory>
+#include <json/json.h>
+#include <libsolidity/codegen/Compiler.h>
+
+namespace dev
+{
+namespace solidity
+{
+
+// Forward declarations
+class Compiler;
+
+class StorageInfo
+{
+public:
+	/// Get the storage layout of a contract
+	/// @param _compiler The compiler used for the contract
+	/// @return          A JSON representation of the contract's storage layout
+	static Json::Value generate(Compiler const& _compiler);
+};
+}
+}

--- a/libsolidity/interface/StorageInfo.h
+++ b/libsolidity/interface/StorageInfo.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <json/json.h>
 #include <libsolidity/codegen/Compiler.h>
+#include <libsolidity/ast/Types.h>
 
 namespace dev
 {
@@ -44,7 +45,7 @@ public:
 	static Json::Value generate(Compiler const* _compiler);
 
 private:
-	static Json::Value processStructMembers(StructType const& structType);
+	static Json::Value processType(TypePointer const& type);
 	static Json::Value processMember(MemberList::Member const& member, std::pair<u256, unsigned> const& location);
 };
 }

--- a/libsolidity/interface/StorageInfo.h
+++ b/libsolidity/interface/StorageInfo.h
@@ -41,7 +41,7 @@ public:
 	/// Get the storage layout of a contract
 	/// @param _compiler The compiler used for the contract
 	/// @return          A JSON representation of the contract's storage layout
-	static Json::Value generate(Compiler const& _compiler);
+	static Json::Value generate(Compiler const* _compiler);
 };
 }
 }

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -112,6 +112,7 @@ static string const g_strSources = "sources";
 static string const g_strSourceList = "sourceList";
 static string const g_strSrcMap = "srcmap";
 static string const g_strSrcMapRuntime = "srcmap-runtime";
+static string const g_strStorageInfo = "storage-layout";
 static string const g_strStandardJSON = "standard-json";
 static string const g_strStrictAssembly = "strict-assembly";
 static string const g_strPrettyJson = "pretty-json";
@@ -172,7 +173,8 @@ static set<string> const g_combinedJsonArgs
 	g_strOpcodes,
 	g_strSignatureHashes,
 	g_strSrcMap,
-	g_strSrcMapRuntime
+	g_strSrcMapRuntime,
+	g_strStorageInfo
 };
 
 /// Possible arguments to for --machine
@@ -932,6 +934,8 @@ void CommandLineInterface::handleCombinedJSON()
 			contractData[g_strNatspecDev] = dev::jsonCompactPrint(m_compiler->natspecDev(contractName));
 		if (requests.count(g_strNatspecUser))
 			contractData[g_strNatspecUser] = dev::jsonCompactPrint(m_compiler->natspecUser(contractName));
+		if (requests.count(g_strStorageInfo))
+			contractData[g_strStorageInfo] = dev::jsonCompactPrint(m_compiler->storageInfo(contractName));
 	}
 
 	bool needsSourceList = requests.count(g_strAst) || requests.count(g_strSrcMap) || requests.count(g_strSrcMapRuntime);

--- a/test/libsolidity/SolidityStorageInfoJson.cpp
+++ b/test/libsolidity/SolidityStorageInfoJson.cpp
@@ -267,6 +267,21 @@ BOOST_AUTO_TEST_CASE(multiple_inheritance_test)
 	checkInterface(sourceCode, interface);
 }
 
+BOOST_AUTO_TEST_CASE(abstract_contract_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint a;
+			function f() internal;
+		}
+	)";
+
+	char const* interface = R"([
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityStorageInfoJson.cpp
+++ b/test/libsolidity/SolidityStorageInfoJson.cpp
@@ -212,10 +212,78 @@ BOOST_AUTO_TEST_CASE(struct_test)
 
 	char const* interface = R"JSON([
 		{ 
-			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "2",
-			"storage": [
+			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "2", "storage": [
 				{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
 				{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
+			]
+		}
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(nested_struct_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			struct bar {
+				uint a;
+				uint b;
+			}
+			struct foo {
+				bar a;
+				uint b;
+			}
+			foo f;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ 
+			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "3", "storage": [
+				{ "name": "a", "offset": "0", "slot": "0", "type": "test.bar", "size": "2", "storage": [
+					{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
+					{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }	
+				] },
+				{ "name": "b", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" }
+			]
+		}
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(deeply_nested_struct_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			struct grandchild {
+				uint a;
+				uint b;
+			}
+			struct child {
+				grandchild a;
+				uint b;
+			}
+			struct foo {
+				child a;
+				uint b;
+			}
+			foo f;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ 
+			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "4", "storage": [
+				{ "name": "a", "offset": "0", "slot": "0", "type": "test.child", "size": "3", "storage": [
+					{ "name": "a", "offset": "0", "slot": "0", "type": "test.grandchild", "size": "2", "storage": [
+						{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
+						{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }	
+					]},
+					{ "name": "b", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" }
+				] },
+				{ "name": "b", "offset": "0", "slot": "3", "type": "uint256", "size": "1", "bytes": "32" }
 			]
 		}
 	])JSON";

--- a/test/libsolidity/SolidityStorageInfoJson.cpp
+++ b/test/libsolidity/SolidityStorageInfoJson.cpp
@@ -211,7 +211,13 @@ BOOST_AUTO_TEST_CASE(struct_test)
 	)";
 
 	char const* interface = R"JSON([
-		{ "name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "2" }
+		{ 
+			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "2",
+			"storage": [
+				{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
+				{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
+			]
+		}
 	])JSON";
 
 	checkInterface(sourceCode, interface);

--- a/test/libsolidity/SolidityStorageInfoJson.cpp
+++ b/test/libsolidity/SolidityStorageInfoJson.cpp
@@ -1,0 +1,274 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <test/Options.h>
+#include <libsolidity/interface/CompilerStack.h>
+#include <libdevcore/Exceptions.h>
+#include <libdevcore/JSON.h>
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+class JSONStorageChecker
+{
+public:
+	JSONStorageChecker(): m_compilerStack() {}
+
+	void checkInterface(std::string const& _code, std::string const& _expectedStorageString)
+	{
+		m_compilerStack.reset(false);
+		m_compilerStack.addSource("", "pragma solidity >=0.0;\n" + _code);
+		m_compilerStack.setEVMVersion(dev::test::Options::get().evmVersion());
+		m_compilerStack.setOptimiserSettings(dev::test::Options::get().optimize);
+		BOOST_REQUIRE_MESSAGE(m_compilerStack.compile(), "Compiling contract failed");
+
+		Json::Value generatedStorage = m_compilerStack.storageInfo(m_compilerStack.lastContractName());
+		Json::Value expectedStorage;
+		BOOST_REQUIRE(jsonParseStrict(_expectedStorageString, expectedStorage));
+
+		// Sort both expected and generated json arrays before comparison, as we don't care about the order
+		std::vector<Json::Value> generated(generatedStorage.begin(), generatedStorage.end());
+		std::vector<Json::Value> expected(expectedStorage.begin(), expectedStorage.end());
+		std::sort(generated.begin(), generated.end());
+		std::sort(expected.begin(), expected.end());
+
+		BOOST_CHECK_MESSAGE(
+			expected == generated,
+			"Expected:\n" << expectedStorage.toStyledString() <<
+			"\n but got:\n" << generatedStorage.toStyledString()
+		);
+	}
+
+protected:
+	CompilerStack m_compilerStack;
+};
+
+BOOST_FIXTURE_TEST_SUITE(SolidityStorageInfoJSON, JSONStorageChecker)
+
+BOOST_AUTO_TEST_CASE(single_var_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint a;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "a", "contract": "test", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_var_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint a;
+			uint b;
+			uint c;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "a", "contract": "test", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
+		{ "name": "b", "contract": "test", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" },
+		{ "name": "c", "contract": "test", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(packing_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint64  a;
+			uint64  b;
+			uint128 c;
+			uint256 d;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", "type": "uint64",  "size": "1", "bytes": "8" },
+		{ "name": "b", "contract": "test", "offset": "8",  "slot": "0", "type": "uint64",  "size": "1", "bytes": "8" },
+		{ "name": "c", "contract": "test", "offset": "16", "slot": "0", "type": "uint128", "size": "1", "bytes": "16" },
+		{ "name": "d", "contract": "test", "offset": "0",  "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(bool_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			bool a;
+			bool b;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", "type": "bool", "size": "1", "bytes": "1" },
+		{ "name": "b", "contract": "test", "offset": "1",  "slot": "0", "type": "bool", "size": "1", "bytes": "1" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(string_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			string a;
+			string b;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", "type": "string", "size": "1", "bytes": "32" },
+		{ "name": "b", "contract": "test", "offset": "0",  "slot": "1", "type": "string", "size": "1", "bytes": "32" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(array_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint[10] arr;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ "name": "arr", "contract": "test", "offset": "0", "slot": "0", "type": "uint256[10]", "size": "10" }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(dynamic_array_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			uint[] arr;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ "name": "arr", "contract": "test", "offset": "0", "slot": "0", "type": "uint256[]", "size": "1", "bytes": "32" }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+
+BOOST_AUTO_TEST_CASE(mapping_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			mapping(uint => uint) m;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ "name": "m", "contract": "test", "offset": "0", "slot": "0", "type": "mapping(uint256 => uint256)", "size": "1", "bytes": "32" }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(struct_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			struct foo {
+				uint a;
+				uint b;
+			}
+			foo f;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ "name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "2" }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(inheritance_test)
+{
+	char const* sourceCode = R"(
+		contract base {
+			uint a;
+		}
+
+		contract test is base {
+			uint b;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "a", "contract": "base", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
+		{ "name": "b", "contract": "test", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(multiple_inheritance_test)
+{
+	char const* sourceCode = R"(
+		contract base {
+			uint b;
+		}
+
+		contract child1 is base {
+			uint c1;
+		}
+
+		contract child2 is base {
+			uint c2;
+		}
+		
+		contract test is child1, child2 {
+			uint t;
+		}
+	)";
+
+	char const* interface = R"([
+		{ "name": "b",  "contract": "base",   "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
+		{ "name": "c1", "contract": "child1", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" },
+		{ "name": "c2", "contract": "child2", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" },
+		{ "name": "t",  "contract": "test",   "offset": "0", "slot": "3", "type": "uint256", "size": "1", "bytes": "32" }
+	])";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}
+}

--- a/test/libsolidity/SolidityStorageInfoJson.cpp
+++ b/test/libsolidity/SolidityStorageInfoJson.cpp
@@ -72,7 +72,9 @@ BOOST_AUTO_TEST_CASE(single_var_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "a", "contract": "test", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" }
+		{ "name": "a", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "uint256", "size": "1", "bytes": "32" }
+		}
 	])";
 
 	checkInterface(sourceCode, interface);
@@ -89,9 +91,12 @@ BOOST_AUTO_TEST_CASE(multiple_var_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "a", "contract": "test", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
-		{ "name": "b", "contract": "test", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" },
-		{ "name": "c", "contract": "test", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" }
+		{ "name": "a", "contract": "test", "offset": "0", "slot": "0",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } },
+		{ "name": "b", "contract": "test", "offset": "0", "slot": "1",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } },
+		{ "name": "c", "contract": "test", "offset": "0", "slot": "2",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } }
 	])";
 
 	checkInterface(sourceCode, interface);
@@ -109,10 +114,14 @@ BOOST_AUTO_TEST_CASE(packing_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", "type": "uint64",  "size": "1", "bytes": "8" },
-		{ "name": "b", "contract": "test", "offset": "8",  "slot": "0", "type": "uint64",  "size": "1", "bytes": "8" },
-		{ "name": "c", "contract": "test", "offset": "16", "slot": "0", "type": "uint128", "size": "1", "bytes": "16" },
-		{ "name": "d", "contract": "test", "offset": "0",  "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
+		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0",
+			"type": { "name": "uint64",  "size": "1", "bytes": "8"  } },
+		{ "name": "b", "contract": "test", "offset": "8",  "slot": "0",
+			"type": { "name": "uint64",  "size": "1", "bytes": "8"  } },
+		{ "name": "c", "contract": "test", "offset": "16", "slot": "0",
+			"type": { "name": "uint128", "size": "1", "bytes": "16" } },
+		{ "name": "d", "contract": "test", "offset": "0",  "slot": "1",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } }
 	])";
 
 	checkInterface(sourceCode, interface);
@@ -128,8 +137,10 @@ BOOST_AUTO_TEST_CASE(bool_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", "type": "bool", "size": "1", "bytes": "1" },
-		{ "name": "b", "contract": "test", "offset": "1",  "slot": "0", "type": "bool", "size": "1", "bytes": "1" }
+		{ "name": "a", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "bool", "size": "1", "bytes": "1" } },
+		{ "name": "b", "contract": "test", "offset": "1", "slot": "0", 
+			"type": { "name": "bool", "size": "1", "bytes": "1" } }
 	])";
 
 	checkInterface(sourceCode, interface);
@@ -145,8 +156,10 @@ BOOST_AUTO_TEST_CASE(string_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", "type": "string", "size": "1", "bytes": "32" },
-		{ "name": "b", "contract": "test", "offset": "0",  "slot": "1", "type": "string", "size": "1", "bytes": "32" }
+		{ "name": "a", "contract": "test", "offset": "0",  "slot": "0", 
+			"type": { "name": "string", "size": "1", "bytes": "32" } },
+		{ "name": "b", "contract": "test", "offset": "0",  "slot": "1", 
+			"type": { "name": "string", "size": "1", "bytes": "32" } }
 	])";
 
 	checkInterface(sourceCode, interface);
@@ -161,7 +174,9 @@ BOOST_AUTO_TEST_CASE(array_test)
 	)";
 
 	char const* interface = R"JSON([
-		{ "name": "arr", "contract": "test", "offset": "0", "slot": "0", "type": "uint256[10]", "size": "10" }
+		{ "name": "arr", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "uint256[10]", "size": "10",
+								"base": { "name": "uint256", "size": "1", "bytes": "32" } } }
 	])JSON";
 
 	checkInterface(sourceCode, interface);
@@ -176,7 +191,9 @@ BOOST_AUTO_TEST_CASE(dynamic_array_test)
 	)";
 
 	char const* interface = R"JSON([
-		{ "name": "arr", "contract": "test", "offset": "0", "slot": "0", "type": "uint256[]", "size": "1", "bytes": "32" }
+		{ "name": "arr", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "uint256[]", "size": "1", "bytes": "32",
+								"base": { "name": "uint256", "size": "1", "bytes": "32" } } }
 	])JSON";
 
 	checkInterface(sourceCode, interface);
@@ -187,12 +204,15 @@ BOOST_AUTO_TEST_CASE(mapping_test)
 {
 	char const* sourceCode = R"(
 		contract test {
-			mapping(uint => uint) m;
+			mapping(uint => uint128) m;
 		}
 	)";
 
 	char const* interface = R"JSON([
-		{ "name": "m", "contract": "test", "offset": "0", "slot": "0", "type": "mapping(uint256 => uint256)", "size": "1", "bytes": "32" }
+		{ "name": "m", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "mapping(uint256 => uint128)", "size": "1", "bytes": "32",
+								"key":   { "name": "uint256", "size": "1", "bytes": "32" },
+								"value": { "name": "uint128", "size": "1", "bytes": "16" } } }
 	])JSON";
 
 	checkInterface(sourceCode, interface);
@@ -211,12 +231,13 @@ BOOST_AUTO_TEST_CASE(struct_test)
 	)";
 
 	char const* interface = R"JSON([
-		{ 
-			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "2", "storage": [
-				{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
-				{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
-			]
-		}
+		{ "name": "f", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "test.foo", "size": "2", 
+								"members": [
+									{ "name": "a", "offset": "0", "slot": "0", 
+										"type": {"name": "uint256", "size": "1", "bytes": "32" } },
+									{ "name": "b", "offset": "0", "slot": "1",
+										"type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } }
 	])JSON";
 
 	checkInterface(sourceCode, interface);
@@ -239,15 +260,18 @@ BOOST_AUTO_TEST_CASE(nested_struct_test)
 	)";
 
 	char const* interface = R"JSON([
-		{ 
-			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "3", "storage": [
-				{ "name": "a", "offset": "0", "slot": "0", "type": "test.bar", "size": "2", "storage": [
-					{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
-					{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }	
-				] },
-				{ "name": "b", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" }
-			]
-		}
+		{ "name": "f", "contract": "test", "offset": "0", "slot": "0",
+			"type": { "name": "test.foo", "size": "3",
+								"members": [
+									{ "name": "a", "offset": "0", "slot": "0", 
+										"type": {"name": "test.bar", "size": "2", 
+										"members": [
+											{ "name": "a", "offset": "0", "slot": "0", 
+												"type": {"name": "uint256", "size": "1", "bytes": "32" } },
+											{ "name": "b", "offset": "0", "slot": "1", 
+												"type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } },
+									{ "name": "b", "offset": "0", "slot": "2", 
+										"type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } }
 	])JSON";
 
 	checkInterface(sourceCode, interface);
@@ -274,18 +298,99 @@ BOOST_AUTO_TEST_CASE(deeply_nested_struct_test)
 	)";
 
 	char const* interface = R"JSON([
-		{ 
-			"name": "f", "contract": "test", "offset": "0", "slot": "0", "type": "test.foo", "size": "4", "storage": [
-				{ "name": "a", "offset": "0", "slot": "0", "type": "test.child", "size": "3", "storage": [
-					{ "name": "a", "offset": "0", "slot": "0", "type": "test.grandchild", "size": "2", "storage": [
-						{ "name": "a", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
-						{ "name": "b", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }	
-					]},
-					{ "name": "b", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" }
-				] },
-				{ "name": "b", "offset": "0", "slot": "3", "type": "uint256", "size": "1", "bytes": "32" }
-			]
+    { "name": "f", "contract": "test", "offset": "0", "slot": "0",
+			"type": { "name": "test.foo", "size": "4",
+								"members": [
+									{ "name": "a", "offset": "0", "slot": "0", 
+										"type": { "name": "test.child", "size": "3", 
+                              "members": [
+                                { "name": "a", "offset": "0", "slot": "0", 
+                                  "type": { "name": "test.grandchild", "size": "2",
+                                            "members": [
+                                              { "name": "a", "offset": "0", "slot": "0", 
+                                                "type": {"name": "uint256", "size": "1", "bytes": "32" } },
+                                              { "name": "b", "offset": "0", "slot": "1", 
+                                                "type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } },
+                                { "name": "b", "offset": "0", "slot": "2", 
+                                  "type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } },
+                  { "name": "b", "offset": "0", "slot": "3", 
+                    "type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(recursive_struct_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			struct Foo {
+				Bar[] bars;
+			}
+			struct Bar {
+				Foo foo;
+			}
+			Bar b;
 		}
+	)";
+
+	// Recursive structs are not visited
+	char const* interface = R"JSON([
+		{ "name": "b", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "test.Bar", "size": "1", "bytes": "32" } }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(dynamic_array_of_struct_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			struct foo {
+				uint a;
+				uint b;
+			}
+			foo[] foos;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ "name": "foos", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "test.foo[]", "size": "1", "bytes": "32",
+								"base": { "name": "test.foo", "size": "2",
+													"members": [
+														{ "name": "a", "offset": "0", "slot": "0", 
+															"type": {"name": "uint256", "size": "1", "bytes": "32" } },
+														{ "name": "b", "offset": "0", "slot": "1",
+															"type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } } }
+	])JSON";
+
+	checkInterface(sourceCode, interface);
+}
+
+BOOST_AUTO_TEST_CASE(mapping_of_struct_test)
+{
+	char const* sourceCode = R"(
+		contract test {
+			struct foo {
+				uint a;
+				uint b;
+			}
+			mapping(string => foo) foos;
+		}
+	)";
+
+	char const* interface = R"JSON([
+		{ "name": "foos", "contract": "test", "offset": "0", "slot": "0", 
+			"type": { "name": "mapping(string => test.foo)", "size": "1", "bytes": "32",
+								"key":   { "name": "string", "size": "1", "bytes": "32" },
+								"value": { "name": "test.foo", "size": "2",
+													 "members": [
+														{ "name": "a", "offset": "0", "slot": "0", 
+															"type": {"name": "uint256", "size": "1", "bytes": "32" } },
+														{ "name": "b", "offset": "0", "slot": "1",
+															"type": {"name": "uint256", "size": "1", "bytes": "32" } } ] } } }
 	])JSON";
 
 	checkInterface(sourceCode, interface);
@@ -304,8 +409,10 @@ BOOST_AUTO_TEST_CASE(inheritance_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "a", "contract": "base", "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
-		{ "name": "b", "contract": "test", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" }
+		{ "name": "a", "contract": "base", "offset": "0", "slot": "0",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } },
+		{ "name": "b", "contract": "test", "offset": "0", "slot": "1",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } }
 	])";
 
 	checkInterface(sourceCode, interface);
@@ -332,10 +439,14 @@ BOOST_AUTO_TEST_CASE(multiple_inheritance_test)
 	)";
 
 	char const* interface = R"([
-		{ "name": "b",  "contract": "base",   "offset": "0", "slot": "0", "type": "uint256", "size": "1", "bytes": "32" },
-		{ "name": "c1", "contract": "child1", "offset": "0", "slot": "1", "type": "uint256", "size": "1", "bytes": "32" },
-		{ "name": "c2", "contract": "child2", "offset": "0", "slot": "2", "type": "uint256", "size": "1", "bytes": "32" },
-		{ "name": "t",  "contract": "test",   "offset": "0", "slot": "3", "type": "uint256", "size": "1", "bytes": "32" }
+		{ "name": "b",  "contract": "base",   "offset": "0", "slot": "0",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } },
+		{ "name": "c1", "contract": "child1", "offset": "0", "slot": "1",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } },
+		{ "name": "c2", "contract": "child2", "offset": "0", "slot": "2",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } },
+		{ "name": "t",  "contract": "test",   "offset": "0", "slot": "3",
+			"type": { "name": "uint256", "size": "1", "bytes": "32" } }
 	])";
 
 	checkInterface(sourceCode, interface);


### PR DESCRIPTION
This PR adds new options to the solc command line interface and standard json interface to output information on the storage layout of a compiled contract in JSON format. 

I'd really appreciate any feedback!

Fixes #3736.

### Use case

In [zeppelin_os](https://github.com/zeppelinos/) we are working on [upgradeability patterns](https://blog.zeppelinos.org/proxy-patterns/) using proxies. To make a long story short, all contract instances are actually proxies that hold the state and `DELEGATECALL` into a single contract acting as a backing implementation. To upgrade the proxy, we simply change the address of the backing implementation to a different one.

However, for two implementations to be "compatible", they **must** share the same storage layout (ie the state variables must have been assigned the same slots in both implementations). Otherwise, when the new implementation attempts to read a storage variable set from the previous one, it may end up reading an incorrect value.

Even though it is possible to infer the position of each variable by manually linearizing the inheritance chain, and assuming that the compiler will honor the ordering in which the state vars were declared, this approach is brittle and could break, should the compiler start optimizing storage layouts (for instance, in order to pack small-sized variables in a single slot). Having this information provided directly by the compiler is a much safer approach.

### Implementation

The information is already collected in [`CompilerContext#m_stateVariables`](https://github.com/spalladino/solidity/blob/storage-info/libsolidity/codegen/CompilerContext.h#L307). This PR just adds a new class `StorageInfo` that reads that information and yields a JSON array with all the relevant information:

```json
[{
  "name": "myvar",
  "contract": "Test",
  "offset": "0",
  "slot": "0",
  "type": "uint256",
  "size": "1",
  "bytes": "32"
}]
```

Note that this involves exposing the internal `m_stateVariables` field of `CompilerContext`, of type `std::map<Declaration const*, std::pair<u256, unsigned>>`, which could be considered as breaking encapsulation. If so, this could be abstracted by exposing an iterator that yields a struct containing the `VariableDeclaration`, `position`, and `offset`, that provides the same information as the map, without revealing the underlying implementation. Not sure if it would be overdesigning, so I left it as simple as possible for now.

### Interface

Adds a new `storage-layout` argument to the combined-json option of the command-line interface:

```bash
$ solc ~/Projects/zeppelin-solidity/contracts/DayLimit.sol --combined-json storage-layout  | jq .
```

```json
{
  "contracts": {
    "/home/spalladino/Projects/zeppelin-solidity/contracts/DayLimit.sol:DayLimit": {
      "storage-layout": "[{\"bytes\":\"32\",\"contract\":\"DayLimit\",\"name\":\"dailyLimit\",\"offset\":\"0\",\"size\":\"1\",\"slot\":\"0\",\"type\":\"uint256\"},{\"bytes\":\"32\",\"contract\":\"DayLimit\",\"name\":\"spentToday\",\"offset\":\"0\",\"size\":\"1\",\"slot\":\"1\",\"type\":\"uint256\"},{\"bytes\":\"32\",\"contract\":\"DayLimit\",\"name\":\"lastDay\",\"offset\":\"0\",\"size\":\"1\",\"slot\":\"2\",\"type\":\"uint256\"}]"
    }
  },
  "version": "0.4.24-develop.2018.4.29+commit.cf59d217.mod.Linux.g++"
}
```

The storage-layout info is packed as a string in the combined json, same as the ABI, natspec, or other similar attributes.

As for the JSON interface, adds a `storage` outputSelection setting:

```bash
$ echo '{"language":"Solidity","sources":{"DayLimit.sol":{"urls":["/home/spalladino/Projects/zeppelin-solidity/contracts/DayLimit.sol"]}},"settings":{"outputSelection":{"*":{"*":["storage"]}}}}' | ./build/solc/solc --standard-json --allow-paths="/home/spalladino/Projects/zeppelin-solidity/contracts" | jq .
```

```json
{
  "contracts": {
    "DayLimit.sol": {
      "DayLimit": {
        "evm": {},
        "storage": [
          {
            "bytes": "32",
            "contract": "DayLimit",
            "name": "dailyLimit",
            "offset": "0",
            "size": "1",
            "slot": "0",
            "type": "uint256"
          },
          {
            "bytes": "32",
            "contract": "DayLimit",
            "name": "spentToday",
            "offset": "0",
            "size": "1",
            "slot": "1",
            "type": "uint256"
          },
          {
            "bytes": "32",
            "contract": "DayLimit",
            "name": "lastDay",
            "offset": "0",
            "size": "1",
            "slot": "2",
            "type": "uint256"
          }
        ]
      }
    }
  },
  "errors": [ ... ],
  "sources": {
    "DayLimit.sol": {
      "id": 0
    }
  }
}
```