### PR TITLE
Code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults:
       command: |
         mkdir -p build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo $CMAKE_OPTIONS
         make -j4
   - run_tests: &run_tests
       name: Tests
@@ -122,6 +122,7 @@ jobs:
       - image: buildpack-deps:artful
     environment:
       TERM: xterm
+      CMAKE_OPTIONS: -DCOVERAGE=ON
     steps:
       - checkout
       - run:
@@ -191,9 +192,19 @@ jobs:
           name: Install dependencies
           command: |
             apt-get -qq update
-            apt-get -qy install libz3-dev libleveldb1v5
+            apt-get -qy install libz3-dev libleveldb1v5 python-pip
+            pip install codecov
       - run: mkdir -p test_results
+      - run:
+          name: Test type checker
+          command: build/test/soltest -t 'syntaxTest*' -- --no-ipc --testpath test
+      - run:
+          name: Coverage of type checker
+          command: codecov --flags type_checker --gcov-root build
       - run: *run_tests
+      - run:
+          name: Coverage of all
+          command: codecov --flags all --gcov-root build
       - store_test_results:
           path: test_results/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,10 @@ jobs:
       - run: *setup_prerelease_commit_hash
       - run: *run_build
       - store_artifacts: *solc_artifact
-      - persist_to_workspace: *all_artifacts
+      - persist_to_workspace:
+          root: build
+          paths:
+            - "*"
 
   build_x86_mac:
     macos:


### PR DESCRIPTION
Fixes #2663.

- Integrates codecov (separate "flags" for type checker only and for all tests).
- Adds `COVERAGE=ON` CMake option to build with coverage instrumentation.
- The linux build moves whole build dir to test job (takes 1 min). I was not able to move only `*.gcda` files with circleci config.