### PR TITLE
Execute external Zeppelin tests before Gnosis

### DIFF
--- a/test/externalTests.sh
+++ b/test/externalTests.sh
@@ -57,5 +57,5 @@ function test_truffle
 }
 
 # Using our temporary fork here. Hopefully to be merged into upstream after the 0.5.0 release.
-test_truffle Gnosis https://github.com/axic/pm-contracts.git -b solidity-050
 test_truffle Zeppelin https://github.com/axic/openzeppelin-solidity.git -b solidity-050
+test_truffle Gnosis https://github.com/axic/pm-contracts.git -b solidity-050


### PR DESCRIPTION
The Gnosis repo is a bit more outdated, running Zeppelin should catch some of the more relevant errors quicker.