### PR TITLE
Fix wrong template parameter passed to boost::get

### DIFF
--- a/libjulia/optimiser/FullInliner.cpp
+++ b/libjulia/optimiser/FullInliner.cpp
@@ -168,10 +168,10 @@ void InlineModifier::visit(Statement& _statement)
 	// Replace pop(0) expression statemets (and others) by empty blocks.
 	if (_statement.type() == typeid(ExpressionStatement))
 	{
-		ExpressionStatement& expSt = boost::get<ExpressionStatement&>(_statement);
+		ExpressionStatement& expSt = boost::get<ExpressionStatement>(_statement);
 		if (expSt.expression.type() == typeid(FunctionalInstruction))
 		{
-			FunctionalInstruction& funInstr = boost::get<FunctionalInstruction&>(expSt.expression);
+			FunctionalInstruction& funInstr = boost::get<FunctionalInstruction>(expSt.expression);
 			if (funInstr.instruction == solidity::Instruction::POP)
 				if (MovableChecker(funInstr.arguments.at(0)).movable())
 					_statement = Block{expSt.location, {}};


### PR DESCRIPTION
Should fix #4124 

The `Expression` and `Statement` type are defined at https://github.com/ethereum/solidity/blob/54b6739962ef45319777ce2aebafdf4b91412d84/libjulia/ASTDataForward.h#L50-L51

We try to `boost::get` an `ExpressionStatement&` from `Statement`; prior to boost 1.59, this causes a static assertion failure because, from boost's point of view, `ExpressionStatement&` is not equal to `ExpressionStatement`. (this check was relaxed in boost 1.59, as point out by @hydai in #4124)

@REPTILEHAUS can you confirm that this commit fixes your issue? Thanks