### PR TITLE
Avoid hanging in tests.sh when IPC program is not found

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -109,9 +109,18 @@ function run_eth()
     sleep 2
 }
 
+function check_eth() {
+    printTask "Running IPC tests with $ETH_PATH..."
+    if ! hash $ETH_PATH 2>/dev/null; then
+      printError "$ETH_PATH not found"    
+      exit 1
+    fi
+}
+
 if [ "$IPC_ENABLED" = true ];
 then
     download_eth
+    check_eth
     ETH_PID=$(run_eth /tmp/test)
 fi
 


### PR DESCRIPTION
Atm, `./scripts/tests.sh` will hang with no feedback other than the message "Commandline tests succesful" if aleth/eth is not found. This happens because the script gets stuck in line 108, trying to reach `/tmp/tests/geth.ipc` and iteratively sleeping for 1 second indefinitely.

This PR simply adds a function that prints a message when the IPC tests start, and checks that the program exists before actually trying to use it. Otherwise, it exits with 1.