### PR TITLE
Dynamic type as mapping key returns error instead of assertion fail

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -110,6 +110,7 @@ Bugfixes:
  * Type Checker: Fix freeze for negative fixed-point literals very close to ``0``, such as ``-1e-100``.
  * Type Checker: Report error when using structs in events without experimental ABIEncoderV2. This used to crash or log the wrong values.
  * Type Checker: Report error when using indexed structs in events with experimental ABIEncoderV2. This used to log wrong values.
+ * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 
 ### 0.4.24 (2018-05-16)

--- a/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_1.sol
@@ -1,0 +1,5 @@
+contract c {
+	mapping(uint[] => uint) data;
+}
+// ----
+// ParserError: (26-27): Expected '=>' but got '['

--- a/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_2.sol
@@ -1,0 +1,8 @@
+contract c {
+	struct S {
+		uint x;
+	}
+	mapping(S => uint) data;
+}
+// ----
+// ParserError: (47-48): Expected elementary type name for mapping key type

--- a/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_3.sol
@@ -1,0 +1,8 @@
+contract c {
+	struct S {
+		string s;
+	}
+	mapping(S => uint) data;
+}
+// ----
+// ParserError: (49-50): Expected elementary type name for mapping key type

--- a/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_nonelementary_key_4.sol
@@ -1,0 +1,5 @@
+contract c {
+	mapping(string[] => uint) data;
+}
+// ----
+// ParserError: (28-29): Expected '=>' but got '['

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_dynamic_key.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_dynamic_key.sol
@@ -1,0 +1,3 @@
+contract c {
+	mapping(string => uint) data;
+}

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_dynamic_key_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_dynamic_key_public.sol
@@ -1,0 +1,5 @@
+contract c {
+	mapping(string => uint) public data;
+}
+// ----
+// TypeError: (14-49): Dynamically-sized keys for public mappings are not supported.


### PR DESCRIPTION
Fixes #633 

Funny that the error `Expected elementary type name for mapping key type` is caught by the Parser.