### PR TITLE
[BREAKING] Disallow functions without implementation to use modifiers.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,7 @@ Breaking Changes:
  * Type Checker: Address members are not included in contract types anymore. An explicit conversion is now required before invoking an ``address`` member from a contract.
  * Remove obsolete ``std`` directory from the Solidity repository. This means accessing ``https://github.com/ethereum/soldity/blob/develop/std/*.sol`` (or ``https://github.com/ethereum/solidity/std/*.sol`` in Remix) will not be possible.
  * References Resolver: Turn missing storage locations into an error. This was already the case in the experimental 0.5.0 mode.
+ * Syntax Checker: Disallow functions without implementation to use modifiers. This was already the case in the experimental 0.5.0 mode.
  * Syntax Checker: Named return values in function types are an error.
  * Syntax Checker: Strictly require visibility specifier for functions. This was already the case in the experimental 0.5.0 mode.
  * Syntax Checker: Disallow unary ``+``. This was already the case in the experimental 0.5.0 mode.

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -213,8 +213,6 @@ bool SyntaxChecker::visit(ContractDefinition const& _contract)
 
 bool SyntaxChecker::visit(FunctionDefinition const& _function)
 {
-	bool const v050 = m_sourceUnit->annotation().experimentalFeatures.count(ExperimentalFeature::V050);
-
 	if (_function.noVisibilitySpecified())
 	{
 		string suggestedVisibility = _function.isFallback() || m_isInterface ? "external" : "public";
@@ -225,12 +223,8 @@ bool SyntaxChecker::visit(FunctionDefinition const& _function)
 	}
 
 	if (!_function.isImplemented() && !_function.modifiers().empty())
-	{
-		if (v050)
-			m_errorReporter.syntaxError(_function.location(), "Functions without implementation cannot have modifiers.");
-		else
-			m_errorReporter.warning(_function.location(), "Modifiers of functions without implementation are ignored." );
-	}
+		m_errorReporter.syntaxError(_function.location(), "Functions without implementation cannot have modifiers.");
+
 	return true;
 }
 

--- a/test/libsolidity/syntaxTests/functionTypes/function_type_constructor.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/function_type_constructor.sol
@@ -3,5 +3,5 @@ contract C {
     constructor() public x;
 }
 // ----
-// Warning: (83-106): Modifiers of functions without implementation are ignored.
+// SyntaxError: (83-106): Functions without implementation cannot have modifiers.
 // DeclarationError: (104-105): Undeclared identifier.

--- a/test/libsolidity/syntaxTests/modifiers/modifiers_on_abstract_functions_no_parser_error.sol
+++ b/test/libsolidity/syntaxTests/modifiers/modifiers_on_abstract_functions_no_parser_error.sol
@@ -9,5 +9,5 @@ contract C
     function bar() public only_owner;
 }
 // ----
-// Warning: (203-236): Modifiers of functions without implementation are ignored.
-// Warning: (241-274): Modifiers of functions without implementation are ignored.
+// SyntaxError: (203-236): Functions without implementation cannot have modifiers.
+// SyntaxError: (241-274): Functions without implementation cannot have modifiers.


### PR DESCRIPTION
another trivial one. tests passing locally (soltest, cmdlineTests.sh)