### PR TITLE
Drop constant keyword only

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ Breaking Changes:
  * General: C99-style scoping rules are enforced now. This was already the case in the experimental 0.5.0 mode.
  * Optimizer: Remove the no-op ``PUSH1 0 NOT AND`` sequence.
  * Parser: Disallow trailing dots that are not followed by a number.
+ * Parser: Remove ``constant`` as function state mutability modifer.
  * Type Checker: Disallow arithmetic operations for boolean variables.
  * Type Checker: Disallow conversions between ``bytesX`` and ``uintY`` of different size.
  * Type Checker: Only accept a single ``bytes`` type for ``.call()`` (and family), ``keccak256()``, ``sha256()`` and ``ripemd160()``.

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -473,7 +473,7 @@ The following statements are considered modifying the state:
     }
 
 .. note::
-  ``constant`` on functions is an alias to ``view``, but this is deprecated and will be dropped in version 0.5.0.
+  ``constant`` on functions used to be an alias to ``view``, but this was dropped in version 0.5.0.
 
 .. note::
   Getter methods are marked ``view``.

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -58,7 +58,7 @@ ArrayTypeName = TypeName '[' Expression? ']'
 FunctionTypeName = 'function' FunctionTypeParameterList ( 'internal' | 'external' | StateMutability )*
                    ( 'returns' FunctionTypeParameterList )?
 StorageLocation = 'memory' | 'storage' | 'calldata'
-StateMutability = 'pure' | 'constant' | 'view' | 'payable'
+StateMutability = 'pure' | 'view' | 'payable'
 
 Block = '{' Statement* '}'
 Statement = IfStatement | WhileStatement | ForStatement | Block | InlineAssemblyStatement |

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -401,7 +401,6 @@ Modifiers
 - ``view`` for functions: Disallows modification of state - this is not enforced yet.
 - ``payable`` for functions: Allows them to receive Ether together with a call.
 - ``constant`` for state variables: Disallows assignment (except initialisation), does not occupy storage slot.
-- ``constant`` for functions: Same as ``view``.
 - ``anonymous`` for events: Does not store event signature as topic.
 - ``indexed`` for event parameters: Stores the parameter as topic.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -376,7 +376,7 @@ be passed via and returned from external function calls.
 
 Function types are notated as follows::
 
-    function (<parameter types>) {internal|external} [pure|constant|view|payable] [returns (<return types>)]
+    function (<parameter types>) {internal|external} [pure|view|payable] [returns (<return types>)]
 
 In contrast to the parameter types, the return types cannot be empty - if the
 function type should not return anything, the whole ``returns (<return types>)``

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -322,11 +322,18 @@ StateMutability Parser::parseStateMutability(Token::Value _token)
 	StateMutability stateMutability(StateMutability::NonPayable);
 	if (_token == Token::Payable)
 		stateMutability = StateMutability::Payable;
-	// FIXME: constant should be removed at the next breaking release
-	else if (_token == Token::View || _token == Token::Constant)
+	else if (_token == Token::View)
 		stateMutability = StateMutability::View;
 	else if (_token == Token::Pure)
 		stateMutability = StateMutability::Pure;
+	else if (_token == Token::Constant)
+	{
+		stateMutability = StateMutability::View;
+		parserError(
+			"The state mutability modifier \"constant\" was removed in version 0.5.0. "
+			"Use \"view\" or \"pure\" instead."
+		);
+	}
 	else
 		solAssert(false, "Invalid state mutability specifier.");
 	m_scanner->next();

--- a/test/libsolidity/ASTLegacyJSON.cpp
+++ b/test/libsolidity/ASTLegacyJSON.cpp
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(function_type)
 	CompilerStack c;
 	c.addSource("a",
 		"contract C { function f(function() external payable returns (uint) x) "
-		"returns (function() external constant returns (uint)) {} }"
+		"returns (function() external view returns (uint)) {} }"
 	);
 	c.setEVMVersion(dev::test::Options::get().evmVersion());
 	c.parseAndAnalyze();

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(complex_control_flow)
 	// we previously considered. This of course reduces accuracy.
 	char const* sourceCode = R"(
 		contract log {
-			function ln(int128 x) constant returns (int128 result) {
+			function ln(int128 x) pure returns (int128 result) {
 				int128 t = x / 256;
 				int128 y = 5545177;
 				x = t;

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -306,62 +306,6 @@ BOOST_AUTO_TEST_CASE(view_function)
 	checkInterface(sourceCode, interface);
 }
 
-// constant is an alias to view above
-BOOST_AUTO_TEST_CASE(constant_function)
-{
-	char const* sourceCode = R"(
-		contract test {
-			function foo(uint a, uint b) returns(uint d) { return a + b; }
-			function boo(uint32 a) constant returns(uint b) { return a * 4; }
-		}
-	)";
-
-	char const* interface = R"([
-	{
-		"name": "foo",
-		"constant": false,
-		"payable" : false,
-		"stateMutability": "nonpayable",
-		"type": "function",
-		"inputs": [
-		{
-			"name": "a",
-			"type": "uint256"
-		},
-		{
-			"name": "b",
-			"type": "uint256"
-		}
-		],
-		"outputs": [
-		{
-			"name": "d",
-			"type": "uint256"
-		}
-		]
-	},
-	{
-		"name": "boo",
-		"constant": true,
-		"payable" : false,
-		"stateMutability": "view",
-		"type": "function",
-		"inputs": [{
-			"name": "a",
-			"type": "uint32"
-		}],
-		"outputs": [
-		{
-			"name": "b",
-			"type": "uint256"
-		}
-		]
-	}
-	])";
-
-	checkInterface(sourceCode, interface);
-}
-
 BOOST_AUTO_TEST_CASE(pure_function)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/syntaxTests/constructor/constructor_state_mutability_new.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_state_mutability_new.sol
@@ -1,13 +1,9 @@
 contract test1 {
-  constructor() constant {}
-}
-contract test2 {
   constructor() view {}
 }
-contract test3 {
+contract test2 {
   constructor() pure {}
 }
 // ----
-// TypeError: (19-44): Constructor must be payable or non-payable, but is "view".
-// TypeError: (66-87): Constructor must be payable or non-payable, but is "view".
-// TypeError: (109-130): Constructor must be payable or non-payable, but is "pure".
+// TypeError: (19-40): Constructor must be payable or non-payable, but is "view".
+// TypeError: (62-83): Constructor must be payable or non-payable, but is "pure".

--- a/test/libsolidity/syntaxTests/constructor/constructor_state_mutability_old.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_state_mutability_old.sol
@@ -1,16 +1,11 @@
 contract test1 {
-    function test1() constant {}
+    function test1() view {}
 }
 contract test2 {
-    function test2() view {}
-}
-contract test3 {
-    function test3() pure {}
+    function test2() pure {}
 }
 // ----
-// Warning: (21-49): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
-// Warning: (73-97): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
-// Warning: (121-145): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
-// TypeError: (21-49): Constructor must be payable or non-payable, but is "view".
-// TypeError: (73-97): Constructor must be payable or non-payable, but is "view".
-// TypeError: (121-145): Constructor must be payable or non-payable, but is "pure".
+// Warning: (21-45): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
+// Warning: (69-93): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
+// TypeError: (21-45): Constructor must be payable or non-payable, but is "view".
+// TypeError: (69-93): Constructor must be payable or non-payable, but is "pure".

--- a/test/libsolidity/syntaxTests/parsing/constant_state_modifier.sol
+++ b/test/libsolidity/syntaxTests/parsing/constant_state_modifier.sol
@@ -1,7 +1,8 @@
 contract C {
 	uint s;
-	// this test should fail starting from 0.5.0
 	function f() public constant returns (uint) {
 		return s;
 	}
 }
+// ----
+// ParserError: (43-51): The state mutability modifier "constant" was removed in version 0.5.0. Use "view" or "pure" instead.


### PR DESCRIPTION
Part of #2502, #4090 and #3656 without the ABI change, so only removes the parser keyword ``constant``.
