### PR TITLE
Update Event emit docs pragma

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -742,7 +742,7 @@ All non-indexed arguments will be stored in the data part of the log.
 
 ::
 
-    pragma solidity ^0.4.0;
+    pragma solidity ^0.4.21;
 
     contract ClientReceipt {
         event Deposit(


### PR DESCRIPTION
Event's `emit` usage was introduced in 0.4.21+