### PR TITLE
Update the coverage info message in cmake

### DIFF
--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -2,7 +2,7 @@ macro(configure_project)
 	set(NAME ${PROJECT_NAME})
 
 	# features
-	eth_default_option(PROFILING OFF)
+	eth_default_option(COVERAGE OFF)
 
 	# components
 	eth_default_option(TESTS ON)
@@ -27,7 +27,7 @@ macro(print_config NAME)
 	message("-- CMAKE_BUILD_TYPE Build type                               ${CMAKE_BUILD_TYPE}")
 	message("-- TARGET_PLATFORM  Target platform                          ${CMAKE_SYSTEM_NAME}")
 	message("--------------------------------------------------------------- features")
-	message("-- PROFILING        Profiling support                        ${PROFILING}")
+	message("-- COVERAGE         Coverage support                         ${COVERAGE}")
 	message("------------------------------------------------------------- components")
 if (SUPPORT_TESTS)
 	message("-- TESTS            Build tests                              ${TESTS}")


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

The PROFILING option was replaced with the COVERAGE option. This updates the cmake info message.

Missed in #4544.