### PR TITLE
Add error code type tokens to the token enum macro, return these toke…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 commit_hash.txt
 prerelease.txt
 
+# dependancies
+/deps
+
 # Compiled Object files
 *.slo
 *.lo

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1531,7 +1531,18 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 			m_scanner->next();
 		}
 		else
-			fatalParserError(string("Expected primary expression."));
+		{
+			if (token == Token::Illegal_Hex)
+			{
+				fatalParserError(string("Odd nibble count in hex string literal."));
+			}
+			else if (0/*your new illegal token check*/)
+			{
+				fatalParserError(string("my_error_description"));
+			}
+			else
+				fatalParserError(string("Expected primary expression."));
+		}
 		break;
 	}
 	return expression;

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -714,11 +714,11 @@ Token::Value Scanner::scanHexString()
 	{
 		char c = m_char;
 		if (!scanHexByte(c))
-			return Token::Illegal;
+			return Token::Illegal_Hex;
 		addLiteralChar(c);
 	}
 	if (m_char != quote)
-		return Token::Illegal;
+		return Token::Illegal_Hex;
 	literal.complete();
 	advance();  // consume quote
 	return Token::StringLiteral;

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -261,6 +261,7 @@ namespace solidity
 	\
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \
+	T(Illegal_Hex, "ILLEGAL_HEX", 0)								   \
 	\
 	/* Scanner-internal use only. */                                   \
 	T(Whitespace, NULL, 0)


### PR DESCRIPTION
…n codes from the scan and handle the codes where appropriate. [odd nibbles gitcoin fix]

Fixes #1802.

### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [ x ] Code compiles correctly
- [ *x  ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ first-time ] Used meaningful commit messages

### Description
Please explain the changes you made here.
*All tests pass except:
-------------------------------------------------------------
C:\GITCOIN\my-solidity\build\test\RelWithDebInfo>soltest.exe -- --no-ipc --no-smt --testpath ../../../test
Running 1511 test cases...
c:/gitcoin/my-solidity/test/libsolidity/solidityscanner.cpp(392): error: in "SolidityScanner/invalid_short_hex_literal": check scanner.next() == Token::Illegal has failed [161 != 160]
c:/gitcoin/my-solidity/test/libsolidity/solidityscanner.cpp(399): error: in "SolidityScanner/invalid_hex_literal_with_space": check scanner.next() == Token::Illegal has failed [161 != 160]
c:/gitcoin/my-solidity/test/libsolidity/solidityscanner.cpp(406): error: in "SolidityScanner/invalid_hex_literal_with_wrong_quotes": check scanner.next() == Token::Illegal has failed [161 != 160]
c:/gitcoin/my-solidity/test/libsolidity/solidityscanner.cpp(413): error: in "SolidityScanner/invalid_hex_literal_nonhex_string": check scanner.next() == Token::Illegal has failed [161 != 160]

*** 4 failures are detected in the test module "SolidityTests"
--------------------------------------------------------------

Is it actually crucial? I do not think so. But I may be wrong.

Explanation of changes:
The scanner has many different functions for pattern matching. When you validate the source code's syntax, on failure return a Token::Illegal_[ret_code_name] and then check the current token for equality with that return code when you need to, and throw a fatalParserError with a custom string. You need to add to the Token "code" enum macro to make new Illegal_[ret_code_name]. I believe you can just extend the if else chain I have started in the Parser.cpp to handle new Token enum types. I have made a comment there.