### PR TITLE
Correctly choose python version for scripts requiring python2.

### DIFF
--- a/scripts/extract_test_cases.py
+++ b/scripts/extract_test_cases.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 # This script reads C++ or RST source files and writes all
 # multi-line strings into individual files.

--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 # This script reads C++ or RST source files and writes all
 # multi-line strings into individual files.


### PR DESCRIPTION
Some of the python scripts only work with ``python2``. Similarly to ``docs/conf.py``, which requires ``python3``, their first line comment should refer to ``/usr/bin/env python2`` instead of ``/usr/bin/python`` - otherwise they will fail on distros that use ``python3`` by default (e.g. Archlinux).