### PR TITLE
Turn named return parameters in function types into an error.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Breaking Changes:
  * Type Checker: Disallow arithmetic operations for boolean variables.
  * Type Checker: Disallow conversions between ``bytesX`` and ``uintY`` of different size.
  * Remove obsolete ``std`` directory from the Solidity repository. This means accessing ``https://github.com/ethereum/soldity/blob/develop/std/*.sol`` (or ``https://github.com/ethereum/solidity/std/*.sol`` in Remix) will not be possible.
+ * Syntax Checker: Named return values in function types are an error.
 
 Language Features:
  * General: Allow appending ``calldata`` keyword to types, to explicitly specify data location for arguments of external functions.

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -255,7 +255,7 @@ bool SyntaxChecker::visit(FunctionTypeName const& _node)
 
 	for (auto const& decl: _node.returnParameterTypeList()->parameters())
 		if (!decl->name().empty())
-			m_errorReporter.warning(decl->location(), "Naming function type return parameters is deprecated.");
+			m_errorReporter.syntaxError(decl->location(), "Return parameters in function types may not be named.");
 
 	return true;
 }

--- a/test/libsolidity/syntaxTests/functionTypes/function_type_return_parameters_with_names.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/function_type_return_parameters_with_names.sol
@@ -1,0 +1,5 @@
+contract C {
+    function(uint) returns (bool ret) f;
+}
+// ----
+// SyntaxError: (41-49): Return parameters in function types may not be named.

--- a/test/libsolidity/syntaxTests/functionTypes/warn_function_type_return_parameters_with_names.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/warn_function_type_return_parameters_with_names.sol
@@ -1,5 +1,0 @@
-contract C {
-    function(uint) returns (bool ret) f;
-}
-// ----
-// Warning: (41-49): Naming function type return parameters is deprecated.

--- a/test/libsolidity/syntaxTests/parsing/function_type_in_struct.sol
+++ b/test/libsolidity/syntaxTests/parsing/function_type_in_struct.sol
@@ -1,6 +1,6 @@
 contract test {
     struct S {
-        function (uint x, uint y) internal returns (uint a) f;
+        function (uint x, uint y) internal returns (uint) f;
         function (uint, uint) external returns (uint) g;
         uint d;
     }
@@ -8,4 +8,3 @@ contract test {
 // ----
 // Warning: (49-55): Naming function type parameters is deprecated.
 // Warning: (57-63): Naming function type parameters is deprecated.
-// Warning: (83-89): Naming function type return parameters is deprecated.


### PR DESCRIPTION
Closes  #2428.