### PR TITLE
Support Manjaro Linux distributions in dependencies script

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -133,7 +133,7 @@ case $(uname -s) in
 # Arch Linux
 #------------------------------------------------------------------------------
 
-            Arch*)
+            Arch*|ManjaroLinux)
                 #Arch
                 echo "Installing solidity dependencies on Arch Linux."
 


### PR DESCRIPTION
This minor change makes the `scripts/install_deps.sh` recognize Manjaro Linux distros, and treats them as Arch distros.

Manjaro Linux distributions are basically the same as Archlinux. From the site:
"Manjaro is a user-friendly Linux distribution based on the independently developed Arch operating system."

https://manjaro.org/