### PR TITLE
[BREAKING] Remove emit workaround

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Breaking Changes:
  * Commandline interface: Require ``-`` if standard input is used as source.
  * General: New keywords: ``calldata``
  * General: ``continue`` in a ``do...while`` loop jumps to the condition (it used to jump to the loop body). Warning: this may silently change the semantics of existing code.
+ * Introduce ``emit`` as a keyword instead of parsing it as identifier.
  * Type Checker: Disallow arithmetic operations for Boolean variables.
  * Disallow trailing dots that are not followed by a number.
  * Remove assembly instructions ``sha3`` and ``suicide``

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -939,10 +939,11 @@ ASTPointer<Statement> Parser::parseStatement()
 	}
 	case Token::Assembly:
 		return parseInlineAssembly(docString);
+	case Token::Emit:
+		statement = parseEmitStatement(docString);
+		break;
 	case Token::Identifier:
-		if (m_scanner->currentLiteral() == "emit")
-			statement = parseEmitStatement(docString);
-		else if (m_insideModifier && m_scanner->currentLiteral() == "_")
+		if (m_insideModifier && m_scanner->currentLiteral() == "_")
 		{
 			statement = ASTNodeFactory(*this).createNode<PlaceholderStatement>(docString);
 			m_scanner->next();
@@ -1062,6 +1063,8 @@ ASTPointer<ForStatement> Parser::parseForStatement(ASTPointer<ASTString> const& 
 
 ASTPointer<EmitStatement> Parser::parseEmitStatement(ASTPointer<ASTString> const& _docString)
 {
+	expectToken(Token::Emit, false);
+
 	ASTNodeFactory nodeFactory(*this);
 	m_scanner->next();
 	ASTNodeFactory eventCallNodeFactory(*this);

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -149,6 +149,7 @@ namespace solidity
 	K(Do, "do", 0)                                                     \
 	K(Else, "else", 0)                                                 \
 	K(Enum, "enum", 0)                                                 \
+	K(Emit, "emit", 0)                                                 \
 	K(Event, "event", 0)                                               \
 	K(External, "external", 0)                                         \
 	K(For, "for", 0)                                                   \


### PR DESCRIPTION
Closes #4107.

This PR introduces ``emit`` as a proper keyword instead of parsing it as identifier.