### PR TITLE
adds some tests wrt. variable assignment

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1133,32 +1133,20 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 				") in value for variable assignment (0) needed"
 			);
 	}
-	else if (valueTypes.size() != variables.size())
+	else if (valueTypes.size() != variables.size() && !valueTypes.empty())
 	{
-		if (v050)
-			m_errorReporter.fatalTypeError(
-				_statement.location(),
-				"Different number of components on the left hand side (" +
-				toString(variables.size()) +
-				") than on the right hand side (" +
-				toString(valueTypes.size()) +
-				")."
-			);
-		else if (!variables.front() && !variables.back())
-			m_errorReporter.fatalTypeError(
-				_statement.location(),
-				"Wildcard both at beginning and end of variable declaration list is only allowed "
-				"if the number of components is equal."
-			);
-		else
-			m_errorReporter.warning(
-				_statement.location(),
-				"Different number of components on the left hand side (" +
-				toString(variables.size()) +
-				") than on the right hand side (" +
-				toString(valueTypes.size()) +
-				")."
-			);
+		// XXX If the RHS is "void", then we already have an error generated elsewhere,
+		// such as "Not enough components (0) in value to assign all variables (1).".
+		// Hence, we only report here iff RHS has values, so we avoid superfluous reports.
+		// See "syntaxTests/parsing/var_assigning_void.sol" as an example.
+		m_errorReporter.fatalTypeError(
+			_statement.location(),
+			"Different number of components on the left hand side (" +
+			toString(variables.size()) +
+			") than on the right hand side (" +
+			toString(valueTypes.size()) +
+			")."
+		);
 	}
 	size_t minNumValues = variables.size();
 	if (!variables.empty() && (!variables.back() || !variables.front()))

--- a/test/libsolidity/syntaxTests/parsing/destructuring_assignment_no_variables.sol
+++ b/test/libsolidity/syntaxTests/parsing/destructuring_assignment_no_variables.sol
@@ -1,0 +1,9 @@
+contract C {
+    // ensures solc fails on multi-assignment without named variables.
+    function g() pure public returns (int, int, int) {}
+    function f() pure public {
+        (,,) = g();
+    }
+}
+// ----
+// ParserError: (182-183): Expected primary expression.

--- a/test/libsolidity/syntaxTests/parsing/var_assigning_void.sol
+++ b/test/libsolidity/syntaxTests/parsing/var_assigning_void.sol
@@ -1,0 +1,18 @@
+// This "v0.5.0" flag is here to avoid a double-warning that got introduced due to the var-keyword removal
+pragma experimental "v0.5.0";
+
+contract C {
+    function returnsVoid() pure public { }
+
+    function testVoidAssignmentStmt() pure public {
+        uint i = 42;
+        i = returnsVoid();
+    }
+
+    function testVoidExprInitialization() pure public {
+        uint i = returnsVoid();
+    }
+}
+// ----
+// TypeError: (280-293): Type tuple() is not implicitly convertible to expected type uint256.
+// TypeError: (366-388): Not enough components (0) in value to assign all variables (1).


### PR DESCRIPTION
* the first test ensures solc fails on multi-assignment without named vars (mind: var keyword is about to be removed also)
* the second test ensures solc fails on assigning void to a variable.

I've been splitting up those tests with regards to the discussion in Gitter. /cc @axic 