### PR TITLE
Split changelog into language and compiler features and set release date.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,21 +1,23 @@
-### 0.4.24 (unreleased)
+### 0.4.24 (2018-05-16)
 
-Features:
- * Remove deprecated ``constant`` as function state modifier from documentation and tests (but still leave it as a valid feature).
- * Build System: Update internal dependency of jsoncpp to 1.8.4, which introduces more strictness and reduces memory usage.
+Language Features:
  * Code Generator: Use native shift instructions on target Constantinople.
- * Control Flow Graph: Add Control Flow Graph as analysis structure.
- * Control Flow Graph: Warn about returning uninitialized storage pointers.
- * Gas Estimator: Only explore paths with higher gas costs. This reduces accuracy but greatly improves the speed of gas estimation.
  * General: Allow multiple variables to be declared as part of a tuple assignment, e.g. ``(uint a, uint b) = ...``.
- * Optimizer: Remove unnecessary masking of the result of known short instructions (``ADDRESS``, ``CALLER``, ``ORIGIN`` and ``COINBASE``).
- * Parser: Display nicer error messages by showing the actual tokens and not internal names.
- * Parser: Use the entire location of the token instead of only its starting position as source location for parser errors.
- * SMT Checker: Support state variables of integer and bool type.
+ * General: Remove deprecated ``constant`` as function state modifier from documentation and tests (but still leave it as a valid feature).
  * Type Checker: Deprecate the ``years`` unit denomination and raise a warning for it (or an error as experimental 0.5.0 feature).
  * Type Checker: Make literals (without explicit type casting) an error for tight packing as experimental 0.5.0 feature.
  * Type Checker: Warn about wildcard tuple assignments (this will turn into an error with version 0.5.0).
  * Type Checker: Warn when ``keccak256``, ``sha256`` and ``ripemd160`` are not used with a single bytes argument (suggest to use ``abi.encodePacked(...)``). This will turn into an error with version 0.5.0.
+
+Compiler Features:
+ * Build System: Update internal dependency of jsoncpp to 1.8.4, which introduces more strictness and reduces memory usage.
+ * Control Flow Graph: Add Control Flow Graph as analysis structure.
+ * Control Flow Graph: Warn about returning uninitialized storage pointers.
+ * Gas Estimator: Only explore paths with higher gas costs. This reduces accuracy but greatly improves the speed of gas estimation.
+ * Optimizer: Remove unnecessary masking of the result of known short instructions (``ADDRESS``, ``CALLER``, ``ORIGIN`` and ``COINBASE``).
+ * Parser: Display nicer error messages by showing the actual tokens and not internal names.
+ * Parser: Use the entire location of the token instead of only its starting position as source location for parser errors.
+ * SMT Checker: Support state variables of integer and bool type.
 
 Bugfixes:
  * Code Generator: Fix ``revert`` with reason coming from a state or local string variable.

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -432,6 +432,10 @@
         "bugs": [], 
         "released": "2018-04-19"
     }, 
+    "0.4.24": {
+        "bugs": [], 
+        "released": "2018-05-16"
+    }, 
     "0.4.3": {
         "bugs": [
             "ZeroFunctionSelector", 


### PR DESCRIPTION
This prepares the 0.4.24 release.