### PR TITLE
Update vote by proposal Name itself, instead of vote by index.

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -86,7 +86,7 @@ of votes.
                 index = proposals.push(Proposal({
                     name: proposalNames[i],
                     voteCount: 0
-                })) -1 ;
+                })) - 1 ;
 
                 //Store the index of Proposal against 
                 //proposalName as the key.

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -62,6 +62,10 @@ of votes.
         // stores a `Voter` struct for each possible address.
         mapping(address => Voter) public voters;
 
+        //State variable that stores the index of the Proposal
+        //in the proposals array, against the proposalName as the key.
+        mapping(bytes32 => uint) public proposalNameIndex;
+
         // A dynamically-sized array of `Proposal` structs.
         Proposal[] public proposals;
 
@@ -70,6 +74,8 @@ of votes.
             chairperson = msg.sender;
             voters[chairperson].weight = 1;
 
+            uint index = 0;
+
             // For each of the provided proposal names,
             // create a new proposal object and add it
             // to the end of the array.
@@ -77,10 +83,14 @@ of votes.
                 // `Proposal({...})` creates a temporary
                 // Proposal object and `proposals.push(...)`
                 // appends it to the end of `proposals`.
-                proposals.push(Proposal({
+                index = proposals.push(Proposal({
                     name: proposalNames[i],
                     voteCount: 0
-                }));
+                })) -1 ;
+
+                //Store the index of Proposal against 
+                //proposalName as the key.
+                proposalNameIndex[proposalNames[i]] = index;
             }
         }
 
@@ -149,8 +159,9 @@ of votes.
         }
 
         /// Give your vote (including votes delegated to you)
-        /// to proposal `proposals[proposal].name`.
-        function vote(uint proposal) public {
+        /// to proposal `proposalNameIndex[proposalName]`.
+        function vote(bytes32 proposalName) public {
+            uint proposal = proposalNameIndex[proposalName];
             Voter storage sender = voters[msg.sender];
             require(!sender.voted, "Already voted.");
             sender.voted = true;

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -62,8 +62,8 @@ of votes.
         // stores a `Voter` struct for each possible address.
         mapping(address => Voter) public voters;
 
-        //State variable that stores the index of the Proposal
-        //in the proposals array, against the proposalName as the key.
+        // State variable that stores the index of the Proposal
+        // in the proposals array, against the proposalName as the key.
         mapping(bytes32 => uint) public proposalNameIndex;
 
         // A dynamically-sized array of `Proposal` structs.
@@ -88,8 +88,8 @@ of votes.
                     voteCount: 0
                 })) - 1 ;
 
-                //Store the index of Proposal against 
-                //proposalName as the key.
+                // Store the index of Proposal against 
+                // proposalName as the key.
                 proposalNameIndex[proposalNames[i]] = index;
             }
         }

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -85,8 +85,8 @@ of votes.
                 // appends it to the end of `proposals`.
                 // `push` method returns array length after
                 // the element is added to the array.
-                // Hence, the `index` of the element is (length - 1)
-                // as array index begins at `0` based.
+                // As array index begins at `0`, the `index` 
+                // of the element is `length - 1`.
                 index = proposals.push(Proposal({
                     name: proposalNames[i],
                     voteCount: 0

--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -83,6 +83,10 @@ of votes.
                 // `Proposal({...})` creates a temporary
                 // Proposal object and `proposals.push(...)`
                 // appends it to the end of `proposals`.
+                // `push` method returns array length after
+                // the element is added to the array.
+                // Hence, the `index` of the element is (length - 1)
+                // as array index begins at `0` based.
                 index = proposals.push(Proposal({
                     name: proposalNames[i],
                     voteCount: 0


### PR DESCRIPTION
## Given code

The example given expects the caller to provide 'index' of `proposalNames` array defined within the contract.

It is **not possible for the external world** to *know* the `index` of an array stored within a contract. Though the list of `proposalNames` are submitted by a caller who is the `chairperson`, it would be **unuserfriendly** for the `chairperson` to publish the `index` of the `proposalNames` along with the proposal Names. Besides, this will force the voter to *pick and remember the index* of the 'proposal Name' for which one wants to vote. This is **unconventional** and a bit tedious too.

## Proposed Update

A ***better solution*** would be to provide the voter and option to ***vote by proposal Name*** itself, instead of *vote by `index`* to the `proposalNames`.

### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

### Description
Please explain the changes you made here.

Thank you for your help!
