### PR TITLE
 Properly handle invalid references used together with _slot and _offset.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -83,6 +83,7 @@ Bugfixes:
  * Fix NatSpec json output for `@notice` and `@dev` tags on contract definitions.
  * References Resolver: Do not crash on using ``_slot`` and ``_offset`` suffixes on their own.
  * References Resolver: Enforce ``storage`` as data location for mappings.
+ * References Resolver: Properly handle invalid references used together with ``_slot`` and ``_offset``.
  * References Resolver: Report error instead of assertion fail when FunctionType has an undeclared type as parameter.
  * Type Checker: Disallow assignments to mappings within tuple assignments as well.
  * Type Checker: Allow assignments to local variables of mapping types.

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -262,8 +262,6 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 				return size_t(-1);
 			}
 			declarations = m_resolver.nameFromCurrentScope(realName);
-			if (!dynamic_cast<VariableDeclaration const*>(declarations.front()))
-				return size_t(-1);
 		}
 		if (declarations.size() != 1)
 			return size_t(-1);

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -262,6 +262,8 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 				return size_t(-1);
 			}
 			declarations = m_resolver.nameFromCurrentScope(realName);
+			if (!dynamic_cast<VariableDeclaration const*>(declarations.front()))
+				return size_t(-1);
 		}
 		if (declarations.size() != 1)
 			return size_t(-1);

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() pure public {
+        assembly {
+            let x := f_slot
+        }
+    }
+}
+// ----
+// DeclarationError: (84-90): Identifier not found.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// DeclarationError: (84-90): Identifier not found.
+// TypeError: (84-90): The suffixes _offset and _slot can only be used on storage variables.


### PR DESCRIPTION
Fixes #4710.