### PR TITLE
First pass at moving FAQs to better locations

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -295,7 +295,7 @@ is no good way to provide the key for the mapping.
 Function Modifiers
 ******************
 
-Modifiers can be used to easily change the behavior of functions.  For example,
+Modifiers can be used to easily change the behaviour of functions.  For example,
 they can automatically check a condition prior to executing the function. Modifiers are
 inheritable properties of contracts and may be overridden by derived contracts.
 
@@ -1054,7 +1054,7 @@ One way is directly in the inheritance list (``is Base(7)``).  The other is in
 the way a modifier would be invoked as part of the header of
 the derived constructor (``Base(_y * _y)``). The first way to
 do it is more convenient if the constructor argument is a
-constant and defines the behavior of the contract or
+constant and defines the behaviour of the contract or
 describes it. The second way has to be used if the
 constructor arguments of the base depend on those of the
 derived contract. Arguments have to be given either in the

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -24,7 +24,7 @@ Creating contracts programatically on Ethereum is best done via using the JavaSc
 As of today it has a method called `web3.eth.Contract <https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#new-contract>`_
 to facilitate contract creation.
 
-When a contract is created, its constructor (a function declared with the ``constructor`` keyword) is executed once, making it useful if you want to execute code when the contract is first mined. See `replicator.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/50_replicator.sol>`_ for an example.
+When a contract is created, its constructor (a function declared with the ``constructor`` keyword) is executed once, including any code in the constructor.
 
 A constructor is optional. Only one constructor is allowed, and this means
 overloading is not supported.

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -24,8 +24,8 @@ Creating contracts programatically on Ethereum is best done via using the JavaSc
 As of today it has a method called `web3.eth.Contract <https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#new-contract>`_
 to facilitate contract creation.
 
-When a contract is created, its constructor (a function declared with the
-``constructor`` keyword) is executed once.
+When a contract is created, its constructor (a function declared with the ``constructor`` keyword) is executed once, making it useful if you want to execute code when the contract is first mined. See `replicator.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/50_replicator.sol>`_ for an example.
+
 A constructor is optional. Only one constructor is allowed, and this means
 overloading is not supported.
 
@@ -295,7 +295,7 @@ is no good way to provide the key for the mapping.
 Function Modifiers
 ******************
 
-Modifiers can be used to easily change the behaviour of functions.  For example,
+Modifiers can be used to easily change the behavior of functions.  For example,
 they can automatically check a condition prior to executing the function. Modifiers are
 inheritable properties of contracts and may be overridden by derived contracts.
 
@@ -1054,11 +1054,11 @@ One way is directly in the inheritance list (``is Base(7)``).  The other is in
 the way a modifier would be invoked as part of the header of
 the derived constructor (``Base(_y * _y)``). The first way to
 do it is more convenient if the constructor argument is a
-constant and defines the behaviour of the contract or
+constant and defines the behavior of the contract or
 describes it. The second way has to be used if the
 constructor arguments of the base depend on those of the
 derived contract. Arguments have to be given either in the
-inheritance list or in modifier-style in the derived constuctor.
+inheritance list or in modifier-style in the derived constructor.
 Specifying arguments in both places is an error.
 
 If a derived contract doesn't specify the arguments to all of its base

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -28,6 +28,9 @@ something like::
         }
     }
 
+...note::
+    A function cannot accept a multi-dimensional array as an inpur parameter.
+
 Output Parameters
 -----------------
 
@@ -60,22 +63,6 @@ Input parameters and output parameters can be used as expressions in
 the function body.  There, they are also usable in the left-hand side
 of assignment.
 
-.. index:: if, else, while, do/while, for, break, continue, return, switch, goto
-
-Control Structures
-===================
-
-Most of the control structures from JavaScript are available in Solidity
-except for ``switch`` and ``goto``. So
-there is: ``if``, ``else``, ``while``, ``do``, ``for``, ``break``, ``continue``, ``return``, ``? :``, with
-the usual semantics known from C or JavaScript.
-
-Parentheses can *not* be omitted for conditionals, but curly brances can be omitted
-around single-statement bodies.
-
-Note that there is no type conversion from non-boolean to boolean types as
-there is in C and JavaScript, so ``if (1) { ... }`` is *not* valid
-Solidity.
 
 .. _multi-return:
 
@@ -85,6 +72,64 @@ Returning Multiple Values
 When a function has multiple output parameters, ``return (v0, v1, ...,
 vn)`` can return multiple values.  The number of components must be
 the same as the number of output parameters.
+
+
+.. index:: return array, return string, array, string, array of strings, dynamic array, variable sized array
+
+.. _return-array:
+
+Returning Strings and Arrays
+----------------------------
+
+You can return strings and arrays from Solidity functions, see `array_receiver_and_returner.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/60_array_receiver_and_returner.sol>`_ for an example.
+
+What is problematic, though, is returning any variably-sized data (e.g. a variably-sized array like ``uint[]`` or an array of strings ``string[]``) from a function **called from within Solidity**. This is a limitation of the EVM and will be solved with the next protocol update.
+
+Returning variably-sized data as part of an external transaction or call doesn't have this problem.
+
+.. index:: return struct, struct
+
+.. _return-struct:
+
+Returning Structs
+-----------------
+
+You can return a ``struct`` from a Solidity function, but only from ``internal`` function calls.
+
+.. index:: if, else, while, do/while, for, break, continue, return, switch, goto
+
+Control Structures
+===================
+
+Most of the `control structures from JavaScript <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling>`_ are available in Solidity except for ``switch`` and ``goto``. The full list is:
+
+- ``if``
+- ``else``
+- ``while``
+- ``do``
+- ``for``
+- ``break``
+- ``continue``
+- ``return``
+- ``? :``
+
+All with the usual semantics from C or JavaScript, with the following caveats.
+
+``for`` loops
+-------------
+
+If you use syntax like ``for (var i = 0; i < a.length; i ++) { a[i] = i; }``, then Solidity implies the type of ``i`` only from ``0``, whose type is ``uint8``. This means that if ``a`` has more than ``255`` elements, your loop will not terminate because ``i`` can only hold values up to ``255``.
+
+It's better to use syntax like ``for (uint i = 0; i < a.length; i ++) { a[i] = i; }``, see `struct_and_for_loop_tester.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/65_struct_and_for_loop_tester.sol>`_ for an example.
+
+
+Conditional Values
+------------------
+
+You *cannot* omit parentheses for conditionals, but you can omit curly braces around single-statement bodies.
+
+There is no type conversion from non-boolean to boolean types as in C and JavaScript, so ``if (1) { ... }`` is *not* valid
+Solidity.
 
 .. index:: ! function;call, function;internal, function;external
 
@@ -117,8 +162,9 @@ External Function Calls
 The expressions ``this.g(8);`` and ``c.g(2);`` (where ``c`` is a contract
 instance) are also valid function calls, but this time, the function
 will be called "externally", via a message call and not directly via jumps.
-Please note that function calls on ``this`` cannot be used in the constructor, as the
-actual contract has not been created yet.
+
+...note::
+     You cannot use the function calls on ``this`` in the constructor, as the actual contract has not been created yet.
 
 Functions of other contracts have to be called externally. For an external call,
 all function arguments have to be copied to memory.
@@ -141,11 +187,8 @@ the gas can be specified with special options ``.value()`` and ``.gas()``, respe
 The modifier ``payable`` has to be used for ``info``, because otherwise, the `.value()`
 option would not be available.
 
-Note that the expression ``InfoFeed(addr)`` performs an explicit type conversion stating
-that "we know that the type of the contract at the given address is ``InfoFeed``" and
-this does not execute a constructor. Explicit type conversions have to be
-handled with extreme caution. Never call a function on a contract where you
-are not sure about its type.
+...note::
+    The expression ``InfoFeed(addr)`` performs an explicit type conversion stating that "we know that the type of the contract at the given address is ``InfoFeed``" and this does not execute a constructor. Explicit type conversions have to be handled with extreme caution. Never call a function on a contract where you are not sure about its type.
 
 We could also have used ``function setFeed(InfoFeed _feed) { feed = _feed; }`` directly.
 Be careful about the fact that ``feed.info.value(10).gas(800)``
@@ -170,6 +213,9 @@ throws an exception or goes out of gas.
     via its functions. Write your functions in a way that, for example, calls to
     external functions happen after any changes to state variables in your contract
     so your contract is not vulnerable to a reentrancy exploit.
+
+...note::
+    A function call from one contract to another does not create its own transaction, you have to look in the overall transaction. This is also the reason why several block explorer do not show Ether sent between contracts correctly.
 
 Named Calls and Anonymous Function Parameters
 ---------------------------------------------
@@ -331,7 +377,7 @@ until the end of a ``{ }``-block. As an exception to this rule, variables declar
 initialization part of a for-loop are only visible until the end of the for-loop.
 
 Variables and other items declared outside of a code block, for example functions, contracts,
-user-defined types, etc., do not change their scoping behaviour. This means you can
+user-defined types, etc., do not change their scoping behavior. This means you can
 use state variables before they are declared and call functions recursively.
 
 As a consequence, the following examples will compile without warnings, since

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -29,7 +29,7 @@ something like::
     }
 
 ...note::
-    A function cannot accept a multi-dimensional array as an inpur parameter.
+    A function cannot accept a multi-dimensional array as an input parameter. This functionality is possible if you enable the experimental ``ABIEncoderV2`` feature by adding ``pragma experimental ABIEncoderV2;`` to your smart contract.
 
 Output Parameters
 -----------------
@@ -83,10 +83,6 @@ Returning Strings and Arrays
 
 You can return strings and arrays from Solidity functions, see `array_receiver_and_returner.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/60_array_receiver_and_returner.sol>`_ for an example.
 
-What is problematic, though, is returning any variably-sized data (e.g. a variably-sized array like ``uint[]`` or an array of strings ``string[]``) from a function **called from within Solidity**. This is a limitation of the EVM and will be solved with the next protocol update.
-
-Returning variably-sized data as part of an external transaction or call doesn't have this problem.
-
 .. index:: return struct, struct
 
 .. _return-struct:
@@ -101,6 +97,9 @@ You can return a ``struct`` from a Solidity function, but only from ``internal``
 Control Structures
 ===================
 
+Supported Expressions
+---------------------
+
 Most of the `control structures from JavaScript <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling>`_ are available in Solidity except for ``switch`` and ``goto``. The full list is:
 
 - ``if``
@@ -114,14 +113,6 @@ Most of the `control structures from JavaScript <https://developer.mozilla.org/e
 - ``? :``
 
 All with the usual semantics from C or JavaScript, with the following caveats.
-
-``for`` loops
--------------
-
-If you use syntax like ``for (var i = 0; i < a.length; i ++) { a[i] = i; }``, then Solidity implies the type of ``i`` only from ``0``, whose type is ``uint8``. This means that if ``a`` has more than ``255`` elements, your loop will not terminate because ``i`` can only hold values up to ``255``.
-
-It's better to use syntax like ``for (uint i = 0; i < a.length; i ++) { a[i] = i; }``, see `struct_and_for_loop_tester.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/65_struct_and_for_loop_tester.sol>`_ for an example.
-
 
 Conditional Values
 ------------------
@@ -164,7 +155,7 @@ instance) are also valid function calls, but this time, the function
 will be called "externally", via a message call and not directly via jumps.
 
 ...note::
-     You cannot use the function calls on ``this`` in the constructor, as the actual contract has not been created yet.
+     You cannot use function calls on ``this`` in the constructor, as the actual contract has not been created yet.
 
 Functions of other contracts have to be called externally. For an external call,
 all function arguments have to be copied to memory.
@@ -215,7 +206,7 @@ throws an exception or goes out of gas.
     so your contract is not vulnerable to a reentrancy exploit.
 
 ...note::
-    A function call from one contract to another does not create its own transaction, you have to look in the overall transaction. This is also the reason why several block explorer do not show Ether sent between contracts correctly.
+    A function call from one contract to another does not create its own transaction, it is a message call as part of the overall transaction. This is also why several block explorer do not show Ether sent between contracts correctly.
 
 Named Calls and Anonymous Function Parameters
 ---------------------------------------------

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -2,7 +2,7 @@
 Expressions and Control Structures
 ##################################
 
-.. index:: ! parameter, parameter;input, parameter;output
+.. index:: ! parameter, parameter;input, parameter;output, parameter;multiple
 
 Input Parameters and Output Parameters
 ======================================
@@ -54,25 +54,15 @@ write::
 
 The names of output parameters can be omitted.
 The output values can also be specified using ``return`` statements.
-The ``return`` statements are also capable of returning multiple
-values, see :ref:`multi-return`.
+
+The ``return`` statements are also capable of returning multiple values using ``return (v0, v1, ..., vn)``. The number of parameters must equal the number of output parameters.
+
 Return parameters are initialized to zero; if they are not explicitly
 set, they stay to be zero.
 
 Input parameters and output parameters can be used as expressions in
 the function body.  There, they are also usable in the left-hand side
 of assignment.
-
-
-.. _multi-return:
-
-Returning Multiple Values
--------------------------
-
-When a function has multiple output parameters, ``return (v0, v1, ...,
-vn)`` can return multiple values.  The number of components must be
-the same as the number of output parameters.
-
 
 .. index:: return array, return string, array, string, array of strings, dynamic array, variable sized array
 

--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -9,92 +9,6 @@ This list was originally compiled by `fivedogit <mailto:fivedogit@gmail.com>`_.
 Basic Questions
 ***************
 
-Is it possible to do something on a specific block number? (e.g. publish a contract or execute a transaction)
-=============================================================================================================
-
-Transactions are not guaranteed to happen on the next block or any future
-specific block, since it is up to the miners to include transactions and not up
-to the submitter of the transaction. This applies to function calls/transactions and contract
-creation transactions.
-
-If you want to schedule future calls of your contract, you can use the
-`alarm clock <http://www.ethereum-alarm-clock.com/>`_.
-
-What is the transaction "payload"?
-==================================
-
-This is just the bytecode "data" sent along with the request.
-
-Is there a decompiler available?
-================================
-
-There is no exact decompiler to Solidity, but
-`Porosity <https://github.com/comaeio/porosity>`_ is close.
-Because some information like variable names, comments, and
-source code formatting is lost in the compilation process,
-it is not possible to completely recover the original source code.
-
-Bytecode can be disassembled to opcodes, a service that is provided by
-several blockchain explorers.
-
-Contracts on the blockchain should have their original source
-code published if they are to be used by third parties.
-
-Create a contract that can be killed and return funds
-=====================================================
-
-First, a word of warning: Killing contracts sounds like a good idea, because "cleaning up"
-is always good, but as seen above, it does not really clean up. Furthermore,
-if Ether is sent to removed contracts, the Ether will be forever lost.
-
-If you want to deactivate your contracts, it is preferable to **disable** them by changing some
-internal state which causes all functions to throw. This will make it impossible
-to use the contract and ether sent to the contract will be returned automatically.
-
-Now to answering the question: Inside a constructor, ``msg.sender`` is the
-creator. Save it. Then ``selfdestruct(creator);`` to kill and return funds.
-
-`example <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/05_greeter.sol>`_
-
-Note that if you ``import "mortal"`` at the top of your contracts and declare
-``contract SomeContract is mortal { ...`` and compile with a compiler that already
-has it (which includes `Remix <https://remix.ethereum.org/>`_), then
-``kill()`` is taken care of for you. Once a contract is "mortal", then you can
-``contractname.kill.sendTransaction({from:eth.coinbase})``, just the same as my
-examples.
-
-Can you return an array or a ``string`` from a solidity function call?
-======================================================================
-
-Yes. See `array_receiver_and_returner.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/60_array_receiver_and_returner.sol>`_.
-
-What is problematic, though, is returning any variably-sized data (e.g. a
-variably-sized array like ``uint[]``) from a fuction **called from within Solidity**.
-This is a limitation of the EVM and will be solved with the next protocol update.
-
-Returning variably-sized data as part of an external transaction or call is fine.
-
-Is it possible to in-line initialize an array like so: ``string[] myarray = ["a", "b"];``
-=========================================================================================
-
-Yes. However it should be noted that this currently only works with statically sized memory arrays. You can even create an inline memory
-array in the return statement. Pretty cool, huh?
-
-Example::
-
-    pragma solidity ^0.4.16;
-
-    contract C {
-        function f() public pure returns (uint8[5]) {
-            string[4] memory adaArr = ["This", "is", "an", "array"];
-            return ([1, 2, 3, 4, 5]);
-        }
-    }
-
-Can a contract function return a ``struct``?
-============================================
-
-Yes, but only in ``internal`` function calls.
 
 If I return an ``enum``, I only get integer values in web3.js. How to get the named values?
 ===========================================================================================
@@ -103,78 +17,6 @@ Enums are not supported by the ABI, they are just supported by Solidity.
 You have to do the mapping yourself for now, we might provide some help
 later.
 
-Can state variables be initialized in-line?
-===========================================
-
-Yes, this is possible for all types (even for structs). However, for arrays it
-should be noted that you must declare them as static memory arrays.
-
-Examples::
-
-    pragma solidity ^0.4.0;
-
-    contract C {
-        struct S {
-            uint a;
-            uint b;
-        }
-
-        S public x = S(1, 2);
-        string name = "Ada";
-        string[4] adaArr = ["This", "is", "an", "array"];
-    }
-
-    contract D {
-        C c = new C();
-    }
-
-How do structs work?
-====================
-
-See `struct_and_for_loop_tester.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/65_struct_and_for_loop_tester.sol>`_.
-
-How do for loops work?
-======================
-
-Very similar to JavaScript. There is one point to watch out for, though:
-
-If you use ``for (var i = 0; i < a.length; i ++) { a[i] = i; }``, then
-the type of ``i`` will be inferred only from ``0``, whose type is ``uint8``.
-This means that if ``a`` has more than ``255`` elements, your loop will
-not terminate because ``i`` can only hold values up to ``255``.
-
-Better use ``for (uint i = 0; i < a.length...``
-
-See `struct_and_for_loop_tester.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/65_struct_and_for_loop_tester.sol>`_.
-
-What are some examples of basic string manipulation (``substring``, ``indexOf``, ``charAt``, etc)?
-==================================================================================================
-
-There are some string utility functions at `stringUtils.sol <https://github.com/ethereum/dapp-bin/blob/master/library/stringUtils.sol>`_
-which will be extended in the future. In addition, Arachnid has written `solidity-stringutils <https://github.com/Arachnid/solidity-stringutils>`_.
-
-For now, if you want to modify a string (even when you only want to know its length),
-you should always convert it to a ``bytes`` first::
-
-    pragma solidity ^0.4.0;
-
-    contract C {
-        string s;
-
-        function append(byte c) public {
-            bytes(s).push(c);
-        }
-
-        function set(uint i, byte c) public {
-            bytes(s)[i] = c;
-        }
-    }
-
-
-Can I concatenate two strings?
-==============================
-
-You have to do it manually for now.
 
 Why is the low-level function ``.call()`` less favorable than instantiating a contract with a variable (``ContractB b;``) and executing its functions (``b.doSomething();``)?
 =============================================================================================================================================================================
@@ -187,10 +29,7 @@ arguments for you.
 See `ping.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_ping.sol>`_ and
 `pong.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_pong.sol>`_.
 
-Is unused gas automatically refunded?
-=====================================
 
-Yes and it is immediate, i.e. done as part of the transaction.
 
 When returning a value of say ``uint`` type, is it possible to return an ``undefined`` or "null"-like value?
 ============================================================================================================
@@ -229,11 +68,7 @@ If you do not want to throw, you can return a pair::
     }
 
 
-Are comments included with deployed contracts and do they increase deployment gas?
-==================================================================================
 
-No, everything that is not needed for execution is removed during compilation.
-This includes, among others, comments, variable names and type names.
 
 What happens if you send ether along with a function call to a contract?
 ========================================================================
@@ -242,12 +77,7 @@ It gets added to the total balance of the contract, just like when you send ethe
 You can only send ether along to a function that has the ``payable`` modifier,
 otherwise an exception is thrown.
 
-Is it possible to get a tx receipt for a transaction executed contract-to-contract?
-===================================================================================
 
-No, a function call from one contract to another does not create its own transaction,
-you have to look in the overall transaction. This is also the reason why several
-block explorer do not show Ether sent between contracts correctly.
 
 What is the ``memory`` keyword? What does it do?
 ================================================
@@ -358,14 +188,7 @@ The correct way to do this is the following::
 Advanced Questions
 ******************
 
-How do you get a random number in a contract? (Implement a self-returning gambling contract.)
-=============================================================================================
 
-Getting randomness right is often the crucial part in a crypto project and
-most failures result from bad random number generators.
-
-If you do not want it to be safe, you build something similar to the `coin flipper <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/35_coin_flipper.sol>`_
-but otherwise, rather use a contract that supplies randomness, like the `RANDAO <https://github.com/randao/randao>`_.
 
 Get return value from non-constant function from another contract
 =================================================================
@@ -375,47 +198,8 @@ The key point is that the calling contract needs to know about the function it i
 See `ping.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_ping.sol>`_
 and `pong.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_pong.sol>`_.
 
-Get contract to do something when it is first mined
-===================================================
 
-Use the constructor. Anything inside it will be executed when the contract is first mined.
 
-See `replicator.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/50_replicator.sol>`_.
-
-How do you create 2-dimensional arrays?
-=======================================
-
-See `2D_array.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/55_2D_array.sol>`_.
-
-Note that filling a 10x10 square of ``uint8`` + contract creation took more than ``800,000``
-gas at the time of this writing. 17x17 took ``2,000,000`` gas. With the limit at
-3.14 million... well, there’s a pretty low ceiling for what you can create right
-now.
-
-Note that merely "creating" the array is free, the costs are in filling it.
-
-Note2: Optimizing storage access can pull the gas costs down considerably, because
-32 ``uint8`` values can be stored in a single slot. The problem is that these optimizations
-currently do not work across loops and also have a problem with bounds checking.
-You might get much better results in the future, though.
-
-What happens to a ``struct``'s mapping when copying over a ``struct``?
-======================================================================
-
-This is a very interesting question. Suppose that we have a contract field set up like such::
-
-    struct User {
-        mapping(string => string) comments;
-    }
-
-    function somefunction public {
-       User user1;
-       user1.comments["Hello"] = "World";
-       User user2 = user1;
-    }
-
-In this case, the mapping of the struct being copied over into the userList is ignored as there is no "list of mapped keys".
-Therefore it is not possible to find out which values should be copied over.
 
 How do I initialize a contract with only a specific amount of wei?
 ==================================================================
@@ -440,11 +224,8 @@ In this example::
         }
     }
 
-Can a contract function accept a two-dimensional array?
-=======================================================
+.. TODO: Does this mean it does work for internal?
 
-This is not yet implemented for external calls and dynamic arrays -
-you can only use one level of dynamic arrays.
 
 What is the relationship between ``bytes32`` and ``string``? Why is it that ``bytes32 somevar = "stringliteral";`` works and what does the saved 32-byte hex value mean?
 ========================================================================================================================================================================
@@ -499,55 +280,6 @@ to create an independent copy of the storage value in memory
 ``h(x)`` successfully modifies ``x`` because only a reference
 and not a copy is passed.
 
-Sometimes, when I try to change the length of an array with ex: ``arrayname.length = 7;`` I get a compiler error ``Value must be an lvalue``. Why?
-==================================================================================================================================================
-
-You can resize a dynamic array in storage (i.e. an array declared at the
-contract level) with ``arrayname.length = <some new length>;``. If you get the
-"lvalue" error, you are probably doing one of two things wrong.
-
-1. You might be trying to resize an array in "memory", or
-
-2. You might be trying to resize a non-dynamic array.
-
-::
-
-    // This will not compile
-
-    pragma solidity ^0.4.18;
-
-    contract C {
-        int8[] dynamicStorageArray;
-        int8[5] fixedStorageArray;
-
-        function f() {
-            int8[] memory memArr;        // Case 1
-            memArr.length++;             // illegal
-
-            int8[5] storage storageArr = fixedStorageArray;   // Case 2
-            storageArr.length++;                             // illegal
-
-            int8[] storage storageArr2 = dynamicStorageArray;
-            storageArr2.length++;                     // legal
-
-
-        }
-    }
-
-**Important note:** In Solidity, array dimensions are declared backwards from the way you
-might be used to declaring them in C or Java, but they are access as in
-C or Java.
-
-For example, ``int8[][5] somearray;`` are 5 dynamic ``int8`` arrays.
-
-The reason for this is that ``T[5]`` is always an array of 5 ``T``'s,
-no matter whether ``T`` itself is an array or not (this is not the
-case in C or Java).
-
-Is it possible to return an array of strings (``string[]``) from a Solidity function?
-=====================================================================================
-
-Not yet, as this requires two levels of dynamic arrays (``string`` is a dynamic array itself).
 
 If you issue a call for an array, it is possible to retrieve the whole array? Or must you write a helper function for that?
 ===========================================================================================================================

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -260,6 +260,10 @@ blocks that are added on top, the less likely it is. So it might be that your tr
 are reverted and even removed from the blockchain, but the longer you wait, the less
 likely it will be.
 
+.. note::
+    Transactions are not guaranteed to happen on the next block or any future specific block, since it is up to the miners to include transactions and not the submitter of the transaction. This applies to function calls/transactions and contract creation transactions.
+
+    If you want to schedule future calls of your contract, you can use the `alarm clock <http://www.ethereum-alarm-clock.com/>`_.
 
 .. _the-ethereum-virtual-machine:
 
@@ -352,6 +356,8 @@ If the gas is used up at any point (i.e. it is negative),
 an out-of-gas exception is triggered, which reverts all modifications
 made to the state in the current call frame.
 
+Any unused gas is refunded as part of the transaction.
+
 .. index:: ! storage, ! memory, ! stack
 
 Storage, Memory and the Stack
@@ -412,7 +418,7 @@ a top-level message call which in turn can create further message calls.
 A contract can decide how much of its remaining **gas** should be sent
 with the inner message call and how much it wants to retain.
 If an out-of-gas exception happens in the inner call (or any
-other exception), this will be signalled by an error value put onto the stack.
+other exception), this will be signaled by an error value put onto the stack.
 In this case, only the gas sent together with the call is used up.
 In Solidity, the calling contract causes a manual exception by default in
 such situations, so that exceptions "bubble up" the call stack.
@@ -472,19 +478,20 @@ receives the address of the new contract on the stack.
 
 .. index:: selfdestruct
 
-Self-destruct
-=============
+Deactivate and Self-destruct
+============================
 
-The only possibility that code is removed from the blockchain is
-when a contract at that address performs the ``selfdestruct`` operation.
-The remaining Ether stored at that address is sent to a designated
-target and then the storage and code is removed from the state.
+The only way to remove code from the blockchain is when a contract at that address performs the ``selfdestruct`` operation. The remaining Ether stored at that address is sent to a designated target and then the storage and code is removed from the state. Removing the contract and 'cleaning it up' sounds like a good idea, but the operation doesn't really clean up. If you send Ether to removed contracts, the Ether is forever lost.
 
-.. warning:: Even if a contract's code does not contain a call to ``selfdestruct``,
-  it can still perform that operation using ``delegatecall`` or ``callcode``.
+.. note::
+    Even if a contract's code does not contain a call to ``selfdestruct``, it can still perform that operation using ``delegatecall`` or ``callcode``.
 
-.. note:: The pruning of old contracts may or may not be implemented by Ethereum
-  clients. Additionally, archive nodes could choose to keep the contract storage
-  and code indefinitely.
+If you want to deactivate your contracts, you should instead **disable** them by changing some internal state which causes all functions to throw an exception. This makes it impossible to use the contract it returns ether immediately.
 
-.. note:: Currently **external accounts** cannot be removed from the state.
+.. note::
+    Currently you cannot remove **external accounts** from the state.
+
+`This contract <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/05_greeter.sol>`_ has an example that does this by checking it's the creator calling the operation inside a constructor and then using ``selfdestruct(creator);`` to kill and return funds.
+
+.. note::
+    The pruning of old contracts may or may not be implemented by Ethereum clients. Additionally, archive nodes could choose to keep the contract storage and code indefinitely.

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -261,7 +261,7 @@ are reverted and even removed from the blockchain, but the longer you wait, the 
 likely it will be.
 
 .. note::
-    Transactions are not guaranteed to happen on the next block or any future specific block, since it is up to the miners to include transactions and not the submitter of the transaction. This applies to function calls/transactions and contract creation transactions.
+    Transactions are not guaranteed to happen on the next block or any future specific block, since it is up to the miners to include transactions and not the submitter of the transaction. This applies to function calls and contract creation transactions.
 
     If you want to schedule future calls of your contract, you can use the `alarm clock <http://www.ethereum-alarm-clock.com/>`_.
 
@@ -356,7 +356,7 @@ If the gas is used up at any point (i.e. it is negative),
 an out-of-gas exception is triggered, which reverts all modifications
 made to the state in the current call frame.
 
-Any unused gas is refunded as part of the transaction.
+Any unused gas is refunded at the end of the transaction.
 
 .. index:: ! storage, ! memory, ! stack
 
@@ -476,22 +476,20 @@ these **create calls** and normal message calls is that the payload data is
 executed and the result stored as code and the caller / creator
 receives the address of the new contract on the stack.
 
-.. index:: selfdestruct
+.. index:: self-destruct, deactivate
 
 Deactivate and Self-destruct
 ============================
 
-The only way to remove code from the blockchain is when a contract at that address performs the ``selfdestruct`` operation. The remaining Ether stored at that address is sent to a designated target and then the storage and code is removed from the state. Removing the contract and 'cleaning it up' sounds like a good idea, but the operation doesn't really clean up. If you send Ether to removed contracts, the Ether is forever lost.
+The only way to remove code from the blockchain is when a contract at that address performs the ``selfdestruct`` operation. The remaining Ether stored at that address is sent to a designated target and then the storage and code is removed from the state. Removing the contract in theory sounds like a good idea, but is potentially dangerous as if someone sends Ether to removed contracts, the Ether is forever lost.
 
 .. note::
     Even if a contract's code does not contain a call to ``selfdestruct``, it can still perform that operation using ``delegatecall`` or ``callcode``.
 
-If you want to deactivate your contracts, you should instead **disable** them by changing some internal state which causes all functions to throw an exception. This makes it impossible to use the contract it returns ether immediately.
+If you want to deactivate your contracts, you should instead **disable** them by changing some internal state which causes all functions to revert. This makes it impossible to use the contract it returns ether immediately.
 
 .. note::
-    Currently you cannot remove **external accounts** from the state.
-
-`This contract <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/05_greeter.sol>`_ has an example that does this by checking it's the creator calling the operation inside a constructor and then using ``selfdestruct(creator);`` to kill and return funds.
+    You cannot remove **external accounts** from the state.
 
 .. note::
-    The pruning of old contracts may or may not be implemented by Ethereum clients. Additionally, archive nodes could choose to keep the contract storage and code indefinitely.
+    The pruning of old contracts may not be implemented by Ethereum clients. Additionally, archive nodes could choose to keep the contract storage and code indefinitely.

--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -210,3 +210,6 @@ for the two input parameters and two returned values.
             p = 2 * (w + h);
         }
     }
+
+.. note::
+    Comments are removed during compilation and don't consume any additional gas.

--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -212,4 +212,4 @@ for the two input parameters and two returned values.
     }
 
 .. note::
-    Comments are removed during compilation and don't consume any additional gas.
+    Comments are removed during compilation and do not consume any additional gas.

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -35,14 +35,19 @@ As always, with open source documentation, please help us extend this section
 Pitfalls
 ********
 
-Private Information and Randomness
-==================================
+Private Information
+===================
 
 Everything you use in a smart contract is publicly visible, even
 local variables and state variables marked ``private``.
 
-Using random numbers in smart contracts is quite tricky if you do not want
-miners to be able to cheat.
+Randomness
+==========
+
+Using random numbers in smart contracts is tricky if you don't want
+miners to be able to cheat. Getting randomness right is often the crucial part in a crypto project and most failures result from bad random number generators.
+
+If you don't want your contract to be safe, try something like the `coin flipper <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/35_coin_flipper.sol>`_ or use a contract that supplies randomness, like the `RANDAO <https://github.com/randao/randao>`_.
 
 Re-Entrancy
 ===========
@@ -289,7 +294,7 @@ unknown contracts, so it is probably better to just always apply this pattern.
 Include a Fail-Safe Mode
 ========================
 
-While making your system fully decentralised will remove any intermediary,
+While making your system fully decentralized will remove any intermediary,
 it might be a good idea, especially for new code, to include some kind
 of fail-safe mechanism:
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -31,7 +31,9 @@ See the :ref:`types` section for valid state variable types and
 :ref:`visibility-and-getters` for possible choices for
 visibility.
 
-You can initialize a state variable inline for all types (even for structs). But for arrays you must declare them as static memory arrays. For example::
+You can initialise a state variable inline for all types (even for structs). But for arrays you must declare them as static memory arrays. This initialisation happens before the constructor is run.
+
+For example::
 
     pragma solidity ^0.4.0;
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -31,9 +31,9 @@ See the :ref:`types` section for valid state variable types and
 :ref:`visibility-and-getters` for possible choices for
 visibility.
 
-You can initialise a state variable inline for all types (even for structs). But for arrays you must declare them as static memory arrays. This initialisation happens before the constructor is run.
+You can initialise a state variable inline for all types (even for structs). But for arrays you must declare them as static storage arrays. For example::
 
-For example::
+.. TODO: Keep the below?
 
     pragma solidity ^0.4.0;
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -33,8 +33,6 @@ visibility.
 
 You can initialise a state variable inline for all types (even for structs). But for arrays you must declare them as static storage arrays. For example::
 
-.. TODO: Keep the below?
-
     pragma solidity ^0.4.0;
 
     contract C {
@@ -51,6 +49,8 @@ You can initialise a state variable inline for all types (even for structs). But
     contract D {
         C c = new C();
     }
+
+.. TODO: Keep the above example?
 
 .. _structure-functions:
 

--- a/docs/structure-of-a-contract.rst
+++ b/docs/structure-of-a-contract.rst
@@ -31,6 +31,25 @@ See the :ref:`types` section for valid state variable types and
 :ref:`visibility-and-getters` for possible choices for
 visibility.
 
+You can initialize a state variable inline for all types (even for structs). But for arrays you must declare them as static memory arrays. For example::
+
+    pragma solidity ^0.4.0;
+
+    contract C {
+        struct S {
+            uint a;
+            uint b;
+        }
+
+        S public x = S(1, 2);
+        string name = "Ada";
+        string[4] adaArr = ["This", "is", "an", "array"];
+    }
+
+    contract D {
+        C c = new C();
+    }
+
 .. _structure-functions:
 
 Functions

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -641,10 +641,10 @@ You can initialize an array inline using syntax such as ``string[] myarray = ["a
         }
     }
 
-You can create and initialize multi-dimensional arrays in the same ways, but note that filling arrays can cost a lot of gas, so make sure you optimize how you use them.
+You can create and initialise multi-dimensional arrays in the same ways, but filling arrays can cost a lot of gas, so make sure you optimise how you use them.
 
 ...note::
-    Optimizing storage access can reduce the gas costs considerably, because you can store 32 ``uint8`` values in a single slot. These optimizations do not work across loops and also have a problem with bounds checking.
+    Optimising storage access can reduce the gas costs considerably, because you can store 32 ``uint8`` values in a single slot. These optimisations do not work across loops and also have a problem with bounds checking.
 
 It is possible to mark arrays ``public`` and have Solidity create a :ref:`getter <visibility-and-getters>`.
 The numeric index will become a required parameter for the getter.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -363,7 +363,7 @@ Function Types
 Function types are the types of functions. Variables of function type
 can be assigned from functions and function parameters of function type
 can be used to pass functions to and return functions from function calls.
-Function types come in two flavors - *internal* and *external* functions:
+Function types come in two flavours - *internal* and *external* functions:
 
 Internal functions can only be called inside the current contract (more specifically,
 inside the current code unit, which also includes internal library functions
@@ -823,7 +823,7 @@ shown in the following example:
 
         function contribute(uint campaignID) public payable {
             Campaign storage c = campaigns[campaignID];
-            // Creates a new temporary memory struct, initialized with the given values
+            // Creates a new temporary memory struct, initialised with the given values
             // and copies it over to storage.
             // Note that you can also use Funder(msg.sender, msg.value) to initialise.
             c.funders[c.numFunders++] = Funder({addr: msg.sender, amount: msg.value});
@@ -981,7 +981,7 @@ Explicit Conversions
 
 If the compiler does not allow implicit conversion but you know what you are
 doing, an explicit type conversion is sometimes possible. Note that this may
-give you some unexpected behavior so be sure to test to ensure that the
+give you some unexpected behaviour so be sure to test to ensure that the
 result is what you want! Take the following example where you are converting
 a negative ``int8`` to a ``uint``:
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -304,11 +304,6 @@ String literals are written with either double or single-quotes (``"foo"`` or ``
 
 String literals support escape characters, such as ``\n``, ``\xNN`` and ``\uNNNN``. ``\xNN`` takes a hex value and inserts the appropriate byte, while ``\uNNNN`` takes a Unicode codepoint and inserts an UTF-8 sequence.
 
-Solidity doesn't have any inbuilt string utility functions, you first have to convert it to a ``bytes`` type before any comparisons or manipulation.
-
-You can find examples of utility functions in `stringUtils.sol <https://github.com/ethereum/dapp-bin/blob/master/library/stringUtils.sol>`_ and `solidity-stringutils <https://github.com/Arachnid/solidity-stringutils>`_.
-.. index:: literal, bytes
-
 Hexadecimal Literals
 --------------------
 
@@ -323,7 +318,7 @@ Hexademical Literals behave like String Literals and have the same convertibilit
 Enums
 -----
 
-Enums are one way to create a user-defined type in Solidity. They are explicitly convertible to and from all integer types but implicit conversion is not allowed.  The explicit conversions check the value ranges at runtime and a failure causes an exception.  Enums needs at least one member.
+Enums are one way to create a user-defined type in Solidity. They are explicitly convertible to and from all integer types but implicit conversion is not allowed. The explicit conversions check the value ranges at runtime and a failure causes an exception. Enums need at least one member.
 
 
 ::
@@ -575,6 +570,32 @@ Forced data location:
 Default data location:
  - parameters (also return) of functions: memory
  - all other local variables: storage
+
+
+.. index:: copy an array, copy a struct
+
+Copying Reference Types
+-----------------------
+
+If you copy an array or struct over another then the mapping of the target is ignored as there is 
+no list of mapped keys and it's impossible to know which values to copy. For example.
+
+::
+
+    struct User {
+        mapping(string => string) comments;
+    }
+
+    function somefunction public {
+       User user1;
+       user1.comments["Hello"] = "World";
+       User user2 = user1;
+    }
+
+
+
+
+
 
 .. index:: ! array
 
@@ -848,23 +869,6 @@ It is not possible for a struct to contain a member of its own type, although th
 
 ...note::
     All the functions above assign a ``struct`` type to a local variable (of the default storage data location). This does not copy the ``struct`` but only stores a reference so that assignments to members of the local variable actually write to the state.
-
-If you copy a struct over another struct, for example.
-
-::
-
-    struct User {
-        mapping(string => string) comments;
-    }
-
-    function somefunction public {
-       User user1;
-       user1.comments["Hello"] = "World";
-       User user2 = user1;
-    }
-
-Then the mapping of the struct being copied over is ignored as there is no list of mapped keys and it's not possible to find out which values should be copied over.
-
 
 You can also directly access the members of the struct without assigning it to a local variable, as in ``campaigns[campaignID].amount = 0``.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -607,7 +607,9 @@ number of bytes, always use one of ``bytes1`` to ``bytes32`` because they are mu
     that you are accessing the low-level bytes of the UTF-8 representation,
     and not the individual characters!
 
-You can initialize an array inline using syntax such as ``string[] myarray = ["a", "b"];``. However, this only works for statically sized memory arrays. For example:
+You can initialize an array inline using syntax such as ``string[] myarray = ["a", "b"];``. However, this only works for statically sized memory arrays. For example.
+
+::
 
     pragma solidity ^0.4.16;
 
@@ -847,7 +849,9 @@ It is not possible for a struct to contain a member of its own type, although th
 ...note::
     All the functions above assign a ``struct`` type to a local variable (of the default storage data location). This does not copy the ``struct`` but only stores a reference so that assignments to members of the local variable actually write to the state.
 
-If you copy a struct over another struct, for example:
+If you copy a struct over another struct, for example.
+
+::
 
     struct User {
         mapping(string => string) comments;

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -310,4 +310,4 @@ Decompiler
 There is no decompiler for Solidity, but `Porosity <https://github.com/comaeio/porosity>`_ is close.
 Because some information like variable names, comments, and source code formatting is lost in the compilation process, it is not possible to completely recover the original source code.
 
-Several blockchain explorers allow you to disassemble bytecode to opcodes, but you should publish the source of blockchain contracts on a blockchain if 3rd parties are allowed to use them.
+Several blockchain explorers allow you to disassemble bytecode to opcodes, but you should publish the source of blockchain contracts on a blockchain if third parties are allowed to use them.

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -301,3 +301,13 @@ Error types
 11. ``CompilerError``: Invalid use of the compiler stack - this should be reported as an issue.
 12. ``FatalError``: Fatal error not processed correctly - this should be reported as an issue.
 13. ``Warning``: A warning, which didn't stop the compilation, but should be addressed if possible.
+
+
+
+Decompiler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is no decompiler for Solidity, but `Porosity <https://github.com/comaeio/porosity>`_ is close.
+Because some information like variable names, comments, and source code formatting is lost in the compilation process, it is not possible to completely recover the original source code.
+
+Several blockchain explorers allow you to disassemble bytecode to opcodes, but you should publish the source of blockchain contracts on a blockchain if 3rd parties are allowed to use them.


### PR DESCRIPTION
Progress on https://github.com/ethereum/solidity/issues/1219 also closes https://github.com/ethereum/solidity/issues/4339 as content is restructured.

I improved some grammar and typos as I merged, but not the entirety of a document, which I'll do later. I haven't reformatted to the 99 char limit as a lot of the exisiting lines already broke that, again maybe a later PR.

Spoke with @chriseth and I had already started working on this intending to create a PR for the whole task, I can break this up into smaller PRs if really needed, and from now on I will do that, which will mean a lot of small PRs to close #1219.

First PR, so I'm sure there's something else that's not quite right :)