### PR TITLE
move bytes and string to arrays section

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -218,6 +218,14 @@ Members:
     It is possible to use an array of bytes as ``byte[]``, but it is wasting a lot of space, 31 bytes every element,
     to be exact, when passing in calls. It is better to use ``bytes``.
 
+Dynamically-sized byte array
+----------------------------
+
+``bytes``:
+    Dynamically-sized byte array, see :ref:`arrays`. Not a value-type!
+``string``:
+    Dynamically-sized UTF-8-encoded string, see :ref:`arrays`. Not a value-type!
+
 .. index:: address, literal;address
 
 .. _address_literals:
@@ -505,18 +513,6 @@ them can be quite expensive, we have to think about whether we want them to be
 stored in **memory** (which is not persisting) or **storage** (where the state
 variables are held).
 
-Dynamically-sized byte array
-----------------------------
-
-``bytes``:
-    Dynamically-sized byte array, see :ref:`arrays`. Not a value-type!
-``string``:
-    Dynamically-sized UTF-8-encoded string, see :ref:`arrays`. Not a value-type!
-
-As a rule of thumb, use ``bytes`` for arbitrary-length raw byte data and ``string``
-for arbitrary-length string (UTF-8) data. If you can limit the length to a certain
-number of bytes, always use one of ``bytes1`` to ``bytes32`` because they are much cheaper.
-
 Data location
 -------------
 
@@ -602,8 +598,10 @@ shaves off one level in the type from the right).
 Variables of type ``bytes`` and ``string`` are special arrays. A ``bytes`` is similar to ``byte[]``,
 but it is packed tightly in calldata. ``string`` is equal to ``bytes`` but does not allow
 length or index access (for now).
-
 So ``bytes`` should always be preferred over ``byte[]`` because it is cheaper.
+As a rule of thumb, use ``bytes`` for arbitrary-length raw byte data and ``string``
+for arbitrary-length string (UTF-8) data. If you can limit the length to a certain
+number of bytes, always use one of ``bytes1`` to ``bytes32`` because they are much cheaper.
 
 .. note::
     If you want to access the byte-representation of a string ``s``, use

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -218,18 +218,6 @@ Members:
     It is possible to use an array of bytes as ``byte[]``, but it is wasting a lot of space, 31 bytes every element,
     to be exact, when passing in calls. It is better to use ``bytes``.
 
-Dynamically-sized byte array
-----------------------------
-
-``bytes``:
-    Dynamically-sized byte array, see :ref:`arrays`. Not a value-type!
-``string``:
-    Dynamically-sized UTF-8-encoded string, see :ref:`arrays`. Not a value-type!
-
-As a rule of thumb, use ``bytes`` for arbitrary-length raw byte data and ``string``
-for arbitrary-length string (UTF-8) data. If you can limit the length to a certain
-number of bytes, always use one of ``bytes1`` to ``bytes32`` because they are much cheaper.
-
 .. index:: address, literal;address
 
 .. _address_literals:
@@ -516,6 +504,18 @@ more carefully than the value-types we have already seen. Since copying
 them can be quite expensive, we have to think about whether we want them to be
 stored in **memory** (which is not persisting) or **storage** (where the state
 variables are held).
+
+Dynamically-sized byte array
+----------------------------
+
+``bytes``:
+    Dynamically-sized byte array, see :ref:`arrays`. Not a value-type!
+``string``:
+    Dynamically-sized UTF-8-encoded string, see :ref:`arrays`. Not a value-type!
+
+As a rule of thumb, use ``bytes`` for arbitrary-length raw byte data and ``string``
+for arbitrary-length string (UTF-8) data. If you can limit the length to a certain
+number of bytes, always use one of ``bytes1`` to ``bytes32`` because they are much cheaper.
 
 Data location
 -------------


### PR DESCRIPTION
Fixes #4188.

This moves the bytes and string types from the value types section to the complex types section.