### PR TITLE
Fixes soltest run against "recent" cpp-ethereum builds.

### DIFF
--- a/test/RPCSession.cpp
+++ b/test/RPCSession.cpp
@@ -245,6 +245,8 @@ void RPCSession::test_setChainParams(vector<string> const& _accounts)
 			"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"extraData": "0x",
 			"gasLimit": "0x1000000000000",
+			"mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+			"nonce": "0x0000000000000042",
 			"difficulty": "1"
 		},
 		"accounts": {


### PR DESCRIPTION
For me, it looks like the following Git commit has introduced this behaviour:

https://github.com/ethereum/cpp-ethereum/commit/42b927d7aa103e21e34c8ba8c5469f532b49f966

This commit adds dummy values for `mixHash` and `nonce` (inspired by values were cpp-ethereum's own tests), and now, soltest runs fine again.
