### PR TITLE
Set tab size specified in .editorconfig to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ trim_trailing_whitespace = true
 
 [*.{cpp,h}]
 indent_style = tab
+indent_size = 4
 
 [*.{py,rst,sh,yml}]
 indent_style = space


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Used meaningful commit messages

### Description
Hello,
In `COODING_STYLE.md`, it said `tab stops are every 4 characters (only relevant for line length).`. But GitHub shows tab as 8 spaces. The solution is to specify tab size in `.editorconfig` file so that GitHub knows how to correctly render tabs.
This will make sources' indent style and spacing consistent in editor and GitHub.
(You can see the effect in https://github.com/sifmelcara/solidity/blob/tab-size/libsolidity/analysis/NameAndTypeResolver.cpp )