### PR TITLE
Added default data locations to parameters for syntax tests.

### DIFF
--- a/test/libsolidity/syntaxTests/constructor/constructor_visibility_new.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_visibility_new.sol
@@ -1,5 +1,5 @@
 // The constructor of a base class should not be visible in the derived class
-contract A { constructor(string) public { } }
+contract A { constructor(string memory) public { } }
 contract B is A {
   function f() pure public {
     A x = A(0); // convert from address
@@ -9,4 +9,4 @@ contract B is A {
   }
 }
 // ----
-// TypeError: (243-247): Explicit type conversion not allowed from "string memory" to "contract A".
+// TypeError: (250-254): Explicit type conversion not allowed from "string memory" to "contract A".

--- a/test/libsolidity/syntaxTests/constructor/constructor_visibility_old.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_visibility_old.sol
@@ -1,5 +1,5 @@
 // The constructor of a base class should not be visible in the derived class
-contract A { function A(string s) public { } }
+contract A { function A(string memory s) public { } }
 contract B is A {
   function f() pure public {
     A x = A(0); // convert from address
@@ -9,5 +9,5 @@ contract B is A {
   }
 }
 // ----
-// Warning: (91-122): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
-// TypeError: (244-248): Explicit type conversion not allowed from "string memory" to "contract A".
+// Warning: (91-129): Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
+// TypeError: (251-255): Explicit type conversion not allowed from "string memory" to "contract A".

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/default_location.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/default_location.sol
@@ -1,18 +1,18 @@
 contract C {
     struct S { bool f; }
     S s;
-    function f() internal view returns (S c) {
+    function f() internal view returns (S memory c) {
         c = s;
     }
-    function g() internal view returns (S) {
+    function g() internal view returns (S memory) {
         return s;
     }
-    function h() internal pure returns (S) {
+    function h() internal pure returns (S memory) {
     }
-    function i(bool flag) internal view returns (S c) {
+    function i(bool flag) internal view returns (S memory c) {
         if (flag) c = s;
     }
-    function j(bool flag) internal view returns (S) {
+    function j(bool flag) internal view returns (S memory) {
         if (flag) return s;
     }
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/039_functions_with_identical_structs_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/039_functions_with_identical_structs_in_interface.sol
@@ -3,9 +3,9 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct S1 { int i; }
     struct S2 { int i; }
-    function f(S1) public pure {}
-    function f(S2) public pure {}
+    function f(S1 memory) public pure {}
+    function f(S2 memory) public pure {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (136-165): Function overload clash during conversion to external types for arguments.
+// TypeError: (143-179): Function overload clash during conversion to external types for arguments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/040_functions_with_different_structs_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/040_functions_with_different_structs_in_interface.sol
@@ -3,8 +3,8 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct S1 { function() external a; }
     struct S2 { bytes24 a; }
-    function f(S1) public pure {}
-    function f(S2) public pure {}
+    function f(S1 memory) public pure {}
+    function f(S2 memory) public pure {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
@@ -2,7 +2,7 @@ pragma experimental ABIEncoderV2;
 
 contract C {
     struct S { function() internal a; }
-    function f(S) public {}
+    function f(S memory) public {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
@@ -2,7 +2,7 @@ pragma experimental ABIEncoderV2;
 
 contract C {
     struct S { mapping(uint => uint) a; }
-    function f(S) public {}
+    function f(S memory) public {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
@@ -3,7 +3,7 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct T { mapping(uint => uint) a; }
     struct S { T[][2] b; }
-    function f(S) public {}
+    function f(S memory) public {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/044_returning_multi_dimensional_arrays_new_abi.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/044_returning_multi_dimensional_arrays_new_abi.sol
@@ -1,7 +1,7 @@
 pragma experimental ABIEncoderV2;
 
 contract C {
-    function f() public pure returns (string[][]) {}
+    function f() public pure returns (string[][] memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() public pure returns (string[][]) {}
+    function f() public pure returns (string[][] memory) {}
 }
 // ----
 // TypeError: (51-61): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() public pure returns (uint[][2]) {}
+    function f() public pure returns (uint[][2] memory) {}
 }
 // ----
 // TypeError: (51-60): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/047_returning_arrays_in_structs_new_abi.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/047_returning_arrays_in_structs_new_abi.sol
@@ -2,7 +2,7 @@ pragma experimental ABIEncoderV2;
 
 contract C {
     struct S { string[] s; }
-    function f() public pure returns (S) {}
+    function f() public pure returns (S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/048_returning_arrays_in_structs_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/048_returning_arrays_in_structs_arrays.sol
@@ -1,6 +1,6 @@
 contract C {
     struct S { string[] s; }
-    function f() public pure returns (S x) {}
+    function f() public pure returns (S memory x) {}
 }
 // ----
-// TypeError: (80-83): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
+// TypeError: (80-90): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
@@ -1,7 +1,7 @@
 contract test {
-    function f(uint[] constant a) public { }
+    function f(uint[] memory constant a) public { }
 }
 // ----
-// TypeError: (31-48): Illegal use of "constant" specifier.
-// TypeError: (31-48): Constants of non-value type not yet implemented.
-// TypeError: (31-48): Uninitialized "constant" variable.
+// TypeError: (31-55): Illegal use of "constant" specifier.
+// TypeError: (31-55): Constants of non-value type not yet implemented.
+// TypeError: (31-55): Uninitialized "constant" variable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/208_assignment_mem_to_local_storage_variable.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/208_assignment_mem_to_local_storage_variable.sol
@@ -1,9 +1,9 @@
 contract C {
     uint[] data;
-    function f(uint[] x) public {
+    function f(uint[] memory x) public {
         uint[] storage dataRef = data;
         dataRef = x;
     }
 }
 // ----
-// TypeError: (121-122): Type uint256[] memory is not implicitly convertible to expected type uint256[] storage pointer.
+// TypeError: (128-129): Type uint256[] memory is not implicitly convertible to expected type uint256[] storage pointer.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/214_assignment_mem_storage_variable_directly.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/214_assignment_mem_storage_variable_directly.sol
@@ -1,6 +1,6 @@
 contract C {
     uint[] data;
-    function f(uint[] x) public {
+    function f(uint[] memory x) public {
         data = x;
     }
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/215_function_argument_mem_to_storage.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/215_function_argument_mem_to_storage.sol
@@ -1,9 +1,9 @@
 contract C {
     function f(uint[] storage x) private {
     }
-    function g(uint[] x) public {
+    function g(uint[] memory x) public {
         f(x);
     }
 }
 // ----
-// TypeError: (106-107): Invalid type for argument in function call. Invalid implicit conversion from uint256[] memory to uint256[] storage pointer requested.
+// TypeError: (113-114): Invalid type for argument in function call. Invalid implicit conversion from uint256[] memory to uint256[] storage pointer requested.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/216_function_argument_storage_to_mem.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/216_function_argument_storage_to_mem.sol
@@ -2,9 +2,9 @@ contract C {
     function f(uint[] storage x) private {
         g(x);
     }
-    function g(uint[] x) public {
+    function g(uint[] memory x) public {
     }
 }
 // ----
-// Warning: (91-99): Unused function parameter. Remove or comment out the variable name to silence this warning.
-// Warning: (80-115): Function state mutability can be restricted to pure
+// Warning: (91-106): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (80-122): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/224_string_bytes_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/224_string_bytes_conversion.sol
@@ -2,16 +2,16 @@ contract Test {
     string s;
     bytes b;
     function h(string _s) external { bytes(_s).length; }
-    function i(string _s) internal { bytes(_s).length; }
+    function i(string memory _s) internal { bytes(_s).length; }
     function j() internal { bytes(s).length; }
     function k(bytes _b) external { string(_b); }
-    function l(bytes _b) internal { string(_b); }
+    function l(bytes memory _b) internal { string(_b); }
     function m() internal { string(b); }
 }
 // ----
 // Warning: (47-99): Function state mutability can be restricted to pure
-// Warning: (104-156): Function state mutability can be restricted to pure
-// Warning: (161-203): Function state mutability can be restricted to view
-// Warning: (208-253): Function state mutability can be restricted to pure
-// Warning: (258-303): Function state mutability can be restricted to pure
-// Warning: (308-344): Function state mutability can be restricted to view
+// Warning: (104-163): Function state mutability can be restricted to pure
+// Warning: (168-210): Function state mutability can be restricted to view
+// Warning: (215-260): Function state mutability can be restricted to pure
+// Warning: (265-317): Function state mutability can be restricted to pure
+// Warning: (322-358): Function state mutability can be restricted to view

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/260_library_memory_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/260_library_memory_struct.sol
@@ -1,8 +1,8 @@
 pragma experimental ABIEncoderV2;
 library c {
     struct S { uint x; }
-    function f() public returns (S ) {}
+    function f() public returns (S memory) {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// Warning: (75-110): Function state mutability can be restricted to pure
+// Warning: (75-116): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/268_function_overload_array_type.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/268_function_overload_array_type.sol
@@ -1,4 +1,4 @@
 contract M {
-    function f(uint[]) public;
-    function f(int[]) public;
+    function f(uint[] memory) public;
+    function f(int[] memory) public;
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/270_inline_array_declaration_and_passing_implicit_conversion_strings.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/270_inline_array_declaration_and_passing_implicit_conversion_strings.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() public returns (string) {
+    function f() public returns (string memory) {
         string memory x = "Hello";
         string memory y = "World";
         string[2] memory z = [x, y];
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// Warning: (17-191): Function state mutability can be restricted to pure
+// Warning: (17-198): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/272_inline_array_declaration_const_string_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/272_inline_array_declaration_const_string_conversion.sol
@@ -1,8 +1,8 @@
 contract C {
-    function f() public returns (string) {
+    function f() public returns (string memory) {
         string[2] memory z = ["Hello", "World"];
         return (z[0]);
     }
 }
 // ----
-// Warning: (17-133): Function state mutability can be restricted to pure
+// Warning: (17-140): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/274_inline_array_declaration_no_type_strings.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/274_inline_array_declaration_no_type_strings.sol
@@ -1,7 +1,7 @@
 contract C {
-    function f() public returns (string) {
+    function f() public returns (string memory) {
         return (["foo", "man", "choo"][1]);
     }
 }
 // ----
-// Warning: (17-105): Function state mutability can be restricted to pure
+// Warning: (17-112): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/403_return_structs.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/403_return_structs.sol
@@ -2,9 +2,9 @@ pragma experimental ABIEncoderV2;
 contract C {
     struct S { uint a; T[] sub; }
     struct T { uint[] x; }
-    function f() public returns (uint, S) {
+    function f() public returns (uint, S memory) {
     }
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// Warning: (112-157): Function state mutability can be restricted to pure
+// Warning: (112-164): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/404_read_returned_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/404_read_returned_struct.sol
@@ -4,7 +4,7 @@ contract A {
         int x;
         int y;
     }
-    function g() public returns (T) {
+    function g() public returns (T memory) {
         return this.g();
     }
 }

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/477_too_large_arrays_for_calldata_internal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/477_too_large_arrays_for_calldata_internal.sol
@@ -1,6 +1,6 @@
 contract C {
-    function f(uint[85678901234] a) pure internal {
+    function f(uint[85678901234] memory a) pure internal {
     }
 }
 // ----
-// TypeError: (28-47): Array is too large to be encoded.
+// TypeError: (28-54): Array is too large to be encoded.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/478_too_large_arrays_for_calldata_public.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/478_too_large_arrays_for_calldata_public.sol
@@ -1,6 +1,6 @@
 contract C {
-    function f(uint[85678901234] a) pure public {
+    function f(uint[85678901234] memory a) pure public {
     }
 }
 // ----
-// TypeError: (28-47): Array is too large to be encoded.
+// TypeError: (28-54): Array is too large to be encoded.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/514_using_for_with_non_library.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/514_using_for_with_non_library.sol
@@ -2,7 +2,7 @@
 library L {
     struct S { uint d; }
     using S for S;
-    function f(S _s) internal {
+    function f(S memory _s) internal {
         _s.d = 1;
     }
 }

--- a/test/libsolidity/syntaxTests/structs/recursion/multi_struct_composition.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/multi_struct_composition.sol
@@ -9,7 +9,7 @@ contract C {
 
   struct W { uint x; }
 
-  function f(T) public pure { }
+  function f(T memory) public pure { }
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/recursion/parallel_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/parallel_structs.sol
@@ -9,7 +9,7 @@ contract TestContract
         SubStruct subStruct1;
         SubStruct subStruct2;
     }
-    function addTestStruct(TestStruct) public pure {}
+    function addTestStruct(TestStruct memory) public pure {}
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
@@ -1,6 +1,6 @@
 contract C {
     struct S { uint a; S[] sub; }
-    function f() public pure returns (uint, S) {
+    function f() public pure returns (uint, S memory) {
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
@@ -1,6 +1,6 @@
 contract C {
     struct S { uint a; S[2][] sub; }
-    function f() public pure returns (uint, S) {
+    function f() public pure returns (uint, S memory) {
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
@@ -1,8 +1,8 @@
 contract C {
     struct S { uint a; S[][][] sub; }
     struct T { S s; }
-    function f() public pure returns (uint x, T t) {
+    function f() public pure returns (uint x, T memory t) {
     }
 }
 // ----
-// TypeError: (119-122): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (119-129): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/tight_packing_literals.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals.sol
@@ -1,8 +1,8 @@
 contract C {
-    function k() pure public returns (bytes) {
+    function k() pure public returns (bytes memory) {
         return abi.encodePacked(1);
     }
 }
 
 // ----
-// TypeError: (92-93): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.
+// TypeError: (99-100): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.

--- a/test/libsolidity/syntaxTests/tight_packing_literals_fine.sol
+++ b/test/libsolidity/syntaxTests/tight_packing_literals_fine.sol
@@ -1,8 +1,8 @@
 contract C {
-    function k() pure public returns (bytes) {
+    function k() pure public returns (bytes memory) {
         return abi.encodePacked(uint8(1));
     }
-    function l() pure public returns (bytes) {
+    function l() pure public returns (bytes memory) {
         return abi.encode(1);
     }
 }

--- a/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode.sol
+++ b/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode.sol
@@ -1,5 +1,5 @@
 contract C {
-    function f() pure public returns (bytes r) {
+    function f() pure public returns (bytes memory r) {
         r = abi.encode(1, 2);
         r = abi.encodePacked(f());
         r = abi.encodeWithSelector(0x12345678, 1);

--- a/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode_arguments.sol
+++ b/test/libsolidity/syntaxTests/viewPure/view_pure_abi_encode_arguments.sol
@@ -3,34 +3,34 @@ contract C {
     function gView() public view returns (uint) { return x; }
     function gNonPayable() public returns (uint) { x = 4; return 0; }
 
-    function f1() view public returns (bytes) {
+    function f1() view public returns (bytes memory) {
         return abi.encode(gView());
     }
-    function f2() view public returns (bytes) {
+    function f2() view public returns (bytes memory) {
         return abi.encodePacked(gView());
     }
-    function f3() view public returns (bytes) {
+    function f3() view public returns (bytes memory) {
         return abi.encodeWithSelector(0x12345678, gView());
     }
-    function f4() view public returns (bytes) {
+    function f4() view public returns (bytes memory) {
         return abi.encodeWithSignature("f(uint256)", gView());
     }
-    function g1() public returns (bytes) {
+    function g1() public returns (bytes memory) {
         return abi.encode(gNonPayable());
     }
-    function g2() public returns (bytes) {
+    function g2() public returns (bytes memory) {
         return abi.encodePacked(gNonPayable());
     }
-    function g3() public returns (bytes) {
+    function g3() public returns (bytes memory) {
         return abi.encodeWithSelector(0x12345678, gNonPayable());
     }
-    function g4() public returns (bytes) {
+    function g4() public returns (bytes memory) {
         return abi.encodeWithSignature("f(uint256)", gNonPayable());
     }
     // This will generate the only warning.
-    function check() public returns (bytes) {
+    function check() public returns (bytes memory) {
         return abi.encode(2);
     }
 }
 // ----
-// Warning: (1044-1121): Function state mutability can be restricted to pure
+// Warning: (1100-1184): Function state mutability can be restricted to pure


### PR DESCRIPTION
As discussed in #4014 and #3402, adds default data locations to existing syntax tests because of upcoming breaking change.