### PR TITLE
V050 var keyword removal preparations (End-to-End tests)

### DIFF
--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -67,7 +67,7 @@ contract AuctionSystem {
 	function onAuctionEnd(string _name) internal;
 
 	function bid(string _name, address _bidder, uint _value) internal {
-		var auction = m_auctions[_name];
+		Auction storage auction = m_auctions[_name];
 		if (auction.endDate > 0 && now > auction.endDate)
 		{
 			emit AuctionEnded(_name, auction.highestBidder);
@@ -117,9 +117,9 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 	}
 
 	function onAuctionEnd(string _name) internal {
-		var auction = m_auctions[_name];
-		var record = m_toRecord[_name];
-		var previousOwner = record.owner;
+		Auction storage auction = m_auctions[_name];
+		Record storage record = m_toRecord[_name];
+		address previousOwner = record.owner;
 		record.renewalDate = now + c_renewalInterval;
 		record.owner = auction.highestBidder;
 		emit Changed(_name);

--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -119,7 +119,7 @@ contract multiowned {
 		// make sure they're an owner
 		if (ownerIndex == 0) return;
 		uint ownerIndexBit = 2**ownerIndex;
-		var pending = m_pending[_operation];
+		PendingState pending = m_pending[_operation];
 		if (pending.ownersDone & ownerIndexBit > 0) {
 			pending.yetNeeded++;
 			pending.ownersDone -= ownerIndexBit;
@@ -178,7 +178,7 @@ contract multiowned {
 	}
 
 	function hasConfirmed(bytes32 _operation, address _owner) constant returns (bool) {
-		var pending = m_pending[_operation];
+		PendingState pending = m_pending[_operation];
 		uint ownerIndex = m_ownerIndex[uint(_owner)];
 
 		// make sure they're an owner
@@ -201,7 +201,7 @@ contract multiowned {
 		// make sure they're an owner
 		if (ownerIndex == 0) return;
 
-		var pending = m_pending[_operation];
+		PendingState pending = m_pending[_operation];
 		// if we're not yet working on this operation, switch over and reset the confirmation status.
 		if (pending.yetNeeded == 0) {
 			// reset count of confirmations needed.

--- a/test/libsolidity/ABIDecoderTests.cpp
+++ b/test/libsolidity/ABIDecoderTests.cpp
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(decode_function_type_array)
 			}
 			// uses "decode from memory"
 			function test1_dynamic() public returns (uint) {
-				var x = new function() external returns (uint)[](3);
+				function () external returns (uint)[] memory x = new function() external returns (uint)[](4);
 				x[0] = this.f1;
 				x[1] = this.f2;
 				x[2] = this.f3;
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(decode_function_type_array)
 			}
 			// uses "decode from calldata"
 			function test2_dynamic() public returns (uint) {
-				var x = new function() external returns (uint)[](3);
+				function () external returns (uint)[] memory x = new function() external returns (uint)[](3);
 				x[0] = this.f1;
 				x[1] = this.f2;
 				x[2] = this.f3;
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE(storage_ptr)
 				r[2] = 3;
 				s.x = 11;
 				s.y = 12;
-				var (a, b, c, d) = L.f(r, s);
+				(uint a, uint b, uint c, uint d) = L.f(r, s);
 				return (r[2], s.x, a, b, c, d);
 			}
 		}

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(conditional_expression_functions)
 			function y() returns (uint) { return 2; }
 
 			function f(bool cond) returns (uint) {
-				var z = cond ? x : y;
+				function () returns (uint) z = cond ? x : y;
 				return z();
 			}
 		}
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(while_loop)
 		contract test {
 			function f(uint n) returns(uint nfac) {
 				nfac = 1;
-				var i = 2;
+				uint i = 2;
 				while (i <= n) nfac *= i++;
 			}
 		}
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(do_while_loop)
 		contract test {
 			function f(uint n) returns(uint nfac) {
 				nfac = 1;
-				var i = 2;
+				uint i = 2;
 				do { nfac *= i++; } while (i <= n);
 			}
 		}
@@ -561,7 +561,8 @@ BOOST_AUTO_TEST_CASE(for_loop)
 		contract test {
 			function f(uint n) returns(uint nfac) {
 				nfac = 1;
-				for (var i = 2; i <= n; i++)
+				uint i;
+				for (i = 2; i <= n; i++)
 					nfac *= i;
 			}
 		}
@@ -735,7 +736,7 @@ BOOST_AUTO_TEST_CASE(many_local_variables)
 	char const* sourceCode = R"(
 		contract test {
 			function run(uint x1, uint x2, uint x3) returns(uint y) {
-				var a = 0x1; var b = 0x10; var c = 0x100;
+				uint8 a = 0x1; uint8 b = 0x10; uint16 c = 0x100;
 				y = a + b + c + x1 + x2 + x3;
 				y += b + x2;
 			}
@@ -1252,7 +1253,7 @@ BOOST_AUTO_TEST_CASE(struct_reference)
 			}
 			function set() {
 				data.z = 2;
-				var map = data.recursive;
+				mapping(uint8 => s2) map = data.recursive;
 				s2 inner = map[0];
 				inner.z = 3;
 				inner.recursive[0].z = inner.recursive[1].z + 1;
@@ -1836,8 +1837,7 @@ BOOST_AUTO_TEST_CASE(uncalled_blockhash)
 		contract C {
 			function f() public view returns (bytes32)
 			{
-				var x = block.blockhash;
-				return x(block.number - 1);
+				return (block.blockhash)(block.number - 1);
 			}
 		}
 	)";
@@ -2061,7 +2061,7 @@ BOOST_AUTO_TEST_CASE(packed_keccak256)
 	char const* sourceCode = R"(
 		contract test {
 			function a(bytes32 input) returns (bytes32 hash) {
-				var b = 65536;
+				uint24 b = 65536;
 				uint c = 256;
 				return keccak256(abi.encodePacked(8, input, b, input, c));
 			}
@@ -2113,7 +2113,7 @@ BOOST_AUTO_TEST_CASE(packed_sha256)
 	char const* sourceCode = R"(
 		contract test {
 			function a(bytes32 input) returns (bytes32 hash) {
-				var b = 65536;
+				uint24 b = 65536;
 				uint c = 256;
 				return sha256(abi.encodePacked(8, input, b, input, c));
 			}
@@ -2140,7 +2140,7 @@ BOOST_AUTO_TEST_CASE(packed_ripemd160)
 	char const* sourceCode = R"(
 		contract test {
 			function a(bytes32 input) returns (bytes32 hash) {
-				var b = 65536;
+				uint24 b = 65536;
 				uint c = 256;
 				return ripemd160(abi.encodePacked(8, input, b, input, c));
 			}
@@ -2319,9 +2319,8 @@ BOOST_AUTO_TEST_CASE(inter_contract_calls_with_local_vars)
 		contract Main {
 			Helper h;
 			function callHelper(uint a, uint b) returns (uint c) {
-				var fu = h.multiply;
-				var y = 9;
-				var ret = fu(a, b);
+				uint8 y = 9;
+				uint256 ret = h.multiply(a, b);
 				return ret + y;
 			}
 			function getHelper() returns (address haddress) {
@@ -2568,10 +2567,8 @@ BOOST_AUTO_TEST_CASE(value_complex)
 			helper h;
 			constructor() payable { h = new helper(); }
 			function sendAmount(uint amount) payable returns (uint256 bal) {
-				var x1 = h.getBalance.value(amount);
 				uint someStackElement = 20;
-				var x2 = x1.gas(1000);
-				return x2.value(amount + 3)();// overwrite value
+				return h.getBalance.value(amount).gas(1000).value(amount + 3)();
 			}
 		}
 	)";
@@ -2591,10 +2588,7 @@ BOOST_AUTO_TEST_CASE(value_insane)
 			helper h;
 			constructor() payable { h = new helper(); }
 			function sendAmount(uint amount) returns (uint256 bal) {
-				var x1 = h.getBalance.value;
-				var x2 = x1(amount).gas;
-				var x3 = x2(1000).value;
-				return x3(amount + 3)();// overwrite value
+				return h.getBalance.value(amount).gas(1000).value(amount + 3)();// overwrite value
 			}
 		}
 	)";
@@ -2815,7 +2809,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_local_variables)
 {
 	char const* sourceCode = R"(
 		contract C {
-			modifier mod1 { var a = 1; var b = 2; _; }
+			modifier mod1 { uint8 a = 1; uint8 b = 2; _; }
 			modifier mod2(bool a) { if (a) return; else _; }
 			function f(bool a) mod1 mod2(a) returns (uint r) { return 3; }
 		}
@@ -2829,7 +2823,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_loop)
 {
 	char const* sourceCode = R"(
 		contract C {
-			modifier repeat(uint count) { for (var i = 0; i < count; ++i) _; }
+			modifier repeat(uint count) { uint i; for (i = 0; i < count; ++i) _; }
 			function f() repeat(10) returns (uint r) { r += 1; }
 		}
 	)";
@@ -3007,8 +3001,7 @@ BOOST_AUTO_TEST_CASE(crazy_elementary_typenames_on_stack)
 			function f() returns (uint r) {
 				uint; uint; uint; uint;
 				int x = -7;
-				var a = uint;
-				return a(x);
+				return uint(x);
 			}
 		}
 	)";
@@ -4074,7 +4067,7 @@ BOOST_AUTO_TEST_CASE(struct_copy_via_local)
 			function test() returns (bool) {
 				data1.a = 1;
 				data1.b = 2;
-				var x = data1;
+				Struct memory x = data1;
 				data2 = x;
 				return data2.a == data1.a && data2.b == data1.b;
 			}
@@ -6295,7 +6288,7 @@ BOOST_AUTO_TEST_CASE(send_zero_ether)
 		contract Main {
 			constructor() payable {}
 			function s() returns (bool) {
-				var r = new Receiver();
+				Receiver r = new Receiver();
 				return r.send(0);
 			}
 		}
@@ -6578,7 +6571,7 @@ BOOST_AUTO_TEST_CASE(bytes_in_constructors_packer)
 		}
 		contract Creator {
 			function f(uint x, bytes s) returns (uint r, byte ch) {
-				var c = new Main(s, x);
+				Main c = new Main(s, x);
 				r = c.m_x();
 				ch = c.part(x);
 			}
@@ -6617,7 +6610,7 @@ BOOST_AUTO_TEST_CASE(arrays_in_constructors)
 		}
 		contract Creator {
 			function f(uint x, address[] s) returns (uint r, address ch) {
-				var c = new Main(s, x);
+				Main c = new Main(s, x);
 				r = c.m_x();
 				ch = c.part(x);
 			}
@@ -7369,8 +7362,8 @@ BOOST_AUTO_TEST_CASE(constant_string_literal)
 			string constant public x = "abefghijklmnopqabcdefghijklmnopqabcdefghijklmnopqabca";
 
 			constructor() {
-				var xx = x;
-				var bb = b;
+				string memory xx = x;
+				bytes32 bb = b;
 			}
 			function getB() returns (bytes32) { return b; }
 			function getX() returns (string) { return x; }
@@ -7461,7 +7454,7 @@ BOOST_AUTO_TEST_CASE(cross_contract_types)
 		contract Lib { struct S {uint a; uint b; } }
 		contract Test {
 			function f() returns (uint r) {
-				var x = Lib.S({a: 2, b: 3});
+				Lib.S memory x = Lib.S({a: 2, b: 3});
 				r = x.b;
 			}
 		}
@@ -7546,7 +7539,7 @@ BOOST_AUTO_TEST_CASE(fixed_arrays_as_return_type)
 		contract B {
 			function f() returns (uint16[5] res, uint16[5] res2)
 			{
-				var a = new A();
+				A a = new A();
 				res = a.f(2);
 				res2 = a.f(1000);
 			}
@@ -7829,13 +7822,13 @@ BOOST_AUTO_TEST_CASE(multi_variable_declaration)
 				a = 1; b = 2; c = 3;
 			}
 			function f() returns (bool) {
-				var (x, y, z) = g();
+				(uint x, uint y, uint z) = g();
 				if (x != 1 || y != 2 || z != 3) return false;
-				var (, a,) = g();
+				(, uint a,) = g();
 				if (a != 2) return false;
-				var (b,) = g();
+				(uint b,) = g();
 				if (b != 1) return false;
-				var (,c) = g();
+				(, uint c) = g();
 				if (c != 3) return false;
 				return true;
 			}
@@ -8037,11 +8030,11 @@ BOOST_AUTO_TEST_CASE(create_memory_array)
 		contract C {
 			struct S { uint[2] a; bytes b; }
 			function f() returns (byte, uint, uint, byte) {
-				var x = new bytes(200);
+				bytes memory x = new bytes(200);
 				x[199] = 'A';
-				var y = new uint[2][](300);
+				uint[2][] memory y = new uint[2][](300);
 				y[203][1] = 8;
-				var z = new S[](180);
+				S[] memory z = new S[](180);
 				z[170].a[1] = 4;
 				z[170].b = new bytes(102);
 				z[170].b[99] = 'B';
@@ -8331,8 +8324,7 @@ BOOST_AUTO_TEST_CASE(bound_function_in_var)
 			D.s public x;
 			function f(uint a) returns (uint) {
 				x.a = 6;
-				var g = x.mul;
-				return g({x: a});
+				return (x.mul)({x: a});
 			}
 		}
 	)";
@@ -9120,7 +9112,7 @@ BOOST_AUTO_TEST_CASE(skip_dynamic_types)
 			}
 			function g() returns (uint, uint) {
 				// Previous implementation "moved" b to the second place and did not skip.
-				var (a, _, b) = this.f();
+				(uint a,, uint b) = this.f();
 				return (a, b);
 			}
 		}
@@ -9146,7 +9138,7 @@ BOOST_AUTO_TEST_CASE(skip_dynamic_types_for_structs)
 				s.a = "abc";
 				s.b = [7, 8, 9];
 				s.y = 6;
-				var (x, a, y) = this.s();
+				(uint x,, uint y) = this.s();
 				return (x, y);
 			}
 		}
@@ -9188,7 +9180,7 @@ BOOST_AUTO_TEST_CASE(create_dynamic_array_with_zero_length)
 	char const* sourceCode = R"(
 		contract C {
 			function f() returns (uint) {
-				var a = new uint[][](0);
+				uint[][] memory a = new uint[][](0);
 				return 7;
 			}
 		}
@@ -10039,7 +10031,7 @@ BOOST_AUTO_TEST_CASE(function_delete_stack)
 		contract C {
 			function a() returns (uint) { return 7; }
 			function test() returns (uint) {
-				var y = a;
+				function () returns (uint) y = a;
 				delete y;
 				y();
 			}
@@ -10077,7 +10069,7 @@ BOOST_AUTO_TEST_CASE(function_array_cross_calls)
 	char const* sourceCode = R"(
 		contract D {
 			function f(function() external returns (function() external returns (uint))[] x)
-				returns (function() external returns (uint)[3] r)
+				public returns (function() external returns (uint)[3] r)
 			{
 				r[0] = x[0]();
 				r[1] = x[1]();
@@ -10085,23 +10077,23 @@ BOOST_AUTO_TEST_CASE(function_array_cross_calls)
 			}
 		}
 		contract C {
-			function test() returns (uint, uint, uint) {
+			function test() public returns (uint, uint, uint) {
 				function() external returns (function() external returns (uint))[] memory x =
 					new function() external returns (function() external returns (uint))[](10);
 				for (uint i = 0; i < x.length; i ++)
 					x[i] = this.h;
 				x[0] = this.htwo;
-				var y = (new D()).f(x);
+				function() external returns (uint)[3] memory y = (new D()).f(x);
 				return (y[0](), y[1](), y[2]());
 			}
-			function e() returns (uint) { return 5; }
-			function f() returns (uint) { return 6; }
-			function g() returns (uint) { return 7; }
+			function e() public returns (uint) { return 5; }
+			function f() public returns (uint) { return 6; }
+			function g() public returns (uint) { return 7; }
 			uint counter;
-			function h() returns (function() external returns (uint)) {
+			function h() public returns (function() external returns (uint)) {
 				return counter++ == 0 ? this.f : this.g;
 			}
-			function htwo() returns (function() external returns (uint)) {
+			function htwo() public returns (function() external returns (uint)) {
 				return this.e;
 			}
 		}
@@ -11230,7 +11222,7 @@ BOOST_AUTO_TEST_CASE(bubble_up_error_messages_through_create)
 		}
 		contract D {
 			function f() public {
-				var x = new E();
+				E x = new E();
 			}
 		}
 		contract C {
@@ -11506,8 +11498,7 @@ BOOST_AUTO_TEST_CASE(function_types_sig)
 			}
 			function h() returns (bytes4) {
 				function () pure external returns (bytes4) fun = this.f;
-				var funvar = fun;
-				return funvar.selector;
+				return fun.selector;
 			}
 			function i() pure returns (bytes4) {
 				return this.x.selector;
@@ -11739,8 +11730,8 @@ BOOST_AUTO_TEST_CASE(snark)
 			Pairing.G1Point memory p2;
 			p1.X = 1; p1.Y = 2;
 			p2.X = 1; p2.Y = 2;
-			var explict_sum = Pairing.add(p1, p2);
-			var scalar_prod = Pairing.mul(p1, 2);
+			Pairing.G1Point memory explict_sum = Pairing.add(p1, p2);
+			Pairing.G1Point memory scalar_prod = Pairing.mul(p1, 2);
 			return (explict_sum.X == scalar_prod.X &&
 					explict_sum.Y == scalar_prod.Y);
 		}

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(literal_true)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f() { var x = true; }
+			function f() { bool x = true; }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(literal_false)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f() { var x = false; }
+			function f() { bool x = false; }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode);
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(int_literal)
 {
 	char const* sourceCode = R"(
 		contract test {
-		  function f() { var x = 0x12345678901234567890; }
+		  function f() { uint x = 0x12345678901234567890; }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode);
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(int_with_wei_ether_subdenomination)
 	char const* sourceCode = R"(
 		contract test {
 			constructor() {
-				 var x = 1 wei;
+				 uint x = 1 wei;
 			}
 		}
 	)";
@@ -230,8 +230,8 @@ BOOST_AUTO_TEST_CASE(int_with_szabo_ether_subdenomination)
 {
 	char const* sourceCode = R"(
 		contract test {
-			constructor() {
-				 var x = 1 szabo;
+			function test () {
+				uint x = 1 szabo;
 			}
 		}
 	)";
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(int_with_finney_ether_subdenomination)
 		contract test {
 			constructor()
 			{
-				 var x = 1 finney;
+				 uint x = 1 finney;
 			}
 		}
 	)";
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(int_with_ether_ether_subdenomination)
 	char const* sourceCode = R"(
 		contract test {
 			constructor() {
-				 var x = 1 ether;
+				 uint x = 1 ether;
 			}
 		}
 	)";
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(comparison)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f() { var x = (0x10aa < 0x11aa) != true; }
+			function f() { bool x = (0x10aa < 0x11aa) != true; }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode);
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(short_circuiting)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f() { var x = true != (4 <= 8 + 10 || 9 != 2); }
+			function f() { bool x = true != (4 <= 8 + 10 || 9 != 2); }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode);
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(intermediately_overflowing_literals)
 	// have been applied
 	char const* sourceCode = R"(
 		contract test {
-			function f() { var x = (0x00ffffffffffffffffffffffffffffffffffffffff * 0xffffffffffffffffffffffffff01) & 0xbf; }
+			function f() { uint8 x = (0x00ffffffffffffffffffffffffffffffffffffffff * 0xffffffffffffffffffffffffff01) & 0xbf; }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode);

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -352,16 +352,16 @@ BOOST_AUTO_TEST_CASE(dynamic_return_types_not_possible)
 		contract C {
 			function f(uint) public returns (string);
 			function g() public {
-				var x = this.f(2);
+				string memory x = this.f(2);
 				// we can assign to x but it is not usable.
 				bytes(x).length;
 			}
 		}
 	)";
 	if (dev::test::Options::get().evmVersion() == EVMVersion::homestead())
-		CHECK_ERROR(sourceCode, TypeError, "Explicit type conversion not allowed from \"inaccessible dynamic type\" to \"bytes storage pointer\".");
+		CHECK_ERROR(sourceCode, TypeError, "Type inaccessible dynamic type is not implicitly convertible to expected type string memory.");
 	else
-		CHECK_WARNING(sourceCode, "Use of the \"var\" keyword is deprecated");
+		CHECK_SUCCESS_NO_WARNINGS(sourceCode);
 }
 
 BOOST_AUTO_TEST_CASE(warn_nonpresent_pragma)

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(storage_write_in_loops)
 		contract test {
 			uint d;
 			function f(uint a) returns (uint r) {
-				var x = d;
+				uint x = d;
 				for (uint i = 1; i < a * a; i++) {
 					r = d;
 					d = i;


### PR DESCRIPTION
This PR eliminates any occurrences of the "var" keyword in the compiled tests and must be merged *before* #4274.

FYI: the last commit in this PR is special and I'd like to get your feedback on this. I did not find any way to express this in Solidity language syntax, and IIRC, any `FunctionType` not of `Kind::External` or `Kind::Internal` or `Kind::External` is lacking representation in Solidity language wrt. var-keyword removal.