### PR TITLE
Use aleth instead of eth

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -73,9 +73,9 @@ fi
 function download_eth()
 {
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        ETH_PATH="$REPO_ROOT/eth"
+        ETH_PATH="$REPO_ROOT/aleth"
     elif [ -z $CI ]; then
-        ETH_PATH="eth"
+        ETH_PATH="aleth"
     else
         mkdir -p /tmp/test
         if grep -i trusty /etc/lsb-release >/dev/null 2>&1


### PR DESCRIPTION
`./scripts/tests.sh` takes the renaming of `eth` to `aleth` into account only when running in CI's.

This super minor change modifies the script to look for the `aleth` binary instead of the `eth` binary. Without these changes, the script hangs right after emitting the message "Commandline tests succesful" because it's waiting for cpp-ethereum to boot up indefinitely.

It might be a good idea to give feedback or throw if the boot up didn't work. Perhaps with a timeout?