### PR TITLE
Added static CSS to Sphinx in order to fix bug with RTD theme table wrapping

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on sphinx_rtd_theme they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,16 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
+
+# A dictionary of values to pass into the template engine’s context for
+# all pages. Single values can also be put in
+# this dictionary using the -A command-line option of sphinx-build.
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in sphinx_rtd_theme
+        ],
+     }
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Fixes #4238 where the table text does not wrap in the Solidity Assembly page, requiring horizontal scrolling: 

There is a bug in the Read the Docs Sphinx theme that does not allow table text to wrap. Adding static CSS overrides for these particular classes solves this. 