### PR TITLE
Update auction end check to use `ended` variable.

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -278,7 +278,7 @@ activate themselves.
             // Revert the call if the bidding
             // period is over.
             require(
-                now <= auctionEnd,
+                !ended,
                 "Auction already ended."
             );
 


### PR DESCRIPTION
The semantics are clearer when this variable is used vs. checking timestamps.