### PR TITLE
Disable gnosis tests temporarily

### DIFF
--- a/test/externalTests.sh
+++ b/test/externalTests.sh
@@ -68,4 +68,6 @@ function test_truffle
 
 # Using our temporary fork here. Hopefully to be merged into upstream after the 0.5.0 release.
 test_truffle Zeppelin https://github.com/axic/openzeppelin-solidity.git solidity-050
-test_truffle Gnosis https://github.com/axic/pm-contracts.git solidity-050
+
+# Disabled temporarily as it needs to be updated to latest Truffle first.
+#test_truffle Gnosis https://github.com/axic/pm-contracts.git solidity-050


### PR DESCRIPTION
One of the reasons tests fail is that we are compiling them for byzantium, but the old Truffle Gnosis is using has an old VM not supporting that. Updating Truffle seems to be breaking Gnosis unfortunately and only the last release supports setting `evmVersion`.