### PR TITLE
Fix 3 warnings for gcc8.1, altered `install_deps.sh` for Arch Linux

### DIFF
--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -606,7 +606,9 @@ bool Parser::isValidNumberLiteral(string const& _literal)
 {
 	try
 	{
-		u256(_literal);
+		// Try to convert _literal to u256.
+		auto tmp = u256(_literal);
+		(void) tmp;
 	}
 	catch (...)
 	{

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -117,7 +117,7 @@ bool hashMatchesContent(string const& _hash, string const& _content)
 	{
 		return dev::h256(_hash) == dev::keccak256(_content);
 	}
-	catch (dev::BadHexCharacter)
+	catch (dev::BadHexCharacter const&)
 	{
 		return false;
 	}
@@ -366,7 +366,7 @@ Json::Value StandardCompiler::compileInternal(Json::Value const& _input)
 				// @TODO use libraries only for the given source
 				libraries[library] = h160(address);
 			}
-			catch (dev::BadHexCharacter)
+			catch (dev::BadHexCharacter const&)
 			{
 				return formatFatalError(
 					"JSONError",

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -133,19 +133,18 @@ case $(uname -s) in
 # Arch Linux
 #------------------------------------------------------------------------------
 
-            Arch)
+            Arch*)
                 #Arch
                 echo "Installing solidity dependencies on Arch Linux."
 
                 # All our dependencies can be found in the Arch Linux official repositories.
                 # See https://wiki.archlinux.org/index.php/Official_repositories
-                # Also adding ethereum-git to allow for testing with the `eth` client
                 sudo pacman -Syu \
                     base-devel \
                     boost \
                     cmake \
                     git \
-                    ethereum-git \
+                    cvc4
                 ;;
 
 #------------------------------------------------------------------------------
@@ -329,7 +328,7 @@ case $(uname -s) in
                     "$install_z3"
                 if [ "$CI" = true ]; then
                     # install Z3 from PPA if the distribution does not provide it
-		            if ! dpkg -l libz3-dev > /dev/null 2>&1
+                    if ! dpkg -l libz3-dev > /dev/null 2>&1
                     then
                         sudo apt-add-repository -y ppa:hvr/z3
                         sudo apt-get -y update


### PR DESCRIPTION
This pull request basically addresses the [Issue](https://gitter.im/ethereum/topics/topic/5afc4eb58c24fe61eaed3fa9/tiny-bug-in-install_deps-script-arch-linux-build-from-source) I mentioned in the gitter channel.

1. `install_deps.sh`
    - "Arch Linux" was not recognized as the Arch distribution. 
    - Removed a dependency that does not exist
        - I could not find a  `pacman` dependency called `ethereum-git; if I didn't miss anything, it does neither exist in the official repo, nor in the AUR.
    - added optional dependencies
2. Fixed 3 gcc warnings (that are considered errors like the `-Werror` flag is used, preventing me from `making` the project).

edit:
I queried for the packet ethereum-git in the AUR and found 
```bash
> yaourt -Ss ethereum-git
aur/cpp-ethereum-git r31888.04e8ca5af-1 (0) (0.00)
    Ethereum C++ client
```
which installs from the https://github.com/ethereum/cpp-ethereum project.
If that's the required packet, it might be easiest to compile it from source inside the script / install `yaourt` and issue a yaourt -S.


Btw:
```bash
> gcc --version
gcc (GCC) 8.1.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```