### PR TITLE
Fix crash when declaring the same var twice in the same scope

### DIFF
--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -96,6 +96,11 @@ void DeclarationContainer::activateVariable(ASTString const& _name)
 	m_invisibleDeclarations.erase(_name);
 }
 
+bool DeclarationContainer::isInvisible(ASTString const& _name) const
+{
+	return m_invisibleDeclarations.count(_name);
+}
+
 bool DeclarationContainer::registerDeclaration(
 	Declaration const& _declaration,
 	ASTString const* _name,

--- a/libsolidity/analysis/DeclarationContainer.h
+++ b/libsolidity/analysis/DeclarationContainer.h
@@ -62,6 +62,9 @@ public:
 	/// VariableDeclarationStatements.
 	void activateVariable(ASTString const& _name);
 
+	/// @returns true if declaration is currently invisible.
+	bool isInvisible(ASTString const& _name) const;
+
 	/// @returns existing declaration names similar to @a _name.
 	/// Searches this and all parent containers.
 	std::vector<ASTString> similarNames(ASTString const& _name) const;

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -156,7 +156,8 @@ bool NameAndTypeResolver::updateDeclaration(Declaration const& _declaration)
 void NameAndTypeResolver::activateVariable(string const& _name)
 {
 	solAssert(m_currentScope, "");
-	m_currentScope->activateVariable(_name);
+	if (m_currentScope->isInvisible(_name))
+		m_currentScope->activateVariable(_name);
 }
 
 vector<Declaration const*> NameAndTypeResolver::resolveName(ASTString const& _name, ASTNode const* _scope) const

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -156,6 +156,11 @@ bool NameAndTypeResolver::updateDeclaration(Declaration const& _declaration)
 void NameAndTypeResolver::activateVariable(string const& _name)
 {
 	solAssert(m_currentScope, "");
+	// Scoped local variables are invisible before activation.
+	// When a local variable is activated, its name is removed
+	// from a scope's invisible variables.
+	// This is used to avoid activation of variables of same name
+	// in the same scope (an error is returned).
 	if (m_currentScope->isInvisible(_name))
 		m_currentScope->activateVariable(_name);
 }

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_same_and_disjoint_scope.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_same_and_disjoint_scope.sol
@@ -1,0 +1,10 @@
+contract test {
+    function f() pure public {
+        uint x;
+        { uint x; }
+        uint x;
+    }
+}
+// ----
+// Warning: (73-79): This declaration shadows an existing declaration.
+// DeclarationError: (91-97): Identifier already declared.

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_same_scope.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_same_scope.sol
@@ -1,0 +1,8 @@
+contract test {
+    function f() pure public {
+        uint x;
+        uint x;
+    }
+}
+// ----
+// DeclarationError: (71-77): Identifier already declared.

--- a/test/libsolidity/syntaxTests/scoping/poly_variable_declaration_same_scope.sol
+++ b/test/libsolidity/syntaxTests/scoping/poly_variable_declaration_same_scope.sol
@@ -1,0 +1,16 @@
+contract test {
+    function f() pure public {
+        uint x;
+        uint x;
+        uint x;
+        uint x;
+        uint x;
+        uint x;
+    }
+}
+// ----
+// DeclarationError: (71-77): Identifier already declared.
+// DeclarationError: (87-93): Identifier already declared.
+// DeclarationError: (103-109): Identifier already declared.
+// DeclarationError: (119-125): Identifier already declared.
+// DeclarationError: (135-141): Identifier already declared.


### PR DESCRIPTION
Fixes #4414 

In #4414 an assertion fails because there is an assumption that the declarations are ok. The error is reached before that, but since it's not fatal the component goes on. My suggestion is to turn the error into fatal.