### PR TITLE
Visual Studio 2017 build-time (linking) fix and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/
 docs/_build
 docs/utils/__pycache__
 docs/utils/*.pyc
+/deps/downloads/
 
 # vim stuff
 *.swp
@@ -43,3 +44,5 @@ docs/utils/*.pyc
 .idea
 browse.VC.db
 CMakeLists.txt.user
+/CMakeSettings.json
+/.vs

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -132,17 +132,6 @@ elseif (DEFINED MSVC)
 	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
 	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
 
-	# Always use Release variant of C++ runtime.
-	# We don't want to provide Debug variants of all dependencies. Some default
-	# flags set by CMake must be tweaked.
-	string(REPLACE "/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-	string(REPLACE "/D_DEBUG" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-	string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-	string(REPLACE "/MDd" "/MD" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-	string(REPLACE "/D_DEBUG" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-	string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
-	set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS OFF)
-
 	# disable empty object file warning
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
 	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification

--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -35,9 +35,7 @@ ExternalProject_Add(jsoncpp-project
                -DJSONCPP_WITH_TESTS=OFF
                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
                -DCMAKE_CXX_FLAGS=${JSONCPP_EXTRA_FLAGS}
-    # Overwrite build and install commands to force Release build on MSVC.
-    BUILD_COMMAND cmake --build <BINARY_DIR> --config Release
-    INSTALL_COMMAND cmake --build <BINARY_DIR> --config Release --target install
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     ${byproducts}
 )
 


### PR DESCRIPTION
As a companion PR to #4467, this PR actually not just fixes building Release mode on VS2017, but also supports Debug modes by not hard-coding nor forcing to Release-mode.

This is actually necessary to properly develop'n'debug using VS2017.

* I also made some minor changes to .gitignore that I do not want to create a seperate PR for (too small)
* along the way, I found that ``cmake`` was hard-coded too, some lines below ``ExternalProject_Add``, so I adapted that one, too.