### PR TITLE
Dockerfile small improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# out-of-tree builds usually go here. This helps improving performance of uploading
+# the build context to the docker image build server
+/build
+
+# in-tree builds
+/deps

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -12,11 +12,27 @@ RUN ./scripts/install_deps.sh
 #Copy working directory on travis to the image
 COPY / $WORKDIR
 
+# Number of parallel jobs during build
+# or 0 for auto-computing (max(1, CPU_core_count * 2/3), a greedy value)
+ARG BUILD_CONCURRENCY="0"
+
 #Install dependencies, eliminate annoying warnings
 RUN sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSOLC_LINK_STATIC=1
-RUN make solc -j$(grep -c ^processor /proc/cpuinfo) && install -s  solc/solc /usr/bin
-#RUN strip solc/solc
+RUN make solc \
+    -j$(awk "BEGIN {                                       \
+        if (${BUILD_CONCURRENCY} != 0) {                   \
+            print(${BUILD_CONCURRENCY});                   \
+        } else {                                           \
+            x=($(grep -c ^processor /proc/cpuinfo) * 2/3); \
+            if (x > 1) {                                   \
+                printf(\"%d\n\", x);                       \
+            } else {                                       \
+                print(1);                                  \
+            }                                              \
+        }                                                  \
+    }")
+RUN strip solc/solc
 
 FROM scratch
 COPY --from=build /solidity/solc/solc /usr/bin/solc

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,18 +1,23 @@
-FROM alpine
+FROM alpine AS build
 MAINTAINER chriseth <chris@ethereum.org>
 #Official solidity docker image
 
 #Establish working directory as solidity
 WORKDIR /solidity
+
+# Build dependencies
+ADD /scripts/install_deps.sh /solidity/scripts/install_deps.sh
+RUN ./scripts/install_deps.sh
+
 #Copy working directory on travis to the image
 COPY / $WORKDIR
 
-#Install dependencies, eliminate annoying warnings, and build release, delete all remaining points and statically link.
-RUN ./scripts/install_deps.sh && sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp &&\
-cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSOLC_LINK_STATIC=1 &&\
-make solc && install -s  solc/solc /usr/bin	&&\
-cd / && rm -rf solidity &&\
-apk del sed build-base git make cmake gcc g++ musl-dev curl-dev boost-dev &&\
-rm -rf /var/cache/apk/*
+#Install dependencies, eliminate annoying warnings
+RUN sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSOLC_LINK_STATIC=1
+RUN make solc -j$(grep -c ^processor /proc/cpuinfo) && install -s  solc/solc /usr/bin
+#RUN strip solc/solc
 
+FROM scratch
+COPY --from=build /solidity/solc/solc /usr/bin/solc
 ENTRYPOINT ["/usr/bin/solc"]


### PR DESCRIPTION
This greatly improves size of the final docker image with the help of
multi-stage docker builds.

With that change, we can also make the build stage readable/maintainable
again by splitting up into multiple RUN statements as well as not
needing to clean-up temporary objects.

The dependencies have been put on top of the primary COPY statement
in order to not rebuild the dependencies each time one wants to rebuild
the docker image (for example due to code changes).

The solc compilation itself is now parallelized to the CPU core count
to speed up those builds that have more cores available on their docker
build system.

Future Notes:
-------------

We could further improve the Dockerfile by explicitely adding the
directories this docker build is interested in (such as solc source code
exclusively).

Or one may want to also use the build step for automated testing (CI)
by enforcing soltest and cmdlineTests.sh right before finalizing the image.