### PR TITLE
[BREAKING] Fix continue inside do-while.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 Breaking Changes:
  * Disallow conversions between bytesX and uintY of different size.
  * Commandline interface: Require ``-`` if standard input is used as source.
+ * General: ``continue`` in a ``do...while`` loop jumps to the condition (it used to jump to the loop body). Warning: this may silently change the semantics of existing code.
  * Type Checker: Disallow arithmetic operations for Boolean variables.
 
 Features:

--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -159,15 +159,14 @@ bool ControlFlowBuilder::visit(WhileStatement const& _whileStatement)
 	{
 		auto afterWhile = newLabel();
 		auto whileBody = createLabelHere();
+		auto condition = newLabel();
 
 		{
-			// Note that "continue" in this case currently indeed jumps to whileBody
-			// and not to the condition. This is inconsistent with JavaScript and C and
-			// therefore a bug. This will be fixed in the future (planned for 0.5.0)
-			// and the Control Flow Graph will have to be adjusted accordingly.
-			BreakContinueScope scope(*this, afterWhile, whileBody);
+			BreakContinueScope scope(*this, afterWhile, condition);
 			appendControlFlow(_whileStatement.body());
 		}
+
+		placeAndConnectLabel(condition);
 		appendControlFlow(_whileStatement.condition());
 
 		connect(m_currentNode, whileBody);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -482,6 +482,27 @@ BOOST_AUTO_TEST_CASE(do_while_loop)
 	testContractAgainstCppOnRange("f(uint256)", do_while_loop_cpp, 0, 5);
 }
 
+BOOST_AUTO_TEST_CASE(do_while_loop_continue)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f() public pure returns(uint r) {
+				uint i = 0;
+				do
+				{
+					if (i > 0) return 0;
+					i++;
+					continue;
+				} while (false);
+				return 42;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(42));
+}
+
 BOOST_AUTO_TEST_CASE(nested_loops)
 {
 	// tests that break and continue statements in nested loops jump to the correct place

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/dowhile_fine.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/dowhile_fine.sol
@@ -23,13 +23,8 @@ contract C {
     }
     function k() internal view returns (S storage c) {
         do {
-            if (s.f) {
-                continue;
-                break;
-            }
-            else {
-                c = s;
-            }
+            c = s;
+            continue;
         } while(false);
     }
 }

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/dowhile_warn.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/dowhile_warn.sol
@@ -21,6 +21,15 @@ contract C {
         do {
             if (s.f) {
                 break;
+            }
+            else {
+                c = s;
+            }
+        } while(false);
+    }
+    function i() internal view returns (S storage c) {
+        do {
+            if (s.f) {
                 continue;
             }
             else {
@@ -28,8 +37,16 @@ contract C {
             }
         } while(false);
     }
+    function j() internal view returns (S storage c) {
+        do {
+            continue;
+            c = s;
+        } while(false);
+    }
 }
 // ----
 // Warning: (87-98): This variable is of storage pointer type and might be returned without assignment. This can cause storage corruption. Assign the variable (potentially from itself) to remove this warning.
 // Warning: (223-234): This variable is of storage pointer type and might be returned without assignment. This can cause storage corruption. Assign the variable (potentially from itself) to remove this warning.
 // Warning: (440-451): This variable is of storage pointer type and might be returned without assignment. This can cause storage corruption. Assign the variable (potentially from itself) to remove this warning.
+// Warning: (654-665): This variable is of storage pointer type and might be returned without assignment. This can cause storage corruption. Assign the variable (potentially from itself) to remove this warning.
+// Warning: (871-882): This variable is of storage pointer type and might be returned without assignment. This can cause storage corruption. Assign the variable (potentially from itself) to remove this warning.


### PR DESCRIPTION
Closes #4121.

Note: this is a dangerous change, since it silently alters behaviour of existing code!