### PR TITLE
[BREAKING] Report empty var tuple decls

### DIFF
--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -22,6 +22,7 @@
 #include <libsolidity/analysis/SemVerHandler.h>
 #include <libsolidity/interface/ErrorReporter.h>
 #include <libsolidity/interface/Version.h>
+#include <boost/algorithm/cxx11/all_of.hpp>
 
 using namespace std;
 using namespace dev;
@@ -250,6 +251,18 @@ bool SyntaxChecker::visit(FunctionTypeName const& _node)
 	for (auto const& decl: _node.returnParameterTypeList()->parameters())
 		if (!decl->name().empty())
 			m_errorReporter.syntaxError(decl->location(), "Return parameters in function types may not be named.");
+
+	return true;
+}
+
+bool SyntaxChecker::visit(VariableDeclarationStatement const& _statement)
+{
+	// Report if none of the variable components in the tuple have a name (only possible via deprecated "var")
+	if (boost::algorithm::all_of_equal(_statement.declarations(), nullptr))
+		m_errorReporter.syntaxError(
+			_statement.location(),
+			"The use of the \"var\" keyword is disallowed. The declaration part of the statement can be removed, since it is empty."
+		);
 
 	return true;
 }

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -69,6 +69,8 @@ private:
 	virtual bool visit(FunctionDefinition const& _function) override;
 	virtual bool visit(FunctionTypeName const& _node) override;
 
+	virtual bool visit(VariableDeclarationStatement const& _statement) override;
+
 	virtual bool visit(StructDefinition const& _struct) override;
 
 	ErrorReporter& m_errorReporter;

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/239_multi_variable_declaration_wildcards_fine.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/239_multi_variable_declaration_wildcards_fine.sol
@@ -13,6 +13,8 @@ contract C {
     }
 }
 // ----
+// SyntaxError: (307-325): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
+// SyntaxError: (335-350): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
 // Warning: (179-198): Different number of components on the left hand side (2) than on the right hand side (3).
 // Warning: (208-233): Different number of components on the left hand side (3) than on the right hand side (2).
 // Warning: (243-262): Different number of components on the left hand side (2) than on the right hand side (3).

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/246_multi_variable_declaration_wildcards_fail_5.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/246_multi_variable_declaration_wildcards_fail_5.sol
@@ -3,4 +3,5 @@ contract C {
     function f() public { var (,) = one(); }
 }
 // ----
+// SyntaxError: (81-96): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
 // TypeError: (81-96): Wildcard both at beginning and end of variable declaration list is only allowed if the number of components is equal.

--- a/test/libsolidity/syntaxTests/types/unnamed_tuple_decl.sol
+++ b/test/libsolidity/syntaxTests/types/unnamed_tuple_decl.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.20;
+
+contract C {
+    function f() internal pure {}
+    function g() internal pure returns (uint) { return 1; }
+    function h() internal pure returns (uint, uint) { return (1, 2); }
+
+    function test() internal pure {
+        var () = f();
+        var () = g();
+        var (,) = h();
+    }
+}
+
+// ----
+// SyntaxError: (249-261): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
+// SyntaxError: (271-283): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
+// SyntaxError: (293-306): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
+// TypeError: (271-283): Too many components (1) in value for variable assignment (0) needed


### PR DESCRIPTION
This PR adds an error message whenever the left-hand-side of a variable declaration has zero named components.

closes #4416