### PR TITLE
Fix: natspec annotations on constructors

### DIFF
--- a/libsolidity/analysis/DocStringAnalyser.h
+++ b/libsolidity/analysis/DocStringAnalyser.h
@@ -48,6 +48,17 @@ private:
 	virtual bool visit(ModifierDefinition const& _modifier) override;
 	virtual bool visit(EventDefinition const& _event) override;
 
+	void checkParameters(
+		CallableDeclaration const& _callable,
+		DocumentedAnnotation& _annotation
+	);
+
+	void handleConstructor(
+		CallableDeclaration const& _callable,
+		Documented const& _node,
+		DocumentedAnnotation& _annotation
+	);
+
 	void handleCallable(
 		CallableDeclaration const& _callable,
 		Documented const& _node,

--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -36,6 +36,15 @@ Json::Value Natspec::userDocumentation(ContractDefinition const& _contractDef)
 	Json::Value doc;
 	Json::Value methods(Json::objectValue);
 
+	auto constructorDefinition(_contractDef.constructor());
+	if (constructorDefinition)
+	{
+		string value = extractDoc(constructorDefinition->annotation().docTags, "notice");
+		if (!value.empty())
+			// add the constructor, only if we have any documentation to add
+			methods["constructor"] = Json::Value(value);
+	}
+
 	string notice = extractDoc(_contractDef.annotation().docTags, "notice");
 	if (!notice.empty())
 		doc["notice"] = Json::Value(notice);
@@ -73,33 +82,21 @@ Json::Value Natspec::devDocumentation(ContractDefinition const& _contractDef)
 	if (!dev.empty())
 		doc["details"] = Json::Value(dev);
 
+	auto constructorDefinition(_contractDef.constructor());
+	if (constructorDefinition) {
+		Json::Value constructor(devDocumentation(constructorDefinition->annotation().docTags));
+		if (!constructor.empty())
+			// add the constructor, only if we have any documentation to add
+			methods["constructor"] = constructor;
+	}
+
 	for (auto const& it: _contractDef.interfaceFunctions())
 	{
 		if (!it.second->hasDeclaration())
 			continue;
-		Json::Value method;
 		if (auto fun = dynamic_cast<FunctionDefinition const*>(&it.second->declaration()))
 		{
-			auto dev = extractDoc(fun->annotation().docTags, "dev");
-			if (!dev.empty())
-				method["details"] = Json::Value(dev);
-
-			auto author = extractDoc(fun->annotation().docTags, "author");
-			if (!author.empty())
-				method["author"] = author;
-
-			auto ret = extractDoc(fun->annotation().docTags, "return");
-			if (!ret.empty())
-				method["return"] = ret;
-
-			Json::Value params(Json::objectValue);
-			auto paramRange = fun->annotation().docTags.equal_range("param");
-			for (auto i = paramRange.first; i != paramRange.second; ++i)
-				params[i->second.paramName] = Json::Value(i->second.content);
-
-			if (!params.empty())
-				method["params"] = params;
-
+			Json::Value method(devDocumentation(fun->annotation().docTags));
 			if (!method.empty())
 				// add the function, only if we have any documentation to add
 				methods[it.second->externalSignature()] = method;
@@ -117,4 +114,32 @@ string Natspec::extractDoc(multimap<string, DocTag> const& _tags, string const& 
 	for (auto i = range.first; i != range.second; i++)
 		value += i->second.content;
 	return value;
+}
+
+Json::Value Natspec::devDocumentation(std::multimap<std::string, DocTag> const &_tags)
+{
+	Json::Value json(Json::objectValue);
+	auto dev = extractDoc(_tags, "dev");
+	if (!dev.empty())
+		json["details"] = Json::Value(dev);
+
+	auto author = extractDoc(_tags, "author");
+	if (!author.empty())
+		json["author"] = author;
+
+	// for constructors, the "return" node will never exist. invalid tags
+	// will already generate an error within dev::solidity::DocStringAnalyzer.
+	auto ret = extractDoc(_tags, "return");
+	if (!ret.empty())
+		json["return"] = ret;
+
+	Json::Value params(Json::objectValue);
+	auto paramRange = _tags.equal_range("param");
+	for (auto i = paramRange.first; i != paramRange.second; ++i)
+		params[i->second.paramName] = Json::Value(i->second.content);
+
+	if (!params.empty())
+		json["params"] = params;
+
+	return json;
 }

--- a/libsolidity/interface/Natspec.h
+++ b/libsolidity/interface/Natspec.h
@@ -54,6 +54,12 @@ public:
 private:
 	/// @returns concatenation of all content under the given tag name.
 	static std::string extractDoc(std::multimap<std::string, DocTag> const& _tags, std::string const& _name);
+
+	/// Helper-function that will create a json object with dev specific annotations, if present.
+	/// @param _tags docTags that are used.
+	/// @return      A JSON representation
+	///              of the contract's developer documentation
+	static Json::Value devDocumentation(std::multimap<std::string, DocTag> const &_tags);
 };
 
 } //solidity NS

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -683,6 +683,131 @@ BOOST_AUTO_TEST_CASE(dev_documenting_no_param_description)
 	expectNatspecError(sourceCode);
 }
 
+BOOST_AUTO_TEST_CASE(user_constructor)
+{
+	char const *sourceCode = R"(
+		contract test {
+			/// @notice this is a really nice constructor
+			constructor(uint a, uint second) public { }
+		}
+	)";
+
+	char const *natspec = R"ABCDEF({
+	"methods" : {
+		"constructor" : "this is a really nice constructor"
+	}
+	})ABCDEF";
+
+	checkNatspec(sourceCode, "test", natspec, true);
+}
+
+BOOST_AUTO_TEST_CASE(user_constructor_and_function)
+{
+	char const *sourceCode = R"(
+		contract test {
+			/// @notice this is a really nice constructor
+			constructor(uint a, uint second) public { }
+			/// another multiplier
+			function mul(uint a, uint second) public returns(uint d) { return a * 7 + second; }
+		}
+	)";
+
+	char const *natspec = R"ABCDEF({
+	"methods" : {
+		"mul(uint256,uint256)" : {
+			"notice" : "another multiplier"
+		},
+		"constructor" : "this is a really nice constructor"
+	}
+	})ABCDEF";
+
+	checkNatspec(sourceCode, "test", natspec, true);
+}
+
+BOOST_AUTO_TEST_CASE(dev_constructor)
+{
+	char const *sourceCode = R"(
+		contract test {
+			/// @author Alex
+			/// @param a the parameter a is really nice and very useful
+			/// @param second the second parameter is not very useful, it just provides additional confusion
+			constructor(uint a, uint second) public { }
+		}
+	)";
+
+	char const *natspec = R"ABCDEF({
+	"methods" : {
+		"constructor" : {
+			"author" : "Alex",
+			"params" : {
+				"a" : "the parameter a is really nice and very useful",
+				"second" : "the second parameter is not very useful, it just provides additional confusion"
+			}
+		}
+	}
+	})ABCDEF";
+
+	checkNatspec(sourceCode, "test", natspec, false);
+}
+
+BOOST_AUTO_TEST_CASE(dev_constructor_return)
+{
+	char const* sourceCode = R"(
+		contract test {
+			/// @author Alex
+			/// @param a the parameter a is really nice and very useful
+			/// @param second the second parameter is not very useful, it just provides additional confusion
+			/// @return return should not work within constructors
+			constructor(uint a, uint second) public { }
+		}
+	)";
+
+	expectNatspecError(sourceCode);
+}
+
+BOOST_AUTO_TEST_CASE(dev_constructor_and_function)
+{
+	char const *sourceCode = R"(
+		contract test {
+			/// @author Alex
+			/// @param a the parameter a is really nice and very useful
+			/// @param second the second parameter is not very useful, it just provides additional confusion
+			constructor(uint a, uint second) public { }
+			/// @dev Multiplies a number by 7 and adds second parameter
+			/// @param a Documentation for the first parameter starts here.
+			/// Since it's a really complicated parameter we need 2 lines
+			/// @param second Documentation for the second parameter
+			/// @return The result of the multiplication
+			/// and cookies with nutella
+			function mul(uint a, uint second) public returns(uint d) {
+				return a * 7 + second;
+			}
+		}
+	)";
+
+	char const *natspec = R"ABCDEF({
+	"methods" : {
+		"mul(uint256,uint256)" : {
+			"details" : "Multiplies a number by 7 and adds second parameter",
+			"params" : {
+				"a" : "Documentation for the first parameter starts here. Since it's a really complicated parameter we need 2 lines",
+				"second" : "Documentation for the second parameter"
+			},
+			"return" : "The result of the multiplication and cookies with nutella"
+		},
+		"constructor" : {
+			"author" : "Alex",
+			"params" : {
+				"a" : "the parameter a is really nice and very useful",
+				"second" : "the second parameter is not very useful, it just provides additional confusion"
+			}
+		}
+	}
+	})ABCDEF";
+
+	checkNatspec(sourceCode, "test", natspec, false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
- natspec annotations on constructore where ignored.
- as discussed: the constructor natspec will be placed within the `methods` node and will just have the name `constructor`.

_Recreated PR. I recreated my `constructor_natspec` branch and cherry-picked the actual change. I wasn't aware of that this will also remove the original PR https://github.com/ethereum/solidity/pull/3666, related to https://github.com/ethereum/solidity/issues/1141._