### PR TITLE
Point the documentation to the new Code of Conduct URL

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -63,7 +63,7 @@ for this project. Also, even though we do CI testing, please test your code and
 ensure that it builds locally before submitting a pull request.
 
 Please note that this project is released with a `Contributor Code of Conduct
-<https://raw.githubusercontent.com/ethereum/solidity/develop/CONDUCT.md>`_.
+<https://raw.githubusercontent.com/ethereum/solidity/develop/CODE_OF_CONDUCT.md>`_.
 By participating in this project you agree to abide by its terms.
 
 Thank you for your help!


### PR DESCRIPTION
Missed in #4649.