### PR TITLE
Update docs allowed mapping key values

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -846,7 +846,7 @@ Mappings
 ========
 
 Mapping types are declared as ``mapping(_KeyType => _ValueType)``.
-Here ``_KeyType`` can be almost any type except for a mapping, a dynamically sized array, a contract, an enum and a struct.
+Here ``_KeyType`` can be almost any type except for a mapping, a dynamically sized array, a contract, a function, an enum and a struct.
 ``_ValueType`` can actually be any type, including mappings.
 
 Mappings can be seen as `hash tables <https://en.wikipedia.org/wiki/Hash_table>`_ which are virtually initialized such that


### PR DESCRIPTION
Functions cannot be used as mapping keys (e.g. the following contract does not compile):

```
pragma solidity ^0.4.24;

contract Foo {
  mapping(function (uint) pure returns (uint) => string) a;
}
```