### PR TITLE
Fixes storage ref var typo error from 'prefix' to 'suffix'

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -929,7 +929,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			}
 			else if (var->type()->dataStoredIn(DataLocation::Storage))
 			{
-				m_errorReporter.typeError(_identifier.location, "You have to use the _slot or _offset prefix to access storage reference variables.");
+				m_errorReporter.typeError(_identifier.location, "You have to use the _slot or _offset suffix to access storage reference variables.");
 				return size_t(-1);
 			}
 			else if (var->type()->sizeOnStack() != 1)

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference.sol
@@ -1,0 +1,11 @@
+contract C {
+    uint[] x;
+    function() { 
+        uint[] storage y = x;
+        assembly {
+            pop(y)
+        }
+    }
+}
+// ----
+// TypeError: (110-111): You have to use the _slot or _offset suffix to access storage reference variables.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_fine.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_fine.sol
@@ -3,9 +3,9 @@ contract C {
     function() public { 
         uint[] storage y = x;
         assembly {
-            pop(y)
+            pop(y_slot)
+            pop(y_offset)
         }
     }
 }
 // ----
-// TypeError: (117-118): You have to use the _slot or _offset suffix to access storage reference variables.


### PR DESCRIPTION
Fixes an inline assembly error typo.