### PR TITLE
solc: Fixes double-quoting path names on stderr.

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -416,11 +416,11 @@ bool CommandLineInterface::readInputFilesAndConfigureRemappings()
 				{
 					if (!ignoreMissing)
 					{
-						cerr << "\"" << infile << "\" is not found" << endl;
+						cerr << infile << " is not found." << endl;
 						return false;
 					}
 					else
-						cerr << "\"" << infile << "\" is not found. Skipping." << endl;
+						cerr << infile << " is not found. Skipping." << endl;
 
 					continue;
 				}
@@ -429,11 +429,11 @@ bool CommandLineInterface::readInputFilesAndConfigureRemappings()
 				{
 					if (!ignoreMissing)
 					{
-						cerr << "\"" << infile << "\" is not a valid file" << endl;
+						cerr << infile << " is not a valid file." << endl;
 						return false;
 					}
 					else
-						cerr << "\"" << infile << "\" is not a valid file. Skipping." << endl;
+						cerr << infile << " is not a valid file. Skipping." << endl;
 
 					continue;
 				}


### PR DESCRIPTION
Before it was possible to get a failure message, such as:

    ""notfound.sol"" is not found

whereas it should be:

    "notfound.sol" is not found.
