### PR TITLE
Unbreak build against Boost 1.68

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -264,7 +264,7 @@ Json::Value Assembly::assemblyJSON(StringMap const& _sourceCodes) const
 					createJsonValue("PUSH [ErrorTag]", i.location().start, i.location().end, ""));
 			else
 				collection.append(
-					createJsonValue("PUSH [tag]", i.location().start, i.location().end, string(i.data())));
+					createJsonValue("PUSH [tag]", i.location().start, i.location().end, i.data().str()));
 			break;
 		case PushSub:
 			collection.append(
@@ -290,7 +290,7 @@ Json::Value Assembly::assemblyJSON(StringMap const& _sourceCodes) const
 			break;
 		case Tag:
 			collection.append(
-				createJsonValue("tag", i.location().start, i.location().end, string(i.data())));
+				createJsonValue("tag", i.location().start, i.location().end, i.data().str()));
 			collection.append(
 				createJsonValue("JUMPDEST", i.location().start, i.location().end));
 			break;


### PR DESCRIPTION
After boostorg/multiprecision@06d03409c048 build fails. See [error log](https://ptpb.pw/5SBF). CC @alexdupre (downstream maintainer).

I don't use Solidity.
