### PR TITLE
Rewrite/redesign data location checking

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -90,7 +90,7 @@ of votes.
             // If the first argument of `require` evaluates
             // to `false`, execution terminates and all
             // changes to the state and to Ether balances
-            // are reverted. 
+            // are reverted.
             // This used to consume all gas in old EVM versions, but
             // not anymore.
             // It is often a good idea to use `require` to check if
@@ -708,7 +708,7 @@ For a contract that fulfills payments, the signed message must include:
 A replay attack is when a signed message is reused to claim authorization for
 a second action.
 To avoid replay attacks we will use the same as in Ethereum transactions
-themselves, a so-called nonce, which is the number of transactions sent by an 
+themselves, a so-called nonce, which is the number of transactions sent by an
 account.
 The smart contract will check if a nonce is used multiple times.
 
@@ -731,7 +731,7 @@ Packing arguments
 Now that we have identified what information to include in the
 signed message, we are ready to put the message together, hash it,
 and sign it. For simplicity, we just concatenate the data.
-The 
+The
 `ethereumjs-abi <https://github.com/ethereumjs/ethereumjs-abi>`_ library provides
 a function called ``soliditySHA3`` that mimics the behavior
 of Solidity's ``keccak256`` function applied to arguments encoded
@@ -750,7 +750,7 @@ creates the proper signature for the ``ReceiverPays`` example:
             ["address", "uint256", "uint256", "address"],
             [recipient, amount, nonce, contractAddress]
         ).toString("hex");
-        
+
         web3.personal.sign(hash, web3.eth.defaultAccount, callback);
     }
 
@@ -779,7 +779,7 @@ at the end of this chapter).
 
 Computing the Message Hash
 --------------------------
- 
+
 The smart contract needs to know exactly what parameters were signed,
 and so it must recreate the message from the parameters and use that
 for signature verification. The functions ``prefixed`` and
@@ -820,7 +820,7 @@ The full contract
         }
 
         /// signature methods.
-        function splitSignature(bytes sig)
+        function splitSignature(bytes memory sig)
             internal
             pure
             returns (uint8 v, bytes32 r, bytes32 s)
@@ -839,7 +839,7 @@ The full contract
             return (v, r, s);
         }
 
-        function recoverSigner(bytes32 message, bytes sig)
+        function recoverSigner(bytes32 message, bytes memory sig)
             internal
             pure
             returns (address)
@@ -874,7 +874,7 @@ two parties (Alice and Bob). Using it involves three steps:
     1. Alice funds a smart contract with Ether. This "opens" the payment channel.
     2. Alice signs messages that specify how much of that Ether is owed to the recipient. This step is repeated for each payment.
     3. Bob "closes" the payment channel, withdrawing their portion of the Ether and sending the remainder back to the sender.
-    
+
 Not ethat only steps 1 and 3 require Ethereum transactions, step 2 means that
 the sender transmits a cryptographically signed message to the recipient via off chain ways (e.g. email).
 This means only two transactions are required to support any number of transfers.
@@ -906,7 +906,7 @@ Each message includes the following information:
 
     * The smart contract's address, used to prevent cross-contract replay attacks.
     * The total amount of Ether that is owed the recipient so far.
-    
+
 A payment channel is closed just once, at the of a series of transfers.
 Because of this, only one of the messages sent will be redeemed. This is why
 each message specifies a cumulative total amount of Ether owed, rather than the
@@ -926,7 +926,7 @@ Here is the modified javascript code to cryptographically sign a message from th
             [contractAddress, amount]
         );
     }
-    
+
     function signMessage(message, callback) {
         web3.personal.sign(
             "0x" + message.toString("hex"),
@@ -934,10 +934,10 @@ Here is the modified javascript code to cryptographically sign a message from th
             callback
         );
     }
-    
+
     // contractAddress is used to prevent cross-contract replay attacks.
     // amount, in wei, specifies how much Ether should be sent.
-    
+
     function signPayment(contractAddress, amount, callback) {
         var message = constructPaymentMessage(contractAddress, amount);
         signMessage(message, callback);
@@ -1003,7 +1003,7 @@ The full contract
             expiration = now + duration;
         }
 
-        function isValidSignature(uint256 amount, bytes signature)
+        function isValidSignature(uint256 amount, bytes memory signature)
             internal
             view
             returns (bool)
@@ -1043,7 +1043,7 @@ The full contract
         /// All functions below this are just taken from the chapter
         /// 'creating and verifying signatures' chapter.
 
-        function splitSignature(bytes sig)
+        function splitSignature(bytes memory sig)
             internal
             pure
             returns (uint8 v, bytes32 r, bytes32 s)
@@ -1058,11 +1058,11 @@ The full contract
                 // final byte (first byte of the next 32 bytes)
                 v := byte(0, mload(add(sig, 96)))
             }
-            
+
             return (v, r, s);
         }
-        
-        function recoverSigner(bytes32 message, bytes sig)
+
+        function recoverSigner(bytes32 message, bytes memory sig)
             internal
             pure
             returns (address)
@@ -1083,7 +1083,7 @@ Note: The function ``splitSignature`` is very simple and does not use all securi
 A real implementation should use a more rigorously tested library, such as
 openzepplin's `version <https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/ECRecovery.sol>`_ of this code.
 
-  
+
 
 Verifying Payments
 ------------------
@@ -1101,7 +1101,7 @@ The recipient should verify each message using the following process:
     2. Verify that the new total is the expected amount.
     3. Verify that the new total does not exceed the amount of Ether escrowed.
     4. Verify that the signature is valid and comes from the payment channel sender.
-    
+
 We'll use the `ethereumjs-util <https://github.com/ethereumjs/ethereumjs-util>`_
 library to write this verifications. The final step can be done a number of ways,
 but if it's being done in **JavaScript**.
@@ -1117,14 +1117,14 @@ above:
             ["\x19Ethereum Signed Message:\n32", hash]
         );
     }
-    
+
     function recoverSigner(message, signature) {
         var split = ethereumjs.Util.fromRpcSig(signature);
         var publicKey = ethereumjs.Util.ecrecover(message, split.v, split.r, split.s);
         var signer = ethereumjs.Util.pubToAddress(publicKey).toString("hex");
         return signer;
     }
-    
+
     function isValidSignature(contractAddress, amount, signature, expectedSigner) {
         var message = prefixed(constructPaymentMessage(contractAddress, amount));
         var signer = recoverSigner(message, signature);

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -160,8 +160,16 @@ void ReferencesResolver::endVisit(UserDefinedTypeName const& _typeName)
 		typeError(_typeName.location(), "Name has to refer to a struct, enum or contract.");
 }
 
+bool ReferencesResolver::visit(FunctionTypeName const& _typeName)
+{
+	m_functionTypeNames.push_back(&_typeName);
+	return true;
+}
+
 void ReferencesResolver::endVisit(FunctionTypeName const& _typeName)
 {
+	solAssert(!m_functionTypeNames.empty(), "");
+	m_functionTypeNames.pop_back();
 	switch (_typeName.visibility())
 	{
 	case VariableDeclaration::Visibility::Internal:
@@ -294,134 +302,91 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 	if (_variable.annotation().type)
 		return;
 
-	TypePointer type;
-	if (_variable.typeName())
+	if (!_variable.typeName())
 	{
-		type = _variable.typeName()->annotation().type;
-		using Location = VariableDeclaration::Location;
-		Location varLoc = _variable.referenceLocation();
-		DataLocation typeLoc = DataLocation::Memory;
-		// References are forced to calldata for external function parameters (not return)
-		// and memory for parameters (also return) of publicly visible functions.
-		// They default to memory for function parameters and storage for local variables.
-		// As an exception, "storage" is allowed for library functions.
-		if (auto ref = dynamic_cast<ReferenceType const*>(type.get()))
-		{
-			bool isPointer = true;
-			if (_variable.isExternalCallableParameter())
-			{
-				auto const& contract = dynamic_cast<ContractDefinition const&>(
-					*dynamic_cast<Declaration const&>(*_variable.scope()).scope()
-				);
-				if (contract.isLibrary())
-				{
-					if (varLoc == Location::Memory)
-						fatalTypeError(_variable.location(),
-							"Location has to be calldata or storage for external "
-							"library functions (remove the \"memory\" keyword)."
-						);
-				}
-				else
-				{
-					// force location of external function parameters (not return) to calldata
-					if (varLoc != Location::CallData && varLoc != Location::Default)
-						fatalTypeError(_variable.location(),
-							"Location has to be calldata for external functions "
-							"(remove the \"memory\" or \"storage\" keyword)."
-						);
-				}
-				if (varLoc == Location::Default)
-					typeLoc = DataLocation::CallData;
-				else
-					typeLoc = varLoc == Location::Memory ? DataLocation::Memory : DataLocation::Storage;
-			}
-			else if (_variable.isCallableParameter() && dynamic_cast<Declaration const&>(*_variable.scope()).isPublic())
-			{
-				auto const& contract = dynamic_cast<ContractDefinition const&>(
-					*dynamic_cast<Declaration const&>(*_variable.scope()).scope()
-				);
-				// force locations of public or external function (return) parameters to memory
-				if (varLoc != Location::Memory && varLoc != Location::Default && !contract.isLibrary())
-					fatalTypeError(_variable.location(),
-						"Location has to be memory for publicly visible functions "
-						"(remove the \"storage\" or \"calldata\" keyword)."
-					);
-				if (varLoc == Location::Default || !contract.isLibrary())
-					typeLoc = DataLocation::Memory;
-				else
-				{
-					if (varLoc == Location::CallData)
-						fatalTypeError(_variable.location(),
-							"Location cannot be calldata for non-external functions "
-							"(remove the \"calldata\" keyword)."
-						);
-					typeLoc = varLoc == Location::Memory ? DataLocation::Memory : DataLocation::Storage;
-				}
-			}
-			else
-			{
-				if (_variable.isConstant())
-				{
-					if (varLoc != Location::Default && varLoc != Location::Memory)
-						fatalTypeError(
-							_variable.location(),
-							"Data location has to be \"memory\" (or unspecified) for constants."
-						);
-					typeLoc = DataLocation::Memory;
-				}
-				else if (varLoc == Location::Default)
-				{
-					if (_variable.isCallableParameter())
-						typeLoc = DataLocation::Memory;
-					else
-					{
-						typeLoc = DataLocation::Storage;
-						if (_variable.isLocalVariable())
-							typeError(
-								_variable.location(),
-								"Data location must be specified as either \"memory\" or \"storage\"."
-							);
-					}
-				}
-				else
-				{
-					switch (varLoc)
-					{
-					case Location::Memory:
-						typeLoc = DataLocation::Memory;
-						break;
-					case Location::Storage:
-						typeLoc = DataLocation::Storage;
-						break;
-					case Location::CallData:
-						fatalTypeError(_variable.location(),
-							"Variable cannot be declared as \"calldata\" (remove the \"calldata\" keyword)."
-						);
-						break;
-					default:
-						solAssert(false, "Unknown data location");
-					}
-				}
-				isPointer = !_variable.isStateVariable();
-			}
-			type = ref->copyForLocation(typeLoc, isPointer);
-		}
-		else if (dynamic_cast<MappingType const*>(type.get()))
-		{
-			if (_variable.isLocalVariable() && varLoc != Location::Storage)
-				typeError(
-					_variable.location(),
-					"Data location for mappings must be specified as \"storage\"."
-				);
-		}
-		else if (varLoc != Location::Default && !ref)
-			typeError(_variable.location(), "Data location can only be given for array or struct types.");
-
-		_variable.annotation().type = type;
+		if (!_variable.canHaveAutoType())
+			solAssert(false, "Explicit type needed.");
+		return; // In this case, an error should have already been thrown since `var` is deprecated.
 	}
-	else if (!_variable.canHaveAutoType())
-		typeError(_variable.location(), "Explicit type needed.");
-	// otherwise we have a "var"-declaration whose type is resolved by the first assignment
+
+	TypePointer type = _variable.typeName()->annotation().type;
+
+	using DataLoc = DataLocation;
+
+	// returns true if the function is defined in a library
+	auto isInLibrary = [](VariableDeclaration const& var) -> bool {
+		ASTNode const* s = dynamic_cast<Declaration const&>(*var.scope()).scope();
+		return (dynamic_cast<ContractDefinition const&>(*s)).isLibrary();
+	};
+
+	if (auto ref = dynamic_cast<ReferenceType const*>(type.get()))
+	{
+		DataLoc typeLoc;
+		if (!m_functionTypeNames.empty()) // the variable declaration is part of FunctionTypeName
+		{
+			if (m_functionTypeNames.back()->visibility() == Declaration::Visibility::External)
+				typeLoc = inferDataLocation(_variable, {DataLoc::CallData, DataLoc::Memory},
+							boost::make_optional(DataLoc::CallData), "function type of external function");
+			else if (m_functionTypeNames.back()->visibility() == Declaration::Visibility::Public)
+				typeLoc = inferDataLocation(_variable, {DataLoc::Memory},
+							boost::make_optional(DataLoc::Memory), "function type of public function");
+			else if (m_functionTypeNames.back()->visibility() == Declaration::Visibility::Internal)
+				typeLoc = inferDataLocation(_variable, {DataLoc::Memory, DataLoc::Storage},
+							boost::none, "function type of internal function");
+			else
+				solAssert(false, "Unknown visibility");
+		}
+		else if (_variable.isExternalCallableParameter())
+		{
+			if (isInLibrary(_variable))
+				// As an exception, "storage" is allowed for library functions.
+				typeLoc = inferDataLocation(_variable, {DataLoc::CallData, DataLoc::Storage},
+							boost::none, "external function in library");
+			else
+				// Reference type's data location are forced to calldata for external function parameters
+				typeLoc = inferDataLocation(_variable, {DataLoc::CallData},
+							boost::make_optional(DataLoc::CallData), "external function");
+		}
+		else if (_variable.isCallableParameter() &&
+				 dynamic_cast<Declaration const&>(*_variable.scope()).isPublic()
+				)
+		{
+			if (isInLibrary(_variable))
+				typeLoc = inferDataLocation(_variable, {DataLoc::Memory, DataLoc::Storage},
+							boost::none, "public function in library");
+			else
+				typeLoc = inferDataLocation(_variable, {DataLoc::Memory},
+							boost::make_optional(DataLoc::Memory), "public function");
+		}
+		else if (_variable.isConstant())
+			typeLoc = inferDataLocation(_variable, {DataLoc::Memory},
+						boost::make_optional(DataLoc::Memory), "reference type constants");
+		else if (_variable.isCallableParameter())
+			typeLoc = inferDataLocation(_variable, {DataLoc::Memory, DataLoc::Storage},
+						boost::none, "reference type parameter");
+		else if (_variable.isLocalVariable())
+			typeLoc = inferDataLocation(_variable, {DataLoc::Storage, DataLoc::Memory},
+						boost::none, "local variables");
+		else if (_variable.isStateVariable())
+			typeLoc = inferDataLocation(_variable, {DataLoc::Storage},
+						boost::make_optional(DataLoc::Storage), "state variables");
+		else
+		{
+			// Got a variable declaration in struct
+			typeLoc = DataLocation::Storage;
+		}
+		bool isPointer = !m_functionTypeNames.empty() ||
+						 _variable.isExternalCallableParameter() ||
+						 ( _variable.isCallableParameter() &&
+						   dynamic_cast<Declaration const&>(*_variable.scope()).isPublic() ) ||
+						 !_variable.isStateVariable();
+		type = ref->copyForLocation(typeLoc, isPointer);
+	}
+	else if (dynamic_cast<MappingType const*>(type.get()) && _variable.isLocalVariable())
+		inferDataLocation(_variable, {DataLoc::Storage}, boost::none, "mapping");
+	else if (_variable.referenceLocation() != VariableDeclaration::Default)
+		typeError(_variable.location(), "Data location can only be given for array, struct or mapping types.");
+	_variable.annotation().type = type;
 }
 
 void ReferencesResolver::typeError(SourceLocation const& _location, string const& _description)
@@ -446,4 +411,65 @@ void ReferencesResolver::fatalDeclarationError(SourceLocation const& _location, 
 {
 	m_errorOccurred = true;
 	m_errorReporter.fatalDeclarationError(_location, _description);
+}
+
+DataLocation ReferencesResolver::inferDataLocation(
+	VariableDeclaration const& _var,
+	std::vector<DataLocation> const& _legitLocations,
+	boost::optional<DataLocation> const& _defaultLocation,
+	std::string const& _varDescription
+)
+{
+	solAssert(_legitLocations.size(), "No legit location given");
+	using DeclaredLoc = VariableDeclaration::Location;
+
+	vector<string> legitLocationStrs;
+	for (auto vl: _legitLocations)
+	{
+		if (vl == DataLocation::Storage)
+			legitLocationStrs.push_back("storage");
+		else if (vl == DataLocation::Memory)
+			legitLocationStrs.push_back("memory");
+		else if (vl == DataLocation::CallData)
+			legitLocationStrs.push_back("calldata");
+		else
+			solAssert(false, "Unknown location");
+	}
+	DeclaredLoc varLoc = _var.referenceLocation();
+
+	if (varLoc != DeclaredLoc::Default)
+	{
+		auto iter = find(_legitLocations.begin(), _legitLocations.end(), variableLocationToDataLocation(varLoc));
+		if (iter != _legitLocations.end())
+			return *iter;
+	}
+	else if (_defaultLocation)
+		return *_defaultLocation;
+
+	string description = "Location has to be " + boost::algorithm::join(legitLocationStrs, " or ") +
+							" for " + _varDescription + ".";
+	if (!_defaultLocation && varLoc == DeclaredLoc::Default) // explicit mention of data location is enforced
+		description += " Use an explicit data location keyword to fix this error.";
+	else if (_defaultLocation && varLoc != DeclaredLoc::Default)
+		description += " Remove the data location keyword to fix this error.";
+
+	typeError(_var.location(), description);
+	// return an arbitrary location because the inference have failed anyway
+	return _legitLocations[0];
+}
+
+DataLocation ReferencesResolver::variableLocationToDataLocation(VariableDeclaration::Location const& _varLoc) const
+{
+	using DeclaredLoc = VariableDeclaration::Location;
+	switch (_varLoc)
+	{
+	case DeclaredLoc::Storage:
+		return DataLocation::Storage;
+	case DeclaredLoc::Memory:
+		return DataLocation::Memory;
+	case DeclaredLoc::CallData:
+		return DataLocation::CallData;
+	default:
+		solAssert(false, "Invalid data location");
+	}
 }

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -70,6 +70,7 @@ private:
 	virtual void endVisit(ModifierDefinition const& _modifierDefinition) override;
 	virtual void endVisit(UserDefinedTypeName const& _typeName) override;
 	virtual void endVisit(FunctionTypeName const& _typeName) override;
+	virtual bool visit(FunctionTypeName const& _typeName) override;
 	virtual void endVisit(Mapping const& _typeName) override;
 	virtual void endVisit(ArrayTypeName const& _typeName) override;
 	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
@@ -88,10 +89,28 @@ private:
 	/// Adds a new error to the list of errors and throws to abort reference resolving.
 	void fatalDeclarationError(SourceLocation const& _location, std::string const& _description);
 
+ 	/// Infer the data location of a variable, will call typeError if the inference fails.
+ 	/// @param _var the variable. Probably already have a VariableDeclaration::Location assigned to it.
+ 	/// @param _legitLocations legit locations for this variable.
+	/// @param _defaultLocation set this parameter to boost::none to enforce explicit location.
+ 	/// @param _varDescription the description of the variable. Will be printed in error messages.
+	/// @returns determined data location
+	DataLocation inferDataLocation(
+		VariableDeclaration const& _var,
+		std::vector<DataLocation> const& _legitLocations,
+		boost::optional<DataLocation> const& _defaultLocation = boost::none,
+		std::string const& _varDescription = ""
+	);
+
+	/// convert VariableDeclaration::Location to corresponding DataLocation
+	DataLocation variableLocationToDataLocation(VariableDeclaration::Location const& _varLoc) const;
+
 	ErrorReporter& m_errorReporter;
 	NameAndTypeResolver& m_resolver;
 	/// Stack of return parameters.
 	std::vector<ParameterList const*> m_returnParameters;
+	/// Stack of function type name
+	std::vector<FunctionTypeName const*> m_functionTypeNames;
 	bool const m_resolveInsideCode;
 	bool m_errorOccurred = false;
 	bool m_experimental050Mode = false;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7689,7 +7689,7 @@ BOOST_AUTO_TEST_CASE(library_call)
 BOOST_AUTO_TEST_CASE(library_function_external)
 {
 	char const* sourceCode = R"(
-		library Lib { function m(bytes b) external pure returns (byte) { return b[2]; } }
+		library Lib { function m(bytes calldata b) external pure returns (byte) { return b[2]; } }
 		contract Test {
 			function f(bytes memory b) public pure returns (byte) {
 				return Lib.m(b);

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -206,10 +206,10 @@ BOOST_AUTO_TEST_CASE(external_structs)
 			struct Simple { uint i; }
 			struct Nested { X[2][] a; uint y; }
 			struct X { bytes32 x; Test t; Simple[] s; }
-			function f(ActionChoices, uint, Simple) external {}
-			function g(Test, Nested) external {}
+			function f(ActionChoices, uint, Simple calldata) external {}
+			function g(Test, Nested calldata) external {}
 			function h(function(Nested memory) external returns (uint)[]) external {}
-			function i(Nested[]) external {}
+			function i(Nested[] calldata) external {}
 		}
 	)";
 	SourceUnit const* sourceUnit = parseAndAnalyse(text);
@@ -234,10 +234,10 @@ BOOST_AUTO_TEST_CASE(external_structs_in_libraries)
 			struct Simple { uint i; }
 			struct Nested { X[2][] a; uint y; }
 			struct X { bytes32 x; Test t; Simple[] s; }
-			function f(ActionChoices, uint, Simple) external {}
-			function g(Test, Nested) external {}
-			function h(function(Nested memory) external returns (uint)[]) external {}
-			function i(Nested[]) external {}
+			function f(ActionChoices, uint, Simple calldata) external {}
+			function g(Test, Nested calldata) external {}
+			function h(function(Nested memory) external returns (uint)[] calldata) external {}
+			function i(Nested[] calldata) external {}
 		}
 	)";
 	SourceUnit const* sourceUnit = parseAndAnalyse(text);

--- a/test/libsolidity/syntaxTests/dataLocations/data_location_in_function_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/data_location_in_function_type.sol
@@ -1,0 +1,11 @@
+library L {
+    struct Nested { uint y; }
+    // data location specifier in function signature should be optional even if there are multiple choices
+    function a(function(Nested) external returns (uint)[] storage) external pure {}
+    function b(function(Nested calldata) external returns (uint)[] storage) external pure {}
+    function c(function(Nested memory) external returns (uint)[] storage) external pure {}
+    function d(function(Nested storage) external returns (uint)[] storage) external pure {}
+}
+
+// ----
+// TypeError: (441-447): Location has to be calldata or memory for function type of external function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_memory.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_memory.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes memory) external;
 }
 // ----
-// TypeError: (31-36): Location has to be calldata for external functions (remove the "memory" or "storage" keyword).
+// TypeError: (31-36): Location has to be calldata for external function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_storage.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_storage.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes storage) external;
 }
 // ----
-// TypeError: (31-36): Location has to be calldata for external functions (remove the "memory" or "storage" keyword).
+// TypeError: (31-36): Location has to be calldata for external function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/function_argument_location_specifier_test_library.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_argument_location_specifier_test_library.sol
@@ -2,4 +2,4 @@ library test {
     function f(bytes calldata) public;
 }
 // ----
-// TypeError: (30-35): Location cannot be calldata for non-external functions (remove the "calldata" keyword).
+// TypeError: (30-35): Location has to be memory or storage for public function in library.

--- a/test/libsolidity/syntaxTests/dataLocations/function_argument_location_specifier_test_non_reference_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_argument_location_specifier_test_non_reference_type.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes4 memory) public;
 }
 // ----
-// TypeError: (31-37): Data location can only be given for array or struct types.
+// TypeError: (31-37): Data location can only be given for array, struct or mapping types.

--- a/test/libsolidity/syntaxTests/dataLocations/function_type_array_as_reference_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_type_array_as_reference_type.sol
@@ -1,0 +1,10 @@
+contract C {
+    struct Nested { uint y; }
+    // ensure that we consider array of function pointers as reference type
+    function a(function(Nested) external returns (uint)[]) public pure {}
+    function b(function(Nested) external returns (uint)[] storage) public pure {}
+    function c(function(Nested) external returns (uint)[] memory) public pure {}
+    function d(function(Nested) external returns (uint)[] calldata) public pure {}
+}
+// ----
+// TypeError: (208-250): Location has to be memory for public function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/function_argument_location_specifier_test_internal_calldata.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/function_argument_location_specifier_test_internal_calldata.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes calldata) internal;
 }
 // ----
-// TypeError: (31-36): Variable cannot be declared as "calldata" (remove the "calldata" keyword).
+// TypeError: (31-36): Location has to be memory or storage for reference type parameter.

--- a/test/libsolidity/syntaxTests/dataLocations/libraryExternalFunction/function_argument_location_specifier_test_external_memory.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraryExternalFunction/function_argument_location_specifier_test_external_memory.sol
@@ -2,4 +2,4 @@ library test {
     function f(bytes memory) external;
 }
 // ----
-// TypeError: (30-35): Location has to be calldata or storage for external library functions (remove the "memory" keyword).
+// TypeError: (30-35): Location has to be calldata or storage for external function in library.

--- a/test/libsolidity/syntaxTests/dataLocations/libraryInternalFunction/function_argument_location_specifier_test_internal_calldata.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraryInternalFunction/function_argument_location_specifier_test_internal_calldata.sol
@@ -2,4 +2,4 @@ library test {
     function f(bytes calldata) internal pure {}
 }
 // ----
-// TypeError: (30-35): Variable cannot be declared as "calldata" (remove the "calldata" keyword).
+// TypeError: (30-35): Location has to be memory or storage for reference type parameter.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_calldata.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_calldata.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes calldata) public;
 }
 // ----
-// TypeError: (31-36): Location has to be memory for publicly visible functions (remove the "storage" or "calldata" keyword).
+// TypeError: (31-36): Location has to be memory for public function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_storage.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_storage.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes storage) public;
 }
 // ----
-// TypeError: (31-36): Location has to be memory for publicly visible functions (remove the "storage" or "calldata" keyword).
+// TypeError: (31-36): Location has to be memory for public function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/variable_declaration_location_specifier_test_non_reference_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/variable_declaration_location_specifier_test_non_reference_type.sol
@@ -7,7 +7,7 @@ contract test {
     }
 }
 // ----
-// TypeError: (48-63): Data location can only be given for array or struct types.
-// TypeError: (71-89): Data location can only be given for array or struct types.
-// TypeError: (97-111): Data location can only be given for array or struct types.
-// TypeError: (119-136): Data location can only be given for array or struct types.
+// TypeError: (48-63): Data location can only be given for array, struct or mapping types.
+// TypeError: (71-89): Data location can only be given for array, struct or mapping types.
+// TypeError: (97-111): Data location can only be given for array, struct or mapping types.
+// TypeError: (119-136): Data location can only be given for array, struct or mapping types.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/204_overwrite_memory_location_external.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/204_overwrite_memory_location_external.sol
@@ -2,4 +2,4 @@ contract C {
     function f(uint[] memory a) external {}
 }
 // ----
-// TypeError: (28-43): Location has to be calldata for external functions (remove the "memory" or "storage" keyword).
+// TypeError: (28-43): Location has to be calldata for external function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/205_overwrite_storage_location_external.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/205_overwrite_storage_location_external.sol
@@ -2,4 +2,4 @@ contract C {
     function f(uint[] storage a) external {}
 }
 // ----
-// TypeError: (28-44): Location has to be calldata for external functions (remove the "memory" or "storage" keyword).
+// TypeError: (28-44): Location has to be calldata for external function. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/471_unspecified_storage_fail.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/471_unspecified_storage_fail.sol
@@ -9,5 +9,5 @@ contract C {
     }
 }
 // ----
-// TypeError: (104-107): Data location must be specified as either "memory" or "storage".
-// TypeError: (123-131): Data location must be specified as either "memory" or "storage".
+// TypeError: (104-107): Location has to be storage or memory for local variables. Use an explicit data location keyword to fix this error.
+// TypeError: (123-131): Location has to be storage or memory for local variables. Use an explicit data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/473_storage_location_non_array_or_struct_disallowed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/473_storage_location_non_array_or_struct_disallowed.sol
@@ -2,4 +2,4 @@ contract C {
     function f(uint storage a) public { }
 }
 // ----
-// TypeError: (28-42): Data location can only be given for array or struct types.
+// TypeError: (28-42): Data location can only be given for array, struct or mapping types.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/474_storage_location_non_array_or_struct_disallowed_is_not_fatal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/474_storage_location_non_array_or_struct_disallowed_is_not_fatal.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (28-42): Data location can only be given for array or struct types.
+// TypeError: (28-42): Data location can only be given for array, struct or mapping types.

--- a/test/libsolidity/syntaxTests/parsing/location_specifiers_for_params.sol
+++ b/test/libsolidity/syntaxTests/parsing/location_specifiers_for_params.sol
@@ -2,4 +2,4 @@ contract Foo {
     function f(uint[] storage constant x, uint[] memory y) internal { }
 }
 // ----
-// TypeError: (30-55): Data location has to be "memory" (or unspecified) for constants.
+// TypeError: (30-55): Location has to be memory for reference type constants. Remove the data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_calldata.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_calldata.sol
@@ -6,4 +6,4 @@ contract c {
     }
 }
 // ----
-// TypeError: (81-113): Data location for mappings must be specified as "storage".
+// TypeError: (81-113): Location has to be storage for mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_default.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_default.sol
@@ -6,4 +6,4 @@ contract c {
     }
 }
 // ----
-// TypeError: (81-104): Data location for mappings must be specified as "storage".
+// TypeError: (81-104): Location has to be storage for mapping. Use an explicit data location keyword to fix this error.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_memory.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_memory.sol
@@ -6,4 +6,4 @@ contract c {
     }
 }
 // ----
-// TypeError: (81-111): Data location for mappings must be specified as "storage".
+// TypeError: (81-111): Location has to be storage for mapping.


### PR DESCRIPTION
WIP. Need to fix tests and add more test cases.
Fixes #4382 , and #4319 can be fixed easily after this PR is merged.
Besides refactoring and fixing #4382, I also tried to enforce data location keyword whenever there is ambiguity. For example, `contract C { function f(bytes b) internal {} }` will cause type error now:
```
a.sol:1:25: Error: Location has to be memory or storage for reference type parameter. Use an explicit data location keyword to fix this error.
contract C { function f(bytes b) internal {} }
                        ^-----^
```
Not sure if this is a good idea though.

I will fix tests and add more test cases if everything looks ok.