### PR TITLE
Add abi.decode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -77,6 +77,7 @@ Language Features:
  * General: Allow ``enum``s in interfaces.
  * General: Allow ``mapping`` storage pointers as arguments and return values in all internal functions.
  * General: Allow ``struct``s in interfaces.
+ * General: Provide access to the ABI decoder through ``abi.decode(bytes memory data, (...))``.
 
 Compiler Features:
  * C API (``libsolc``): Export the ``solidity_license``, ``solidity_version`` and ``solidity_compile`` methods.

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -318,6 +318,7 @@ The following is the order of precedence for operators, listed in order of evalu
 Global Variables
 ================
 
+- ``abi.decode(bytes encodedData, (...)) returns (...)``: :ref:`ABI <ABI>`-decodes the provided data. The types are given in parentheses as second argument. Example: ``(uint a, uint[2] memory b, bytes memory c) = abi.decode(data, (uint, uint[2], bytes))``
 - ``abi.encode(...) returns (bytes)``: :ref:`ABI <ABI>`-encodes the given arguments
 - ``abi.encodePacked(...) returns (bytes)``: Performs :ref:`packed encoding <abi_packed_mode>` of the given arguments
 - ``abi.encodeWithSelector(bytes4 selector, ...) returns (bytes)``: :ref:`ABI <ABI>`-encodes the given arguments

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -96,9 +96,10 @@ Block and Transaction Properties
 
 .. index:: abi, encoding, packed
 
-ABI Encoding Functions
-----------------------
+ABI Encoding and Decoding Functions
+-----------------------------------
 
+- ``abi.decode(bytes encodedData, (...)) returns (...)``: ABI-decodes the given data, while the types are given in parentheses as second argument. Example: ``(uint a, uint[2] memory b, bytes memory c) = abi.decode(data, (uint, uint[2], bytes))``
 - ``abi.encode(...) returns (bytes)``: ABI-encodes the given arguments
 - ``abi.encodePacked(...) returns (bytes)``: Performs :ref:`packed encoding <abi_packed_mode>` of the given arguments
 - ``abi.encodeWithSelector(bytes4 selector, ...) returns (bytes)``: ABI-encodes the given arguments starting from the second and prepends the given four-byte selector

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -91,6 +91,11 @@ private:
 	// and reports an error, if not.
 	void checkExpressionAssignment(Type const& _type, Expression const& _expression);
 
+	/// Performs type checks for ``abi.decode(bytes memory, (...))`` and returns the
+	/// return type (which is basically the second argument) if successful. It returns
+	/// the empty tuple type or error.
+	TypePointer typeCheckABIDecodeAndRetrieveReturnType(FunctionCall const& _functionCall, bool _abiEncoderV2);
+
 	virtual void endVisit(InheritanceSpecifier const& _inheritance) override;
 	virtual void endVisit(UsingForDirective const& _usingFor) override;
 	virtual bool visit(StructDefinition const& _struct) override;

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -295,7 +295,7 @@ void ViewPureChecker::endVisit(MemberAccess const& _memberAccess)
 	{
 		// we can ignore the kind of magic and only look at the name of the member
 		set<string> static const pureMembers{
-			"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "data", "sig", "blockhash"
+			"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "decode", "data", "sig", "blockhash"
 		};
 		if (!pureMembers.count(member))
 			mutability = StateMutability::View;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2553,6 +2553,7 @@ string FunctionType::richIdentifier() const
 	case Kind::ABIEncodePacked: id += "abiencodepacked"; break;
 	case Kind::ABIEncodeWithSelector: id += "abiencodewithselector"; break;
 	case Kind::ABIEncodeWithSignature: id += "abiencodewithsignature"; break;
+	case Kind::ABIDecode: id += "abidecode"; break;
 	default: solAssert(false, "Unknown function location."); break;
 	}
 	id += "_" + stateMutabilityToString(m_stateMutability);
@@ -2959,7 +2960,8 @@ bool FunctionType::isPure() const
 		m_kind == Kind::ABIEncode ||
 		m_kind == Kind::ABIEncodePacked ||
 		m_kind == Kind::ABIEncodeWithSelector ||
-		m_kind == Kind::ABIEncodeWithSignature;
+		m_kind == Kind::ABIEncodeWithSignature ||
+		m_kind == Kind::ABIDecode;
 }
 
 TypePointers FunctionType::parseElementaryTypeVector(strings const& _types)
@@ -3313,6 +3315,15 @@ MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const*) const
 				strings{},
 				strings{},
 				FunctionType::Kind::ABIEncodeWithSignature,
+				true,
+				StateMutability::Pure
+			)},
+			{"decode", make_shared<FunctionType>(
+				TypePointers(),
+				TypePointers(),
+				strings{},
+				strings{},
+				FunctionType::Kind::ABIDecode,
 				true,
 				StateMutability::Pure
 			)}

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -934,6 +934,7 @@ public:
 		ABIEncodePacked,
 		ABIEncodeWithSelector,
 		ABIEncodeWithSignature,
+		ABIDecode,
 		GasLeft ///< gasleft()
 	};
 

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_calldata.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_calldata.sol
@@ -1,0 +1,8 @@
+// This restriction might be lifted in the future
+contract C {
+  function f() public pure {
+    abi.decode("abc", (bytes calldata));
+  }
+}
+// ----
+// ParserError: (121-129): Expected ',' but got 'calldata'

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_arg_count.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_arg_count.sol
@@ -1,0 +1,12 @@
+contract C {
+  function f() public pure {
+    abi.decode();
+    abi.decode(msg.data);
+    abi.decode(msg.data, uint, uint);
+  }
+}
+// ----
+// TypeError: (46-58): This function takes two arguments, but 0 were provided.
+// TypeError: (64-84): This function takes two arguments, but 1 were provided.
+// TypeError: (90-122): This function takes two arguments, but 3 were provided.
+// TypeError: (111-115): The second argument to "abi.decode" has to be a tuple of types.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_memory.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_memory.sol
@@ -1,0 +1,7 @@
+contract C {
+  function f() public pure {
+    abi.decode("abc", (bytes memory, uint[][2] memory));
+  }
+}
+// ----
+// ParserError: (71-77): Expected ',' but got 'memory'

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_memory_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_memory_v2.sol
@@ -1,0 +1,10 @@
+pragma experimental "ABIEncoderV2";
+
+contract C {
+  struct S { uint x; uint[] b; }
+  function f() public pure returns (S memory, bytes memory, uint[][2] memory) {
+    return abi.decode("abc", (S, bytes, uint[][2]));
+  }
+}
+// ----
+// Warning: (0-35): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nontuple.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nontuple.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public pure {
+    abi.decode("abc", uint);
+    abi.decode("abc", this);
+    abi.decode("abc", f());
+  }
+}
+// ----
+// TypeError: (64-68): The second argument to "abi.decode" has to be a tuple of types.
+// TypeError: (93-97): The second argument to "abi.decode" has to be a tuple of types.
+// TypeError: (122-125): The second argument to "abi.decode" has to be a tuple of types.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_simple.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_simple.sol
@@ -1,0 +1,5 @@
+contract C {
+  function f() public pure returns (uint, bytes32, C) {
+    return abi.decode("abc", (uint, bytes32, C));
+  }
+}

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_singletontuple.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_singletontuple.sol
@@ -1,0 +1,6 @@
+contract C {
+  function f() public pure returns (uint) {
+    return abi.decode("abc", (uint));
+  }
+}
+// ----

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_storage.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_storage.sol
@@ -1,0 +1,8 @@
+// This restriction might be lifted in the future
+contract C {
+  function f() {
+    abi.decode("abc", (bytes storage));
+  }
+}
+// ----
+// ParserError: (109-116): Expected ',' but got 'storage'


### PR DESCRIPTION
Fixes #3876
 
There might be an argument for rather using `abi.decode(data, (type1, type2))` instead of `abi.decode(data, type1, type2)`