### PR TITLE
Assert that type identifier contains only valid characters

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -108,7 +108,7 @@ Grammar::
         'break' | 'continue'
     FunctionCall =
         Identifier '(' ( Expression ( ',' Expression )* )? ')'
-    Identifier = [a-zA-Z_$] [a-zA-Z_0-9]*
+    Identifier = [a-zA-Z_$] [a-zA-Z_$0-9]*
     IdentifierList = Identifier ( ',' Identifier)*
     TypeName = Identifier | BuiltinTypeName
     BuiltinTypeName = 'bool' | [us] ( '8' | '32' | '64' | '128' | '256' )

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -254,6 +254,17 @@ string Type::escapeIdentifier(string const& _identifier)
 	return ret;
 }
 
+string Type::identifier() const
+{
+	string ret = escapeIdentifier(richIdentifier());
+	solAssert(ret.find_first_of("0123456789") != 0, "Identifier cannot start with a number.");
+	solAssert(
+		ret.find_first_not_of("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMONPQRSTUVWXYZ_$") == string::npos,
+		"Identifier contains invalid characters."
+	);
+	return ret;
+}
+
 TypePointer Type::fromElementaryTypeName(ElementaryTypeNameToken const& _type)
 {
 	solAssert(Token::isElementaryTypeName(_type.token()),

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -172,7 +172,7 @@ public:
 	/// only if they have the same identifier.
 	/// The identifier should start with "t_".
 	/// Will not contain any character which would be invalid as an identifier.
-	std::string identifier() const { return escapeIdentifier(richIdentifier()); }
+	std::string identifier() const;
 
 	/// More complex identifier strings use "parentheses", where $_ is interpreted as as
 	/// "opening parenthesis", _$ as "closing parenthesis", _$_ as "comma" and any $ that


### PR DESCRIPTION
Fixes #4732.