### PR TITLE
Supply git as a dependency for building in docker

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -159,7 +159,7 @@ case $(uname -s) in
                 # See https://pkgs.alpinelinux.org/
 
                 apk update
-                apk add boost-dev build-base cmake
+                apk add boost-dev build-base cmake git
 
                 ;;
 


### PR DESCRIPTION
Otherwise, the build will fail complaining about not nowing a commit
hash to label the version with.