### PR TITLE
Ensures an empty use of var keyword is caught with the proper non-fatal error message

### DIFF
--- a/test/libsolidity/syntaxTests/parsing/tuples_decl_without_rhs.sol
+++ b/test/libsolidity/syntaxTests/parsing/tuples_decl_without_rhs.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        (uint a, uint b, uint c);
+    }
+}
+// ----
+// ParserError: (76-77): Expected '=' but got ';'

--- a/test/libsolidity/syntaxTests/types/var_empty_decl_0.sol
+++ b/test/libsolidity/syntaxTests/types/var_empty_decl_0.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure {
+        var ();
+        var (,);
+    }
+}
+// ----
+// SyntaxError: (52-58): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.
+// SyntaxError: (68-75): The use of the "var" keyword is disallowed. The declaration part of the statement can be removed, since it is empty.

--- a/test/libsolidity/syntaxTests/types/var_empty_decl_1.sol
+++ b/test/libsolidity/syntaxTests/types/var_empty_decl_1.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        var a;
+        a.NeverReachedByParser();
+    }
+}
+// ----
+// TypeError: (52-57): Use of the "var" keyword is disallowed.

--- a/test/libsolidity/syntaxTests/types/var_empty_decl_2.sol
+++ b/test/libsolidity/syntaxTests/types/var_empty_decl_2.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure {
+        var (b, c);
+        b.WeMustNotReachHere();
+        c.FailsToLookupToo();
+    }
+}
+// ----
+// TypeError: (52-62): Use of the "var" keyword is disallowed.

--- a/test/libsolidity/syntaxTests/types/var_empty_decl_3.sol
+++ b/test/libsolidity/syntaxTests/types/var_empty_decl_3.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        var (d, e,);
+    }
+}
+// ----
+// TypeError: (52-63): Use of the "var" keyword is disallowed.


### PR DESCRIPTION
This PR improves some error diagnostics wrt. ``var`` keyword uses.