### PR TITLE
minimal required fix to fully compile'n'link on Visual Studio 2017

### DIFF
--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -35,6 +35,7 @@ ExternalProject_Add(jsoncpp-project
                -DJSONCPP_WITH_TESTS=OFF
                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
                -DCMAKE_CXX_FLAGS=${JSONCPP_EXTRA_FLAGS}
+               -DCMAKE_BUILD_TYPE=Release
     # Overwrite build and install commands to force Release build on MSVC.
     BUILD_COMMAND cmake --build <BINARY_DIR> --config Release
     INSTALL_COMMAND cmake --build <BINARY_DIR> --config Release --target install


### PR DESCRIPTION
Hi,

this is the *minimal* version of my fix to properly compile *and* link on Visual Studio 2017 (latest version).

I am not sure how on earth other people can properly ``link`` without that change, except, that my VS2017 is maybe to new and the fact, that I am using the native Visual Studio's support for CMake files (that is: I am not using generated .sln files).

I will however provide a second PR (linking this one) with some more changes I'd like to see on top, closely related to building Solidity on Windows via Visual Studio.