### PR TITLE
Update isolate_tests.py

### DIFF
--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -10,7 +10,7 @@ import sys
 import re
 import os
 import hashlib
-from os.path import join
+from os.path import join, isfile
 
 def extract_test_cases(path):
     lines = open(path, 'rb').read().splitlines()
@@ -77,24 +77,31 @@ def write_cases(tests):
     for test in tests:
         open('test_%s.sol' % hashlib.sha256(test).hexdigest(), 'wb').write(test)
 
+
+def extract_and_write(f, path):
+        if docs:
+            cases = extract_docs_cases(path)
+        else:
+            if f.endswith(".sol"):
+                cases = [open(path, "r").read()]
+            else:
+                cases = extract_test_cases(path)
+        write_cases(cases)
+
 if __name__ == '__main__':
     path = sys.argv[1]
     docs = False
     if len(sys.argv) > 2 and sys.argv[2] == 'docs':
       docs = True
 
-    for root, subdirs, files in os.walk(path):
-        if '_build' in subdirs:
-          subdirs.remove('_build')
-        if 'compilationTests' in subdirs:
-          subdirs.remove('compilationTests')
-        for f in files:
-            path = join(root, f)
-            if docs:
-              cases = extract_docs_cases(path)
-            else:
-              if f.endswith(".sol"):
-                cases = [open(path, "r").read()]
-              else:
-                cases = extract_test_cases(path)
-            write_cases(cases)
+    if isfile(path):
+        extract_and_write(path, path)
+    else: 
+        for root, subdirs, files in os.walk(path):
+            if '_build' in subdirs:
+                subdirs.remove('_build')
+            if 'compilationTests' in subdirs:
+                subdirs.remove('compilationTests')
+            for f in files:
+                path = join(root, f)
+                extract_and_write(f, path)

--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -82,8 +82,8 @@ def extract_and_write(f, path):
         if docs:
             cases = extract_docs_cases(path)
         else:
-            if f.endswith(".sol"):
-                cases = [open(path, "r").read()]
+            if f.endswith('.sol'):
+                cases = [open(path, 'r').read()]
             else:
                 cases = extract_test_cases(path)
         write_cases(cases)


### PR DESCRIPTION
On the documentation the examples for the usage of isolate_tests.py are shown with single files, and it's currently not working. It only works for folders or wildcards that return more than one file, since that's how os.walk works within a loop for that cases.

Proposed an simple and easy fix.

I extracted the core functionality for extracting tests from files, and made another function called `extract_and_write`
If the program receives a single file the function `extract_and_write` is called once, it even works for `docs` when specified.
If the program receives a path or a wildcard, works as used to.

Merging this even fixes the need to review the examples where a single file was used as an input.