### PR TITLE
[WIP] Static Elementary Types Introduced

### DIFF
--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -355,6 +355,19 @@ private:
 	Modifier m_modifier;
 };
 
+struct ElementaryTypes
+{
+	static IntegerType Address;
+	// static const ArrayType BytesMemory;
+	// static const ArrayType StringMemory;
+	// ElementaryTypes()
+	// {
+	// 	Address = IntegerType(160, IntegerType::Modifier::Address);
+	// };
+};
+IntegerType ElementaryTypes::Address = IntegerType(160, IntegerType::Modifier::Address);
+
+
 /**
  * A fixed point type number (signed, unsigned).
  */


### PR DESCRIPTION
### Your checklist for this pull request
Fixes #4502 
Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Used meaningful commit messages

### Description
Please explain the changes you made here.
Added struct called Elementary Types to replace the frequently used `IntegerType(160, IntegerType::Modifier::Address);` and `ArrayType(DataLocation::Memory, true)` etc , they can be directly referenced like `ElementaryTypes::Address` making it more readable .
Thank you for your help!
