### PR TITLE
Fix NatSpec json output for "@notice" and "@dev" tags on contract definitions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,7 @@ Compiler Features:
 Bugfixes:
  * Tests: Fix chain parameters to make ipc tests work with newer versions of cpp-ethereum.
  * Code Generator: Fix allocation of byte arrays (zeroed out too much memory).
+ * Fix NatSpec json output for `@notice` and `@dev` tags on contract definitions.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 
 ### 0.4.24 (2018-05-16)

--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -36,6 +36,10 @@ Json::Value Natspec::userDocumentation(ContractDefinition const& _contractDef)
 	Json::Value doc;
 	Json::Value methods(Json::objectValue);
 
+	string notice = extractDoc(_contractDef.annotation().docTags, "notice");
+	if (!notice.empty())
+		doc["notice"] = Json::Value(notice);
+
 	for (auto const& it: _contractDef.interfaceFunctions())
 		if (it.second->hasDeclaration())
 			if (auto const* f = dynamic_cast<FunctionDefinition const*>(&it.second->declaration()))
@@ -65,6 +69,9 @@ Json::Value Natspec::devDocumentation(ContractDefinition const& _contractDef)
 	auto title = extractDoc(_contractDef.annotation().docTags, "title");
 	if (!title.empty())
 		doc["title"] = title;
+	auto dev = extractDoc(_contractDef.annotation().docTags, "dev");
+	if (!dev.empty())
+		doc["details"] = Json::Value(dev);
 
 	for (auto const& it: _contractDef.interfaceFunctions())
 	{


### PR DESCRIPTION
Fixes issue https://github.com/ethereum/solidity/issues/4446