### PR TITLE
Fix shared boost test library build by customizing main

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,4 +24,8 @@ add_executable(soltest ${sources} ${headers}
 )
 target_link_libraries(soltest PRIVATE libsolc solidity lll evmasm devcore ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES})
 
+if (NOT Boost_USE_STATIC_LIBS)
+    target_compile_definitions(soltest PUBLIC -DBOOST_TEST_DYN_LINK)
+endif()
+
 add_subdirectory(tools)

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -153,3 +153,18 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 
 	return 0;
 }
+
+// BOOST_TEST_DYN_LINK should be defined if user want to link against shared boost test library
+#ifdef BOOST_TEST_DYN_LINK
+
+// Because we want to have customized initialization function and support shared boost libraries at the same time,
+// we are forced to customize the entry point.
+// see: https://www.boost.org/doc/libs/1_67_0/libs/test/doc/html/boost_test/adv_scenarios/shared_lib_customizations/init_func.html
+
+int main(int argc, char* argv[])
+{
+	auto init_unit_test = []() -> bool { init_unit_test_suite(0, nullptr); return true; };
+	return boost::unit_test::unit_test_main(init_unit_test, argc, argv);
+}
+
+#endif


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Used meaningful commit messages

### Description

Dynamic linking to boost test was broken by #4572 (which address the misuse of boost unit test library).

Customizing main is needed according to boost document: https://www.boost.org/doc/libs/1_67_0/libs/test/doc/html/boost_test/adv_scenarios/shared_lib_customizations/init_func.html

This patch doesn't affect static link boost build. Not sure if this fix creates potential issue for shared build though.

I use `cmake -DBoost_USE_STATIC_LIBS=OFF -DBUILD_SHARED_LIBS=ON -DINSTALL_LLLC=ON -DCMAKE_CXX_FLAGS="-DBOOST_TEST_DYN_LINK" ..` to configure the build for shared boost libraries.

cc @chfast could you review this change? Thanks very much