### PR TITLE
Remove trailing whitespace in missing visibility warning.

### DIFF
--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -58,8 +58,8 @@ bool StaticAnalyzer::visit(FunctionDefinition const& _function)
 			_function.location(),
 			"No visibility specified. Defaulting to \"" +
 			Declaration::visibilityToString(_function.visibility()) +
-			"\". " +
-			(isInterface ? "In interfaces it defaults to external." : "")
+			"\"." +
+			(isInterface ? " In interfaces it defaults to external." : "")
 		);
 	if (_function.isImplemented())
 		m_currentFunction = &_function;

--- a/test/libsolidity/syntaxTests/constructor/constructor_no_visibility.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_no_visibility.sol
@@ -1,3 +1,3 @@
 contract A { constructor() {} }
 // ----
-// Warning: (13-29): No visibility specified. Defaulting to "public". 
+// Warning: (13-29): No visibility specified. Defaulting to "public".

--- a/test/libsolidity/syntaxTests/fallback/default_visibility.sol
+++ b/test/libsolidity/syntaxTests/fallback/default_visibility.sol
@@ -3,4 +3,4 @@ contract C {
     function() {}
 }
 // ----
-// Warning: (90-103): No visibility specified. Defaulting to "public". 
+// Warning: (90-103): No visibility specified. Defaulting to "public".

--- a/test/libsolidity/syntaxTests/visibility/function_no_visibility.sol
+++ b/test/libsolidity/syntaxTests/visibility/function_no_visibility.sol
@@ -2,4 +2,4 @@ contract C {
     function f() pure { }
 }
 // ----
-// Warning: (17-38): No visibility specified. Defaulting to "public". 
+// Warning: (17-38): No visibility specified. Defaulting to "public".


### PR DESCRIPTION
Came up in #4396.