### PR TITLE
FixedBytes(0) is invalid, do not check for it in ABIEncoderV2

### DIFF
--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -228,7 +228,8 @@ string ABIFunctions::cleanupFunction(Type const& _type, bool _revertOnFailure)
 			if (type.numBytes() == 32)
 				templ("body", "cleaned := value");
 			else if (type.numBytes() == 0)
-				templ("body", "cleaned := 0");
+				// This is disallowed in the type system.
+				solAssert(false, "");
 			else
 			{
 				size_t numBits = type.numBytes() * 8;

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -12489,6 +12489,44 @@ BOOST_AUTO_TEST_CASE(abi_encode_with_signaturev2)
 	ABI_CHECK(callContractFunction("f4()"), expectation);
 }
 
+BOOST_AUTO_TEST_CASE(abi_encode_empty_string)
+{
+	char const* sourceCode = R"(
+		// Tests that this will not end up using a "bytes0" type
+		// (which would assert)
+		contract C {
+			function f() public pure returns (bytes memory, bytes memory) {
+				return (abi.encode(""), abi.encodePacked(""));
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(
+		0x40, 0xc0,
+		0x60, 0x20, 0x00, 0x00,
+		0x00
+	));
+}
+
+BOOST_AUTO_TEST_CASE(abi_encode_empty_string_v2)
+{
+	char const* sourceCode = R"(
+		// Tests that this will not end up using a "bytes0" type
+		// (which would assert)
+		pragma experimental ABIEncoderV2;
+		contract C {
+			function f() public pure returns (bytes memory, bytes memory) {
+				return (abi.encode(""), abi.encodePacked(""));
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(
+		0x40, 0xa0,
+		0x40, 0x20, 0x00,
+		0x00
+	));
+}
 BOOST_AUTO_TEST_CASE(abi_encode_call)
 {
 	char const* sourceCode = R"T(


### PR DESCRIPTION
There is a typesystem assertion at https://github.com/ethereum/solidity/blob/develop/libsolidity/ast/Types.cpp#L1322

This line wasn't tested for in the ABIEncoderV2 tests, because it cannot be tested for :)
