### PR TITLE
Fix cmake when custom CMAKE_INSTALL_LIBDIR is given

### DIFF
--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -6,15 +6,8 @@ else()
     set(JSONCPP_CMAKE_COMMAND ${CMAKE_COMMAND})
 endif()
 
-include(GNUInstallDirs)
-set(libdir ${CMAKE_INSTALL_LIBDIR})
-if(CMAKE_LIBRARY_ARCHITECTURE)
-    # Do not use Debian multiarch library dir.
-    string(REPLACE "/${CMAKE_LIBRARY_ARCHITECTURE}" "" libdir ${libdir})
-endif()
-
 set(prefix "${CMAKE_BINARY_DIR}/deps")
-set(JSONCPP_LIBRARY "${prefix}/${libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(JSONCPP_INCLUDE_DIR "${prefix}/include")
 
 if(NOT MSVC)
@@ -36,6 +29,7 @@ ExternalProject_Add(jsoncpp-project
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_INSTALL_LIBDIR=lib
                # Build static lib but suitable to be included in a shared lib.
                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
                -DJSONCPP_WITH_TESTS=OFF


### PR DESCRIPTION
According to [cmake doc](https://cmake.org/cmake/help/v3.11/module/GNUInstallDirs.html), we cannot assume `CMAKE_INSTALL_LIBDIR` is a relative path. People often use `cmake -DCMAKE_INSTALL_LIBDIR=/some/custome/library/path` to specify where the libraries should install to. 

Simply use `lib` as temporary libdir is probably a solution.

Inconsistent `CMAKE_INSTALL_LIBDIR` problem addressed by @aarlt and @chriseth ( https://github.com/ethereum/solidity/pull/3467#issuecomment-364265583 ) is fixed by passing `-DCMAKE_INSTALL_LIBDIR=lib` to jsoncpp's cmake.

We don't need `GNUInstallDirs` here because jsoncpp's build is only temporary used anyway.

@chfast could you take a look? Thanks so much