### PR TITLE
Proper source locations for parser errors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Features:
  * Gas Estimator: Only explore paths with higher gas costs. This reduces accuracy but greatly improves the speed of gas estimation.
  * Optimizer: Remove unnecessary masking of the result of known short instructions (``ADDRESS``, ``CALLER``, ``ORIGIN`` and ``COINBASE``).
  * Parser: Display nicer error messages by showing the actual tokens and not internal names.
+ * Parser: Use the entire location of the token instead of only its starting position as source location for parser errors.
  * Type Checker: Deprecate the ``years`` unit denomination and raise a warning for it (or an error as experimental 0.5.0 feature).
  * Type Checker: Make literals (without explicit type casting) an error for tight packing as experimental 0.5.0 feature.
  * Type Checker: Warn about wildcard tuple assignments (this will turn into an error with version 0.5.0).

--- a/libsolidity/parsing/ParserBase.cpp
+++ b/libsolidity/parsing/ParserBase.cpp
@@ -106,10 +106,10 @@ void ParserBase::decreaseRecursionDepth()
 
 void ParserBase::parserError(string const& _description)
 {
-	m_errorReporter.parserError(SourceLocation(position(), position(), sourceName()), _description);
+	m_errorReporter.parserError(SourceLocation(position(), endPosition(), sourceName()), _description);
 }
 
 void ParserBase::fatalParserError(string const& _description)
 {
-	m_errorReporter.fatalParserError(SourceLocation(position(), position(), sourceName()), _description);
+	m_errorReporter.fatalParserError(SourceLocation(position(), endPosition(), sourceName()), _description);
 }

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(compilation_error)
 				dev::jsonCompactPrint(error),
 				"{\"component\":\"general\",\"formattedMessage\":\"fileA:1:23: ParserError: Expected identifier but got '}'\\n"
 				"contract A { function }\\n                      ^\\n\",\"message\":\"Expected identifier but got '}'\","
-				"\"severity\":\"error\",\"sourceLocation\":{\"end\":22,\"file\":\"fileA\",\"start\":22},\"type\":\"ParserError\"}"
+				"\"severity\":\"error\",\"sourceLocation\":{\"end\":23,\"file\":\"fileA\",\"start\":22},\"type\":\"ParserError\"}"
 			);
 		}
 	}

--- a/test/libsolidity/syntaxTests/functionTypes/function_type_constructor_local.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/function_type_constructor_local.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// ParserError: (118-118): Expected ';' but got identifier
+// ParserError: (118-119): Expected ';' but got identifier

--- a/test/libsolidity/syntaxTests/parsing/constant_is_keyword.sol
+++ b/test/libsolidity/syntaxTests/parsing/constant_is_keyword.sol
@@ -2,4 +2,4 @@ contract Foo {
 	uint constant = 4;
 }
 // ----
-// ParserError: (30-30): Expected identifier but got '='
+// ParserError: (30-31): Expected identifier but got '='

--- a/test/libsolidity/syntaxTests/parsing/emit_without_event.sol
+++ b/test/libsolidity/syntaxTests/parsing/emit_without_event.sol
@@ -5,4 +5,4 @@ contract C {
 	}
 }
 // ----
-// ParserError: (49-49): Expected '(' but got ';'
+// ParserError: (49-50): Expected '(' but got ';'

--- a/test/libsolidity/syntaxTests/parsing/empty_enum.sol
+++ b/test/libsolidity/syntaxTests/parsing/empty_enum.sol
@@ -2,4 +2,4 @@ contract c {
 	enum foo { }
 }
 // ----
-// ParserError: (25-25): enum with no members is not allowed.
+// ParserError: (25-26): enum with no members is not allowed.

--- a/test/libsolidity/syntaxTests/parsing/event_with_no_argument_list.sol
+++ b/test/libsolidity/syntaxTests/parsing/event_with_no_argument_list.sol
@@ -2,4 +2,4 @@ contract c {
 	event e;
 }
 // ----
-// ParserError: (21-21): Expected '(' but got ';'
+// ParserError: (21-22): Expected '(' but got ';'

--- a/test/libsolidity/syntaxTests/parsing/external_variable.sol
+++ b/test/libsolidity/syntaxTests/parsing/external_variable.sol
@@ -2,4 +2,4 @@ contract c {
 	uint external x;
 }
 // ----
-// ParserError: (19-19): Expected identifier but got 'external'
+// ParserError: (19-27): Expected identifier but got 'external'

--- a/test/libsolidity/syntaxTests/parsing/fixed_literal_with_double_radix.sol
+++ b/test/libsolidity/syntaxTests/parsing/fixed_literal_with_double_radix.sol
@@ -2,4 +2,4 @@ contract A {
 	fixed40x40 pi = 3.14.15;
 }
 // ----
-// ParserError: (34-34): Expected ';' but got 'Number'
+// ParserError: (34-37): Expected ';' but got 'Number'

--- a/test/libsolidity/syntaxTests/parsing/function_type_as_storage_variable_with_modifiers.sol
+++ b/test/libsolidity/syntaxTests/parsing/function_type_as_storage_variable_with_modifiers.sol
@@ -2,4 +2,4 @@ contract test {
 	function (uint, uint) modifier1() returns (uint) f1;
 }
 // ----
-// ParserError: (66-66): Expected '{' but got identifier
+// ParserError: (66-68): Expected '{' but got identifier

--- a/test/libsolidity/syntaxTests/parsing/inline_array_empty_cells_check_lvalue.sol
+++ b/test/libsolidity/syntaxTests/parsing/inline_array_empty_cells_check_lvalue.sol
@@ -6,4 +6,4 @@ contract c {
 	}
 }
 // ----
-// ParserError: (62-62): Expected expression (inline array elements cannot be omitted).
+// ParserError: (62-63): Expected expression (inline array elements cannot be omitted).

--- a/test/libsolidity/syntaxTests/parsing/inline_array_empty_cells_check_without_lvalue.sol
+++ b/test/libsolidity/syntaxTests/parsing/inline_array_empty_cells_check_without_lvalue.sol
@@ -5,4 +5,4 @@ contract c {
 	}
 }
 // ----
-// ParserError: (75-75): Expected expression (inline array elements cannot be omitted).
+// ParserError: (75-76): Expected expression (inline array elements cannot be omitted).

--- a/test/libsolidity/syntaxTests/parsing/invalid_fixed_conversion_leading_zeroes_check.sol
+++ b/test/libsolidity/syntaxTests/parsing/invalid_fixed_conversion_leading_zeroes_check.sol
@@ -4,4 +4,4 @@ contract test {
 	}
 }
 // ----
-// ParserError: (44-44): Expected primary expression.
+// ParserError: (44-47): Expected primary expression.

--- a/test/libsolidity/syntaxTests/parsing/local_const_variable.sol
+++ b/test/libsolidity/syntaxTests/parsing/local_const_variable.sol
@@ -6,4 +6,4 @@ contract Foo {
 	}
 }
 // ----
-// ParserError: (67-67): Expected ';' but got 'constant'
+// ParserError: (67-75): Expected ';' but got 'constant'

--- a/test/libsolidity/syntaxTests/parsing/location_specifiers_for_state_variables.sol
+++ b/test/libsolidity/syntaxTests/parsing/location_specifiers_for_state_variables.sol
@@ -2,4 +2,4 @@ contract Foo {
 	uint[] memory x;
 }
 // ----
-// ParserError: (23-23): Expected identifier but got 'memory'
+// ParserError: (23-29): Expected identifier but got 'memory'

--- a/test/libsolidity/syntaxTests/parsing/location_specifiers_with_var.sol
+++ b/test/libsolidity/syntaxTests/parsing/location_specifiers_with_var.sol
@@ -2,4 +2,4 @@ contract Foo {
 	function f() { var memory x; }
 }
 // ----
-// ParserError: (35-35): Location specifier needs explicit type name.
+// ParserError: (35-41): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/malformed_enum_declaration.sol
+++ b/test/libsolidity/syntaxTests/parsing/malformed_enum_declaration.sol
@@ -2,4 +2,4 @@ contract c {
 	enum foo { WARNING,}
 }
 // ----
-// ParserError: (33-33): Expected identifier after ','
+// ParserError: (33-34): Expected identifier after ','

--- a/test/libsolidity/syntaxTests/parsing/missing_argument_in_named_args.sol
+++ b/test/libsolidity/syntaxTests/parsing/missing_argument_in_named_args.sol
@@ -3,4 +3,4 @@ contract test {
 	function b() returns (uint r) { r = a({a: , b: , c: }); }
 }
 // ----
-// ParserError: (146-146): Expected primary expression.
+// ParserError: (146-147): Expected primary expression.

--- a/test/libsolidity/syntaxTests/parsing/missing_parameter_name_in_named_args.sol
+++ b/test/libsolidity/syntaxTests/parsing/missing_parameter_name_in_named_args.sol
@@ -3,4 +3,4 @@ contract test {
 	function b() returns (uint r) { r = a({: 1, : 2, : 3}); }
 }
 // ----
-// ParserError: (143-143): Expected identifier but got ':'
+// ParserError: (143-144): Expected identifier but got ':'

--- a/test/libsolidity/syntaxTests/parsing/missing_variable_name_in_declaration.sol
+++ b/test/libsolidity/syntaxTests/parsing/missing_variable_name_in_declaration.sol
@@ -2,4 +2,4 @@ contract test {
     uint256 ;
 }
 // ----
-// ParserError: (28-28): Expected identifier but got ';'
+// ParserError: (28-29): Expected identifier but got ';'

--- a/test/libsolidity/syntaxTests/parsing/modifier_without_semicolon.sol
+++ b/test/libsolidity/syntaxTests/parsing/modifier_without_semicolon.sol
@@ -2,4 +2,4 @@ contract c {
 	modifier mod { if (msg.sender == 0) _ }
 }
 // ----
-// ParserError: (52-52): Expected ';' but got '}'
+// ParserError: (52-53): Expected ';' but got '}'

--- a/test/libsolidity/syntaxTests/parsing/new_invalid_type_name.sol
+++ b/test/libsolidity/syntaxTests/parsing/new_invalid_type_name.sol
@@ -4,4 +4,4 @@ contract C {
 	}
 }
 // ----
-// ParserError: (35-35): Expected explicit type name.
+// ParserError: (35-38): Expected explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/payable_accessor.sol
+++ b/test/libsolidity/syntaxTests/parsing/payable_accessor.sol
@@ -2,4 +2,4 @@ contract test {
 	uint payable x;
 }
 // ----
-// ParserError: (22-22): Expected identifier but got 'payable'
+// ParserError: (22-29): Expected identifier but got 'payable'

--- a/test/libsolidity/syntaxTests/parsing/return_var.sol
+++ b/test/libsolidity/syntaxTests/parsing/return_var.sol
@@ -9,17 +9,17 @@ contract C {
     function f() public pure returns (var storage x, var storage y) {}
 }
 // ----
-// ParserError: (38-38): Expected explicit type name.
-// ParserError: (71-71): Expected explicit type name.
-// ParserError: (106-106): Expected explicit type name.
-// ParserError: (157-157): Expected explicit type name.
-// ParserError: (192-192): Expected explicit type name.
-// ParserError: (199-199): Expected explicit type name.
-// ParserError: (247-247): Expected explicit type name.
-// ParserError: (251-251): Location specifier needs explicit type name.
-// ParserError: (301-301): Expected explicit type name.
-// ParserError: (305-305): Location specifier needs explicit type name.
-// ParserError: (357-357): Expected explicit type name.
-// ParserError: (361-361): Location specifier needs explicit type name.
-// ParserError: (372-372): Expected explicit type name.
-// ParserError: (376-376): Location specifier needs explicit type name.
+// ParserError: (38-41): Expected explicit type name.
+// ParserError: (71-74): Expected explicit type name.
+// ParserError: (106-109): Expected explicit type name.
+// ParserError: (157-160): Expected explicit type name.
+// ParserError: (192-195): Expected explicit type name.
+// ParserError: (199-202): Expected explicit type name.
+// ParserError: (247-250): Expected explicit type name.
+// ParserError: (251-258): Location specifier needs explicit type name.
+// ParserError: (301-304): Expected explicit type name.
+// ParserError: (305-312): Location specifier needs explicit type name.
+// ParserError: (357-360): Expected explicit type name.
+// ParserError: (361-368): Location specifier needs explicit type name.
+// ParserError: (372-375): Expected explicit type name.
+// ParserError: (376-383): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/single_function_param_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/single_function_param_trailing_comma.sol
@@ -2,4 +2,4 @@ contract test {
 	function(uint a,) {}
 }
 // ----
-// ParserError: (32-32): Unexpected trailing comma in parameter list.
+// ParserError: (32-33): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/single_return_param_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/single_return_param_trailing_comma.sol
@@ -2,4 +2,4 @@ contract test {
 	function() returns (uint a,) {}
 }
 // ----
-// ParserError: (43-43): Unexpected trailing comma in parameter list.
+// ParserError: (43-44): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/trailing_comma_in_named_args.sol
+++ b/test/libsolidity/syntaxTests/parsing/trailing_comma_in_named_args.sol
@@ -3,4 +3,4 @@ contract test {
 	function b() returns (uint r) { r = a({a: 1, b: 2, c: 3, }); }
 }
 // ----
-// ParserError: (159-159): Unexpected trailing comma.
+// ParserError: (159-160): Unexpected trailing comma.

--- a/test/libsolidity/syntaxTests/parsing/tuples_without_commas.sol
+++ b/test/libsolidity/syntaxTests/parsing/tuples_without_commas.sol
@@ -4,4 +4,4 @@ contract C {
 	}
 }
 // ----
-// ParserError: (42-42): Expected ',' but got 'Number'
+// ParserError: (42-43): Expected ',' but got 'Number'

--- a/test/libsolidity/syntaxTests/parsing/var_array.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_array.sol
@@ -2,4 +2,4 @@ contract Foo {
 	function f() { var[] a; }
 }
 // ----
-// ParserError: (34-34): Expected identifier but got '['
+// ParserError: (34-35): Expected identifier but got '['

--- a/test/libsolidity/syntaxTests/parsing/var_in_function_arguments.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_in_function_arguments.sol
@@ -9,17 +9,17 @@ contract C {
     function f(var storage x, var storage y) public pure {}
 }
 // ----
-// ParserError: (28-28): Expected explicit type name.
-// ParserError: (63-63): Expected explicit type name.
-// ParserError: (100-100): Expected explicit type name.
-// ParserError: (107-107): Expected explicit type name.
-// ParserError: (152-152): Expected explicit type name.
-// ParserError: (189-189): Expected explicit type name.
-// ParserError: (234-234): Expected explicit type name.
-// ParserError: (238-238): Location specifier needs explicit type name.
-// ParserError: (277-277): Expected explicit type name.
-// ParserError: (281-281): Location specifier needs explicit type name.
-// ParserError: (322-322): Expected explicit type name.
-// ParserError: (326-326): Location specifier needs explicit type name.
-// ParserError: (337-337): Expected explicit type name.
-// ParserError: (341-341): Location specifier needs explicit type name.
+// ParserError: (28-31): Expected explicit type name.
+// ParserError: (63-66): Expected explicit type name.
+// ParserError: (100-103): Expected explicit type name.
+// ParserError: (107-110): Expected explicit type name.
+// ParserError: (152-155): Expected explicit type name.
+// ParserError: (189-192): Expected explicit type name.
+// ParserError: (234-237): Expected explicit type name.
+// ParserError: (238-245): Location specifier needs explicit type name.
+// ParserError: (277-280): Expected explicit type name.
+// ParserError: (281-288): Location specifier needs explicit type name.
+// ParserError: (322-325): Expected explicit type name.
+// ParserError: (326-333): Location specifier needs explicit type name.
+// ParserError: (337-340): Expected explicit type name.
+// ParserError: (341-348): Location specifier needs explicit type name.

--- a/test/libsolidity/syntaxTests/parsing/var_storage_var.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_storage_var.sol
@@ -2,4 +2,4 @@ contract C {
     var a;
 }
 // ----
-// ParserError: (17-17): Function, variable, struct or modifier declaration expected.
+// ParserError: (17-20): Function, variable, struct or modifier declaration expected.

--- a/test/libsolidity/syntaxTests/parsing/variable_definition_in_mapping.sol
+++ b/test/libsolidity/syntaxTests/parsing/variable_definition_in_mapping.sol
@@ -4,4 +4,4 @@ contract test {
 	}
 }
 // ----
-// ParserError: (44-44): Expected elementary type name for mapping key type
+// ParserError: (44-47): Expected elementary type name for mapping key type


### PR DESCRIPTION
Closes #3874.

It may be good to merge this quickly, since all future parser tests will be affected.