### PR TITLE
Install a different jsoncpp version on cirleci to ensure compilation never clashes with the internal one

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -129,6 +129,7 @@ jobs:
           command: |
             apt-get -qq update
             apt-get -qy install cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libz3-dev
+            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
       - run: *setup_prerelease_commit_hash
       - run: *run_build
       - store_artifacts: *solc_artifact
@@ -150,6 +151,8 @@ jobs:
             brew install z3
             brew install boost
             brew install cmake
+            brew install wget
+            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
       - run: *setup_prerelease_commit_hash
       - run: *run_build
       - store_artifacts: *solc_artifact

--- a/scripts/install_obsolete_jsoncpp_1_7_4.sh
+++ b/scripts/install_obsolete_jsoncpp_1_7_4.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+TEMPDIR=$(mktemp -d)
+(
+    cd $TEMPDIR
+    wget https://github.com/open-source-parsers/jsoncpp/archive/1.7.4.tar.gz
+    tar xvzf "1.7.4.tar.gz"
+    cd "jsoncpp-1.7.4"
+    mkdir -p build
+    cd build
+    cmake -DARCHIVE_INSTALL_DIR=. -G "Unix Makefiles" ..
+    make
+    make install
+)
+rm -rf $TEMPDIR


### PR DESCRIPTION
Fixes #3934.

Tested on circleci for build_x86_linux. The installed jsoncpp is 1.7.4. However, I cannot test on circleci for mac since this requires mac plan.