### PR TITLE
[BREAKING] Underscores in numeric literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ browse.VC.db
 CMakeLists.txt.user
 /CMakeSettings.json
 /.vs
+/.cproject
+/.project

--- a/Changelog.md
+++ b/Changelog.md
@@ -147,6 +147,7 @@ Features:
  * General: Introduce new constructor syntax using the ``constructor`` keyword as experimental 0.5.0 feature.
  * General: Limit the number of errors output in a single run to 256.
  * General: Support accessing dynamic return data in post-byzantium EVMs.
+ * General: Allow underscores in numeric and hex literals to separate thousands and quads.
  * Inheritance: Error when using empty parentheses for base class constructors that require arguments as experimental 0.5.0 feature.
  * Inheritance: Error when using no parentheses in modifier-style constructor calls as experimental 0.5.0 feature.
  * Interfaces: Allow overriding external functions in interfaces with public in an implementing contract.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -284,8 +284,8 @@ one side.  Examples include ``1.``, ``.1`` and ``1.3``.
 Scientific notation is also supported, where the base can have fractions, while the exponent cannot.
 Examples include ``2e10``, ``-2e10``, ``2e-10``, ``2.5e1``.
 
-Underscores can be used to separate digits of a numeric literal to aid readability.
-For example, ``123_000``, ``0x2eff_abde``, ``1_233e34_89`` are all valid. Underscores are only allowed between two digits.
+Underscores can be used to separate the digits of a numeric literal to aid readability.
+For example, ``123_000``, ``0x2eff_abde``, ``1233_e348_9a`` are all valid. Underscores are only allowed between two digits. For hex literals, underscores are only allowed to separate groups of 4 hex digits.
 
 Number literal expressions retain arbitrary precision until they are converted to a non-literal type (i.e. by
 using them together with a non-literal expression).

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -284,6 +284,9 @@ one side.  Examples include ``1.``, ``.1`` and ``1.3``.
 Scientific notation is also supported, where the base can have fractions, while the exponent cannot.
 Examples include ``2e10``, ``-2e10``, ``2e-10``, ``2.5e1``.
 
+Underscores can be used to separate digits of a numeric literal to aid readability.
+For example, ``123_000``, ``0x2eff_abde``, ``1_233e34_89`` are all valid. Underscores are only allowed between two digits.
+
 Number literal expressions retain arbitrary precision until they are converted to a non-literal type (i.e. by
 using them together with a non-literal expression).
 This means that computations do not overflow and divisions do not truncate

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -285,7 +285,9 @@ Scientific notation is also supported, where the base can have fractions, while 
 Examples include ``2e10``, ``-2e10``, ``2e-10``, ``2.5e1``.
 
 Underscores can be used to separate the digits of a numeric literal to aid readability.
-For example, ``123_000``, ``0x2eff_abde``, ``1233_e348_9a`` are all valid. Underscores are only allowed between two digits. For hex literals, underscores are only allowed to separate groups of 4 hex digits.
+For example, decimal ``123_000``, hexadecimal ``0x2eff_abde``, scientific decimal notation ``1_2e345_678`` are all valid.
+Underscores are only allowed between two digits and only one consecutive underscore is allowed.
+There is no additional semantic meaning added to a number literal containing underscores.
 
 Number literal expressions retain arbitrary precision until they are converted to a non-literal type (i.e. by
 using them together with a non-literal expression).

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -188,39 +188,38 @@ bool SyntaxChecker::visit(Throw const& _throwStatement)
 
 bool SyntaxChecker::visit(Literal const& _literal)
 {
-	if (!_literal.isHexNumber())
+	if (_literal.token() != Token::Number)
 		return true;
-	// We have a hex literal. Do underscore validation
-	solAssert(_literal.value().substr(0, 2) == "0x", "");
-	ASTString value = _literal.value().substr(2); // Skip the 0x
-	vector<ASTString> parts;
-	boost::split(parts, value, boost::is_any_of("_"));
 
-	if (parts.size() == 1) // no underscores
-		return true;
-	// Everything except first and last part must be 4 chars in length
-	for (size_t i = 1; i + 1 < parts.size(); ++i)
+	ASTString const& value = _literal.value();
+	solAssert(!value.empty(), "");
+
+	// Generic checks no matter what base this number literal is of:
+	if (value.back() == '_')
 	{
-		if (parts[i].size() != 4)
-			m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in hex literal. Found inner part with " + to_string(parts[i].size()) + " digits (has to be 4 digits).");
+		m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in number literal. No trailing underscores allowed.");
+		return true;
 	}
 
-	// Validate rightmost block
-	if (parts.back().size() == 4) // If ends with 4 digits, then no need to validate first block
+	if (value.find("__") != ASTString::npos)
+	{
+		m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.");
 		return true;
-
-	// Validate leftmost block
-	// If first part is 4 digits then last part's length has to be even to avoid ambiguity over zero padding
-	if (parts.front().size() == 4)
-	{
-		if (parts.back().size() % 2 == 0)
-			return true;
-		m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in hex literal. If the first part has 4 digits, it is assumed to be a byte sequence instead of a number and thus the last part should have an even number of digits.");
 	}
-	else
+
+	if (!_literal.isHexNumber()) // decimal literal
 	{
-		// Both first and last part is invalid
-		m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in hex literal. First or last part must have 4 digits.");
+		if (value.find("._") != ASTString::npos)
+			m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.");
+
+		if (value.find("_.") != ASTString::npos)
+			m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.");
+
+		if (value.find("_e") != ASTString::npos)
+			m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in number literal. No underscore at the end of the mantissa allowed.");
+
+		if (value.find("e_") != ASTString::npos)
+			m_errorReporter.syntaxError(_literal.location(), "Invalid use of underscores in number literal. No underscore in front of exponent allowed.");
 	}
 
 	return true;

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -73,6 +73,7 @@ private:
 	virtual bool visit(VariableDeclarationStatement const& _statement) override;
 
 	virtual bool visit(StructDefinition const& _struct) override;
+	virtual bool visit(Literal const& _literal) override;
 
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -773,21 +773,22 @@ tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _literal
 	rational value;
 	try
 	{
-		auto expPoint = find(_literal.value().begin(), _literal.value().end(), 'e');
-		if (expPoint == _literal.value().end())
-			expPoint = find(_literal.value().begin(), _literal.value().end(), 'E');
+		ASTString valueString = _literal.value();
+		boost::erase_all(valueString, "_");// Remove underscore separators
 
-		if (boost::starts_with(_literal.value(), "0x"))
+		auto expPoint = find(valueString.begin(), valueString.end(), 'e');
+		if (expPoint == valueString.end())
+			expPoint = find(valueString.begin(), valueString.end(), 'E');
+
+		if (boost::starts_with(valueString, "0x"))
 		{
 			// process as hex
-			ASTString valueString = _literal.value();
-			boost::erase_all(valueString, "_");// Remove underscore separators
 			value = bigint(valueString);
 		}
-		else if (expPoint != _literal.value().end())
+		else if (expPoint != valueString.end())
 		{
 			// Parse mantissa and exponent. Checks numeric limit.
-			tuple<bool, rational> mantissa = parseRational(string(_literal.value().begin(), expPoint));
+			tuple<bool, rational> mantissa = parseRational(string(valueString.begin(), expPoint));
 
 			if (!get<0>(mantissa))
 				return make_tuple(false, rational(0));
@@ -797,7 +798,7 @@ tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _literal
 			if (value == 0)
 				return make_tuple(true, rational(0));
 
-			bigint exp = bigint(string(expPoint + 1, _literal.value().end()));
+			bigint exp = bigint(string(expPoint + 1, valueString.end()));
 
 			if (exp > numeric_limits<int32_t>::max() || exp < numeric_limits<int32_t>::min())
 				return make_tuple(false, rational(0));
@@ -826,7 +827,7 @@ tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _literal
 		else
 		{
 			// parse as rational number
-			tuple<bool, rational> tmp = parseRational(_literal.value());
+			tuple<bool, rational> tmp = parseRational(valueString);
 			if (!get<0>(tmp))
 				return tmp;
 			value = get<1>(tmp);

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -39,6 +39,7 @@
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <limits>
 
@@ -779,7 +780,9 @@ tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _literal
 		if (boost::starts_with(_literal.value(), "0x"))
 		{
 			// process as hex
-			value = bigint(_literal.value());
+			ASTString valueString = _literal.value();
+			boost::erase_all(valueString, "_");// Remove underscore separators
+			value = bigint(valueString);
 		}
 		else if (expPoint != _literal.value().end())
 		{

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -726,21 +726,26 @@ Token::Value Scanner::scanHexString()
 
 void Scanner::scanDecimalDigits()
 {
-	if (!isDecimalDigit(m_char)) // avoid underscore at beginning
-		return;
-	while (isDecimalDigit(m_char) || m_char == '_') 
+	// Parse for regex [:digit:]+(_[:digit:]+)*
+
+	do
 	{
+		if (!isDecimalDigit(m_char))
+			return;
+		while (isDecimalDigit(m_char))
+			addLiteralCharAndAdvance();
+
 		if (m_char == '_') 
 		{
 			advance();
-			if (!isDecimalDigit(m_char)) // avoid trailing underscore
+			if (!isDecimalDigit(m_char)) // Trailing underscore. Rollback and allow next step to flag it as illegal
 			{
 				rollback(1);
-				break;
+				return;
 			}
 		}
-		addLiteralCharAndAdvance();
 	}
+	while (isDecimalDigit(m_char));
 }
 
 Token::Value Scanner::scanNumber(char _charSeen)
@@ -768,19 +773,17 @@ Token::Value Scanner::scanNumber(char _charSeen)
 				addLiteralCharAndAdvance();
 				if (!isHexDigit(m_char))
 					return Token::Illegal; // we must have at least one hex digit after 'x'/'X'
-				while (isHexDigit(m_char) || m_char == '_') // same logic as scanDecimalDigits
+				char last = m_char;
+				while (isHexDigit(m_char) || m_char == '_') // Unlike decimal digits, we keep the underscores for later validation
 				{
-					if (m_char == '_') 
-					{
-						advance();
-						if (!isHexDigit(m_char)) // avoid trailing underscore
-						{
-							rollback(1);
-							break;
-						}
-					}
+					if (m_char == '_' && last == '_')
+						return Token::Illegal; // Double underscore
+
+					last = m_char;
 					addLiteralCharAndAdvance();
 				}
+				if (last == '_')
+					return Token::Illegal; // Trailing underscore
 			}
 			else if (isDecimalDigit(m_char))
 				// We do not allow octal numbers

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -726,8 +726,21 @@ Token::Value Scanner::scanHexString()
 
 void Scanner::scanDecimalDigits()
 {
-	while (isDecimalDigit(m_char))
+	if (!isDecimalDigit(m_char)) // avoid underscore at beginning
+		return;
+	while (isDecimalDigit(m_char) || m_char == '_') 
+	{
+		if (m_char == '_') 
+		{
+			advance();
+			if (!isDecimalDigit(m_char)) // avoid trailing underscore
+			{
+				rollback(1);
+				break;
+			}
+		}
 		addLiteralCharAndAdvance();
+	}
 }
 
 Token::Value Scanner::scanNumber(char _charSeen)
@@ -755,8 +768,19 @@ Token::Value Scanner::scanNumber(char _charSeen)
 				addLiteralCharAndAdvance();
 				if (!isHexDigit(m_char))
 					return Token::Illegal; // we must have at least one hex digit after 'x'/'X'
-				while (isHexDigit(m_char))
+				while (isHexDigit(m_char) || m_char == '_') // same logic as scanDecimalDigits
+				{
+					if (m_char == '_') 
+					{
+						advance();
+						if (!isHexDigit(m_char)) // avoid trailing underscore
+						{
+							rollback(1);
+							break;
+						}
+					}
 					addLiteralCharAndAdvance();
+				}
 			}
 			else if (isDecimalDigit(m_char))
 				// We do not allow octal numbers

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -724,28 +724,18 @@ Token::Value Scanner::scanHexString()
 	return Token::StringLiteral;
 }
 
+// Parse for regex [:digit:]+(_[:digit:]+)*
 void Scanner::scanDecimalDigits()
 {
-	// Parse for regex [:digit:]+(_[:digit:]+)*
+	// MUST begin with a decimal digit.
+	if (!isDecimalDigit(m_char))
+		return;
 
-	do
-	{
-		if (!isDecimalDigit(m_char))
-			return;
-		while (isDecimalDigit(m_char))
-			addLiteralCharAndAdvance();
+	// May continue with decimal digit or underscore for grouping.
+	do addLiteralCharAndAdvance();
+	while (!m_source.isPastEndOfInput() && (isDecimalDigit(m_char) || m_char == '_'));
 
-		if (m_char == '_') 
-		{
-			advance();
-			if (!isDecimalDigit(m_char)) // Trailing underscore. Rollback and allow next step to flag it as illegal
-			{
-				rollback(1);
-				return;
-			}
-		}
-	}
-	while (isDecimalDigit(m_char));
+	// Defer further validation of underscore to SyntaxChecker.
 }
 
 Token::Value Scanner::scanNumber(char _charSeen)
@@ -756,6 +746,8 @@ Token::Value Scanner::scanNumber(char _charSeen)
 	{
 		// we have already seen a decimal point of the float
 		addLiteralChar('.');
+		if (m_char == '_')
+			return Token::Illegal;
 		scanDecimalDigits();  // we know we have at least one digit
 	}
 	else
@@ -773,17 +765,9 @@ Token::Value Scanner::scanNumber(char _charSeen)
 				addLiteralCharAndAdvance();
 				if (!isHexDigit(m_char))
 					return Token::Illegal; // we must have at least one hex digit after 'x'/'X'
-				char last = m_char;
-				while (isHexDigit(m_char) || m_char == '_') // Unlike decimal digits, we keep the underscores for later validation
-				{
-					if (m_char == '_' && last == '_')
-						return Token::Illegal; // Double underscore
 
-					last = m_char;
+				while (isHexDigit(m_char) || m_char == '_') // We keep the underscores for later validation
 					addLiteralCharAndAdvance();
-				}
-				if (last == '_')
-					return Token::Illegal; // Trailing underscore
 			}
 			else if (isDecimalDigit(m_char))
 				// We do not allow octal numbers
@@ -795,9 +779,17 @@ Token::Value Scanner::scanNumber(char _charSeen)
 			scanDecimalDigits();  // optional
 			if (m_char == '.')
 			{
-				// A '.' has to be followed by a number.
+				if (!m_source.isPastEndOfInput(1) && m_source.get(1) == '_')
+				{
+					// Assume the input may be a floating point number with leading '_' in fraction part.
+					// Recover by consuming it all but returning `Illegal` right away.
+					addLiteralCharAndAdvance(); // '.'
+					addLiteralCharAndAdvance(); // '_'
+					scanDecimalDigits();
+				}
 				if (m_source.isPastEndOfInput() || !isDecimalDigit(m_source.get(1)))
 				{
+					// A '.' has to be followed by a number.
 					literal.complete();
 					return Token::Number;
 				}
@@ -812,8 +804,18 @@ Token::Value Scanner::scanNumber(char _charSeen)
 		solAssert(kind != HEX, "'e'/'E' must be scanned as part of the hex number");
 		if (kind != DECIMAL)
 			return Token::Illegal;
+		else if (!m_source.isPastEndOfInput(1) && m_source.get(1) == '_')
+		{
+			// Recover from wrongly placed underscore as delimiter in literal with scientific
+			// notation by consuming until the end.
+			addLiteralCharAndAdvance(); // 'e'
+			addLiteralCharAndAdvance(); // '_'
+			scanDecimalDigits();
+			literal.complete();
+			return Token::Number;
+		}
 		// scan exponent
-		addLiteralCharAndAdvance();
+		addLiteralCharAndAdvance(); // 'e' | 'E'
 		if (m_char == '+' || m_char == '-')
 			addLiteralCharAndAdvance();
 		if (!isDecimalDigit(m_char))

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -12836,6 +12836,22 @@ BOOST_AUTO_TEST_CASE(write_storage_external)
 	ABI_CHECK(callContractFunction("h()"), encodeArgs(12));
 }
 
+BOOST_AUTO_TEST_CASE(test_underscore_in_hex)
+{
+	char const* sourceCode = R"(
+		contract test {
+			function f(bool cond) returns (uint) {
+				uint32 x = 0x1234_ab;
+				uint y = 0x1234_abcd_1234;
+				return cond ? x : y;
+			}
+		}
+	)";
+	compileAndRun(sourceCode);
+	ABI_CHECK(callContractFunction("f(bool)", true), encodeArgs(u256(0x1234ab)));
+	ABI_CHECK(callContractFunction("f(bool)", false), encodeArgs(u256(0x1234abcd1234)));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -12840,7 +12840,7 @@ BOOST_AUTO_TEST_CASE(test_underscore_in_hex)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f(bool cond) returns (uint) {
+			function f(bool cond) public pure returns (uint) {
 				uint32 x = 0x1234_ab;
 				uint y = 0x1234_abcd_1234;
 				return cond ? x : y;

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -155,6 +155,172 @@ BOOST_AUTO_TEST_CASE(trailing_dot)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
+BOOST_AUTO_TEST_CASE(underscores_in_integer)
+{
+	Scanner scanner(CharStream("var x = 1_23_4;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "1234");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+}
+
+BOOST_AUTO_TEST_CASE(underscores_in_scientific_notation)
+{
+	Scanner scanner(CharStream("var x = 1_2e10;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "12e10");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+}
+
+BOOST_AUTO_TEST_CASE(underscores_in_scientific_notation_in_exp_part)
+{
+	Scanner scanner(CharStream("var x = 12e1_0;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "12e10");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+}
+
+
+BOOST_AUTO_TEST_CASE(underscores_in_hex)
+{
+	Scanner scanner(CharStream("var x = 0xab_19cf;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0xab19cf");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_integer_is_identifier)
+{
+	Scanner scanner(CharStream("var x = _12;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_decimal_is_identifier)
+{
+	Scanner scanner(CharStream("var x = _1.2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_decimal_after_dot_illegal)
+{
+	Scanner scanner(CharStream("var x = 1._2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_exp_are_identifier)
+{
+	Scanner scanner(CharStream("var x = _1e2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_exp_after_e_illegal)
+{
+	Scanner scanner(CharStream("var x = 1e_2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_hex_illegal)
+{
+	Scanner scanner(CharStream("var x = 0x_abc;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(trailing_underscore_integer_illegal)
+{
+	Scanner scanner(CharStream("var x = 12_;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_after_decimal_illegal)
+{
+	Scanner scanner(CharStream("var x = 1.2_;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(leading_underscore_before_decimal_illegal)
+{
+	Scanner scanner(CharStream("var x = 1_.2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(trailing_underscore_exp_illegal)
+{
+	Scanner scanner(CharStream("var x = 1e2_;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(trailing_underscore_exp_before_e_illegal)
+{
+	Scanner scanner(CharStream("var x = 1_e2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(trailing_underscore_hex_illegal)
+{
+	Scanner scanner(CharStream("var x = 0xabc_;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
+BOOST_AUTO_TEST_CASE(double_underscore_illegal)
+{
+	Scanner scanner(CharStream("var x = 1__2;"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+}
+
 BOOST_AUTO_TEST_CASE(negative_numbers)
 {
 	Scanner scanner(CharStream("var x = -.2 + -0x78 + -7.3 + 8.9 + 2e-2;"));

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -155,170 +155,74 @@ BOOST_AUTO_TEST_CASE(trailing_dot)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
-BOOST_AUTO_TEST_CASE(underscores_in_integer)
-{
-	Scanner scanner(CharStream("var x = 1_23_4;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "1234");
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-}
-
-BOOST_AUTO_TEST_CASE(underscores_in_scientific_notation)
-{
-	Scanner scanner(CharStream("var x = 1_2e10;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "12e10");
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-}
-
-BOOST_AUTO_TEST_CASE(underscores_in_scientific_notation_in_exp_part)
-{
-	Scanner scanner(CharStream("var x = 12e1_0;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "12e10");
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-}
-
-
-BOOST_AUTO_TEST_CASE(underscores_in_hex)
-{
-	Scanner scanner(CharStream("var x = 0xab_19cf;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0xab_19cf");
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-}
-
-BOOST_AUTO_TEST_CASE(leading_underscore_integer_is_identifier)
-{
-	Scanner scanner(CharStream("var x = _12;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-}
-
 BOOST_AUTO_TEST_CASE(leading_underscore_decimal_is_identifier)
 {
-	Scanner scanner(CharStream("var x = _1.2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	// Actual error is cought by SyntaxChecker.
+	Scanner scanner(CharStream("_1.2"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(leading_underscore_decimal_after_dot_illegal)
 {
-	Scanner scanner(CharStream("var x = 1._2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	// Actual error is cought by SyntaxChecker.
+	Scanner scanner(CharStream("1._2"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+
+	scanner.reset(CharStream("1._"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(leading_underscore_exp_are_identifier)
 {
-	Scanner scanner(CharStream("var x = _1e2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	// Actual error is cought by SyntaxChecker.
+	Scanner scanner(CharStream("_1e2"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(leading_underscore_exp_after_e_illegal)
 {
-	Scanner scanner(CharStream("var x = 1e_2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	// Actual error is cought by SyntaxChecker.
+	Scanner scanner(CharStream("1e_2"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "1e_2");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(leading_underscore_hex_illegal)
 {
-	Scanner scanner(CharStream("var x = 0x_abc;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
+	Scanner scanner(CharStream("0x_abc"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
-BOOST_AUTO_TEST_CASE(trailing_underscore_integer_illegal)
+BOOST_AUTO_TEST_CASE(fixed_number_invalid_underscore_front)
 {
-	Scanner scanner(CharStream("var x = 12_;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	// Actual error is cought by SyntaxChecker.
+	Scanner scanner(CharStream("12._1234_1234"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
-BOOST_AUTO_TEST_CASE(leading_underscore_after_decimal_illegal)
+BOOST_AUTO_TEST_CASE(number_literals_with_trailing_underscore_at_eos)
 {
-	Scanner scanner(CharStream("var x = 1.2_;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-}
+	// Actual error is cought by SyntaxChecker.
+	Scanner scanner(CharStream("0x123_"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-BOOST_AUTO_TEST_CASE(leading_underscore_before_decimal_illegal)
-{
-	Scanner scanner(CharStream("var x = 1_.2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-}
+	scanner.reset(CharStream("123_"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-BOOST_AUTO_TEST_CASE(trailing_underscore_exp_illegal)
-{
-	Scanner scanner(CharStream("var x = 1e2_;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-}
-
-BOOST_AUTO_TEST_CASE(trailing_underscore_exp_before_e_illegal)
-{
-	Scanner scanner(CharStream("var x = 1_e2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-}
-
-BOOST_AUTO_TEST_CASE(trailing_underscore_hex_illegal)
-{
-	Scanner scanner(CharStream("var x = 0xabc_;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-}
-
-BOOST_AUTO_TEST_CASE(double_underscore_illegal)
-{
-	Scanner scanner(CharStream("var x = 1__2;"));
-	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
-	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	scanner.reset(CharStream("12.34_"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(negative_numbers)

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(underscores_in_hex)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0xab19cf");
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0xab_19cf");
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal.sol
@@ -1,0 +1,13 @@
+contract C {
+  function f() public pure {
+    uint d1 = 654_321;
+    uint d2 =  54_321;
+    uint d3 =   4_321;
+    uint d4 = 5_43_21;
+    uint d5 = 1_2e10;
+    uint d6 = 12e1_0;
+
+    d1; d2; d3; d4; d5; d6;
+  }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol
@@ -1,0 +1,13 @@
+contract C {
+  function f() public pure {
+    uint D1 = 1234_;
+    uint D2 = 12__34;
+    uint D3 = 12_e34;
+    uint D4 = 12e_34;
+  }
+}
+// ----
+// SyntaxError: (56-61): Invalid use of underscores in number literal. No trailing underscores allowed.
+// SyntaxError: (77-83): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.
+// SyntaxError: (99-105): Invalid use of underscores in number literal. No underscore at the end of the mantissa allowed.
+// SyntaxError: (121-127): Invalid use of underscores in number literal. No underscore in front of exponent allowed.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed.sol
@@ -1,0 +1,9 @@
+contract C {
+  function f() public pure {
+    fixed f1 = 3.14_15;
+    fixed f2 = 3_1.4_15;
+
+    f1; f2;
+  }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed_fail.sol
@@ -1,0 +1,17 @@
+contract C {
+  function f() public pure {
+    fixed F1 = 3.1415_;
+    fixed F2 = 3__1.4__15;
+    fixed F3 = 1_.2;
+    fixed F4 = 1._2;
+    fixed F5 = 1.2e_12;
+    fixed F6 = 1._;
+  }
+}
+// ----
+// SyntaxError: (57-64): Invalid use of underscores in number literal. No trailing underscores allowed.
+// SyntaxError: (81-91): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.
+// SyntaxError: (108-112): Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.
+// SyntaxError: (129-133): Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.
+// SyntaxError: (150-157): Invalid use of underscores in number literal. No underscore in front of exponent allowed.
+// SyntaxError: (174-177): Invalid use of underscores in number literal. No trailing underscores allowed.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_hex.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_hex.sol
@@ -1,0 +1,13 @@
+contract C {
+  function f() public pure {
+    uint x1 = 0x8765_4321;
+    uint x2 = 0x765_4321;
+    uint x3 = 0x65_4321;
+    uint x4 = 0x5_4321;
+    uint x5 = 0x123_1234_1234_1234;
+    uint x6 = 0x123456_1234_1234;
+
+    x1; x2; x3; x4; x5; x6;
+  }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_hex_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_hex_fail.sol
@@ -1,0 +1,7 @@
+contract C {
+  function f() public pure {
+    uint X1 = 0x1234__1234__1234__123;
+  }
+}
+// ----
+// SyntaxError: (56-79): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.


### PR DESCRIPTION
Closes #1677

Follows https://www.python.org/dev/peps/pep-0515/

This is a recreation of the PR #3120, that got accidentally closed and couldn't be recovered (easily). My apologies, @Balajiganapathi. I however retained your original commits and will now attempt finishing them.

### Notes

This PR finalizes the original PR #3120. Changes include:
* Shifting validation of underscores as far back as possible (from Lexical analysis to SyntaxChecker) to provide better error diagnostics.
* Adds tests to `tests/libsolidity/syntaxChecker/parsing/`.
* We agreed to keep rules as similar as possible to recent Python, i.e. minimal validation is done, no thus, grouping width is forced neither on decimal nor on hexadecimal.