### PR TITLE
Added peephole optimization for consecutive ISZERO opcodes.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ Breaking Changes:
  * General: Disallow combining hex numbers with unit denominations (e.g. ``0x1e wei``). This was already the case in the experimental 0.5.0 mode.
  * Name Resolver: Do not exclude public state variables when looking for conflicting declarations.
  * Optimizer: Remove the no-op ``PUSH1 0 NOT AND`` sequence.
+ * Optimizer: Peephole optimization for redundant consecutive `ISZERO` opcodes.
  * Parser: Disallow trailing dots that are not followed by a number.
  * Parser: Remove ``constant`` as function state mutability modifer.
  * Type Checker: Disallow assignments between tuples with different numbers of components. This was already the case in the experimental 0.5.0 mode.

--- a/libevmasm/PeepholeOptimiser.cpp
+++ b/libevmasm/PeepholeOptimiser.cpp
@@ -109,6 +109,23 @@ struct PushPop: SimplePeepholeOptimizerMethod<PushPop, 2>
 	}
 };
 
+struct TripleIsZero: SimplePeepholeOptimizerMethod<TripleIsZero, 3>
+{
+	static bool applySimple(
+      AssemblyItem const& _isZero1, 
+      AssemblyItem const& _isZero2, 
+      AssemblyItem const& _isZero3, 
+      std::back_insert_iterator<AssemblyItems> _out
+  )
+	{
+    if(_isZero1 == Instruction::ISZERO && _isZero2 == Instruction::ISZERO && _isZero3 == Instruction::ISZERO) {
+      *_out = Instruction::ISZERO;
+      return true;
+    }
+    else return false;
+	}
+};
+
 struct OpPop: SimplePeepholeOptimizerMethod<OpPop, 2>
 {
 	static bool applySimple(
@@ -322,7 +339,7 @@ bool PeepholeOptimiser::optimise()
 {
 	OptimiserState state {m_items, 0, std::back_inserter(m_optimisedItems)};
 	while (state.i < m_items.size())
-		applyMethods(state, PushPop(), OpPop(), DoublePush(), DoubleSwap(), CommutativeSwap(), SwapComparison(), JumpToNext(), UnreachableCode(), TagConjunctions(), TruthyAnd(), Identity());
+		applyMethods(state, PushPop(), TripleIsZero(), OpPop(), DoublePush(), DoubleSwap(), CommutativeSwap(), SwapComparison(), JumpToNext(), UnreachableCode(), TagConjunctions(), TruthyAnd(), Identity());
 	if (m_optimisedItems.size() < m_items.size() || (
 		m_optimisedItems.size() == m_items.size() && (
 			eth::bytesRequired(m_optimisedItems, 3) < eth::bytesRequired(m_items, 3) ||

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -992,6 +992,92 @@ BOOST_AUTO_TEST_CASE(peephole_truthy_and)
   );
 }
 
+BOOST_AUTO_TEST_CASE(peephole_triple_iszero)
+{
+  // 1 ISZERO should remain as 1 ISZERO.
+  AssemblyItems items_single{
+    Instruction::ISZERO
+  };
+  AssemblyItems expectation_single{
+    Instruction::ISZERO
+  };
+  PeepholeOptimiser peepOpt_single(items_single);
+  BOOST_REQUIRE(!peepOpt_single.optimise()); // Not expected to optimise.
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    items_single.begin(), items_single.end(),
+    expectation_single.begin(), expectation_single.end()
+  );
+  
+  // 2 ISZEROes should remain as 2 ISZEROes.
+  AssemblyItems items_double{
+    Instruction::ISZERO,
+    Instruction::ISZERO
+  };
+  AssemblyItems expectation_double{
+    Instruction::ISZERO,
+    Instruction::ISZERO
+  };
+  PeepholeOptimiser peepOpt_double(items_double);
+  BOOST_REQUIRE(!peepOpt_double.optimise()); // Not expected to optimise.
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    items_double.begin(), items_double.end(),
+    expectation_double.begin(), expectation_double.end()
+  );
+  
+  // 3 ISZEROes should become 1 ISZERO.
+  AssemblyItems items_triple{
+    Instruction::ISZERO,
+    Instruction::ISZERO,
+    Instruction::ISZERO
+  };
+  AssemblyItems expectation_triple{
+    Instruction::ISZERO
+  };
+  PeepholeOptimiser peepOpt_triple(items_triple);
+  BOOST_REQUIRE(peepOpt_triple.optimise());
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    items_triple.begin(), items_triple.end(),
+    expectation_triple.begin(), expectation_triple.end()
+  );
+  
+  // 4 ISZEROes should become 2 ISZEROes.
+  AssemblyItems items_quad{
+    Instruction::ISZERO,
+    Instruction::ISZERO,
+    Instruction::ISZERO,
+    Instruction::ISZERO
+  };
+  AssemblyItems expectation_quad{
+    Instruction::ISZERO,
+    Instruction::ISZERO
+  };
+  PeepholeOptimiser peepOpt_quad(items_quad);
+  BOOST_REQUIRE(peepOpt_quad.optimise());
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    items_quad.begin(), items_quad.end(),
+    expectation_quad.begin(), expectation_quad.end()
+  );
+  
+  // 5 ISZEROes should become 1 ISZERO.
+  AssemblyItems items_quint{
+    Instruction::ISZERO,
+    Instruction::ISZERO,
+    Instruction::ISZERO,
+    Instruction::ISZERO,
+    Instruction::ISZERO
+  };
+  AssemblyItems expectation_quint{
+    Instruction::ISZERO
+  };
+  PeepholeOptimiser peepOpt_quint(items_quint);
+  BOOST_REQUIRE(peepOpt_quint.optimise());
+  BOOST_REQUIRE(peepOpt_quint.optimise());
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+    items_quint.begin(), items_quint.end(),
+    expectation_quint.begin(), expectation_quint.end()
+  );
+}
+
 BOOST_AUTO_TEST_CASE(jumpdest_removal)
 {
 	AssemblyItems items{


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary (Not needed in this case)
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

I've observed that EVM output often contains sequences of ISZERO opcodes with more than 2 elements. For example, in the EVM opcode structure that returns a boolean value:

```
239 JUMPDEST
240 PUSH1 40
242 DUP1
243 MLOAD
244 SWAP2
245 ISZERO // <------- HERE
246 ISZERO
247 ISZERO
248 ISZERO
249 DUP3
250 MSTORE
251 MLOAD
252 PUSH1 20
254 SWAP1
255 SWAP2
256 ADD
257 DUP2
258 SWAP1
259 SUB
260 SWAP1
261 RETURN
```

As far as I can tell, these sequences make sense as long as there is 1 or 2 elements at most. Eg. 3 consecutive ISZEROes are equivalent to a single one. We don't want to cancel out 2 ISZEROes though, because they have the potential consequence of changing a top stack value that is neither 0 or 1 to a boolean.  

This simple peephole optimization ensures that there is never more than two consecutive ISZERO opcodes.

NOTE:
I see that the CSE optimizer already tackles this optimization, but I thought I'd still make the PR for you to consider this lower level implementation for the optimization. 