### PR TITLE
grammar: remove stray IdentifierList rule

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -79,7 +79,6 @@ Return = 'return' Expression?
 Throw = 'throw'
 EmitStatement = 'emit' FunctionCall
 VariableDefinition = (VariableDeclaration | '(' VariableDeclaration? (',' VariableDeclaration? )* ')' ) ( '=' Expression )?
-IdentifierList = '(' ( Identifier? ',' )* Identifier? ')'
 
 // Precedence by order (see github.com/ethereum/solidity/pull/732)
 Expression


### PR DESCRIPTION
This was left in #4274 (dbd0723)

Fixes #4186.