### PR TITLE
Do not include single-header boost_unit_test

### DIFF
--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -28,7 +28,7 @@
 #pragma warning(push)
 #pragma warning(disable:4535) // calling _set_se_translator requires /EHa
 #endif
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
Fixes #3909. Fixes #3845.

Do not mix 2 different usage variants of boost_unit_test. If you link with static libs do not include the single-header variant.

See https://www.boost.org/doc/libs/1_67_0/libs/test/doc/html/boost_test/usage_variants.html#boost_test.usage_variants.single_header