### PR TITLE
[BREAKING] Allocate local variables according to their scope

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,7 @@ Compiler Features:
  * C API (``libsolc``): Export the ``solidity_license``, ``solidity_version`` and ``solidity_compile`` methods.
  * Type Checker: Show named argument in case of error.
  * Tests: Determine transaction status during IPC calls.
+ * Code Generator: Allocate and free local variables according to their scope.
 
 Bugfixes:
  * Tests: Fix chain parameters to make ipc tests work with newer versions of cpp-ethereum.

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -128,6 +128,8 @@ void CompilerContext::addVariable(VariableDeclaration const& _declaration,
 {
 	solAssert(m_asm->deposit() >= 0 && unsigned(m_asm->deposit()) >= _offsetToCurrent, "");
 	unsigned sizeOnStack = _declaration.annotation().type->sizeOnStack();
+	// Variables should not have stack size other than [1, 2],
+	// but that might change when new types are introduced.
 	solAssert(sizeOnStack == 1 || sizeOnStack == 2, "");
 	m_localVariables[&_declaration].push_back(unsigned(m_asm->deposit()) - _offsetToCurrent);
 }
@@ -146,11 +148,17 @@ void CompilerContext::removeVariablesAboveStackHeight(unsigned _stackHeight)
 	for (auto _var: m_localVariables)
 	{
 		solAssert(!_var.second.empty(), "");
+		solAssert(_var.second.back() <= stackHeight(), "");
 		if (_var.second.back() >= _stackHeight)
 			toRemove.push_back(_var.first);
 	}
 	for (auto _var: toRemove)
 		removeVariable(*_var);
+}
+
+unsigned CompilerContext::numberOfLocalVariables() const
+{
+	return m_localVariables.size();
 }
 
 eth::Assembly const& CompilerContext::compiledContract(const ContractDefinition& _contract) const

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -127,6 +127,8 @@ void CompilerContext::addVariable(VariableDeclaration const& _declaration,
 								  unsigned _offsetToCurrent)
 {
 	solAssert(m_asm->deposit() >= 0 && unsigned(m_asm->deposit()) >= _offsetToCurrent, "");
+	unsigned sizeOnStack = _declaration.annotation().type->sizeOnStack();
+	solAssert(sizeOnStack == 1 || sizeOnStack == 2, "");
 	m_localVariables[&_declaration].push_back(unsigned(m_asm->deposit()) - _offsetToCurrent);
 }
 

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -130,12 +130,25 @@ void CompilerContext::addVariable(VariableDeclaration const& _declaration,
 	m_localVariables[&_declaration].push_back(unsigned(m_asm->deposit()) - _offsetToCurrent);
 }
 
-void CompilerContext::removeVariable(VariableDeclaration const& _declaration)
+void CompilerContext::removeVariable(Declaration const& _declaration)
 {
 	solAssert(m_localVariables.count(&_declaration) && !m_localVariables[&_declaration].empty(), "");
 	m_localVariables[&_declaration].pop_back();
 	if (m_localVariables[&_declaration].empty())
 		m_localVariables.erase(&_declaration);
+}
+
+void CompilerContext::removeVariablesAboveStackHeight(unsigned _stackHeight)
+{
+	vector<Declaration const*> toRemove;
+	for (auto _var: m_localVariables)
+	{
+		solAssert(!_var.second.empty(), "");
+		if (_var.second.back() >= _stackHeight)
+			toRemove.push_back(_var.first);
+	}
+	for (auto _var: toRemove)
+		removeVariable(*_var);
 }
 
 eth::Assembly const& CompilerContext::compiledContract(const ContractDefinition& _contract) const

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -71,7 +71,9 @@ public:
 
 	void addStateVariable(VariableDeclaration const& _declaration, u256 const& _storageOffset, unsigned _byteOffset);
 	void addVariable(VariableDeclaration const& _declaration, unsigned _offsetToCurrent = 0);
-	void removeVariable(VariableDeclaration const& _declaration);
+	void removeVariable(Declaration const& _declaration);
+	/// Removes all local variables currently allocated above _stackHeight.
+	void removeVariablesAboveStackHeight(unsigned _stackHeight);
 
 	void setCompiledContracts(std::map<ContractDefinition const*, eth::Assembly const*> const& _contracts) { m_compiledContracts = _contracts; }
 	eth::Assembly const& compiledContract(ContractDefinition const& _contract) const;

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -74,6 +74,8 @@ public:
 	void removeVariable(Declaration const& _declaration);
 	/// Removes all local variables currently allocated above _stackHeight.
 	void removeVariablesAboveStackHeight(unsigned _stackHeight);
+	/// Returns the number of currently allocated local variables.
+	unsigned numberOfLocalVariables() const;
 
 	void setCompiledContracts(std::map<ContractDefinition const*, eth::Assembly const*> const& _contracts) { m_compiledContracts = _contracts; }
 	eth::Assembly const& compiledContract(ContractDefinition const& _contract) const;

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1172,6 +1172,7 @@ void CompilerUtils::popStackSlots(size_t _amount)
 
 void CompilerUtils::popAndJump(unsigned _toHeight, eth::AssemblyItem const& _jumpTo)
 {
+	solAssert(m_context.stackHeight() >= _toHeight, "");
 	unsigned amount = m_context.stackHeight() - _toHeight;
 	popStackSlots(amount);
 	m_context.appendJumpTo(_jumpTo);

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1170,6 +1170,14 @@ void CompilerUtils::popStackSlots(size_t _amount)
 		m_context << Instruction::POP;
 }
 
+void CompilerUtils::popAndJump(unsigned _toHeight, eth::AssemblyItem const& _jumpTo)
+{
+	unsigned amount = m_context.stackHeight() - _toHeight;
+	popStackSlots(amount);
+	m_context.appendJumpTo(_jumpTo);
+	m_context.adjustStackOffset(amount);
+}
+
 unsigned CompilerUtils::sizeOnStack(vector<shared_ptr<Type const>> const& _variableTypes)
 {
 	unsigned size = 0;

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -241,6 +241,10 @@ public:
 	void popStackElement(Type const& _type);
 	/// Removes element from the top of the stack _amount times.
 	void popStackSlots(size_t _amount);
+	/// Pops slots from the stack such that its height is _toHeight.
+	/// Adds jump to _jumpTo.
+	/// Readjusts the stack offset to the original value.
+	void popAndJump(unsigned _toHeight, eth::AssemblyItem const& _jumpTo);
 
 	template <class T>
 	static unsigned sizeOnStack(std::vector<T> const& _variables);

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -999,6 +999,7 @@ eth::AssemblyPointer ContractCompiler::cloneRuntime() const
 void ContractCompiler::popScopedVariables(ASTNode const* _node)
 {
 	unsigned blockHeight = m_scopeStackHeight.at(m_modifierDepth).at(_node);
+	solAssert(m_context.stackHeight() >= blockHeight, "");
 	unsigned stackDiff = m_context.stackHeight() - blockHeight;
 	CompilerUtils(m_context).popStackSlots(stackDiff);
 	m_context.removeVariablesAboveStackHeight(blockHeight);

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -109,6 +109,8 @@ private:
 	virtual bool visit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
 	virtual bool visit(ExpressionStatement const& _expressionStatement) override;
 	virtual bool visit(PlaceholderStatement const&) override;
+	virtual bool visit(Block const& _block) override;
+	virtual void endVisit(Block const& _block) override;
 
 	/// Repeatedly visits all function which are referenced but which are not compiled yet.
 	void appendMissingFunctions();
@@ -123,19 +125,35 @@ private:
 	/// @returns the runtime assembly for clone contracts.
 	eth::AssemblyPointer cloneRuntime() const;
 
+	/// Frees the variables of a certain scope (to be used when leaving).
+	void popScopedVariables(ASTNode const* _node);
+
+	/// Pops _amount slots from the stack and jumps to _jumpTo.
+	/// Also readjusts the stack offset to the original value.
+	void popAndJump(unsigned _amount, eth::AssemblyItem const& _jumpTo);
+
+	/// Sets the stack height for the visited loop.
+	void visitLoop(BreakableStatement const* _loop);
+
 	bool const m_optimise;
 	/// Pointer to the runtime compiler in case this is a creation compiler.
 	ContractCompiler* m_runtimeCompiler = nullptr;
 	CompilerContext& m_context;
-	std::vector<eth::AssemblyItem> m_breakTags; ///< tag to jump to for a "break" statement
-	std::vector<eth::AssemblyItem> m_continueTags; ///< tag to jump to for a "continue" statement
-	/// Tag to jump to for a "return" statement, needs to be stacked because of modifiers.
-	std::vector<eth::AssemblyItem> m_returnTags;
+	/// Tag to jump to for a "break" statement and the stack height after freeing the local loop variables.
+	std::vector<std::pair<eth::AssemblyItem, unsigned>> m_breakTags;
+	/// Tag to jump to for a "continue" statement and the stack height after freeing the local loop variables.
+	std::vector<std::pair<eth::AssemblyItem, unsigned>> m_continueTags;
+	/// Tag to jump to for a "return" statement and the stack height after freeing the local function or modifier variables.
+	/// Needs to be stacked because of modifiers.
+	std::vector<std::pair<eth::AssemblyItem, unsigned>> m_returnTags;
 	unsigned m_modifierDepth = 0;
 	FunctionDefinition const* m_currentFunction = nullptr;
-	unsigned m_stackCleanupForReturn = 0; ///< this number of stack elements need to be removed before jump to m_returnTag
+
 	// arguments for base constructors, filled in derived-to-base order
 	std::map<FunctionDefinition const*, ASTNode const*> const* m_baseArguments;
+
+	/// Stores the variables that were declared inside a specific scope, for each modifier depth.
+	std::map<unsigned, std::map<ASTNode const*, unsigned>> m_scopeStackHeight;
 };
 
 }

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -128,12 +128,8 @@ private:
 	/// Frees the variables of a certain scope (to be used when leaving).
 	void popScopedVariables(ASTNode const* _node);
 
-	/// Pops _amount slots from the stack and jumps to _jumpTo.
-	/// Also readjusts the stack offset to the original value.
-	void popAndJump(unsigned _amount, eth::AssemblyItem const& _jumpTo);
-
 	/// Sets the stack height for the visited loop.
-	void visitLoop(BreakableStatement const* _loop);
+	void storeStackHeight(ASTNode const* _node);
 
 	bool const m_optimise;
 	/// Pointer to the runtime compiler in case this is a creation compiler.

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(array_multiple_local_vars)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f(uint256[] seq) public pure returns (uint256) {
+			function f(uint256[] seq) external pure returns (uint256) {
 				uint i = 0;
 				uint sum = 0;
 				while (i < seq.length)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -523,6 +523,57 @@ BOOST_AUTO_TEST_CASE(do_while_loop_continue)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(42));
 }
 
+BOOST_AUTO_TEST_CASE(do_while_loop_multiple_local_vars)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint x) public pure returns(uint r) {
+				uint i = 0;
+				do
+				{
+					uint z = x * 2;
+					if (z < 4) break;
+					else {
+						uint k = z + 1;
+						if (k < 8) {
+							x++;
+							continue;
+						}
+					}
+					if (z > 12) return 0;
+					x++;
+					i++;
+				} while (true);
+				return 42;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+
+	auto do_while = [](u256 n) -> u256
+	{
+		u256 i = 0;
+		do
+		{
+			u256 z = n * 2;
+			if (z < 4) break;
+			else {
+				u256 k = z + 1;
+				if (k < 8) {
+					n++;
+					continue;
+				}
+			}
+			if (z > 12) return 0;
+			n++;
+			i++;
+		} while (true);
+		return 42;
+	};
+
+	testContractAgainstCppOnRange("f(uint256)", do_while, 0, 12);
+}
+
 BOOST_AUTO_TEST_CASE(nested_loops)
 {
 	// tests that break and continue statements in nested loops jump to the correct place
@@ -573,6 +624,109 @@ BOOST_AUTO_TEST_CASE(nested_loops)
 
 	testContractAgainstCppOnRange("f(uint256)", nested_loops_cpp, 0, 12);
 }
+
+BOOST_AUTO_TEST_CASE(nested_loops_multiple_local_vars)
+{
+	// tests that break and continue statements in nested loops jump to the correct place
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint x) returns(uint y) {
+				while (x > 0) {
+					uint z = x + 10;
+					uint k = z + 1;
+					if (k > 20) break;
+					if (k > 15) {
+						x--;
+						continue;
+					}
+					while (k > 10) {
+						uint m = k - 1;
+						if (m == 10) return x;
+						return k;
+					}
+					x--;
+					break;
+				}
+				return x;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+
+	auto nested_loops_cpp = [](u256 n) -> u256
+	{
+		while (n > 0)
+		{
+			u256 z = n + 10;
+			u256 k = z + 1;
+			if (k > 20) break;
+			if (k > 15) {
+				n--;
+				continue;
+			}
+			while (k > 10)
+			{
+				u256 m = k - 1;
+				if (m == 10) return n;
+				return k;
+			}
+			n--;
+			break;
+		}
+
+		return n;
+	};
+
+	testContractAgainstCppOnRange("f(uint256)", nested_loops_cpp, 0, 12);
+}
+
+BOOST_AUTO_TEST_CASE(for_loop_multiple_local_vars)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(uint x) public pure returns(uint r) {
+				for (uint i = 0; i < 12; i++)
+				{
+					uint z = x + 1;
+					if (z < 4) break;
+					else {
+						uint k = z * 2;
+						if (i + k < 10) {
+							x++;
+							continue;
+						}
+					}
+					if (z > 8) return 0;
+					x++;
+				}
+				return 42;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+
+	auto for_loop = [](u256 n) -> u256
+	{
+		for (u256 i = 0; i < 12; i++)
+		{
+			u256 z = n + 1;
+			if (z < 4) break;
+			else {
+				u256 k = z * 2;
+				if (i + k < 10) {
+					n++;
+					continue;
+				}
+			}
+			if (z > 8) return 0;
+			n++;
+		}
+		return 42;
+	};
+
+	testContractAgainstCppOnRange("f(uint256)", for_loop, 0, 12);
+}
+
 
 BOOST_AUTO_TEST_CASE(for_loop)
 {

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -802,7 +802,7 @@ BOOST_AUTO_TEST_CASE(nested_for_loop_multiple_local_vars)
 						}
 					}
 					if (x > 30) {
-					    return 42;
+						return 42;
 						uint b = 0xcafe;
 					}
 				}
@@ -9494,7 +9494,9 @@ BOOST_AUTO_TEST_CASE(break_in_modifier)
 				}
 			}
 			function f() run {
-				x++;
+				uint k = x;
+				uint t = k + 1;
+				x = t;
 			}
 		}
 	)";
@@ -9516,7 +9518,9 @@ BOOST_AUTO_TEST_CASE(continue_in_modifier)
 				}
 			}
 			function f() run {
-				x++;
+				uint k = x;
+				uint t = k + 1;
+				x = t;
 			}
 		}
 	)";
@@ -9538,7 +9542,9 @@ BOOST_AUTO_TEST_CASE(return_in_modifier)
 				}
 			}
 			function f() run {
-				x++;
+				uint k = x;
+				uint t = k + 1;
+				x = t;
 			}
 		}
 	)";
@@ -9560,7 +9566,9 @@ BOOST_AUTO_TEST_CASE(stacked_return_with_modifiers)
 				}
 			}
 			function f() run {
-				x++;
+				uint k = x;
+				uint t = k + 1;
+				x = t;
 			}
 		}
 	)";


### PR DESCRIPTION
Implements #3672. Closes #3222.

There are two scenarios so far:

1) No `break`/`continue`. That's the simple case, local vars are allocated when declared, and freed when the execution leaves their scope.

2) `Break`. Every `break` statement inside a loop requires a different amount of `pop`s, depending on the amount of local variables declared until that point.
```
function f(bool b, bool c, bool d) public pure {
	uint x;
	for (uint i = 0; i < 10; ++i) {
		uint y = 12;
		if (b) break;
		if (c) {
			uint z = 39;
			if (d) break;
			x += z;
		}
		x += y;
	}
}
```
In this example, the second `break` jumps to `tag_14`, since it requires 3 pops: `z`, `y` and `i`.
The first `break` jumps to `tag_11`, since it needs to free only `y` and `i`.
Any execution where a `break` happens, after freeing the local vars, jumps to the actual end of the loop, in this case `tag_15`.
Here we have `tag_8` as the end of the loop for executions that do not have any `break` (loop condition failure jumps here), in which case we know that the local variables are freed in the end of their scopes (as in `1`) and we only have to free loop init vars, in this case `i`.
```
   ...
    tag_14:
      pop
    tag_11:
      pop
      pop
      jump(tag_15)
    tag_8:
        /* "break.sol":135:141  uint i */
      pop
        /* "break.sol":130:273  for (uint i = 0; i < 10; ++i) {... */
    tag_15:
    ...
```

I had to comment out two stack height checks (to be adjusted manually) and two other checks such that exceptions do not occur:
libevmasm/Assembly.h:94
libevmasm/Assembly.cpp:328

I'm investigating the exceptions.