### PR TITLE
Pull before pushing to bytecode (as on *ix).

### DIFF
--- a/scripts/bytecodecompare/storebytecode.bat
+++ b/scripts/bytecodecompare/storebytecode.bat
@@ -39,4 +39,5 @@ set REPORT=%DIRECTORY%/windows.txt
 cp ../report.txt %REPORT%
 git add %REPORT%
 git commit -a -m "Added report."
+git pull --rebase
 git push origin 2>&1


### PR DESCRIPTION
This hopefully improves our test stability on windows.