### PR TITLE
Move absolutePath/sanitizePath helpers from CompilerStack to libdevcore

### DIFF
--- a/libdevcore/CommonIO.cpp
+++ b/libdevcore/CommonIO.cpp
@@ -187,3 +187,23 @@ boost::filesystem::path dev::weaklyCanonicalFilesystemPath(boost::filesystem::pa
 		return head / tail;
 	}
 }
+
+string dev::absolutePath(string const& _path, string const& _reference)
+{
+	boost::filesystem::path p(_path);
+	// Anything that does not start with `.` is an absolute path.
+	if (p.begin() == p.end() || (*p.begin() != "." && *p.begin() != ".."))
+		return _path;
+	boost::filesystem::path result(_reference);
+	result.remove_filename();
+	for (boost::filesystem::path::iterator it = p.begin(); it != p.end(); ++it)
+		if (*it == "..")
+			result = result.parent_path();
+		else if (*it != ".")
+			result /= *it;
+	return result.generic_string();
+}
+
+string dev::sanitizePath(string const& _path) {
+	return boost::filesystem::path(_path).generic_string();
+}

--- a/libdevcore/CommonIO.h
+++ b/libdevcore/CommonIO.h
@@ -62,4 +62,10 @@ std::string toString(_T const& _t)
 /// Should be replaced by the boost implementation as soon as support for boost<1.60 can be dropped.
 boost::filesystem::path weaklyCanonicalFilesystemPath(boost::filesystem::path const &_path);
 
+/// @returns the absolute path corresponding to @a _path relative to @a _reference.
+std::string absolutePath(std::string const& _path, std::string const& _reference);
+
+/// Helper function to return path converted strings.
+std::string sanitizePath(std::string const& _path);
+
 }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -583,7 +583,7 @@ StringMap CompilerStack::loadMissingSources(SourceUnit const& _ast, std::string 
 	for (auto const& node: _ast.nodes())
 		if (ImportDirective const* import = dynamic_cast<ImportDirective*>(node.get()))
 		{
-			string importPath = absolutePath(import->path(), _sourcePath);
+			string importPath = dev::absolutePath(import->path(), _sourcePath);
 			// The current value of `path` is the absolute path as seen from this source file.
 			// We first have to apply remappings before we can store the actual absolute path
 			// as seen globally.
@@ -626,8 +626,8 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 
 	for (auto const& redir: m_remappings)
 	{
-		string context = sanitizePath(redir.context);
-		string prefix = sanitizePath(redir.prefix);
+		string context = dev::sanitizePath(redir.context);
+		string prefix = dev::sanitizePath(redir.prefix);
 
 		// Skip if current context is closer
 		if (context.length() < longestContext)
@@ -644,7 +644,7 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 
 		longestContext = context.length();
 		longestPrefix = prefix.length();
-		bestMatchTarget = sanitizePath(redir.target);
+		bestMatchTarget = dev::sanitizePath(redir.target);
 	}
 	string path = bestMatchTarget;
 	path.append(_path.begin() + longestPrefix, _path.end());
@@ -679,23 +679,6 @@ void CompilerStack::resolveImports()
 			toposort(&sourcePair.second);
 
 	swap(m_sourceOrder, sourceOrder);
-}
-
-string CompilerStack::absolutePath(string const& _path, string const& _reference)
-{
-	using path = boost::filesystem::path;
-	path p(_path);
-	// Anything that does not start with `.` is an absolute path.
-	if (p.begin() == p.end() || (*p.begin() != "." && *p.begin() != ".."))
-		return _path;
-	path result(_reference);
-	result.remove_filename();
-	for (path::iterator it = p.begin(); it != p.end(); ++it)
-		if (*it == "..")
-			result = result.parent_path();
-		else if (*it != ".")
-			result /= *it;
-	return result.generic_string();
 }
 
 namespace

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -36,7 +36,6 @@
 #include <json/json.h>
 
 #include <boost/noncopyable.hpp>
-#include <boost/filesystem.hpp>
 
 #include <ostream>
 #include <string>
@@ -273,12 +272,6 @@ private:
 	StringMap loadMissingSources(SourceUnit const& _ast, std::string const& _path);
 	std::string applyRemapping(std::string const& _path, std::string const& _context);
 	void resolveImports();
-
-	/// @returns the absolute path corresponding to @a _path relative to @a _reference.
-	static std::string absolutePath(std::string const& _path, std::string const& _reference);
-
-	/// Helper function to return path converted strings.
-	static std::string sanitizePath(std::string const& _path) { return boost::filesystem::path(_path).generic_string(); }
 
 	/// @returns true if the contract is requested to be compiled.
 	bool isRequestedContract(ContractDefinition const& _contract) const;


### PR DESCRIPTION
The goal is to have filesystem related helpers in libdevcore (as most of them are there) and reduce the size of CompilerStack.