### PR TITLE
removed addtional solc in docker command

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -64,7 +64,7 @@ repository contains potentially unstable changes in the develop branch.
 
 .. code:: bash
 
-    docker run ethereum/solc:stable solc --version
+    docker run ethereum/solc:stable --version
 
 Currently, the docker image only contains the compiler executable,
 so you have to do some additional work to link in the source and


### PR DESCRIPTION
the additional solc in the docker run command is very misleading as it only works when you check the version. when you actually need to compile something, the solc needs to be omitted.  
i.e. ``docker run -v `pwd`:/contracts ethereum/solc:stable solc --abi /contracts/contract.sol`` does not work and produces error:
`""solc"" is not found.`
the correct way to use it is:
``docker run -v `pwd`:/contracts ethereum/solc:stable --abi /contracts/contract.sol``
This is also a weird behaviour on solc such that `solc solc --version` works.