### PR TITLE
Improve exception handling in soltest and isoltest.

### DIFF
--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -268,9 +268,16 @@ int SyntaxTest::registerTests(
 			[fullpath]
 			{
 				BOOST_REQUIRE_NO_THROW({
-					stringstream errorStream;
-					if (!SyntaxTest(fullpath.string()).run(errorStream))
-						BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
+					try
+					{
+						stringstream errorStream;
+						if (!SyntaxTest(fullpath.string()).run(errorStream))
+							BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
+					}
+					catch (boost::exception const& _e)
+					{
+						BOOST_ERROR("Exception during syntax test: " << boost::diagnostic_information(_e));
+					}
 				});
 			},
 			_path.stem().string(),

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -150,39 +150,22 @@ SyntaxTestTool::Result SyntaxTestTool::process()
 		m_test = unique_ptr<SyntaxTest>(new SyntaxTest(m_path.string()));
 		success = m_test->run(outputMessages, "  ", m_formatted);
 	}
-	catch(CompilerError const& _e)
+	catch(boost::exception const& _e)
 	{
 		FormattedScope(cout, m_formatted, {BOLD, RED}) <<
-			"Exception: " << SyntaxTest::errorMessage(_e) << endl;
-		return Result::Exception;
-	}
-	catch(InternalCompilerError const& _e)
-	{
-		FormattedScope(cout, m_formatted, {BOLD, RED}) <<
-			"InternalCompilerError: " << SyntaxTest::errorMessage(_e) << endl;
-		return Result::Exception;
-	}
-	catch(FatalError const& _e)
-	{
-		FormattedScope(cout, m_formatted, {BOLD, RED}) <<
-			"FatalError: " << SyntaxTest::errorMessage(_e) << endl;
-		return Result::Exception;
-	}
-	catch(UnimplementedFeatureError const& _e)
-	{
-		FormattedScope(cout, m_formatted, {BOLD, RED}) <<
-			"UnimplementedFeatureError: " << SyntaxTest::errorMessage(_e) << endl;
+			"Exception during syntax test: " << boost::diagnostic_information(_e) << endl;
 		return Result::Exception;
 	}
 	catch (std::exception const& _e)
 	{
-		FormattedScope(cout, m_formatted, {BOLD, RED}) << "Exception: " << _e.what() << endl;
+		FormattedScope(cout, m_formatted, {BOLD, RED}) <<
+			"Exception during syntax test: " << _e.what() << endl;
 		return Result::Exception;
 	}
 	catch(...)
 	{
 		FormattedScope(cout, m_formatted, {BOLD, RED}) <<
-			"Unknown Exception" << endl;
+			"Unknown exception during syntax test." << endl;
 		return Result::Exception;
 	}
 


### PR DESCRIPTION
Fixes #4271. Fixes #4270.

This improves the output of both soltest and isoltest in case of failed assertions and exceptions during the test run.