### PR TITLE
[TO BE REDONE] Infrastructure for extracting semantics tests.

### DIFF
--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -49,8 +49,13 @@ string getIPCSocketPath()
 
 }
 
-ExecutionFramework::ExecutionFramework() :
-	m_rpc(RPCSession::instance(getIPCSocketPath())),
+ExecutionFramework::ExecutionFramework():
+	ExecutionFramework(getIPCSocketPath())
+{
+}
+
+ExecutionFramework::ExecutionFramework(string const& _ipcPath):
+	m_rpc(RPCSession::instance(_ipcPath)),
 	m_evmVersion(dev::test::Options::get().evmVersion()),
 	m_optimize(dev::test::Options::get().optimize),
 	m_showMessages(dev::test::Options::get().showMessages),

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -53,6 +53,7 @@ class ExecutionFramework
 
 public:
 	ExecutionFramework();
+	ExecutionFramework(std::string const& _ipcPath);
 	virtual ~ExecutionFramework() = default;
 
 	virtual bytes const& compileAndRunWithoutCheck(

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -37,6 +37,7 @@
 
 #include <test/Options.h>
 #include <test/libsolidity/SyntaxTest.h>
+#include <test/libsolidity/SemanticsTest.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -147,6 +148,16 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 			"SolidityOptimizer"
 		})
 			removeTestSuite(suite);
+	}
+	else
+	{
+		SemanticsTest::ipcPath = dev::test::Options::get().ipcPath;
+		solAssert(registerTests(
+			master,
+			dev::test::Options::get().testPath / "libsolidity",
+			"semanticsTests",
+			SemanticsTest::create
+		) > 0, "no semantics tests found");
 	}
 	if (dev::test::Options::get().disableSMT)
 		removeTestSuite("SMTChecker");

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -74,7 +74,7 @@ int registerTests(
 	boost::unit_test::test_suite& _suite,
 	boost::filesystem::path const& _basepath,
 	boost::filesystem::path const& _path,
-	TestCase::TestCaseCreator _testCaseCreator
+	TestCase::TestCaseCreator const& _testCaseCreator
 )
 {
 	int numTestsAdded = 0;

--- a/test/libsolidity/SemanticsTest.cpp
+++ b/test/libsolidity/SemanticsTest.cpp
@@ -1,0 +1,533 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/libsolidity/SemanticsTest.h>
+#include <test/Options.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/throw_exception.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+using namespace dev;
+using namespace solidity;
+using namespace dev::solidity::test;
+using namespace dev::solidity::test::formatting;
+using namespace std;
+namespace fs = boost::filesystem;
+using namespace boost;
+using namespace boost::algorithm;
+using namespace boost::unit_test;
+
+SemanticsTest::SemanticsTest(string const& _filename):
+	SolidityExecutionFramework(ipcPath)
+{
+	ifstream file(_filename);
+	if (!file)
+		BOOST_THROW_EXCEPTION(runtime_error("Cannot open test contract: \"" + _filename + "\"."));
+	file.exceptions(ios::badbit);
+
+	m_source = parseSource(file);
+	m_calls = parseCalls(file);
+}
+
+
+bool SemanticsTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+{
+	compileAndRun(m_source);
+
+	bool success = true;
+	m_results.clear();
+	for (auto const& test: m_calls)
+	{
+		m_results.emplace_back(callContractFunctionWithValueNoEncoding(
+			test.signature,
+			test.value,
+			test.argumentBytes
+		));
+
+		if (m_results.back() != test.expectedBytes)
+			success = false;
+	}
+
+	if (!success)
+	{
+		string nextIndentLevel = _linePrefix + "  ";
+		FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
+		printCalls(false, _stream, nextIndentLevel, _formatted);
+		FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << endl;
+		printCalls(true, _stream, nextIndentLevel, _formatted);
+		return false;
+	}
+	return true;
+}
+
+void SemanticsTest::printSource(ostream &_stream, string const &_linePrefix, bool const) const
+{
+	stringstream stream(m_source);
+	string line;
+	while (getline(stream, line))
+		_stream << _linePrefix << line << endl;
+}
+
+void SemanticsTest::printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const
+{
+	printCalls(true, _stream, _linePrefix, false);
+}
+
+bool SemanticsTest::ByteRangeFormat::padsLeft() const
+{
+	switch (type)
+	{
+		case Bool:
+		case Dec:
+		case Hex:
+		case SignedDec:
+			return true;
+		case Hash:
+		case HexString:
+		case String:
+			return false;
+		default:
+			solAssert(false, "");
+	}
+}
+
+std::string SemanticsTest::ByteRangeFormat::tryFormat(
+	bytes::const_iterator _it,
+	bytes::const_iterator _end
+) const
+{
+	solAssert(_it < _end, "");
+	solAssert(length != 0, "");
+
+	if (padded)
+	{
+		size_t paddedLength = ((length + 31) & ~31);
+		if (size_t(_end - _it) < paddedLength) return {};
+		auto isZero = [](byte const& _v) -> bool { return _v == 0; };
+		if (padsLeft())
+		{
+			if (!all_of(_it, _it + (paddedLength - length), isZero))
+				return {};
+			_it += paddedLength - length;
+		}
+		else if (!all_of(_it + length, _it + paddedLength, isZero))
+			return {};
+	}
+	else if (size_t(_end - _it) < length)
+		return {};
+
+	bytes byteRange(_it, _it + length);
+	stringstream result;
+	switch(type)
+	{
+		case ByteRangeFormat::SignedDec:
+			if (*_it & 0x80)
+			{
+				for (auto& v: byteRange)
+					v ^= 0xFF;
+				result << "-" << fromBigEndian<u256>(byteRange) + 1;
+			}
+			else
+				result << fromBigEndian<u256>(byteRange);
+			break;
+		case ByteRangeFormat::Dec:
+			result << fromBigEndian<u256>(byteRange);
+			break;
+		case ByteRangeFormat::Hash:
+		case ByteRangeFormat::Hex:
+			result << "0x" << hex << fromBigEndian<u256>(byteRange);
+			break;
+		case ByteRangeFormat::HexString:
+			result << "hex\"" << toHex(byteRange) << "\"";
+			break;
+		case ByteRangeFormat::Bool:
+		{
+			auto val = fromBigEndian<u256>(byteRange);
+			if (val == u256(1))
+				result << "true";
+			else if (val == u256(0))
+				result << "false";
+			else
+				return {};
+			break;
+		}
+		case ByteRangeFormat::String:
+		{
+			result << "\"";
+			bool expectZeros = false;
+			for (auto const& v: byteRange)
+			{
+				if (expectZeros && v != 0)
+					return {};
+				if (v == 0) expectZeros = true;
+				else
+				{
+					if (!isprint(v) || v == '"')
+						return {};
+					result << v;
+				}
+			}
+			result << "\"";
+			break;
+		}
+	}
+
+	return result.str();
+
+}
+
+SemanticsTest::ByteRangeFormat ChooseNextRangeFormat(bytes::const_iterator _start, bytes::const_iterator _end)
+{
+	// TODO: use some heuristic to choose a better format
+	solAssert(_start < _end, "");
+	size_t length = size_t(_end - _start);
+	if (length >= 32)
+		return {32, SemanticsTest::ByteRangeFormat::Hex, true};
+	else
+		return {length, SemanticsTest::ByteRangeFormat::HexString, false};
+}
+
+string SemanticsTest::bytesToString(
+	bytes const& _bytes,
+	vector<ByteRangeFormat> const& _formatList
+)
+{
+	string result;
+
+	auto it = _bytes.begin();
+	bool padded = true;
+
+	auto formatit = _formatList.begin();
+
+	while(it != _bytes.end())
+	{
+		ByteRangeFormat format = (formatit == _formatList.end())?
+			ChooseNextRangeFormat(it, _bytes.end()) : *formatit++;
+
+		// check for end of unpadded block
+		if (!padded && format.padded)
+		{
+			result += ")";
+			padded = true;
+		}
+
+		if (it != _bytes.begin())
+			result += ", ";
+
+		// check for beginning of unpadded block
+		if (padded && !format.padded)
+		{
+			result += "unpadded(";
+			padded = false;
+		}
+
+		string formatted = format.tryFormat(it, _bytes.end());
+		if (!formatted.empty())
+		{
+			result += formatted;
+			if (format.padded)
+				it += (format.length + 31) & ~31;
+			else
+				it += format.length;
+		}
+		else
+			formatit = _formatList.end();
+	}
+
+	if (!padded)
+		result += ")";
+
+	solAssert(stringToBytes(result) == _bytes, "Conversion to string failed.");
+	return result;
+}
+
+bytes SemanticsTest::stringToBytes(string _list, vector<ByteRangeFormat>* _formatList, bool padded)
+{
+	bytes result;
+	auto it = _list.begin();
+	while (it != _list.end())
+	{
+		if (isdigit(*it) || (*it == '-' && (it + 1) != _list.end() && isdigit(*(it + 1))))
+		{
+			ByteRangeFormat::Type type = ByteRangeFormat::Dec;
+			bool isNegative = (*it == '-');
+
+			if (_formatList)
+			{
+				// note that signed hex numbers will be parsed correctly,
+				// but re-encoded as signed dec numbers
+				if (isNegative)
+					type = ByteRangeFormat::SignedDec;
+				else if (*it == '0' && it + 1 != _list.end() && *(it + 1) == 'x')
+					type = ByteRangeFormat::Hex;
+				else
+					type = ByteRangeFormat::Dec;
+			}
+
+			auto valueBegin = it;
+			while (it != _list.end() && !isspace(*it) && *it != ',')
+				++it;
+
+			bytes newBytes;
+			u256 numberValue(string(valueBegin, it));
+			if (padded)
+				newBytes = toBigEndian(numberValue);
+			else if (numberValue == u256(0))
+				newBytes = bytes{0};
+			else
+				newBytes = toCompactBigEndian(numberValue);
+
+			if (_formatList)
+				_formatList->emplace_back(ByteRangeFormat{newBytes.size(), type, padded});
+
+			result += newBytes;
+		}
+		else if (*it == '"')
+		{
+			++it;
+			auto stringBegin = it;
+			// TODO: handle escaped quotes, resp. escape sequences in general
+			while (it != _list.end() && *it != '"')
+				++it;
+			bytes stringBytes = asBytes(string(stringBegin, it));
+			expect(it, _list.end(), '"');
+
+			result += stringBytes;
+			if (padded)
+				result += bytes((32 - stringBytes.size() % 32) % 32, 0);
+			if (_formatList)
+				_formatList->emplace_back(ByteRangeFormat{stringBytes.size(), ByteRangeFormat::String, padded});
+		}
+		else if (starts_with(iterator_range<string::iterator>(it, _list.end()), "keccak256("))
+		{
+			if (_formatList)
+				_formatList->emplace_back(ByteRangeFormat{32, ByteRangeFormat::Hash, padded});
+
+			it += 10; // skip "keccak256("
+
+			unsigned int parenthesisLevel = 1;
+			auto nestedListBegin = it;
+			while (it != _list.end())
+			{
+				if (*it == '(') ++parenthesisLevel;
+				else if (*it == ')')
+				{
+					--parenthesisLevel;
+					if (parenthesisLevel == 0)
+						break;
+				}
+				++it;
+			}
+			bytes nestedResult = stringToBytes(string(nestedListBegin, it));
+			expect(it, _list.end(), ')');
+			result += keccak256(nestedResult).asBytes();
+		}
+		else if (starts_with(iterator_range<string::iterator>(it, _list.end()), "hex\""))
+		{
+			it += 4; // skip "hex\""
+			auto hexStringBegin = it;
+			while (it != _list.end() && *it != '"')
+				++it;
+			string hexString(hexStringBegin, it);
+			bytes hexBytes = fromHex(hexString);
+			expect(it, _list.end(), '"');
+
+			result += hexBytes;
+			if (padded)
+				result += bytes((32 - hexBytes.size() % 32) % 32, 0);
+			if (_formatList)
+				_formatList->emplace_back(ByteRangeFormat{hexBytes.size(), ByteRangeFormat::HexString, padded});
+		}
+		else if (starts_with(iterator_range<string::iterator>(it, _list.end()), "unpadded("))
+		{
+			it += 9; // skip "unpadded("
+
+			unsigned int parenthesisLevel = 1;
+			auto nestedListBegin = it;
+			while (it != _list.end())
+			{
+				if (*it == '(') ++parenthesisLevel;
+				else if (*it == ')')
+				{
+					--parenthesisLevel;
+					if (parenthesisLevel == 0)
+						break;
+				}
+				++it;
+			}
+			result += stringToBytes(string(nestedListBegin, it), _formatList, false);
+			expect(it, _list.end(), ')');
+		}
+		else if (starts_with(iterator_range<string::iterator>(it, _list.end()), "true"))
+		{
+			it += 4; // skip "true"
+			if (padded)
+				result += bytes(31, 0);
+			result += bytes{1};
+			if (_formatList)
+				_formatList->emplace_back(ByteRangeFormat{1, ByteRangeFormat::Bool, padded});
+		}
+		else if (starts_with(iterator_range<string::iterator>(it, _list.end()), "false"))
+		{
+			it += 5; // skip "false"
+			if (padded)
+				result += bytes(31, 0);
+			result += bytes{0};
+			if (_formatList)
+				_formatList->emplace_back(ByteRangeFormat{1, ByteRangeFormat::Bool, padded});
+		}
+		else
+			BOOST_THROW_EXCEPTION(runtime_error("Test expectations contain invalidly formatted data."));
+
+		skipWhitespace(it, _list.end());
+		if (it != _list.end())
+			expect(it, _list.end(), ',');
+		skipWhitespace(it, _list.end());
+	}
+	return result;
+}
+
+void SemanticsTest::printCalls(
+	bool _actualResults,
+	ostream& _stream,
+	string const& _linePrefix,
+	bool const _formatted
+) const
+{
+	solAssert(m_calls.size() == m_results.size(), "");
+	for (size_t i = 0; i < m_calls.size(); i++)
+	{
+		auto const& call = m_calls[i];
+		_stream << _linePrefix << call.signature;
+		if (call.value > u256(0))
+			_stream << "[" << call.value << "]";
+		if (!call.arguments.empty())
+		{
+			_stream << ": " << call.arguments;
+		}
+		_stream << endl;
+		string result;
+		std::vector<ByteRangeFormat> formatList;
+		auto expectedBytes = stringToBytes(call.expectedResult, &formatList);
+		if (_actualResults)
+			result = bytesToString(m_results[i], formatList);
+		else
+			result = call.expectedResult;
+
+		_stream << _linePrefix;
+		if (_formatted && m_results[i] != expectedBytes)
+			_stream << formatting::RED_BACKGROUND;
+		if (result.empty())
+			_stream << "REVERT";
+		else
+			_stream << "-> " << result;
+		if (_formatted && m_results[i] != expectedBytes)
+			_stream << formatting::RESET;
+		_stream << endl;
+	}
+}
+
+vector<SemanticsTest::SemanticsTestFunctionCall> SemanticsTest::parseCalls(istream& _stream)
+{
+	vector<SemanticsTestFunctionCall> expectations;
+	string line;
+	while (getline(_stream, line))
+	{
+		auto it = line.begin();
+
+		skipSlashes(it, line.end());
+		skipWhitespace(it, line.end());
+
+		string arguments;
+		bytes argumentBytes;
+		u256 ether(0);
+		string expectedResult;
+		bytes expectedBytes;
+		vector<ByteRangeFormat> expectedFormat;
+
+		if (it == line.end())
+			continue;
+
+		auto signatureBegin = it;
+		while (it != line.end() && *it != ')')
+			++it;
+		expect(it, line.end(), ')');
+
+		string signature(signatureBegin, it);
+
+		if (it != line.end() && *it == '[')
+		{
+			++it;
+			auto etherBegin = it;
+			while (it != line.end() && *it != ']')
+				++it;
+			string etherString(etherBegin, it);
+			ether = u256(etherString);
+			expect(it, line.end(), ']');
+		}
+
+		skipWhitespace(it, line.end());
+
+		if (it != line.end())
+		{
+			expect(it, line.end(), ':');
+			skipWhitespace(it, line.end());
+			arguments = string(it, line.end());
+			argumentBytes = stringToBytes(arguments);
+		}
+
+		if (!getline(_stream, line))
+			throw runtime_error("Invalid test expectation. No result specified.");
+
+		it = line.begin();
+		skipSlashes(it, line.end());
+		skipWhitespace(it, line.end());
+
+		if (it != line.end() && *it == '-')
+		{
+			expect(it, line.end(), '-');
+			expect(it, line.end(), '>');
+
+			skipWhitespace(it, line.end());
+
+			expectedResult = string(it, line.end());
+			expectedBytes = stringToBytes(expectedResult, &expectedFormat);
+		}
+		else
+			for (char c: string("REVERT"))
+				expect(it, line.end(), c);
+
+		expectations.emplace_back(SemanticsTestFunctionCall{
+			std::move(signature),
+			std::move(arguments),
+			std::move(argumentBytes),
+			std::move(ether),
+			std::move(expectedResult),
+			std::move(expectedBytes),
+			std::move(expectedFormat)
+		});
+	}
+	return expectations;
+}
+
+string SemanticsTest::ipcPath;

--- a/test/libsolidity/SemanticsTest.h
+++ b/test/libsolidity/SemanticsTest.h
@@ -111,9 +111,11 @@ private:
 		std::vector<ByteRangeFormat> expectedFormat;
 	};
 
-	static std::vector<SemanticsTestFunctionCall> parseCalls(std::istream& _stream);
+	void parseExpectations(std::istream &_stream);
 
-
+	std::map<std::string, dev::test::Address> m_libraryAddresses;
+	std::vector<std::function<void(void)>> m_initializations;
+	bool m_hasDeploy = false;
 	std::string m_source;
 	std::vector<SemanticsTestFunctionCall> m_calls;
 	std::vector<bytes> m_results;

--- a/test/libsolidity/SemanticsTest.h
+++ b/test/libsolidity/SemanticsTest.h
@@ -116,6 +116,8 @@ private:
 
 	void parseExpectations(std::istream &_stream);
 
+	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments);
+
 	std::map<std::string, dev::test::Address> m_libraryAddresses;
 	std::vector<std::function<void(void)>> m_initializations;
 	bool m_hasDeploy = false;

--- a/test/libsolidity/SemanticsTest.h
+++ b/test/libsolidity/SemanticsTest.h
@@ -107,6 +107,7 @@ private:
 		bytes argumentBytes;
 		std::string argumentComment;
 		u256 etherValue;
+		bool expectedStatus = true;
 		std::string expectedResult;
 		bytes expectedBytes;
 		std::vector<ByteRangeFormat> expectedFormat;
@@ -120,7 +121,7 @@ private:
 	bool m_hasDeploy = false;
 	std::string m_source;
 	std::vector<SemanticsTestFunctionCall> m_calls;
-	std::vector<bytes> m_results;
+	std::vector<std::pair<bool, bytes>> m_results;
 };
 
 }

--- a/test/libsolidity/SemanticsTest.h
+++ b/test/libsolidity/SemanticsTest.h
@@ -1,0 +1,124 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <test/libsolidity/FormattedScope.h>
+#include <test/libsolidity/SolidityExecutionFramework.h>
+#include <test/libsolidity/TestCase.h>
+#include <libsolidity/interface/Exceptions.h>
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+class SemanticsTest: SolidityExecutionFramework, public TestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(std::string const& _filename)
+	{ return std::unique_ptr<TestCase>(new SemanticsTest(_filename)); }
+	SemanticsTest(std::string const& _filename);
+	virtual ~SemanticsTest() {}
+
+	virtual bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+
+	virtual void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool const _formatted = false) const override;
+	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
+
+	/// Represents the format used to represent a range of bytes in the test expectations.
+	/// Used to attempt to reformat mismatching results using the same format as the expectations.
+	struct ByteRangeFormat
+	{
+		enum Type {
+			Bool,
+			String,
+			Dec,
+			Hash,
+			Hex,
+			HexString,
+			SignedDec
+		};
+
+		/// Unpadded length of the byte range.
+		std::size_t length;
+		/// Encoding type of the byte range.
+		Type type;
+		/// true, if the byte range was padded.
+		bool padded;
+		/// @returns true, if the byte range is padded to the left, false otherwise.
+		bool padsLeft() const;
+		/// Tries to format the byte range from @arg _it to @arg _end.
+		/// @returns A string representing the byte range or the empty string if formatting failed.
+		std::string tryFormat(bytes::const_iterator _it, bytes::const_iterator _end) const;
+	};
+
+	/// Converts @arg _bytes to a formatted string representation.
+	/// Attempts to use the format given in @arg _formatList, if possible, and uses
+	/// generic formatting as fallback.
+	static std::string bytesToString(
+		bytes const& _bytes,
+		std::vector<ByteRangeFormat> const& _formatList
+	);
+	/// Parses the bytes encoded in the comma separated string @arg _list.
+	/// If @arg _formatList is not nullptr, the formatting of the string is appended.
+	/// If @arg _padded is true (default), 32-byte padding is used for all elements of the string.
+	/// Otherwise no padding is applied (used for "unpadded(...)" blocks).
+	static bytes stringToBytes(
+		std::string _list,
+		std::vector<ByteRangeFormat>* _formatList = nullptr,
+		bool padded = true
+	);
+
+	static std::string ipcPath;
+private:
+	void printCalls(
+		bool _actualResults,
+		std::ostream& _stream,
+		std::string const& _linePrefix,
+		bool const _formatted = false
+	) const;
+
+	struct SemanticsTestFunctionCall
+	{
+		std::string signature;
+		std::string arguments;
+		bytes argumentBytes;
+		u256 value;
+		std::string expectedResult;
+		bytes expectedBytes;
+		std::vector<ByteRangeFormat> expectedFormat;
+	};
+
+	static std::vector<SemanticsTestFunctionCall> parseCalls(std::istream& _stream);
+
+
+	std::string m_source;
+	std::vector<SemanticsTestFunctionCall> m_calls;
+	std::vector<bytes> m_results;
+};
+
+}
+}
+}

--- a/test/libsolidity/SemanticsTest.h
+++ b/test/libsolidity/SemanticsTest.h
@@ -105,10 +105,12 @@ private:
 		std::string signature;
 		std::string arguments;
 		bytes argumentBytes;
-		u256 value;
+		std::string argumentComment;
+		u256 etherValue;
 		std::string expectedResult;
 		bytes expectedBytes;
 		std::vector<ByteRangeFormat> expectedFormat;
+		std::string resultComment;
 	};
 
 	void parseExpectations(std::istream &_stream);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7212,21 +7212,6 @@ BOOST_AUTO_TEST_CASE(storage_string_as_mapping_key_without_variable)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(2)));
 }
 
-BOOST_AUTO_TEST_CASE(library_call)
-{
-	char const* sourceCode = R"(
-		library Lib { function m(uint x, uint y) returns (uint) { return x * y; } }
-		contract Test {
-			function f(uint x) returns (uint) {
-				return Lib.m(x, 9);
-			}
-		}
-	)";
-	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
-	ABI_CHECK(callContractFunction("f(uint256)", u256(33)), encodeArgs(u256(33) * 9));
-}
-
 BOOST_AUTO_TEST_CASE(library_function_external)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -28,7 +28,12 @@ using namespace dev::test;
 using namespace dev::solidity;
 using namespace dev::solidity::test;
 
-SolidityExecutionFramework::SolidityExecutionFramework() :
+SolidityExecutionFramework::SolidityExecutionFramework():
 	ExecutionFramework()
+{
+}
+
+SolidityExecutionFramework::SolidityExecutionFramework(std::string const& _ipcPath):
+	ExecutionFramework(_ipcPath)
 {
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -43,6 +43,7 @@ class SolidityExecutionFramework: public dev::test::ExecutionFramework
 
 public:
 	SolidityExecutionFramework();
+	SolidityExecutionFramework(std::string const& _ipcPath);
 
 	virtual bytes const& compileAndRunWithoutCheck(
 		std::string const& _sourceCode,

--- a/test/libsolidity/TestCase.h
+++ b/test/libsolidity/TestCase.h
@@ -34,7 +34,7 @@ namespace test
 class TestCase
 {
 public:
-	using TestCaseCreator = std::unique_ptr<TestCase>(*)(std::string const&);
+	using TestCaseCreator = std::function<std::unique_ptr<TestCase>(std::string const&)>;
 
 	virtual ~TestCase() {}
 

--- a/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_false_literal.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_false_literal.sol
@@ -1,0 +1,8 @@
+contract test {
+    function f() returns(uint d) {
+        return false ? 5 : 10;
+    }
+}
+// ----
+// f()
+// -> 10

--- a/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_multiple.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_multiple.sol
@@ -1,0 +1,17 @@
+contract test {
+    function f(uint x) returns(uint d) {
+        return x > 100 ?
+                    x > 1000 ? 1000 : 100
+                    :
+                    x > 50 ? 50 : 10;
+    }
+}
+// ----
+// f(uint256): 1001
+// -> 1000
+// f(uint256): 500
+// -> 100
+// f(uint256): 80
+// -> 50
+// f(uint256): 40
+// -> 10

--- a/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_storage_memory_1.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_storage_memory_1.sol
@@ -1,0 +1,29 @@
+contract test {
+    bytes2[2] data1;
+    function f(bool cond) returns (uint) {
+        bytes2[2] memory x;
+        x[0] = "aa";
+        bytes2[2] memory y;
+        y[0] = "bb";
+
+        data1 = cond ? x : y;
+
+        uint ret = 0;
+        if (data1[0] == "aa")
+        {
+            ret = 1;
+        }
+
+        if (data1[0] == "bb")
+        {
+            ret = 2;
+        }
+
+        return ret;
+    }
+}
+// ----
+// f(bool): true
+// -> 1
+// f(bool): false
+// -> 2

--- a/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_storage_memory_2.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_storage_memory_2.sol
@@ -1,0 +1,30 @@
+contract test {
+    bytes2[2] data1;
+    function f(bool cond) returns (uint) {
+        data1[0] = "cc";
+
+        bytes2[2] memory x;
+        bytes2[2] memory y;
+        y[0] = "bb";
+
+        x = cond ? y : data1;
+
+        uint ret = 0;
+        if (x[0] == "bb")
+        {
+            ret = 1;
+        }
+
+        if (x[0] == "cc")
+        {
+            ret = 2;
+        }
+
+        return ret;
+    }
+}
+// ----
+// f(bool): true
+// -> 1
+// f(bool): false
+// -> 2

--- a/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_true_literal.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_true_literal.sol
@@ -1,0 +1,8 @@
+contract test {
+    function f() returns(uint d) {
+        return true ? 5 : 10;
+    }
+}
+// ----
+// f()
+// -> 5

--- a/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_with_return_values.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/conditional_expression_with_return_values.sol
@@ -1,0 +1,10 @@
+contract test {
+    function f(bool cond, uint v) returns (uint a, uint b) {
+        cond ? a = v : b = v;
+    }
+}
+// ----
+// f(bool,uint256): true, 20
+// -> 20, 0
+// f(bool,uint256): false, 20
+// -> 0, 20

--- a/test/libsolidity/semanticsTests/EndToEnd/empty_contract.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/empty_contract.sol
@@ -1,0 +1,4 @@
+contract test { }
+// ----
+// i_am_not_there()
+// REVERT

--- a/test/libsolidity/semanticsTests/EndToEnd/exp_operator_const.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/exp_operator_const.sol
@@ -1,0 +1,6 @@
+contract test {
+    function f() returns(uint d) { return 2 ** 3; }
+}
+// ----
+// f()
+// -> 8

--- a/test/libsolidity/semanticsTests/EndToEnd/exp_operator_const_signed.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/exp_operator_const_signed.sol
@@ -1,0 +1,6 @@
+contract test {
+    function f() returns(int d) { return (-2) ** 3; }
+}
+// ----
+// f()
+// -> -8

--- a/test/libsolidity/semanticsTests/EndToEnd/exp_zero_literal.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/exp_zero_literal.sol
@@ -1,0 +1,6 @@
+contract test {
+    function f() returns(uint d) { return 0 ** 0; }
+}
+// ----
+// f()
+// -> 1

--- a/test/libsolidity/semanticsTests/EndToEnd/library_call.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/library_call.sol
@@ -1,0 +1,10 @@
+library Lib { function m(uint x, uint y) returns (uint) { return x * y; } }
+contract Test {
+    function f(uint x) returns (uint) {
+        return Lib.m(x, 9);
+    }
+}
+// ----
+// DEPLOYLIB: Lib
+// f(uint256): 33
+// -> 297

--- a/test/libsolidity/semanticsTests/EndToEnd/multiple_elementary_accessors.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/multiple_elementary_accessors.sol
@@ -1,0 +1,25 @@
+contract test {
+    uint256 public data;
+    bytes6 public name;
+    bytes32 public a_hash;
+    address public an_address;
+    function test() {
+        data = 8;
+        name = "Celina";
+        a_hash = keccak256("\x7b");
+        an_address = address(0x1337);
+        super_secret_data = 42;
+    }
+    uint256 super_secret_data;
+}
+// ----
+// data()
+// -> 8
+// name()
+// -> "Celina"
+// a_hash()
+// -> keccak256(unpadded(123))
+// an_address()
+// -> 0x1337
+// super_secret_data()
+// REVERT

--- a/test/libsolidity/semanticsTests/EndToEnd/return_string.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/return_string.sol
@@ -1,0 +1,20 @@
+contract Main {
+    string public s;
+    function set(string _s) external returns (bool) {
+        s = _s;
+        return true;
+    }
+    function get1() returns (string r) {
+        return s;
+    }
+    function get2() returns (string r) {
+        r = s;
+    }
+}
+// ----
+// set(string): 0x20, 5, "Julia"
+// -> true
+// get1()
+// -> 0x20, 5, "Julia"
+// get2()
+// -> 0x20, 5, "Julia"

--- a/test/libsolidity/semanticsTests/EndToEnd/return_string.sol
+++ b/test/libsolidity/semanticsTests/EndToEnd/return_string.sol
@@ -1,8 +1,7 @@
 contract Main {
     string public s;
-    function set(string _s) external returns (bool) {
+    function set(string _s) external {
         s = _s;
-        return true;
     }
     function get1() returns (string r) {
         return s;
@@ -13,7 +12,7 @@ contract Main {
 }
 // ----
 // set(string): 0x20, 5, "Julia"
-// -> true
+// ->
 // get1()
 // -> 0x20, 5, "Julia"
 // get2()

--- a/test/libsolidity/semanticsTests/smoke.sol
+++ b/test/libsolidity/semanticsTests/smoke.sol
@@ -1,0 +1,40 @@
+contract C {
+    function f(uint256 a) public returns(uint256, uint256) {
+        return (a, a);
+    }
+    function g() public returns(uint256) {
+        return 42000;
+    }
+    function g2() public returns(uint256) {
+        return 0x42001;
+    }
+    function h() public returns(uint256) {
+        revert();
+    }
+    function i() public returns(bytes32) {
+        return bytes32("abc");
+    }
+    function j() public returns(bool) {
+        return true;
+    }
+    function k() public returns(bytes32) {
+        return bytes2(0x1234);
+    }
+}
+// ----
+// f(uint256): 21
+// -> 21, 21
+// g()
+// -> 42000
+// g2()
+// -> 0x42001
+// h()
+// REVERT
+// non_existing()
+// REVERT
+// i()
+// -> "abc"
+// j()
+// -> true
+// k()
+// -> hex"1234"

--- a/test/libsolidity/semanticsTests/smoke.sol
+++ b/test/libsolidity/semanticsTests/smoke.sol
@@ -24,6 +24,8 @@ contract C {
 // ----
 // f(uint256): 21
 // -> 21, 21
+// f(uint256): 42 # some comment
+// -> 42, 42 # some other comment
 // g()
 // -> 42000
 // g2()

--- a/test/libsolidity/semanticsTests/smoke.sol
+++ b/test/libsolidity/semanticsTests/smoke.sol
@@ -8,7 +8,7 @@ contract C {
     function g2() public returns(uint256) {
         return 0x42001;
     }
-    function h() public returns(uint256) {
+    function h() public {
         revert();
     }
     function i() public returns(bytes32) {

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(solfuzzer fuzzer.cpp)
 target_link_libraries(solfuzzer PRIVATE libsolc evmasm ${Boost_PROGRAM_OPTIONS_LIBRARIES} ${Boost_SYSTEM_LIBRARIES})
 
-add_executable(isoltest isoltest.cpp ../Options.cpp ../libsolidity/TestCase.cpp ../libsolidity/SyntaxTest.cpp
-        ../libsolidity/AnalysisFramework.cpp ../libsolidity/SolidityExecutionFramework.cpp ../ExecutionFramework.cpp
-        ../RPCSession.cpp)
+add_executable(isoltest isoltest.cpp ../Options.cpp ../libsolidity/TestCase.cpp ../libsolidity/SemanticsTest.cpp
+        ../libsolidity/SyntaxTest.cpp ../libsolidity/AnalysisFramework.cpp ../libsolidity/SolidityExecutionFramework.cpp
+        ../ExecutionFramework.cpp ../RPCSession.cpp)
 target_link_libraries(isoltest PRIVATE libsolc solidity evmasm ${Boost_PROGRAM_OPTIONS_LIBRARIES} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES})

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -49,7 +49,7 @@ class TestTool
 {
 public:
 	TestTool(
-		TestCase::TestCaseCreator _testCaseCreator,
+		TestCase::TestCaseCreator const& _testCaseCreator,
 		string const& _name,
 		fs::path const& _path,
 		bool _formatted
@@ -66,7 +66,7 @@ public:
 	Result process();
 
 	static TestStats processPath(
-		TestCase::TestCaseCreator _testCaseCreator,
+		TestCase::TestCaseCreator const& _testCaseCreator,
 		fs::path const& _basepath,
 		fs::path const& _path,
 		bool const _formatted
@@ -182,7 +182,7 @@ TestTool::Request TestTool::handleResponse(bool const _exception)
 }
 
 TestStats TestTool::processPath(
-	TestCase::TestCaseCreator _testCaseCreator,
+	TestCase::TestCaseCreator const& _testCaseCreator,
 	fs::path const& _basepath,
 	fs::path const& _path,
 	bool const _formatted


### PR DESCRIPTION
Closes #4223.

Encoding and decoding of arguments and results is still a mess, although it should already be functional for many cases.