### PR TITLE
 Add ANSI colors to solc console output

### DIFF
--- a/build/deps/include/termcolor.h
+++ b/build/deps/include/termcolor.h
@@ -1,0 +1,546 @@
+#ifndef TERMCOLOR_HPP_
+#define TERMCOLOR_HPP_
+
+// the following snippet of code detects the current OS and
+// defines the appropriate macro that is used to wrap some
+// platform specific things
+#if defined(_WIN32) || defined(_WIN64)
+#   define TERMCOLOR_OS_WINDOWS
+#elif defined(__APPLE__)
+#   define TERMCOLOR_OS_MACOS
+#elif defined(__unix__) || defined(__unix)
+#   define TERMCOLOR_OS_LINUX
+#else
+#   error unsupported platform
+#endif
+
+
+// This headers provides the `isatty()`/`fileno()` functions,
+// which are used for testing whether a standart stream refers
+// to the terminal. As for Windows, we also need WinApi funcs
+// for changing colors attributes of the terminal.
+#if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+#   include <unistd.h>
+#elif defined(TERMCOLOR_OS_WINDOWS)
+#   include <io.h>
+#   include <windows.h>
+#endif
+
+
+#include <iostream>
+#include <cstdio>
+
+
+
+namespace termcolor
+{
+    // Forward declaration of the `_internal` namespace.
+    // All comments are below.
+    namespace _internal
+    {
+        // An index to be used to access a private storage of I/O streams. See
+        // colorize / nocolorize I/O manipulators for details.
+        static int colorize_index = std::ios_base::xalloc();
+
+        inline FILE* get_standard_stream(const std::ostream& stream);
+        inline bool is_colorized(std::ostream& stream);
+        inline bool is_atty(const std::ostream& stream);
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background=-1);
+    #endif
+    }
+
+    inline
+    std::ostream& colorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 1L;
+        return stream;
+    }
+
+    inline
+    std::ostream& nocolorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 0L;
+        return stream;
+    }
+
+    inline
+    std::ostream& reset(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[00m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1, -1);
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& bold(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[1m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& dark(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[2m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& underline(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[4m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& blink(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[5m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& reverse(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[7m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& concealed(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[8m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[30m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[31m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[32m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[33m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[34m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[35m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[36m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[37m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+
+
+    inline
+    std::ostream& on_grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[40m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[41m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[42m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[43m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[44m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[45m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[46m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[47m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+
+        return stream;
+    }
+
+
+
+    //! Since C++ hasn't a way to hide something in the header from
+    //! the outer access, I have to introduce this namespace which
+    //! is used for internal purpose and should't be access from
+    //! the user code.
+    namespace _internal
+    {
+        //! Since C++ hasn't a true way to extract stream handler
+        //! from the a given `std::ostream` object, I have to write
+        //! this kind of hack.
+        inline
+        FILE* get_standard_stream(const std::ostream& stream)
+        {
+            if (&stream == &std::cout)
+                return stdout;
+            else if ((&stream == &std::cerr) || (&stream == &std::clog))
+                return stderr;
+
+            return 0;
+        }
+
+        // Say whether a given stream should be colorized or not. It's always
+        // true for ATTY streams and may be true for streams marked with
+        // colorize flag.
+        inline
+        bool is_colorized(std::ostream& stream)
+        {
+            return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index));
+        }
+
+        //! Test whether a given `std::ostream` object refers to
+        //! a terminal.
+        inline
+        bool is_atty(const std::ostream& stream)
+        {
+            FILE* std_stream = get_standard_stream(stream);
+
+            // Unfortunately, fileno() ends with segmentation fault
+            // if invalid file descriptor is passed. So we need to
+            // handle this case gracefully and assume it's not a tty
+            // if standard stream is not detected, and 0 is returned.
+            if (!std_stream)
+                return false;
+
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            return ::isatty(fileno(std_stream));
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            return ::_isatty(_fileno(std_stream));
+        #endif
+        }
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        //! Change Windows Terminal colors attribute. If some
+        //! parameter is `-1` then attribute won't changed.
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background)
+        {
+            // yeah, i know.. it's ugly, it's windows.
+            static WORD defaultAttributes = 0;
+
+            // Windows doesn't have ANSI escape sequences and so we use special
+            // API to change Terminal output color. That means we can't
+            // manipulate colors by means of "std::stringstream" and hence
+            // should do nothing in this case.
+            if (!_internal::is_atty(stream))
+                return;
+
+            // get terminal handle
+            HANDLE hTerminal = INVALID_HANDLE_VALUE;
+            if (&stream == &std::cout)
+                hTerminal = GetStdHandle(STD_OUTPUT_HANDLE);
+            else if (&stream == &std::cerr)
+                hTerminal = GetStdHandle(STD_ERROR_HANDLE);
+
+            // save default terminal attributes if it unsaved
+            if (!defaultAttributes)
+            {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                    return;
+                defaultAttributes = info.wAttributes;
+            }
+
+            // restore all default settings
+            if (foreground == -1 && background == -1)
+            {
+                SetConsoleTextAttribute(hTerminal, defaultAttributes);
+                return;
+            }
+
+            // get current settings
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                return;
+
+            if (foreground != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0x0F);
+                info.wAttributes |= static_cast<WORD>(foreground);
+            }
+
+            if (background != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0xF0);
+                info.wAttributes |= static_cast<WORD>(background);
+            }
+
+            SetConsoleTextAttribute(hTerminal, info.wAttributes);
+        }
+    #endif // TERMCOLOR_OS_WINDOWS
+
+    } // namespace _internal
+
+} // namespace termcolor
+
+
+#undef TERMCOLOR_OS_WINDOWS
+#undef TERMCOLOR_OS_MACOS
+#undef TERMCOLOR_OS_LINUX
+
+#endif // TERMCOLOR_HPP_

--- a/cmake/templates/license.h.in
+++ b/cmake/templates/license.h.in
@@ -66,6 +66,39 @@ jsoncpp:
   Public Domain "license" you can re-license your copy using whatever
   license you like.
 
+termcolor:
+  Copyright (c) 2013, Ihor Kalnytskyi.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms of the software as well
+  as documentation, with or without modification, are permitted provided
+  that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * The names of the contributors may not be used to endorse or
+    promote products derived from this software without specific
+    prior written permission.
+
+  THIS SOFTWARE AND DOCUMENTATION IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+  NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+  OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE AND DOCUMENTATION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+  DAMAGE.
+
 All other code is licensed under GPL version 3:
 
 )"};

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -360,7 +360,7 @@ void CompilerContext::appendInlineAssembly(
 		for (auto const& error: errorReporter.errors())
 			message += SourceReferenceFormatter::formatExceptionInformation(
 				*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "Error",
+				error->severity(),
 				[&](string const&) -> Scanner const& { return *scanner; }
 			);
 		message += "-------------------------------------------\n";

--- a/libsolidity/interface/Exceptions.cpp
+++ b/libsolidity/interface/Exceptions.cpp
@@ -67,3 +67,18 @@ Error::Error(Error::Type _type, const std::string& _description, const SourceLoc
 		*this << errinfo_sourceLocation(_location);
 	*this << errinfo_comment(_description);
 }
+
+string dev::solidity::severityToString(Error::Severity const& _severity)
+{
+	switch (_severity)
+	{
+	case Error::Severity::Fatal:
+		return "Fatal";
+	case Error::Severity::Error:
+		return "Error";
+	case Error::Severity::Warning:
+		return "Warning";
+	default:
+		solAssert(false, "Unknown severity.");
+	}
+}

--- a/libsolidity/interface/Exceptions.h
+++ b/libsolidity/interface/Exceptions.h
@@ -63,6 +63,13 @@ public:
 		Warning
 	};
 
+	enum class Severity
+	{
+		Fatal,
+		Error,
+		Warning
+	};
+
 	explicit Error(
 		Type _type,
 		SourceLocation const& _location = SourceLocation(),
@@ -72,6 +79,11 @@ public:
 	Error(Type _type, std::string const& _description, SourceLocation const& _location = SourceLocation());
 
 	Type type() const { return m_type; }
+
+	Severity severity() const {
+		return (m_type == Type::Warning) ? Severity::Warning : Severity::Error;
+	}
+
 	std::string const& typeName() const { return m_typeName; }
 
 	/// helper functions
@@ -127,6 +139,8 @@ public:
 
 using errinfo_sourceLocation = boost::error_info<struct tag_sourceLocation, SourceLocation>;
 using errinfo_secondarySourceLocation = boost::error_info<struct tag_secondarySourceLocation, SecondarySourceLocation>;
+
+std::string severityToString(Error::Severity const& _severity);
 
 }
 }

--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -96,7 +96,7 @@ void SourceReferenceFormatter::printSourceName(SourceLocation const* _location)
 
 void SourceReferenceFormatter::printExceptionInformation(
 	Exception const& _exception,
-	string const& _name
+	Error::Severity const& _severity
 )
 {
 	SourceLocation const* location = boost::get_error_info<errinfo_sourceLocation>(_exception);
@@ -104,7 +104,7 @@ void SourceReferenceFormatter::printExceptionInformation(
 
 	printSourceName(location);
 
-	m_stream << _name;
+	m_stream << severityToString(_severity);
 	if (string const* description = boost::get_error_info<errinfo_comment>(_exception))
 		m_stream << ": " << *description << endl;
 	else

--- a/libsolidity/interface/SourceReferenceFormatter.h
+++ b/libsolidity/interface/SourceReferenceFormatter.h
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <functional>
 #include <libevmasm/SourceLocation.h>
+#include <libsolidity/interface/Exceptions.h>
 
 namespace dev
 {
@@ -53,18 +54,22 @@ public:
 
 	/// Prints source location if it is given.
 	void printSourceLocation(SourceLocation const* _location);
-	void printExceptionInformation(Exception const& _exception, std::string const& _name);
+	void printExceptionInformation(
+		Exception const& _exception,
+		Error::Severity const& _severity
+	);
 
 	static std::string formatExceptionInformation(
 		Exception const& _exception,
-		std::string const& _name,
+		Error::Severity const& _severity,
 		ScannerFromSourceNameFun const& _scannerFromSourceName
 	)
 	{
 		std::ostringstream errorOutput;
 
 		SourceReferenceFormatter formatter(errorOutput, _scannerFromSourceName);
-		formatter.printExceptionInformation(_exception, _name);
+		formatter.printExceptionInformation(_exception, _severity);
+
 		return errorOutput.str();
 	}
 private:

--- a/libsolidity/interface/SourceReferenceFormatter.h
+++ b/libsolidity/interface/SourceReferenceFormatter.h
@@ -53,7 +53,10 @@ public:
 	{}
 
 	/// Prints source location if it is given.
-	void printSourceLocation(SourceLocation const* _location);
+	void printSourceLocation(
+		SourceLocation const* _location,
+		Error::Severity const& _severity
+	);
 	void printExceptionInformation(
 		Exception const& _exception,
 		Error::Severity const& _severity

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -837,17 +837,14 @@ bool CommandLineInterface::processInput()
 		bool successful = m_compiler->compile();
 
 		for (auto const& error: m_compiler->errors())
-			formatter.printExceptionInformation(
-				*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-			);
+			formatter.printExceptionInformation(*error, error->severity());
 
 		if (!successful)
 			return false;
 	}
 	catch (CompilerError const& _exception)
 	{
-		formatter.printExceptionInformation(_exception, "Compiler error");
+		formatter.printExceptionInformation(_exception, Error::Severity::Fatal);
 		return false;
 	}
 	catch (InternalCompilerError const& _exception)
@@ -867,7 +864,7 @@ bool CommandLineInterface::processInput()
 		if (_error.type() == Error::Type::DocstringParsingError)
 			cerr << "Documentation parsing error: " << *boost::get_error_info<errinfo_comment>(_error) << endl;
 		else
-			formatter.printExceptionInformation(_error, _error.typeName());
+			formatter.printExceptionInformation(_error, _error.severity());
 
 		return false;
 	}
@@ -1133,10 +1130,8 @@ bool CommandLineInterface::assemble(
 		SourceReferenceFormatter formatter(cerr, scannerFromSourceName);
 
 		for (auto const& error: stack.errors())
-			formatter.printExceptionInformation(
-				*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-			);
+			formatter.printExceptionInformation(*error, error->severity());
+
 		if (!Error::containsOnlyWarnings(stack.errors()))
 			successful = false;
 	}

--- a/test/libjulia/Common.cpp
+++ b/test/libjulia/Common.cpp
@@ -45,10 +45,7 @@ void dev::julia::test::printErrors(ErrorList const& _errors, Scanner const& _sca
 	SourceReferenceFormatter formatter(cout, [&](std::string const&) -> Scanner const& { return _scanner; });
 
 	for (auto const& error: _errors)
-		formatter.printExceptionInformation(
-			*error,
-			(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-		);
+		formatter.printExceptionInformation(*error, error->severity());
 }
 
 

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -126,7 +126,7 @@ string AnalysisFramework::formatError(Error const& _error) const
 {
 	return SourceReferenceFormatter::formatExceptionInformation(
 			_error,
-			(_error.type() == Error::Type::Warning) ? "Warning" : "Error",
+			_error.severity(),
 			[&](std::string const& _sourceName) -> solidity::Scanner const& { return m_compiler.scanner(_sourceName); }
 		);
 }

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -139,8 +139,8 @@ BOOST_AUTO_TEST_CASE(non_overlapping_filtered_costs)
 				auto scannerFromSource = [&](string const& _sourceName) -> Scanner const& { return m_compiler.scanner(_sourceName); };
 				SourceReferenceFormatter formatter(cout, scannerFromSource);
 
-				formatter.printSourceLocation(&first->first->location());
-				formatter.printSourceLocation(&second->first->location());
+				formatter.printSourceLocation(&first->first->location(), Error::Severity::Error);
+				formatter.printSourceLocation(&second->first->location(), Error::Severity::Error);
 			}
 	}
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -76,10 +76,8 @@ public:
 			SourceReferenceFormatter formatter(std::cerr, scannerFromSourceName);
 
 			for (auto const& error: m_compiler.errors())
-				formatter.printExceptionInformation(
-					*error,
-					(error->type() == Error::Type::Warning) ? "Warning" : "Error"
-				);
+				formatter.printExceptionInformation(*error, error->severity());
+
 			BOOST_ERROR("Compiling contract failed");
 		}
 		eth::LinkerObject obj = m_compiler.object(_contractName.empty() ? m_compiler.lastContractName() : _contractName);


### PR DESCRIPTION
This builds on top of #4338 and adds ANSI colored output. Part of the split of #3046.

It also changes the underline to be ^^^^ instead of ^---^. No other formatting changes have been made to the output.