### PR TITLE
Disallow ambiguous implicit and explicit conversions from number literals to bytesXX

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -57,7 +57,9 @@ Breaking Changes:
  * Type Checker: Interface functions must be declared external. This was already the case in the experimental 0.5.0 mode.
  * Type Checker: Address members are not included in contract types anymore. An explicit conversion is now required before invoking an ``address`` member from a contract.
  * Type Checker: Disallow "loose assembly" syntax entirely. This means that jump labels, jumps and non-functional instructions cannot be used anymore.
- * Remove obsolete ``std`` directory from the Solidity repository. This means accessing ``https://github.com/ethereum/solidity/blob/develop/std/*.sol`` (or ``https://github.com/ethereum/solidity/std/*.sol`` in Remix) will not be possible.
+ * Type System: Disallow explicit and implicit conversions from decimal literals to ``bytesXX`` types.
+ * Type System: Disallow explicit and implicit conversions from hex literals to ``bytesXX`` types of different size.
+ * Remove obsolete ``std`` directory from the Solidity repository. This means accessing ``https://github.com/ethereum/soldity/blob/develop/std/*.sol`` (or ``https://github.com/ethereum/solidity/std/*.sol`` in Remix) will not be possible.
  * References Resolver: Turn missing storage locations into an error. This was already the case in the experimental 0.5.0 mode.
  * Syntax Checker: Disallow functions without implementation to use modifiers. This was already the case in the experimental 0.5.0 mode.
  * Syntax Checker: Named return values in function types are an error.

--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -444,7 +444,7 @@ For example,
     pragma solidity >0.4.24;
 
     contract Test {
-      constructor() public { b = 0x12345678901234567890123456789012; }
+      constructor() public { b = hex"12345678901234567890123456789012"; }
       event Event(uint indexed a, bytes32 b);
       event Event2(uint indexed a, bytes32 b);
       function foo(uint a) public { emit Event(a, b); }

--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -114,8 +114,7 @@ This means that cyclic creation dependencies are impossible.
             returns (bool ok)
         {
             // Check some arbitrary condition.
-            address tokenAddress = msg.sender;
-            return (keccak256(abi.encodePacked(newOwner)) & 0xff) == (bytes20(tokenAddress) & 0xff);
+            return currentOwner != newOwner;
         }
     }
 
@@ -811,12 +810,12 @@ as topics. The event call above can be performed in the same way as
 
     contract C {
         function f() public payable {
-            bytes32 _id = 0x420042;
+            uint256 _id = 0x420042;
             log3(
                 bytes32(msg.value),
                 bytes32(0x50cb9fe53daa9737b786ab3646f04d0150dc50ef4e75f59509d83667ad5adb20),
                 bytes32(uint256(msg.sender)),
-                _id
+                bytes32(_id)
             );
         }
     }

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -773,7 +773,7 @@ Members
             // but can be treated identical to "uint8[]"
             m_byteData = data;
             m_byteData.length += 7;
-            m_byteData[3] = byte(8);
+            m_byteData[3] = 0x08;
             delete m_byteData[2];
         }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2348,22 +2348,6 @@ void TypeChecker::expectType(Expression const& _expression, Type const& _expecte
 				"."
 			);
 	}
-
-	if (
-		type(_expression)->category() == Type::Category::RationalNumber &&
-		_expectedType.category() == Type::Category::FixedBytes
-	)
-	{
-		auto literal = dynamic_cast<Literal const*>(&_expression);
-
-		if (literal && !literal->isHexNumber())
-			m_errorReporter.warning(
-				_expression.location(),
-				"Decimal literal assigned to bytesXX variable will be left-aligned. "
-				"Use an explicit conversion to silence this warning."
-			);
-	}
-
 }
 
 void TypeChecker::requireLValue(Expression const& _expression)

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -423,12 +423,12 @@ public:
 
 	virtual Category category() const override { return Category::RationalNumber; }
 
-	/// @returns true if the literal is a valid integer.
-	static std::tuple<bool, rational> isValidLiteral(Literal const& _literal);
+	static TypePointer forLiteral(Literal const& _literal);
 
-	explicit RationalNumberType(rational const& _value):
-		m_value(_value)
+	explicit RationalNumberType(rational const& _value, TypePointer const& _compatibleBytesType = TypePointer()):
+		m_value(_value), m_compatibleBytesType(_compatibleBytesType)
 	{}
+
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
@@ -461,6 +461,13 @@ public:
 
 private:
 	rational m_value;
+
+	/// Bytes type to which the rational can be explicitly converted.
+	/// Empty for all rationals that are not directly parsed from hex literals.
+	TypePointer m_compatibleBytesType;
+
+	/// @returns true if the literal is a valid integer.
+	static std::tuple<bool, rational> isValidLiteral(Literal const& _literal);
 
 	/// @returns true if the literal is a valid rational number.
 	static std::tuple<bool, rational> parseRational(std::string const& _value);

--- a/test/compilationTests/stringutils/strings.sol
+++ b/test/compilationTests/stringutils/strings.sol
@@ -83,23 +83,23 @@ library strings {
         uint ret;
         if (self == 0)
             return 0;
-        if (self & 0xffffffffffffffffffffffffffffffff == 0) {
+        if (uint256(self) & 0xffffffffffffffffffffffffffffffff == 0) {
             ret += 16;
             self = bytes32(uint(self) / 0x100000000000000000000000000000000);
         }
-        if (self & 0xffffffffffffffff == 0) {
+        if (uint256(self) & 0xffffffffffffffff == 0) {
             ret += 8;
             self = bytes32(uint(self) / 0x10000000000000000);
         }
-        if (self & 0xffffffff == 0) {
+        if (uint256(self) & 0xffffffff == 0) {
             ret += 4;
             self = bytes32(uint(self) / 0x100000000);
         }
-        if (self & 0xffff == 0) {
+        if (uint256(self) & 0xffff == 0) {
             ret += 2;
             self = bytes32(uint(self) / 0x10000);
         }
-        if (self & 0xff == 0) {
+        if (uint256(self) & 0xff == 0) {
             ret += 1;
         }
         return 32 - ret;

--- a/test/libsolidity/ABIDecoderTests.cpp
+++ b/test/libsolidity/ABIDecoderTests.cpp
@@ -792,8 +792,8 @@ BOOST_AUTO_TEST_CASE(return_dynamic_types_cross_call_advanced)
 				a = "1234567890123456789012345678901234567890";
 				b = uint(-1);
 				c = new bytes20[](4);
-				c[0] = bytes20(1234);
-				c[3] = bytes20(6789);
+				c[0] = bytes20(uint160(1234));
+				c[3] = bytes20(uint160(6789));
 				d = 0x1234;
 			}
 			function f() public returns (bytes memory, uint, bytes20[] memory, uint) {

--- a/test/libsolidity/ABIEncoderTests.cpp
+++ b/test/libsolidity/ABIEncoderTests.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(conversion)
 				int8 c;
 				int16 d;
 				assembly { a := sub(0, 1) c := 0x0101ff d := 0xff01 }
-				emit E(10, x, a, uint8(b), c, int8(d));
+				emit E(bytes4(uint32(10)), x, a, uint8(b), c, int8(d));
 			}
 		}
 	)";

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(non_overlapping_filtered_costs)
 			function f(uint a) public returns (uint b) {
 				x.length = a;
 				for (; a < 200; ++a) {
-					x[a] = 9;
+					x[a] = 0x09;
 					b = a * a;
 				}
 				return f(a - 1);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2211,7 +2211,7 @@ BOOST_AUTO_TEST_CASE(log0)
 	char const* sourceCode = R"(
 		contract test {
 			function a() public {
-				log0(1);
+				log0(bytes32(uint256(1)));
 			}
 		}
 	)";
@@ -2228,7 +2228,7 @@ BOOST_AUTO_TEST_CASE(log1)
 	char const* sourceCode = R"(
 		contract test {
 			function a() public {
-				log1(1, 2);
+				log1(bytes32(uint256(1)), bytes32(uint256(2)));
 			}
 		}
 	)";
@@ -2246,7 +2246,7 @@ BOOST_AUTO_TEST_CASE(log2)
 	char const* sourceCode = R"(
 		contract test {
 			function a() public {
-				log2(1, 2, 3);
+				log2(bytes32(uint256(1)), bytes32(uint256(2)), bytes32(uint256(3)));
 			}
 		}
 	)";
@@ -2265,7 +2265,7 @@ BOOST_AUTO_TEST_CASE(log3)
 	char const* sourceCode = R"(
 		contract test {
 			function a() public {
-				log3(1, 2, 3, 4);
+				log3(bytes32(uint256(1)), bytes32(uint256(2)), bytes32(uint256(3)), bytes32(uint256(4)));
 			}
 		}
 	)";
@@ -2284,7 +2284,7 @@ BOOST_AUTO_TEST_CASE(log4)
 	char const* sourceCode = R"(
 		contract test {
 			function a() public {
-				log4(1, 2, 3, 4, 5);
+				log4(bytes32(uint256(1)), bytes32(uint256(2)), bytes32(uint256(3)), bytes32(uint256(4)), bytes32(uint256(5)));
 			}
 		}
 	)";
@@ -2303,7 +2303,7 @@ BOOST_AUTO_TEST_CASE(log_in_constructor)
 	char const* sourceCode = R"(
 		contract test {
 			constructor() public {
-				log1(1, 2);
+				log1(bytes32(uint256(1)), bytes32(uint256(2)));
 			}
 		}
 	)";
@@ -5017,7 +5017,7 @@ BOOST_AUTO_TEST_CASE(array_copy_target_simple)
 			function test() public returns (bytes17 a, bytes17 b, bytes17 c, bytes17 d, bytes17 e) {
 				for (uint i = 0; i < data1.length; ++i)
 					data1[i] = bytes8(uint64(i));
-				data2[8] = data2[9] = 2;
+				data2[8] = data2[9] = bytes8(uint64(2));
 				data2 = data1;
 				a = data2[1];
 				b = data2[2];
@@ -5076,10 +5076,10 @@ BOOST_AUTO_TEST_CASE(array_copy_target_leftover2)
 			bytes8[4] data1; // fits into one slot
 			bytes10[6] data2; // 4 elements need two slots
 			function test() public returns (bytes10 r1, bytes10 r2, bytes10 r3) {
-				data1[0] = 1;
-				data1[1] = 2;
-				data1[2] = 3;
-				data1[3] = 4;
+				data1[0] = bytes8(uint64(1));
+				data1[1] = bytes8(uint64(2));
+				data1[2] = bytes8(uint64(3));
+				data1[3] = bytes8(uint64(4));
 				for (uint i = 0; i < data2.length; ++i)
 					data2[i] = bytes10(uint80(0xffff00 | (1 + i)));
 				data2 = data1;
@@ -5274,13 +5274,13 @@ BOOST_AUTO_TEST_CASE(byte_array_push)
 		contract c {
 			bytes data;
 			function test() public returns (bool x) {
-				if (data.push(5) != 1)  return true;
-				if (data[0] != 5) return true;
-				data.push(4);
-				if (data[1] != 4) return true;
-				uint l = data.push(3);
-				if (data[2] != 3) return true;
-				if (l != 3) return true;
+				if (data.push(0x05) != 1)  return true;
+				if (data[0] != 0x05) return true;
+				data.push(0x04);
+				if (data[1] != 0x04) return true;
+				uint l = data.push(0x03);
+				if (data[2] != 0x03) return true;
+				if (l != 0x03) return true;
 			}
 		}
 	)";
@@ -5453,11 +5453,11 @@ BOOST_AUTO_TEST_CASE(byte_array_pop)
 		contract c {
 			bytes data;
 			function test() public returns (uint x, uint y, uint l) {
-				data.push(7);
-				x = data.push(3);
+				data.push(0x07);
+				x = data.push(0x03);
 				data.pop();
 				data.pop();
-				y = data.push(2);
+				y = data.push(0x02);
 				l = data.length;
 			}
 		}
@@ -5490,9 +5490,9 @@ BOOST_AUTO_TEST_CASE(byte_array_pop_storage_empty)
 		contract c {
 			bytes data;
 			function test() public {
-				data.push(7);
-				data.push(5);
-				data.push(3);
+				data.push(0x07);
+				data.push(0x05);
+				data.push(0x03);
 				data.pop();
 				data.pop();
 				data.pop();
@@ -5538,7 +5538,7 @@ BOOST_AUTO_TEST_CASE(byte_array_pop_long_storage_empty_garbage_ref)
 			bytes data;
 			function test() public {
 				for (uint8 i = 0; i <= 40; i++)
-					data.push(3);
+					data.push(0x03);
 				for (uint8 j = 0; j <= 40; j++) {
 					assembly {
 						mstore(0, "garbage")
@@ -5560,7 +5560,7 @@ BOOST_AUTO_TEST_CASE(byte_array_pop_masking_long)
 			bytes data;
 			function test() public returns (bytes memory) {
 				for (uint i = 0; i < 34; i++)
-					data.push(3);
+					data.push(0x03);
 				data.pop();
 				return data;
 			}
@@ -5582,7 +5582,7 @@ BOOST_AUTO_TEST_CASE(byte_array_pop_copy_long)
 			bytes data;
 			function test() public returns (bytes memory) {
 				for (uint i = 0; i < 33; i++)
-					data.push(3);
+					data.push(0x03);
 				for (uint j = 0; j < 4; j++)
 					data.pop();
 				return data;
@@ -5672,10 +5672,10 @@ BOOST_AUTO_TEST_CASE(bytes_index_access)
 				data[31] = 0x77;
 				data[32] = 0x14;
 
-				data[31] = 1;
-				data[31] |= 8;
-				data[30] = 1;
-				data[32] = 3;
+				data[31] = 0x01;
+				data[31] |= 0x08;
+				data[30] = 0x01;
+				data[32] = 0x03;
 				return uint(uint8(data[30])) * 0x100 | uint(uint8(data[31])) * 0x10 | uint(uint8(data[32]));
 			}
 		}
@@ -5703,7 +5703,7 @@ BOOST_AUTO_TEST_CASE(bytes_delete_element)
 				delete data[94];
 				delete data[96];
 				delete data[98];
-				return data[94] == 0 && data[95] == 95 && data[96] == 0 && data[97] == 97;
+				return data[94] == 0 && uint8(data[95]) == 95 && data[96] == 0 && uint8(data[97]) == 97;
 			}
 		}
 	)";
@@ -6060,19 +6060,19 @@ BOOST_AUTO_TEST_CASE(packed_storage_structs_bytes)
 			s2 data;
 			byte y;
 			function test() public returns (bool) {
-				x = 1;
-				data.a = 2;
-				data.inner.a = 3;
-				data.inner.b = 4;
+				x = 0x01;
+				data.a = 0x02;
+				data.inner.a = 0x03;
+				data.inner.b = 0x04;
 				data.inner.c = "1234567890";
 				data.inner.d = "123456789";
 				data.inner.e = "abcdefghij";
-				data.b = 5;
-				data.c = 6;
-				y = 7;
-				return x == 1 && data.a == 2 && data.inner.a == 3 && data.inner.b == 4 &&
+				data.b = 0x05;
+				data.c = byte(0x06);
+				y = 0x07;
+				return x == 0x01 && data.a == 0x02 && data.inner.a == 0x03 && data.inner.b == 0x04 &&
 					data.inner.c == "1234567890" && data.inner.d == "123456789" &&
-					data.inner.e == "abcdefghij" && data.b == 5 && data.c == 6 && y == 7;
+					data.inner.e == "abcdefghij" && data.b == 0x05 && data.c == byte(0x06) && y == 0x07;
 			}
 		}
 	)";
@@ -8062,17 +8062,17 @@ BOOST_AUTO_TEST_CASE(short_strings)
 				if (data1[4] != "4") return 11;
 				for (uint i = 0; i < data1.length; i ++)
 					data1[i] = byte(uint8(i * 3));
-				if (data1[4] != 4 * 3) return 12;
-				if (data1[67] != 67 * 3) return 13;
+				if (uint8(data1[4]) != 4 * 3) return 12;
+				if (uint8(data1[67]) != 67 * 3) return 13;
 				// change length: long -> short
 				data1.length = 22;
 				if (data1.length != 22) return 14;
-				if (data1[21] != byte(21 * 3)) return 15;
-				if (data1[2] != 2 * 3) return 16;
+				if (uint8(data1[21]) != 21 * 3) return 15;
+				if (uint8(data1[2]) != 2 * 3) return 16;
 				// change length: short -> shorter
 				data1.length = 19;
 				if (data1.length != 19) return 17;
-				if (data1[7] != byte(7 * 3)) return 18;
+				if (uint8(data1[7]) != 7 * 3) return 18;
 				// and now again to original size
 				data1.length = 22;
 				if (data1.length != 22) return 19;
@@ -8888,7 +8888,7 @@ BOOST_AUTO_TEST_CASE(fixed_bytes_length_access)
 		contract C {
 			byte a;
 			function f(bytes32 x) public returns (uint, uint, uint) {
-				return (x.length, bytes16(2).length, a.length + 7);
+				return (x.length, bytes16(uint128(2)).length, a.length + 7);
 			}
 		}
 	)";
@@ -9383,9 +9383,9 @@ BOOST_AUTO_TEST_CASE(iszero_bnot_correct)
 	char const* sourceCode = R"(
 		contract C {
 			function f() public returns (bool) {
-				bytes32 x = 1;
+				bytes32 x = bytes32(uint256(1));
 				assembly { x := not(x) }
-				if (x != ~bytes32(1)) return false;
+				if (x != ~bytes32(uint256(1))) return false;
 				assembly { x := iszero(x) }
 				if (x != bytes32(0)) return false;
 				return true;
@@ -9404,7 +9404,7 @@ BOOST_AUTO_TEST_CASE(cleanup_bytes_types)
 			function f(bytes2 a, uint16 x) public returns (uint) {
 				if (a != "ab") return 1;
 				if (x != 0x0102) return 2;
-				if (bytes3(uint24(x)) != 0x0102) return 3;
+				if (bytes3(uint24(x)) != 0x000102) return 3;
 				return 0;
 			}
 		}
@@ -9736,7 +9736,7 @@ BOOST_AUTO_TEST_CASE(failing_ecrecover_invalid_input)
 	char const* sourceCode = R"(
 		contract C {
 			function f() public returns (address) {
-				return ecrecover(bytes32(uint(-1)), 1, 2, 3);
+				return ecrecover(bytes32(uint(-1)), 1, bytes32(uint(2)), bytes32(uint(3)));
 			}
 		}
 	)";
@@ -9754,8 +9754,8 @@ BOOST_AUTO_TEST_CASE(failing_ecrecover_invalid_input_proper)
 					0, // invalid v value
 					0x6944c77849b18048f6abe0db8084b0d0d0689cdddb53d2671c36967b58691ad4,
 					0xef4f06ba4f78319baafd0424365777241af4dfd3da840471b4b4b087b7750d0d,
-					0x00ca35b7d915458ef540ade6068dfe2f44e8fa733c,
-					0x00ca35b7d915458ef540ade6068dfe2f44e8fa733c
+					0x000000000000000000000000ca35b7d915458ef540ade6068dfe2f44e8fa733c,
+					0x000000000000000000000000ca35b7d915458ef540ade6068dfe2f44e8fa733c
 				);
 			}
 			function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s, uint blockExpired, bytes32 salt)

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/161_warns_assigning_decimal_to_bytesxx.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/161_warns_assigning_decimal_to_bytesxx.sol
@@ -1,5 +1,0 @@
-contract Foo {
-    bytes32 a = 7;
-}
-// ----
-// Warning: (31-32): Decimal literal assigned to bytesXX variable will be left-aligned. Use an explicit conversion to silence this warning.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/162_does_not_warn_assigning_hex_number_to_bytesxx.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/162_does_not_warn_assigning_hex_number_to_bytesxx.sol
@@ -1,3 +1,0 @@
-contract Foo {
-    bytes32 a = 0x1234;
-}

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/163_explicit_conversion_from_decimal_to_bytesxx.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/163_explicit_conversion_from_decimal_to_bytesxx.sol
@@ -1,3 +1,0 @@
-contract Foo {
-    bytes32 a = bytes32(7);
-}

--- a/test/libsolidity/syntaxTests/types/bytesm.sol
+++ b/test/libsolidity/syntaxTests/types/bytesm.sol
@@ -1,5 +1,5 @@
 contract C {
-  byte b = byte(1);
+  byte b = byte(0x01);
   bytes1 b1 = b;
   bytes2 b2 = b1;
   bytes3 b3 = b2;

--- a/test/libsolidity/syntaxTests/types/decimal_literal_to_bytesXX_explicit.sol
+++ b/test/libsolidity/syntaxTests/types/decimal_literal_to_bytesXX_explicit.sol
@@ -1,0 +1,23 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = bytes1(1);
+     bytes2 b2 = bytes2(1);
+     bytes2 b3 = bytes2(256);
+     bytes3 b4 = bytes3(1);
+     bytes3 b5 = bytes3(65536);
+     bytes4 b6 = bytes4(1);
+     bytes4 b7 = bytes4(16777216);
+     bytes16 b8 = bytes16(1);
+     bytes32 b9 = bytes32(1);
+   }
+}
+// ----
+// TypeError: (60-69): Explicit type conversion not allowed from "int_const 1" to "bytes1".
+// TypeError: (88-97): Explicit type conversion not allowed from "int_const 1" to "bytes2".
+// TypeError: (116-127): Explicit type conversion not allowed from "int_const 256" to "bytes2".
+// TypeError: (146-155): Explicit type conversion not allowed from "int_const 1" to "bytes3".
+// TypeError: (174-187): Explicit type conversion not allowed from "int_const 65536" to "bytes3".
+// TypeError: (206-215): Explicit type conversion not allowed from "int_const 1" to "bytes4".
+// TypeError: (234-250): Explicit type conversion not allowed from "int_const 16777216" to "bytes4".
+// TypeError: (270-280): Explicit type conversion not allowed from "int_const 1" to "bytes16".
+// TypeError: (300-310): Explicit type conversion not allowed from "int_const 1" to "bytes32".

--- a/test/libsolidity/syntaxTests/types/decimal_literal_to_bytesXX_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/decimal_literal_to_bytesXX_implicit.sol
@@ -1,0 +1,23 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = 1;
+     bytes2 b2 = 1;
+     bytes2 b3 = 256;
+     bytes3 b4 = 1;
+     bytes3 b5 = 65536;
+     bytes4 b6 = 1;
+     bytes4 b7 = 16777216;
+     bytes16 b8 = 1;
+     bytes32 b9 = 1;
+   }
+}
+// ----
+// TypeError: (48-61): Type int_const 1 is not implicitly convertible to expected type bytes1.
+// TypeError: (68-81): Type int_const 1 is not implicitly convertible to expected type bytes2.
+// TypeError: (88-103): Type int_const 256 is not implicitly convertible to expected type bytes2.
+// TypeError: (110-123): Type int_const 1 is not implicitly convertible to expected type bytes3.
+// TypeError: (130-147): Type int_const 65536 is not implicitly convertible to expected type bytes3.
+// TypeError: (154-167): Type int_const 1 is not implicitly convertible to expected type bytes4.
+// TypeError: (174-194): Type int_const 16777216 is not implicitly convertible to expected type bytes4.
+// TypeError: (201-215): Type int_const 1 is not implicitly convertible to expected type bytes16.
+// TypeError: (222-236): Type int_const 1 is not implicitly convertible to expected type bytes32.

--- a/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_different_size_explicit.sol
+++ b/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_different_size_explicit.sol
@@ -1,0 +1,31 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = bytes1(0x1);
+     bytes1 b2 = bytes1(0x100);
+     bytes2 b3 = bytes2(0xFF);
+     bytes2 b4 = bytes2(0x100);
+     bytes2 b5 = bytes2(0x10000);
+     bytes3 b6 = bytes3(0xFFFF);
+     bytes3 b7 = bytes3(0x10000);
+     bytes3 b8 = bytes3(0x1000000);
+     bytes4 b9 = bytes4(0xFFFFFF);
+     bytes4 b10 = bytes4(0x1000000);
+     bytes4 b11 = bytes4(0x100000000);
+     bytes16 b12 = bytes16(0x1);
+     bytes32 b13 = bytes32(0x1);
+   }
+}
+// ----
+// TypeError: (60-71): Explicit type conversion not allowed from "int_const 1" to "bytes1".
+// TypeError: (90-103): Explicit type conversion not allowed from "int_const 256" to "bytes1".
+// TypeError: (122-134): Explicit type conversion not allowed from "int_const 255" to "bytes2".
+// TypeError: (153-166): Explicit type conversion not allowed from "int_const 256" to "bytes2".
+// TypeError: (185-200): Explicit type conversion not allowed from "int_const 65536" to "bytes2".
+// TypeError: (219-233): Explicit type conversion not allowed from "int_const 65535" to "bytes3".
+// TypeError: (252-267): Explicit type conversion not allowed from "int_const 65536" to "bytes3".
+// TypeError: (286-303): Explicit type conversion not allowed from "int_const 16777216" to "bytes3".
+// TypeError: (322-338): Explicit type conversion not allowed from "int_const 16777215" to "bytes4".
+// TypeError: (358-375): Explicit type conversion not allowed from "int_const 16777216" to "bytes4".
+// TypeError: (395-414): Explicit type conversion not allowed from "int_const 4294967296" to "bytes4".
+// TypeError: (435-447): Explicit type conversion not allowed from "int_const 1" to "bytes16".
+// TypeError: (468-480): Explicit type conversion not allowed from "int_const 1" to "bytes32".

--- a/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_different_size_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_different_size_implicit.sol
@@ -1,0 +1,31 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = 0x1;
+     bytes1 b2 = 0x100;
+     bytes2 b3 = 0xFF;
+     bytes2 b4 = 0x100;
+     bytes2 b5 = 0x10000;
+     bytes3 b6 = 0xFFFF;
+     bytes3 b7 = 0x10000;
+     bytes3 b8 = 0x1000000;
+     bytes4 b9 = 0xFFFFFF;
+     bytes4 b10 = 0x1000000;
+     bytes4 b11 = 0x100000000;
+     bytes16 b12 = 0x1;
+     bytes32 b13 = 0x1;
+   }
+}
+// ----
+// TypeError: (48-63): Type int_const 1 is not implicitly convertible to expected type bytes1.
+// TypeError: (70-87): Type int_const 256 is not implicitly convertible to expected type bytes1.
+// TypeError: (94-110): Type int_const 255 is not implicitly convertible to expected type bytes2.
+// TypeError: (117-134): Type int_const 256 is not implicitly convertible to expected type bytes2.
+// TypeError: (141-160): Type int_const 65536 is not implicitly convertible to expected type bytes2.
+// TypeError: (167-185): Type int_const 65535 is not implicitly convertible to expected type bytes3.
+// TypeError: (192-211): Type int_const 65536 is not implicitly convertible to expected type bytes3.
+// TypeError: (218-239): Type int_const 16777216 is not implicitly convertible to expected type bytes3.
+// TypeError: (246-266): Type int_const 16777215 is not implicitly convertible to expected type bytes4.
+// TypeError: (273-295): Type int_const 16777216 is not implicitly convertible to expected type bytes4.
+// TypeError: (302-326): Type int_const 4294967296 is not implicitly convertible to expected type bytes4.
+// TypeError: (333-350): Type int_const 1 is not implicitly convertible to expected type bytes16.
+// TypeError: (357-374): Type int_const 1 is not implicitly convertible to expected type bytes32.

--- a/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_same_size_explicit.sol
+++ b/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_same_size_explicit.sol
@@ -1,0 +1,13 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = bytes1(0x01);
+     bytes1 b2 = bytes1(0xFF);
+     bytes2 b3 = bytes2(0x0100);
+     bytes2 b4 = bytes2(0xFFFF);
+     bytes3 b5 = bytes3(0x010000);
+     bytes3 b6 = bytes3(0xFFFFFF);
+     bytes4 b7 = bytes4(0x01000000);
+     bytes4 b8 = bytes4(0xFFFFFFFF);
+     b1; b2; b3; b4; b5; b6; b7; b8;
+   }
+}

--- a/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_same_size_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/hex_literal_to_bytesXX_same_size_implicit.sol
@@ -1,0 +1,13 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = 0x01;
+     bytes1 b2 = 0xFF;
+     bytes2 b3 = 0x0100;
+     bytes2 b4 = 0xFFFF;
+     bytes3 b5 = 0x010000;
+     bytes3 b6 = 0xFFFFFF;
+     bytes4 b7 = 0x01000000;
+     bytes4 b8 = 0xFFFFFFFF;
+     b1; b2; b3; b4; b5; b6; b7; b8;
+   }
+}

--- a/test/libsolidity/syntaxTests/types/zero_literal_to_bytesXX_explicit.sol
+++ b/test/libsolidity/syntaxTests/types/zero_literal_to_bytesXX_explicit.sol
@@ -1,0 +1,30 @@
+contract C {
+    function f() public pure {
+      bytes1 b1 = bytes1(0);
+      bytes2 b2 = bytes2(0);
+      bytes3 b3 = bytes3(0);
+      bytes4 b4 = bytes4(0);
+      bytes8 b8 = bytes8(0);
+      bytes16 b16 = bytes16(0);
+      bytes32 b32 = bytes32(0);
+      b1; b2; b3; b4; b8; b16; b32;
+    }
+    function g() public pure {
+      bytes1 b1 = bytes1(0x000);
+      bytes2 b2 = bytes2(0x00000);
+      bytes3 b3 = bytes3(0x0000000);
+      bytes4 b4 = bytes4(0x000000000);
+      bytes8 b8 = bytes8(0x00000000000000000);
+      b1; b2; b3; b4; b8;
+    }
+    function h() public pure {
+      bytes1 b1 = bytes1(0x0);
+      bytes2 b2 = bytes2(0x0);
+      bytes3 b3 = bytes3(0x0);
+      bytes4 b4 = bytes4(0x0);
+      bytes8 b8 = bytes8(0x0);
+      bytes16 b16 = bytes16(0x0);
+      bytes32 b32 = bytes32(0x0);
+      b1; b2; b3; b4; b8; b16; b32;
+    }
+}

--- a/test/libsolidity/syntaxTests/types/zero_literal_to_bytesXX_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/zero_literal_to_bytesXX_implicit.sol
@@ -1,0 +1,30 @@
+contract C {
+    function f() public pure {
+      bytes1 b1 = 0;
+      bytes2 b2 = 0;
+      bytes3 b3 = 0;
+      bytes4 b4 = 0;
+      bytes8 b8 = 0;
+      bytes16 b16 = 0;
+      bytes32 b32 = 0;
+      b1; b2; b3; b4; b8; b16; b32;
+    }
+    function g() public pure {
+      bytes1 b1 = 0x000;
+      bytes2 b2 = 0x00000;
+      bytes3 b3 = 0x0000000;
+      bytes4 b4 = 0x000000000;
+      bytes8 b8 = 0x00000000000000000;
+      b1; b2; b3; b4; b8;
+    }
+    function h() public pure {
+      bytes1 b1 = 0x0;
+      bytes2 b2 = 0x0;
+      bytes3 b3 = 0x0;
+      bytes4 b4 = 0x0;
+      bytes8 b8 = 0x0;
+      bytes16 b16 = 0x0;
+      bytes32 b32 = 0x0;
+      b1; b2; b3; b4; b8; b16; b32;
+    }
+}

--- a/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions.sol
@@ -9,7 +9,7 @@ contract C {
     function g() pure public {
         bytes32 x = keccak256("abc");
         bytes32 y = sha256("abc");
-        address z = ecrecover(bytes32(1), uint8(2), bytes32(3), bytes32(4));
+        address z = ecrecover(bytes32(uint256(1)), uint8(2), bytes32(uint256(3)), bytes32(uint256(4)));
         require(true);
         assert(true);
         x; y; z;

--- a/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions_restrict_warning.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions_restrict_warning.sol
@@ -2,7 +2,7 @@ contract C {
     function f() view public {
         bytes32 x = keccak256("abc");
         bytes32 y = sha256("abc");
-        address z = ecrecover(bytes32(1), uint8(2), bytes32(3), bytes32(4));
+        address z = ecrecover(bytes32(uint256(1)), uint8(2), bytes32(uint256(3)), bytes32(uint256(4)));
         require(true);
         assert(true);
         x; y; z;
@@ -10,12 +10,12 @@ contract C {
     function g() public {
         bytes32 x = keccak256("abc");
         bytes32 y = sha256("abc");
-        address z = ecrecover(bytes32(1), uint8(2), bytes32(3), bytes32(4));
+        address z = ecrecover(bytes32(uint256(1)), uint8(2), bytes32(uint256(3)), bytes32(uint256(4)));
         require(true);
         assert(true);
         x; y; z;
     }
 }
 // ----
-// Warning: (17-261): Function state mutability can be restricted to pure
-// Warning: (266-505): Function state mutability can be restricted to pure
+// Warning: (17-288): Function state mutability can be restricted to pure
+// Warning: (293-559): Function state mutability can be restricted to pure


### PR DESCRIPTION
Fixes #3942. Closes #3899.

I considered restricting string literals and hex string literals as well, but dropped the idea, so this is just about decimal and hex number literals.

The reasoning is the following:
  - hex"01234" and "abc" are implicitly of fixed bytes type and as thus can still be converted to longer bytes types.
  - However, hex"01234" and "abc" are not directly explicitly convertible to (u)intXX types, but only through an explicit conversion to a sized bytes type.

This above was already the case and is not changed in this PR.

Changes in this PR:
  - decimal numbers 1234 are implicitly integers and can only be explicitly converted to bytes types through an explicit conversion to a sized integer type.
  - hex numbers 0x1234 are implicitly integers as well, but they *can* be explicitly converted to bytes types directly, *if* they have a matching number of digits (and therefore padding is clear).
  - As an exception both decimal and hex literals with value zero can be explicitly converted to any bytes type.

That's the most consistent concept I have come up with so far.

Probably the external tests will have to be adjusted.