### PR TITLE
CMake: Fix libdir for jsoncpp external project in special case

### DIFF
--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -7,8 +7,14 @@ else()
 endif()
 
 include(GNUInstallDirs)
+set(libdir ${CMAKE_INSTALL_LIBDIR})
+if(CMAKE_LIBRARY_ARCHITECTURE)
+    # Do not use Debian multiarch library dir.
+    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" libdir ${libdir})
+endif()
+
 set(prefix "${CMAKE_BINARY_DIR}/deps")
-set(JSONCPP_LIBRARY "${prefix}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(JSONCPP_LIBRARY "${prefix}/${libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(JSONCPP_INCLUDE_DIR "${prefix}/include")
 
 if(NOT MSVC)


### PR DESCRIPTION
When building on Debian/Ubuntu with install prefix /usr (e.g. in PPA builds) the CMAKE_INSTALL_LIBDIR is resolved to lib/x86_64-linux-gnu. For jsoncpp external project this is never the case because the install prefix is not /usr. Remove multiarch part from libdir if there.