### PR TITLE
Added guards for unknown pragmas

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -36,13 +36,6 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 	add_compile_options(-Wextra)
 	add_compile_options(-Werror)
 
-	# Disable warnings about unknown pragmas (which is enabled by -Wall).  I assume we have external
-	# dependencies (probably Boost) which have some of these.   Whatever the case, we shouldn't be
-	# disabling these globally.   Instead, we should pragma around just the problem #includes.
-	#
-	# TODO - Track down what breaks if we do NOT do this.
-	add_compile_options(-Wno-unknown-pragmas)
-
 	# Configuration-specific compiler settings.
 	set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g -DETH_DEBUG")
 	set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
@@ -73,13 +66,13 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			# TODO - Is this even necessary?  Why?
 			# See http://stackoverflow.com/questions/19774778/when-is-it-necessary-to-use-use-the-flag-stdlib-libstdc.
 			add_compile_options(-stdlib=libstdc++)
-			
+
 			# Tell Boost that we're using Clang's libc++.   Not sure exactly why we need to do.
 			add_definitions(-DBOOST_ASIO_HAS_CLANG_LIBCXX)
-			
+
 			# Use fancy colors in the compiler diagnostics
 			add_compile_options(-fcolor-diagnostics)
-			
+
 			# See "How to silence unused command line argument error with clang without disabling it?"
 			# When using -Werror with clang, it transforms "warning: argument unused during compilation" messages
 			# into errors, which makes sense.

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -40,7 +40,6 @@
 #include <libdevcore/vector_ref.h>
 
 #if defined(__GNUC__)
-#pragma warning(push)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif // defined(__GNUC__)
@@ -57,7 +56,6 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #if defined(__GNUC__)
-#pragma warning(pop)
 #pragma GCC diagnostic pop
 #endif // defined(__GNUC__)
 

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -29,12 +29,18 @@
 #include <tuple>
 #include <memory>
 #include <ostream>
-#pragma warning(push)
-#pragma GCC diagnostic push
+
+#if defined(__clang__)
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wredeclared-class-member"
+#endif // defined(__clang__)
+
 #include <boost/bimap.hpp>
-#pragma warning(pop)
-#pragma GCC diagnostic pop
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif // defined(__clang__)
+
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Exceptions.h>
 #include <libevmasm/ExpressionClasses.h>

--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -22,12 +22,18 @@
 #include "CodeFragment.h"
 
 #include <boost/algorithm/string.hpp>
-#pragma warning(push)
+
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif // defined(__GNUC__)
+
 #include <boost/spirit/include/support_utree.hpp>
-#pragma warning(pop)
+
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif // defined(__GNUC__)
+
 #include <libdevcore/CommonIO.h>
 #include <libevmasm/Instruction.h>
 #include "CompilerState.h"


### PR DESCRIPTION
EDIT: I will have a look at the VS failures 

### Checklist

- [x] Code compiles correctly
- [x] All tests passing
- [ ] ~~Created tests which fail without the change (if possible)~~
- [ ] ~~Extended the README / documentation, if necessary~~
- [x] Used meaningful commit messages

### Description

Removed push/pop if there was no change to the warnings *in the same
file* for a given compiler. This assumes the imported boost headers use
a warning stack themselves.

The pragmas don't seem to be required anymore, but were not removed to
mantain compatibility with older versions of the boost library.

Compiled with
- clang version 6.0.1 (tags/RELEASE_601/final)
- gcc (GCC) 8.1.1 20180531
 against:
- libboost 1.67.0-5
