### PR TITLE
Add contract type to types documentation

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -199,25 +199,31 @@ The ``.gas()`` option is available on all three methods, while the ``.value()`` 
 Contract Types
 --------------
 
-Every :ref:`contract<contracts>` defines its own type. Contracts can be implicitly converted
-to contracts they inherit from. They can be explicitly converted from and to ``address`` types.
+Every :ref:`contract<contracts>` defines its own type, defined by its smart
+contract that you can call from another contract. For example (where ``Token``
+is a contract) ::
 
-Contracts can also be instantiated (which here means they are newly created). You can find more details in
-the :ref:`'Contracts via new'<creating-contracts>` section.
+   Token token = new Token();
 
-The data representation of a contract is identical to that of the ``address`` type and
-this type is also used in the :ref:`ABI<ABI>`.
-
-Contracts do not support any operators.
-
-The members of contract types are the external functions of the contract including
-public state variables.
+Contracts can be implicitly converted to contracts they inherit from, and can be explicitly converted from and to the ``address`` type.
 
 .. note::
     Starting with version 0.5.0 contracts do not derive from the address type, but can still be explicitly converted to address.
 
-.. index:: byte array, bytes32
 
+Contracts can also be instantiated (which means they are newly created). You
+can find more details in the :ref:`'Contracts via new'<creating-contracts>`
+section.
+
+The data representation of a contract is identical to that of the ``address``
+type and this type is also used in the :ref:`ABI<ABI>`.
+
+Contracts do not support any operators.
+
+The members of contract types are the external functions of the contract
+including public state variables.
+
+.. index:: byte array, bytes32
 
 Fixed-size byte arrays
 ----------------------

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -200,15 +200,18 @@ Contract Types
 --------------
 
 Every :ref:`contract<contracts>` defines its own type.
-Contracts can be implicitly converted to contracts they inherit from,
-and can be explicitly converted from and to the ``address`` type.
+You can implicitly convert contracts to contracts they inherit from,
+and explicitly convert them to and from the ``address`` type.
 
 .. note::
     Starting with version 0.5.0 contracts do not derive from the address type,
     but can still be explicitly converted to address.
 
+If you declare a local variable of contract type (`MyContract c`), you can call
+functions on that contract. Take care to assign it from somewhere that is the
+same contract type.
 
-Contracts can also be instantiated (which means they are newly created). You
+You can also instantiate contracts (which means they are newly created). You
 can find more details in the :ref:`'Contracts via new'<creating-contracts>`
 section.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -192,11 +192,18 @@ The ``.gas()`` option is available on all three methods, while the ``.value()`` 
 .. note::
     The use of ``callcode`` is discouraged and will be removed in the future.
 
+.. index:: ! contract type, ! type; contract
+
+.. _contract_types:
+
 Contract Types
 --------------
 
 Every :ref:`contract<contracts>` defines its own type. Contracts can be implicitly converted
 to contracts they inherit from. They can be explicitly converted from and to ``address`` types.
+
+Contracts can also be instantiated (which here means they are newly created). You can find more details in
+the :ref:`'Contracts via new'<creating-contracts>` section.
 
 The data representation of a contract is identical to that of the ``address`` type and
 this type is also used in the :ref:`ABI<ABI>`.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -199,16 +199,13 @@ The ``.gas()`` option is available on all three methods, while the ``.value()`` 
 Contract Types
 --------------
 
-Every :ref:`contract<contracts>` defines its own type, defined by its smart
-contract that you can call from another contract. For example (where ``Token``
-is a contract) ::
-
-   Token token = new Token();
-
-Contracts can be implicitly converted to contracts they inherit from, and can be explicitly converted from and to the ``address`` type.
+Every :ref:`contract<contracts>` defines its own type.
+Contracts can be implicitly converted to contracts they inherit from,
+and can be explicitly converted from and to the ``address`` type.
 
 .. note::
-    Starting with version 0.5.0 contracts do not derive from the address type, but can still be explicitly converted to address.
+    Starting with version 0.5.0 contracts do not derive from the address type,
+    but can still be explicitly converted to address.
 
 
 Contracts can also be instantiated (which means they are newly created). You


### PR DESCRIPTION
### Checklist
- [x ] All tests passing
- [x ] Extended the README / documentation, if necessary
- [x ] Used meaningful commit messages

### Description
This PR closes https://github.com/ethereum/solidity/issues/1211.

The only source I could find that mentions clearly that Contract types inherit from address types was here (https://ethereumbuilders.gitbooks.io/guide/content/en/solidity_features.html), so I think it's true, but I'm not 100% certain.