### PR TITLE
AsmParser,TypeChecker: Fix typos.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1848,7 +1848,7 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 		if (functionType->takesArbitraryParameters())
 			m_errorReporter.typeError(
 				_functionCall.location(),
-				"Named arguments cannnot be used for functions that take arbitrary parameters."
+				"Named arguments cannot be used for functions that take arbitrary parameters."
 			);
 		else if (parameterNames.size() > argumentNames.size())
 			m_errorReporter.typeError(_functionCall.location(), "Some argument names are missing.");

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -150,7 +150,7 @@ assembly::Statement Parser::parseStatement()
 			expectToken(Token::Comma);
 			elementary = parseElementaryOperation();
 			if (elementary.type() != typeid(assembly::Identifier))
-				fatalParserError("Variable name expected in multiple assignemnt.");
+				fatalParserError("Variable name expected in multiple assignment.");
 			assignment.variableNames.emplace_back(boost::get<assembly::Identifier>(elementary));
 		}
 		while (currentToken() == Token::Comma);

--- a/test/libjulia/Parser.cpp
+++ b/test/libjulia/Parser.cpp
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(recursion_depth)
 BOOST_AUTO_TEST_CASE(multiple_assignment)
 {
 	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} 123:u256, x := f() }", ParserError, "Label name / variable name must precede \",\" (multiple assignment).");
-	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} x, 123:u256 := f() }", ParserError, "Variable name expected in multiple assignemnt.");
+	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} x, 123:u256 := f() }", ParserError, "Variable name expected in multiple assignment.");
 
 	/// NOTE: Travis hiccups if not having a variable
 	char const* text = R"(

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(recursion_depth)
 BOOST_AUTO_TEST_CASE(multiple_assignment)
 {
 	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} 123, x := f() }", ParserError, "Label name / variable name must precede \",\" (multiple assignment).");
-	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} x, 123 := f() }", ParserError, "Variable name expected in multiple assignemnt.");
+	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} x, 123 := f() }", ParserError, "Variable name expected in multiple assignment.");
 
 	/// NOTE: Travis hiccups if not having a variable
 	char const* text = R"(

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_for_functions_that_take_arbitrary_parameters.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_for_functions_that_take_arbitrary_parameters.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() pure public {
+        abi.encodeWithSelector({selector:"abc"});
+    }
+}
+// ----
+// TypeError: (52-92): Named arguments cannot be used for functions that take arbitrary parameters.


### PR DESCRIPTION
Fix typos. The change requested as a separate PR during codespell PR.

Refs: #4442