### PR TITLE
Consider fixed-size arrays when checking for recursive structs.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -64,6 +64,7 @@ Bugfixes:
  * Tests: Fix chain parameters to make ipc tests work with newer versions of cpp-ethereum.
  * Code Generator: Fix allocation of byte arrays (zeroed out too much memory).
  * Fix NatSpec json output for `@notice` and `@dev` tags on contract definitions.
+ * Type Checker: Consider fixed size arrays when checking for recursive structs.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 
 ### 0.4.24 (2018-05-16)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -607,6 +607,12 @@ bool TypeChecker::visit(StructDefinition const& _struct)
 				auto const& typeName = dynamic_cast<UserDefinedTypeName const&>(*member->typeName());
 				check(&dynamic_cast<StructDefinition const&>(*typeName.annotation().referencedDeclaration), parents);
 			}
+			else if (auto arrayType = dynamic_cast<ArrayType const*>(type(*member).get()))
+			{
+				if (!arrayType->isDynamicallySized())
+					if (auto structType = dynamic_cast<StructType const*>(arrayType->baseType().get()))
+						check(&structType->structDefinition(), parents);
+			}
 	};
 	check(&_struct, StructPointersSet{});
 

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_directly_recursive_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_directly_recursive_dynamic_array.sol
@@ -1,0 +1,7 @@
+contract Test {
+    struct MyStructName {
+        address addr;
+        MyStructName[] x;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_directly_recursive_fixed_array.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_directly_recursive_fixed_array.sol
@@ -1,0 +1,8 @@
+contract Test {
+    struct MyStructName {
+        address addr;
+        MyStructName[1] x;
+    }
+}
+// ----
+// TypeError: (20-96): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_complex.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_complex.sol
@@ -1,0 +1,18 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName4[1] x;
+    }
+    struct MyStructName2 {
+        MyStructName1 x;
+    }
+    struct MyStructName3 {
+        MyStructName2[1] x;
+    }
+    struct MyStructName4 {
+        MyStructName3 x;
+    }
+}
+// ----
+// TypeError: (20-121): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_array1.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_array1.sol
@@ -1,0 +1,11 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2[] x;
+    }
+    struct MyStructName2 {
+        MyStructName1 x;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_array2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_array2.sol
@@ -1,0 +1,11 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2 x;
+    }
+    struct MyStructName2 {
+        MyStructName1[] x;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_array3.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_array3.sol
@@ -1,0 +1,11 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2[] x;
+    }
+    struct MyStructName2 {
+        MyStructName1[] x;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_multi_array.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_dynamic_multi_array.sol
@@ -1,0 +1,21 @@
+contract Test {
+    struct S1 {
+        S2[1][] x;
+    }
+    struct S2 {
+        S1 x;
+    }
+    struct T1 {
+        T2[][1] x;
+    }
+    struct T2 {
+        T1 x;
+    }
+    struct R1 {
+        R2[][] x;
+    }
+    struct R2 {
+        R1 x;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_array1.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_array1.sol
@@ -1,0 +1,12 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2[1] x;
+    }
+    struct MyStructName2 {
+        MyStructName1 x;
+    }
+}
+// ----
+// TypeError: (20-121): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_array2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_array2.sol
@@ -1,0 +1,12 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2 x;
+    }
+    struct MyStructName2 {
+        MyStructName1[1] x;
+    }
+}
+// ----
+// TypeError: (20-118): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_array3.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_array3.sol
@@ -1,0 +1,12 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2[1] x;
+    }
+    struct MyStructName2 {
+        MyStructName1[1] x;
+    }
+}
+// ----
+// TypeError: (20-121): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_multi_array.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_indirectly_recursive_fixed_multi_array.sol
@@ -1,0 +1,12 @@
+contract Test {
+    struct MyStructName1 {
+        address addr;
+        uint256 count;
+        MyStructName2[1][1] x;
+    }
+    struct MyStructName2 {
+        MyStructName1 x;
+    }
+}
+// ----
+// TypeError: (20-124): Recursive struct definition.

--- a/test/libsolidity/syntaxTests/structs/recursion/struct_definition_not_really_recursive_array.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/struct_definition_not_really_recursive_array.sol
@@ -1,0 +1,4 @@
+contract Test {
+    struct S1 { uint a; }
+    struct S2 { S1[1] x; S1[1] y; }
+}


### PR DESCRIPTION
Fixes #4483.
