### PR TITLE
jsoncpp: Force install libdir in jsoncpp external project

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ defaults:
       command: |
         mkdir -p build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr
         make -j4
   - run_tests: &run_tests
       name: Tests

--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -6,15 +6,8 @@ else()
     set(JSONCPP_CMAKE_COMMAND ${CMAKE_COMMAND})
 endif()
 
-include(GNUInstallDirs)
-set(libdir ${CMAKE_INSTALL_LIBDIR})
-if(CMAKE_LIBRARY_ARCHITECTURE)
-    # Do not use Debian multiarch library dir.
-    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" libdir ${libdir})
-endif()
-
 set(prefix "${CMAKE_BINARY_DIR}/deps")
-set(JSONCPP_LIBRARY "${prefix}/${libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(JSONCPP_INCLUDE_DIR "${prefix}/include")
 
 if(NOT MSVC)
@@ -34,6 +27,7 @@ ExternalProject_Add(jsoncpp-project
     URL_HASH SHA256=c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6
     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+               -DCMAKE_INSTALL_LIBDIR=lib
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                # Build static lib but suitable to be included in a shared lib.


### PR DESCRIPTION
Instead of guessing the install dir for libraries decided by GNUInstalDirs module (what changes with OS and CMake version) force jsoncpp to always use "lib".