### PR TITLE
Install a different jsoncpp version on cirleci to ensure compilation never clashes with the internal one

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -123,6 +123,7 @@ jobs:
           command: |
             apt-get -qq update
             apt-get -qy install cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libz3-dev
+            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
       - run: *setup_prerelease_commit_hash
       - run: *run_build
       - store_artifacts: *solc_artifact
@@ -142,6 +143,7 @@ jobs:
             brew install z3
             brew install boost
             brew install cmake
+            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
       - run: *setup_prerelease_commit_hash
       - run: *run_build
       - store_artifacts: *solc_artifact

--- a/scripts/install_obsolete_jsoncpp_1_7_4.sh
+++ b/scripts/install_obsolete_jsoncpp_1_7_4.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -e
+
+TEMPDIR=$(mktemp -d)
+JSONCPP="jsoncpp-1.7.4"
+wget -O "$TEMPDIR/$JSONCPP.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.7.4.tar.gz
+
+tar xvzf "$TEMPDIR/${JSONCPP}.tar.gz" -C $TEMPDIR
+
+cd $TEMPDIR/$JSONCPP
+mkdir -p build/debug
+cd build/debug
+cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DARCHIVE_INSTALL_DIR=. -G "Unix Makefiles" ../..
+make
+make install
+
+rm -rf $TEMPDIR
+


### PR DESCRIPTION
Fixes #3934.

The installed jsoncpp is 1.7.4. 

