### PR TITLE
drop var-keyword in compilationTests in favor of explicit types

### DIFF
--- a/test/compilationTests/corion/ico.sol
+++ b/test/compilationTests/corion/ico.sol
@@ -309,7 +309,7 @@ contract ico is safeMath {
             require( beneficiaryAddress.send(0.2 ether) );
             _value = safeSub(_value, 0.2 ether);
         }
-        var _reward = getIcoReward(_value);
+        uint256 _reward = getIcoReward(_value);
         require( _reward > 0 );
         require( token(tokenAddr).mint(beneficiaryAddress, _reward) );
         brought[beneficiaryAddress].eth = safeAdd(brought[beneficiaryAddress].eth, _value);

--- a/test/compilationTests/corion/module.sol
+++ b/test/compilationTests/corion/module.sol
@@ -90,7 +90,7 @@ contract module {
             @newModuleAddress   New module handler address
         */
         require( moduleStatus != status.New && moduleStatus != status.Disconnected);
-        var (_success, _balance) = abstractModuleHandler(moduleHandlerAddress).balanceOf(address(this));
+        (bool _success, uint256 _balance) = abstractModuleHandler(moduleHandlerAddress).balanceOf(address(this));
         require( _success );
         if ( _balance > 0 ) {
             require( abstractModuleHandler(moduleHandlerAddress).transfer(address(this), newModuleAddress, _balance, false) );

--- a/test/compilationTests/corion/moduleHandler.sol
+++ b/test/compilationTests/corion/moduleHandler.sol
@@ -69,7 +69,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @call   Is connect to the module or not.
         */
         if ( call ) { require( abstractModule(input.addr).connectModule() ); }
-        var (success, found, id) = getModuleIDByAddress(input.addr);
+        (bool success, bool found, uint256 id) = getModuleIDByAddress(input.addr);
         require( success && ! found );
         (success, found, id) = getModuleIDByHash(input.name);
         require( success && ! found );
@@ -90,7 +90,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @found      Is there any result.
             @success    Was the transaction succesfull or not.
         */
-        var (_success, _found, _id) = getModuleIDByName(name);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName(name);
         if ( _success && _found ) { return (true, true, modules[_id].addr); }
         return (true, false, 0x00);
     }
@@ -149,7 +149,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @bool           Was there any result or not.
             @callCallback   Call the replaceable module to confirm replacement or not.
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success );
         if ( ! ( _found && modules[_id].name == keccak256('Publisher') )) {
             require( block.number < debugModeUntil );
@@ -172,7 +172,7 @@ contract moduleHandler is multiOwner, announcementTypes {
         if ( ! insertAndCheckDo(calcDoHash("callReplaceCallback", keccak256(moduleName, newModule))) ) {
             return true;
         }
-        var (_success, _found, _id) = getModuleIDByName(moduleName);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName(moduleName);
         require( _success);
         require( abstractModule(modules[_id].addr).replaceModule(newModule) );
         return true;
@@ -188,7 +188,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @transferEvent      Gets it new transaction notification?
             @bool               Was there any result or not.
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success );
         if ( ! ( _found && modules[_id].name == keccak256('Publisher') )) {
             require( block.number < debugModeUntil );
@@ -207,7 +207,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @bool           Was the function successfull?
             @callCallback   Call the replaceable module to confirm replacement or not.
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success );
         if ( ! ( _found && modules[_id].name == keccak256('Publisher') )) {
             require( block.number < debugModeUntil );
@@ -229,7 +229,7 @@ contract moduleHandler is multiOwner, announcementTypes {
         if ( ! insertAndCheckDo(calcDoHash("callDisableCallback", keccak256(moduleName))) ) {
             return true;
         }
-        var (_success, _found, _id) = getModuleIDByName(moduleName);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName(moduleName);
         require( _success);
         require( abstractModule(modules[_id].addr).disableModule(true) );
         return true;
@@ -247,7 +247,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @value      amount.
             @bool       Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success && _found && modules[_id].name == keccak256('Token') );
         for ( uint256 a=0 ; a<modules.length ; a++ ) {
             if ( modules[a].transferEvent && abstractModule(modules[a].addr).isActive() ) {
@@ -266,7 +266,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @reward         Coin emission in this Schelling round.
             @bool           Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success && _found && modules[_id].name == keccak256('Schelling') );
         for ( uint256 a=0 ; a<modules.length ; a++ ) {
             if ( modules[a].schellingEvent && abstractModule(modules[a].addr).isActive() ) {
@@ -285,7 +285,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @newHandler     Address of the new ModuleHandler.
             @bool           Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success );
         if ( ! ( _found && modules[_id].name == keccak256('Publisher') )) {
             require( block.number < debugModeUntil );
@@ -306,7 +306,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @value      balance.
             @success    was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByName('Token');
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName('Token');
         require( _success && _found );
         return (true, token(modules[_id].addr).balanceOf(owner));
     }
@@ -317,7 +317,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @value      amount.
             @success    was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByName('Token');
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName('Token');
         require( _success && _found );
         return (true, token(modules[_id].addr).totalSupply());
     }
@@ -328,7 +328,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @ico        Is ICO in progress?.
             @success    was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByName('Token');
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName('Token');
         require( _success && _found );
         return (true, token(modules[_id].addr).isICO());
     }
@@ -339,7 +339,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @round      Schelling round.
             @success    was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByName('Schelling');
+        (bool _success, bool _found, uint256 _id) = getModuleIDByName('Schelling');
         require( _success && _found );
         return (true, schelling(modules[_id].addr).getCurrentSchellingRoundID());
     }
@@ -352,7 +352,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             
             @success    Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success && _found && modules[_id].name == keccak256('Provider') );
         (_success, _found, _id) = getModuleIDByName('Token');
         require( _success && _found );
@@ -369,7 +369,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @fee        Transaction fee will be charged or not?
             @success    Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success && _found );
         (_success, _found, _id) = getModuleIDByName('Token');
         require( _success && _found );
@@ -384,7 +384,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @value      Token amount.
             @success    Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success && _found && modules[_id].name == keccak256('Provider') );
         (_success, _found, _id) = getModuleIDByName('Token');
         require( _success && _found );
@@ -399,7 +399,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @value      Token amount.
             @success    Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success && _found && modules[_id].name == keccak256('Schelling') );
         (_success, _found, _id) = getModuleIDByName('Token');
         require( _success && _found );
@@ -415,7 +415,7 @@ contract moduleHandler is multiOwner, announcementTypes {
             @value      New value
             @success    Was the function successfull?
         */
-        var (_success, _found, _id) = getModuleIDByAddress(msg.sender);
+        (bool _success, bool _found, uint256 _id) = getModuleIDByAddress(msg.sender);
         require( _success );
         if ( ! ( _found && modules[_id].name == keccak256('Publisher') )) {
             require( block.number < debugModeUntil );

--- a/test/compilationTests/corion/premium.sol
+++ b/test/compilationTests/corion/premium.sol
@@ -19,7 +19,7 @@ contract premium is module, safeMath {
         return true;
     }
     modifier isReady {
-        var (_success, _active) = super.isActive();
+        (bool _success, bool _active) = super.isActive();
         require( _success && _active ); 
         _;
     }
@@ -150,7 +150,7 @@ contract premium is module, safeMath {
             @remaining      Tokens to be spent
             @nonce          Transaction count
         */
-        var (_success, _remaining, _nonce) = db.getAllowance(owner, spender);
+        (bool _success, uint256 _remaining, uint256 _nonce) = db.getAllowance(owner, spender);
         require( _success );
         return (_remaining, _nonce);
     }
@@ -202,7 +202,7 @@ contract premium is module, safeMath {
             @success    If the function was successful.
         */
         if ( from != msg.sender ) {
-            var (_success, _reamining, _nonce) = db.getAllowance(from, msg.sender);
+            (bool _success, uint256 _reamining, uint256 _nonce) = db.getAllowance(from, msg.sender);
             require( _success );
             _reamining = safeSub(_reamining, amount);
             _nonce = safeAdd(_nonce, 1);
@@ -255,7 +255,7 @@ contract premium is module, safeMath {
             @extraData      Extra data that will be given to the receiver
         */
         _transfer(from, to, amount);
-        var (_success, _back) = thirdPartyPContractAbstract(to).receiveCorionPremiumToken(from, amount, extraData);
+        (bool _success, uint256 _back) = thirdPartyPContractAbstract(to).receiveCorionPremiumToken(from, amount, extraData);
         require( _success );
         require( amount > _back );
         if ( _back > 0 ) {

--- a/test/compilationTests/corion/provider.sol
+++ b/test/compilationTests/corion/provider.sol
@@ -12,7 +12,7 @@ contract provider is module, safeMath, announcementTypes {
     function connectModule() external returns (bool success) {
         require( super.isModuleHandler(msg.sender) );
         super._connectModule();
-        var (_success, currentSchellingRound) = moduleHandler(moduleHandlerAddress).getCurrentSchellingRoundID();
+        (bool _success, uint256 currentSchellingRound) = moduleHandler(moduleHandlerAddress).getCurrentSchellingRoundID();
         require( _success );
         return true;
     }
@@ -49,7 +49,7 @@ contract provider is module, safeMath, announcementTypes {
         return true;
     }
     modifier isReady {
-        var (_success, _active) = super.isActive();
+        (bool _success, bool _active) = super.isActive();
         require( _success && _active ); 
         _;
     }
@@ -192,8 +192,8 @@ contract provider is module, safeMath, announcementTypes {
             @newValue       new
             @priv           Is the provider private?
         */
-        var a = rightForInterest(oldValue, priv);
-        var b = rightForInterest(newValue, priv);
+        bool a = rightForInterest(oldValue, priv);
+        bool b = rightForInterest(newValue, priv);
         if ( a && b ) {
             globalFunds[currentSchellingRound].supply = globalFunds[currentSchellingRound].supply - oldValue + newValue;
         } else if ( a && ! b ) {
@@ -243,7 +243,7 @@ contract provider is module, safeMath, announcementTypes {
         require( checkCorrectRate(priv, rate) );
         
         providers[msg.sender].currentHeight++;
-        var currHeight = providers[msg.sender].currentHeight;
+        uint256 currHeight = providers[msg.sender].currentHeight;
         providers[msg.sender].data[currHeight].valid           = true;
         if ( admin == 0x00 ) { 
             providers[msg.sender].data[currHeight].admin      = msg.sender;
@@ -284,7 +284,7 @@ contract provider is module, safeMath, announcementTypes {
             @info               Short intro.
             @rate               Rate of the emission what will be given to the client.
         */
-        var currHeight = providers[addr].currentHeight;
+        uint256 currHeight = providers[addr].currentHeight;
         require( providers[addr].data[currHeight].valid );
         require( checkCorrectRate(providers[addr].data[currHeight].priv, rate) );
         require( providers[addr].data[currHeight].admin == msg.sender || msg.sender == addr );
@@ -360,7 +360,7 @@ contract provider is module, safeMath, announcementTypes {
             It is only possible to close that active provider which is owned by the sender itself after calling the whole share of the emission.
             Whom were connected to the provider those clients will have to disconnect after they’ve called their share of emission which was not called before.
         */
-        var currHeight = providers[msg.sender].currentHeight;
+        uint256 currHeight = providers[msg.sender].currentHeight;
         require( providers[msg.sender].data[currHeight].valid );
         require( providers[msg.sender].data[currHeight].paidUpTo == currentSchellingRound );
         
@@ -377,7 +377,7 @@ contract provider is module, safeMath, announcementTypes {
             
             @addr       Array of the addresses for whom the connection is allowed.
         */
-        var currHeight = providers[provider].currentHeight;
+        uint256 currHeight = providers[provider].currentHeight;
         require( providers[provider].data[currHeight].valid );
         require( providers[provider].data[currHeight].priv );
         require( providers[provider].data[currHeight].admin == msg.sender );
@@ -395,7 +395,7 @@ contract provider is module, safeMath, announcementTypes {
             
             @addr      Array of the addresses for whom the connection is allowed.
         */
-        var currHeight = providers[provider].currentHeight;
+        uint256 currHeight = providers[provider].currentHeight;
         require( providers[provider].data[currHeight].valid );
         require( providers[provider].data[currHeight].priv );
         require( providers[provider].data[currHeight].admin == msg.sender );
@@ -417,7 +417,7 @@ contract provider is module, safeMath, announcementTypes {
             
             @provider       Address of the provider.
         */
-        var currHeight = providers[provider].currentHeight;
+        uint256 currHeight = providers[provider].currentHeight;
         require( ! providers[msg.sender].data[currHeight].valid );
         require( clients[msg.sender].providerAddress == 0x00 );
         require( providers[provider].data[currHeight].valid );
@@ -425,7 +425,7 @@ contract provider is module, safeMath, announcementTypes {
             require( providers[provider].data[currHeight].allowedUsers[msg.sender] &&
                      providers[provider].data[currHeight].clientsCount < privateProviderLimit );
         }
-        var bal = getTokenBalance(msg.sender);
+        uint256 bal = getTokenBalance(msg.sender);
         require( moduleHandler(moduleHandlerAddress).processTransactionFee(msg.sender, bal) );
         
         checkFloatingSupply(provider, currHeight, false, bal);
@@ -445,9 +445,9 @@ contract provider is module, safeMath, announcementTypes {
             Before disconnecting we should poll our share from the token emission even if there was nothing factually.
             It is only possible to disconnect those providers who were connected by us before.
         */
-        var provider = clients[msg.sender].providerAddress;
+        address provider = clients[msg.sender].providerAddress;
         require( provider != 0x0 );
-        var currHeight = clients[msg.sender].providerHeight;
+        uint256 currHeight = clients[msg.sender].providerHeight;
         bool providerHasClosed = false;
         if ( providers[provider].data[currHeight].close > 0 ) {
             providerHasClosed = true;
@@ -456,7 +456,7 @@ contract provider is module, safeMath, announcementTypes {
             require( clients[msg.sender].paidUpTo == currentSchellingRound );
         }
         
-        var bal = getTokenBalance(msg.sender);
+        uint256 bal = getTokenBalance(msg.sender);
         if ( ! providerHasClosed ) {
             providers[provider].data[currHeight].clientsCount--;
             checkFloatingSupply(provider, currHeight, true, bal);
@@ -500,9 +500,9 @@ contract provider is module, safeMath, announcementTypes {
             @provider           Address of the provider
             @reward             Accumulated amount from the previous rounds.
         */
-        var _limit = limit;
-        var _beneficiary = beneficiary;
-        var _provider = provider;
+        uint256 _limit = limit;
+        address _beneficiary = beneficiary;
+        address _provider = provider;
         if ( _limit == 0 ) { _limit = gasProtectMaxRounds; }
         if ( _beneficiary == 0x00 ) { _beneficiary = msg.sender; }
         if ( _provider == 0x00 ) { _provider = msg.sender; }
@@ -537,7 +537,7 @@ contract provider is module, safeMath, announcementTypes {
         uint256 provHeight;
         bool interest = false;
         uint256 a;
-        var rate = clients[msg.sender].lastRate;
+        uint8 rate = clients[msg.sender].lastRate;
         for ( a = (clients[msg.sender].paidUpTo + 1) ; a <= currentSchellingRound ; a++ ) {
             if (globalFunds[a].reward > 0 && globalFunds[a].supply > 0) {
                 provAddr = clients[msg.sender].providerAddress;
@@ -587,7 +587,7 @@ contract provider is module, safeMath, announcementTypes {
         uint256 currHeight = providers[addr].currentHeight;
         uint256 LTSID = providers[addr].data[currHeight].lastSupplyID;
         uint256 a;
-        var rate = providers[addr].data[currHeight].lastPaidRate;
+        uint8 rate = providers[addr].data[currHeight].lastPaidRate;
         for ( a = (providers[addr].data[currHeight].paidUpTo + 1) ; a <= currentSchellingRound ; a++ ) {
             if (globalFunds[a].reward > 0 && globalFunds[a].supply > 0) {
                 if ( providers[addr].data[currHeight].rateHistory[a].valid ) {
@@ -754,7 +754,7 @@ contract provider is module, safeMath, announcementTypes {
                 clients[addr].supply[currentSchellingRound] = TEMath(clients[addr].supply[currentSchellingRound], value, neg);
             }
         } else if ( providers[addr].data[providers[addr].currentHeight].valid ) {
-            var currentHeight = providers[addr].currentHeight;
+            uint256 currentHeight = providers[addr].currentHeight;
             if ( neg ) {
                 uint256 balance = getTokenBalance(addr);
                 if ( providers[addr].data[currentHeight].priv ) {
@@ -776,7 +776,7 @@ contract provider is module, safeMath, announcementTypes {
             
             @balance    Balance of the address.
         */
-        var (_success, _balance) = moduleHandler(moduleHandlerAddress).balanceOf(addr);
+        (bool _success, uint256 _balance) = moduleHandler(moduleHandlerAddress).balanceOf(addr);
         require( _success );
         return _balance;
     }
@@ -786,7 +786,7 @@ contract provider is module, safeMath, announcementTypes {
             
             @isICO      Is the ICO in proccess or not?
         */
-        var (_success, _isICO) = moduleHandler(moduleHandlerAddress).isICO();
+        (bool _success, bool _isICO) = moduleHandler(moduleHandlerAddress).isICO();
         require( _success );
         return _isICO;
     }

--- a/test/compilationTests/corion/publisher.sol
+++ b/test/compilationTests/corion/publisher.sol
@@ -111,7 +111,7 @@ contract publisher is announcementTypes, module, safeMath {
             @success        Opposed or not
         */
         if ( ! oppositable ) { return false; }
-        var (_success, _amount) = moduleHandler(moduleHandlerAddress).totalSupply();
+        (bool _success, uint256 _amount) = moduleHandler(moduleHandlerAddress).totalSupply();
         require( _success );
         return _amount * oppositeRate / 100 > weight;
     }
@@ -229,7 +229,7 @@ contract publisher is announcementTypes, module, safeMath {
                 newArrayID = a;
             }
         }
-        var (_success, _balance) = moduleHandler(moduleHandlerAddress).balanceOf(msg.sender);
+        (bool _success, uint256 _balance) = moduleHandler(moduleHandlerAddress).balanceOf(msg.sender);
         require( _success );
         require( _balance > 0);
         if ( foundEmptyArrayID ) {
@@ -266,7 +266,7 @@ contract publisher is announcementTypes, module, safeMath {
             Inner function to check the ICO status.
             @bool       Is the ICO in proccess or not?
         */
-        var (_success, _isICO) = moduleHandler(moduleHandlerAddress).isICO();
+        (bool _success, bool _isICO) = moduleHandler(moduleHandlerAddress).isICO();
         require( _success );
         return _isICO;
     }

--- a/test/compilationTests/corion/schelling.sol
+++ b/test/compilationTests/corion/schelling.sol
@@ -151,15 +151,15 @@ contract schelling is module, announcementTypes, schellingVars {
         */
         require( super.isModuleHandler(msg.sender) );
         if ( to == address(this) ) {
-            var currentRound = getCurrentRound();
-            var round = getRound(currentRound);
+            uint256 currentRound = getCurrentRound();
+            schellingVars._rounds memory round = getRound(currentRound);
             round.reward += value;
             setRound(currentRound, round);
         }
         return true;
     }
     modifier isReady {
-        var (_success, _active) = super.isActive();
+        (bool _success, bool _active) = super.isActive();
         require( _success && _active ); 
         _;
     }
@@ -167,7 +167,7 @@ contract schelling is module, announcementTypes, schellingVars {
         Schelling database functions.
     */
     function getFunds(address addr) internal returns (uint256) {
-        var (a, b) = db.getFunds(addr);
+        (bool a, uint256 b) = db.getFunds(addr);
         require( a );
         return b;
     }
@@ -184,7 +184,7 @@ contract schelling is module, announcementTypes, schellingVars {
             ) );
     }    
     function getVoter(address addr) internal returns (_voter) {
-        var (a, b, c, d, e, f) = db.getVoter(addr);
+        (bool a, uint256 b, bytes32 c, schellingVars.voterStatus d, bool e, uint256 f) = db.getVoter(addr);
         require( a );
         return _voter(b, c, d, e, f);
     }
@@ -198,7 +198,7 @@ contract schelling is module, announcementTypes, schellingVars {
             ) );
     }
     function pushRound(_rounds round) internal returns (uint256) {
-        var (a, b) = db.pushRound( 
+        (bool a, uint256 b) = db.pushRound( 
             round.totalAboveWeight,
             round.totalBelowWeight,
             round.reward,
@@ -209,12 +209,12 @@ contract schelling is module, announcementTypes, schellingVars {
         return b;
     }
     function getRound(uint256 id) internal returns (_rounds) {
-        var (a, b, c, d, e, f) = db.getRound(id);
+        (bool a, uint256 b, uint256 c, uint256 d, uint256 e, bool f) = db.getRound(id);
         require( a );
         return _rounds(b, c, d, e, f);
     }
     function getCurrentRound() internal returns (uint256) {
-        var (a, b) = db.getCurrentRound();
+        (bool a, uint256 b) = db.getCurrentRound();
         require( a );
         return b;
     }
@@ -222,7 +222,7 @@ contract schelling is module, announcementTypes, schellingVars {
         require( db.setCurrentSchellingRound(id) );
     }
     function getCurrentSchellingRound() internal returns(uint256) {
-        var (a, b) = db.getCurrentSchellingRound();
+        (bool a, uint256 b) = db.getCurrentSchellingRound();
         require( a );
         return b;
     }
@@ -230,7 +230,7 @@ contract schelling is module, announcementTypes, schellingVars {
         require( db.setSchellingExpansion(id, amount) );
     }
     function getSchellingExpansion(uint256 id) internal returns(uint256) {
-        var (a, b) = db.getSchellingExpansion(id);
+        (bool a, uint256 b) = db.getSchellingExpansion(id);
         require( a );
         return b;
     }
@@ -289,8 +289,8 @@ contract schelling is module, announcementTypes, schellingVars {
         */
         nextRound();
         
-        var currentRound = getCurrentRound();
-        var round = getRound(currentRound);
+        uint256 currentRound = getCurrentRound();
+        schellingVars._rounds memory round = getRound(currentRound);
         _voter memory voter;
         uint256 funds;
         
@@ -323,7 +323,7 @@ contract schelling is module, announcementTypes, schellingVars {
         */
         nextRound();
         
-        var currentRound = getCurrentRound();
+        uint256 currentRound = getCurrentRound();
         _rounds memory round;
         _voter memory voter;
         uint256 funds;
@@ -369,7 +369,7 @@ contract schelling is module, announcementTypes, schellingVars {
         */
         nextRound();
         
-        var currentRound = getCurrentRound();
+        uint256 currentRound = getCurrentRound();
         _rounds memory round;
         _voter memory voter;
         uint256 funds;
@@ -403,8 +403,8 @@ contract schelling is module, announcementTypes, schellingVars {
             
             @beneficiary        Address of the beneficiary
         */
-        var voter = getVoter(msg.sender);
-        var funds = getFunds(msg.sender);
+        schellingVars._voter memory voter = getVoter(msg.sender);
+        uint256 funds = getFunds(msg.sender);
         
         address _beneficiary = msg.sender;
         if (beneficiary != 0x0) { _beneficiary = beneficiary; }
@@ -423,18 +423,18 @@ contract schelling is module, announcementTypes, schellingVars {
             
             @reward         Prize
         */
-        var voter = getVoter(msg.sender);
+        schellingVars._voter memory voter = getVoter(msg.sender);
         return voter.rewards;
     }
     function nextRound() internal returns (bool) {
         /*
             Inside function, checks the time of the Schelling round and if its needed, creates a new Schelling round.
         */
-        var currentRound = getCurrentRound();
-        var round = getRound(currentRound);
+        uint256 currentRound = getCurrentRound();
+        _rounds memory round = getRound(currentRound);
         _rounds memory newRound;
         _rounds memory prevRound;
-        var currentSchellingRound = getCurrentSchellingRound();
+        uint256 currentSchellingRound = getCurrentSchellingRound();
         
         if ( round.blockHeight+roundBlockDelay > block.number) { return false; }
         
@@ -469,10 +469,10 @@ contract schelling is module, announcementTypes, schellingVars {
             
             @amount          Amount of deposit.
         */
-        var voter = getVoter(msg.sender);
-        var funds = getFunds(msg.sender);
+        _voter memory voter = getVoter(msg.sender);
+        uint256 funds = getFunds(msg.sender);
         
-        var (a, b) = moduleHandler(moduleHandlerAddress).isICO();
+        (bool a, bool b) = moduleHandler(moduleHandlerAddress).isICO();
         require( b && b );
         require( voter.status == voterStatus.base );
         require( amount > 0 );
@@ -487,8 +487,8 @@ contract schelling is module, announcementTypes, schellingVars {
             If the deposit isn’t lost, it can be withdrawn.
             By withdrawn, the deposit will be sent from Schelling address to the users address, charged with transaction fee..
         */
-        var voter = getVoter(msg.sender);
-        var funds = getFunds(msg.sender);
+        _voter memory voter = getVoter(msg.sender);
+        uint256 funds = getFunds(msg.sender);
         
         require( funds > 0 );
         require( voter.status == voterStatus.base );
@@ -550,7 +550,7 @@ contract schelling is module, announcementTypes, schellingVars {
             
             @uint256        Whole token amount
         */
-        var (_success, _amount) = moduleHandler(moduleHandlerAddress).totalSupply();
+        (bool _success, uint256 _amount) = moduleHandler(moduleHandlerAddress).totalSupply();
         require( _success );
         return _amount;
     }
@@ -563,7 +563,7 @@ contract schelling is module, announcementTypes, schellingVars {
             
             @balance    Balance of the address.
         */
-        var (_success, _balance) = moduleHandler(moduleHandlerAddress).balanceOf(addr);
+        (bool _success, uint256 _balance) = moduleHandler(moduleHandlerAddress).balanceOf(addr);
         require( _success );
         return _balance;
     }

--- a/test/compilationTests/corion/token.sol
+++ b/test/compilationTests/corion/token.sol
@@ -22,7 +22,7 @@ contract token is safeMath, module, announcementTypes {
         return true;
     }
     modifier isReady {
-        var (_success, _active) = super.isActive();
+        (bool _success, bool _active) = super.isActive();
         require( _success && _active ); 
         _;
     }
@@ -165,7 +165,7 @@ contract token is safeMath, module, announcementTypes {
             @remaining     Tokens to be spent
             @nonce         Transaction count
         */
-        var (_success, _remaining, _nonce) = db.getAllowance(owner, spender);
+        (bool _success, uint256 _remaining, uint256 _nonce) = db.getAllowance(owner, spender);
         require( _success );
         return (_remaining, _nonce);
     }
@@ -217,7 +217,7 @@ contract token is safeMath, module, announcementTypes {
             @success    Was the Function successful?
         */
         if ( from != msg.sender ) {
-            var (_success, _reamining, _nonce) = db.getAllowance(from, msg.sender);
+            (bool _success, uint256 _reamining, uint256 _nonce) = db.getAllowance(from, msg.sender);
             require( _success );
             _reamining = safeSub(_reamining, amount);
             _nonce = safeAdd(_nonce, 1);
@@ -298,7 +298,7 @@ contract token is safeMath, module, announcementTypes {
             @extraData      Extra data the receiver will get
         */
         _transfer(from, to, amount, exchangeAddress == to);
-        var (_success, _back) = thirdPartyContractAbstract(to).receiveCorionToken(from, amount, extraData);
+        (bool _success, uint256 _back) = thirdPartyContractAbstract(to).receiveCorionToken(from, amount, extraData);
         require( _success );
         require( amount > _back );
         if ( _back > 0 ) {
@@ -321,7 +321,7 @@ contract token is safeMath, module, announcementTypes {
             @fee        Deduct transaction fee - yes or no?
         */
         if( fee ) {
-            var (success, _fee) = getTransactionFee(amount);
+            (bool success, uint256 _fee) = getTransactionFee(amount);
             require( success );
             require( db.balanceOf(from) >= amount + _fee );
         }
@@ -366,7 +366,7 @@ contract token is safeMath, module, announcementTypes {
             @value      Quantity to calculate the fee
         */
         if ( isICO ) { return; }
-        var (_success, _fee) = getTransactionFee(value);
+        (bool _success, uint256 _fee) = getTransactionFee(value);
         require( _success );
         uint256 _forBurn = _fee * transactionFeeBurn / 100;
         uint256 _forSchelling = _fee - _forBurn;

--- a/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
+++ b/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
@@ -95,7 +95,7 @@ contract LMSRMarketMaker is MarketMaker {
         // The price function is exp(quantities[i]/b) / sum(exp(q/b) for q in quantities)
         // To avoid overflow, calculate with
         // exp(quantities[i]/b - offset) / sum(exp(q/b - offset) for q in quantities)
-        var (sum, , outcomeExpTerm) = sumExpOffset(logN, netOutcomeTokensSold, funding, outcomeTokenIndex);
+        (uint256 sum, , uint256 outcomeExpTerm) = sumExpOffset(logN, netOutcomeTokensSold, funding, outcomeTokenIndex);
         return outcomeExpTerm / (sum / ONE);
     }
 
@@ -116,7 +116,7 @@ contract LMSRMarketMaker is MarketMaker {
         // The cost function is C = b * log(sum(exp(q/b) for q in quantities)).
         // To avoid overflow, we need to calc with an exponent offset:
         // C = b * (offset + log(sum(exp(q/b - offset) for q in quantities)))
-        var (sum, offset, ) = sumExpOffset(logN, netOutcomeTokensSold, funding, 0);
+        (uint256 sum, int256 offset, ) = sumExpOffset(logN, netOutcomeTokensSold, funding, 0);
         costLevel = Math.ln(sum);
         costLevel = costLevel.add(offset);
         costLevel = (costLevel.mul(int(ONE)) / logN).mul(int(funding));

--- a/test/compilationTests/gnosis/Oracles/MajorityOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/MajorityOracle.sol
@@ -72,7 +72,7 @@ contract MajorityOracle is Oracle {
         constant
         returns (bool)
     {
-        var (outcomeSet, ) = getStatusAndOutcome();
+        (bool outcomeSet, ) = getStatusAndOutcome();
         return outcomeSet;
     }
 
@@ -83,7 +83,7 @@ contract MajorityOracle is Oracle {
         constant
         returns (int)
     {
-        var (, winningOutcome) = getStatusAndOutcome();
+        (, int winningOutcome) = getStatusAndOutcome();
         return winningOutcome;
     }
 }

--- a/test/compilationTests/milestonetracker/MilestoneTracker.sol
+++ b/test/compilationTests/milestonetracker/MilestoneTracker.sol
@@ -216,22 +216,22 @@ contract MilestoneTracker {
         // Decode the RLP encoded milestones and add them to the milestones list
         bytes memory mProposedMilestones = proposedMilestones;
 
-        var itmProposals = mProposedMilestones.toRLPItem(true);
+        RLP.RLPItem memory itmProposals = mProposedMilestones.toRLPItem(true);
 
         if (!itmProposals.isList()) throw;
 
-        var itrProposals = itmProposals.iterator();
+        RLP.Iterator memory itrProposals = itmProposals.iterator();
 
         while(itrProposals.hasNext()) {
 
 
-            var itmProposal = itrProposals.next();
+            RLP.RLPItem memory itmProposal = itrProposals.next();
 
             Milestone milestone = milestones[milestones.length ++];
 
             if (!itmProposal.isList()) throw;
 
-            var itrProposal = itmProposal.iterator();
+            RLP.Iterator memory itrProposal = itmProposal.iterator();
 
             milestone.description = itrProposal.next().toAscii();
             milestone.url = itrProposal.next().toAscii();

--- a/test/compilationTests/milestonetracker/RLP.sol
+++ b/test/compilationTests/milestonetracker/RLP.sol
@@ -32,8 +32,8 @@ library RLP {
 
  function next(Iterator memory self) internal constant returns (RLPItem memory subItem) {
      if(hasNext(self)) {
-         var ptr = self._unsafe_nextPtr;
-         var itemLength = _itemLength(ptr);
+         uint ptr = self._unsafe_nextPtr;
+         uint itemLength = _itemLength(ptr);
          subItem._unsafe_memPtr = ptr;
          subItem._unsafe_length = itemLength;
          self._unsafe_nextPtr = ptr + itemLength;
@@ -50,7 +50,7 @@ library RLP {
  }
 
  function hasNext(Iterator memory self) internal constant returns (bool) {
-     var item = self._unsafe_item;
+     RLPItem memory item = self._unsafe_item;
      return self._unsafe_nextPtr < item._unsafe_memPtr + item._unsafe_length;
  }
 
@@ -76,7 +76,7 @@ library RLP {
  /// @param strict Will throw if the data is not RLP encoded.
  /// @return An RLPItem
  function toRLPItem(bytes memory self, bool strict) internal constant returns (RLPItem memory) {
-     var item = toRLPItem(self);
+     RLPItem memory item = toRLPItem(self);
      if(strict) {
          uint len = self.length;
          if(_payloadOffset(item) > len)
@@ -170,7 +170,7 @@ library RLP {
  /// @param self The RLPItem.
  /// @return The bytes.
  function toBytes(RLPItem memory self) internal constant returns (bytes memory bts) {
-     var len = self._unsafe_length;
+     uint len = self._unsafe_length;
      if (len == 0)
          return;
      bts = new bytes(len);
@@ -184,7 +184,7 @@ library RLP {
  function toData(RLPItem memory self) internal constant returns (bytes memory bts) {
      if(!isData(self))
          throw;
-     var (rStartPos, len) = _decode(self);
+     (uint rStartPos, uint len) = _decode(self);
      bts = new bytes(len);
      _copyToBytes(rStartPos, bts, len);
  }
@@ -196,9 +196,9 @@ library RLP {
  function toList(RLPItem memory self) internal constant returns (RLPItem[] memory list) {
      if(!isList(self))
          throw;
-     var numItems = items(self);
+     uint numItems = items(self);
      list = new RLPItem[](numItems);
-     var it = iterator(self);
+     Iterator memory it = iterator(self);
      uint idx;
      while(hasNext(it)) {
          list[idx] = next(it);
@@ -213,7 +213,7 @@ library RLP {
  function toAscii(RLPItem memory self) internal constant returns (string memory str) {
      if(!isData(self))
          throw;
-     var (rStartPos, len) = _decode(self);
+     (uint rStartPos, uint len) = _decode(self);
      bytes memory bts = new bytes(len);
      _copyToBytes(rStartPos, bts, len);
      str = string(bts);
@@ -226,7 +226,7 @@ library RLP {
  function toUint(RLPItem memory self) internal constant returns (uint data) {
      if(!isData(self))
          throw;
-     var (rStartPos, len) = _decode(self);
+     (uint rStartPos, uint len) = _decode(self);
      if (len > 32 || len == 0)
          throw;
      assembly {
@@ -241,7 +241,7 @@ library RLP {
  function toBool(RLPItem memory self) internal constant returns (bool data) {
      if(!isData(self))
          throw;
-     var (rStartPos, len) = _decode(self);
+     (uint rStartPos, uint len) = _decode(self);
      if (len != 1)
          throw;
      uint temp;
@@ -260,7 +260,7 @@ library RLP {
  function toByte(RLPItem memory self) internal constant returns (byte data) {
      if(!isData(self))
          throw;
-     var (rStartPos, len) = _decode(self);
+     (uint rStartPos, uint len) = _decode(self);
      if (len != 1)
          throw;
      uint8 temp;
@@ -293,7 +293,7 @@ library RLP {
  function toAddress(RLPItem memory self) internal constant returns (address data) {
      if(!isData(self))
          throw;
-     var (rStartPos, len) = _decode(self);
+     (uint rStartPos, uint len) = _decode(self);
      if (len != 20)
          throw;
      assembly {

--- a/test/compilationTests/stringutils/strings.sol
+++ b/test/compilationTests/stringutils/strings.sol
@@ -135,7 +135,7 @@ library strings {
      * @return A newly allocated string containing the slice's text.
      */
     function toString(slice self) internal returns (string) {
-        var ret = new string(self._len);
+        string memory ret = new string(self._len);
         uint retptr;
         assembly { retptr := add(ret, 32) }
 
@@ -153,8 +153,8 @@ library strings {
      */
     function len(slice self) internal returns (uint) {
         // Starting at ptr-31 means the LSB will be the byte we care about
-        var ptr = self._ptr - 31;
-        var end = ptr + self._len;
+        uint ptr = self._ptr - 31;
+        uint end = ptr + self._len;
         uint len;
         for (len = 0; ptr < end; len++) {
             uint8 b;
@@ -199,8 +199,8 @@ library strings {
         if (other._len < self._len)
             shortest = other._len;
 
-        var selfptr = self._ptr;
-        var otherptr = other._ptr;
+        uint selfptr = self._ptr;
+        uint otherptr = other._ptr;
         for (uint idx = 0; idx < shortest; idx += 32) {
             uint a;
             uint b;
@@ -211,7 +211,7 @@ library strings {
             if (a != b) {
                 // Mask out irrelevant bytes and check again
                 uint mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
-                var diff = (a & mask) - (b & mask);
+                uint diff = (a & mask) - (b & mask);
                 if (diff != 0)
                     return int(diff);
             }
@@ -300,7 +300,7 @@ library strings {
 
         // Load the rune into the MSBs of b
         assembly { word:= mload(mload(add(self, 32))) }
-        var b = word / div;
+        uint b = word / div;
         if (b < 0x80) {
             ret = b;
             len = 1;
@@ -410,7 +410,7 @@ library strings {
             return false;
         }
 
-        var selfptr = self._ptr + self._len - needle._len;
+        uint selfptr = self._ptr + self._len - needle._len;
 
         if (selfptr == needle._ptr) {
             return true;
@@ -438,7 +438,7 @@ library strings {
             return self;
         }
 
-        var selfptr = self._ptr + self._len - needle._len;
+        uint selfptr = self._ptr + self._len - needle._len;
         bool equal = true;
         if (selfptr != needle._ptr) {
             assembly {
@@ -668,7 +668,7 @@ library strings {
      * @return The concatenation of the two strings.
      */
     function concat(slice self, slice other) internal returns (string) {
-        var ret = new string(self._len + other._len);
+        string memory ret = new string(self._len + other._len);
         uint retptr;
         assembly { retptr := add(ret, 32) }
         memcpy(retptr, self._ptr, self._len);
@@ -692,7 +692,7 @@ library strings {
         for(uint i = 0; i < parts.length; i++)
             len += parts[i]._len;
 
-        var ret = new string(len);
+        string memory ret = new string(len);
         uint retptr;
         assembly { retptr := add(ret, 32) }
 

--- a/test/compilationTests/zeppelin/ownership/Shareable.sol
+++ b/test/compilationTests/zeppelin/ownership/Shareable.sol
@@ -83,7 +83,7 @@ contract Shareable {
       return;
     }
     uint256 ownerIndexBit = 2**index;
-    var pending = pendings[_operation];
+    PendingState memory pending = pendings[_operation];
     if (pending.ownersDone & ownerIndexBit > 0) {
       pending.yetNeeded++;
       pending.ownersDone -= ownerIndexBit;
@@ -116,7 +116,7 @@ contract Shareable {
    * @return True if the owner has confirmed and false otherwise.
    */
   function hasConfirmed(bytes32 _operation, address _owner) constant returns (bool) {
-    var pending = pendings[_operation];
+    PendingState memory pending = pendings[_operation];
     uint256 index = ownerIndex[_owner];
 
     // make sure they're an owner
@@ -142,7 +142,7 @@ contract Shareable {
       throw;
     }
 
-    var pending = pendings[_operation];
+    PendingState memory pending = pendings[_operation];
     // if we're not yet working on this operation, switch over and reset the confirmation status.
     if (pending.yetNeeded == 0) {
       // reset count of confirmations needed.

--- a/test/compilationTests/zeppelin/token/StandardToken.sol
+++ b/test/compilationTests/zeppelin/token/StandardToken.sol
@@ -24,7 +24,7 @@ contract StandardToken is ERC20, BasicToken {
    * @param _value uint256 the amout of tokens to be transfered
    */
   function transferFrom(address _from, address _to, uint256 _value) {
-    var _allowance = allowed[_from][msg.sender];
+    uint256 _allowance = allowed[_from][msg.sender];
 
     // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
     // if (_value > _allowance) throw;


### PR DESCRIPTION
This PR is a prep for #4274 and contains all the changes that can be applied before the latter PR is to be merged.

Also @chriseth, I could do the same with the soltest's, and I wonder whether or not to do it in *this* PR or create another one (also for documentation .rst file adapts to not use/mention "var"). - What do you think?