### PR TITLE
Signed Right Shift: Additional test and more explanation.

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1088,8 +1088,13 @@ TypePointer RationalNumberType::binaryOperatorResult(Token::Value _operator, Typ
 				else
 				{
 					if (m_value.numerator() < 0)
-						// add 1 to the negative value before dividing to get a result that is strictly too large
-						// subtract 1 afterwards to round towards negative infinity
+						// Add 1 to the negative value before dividing to get a result that is strictly too large,
+						// then subtract 1 afterwards to round towards negative infinity.
+						// This is the same algorithm as used in ExpressionCompiler::appendShiftOperatorCode(...).
+						// To see this note that for negative x, xor(x,all_ones) = (-x-1) and
+						// therefore xor(div(xor(x,all_ones), exp(2, shift_amount)), all_ones) is
+						// -(-x - 1) / 2^shift_amount - 1, which is the same as
+						// (x + 1) / 2^shift_amount - 1.
 						value = rational((m_value.numerator() + 1) / boost::multiprecision::pow(bigint(2), exponent) - bigint(1), 1);
 					else
 						value = rational(m_value.numerator() / boost::multiprecision::pow(bigint(2), exponent), 1);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -10508,6 +10508,39 @@ BOOST_AUTO_TEST_CASE(shift_right_garbled)
 	ABI_CHECK(callContractFunction("f(uint8,uint8)", u256(0x0), u256(0x1004)), encodeArgs(u256(0xf)));
 }
 
+BOOST_AUTO_TEST_CASE(shift_right_garbled_signed)
+{
+	char const* sourceCode = R"(
+			contract C {
+				function f(int8 a, uint8 b) returns (int) {
+					assembly {
+						a := 0xfffffff0
+					}
+					// Higher bits should be signextended before the shift
+					return a >> b;
+				}
+				function g(int8 a, uint8 b) returns (int) {
+					assembly {
+						a := 0xf0
+					}
+					// Higher bits should be signextended before the shift
+					return a >> b;
+				}
+			}
+		)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("f(int8,uint8)", u256(0x0), u256(3)), encodeArgs(u256(-2)));
+	ABI_CHECK(callContractFunction("f(int8,uint8)", u256(0x0), u256(4)), encodeArgs(u256(-1)));
+	ABI_CHECK(callContractFunction("f(int8,uint8)", u256(0x0), u256(0xFF)), encodeArgs(u256(-1)));
+	ABI_CHECK(callContractFunction("f(int8,uint8)", u256(0x0), u256(0x1003)), encodeArgs(u256(-2)));
+	ABI_CHECK(callContractFunction("f(int8,uint8)", u256(0x0), u256(0x1004)), encodeArgs(u256(-1)));
+	ABI_CHECK(callContractFunction("g(int8,uint8)", u256(0x0), u256(3)), encodeArgs(u256(-2)));
+	ABI_CHECK(callContractFunction("g(int8,uint8)", u256(0x0), u256(4)), encodeArgs(u256(-1)));
+	ABI_CHECK(callContractFunction("g(int8,uint8)", u256(0x0), u256(0xFF)), encodeArgs(u256(-1)));
+	ABI_CHECK(callContractFunction("g(int8,uint8)", u256(0x0), u256(0x1003)), encodeArgs(u256(-2)));
+	ABI_CHECK(callContractFunction("g(int8,uint8)", u256(0x0), u256(0x1004)), encodeArgs(u256(-1)));
+}
+
 BOOST_AUTO_TEST_CASE(shift_right_uint32)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
More explanation for the literal version of signed right shifts and an additional test to check whether signed integers are properly signextended before arithmetic right shifts.