### PR TITLE
Add a Severity enum to errors

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -360,7 +360,7 @@ void CompilerContext::appendInlineAssembly(
 		for (auto const& error: errorReporter.errors())
 			message += SourceReferenceFormatter::formatExceptionInformation(
 				*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "Error",
+				error->severity(),
 				[&](string const&) -> Scanner const& { return *scanner; }
 			);
 		message += "-------------------------------------------\n";

--- a/libsolidity/interface/Exceptions.cpp
+++ b/libsolidity/interface/Exceptions.cpp
@@ -67,3 +67,18 @@ Error::Error(Error::Type _type, const std::string& _description, const SourceLoc
 		*this << errinfo_sourceLocation(_location);
 	*this << errinfo_comment(_description);
 }
+
+string dev::solidity::severityToString(Error::Severity const& _severity)
+{
+	switch (_severity)
+	{
+	case Error::Severity::Fatal:
+		return "Fatal";
+	case Error::Severity::Error:
+		return "Error";
+	case Error::Severity::Warning:
+		return "Warning";
+	default:
+		solAssert(false, "Unknown severity.");
+	}
+}

--- a/libsolidity/interface/Exceptions.h
+++ b/libsolidity/interface/Exceptions.h
@@ -63,6 +63,13 @@ public:
 		Warning
 	};
 
+	enum class Severity
+	{
+		Fatal,
+		Error,
+		Warning
+	};
+
 	explicit Error(
 		Type _type,
 		SourceLocation const& _location = SourceLocation(),
@@ -72,6 +79,11 @@ public:
 	Error(Type _type, std::string const& _description, SourceLocation const& _location = SourceLocation());
 
 	Type type() const { return m_type; }
+
+	Severity severity() const {
+		return (m_type == Type::Warning) ? Severity::Warning : Severity::Error;
+	}
+
 	std::string const& typeName() const { return m_typeName; }
 
 	/// helper functions
@@ -127,6 +139,8 @@ public:
 
 using errinfo_sourceLocation = boost::error_info<struct tag_sourceLocation, SourceLocation>;
 using errinfo_secondarySourceLocation = boost::error_info<struct tag_secondarySourceLocation, SecondarySourceLocation>;
+
+std::string severityToString(Error::Severity const& _severity);
 
 }
 }

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -96,7 +96,7 @@ void SourceReferenceFormatter::printSourceName(SourceLocation const* _location)
 
 void SourceReferenceFormatter::printExceptionInformation(
 	Exception const& _exception,
-	string const& _name
+	Error::Severity const& _severity
 )
 {
 	SourceLocation const* location = boost::get_error_info<errinfo_sourceLocation>(_exception);
@@ -104,7 +104,7 @@ void SourceReferenceFormatter::printExceptionInformation(
 
 	printSourceName(location);
 
-	m_stream << _name;
+	m_stream << severityToString(_severity);
 	if (string const* description = boost::get_error_info<errinfo_comment>(_exception))
 		m_stream << ": " << *description << endl;
 	else

--- a/libsolidity/interface/SourceReferenceFormatter.h
+++ b/libsolidity/interface/SourceReferenceFormatter.h
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <functional>
 #include <libevmasm/SourceLocation.h>
+#include <libsolidity/interface/Exceptions.h>
 
 namespace dev
 {
@@ -53,18 +54,22 @@ public:
 
 	/// Prints source location if it is given.
 	void printSourceLocation(SourceLocation const* _location);
-	void printExceptionInformation(Exception const& _exception, std::string const& _name);
+	void printExceptionInformation(
+		Exception const& _exception,
+		Error::Severity const& _severity
+	);
 
 	static std::string formatExceptionInformation(
 		Exception const& _exception,
-		std::string const& _name,
+		Error::Severity const& _severity,
 		ScannerFromSourceNameFun const& _scannerFromSourceName
 	)
 	{
 		std::ostringstream errorOutput;
 
 		SourceReferenceFormatter formatter(errorOutput, _scannerFromSourceName);
-		formatter.printExceptionInformation(_exception, _name);
+		formatter.printExceptionInformation(_exception, _severity);
+
 		return errorOutput.str();
 	}
 private:

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -837,17 +837,14 @@ bool CommandLineInterface::processInput()
 		bool successful = m_compiler->compile();
 
 		for (auto const& error: m_compiler->errors())
-			formatter.printExceptionInformation(
-				*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-			);
+			formatter.printExceptionInformation(*error, error->severity());
 
 		if (!successful)
 			return false;
 	}
 	catch (CompilerError const& _exception)
 	{
-		formatter.printExceptionInformation(_exception, "Compiler error");
+		formatter.printExceptionInformation(_exception, Error::Severity::Fatal);
 		return false;
 	}
 	catch (InternalCompilerError const& _exception)
@@ -867,7 +864,7 @@ bool CommandLineInterface::processInput()
 		if (_error.type() == Error::Type::DocstringParsingError)
 			cerr << "Documentation parsing error: " << *boost::get_error_info<errinfo_comment>(_error) << endl;
 		else
-			formatter.printExceptionInformation(_error, _error.typeName());
+			formatter.printExceptionInformation(_error, _error.severity());
 
 		return false;
 	}
@@ -1133,10 +1130,8 @@ bool CommandLineInterface::assemble(
 		SourceReferenceFormatter formatter(cerr, scannerFromSourceName);
 
 		for (auto const& error: stack.errors())
-			formatter.printExceptionInformation(
-				*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-			);
+			formatter.printExceptionInformation(*error, error->severity());
+
 		if (!Error::containsOnlyWarnings(stack.errors()))
 			successful = false;
 	}

--- a/test/libjulia/Common.cpp
+++ b/test/libjulia/Common.cpp
@@ -45,10 +45,7 @@ void dev::julia::test::printErrors(ErrorList const& _errors, Scanner const& _sca
 	SourceReferenceFormatter formatter(cout, [&](std::string const&) -> Scanner const& { return _scanner; });
 
 	for (auto const& error: _errors)
-		formatter.printExceptionInformation(
-			*error,
-			(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-		);
+		formatter.printExceptionInformation(*error, error->severity());
 }
 
 

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -126,7 +126,7 @@ string AnalysisFramework::formatError(Error const& _error) const
 {
 	return SourceReferenceFormatter::formatExceptionInformation(
 			_error,
-			(_error.type() == Error::Type::Warning) ? "Warning" : "Error",
+			_error.severity(),
 			[&](std::string const& _sourceName) -> solidity::Scanner const& { return m_compiler.scanner(_sourceName); }
 		);
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -76,10 +76,8 @@ public:
 			SourceReferenceFormatter formatter(std::cerr, scannerFromSourceName);
 
 			for (auto const& error: m_compiler.errors())
-				formatter.printExceptionInformation(
-					*error,
-					(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-				);
+				formatter.printExceptionInformation(*error, error->severity());
+
 			BOOST_ERROR("Compiling contract failed");
 		}
 		eth::LinkerObject obj = m_compiler.object(_contractName.empty() ? m_compiler.lastContractName() : _contractName);


### PR DESCRIPTION
This is the first part of the split of #3046. It adds a severity enum so that the formatter can pick the appropriate colors to underline each message type.