### PR TITLE
[BREAKING] var keyword removal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Breaking Changes:
  * General: ``continue`` in a ``do...while`` loop jumps to the condition (it used to jump to the loop body). Warning: this may silently change the semantics of existing code.
  * General: Disallow declaring empty structs.
  * General: Disallow raw ``callcode`` (was already deprecated in 0.4.12). It is still possible to use it via inline assembly.
+ * General: Disallow ``var`` keyword.
  * General: Disallow ``sha3`` and ``suicide`` aliases.
  * General: Disallow the ``years`` unit denomination (was already deprecated in 0.4.24)
  * General: Introduce ``emit`` as a keyword instead of parsing it as identifier.

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -1328,9 +1328,9 @@ custom types without the overhead of external function calls:
         using BigInt for BigInt.bigint;
 
         function f() public pure {
-            var x = BigInt.fromUint(7);
-            var y = BigInt.fromUint(uint(-1));
-            var z = x.add(y);
+            BigInt.bigint memory x = BigInt.fromUint(7);
+            BigInt.bigint memory y = BigInt.fromUint(uint(-1));
+            BigInt.bigint memory z = x.add(y);
         }
     }
 

--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -136,14 +136,9 @@ See `struct_and_for_loop_tester.sol <https://github.com/fivedogit/solidity-baby-
 How do for loops work?
 ======================
 
-Very similar to JavaScript. There is one point to watch out for, though:
+Very similar to JavaScript. Such as the following example:
 
-If you use ``for (var i = 0; i < a.length; i ++) { a[i] = i; }``, then
-the type of ``i`` will be inferred only from ``0``, whose type is ``uint8``.
-This means that if ``a`` has more than ``255`` elements, your loop will
-not terminate because ``i`` can only hold values up to ``255``.
-
-Better use ``for (uint i = 0; i < a.length...``
+``for (uint i = 0; i < a.length; i ++) { a[i] = i; }``
 
 See `struct_and_for_loop_tester.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/65_struct_and_for_loop_tester.sol>`_.
 

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -78,7 +78,7 @@ Break = 'break'
 Return = 'return' Expression?
 Throw = 'throw'
 EmitStatement = 'emit' FunctionCall
-VariableDefinition = ('var' IdentifierList | VariableDeclaration | '(' VariableDeclaration? (',' VariableDeclaration? )* ')' ) ( '=' Expression )?
+VariableDefinition = (VariableDeclaration | '(' VariableDeclaration? (',' VariableDeclaration? )* ')' ) ( '=' Expression )?
 IdentifierList = '(' ( Identifier? ',' )* Identifier? ')'
 
 // Precedence by order (see github.com/ethereum/solidity/pull/732)
@@ -140,8 +140,7 @@ TupleExpression = '(' ( Expression? ( ',' Expression? )*  )? ')'
 
 ElementaryTypeNameExpression = ElementaryTypeName
 
-ElementaryTypeName = 'address' | 'bool' | 'string' | 'var'
-                   | Int | Uint | Byte | Fixed | Ufixed
+ElementaryTypeName = 'address' | 'bool' | 'string' | Int | Uint | Byte | Fixed | Ufixed
 
 Int = 'int' | 'int8' | 'int16' | 'int24' | 'int32' | 'int40' | 'int48' | 'int56' | 'int64' | 'int72' | 'int80' | 'int88' | 'int96' | 'int104' | 'int112' | 'int120' | 'int128' | 'int136' | 'int144' | 'int152' | 'int160' | 'int168' | 'int176' | 'int184' | 'int192' | 'int200' | 'int208' | 'int216' | 'int224' | 'int232' | 'int240' | 'int248' | 'int256'
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -157,7 +157,7 @@ These steps are applied to each basic block and the newly generated code is used
 
 ::
 
-    var x = 7;
+    uint x = 7;
     data[7] = 9;
     if (data[x] != x + 2)
       return 2;

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -103,7 +103,7 @@ outlined further below:
         mapping(address => uint) shares;
         /// Withdraw your share.
         function withdraw() public {
-            var share = shares[msg.sender];
+            uint share = shares[msg.sender];
             shares[msg.sender] = 0;
             msg.sender.transfer(share);
         }
@@ -224,7 +224,6 @@ If your wallet had checked ``msg.sender`` for authorization, it would get the ad
 Minor Details
 =============
 
-- In ``for (var i = 0; i < arrayName.length; i++) { ... }``, the type of ``i`` will be ``uint8``, because this is the smallest type that is required to hold the value ``0``. If the array has more than 255 elements, the loop will not terminate.
 - Types that do not occupy the full 32 bytes might contain "dirty higher order bits".
   This is especially important if you access ``msg.data`` - it poses a malleability risk:
   You can craft transactions that call a function ``f(uint8 x)`` with a raw byte argument

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -7,10 +7,8 @@ Types
 *****
 
 Solidity is a statically typed language, which means that the type of each
-variable (state and local) needs to be specified (or at least known -
-see :ref:`type-deduction` below) at
-compile-time. Solidity provides several elementary types which can be combined
-to form complex types.
+variable (state and local) needs to be specified.
+Solidity provides several elementary types which can be combined to form complex types.
 
 In addition, types can interact with each other in expressions containing
 operators. For a quick reference of the various operators, see :ref:`order`.
@@ -548,7 +546,7 @@ memory-stored reference type do not create a copy.
         // the data location of memoryArray is memory
         function f(uint[] memoryArray) public {
             x = memoryArray; // works, copies the whole array to storage
-            var y = x; // works, assigns a pointer, data location of y is storage
+            uint[] storage y = x; // works, assigns a pointer, data location of y is storage
             y[7]; // fine, returns the 8th element
             y.length = 2; // fine, modifies x through y
             delete x; // fine, clears the array, also modifies y
@@ -985,27 +983,4 @@ converted to a matching size. This makes alignment and padding explicit::
     uint16 x = 0xffff;
     bytes32(uint256(x)); // pad on the left
     bytes32(bytes2(x)); // pad on the right
-
-.. index:: ! type;deduction, ! var
-
-.. _type-deduction:
-
-Type Deduction
-==============
-
-For convenience, it is not always necessary to explicitly specify the type of a
-variable, the compiler automatically infers it from the type of the first
-expression that is assigned to the variable::
-
-    uint24 x = 0x123;
-    var y = x;
-
-Here, the type of ``y`` will be ``uint24``. Using ``var`` is not possible for function
-parameters or return parameters.
-
-.. warning::
-    The type is only deduced from the first assignment, so
-    the loop in the following snippet is infinite, as ``i`` will have the type
-    ``uint8`` and the highest value of this type is smaller than ``2000``.
-    ``for (var i = 0; i < 2000; i++) { ... }``
 

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -262,14 +262,9 @@ bool SyntaxChecker::visit(FunctionTypeName const& _node)
 
 bool SyntaxChecker::visit(VariableDeclaration const& _declaration)
 {
-	bool const v050 = m_sourceUnit->annotation().experimentalFeatures.count(ExperimentalFeature::V050);
-
 	if (!_declaration.typeName())
 	{
-		if (v050)
-			m_errorReporter.syntaxError(_declaration.location(), "Use of the \"var\" keyword is deprecated.");
-		else
-			m_errorReporter.warning(_declaration.location(), "Use of the \"var\" keyword is deprecated.");
+		m_errorReporter.syntaxError(_declaration.location(), "Use of the \"var\" keyword is disallowed.");
 	}
 	return true;
 }


### PR DESCRIPTION
This is my work-in-progress branch-PR for the removal of the var keyword.

That means:
* the var keyword is simply disallowed instead of completely removed (for now)
* all tests have been adjusted to not test (or depend on) the var keyword anymore.

