### PR TITLE
Properly show constructor/fallback in FunctionDefinition.fullyQualfiedName

### DIFF
--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -347,15 +347,6 @@ string FunctionDefinition::externalSignature() const
 	return FunctionType(*this).externalSignature();
 }
 
-string FunctionDefinition::fullyQualifiedName() const
-{
-	auto const* contract = dynamic_cast<ContractDefinition const*>(scope());
-	solAssert(contract, "Enclosing scope of function definition was not set.");
-
-	auto fname = name().empty() ? "<fallback>" : name();
-	return sourceUnitName() + ":" + contract->name() + "." + fname;
-}
-
 FunctionDefinitionAnnotation& FunctionDefinition::annotation() const
 {
 	if (!m_annotation)

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -206,7 +206,6 @@ public:
 	bool isVisibleInDerivedContracts() const { return isVisibleInContract() && visibility() >= Visibility::Internal; }
 	bool isVisibleAsLibraryMember() const { return visibility() >= Visibility::Internal; }
 
-	std::string fullyQualifiedName() const { return sourceUnitName() + ":" + name(); }
 
 	virtual bool isLValue() const { return false; }
 	virtual bool isPartOfExternalInterface() const { return false; }
@@ -405,6 +404,8 @@ public:
 	bool constructorIsPublic() const;
 	/// Returns the fallback function or nullptr if no fallback function was specified.
 	FunctionDefinition const* fallbackFunction() const;
+
+	std::string fullyQualifiedName() const { return sourceUnitName() + ":" + name(); }
 
 	virtual TypePointer type() const override;
 
@@ -619,7 +620,6 @@ public:
 	std::vector<ASTPointer<ModifierInvocation>> const& modifiers() const { return m_functionModifiers; }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameters() const { return m_returnParameters->parameters(); }
 	Block const& body() const { solAssert(m_body, ""); return *m_body; }
-	std::string fullyQualifiedName() const;
 	virtual bool isVisibleInContract() const override
 	{
 		return Declaration::isVisibleInContract() && !isConstructor() && !isFallback();


### PR DESCRIPTION
This function doesn't seem to be used however.

It is only used on `ContractDefinition`, but in the AST hierarchy only `FunctionDefinition` overrides this function.