### PR TITLE
Replace boost:lexical_cast<std::string> for std::to_string.

### DIFF
--- a/libdevcore/Exceptions.cpp
+++ b/libdevcore/Exceptions.cpp
@@ -43,7 +43,7 @@ string Exception::lineInfo() const
 		ret += *file;
 	ret += ':';
 	if (line)
-		ret += boost::lexical_cast<string>(*line);
+		ret += std::to_string(*line);
 	return ret;
 }
 

--- a/libdevcore/Exceptions.cpp
+++ b/libdevcore/Exceptions.cpp
@@ -17,8 +17,6 @@
 
 #include <libdevcore/Exceptions.h>
 
-#include <boost/lexical_cast.hpp>
-
 using namespace std;
 using namespace dev;
 
@@ -43,7 +41,7 @@ string Exception::lineInfo() const
 		ret += *file;
 	ret += ':';
 	if (line)
-		ret += std::to_string(*line);
+		ret += to_string(*line);
 	return ret;
 }
 

--- a/libjulia/backends/evm/EVMCodeTransform.cpp
+++ b/libjulia/backends/evm/EVMCodeTransform.cpp
@@ -529,7 +529,7 @@ int CodeTransform::variableHeightDiff(solidity::assembly::Scope::Variable const&
 	if (heightDiff <= (_forSwap ? 1 : 0) || heightDiff > (_forSwap ? 17 : 16))
 	{
 		solUnimplemented(
-			"Variable inaccessible, too deep inside stack (" + boost::lexical_cast<string>(heightDiff) + ")"
+			"Variable inaccessible, too deep inside stack (" + to_string(heightDiff) + ")"
 		);
 		return 0;
 	}

--- a/libjulia/optimiser/NameDispenser.cpp
+++ b/libjulia/optimiser/NameDispenser.cpp
@@ -31,7 +31,7 @@ string NameDispenser::newName(string const& _prefix)
 	while (name.empty() || m_usedNames.count(name))
 	{
 		suffix++;
-		name = _prefix + "_" + std::to_string(suffix);
+		name = _prefix + "_" + to_string(suffix);
 	}
 	m_usedNames.insert(name);
 	return name;

--- a/liblll/Parser.cpp
+++ b/liblll/Parser.cpp
@@ -143,7 +143,7 @@ void dev::lll::parseTreeLLL(string const& _s, sp::utree& o_out)
 	catch (qi::expectation_failure<it> const& e)
 	{
 		std::string fragment(e.first, e.last);
-		std::string loc = std::to_string(std::distance(s.cbegin(), e.first) - 1);
+		std::string loc = to_string(std::distance(s.cbegin(), e.first) - 1);
 		std::string reason("Lexer failure at " + loc + ": '" + fragment + "'");
 		BOOST_THROW_EXCEPTION(ParserException() << errinfo_comment(reason));
 	}

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -126,7 +126,7 @@ string ASTJsonConverter::sourceLocationToString(SourceLocation const& _location)
 	int length = -1;
 	if (_location.start >= 0 && _location.end >= 0)
 		length = _location.end - _location.start;
-	return std::to_string(_location.start) + ":" + std::to_string(length) + ":" + std::to_string(sourceIndex);
+	return to_string(_location.start) + ":" + to_string(length) + ":" + to_string(sourceIndex);
 }
 
 string ASTJsonConverter::namePathToString(std::vector<ASTString> const& _namePath)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -476,7 +476,7 @@ string IntegerType::richIdentifier() const
 	if (isAddress())
 		return "t_address";
 	else
-		return "t_" + string(isSigned() ? "" : "u") + "int" + std::to_string(numBits());
+		return "t_" + string(isSigned() ? "" : "u") + "int" + to_string(numBits());
 }
 
 bool IntegerType::isImplicitlyConvertibleTo(Type const& _convertTo) const
@@ -642,7 +642,7 @@ FixedPointType::FixedPointType(unsigned _totalBits, unsigned _fractionalDigits, 
 
 string FixedPointType::richIdentifier() const
 {
-	return "t_" + string(isSigned() ? "" : "u") + "fixed" + std::to_string(m_totalBits) + "x" + std::to_string(m_fractionalDigits);
+	return "t_" + string(isSigned() ? "" : "u") + "fixed" + to_string(m_totalBits) + "x" + to_string(m_fractionalDigits);
 }
 
 bool FixedPointType::isImplicitlyConvertibleTo(Type const& _convertTo) const
@@ -1381,7 +1381,7 @@ MemberList::MemberMap FixedBytesType::nativeMembers(const ContractDefinition*) c
 
 string FixedBytesType::richIdentifier() const
 {
-	return "t_bytes" + std::to_string(m_bytes);
+	return "t_bytes" + to_string(m_bytes);
 }
 
 bool FixedBytesType::operator==(Type const& _other) const
@@ -1824,7 +1824,7 @@ TypePointer ArrayType::copyForLocation(DataLocation _location, bool _isPointer) 
 
 string ContractType::richIdentifier() const
 {
-	return (m_super ? "t_super" : "t_contract") + parenthesizeUserIdentifier(m_contract.name()) + std::to_string(m_contract.id());
+	return (m_super ? "t_super" : "t_contract") + parenthesizeUserIdentifier(m_contract.name()) + to_string(m_contract.id());
 }
 
 bool ContractType::operator==(Type const& _other) const
@@ -1938,7 +1938,7 @@ bool StructType::isImplicitlyConvertibleTo(const Type& _convertTo) const
 
 string StructType::richIdentifier() const
 {
-	return "t_struct" + parenthesizeUserIdentifier(m_struct.name()) + std::to_string(m_struct.id()) + identifierLocationSuffix();
+	return "t_struct" + parenthesizeUserIdentifier(m_struct.name()) + to_string(m_struct.id()) + identifierLocationSuffix();
 }
 
 bool StructType::operator==(Type const& _other) const
@@ -2164,7 +2164,7 @@ TypePointer EnumType::unaryOperatorResult(Token::Value _operator) const
 
 string EnumType::richIdentifier() const
 {
-	return "t_enum" + parenthesizeUserIdentifier(m_enum.name()) + std::to_string(m_enum.id());
+	return "t_enum" + parenthesizeUserIdentifier(m_enum.name()) + to_string(m_enum.id());
 }
 
 bool EnumType::operator==(Type const& _other) const
@@ -3136,7 +3136,7 @@ string ModifierType::toString(bool _short) const
 
 string ModuleType::richIdentifier() const
 {
-	return "t_module_" + std::to_string(m_sourceUnit.id());
+	return "t_module_" + to_string(m_sourceUnit.id());
 }
 
 bool ModuleType::operator==(Type const& _other) const

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -50,7 +50,7 @@ class StackHeightChecker
 public:
 	explicit StackHeightChecker(CompilerContext const& _context):
 		m_context(_context), stackHeight(m_context.stackHeight()) {}
-	void check() { solAssert(m_context.stackHeight() == stackHeight, std::string("I sense a disturbance in the stack: ") + std::to_string(m_context.stackHeight()) + " vs " + std::to_string(stackHeight)); }
+	void check() { solAssert(m_context.stackHeight() == stackHeight, std::string("I sense a disturbance in the stack: ") + to_string(m_context.stackHeight()) + " vs " + to_string(stackHeight)); }
 private:
 	CompilerContext const& m_context;
 	unsigned stackHeight;

--- a/libsolidity/inlineasm/AsmAnalysis.cpp
+++ b/libsolidity/inlineasm/AsmAnalysis.cpp
@@ -85,7 +85,7 @@ bool AsmAnalyzer::operator()(assembly::Literal const& _literal)
 	{
 		m_errorReporter.typeError(
 			_literal.location,
-			"String literal too long (" + boost::lexical_cast<std::string>(_literal.value.size()) + " > 32)"
+			"String literal too long (" + std::to_string(_literal.value.size()) + " > 32)"
 		);
 		return false;
 	}
@@ -185,7 +185,7 @@ bool AsmAnalyzer::operator()(assembly::ExpressionStatement const& _statement)
 		Error::Type errorType = m_flavour == AsmFlavour::Loose ? *m_errorTypeForLoose : Error::Type::TypeError;
 		string msg =
 			"Top-level expressions are not supposed to return values (this expression returns " +
-			boost::lexical_cast<string>(m_stackHeight - initialStackHeight) +
+			std::to_string(m_stackHeight - initialStackHeight) +
 			" value" +
 			(m_stackHeight - initialStackHeight == 1 ? "" : "s") +
 			"). Use ``pop()`` or assign them.";
@@ -322,8 +322,8 @@ bool AsmAnalyzer::operator()(assembly::FunctionCall const& _funCall)
 		{
 			m_errorReporter.typeError(
 				_funCall.functionName.location,
-				"Expected " + boost::lexical_cast<string>(arguments) + " arguments but got " +
-				boost::lexical_cast<string>(_funCall.arguments.size()) + "."
+				"Expected " + std::to_string(arguments) + " arguments but got " +
+				std::to_string(_funCall.arguments.size()) + "."
 			);
 			success = false;
 		}
@@ -477,7 +477,7 @@ bool AsmAnalyzer::expectDeposit(int _deposit, int _oldHeight, SourceLocation con
 		m_errorReporter.typeError(
 			_location,
 			"Expected expression to return one item to the stack, but did return " +
-			boost::lexical_cast<string>(m_stackHeight - _oldHeight) +
+			std::to_string(m_stackHeight - _oldHeight) +
 			" items."
 		);
 		return false;

--- a/libsolidity/inlineasm/AsmAnalysis.cpp
+++ b/libsolidity/inlineasm/AsmAnalysis.cpp
@@ -85,7 +85,7 @@ bool AsmAnalyzer::operator()(assembly::Literal const& _literal)
 	{
 		m_errorReporter.typeError(
 			_literal.location,
-			"String literal too long (" + std::to_string(_literal.value.size()) + " > 32)"
+			"String literal too long (" + to_string(_literal.value.size()) + " > 32)"
 		);
 		return false;
 	}
@@ -185,7 +185,7 @@ bool AsmAnalyzer::operator()(assembly::ExpressionStatement const& _statement)
 		Error::Type errorType = m_flavour == AsmFlavour::Loose ? *m_errorTypeForLoose : Error::Type::TypeError;
 		string msg =
 			"Top-level expressions are not supposed to return values (this expression returns " +
-			std::to_string(m_stackHeight - initialStackHeight) +
+			to_string(m_stackHeight - initialStackHeight) +
 			" value" +
 			(m_stackHeight - initialStackHeight == 1 ? "" : "s") +
 			"). Use ``pop()`` or assign them.";
@@ -322,8 +322,8 @@ bool AsmAnalyzer::operator()(assembly::FunctionCall const& _funCall)
 		{
 			m_errorReporter.typeError(
 				_funCall.functionName.location,
-				"Expected " + std::to_string(arguments) + " arguments but got " +
-				std::to_string(_funCall.arguments.size()) + "."
+				"Expected " + to_string(arguments) + " arguments but got " +
+				to_string(_funCall.arguments.size()) + "."
 			);
 			success = false;
 		}
@@ -477,7 +477,7 @@ bool AsmAnalyzer::expectDeposit(int _deposit, int _oldHeight, SourceLocation con
 		m_errorReporter.typeError(
 			_location,
 			"Expected expression to return one item to the stack, but did return " +
-			std::to_string(m_stackHeight - _oldHeight) +
+			to_string(m_stackHeight - _oldHeight) +
 			" items."
 		);
 		return false;

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -279,7 +279,7 @@ assembly::Expression Parser::parseExpression()
 				"Expected '(' (instruction \"" +
 				instructionNames().at(instr.instruction) +
 				"\" expects " +
-				std::to_string(args) +
+				to_string(args) +
 				" arguments)"
 			));
 	}
@@ -502,7 +502,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 					"Expected expression (instruction \"" +
 					instructionNames().at(instr) +
 					"\" expects " +
-					std::to_string(args) +
+					to_string(args) +
 					" arguments)"
 				));
 
@@ -514,7 +514,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 						"Expected ',' (instruction \"" +
 						instructionNames().at(instr) +
 						"\" expects " +
-						std::to_string(args) +
+						to_string(args) +
 						" arguments)"
 					));
 				else
@@ -527,7 +527,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 				"Expected ')' (instruction \"" +
 				instructionNames().at(instr) +
 				"\" expects " +
-				std::to_string(args) +
+				to_string(args) +
 				" arguments)"
 			));
 		expectToken(Token::RParen);

--- a/libsolidity/inlineasm/AsmParser.cpp
+++ b/libsolidity/inlineasm/AsmParser.cpp
@@ -279,7 +279,7 @@ assembly::Expression Parser::parseExpression()
 				"Expected '(' (instruction \"" +
 				instructionNames().at(instr.instruction) +
 				"\" expects " +
-				boost::lexical_cast<string>(args) +
+				std::to_string(args) +
 				" arguments)"
 			));
 	}
@@ -502,7 +502,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 					"Expected expression (instruction \"" +
 					instructionNames().at(instr) +
 					"\" expects " +
-					boost::lexical_cast<string>(args) +
+					std::to_string(args) +
 					" arguments)"
 				));
 
@@ -514,7 +514,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 						"Expected ',' (instruction \"" +
 						instructionNames().at(instr) +
 						"\" expects " +
-						boost::lexical_cast<string>(args) +
+						std::to_string(args) +
 						" arguments)"
 					));
 				else
@@ -527,7 +527,7 @@ assembly::Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 				"Expected ')' (instruction \"" +
 				instructionNames().at(instr) +
 				"\" expects " +
-				boost::lexical_cast<string>(args) +
+				std::to_string(args) +
 				" arguments)"
 			));
 		expectToken(Token::RParen);

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -965,17 +965,17 @@ string CompilerStack::computeSourceMapping(eth::AssemblyItems const& _items) con
 		if (components-- > 0)
 		{
 			if (location.start != prevStart)
-				ret += std::to_string(location.start);
+				ret += to_string(location.start);
 			if (components-- > 0)
 			{
 				ret += ':';
 				if (length != prevLength)
-					ret += std::to_string(length);
+					ret += to_string(length);
 				if (components-- > 0)
 				{
 					ret += ':';
 					if (sourceIndex != prevSourceIndex)
-						ret += std::to_string(sourceIndex);
+						ret += to_string(sourceIndex);
 					if (components-- > 0)
 					{
 						ret += ':';

--- a/libsolidity/interface/Exceptions.h
+++ b/libsolidity/interface/Exceptions.h
@@ -117,7 +117,7 @@ public:
 		if (occurrences > 32)
 		{
 			infos.resize(32);
-			_message += " Truncated from " + boost::lexical_cast<std::string>(occurrences) + " to the first 32 occurrences.";
+			_message += " Truncated from " + std::to_string(occurrences) + " to the first 32 occurrences.";
 		}
 	}
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -30,7 +30,6 @@
 #include <libevmasm/Assembly.h>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <string>
 #include <tuple>

--- a/test/liblll/Compiler.cpp
+++ b/test/liblll/Compiler.cpp
@@ -130,17 +130,17 @@ BOOST_AUTO_TEST_CASE(switch_inconsistent_return_count)
 BOOST_AUTO_TEST_CASE(disallowed_asm_instructions)
 {
 	for (unsigned i = 1; i <= 32; i++)
-		BOOST_CHECK(!successCompile("(asm PUSH" + boost::lexical_cast<string>(i) + ")"));
+		BOOST_CHECK(!successCompile("(asm PUSH" + to_string(i) + ")"));
 }
 
 BOOST_AUTO_TEST_CASE(disallowed_functional_asm_instructions)
 {
 	for (unsigned i = 1; i <= 32; i++)
-		BOOST_CHECK(!successCompile("(PUSH" + boost::lexical_cast<string>(i) + ")"));
+		BOOST_CHECK(!successCompile("(PUSH" + to_string(i) + ")"));
 	for (unsigned i = 1; i <= 16; i++)
-		BOOST_CHECK(!successCompile("(DUP" + boost::lexical_cast<string>(i) + ")"));
+		BOOST_CHECK(!successCompile("(DUP" + to_string(i) + ")"));
 	for (unsigned i = 1; i <= 16; i++)
-		BOOST_CHECK(!successCompile("(SWAP" + boost::lexical_cast<string>(i) + ")"));
+		BOOST_CHECK(!successCompile("(SWAP" + to_string(i) + ")"));
 	BOOST_CHECK(!successCompile("(JUMPDEST)"));
 }
 

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -25,7 +25,6 @@
 #include <libevmasm/Instruction.h>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <chrono>
 #include <string>
@@ -82,8 +81,8 @@ public:
 		BOOST_CHECK_MESSAGE(
 			_optimizeRuns < 50 || optimizedSize < nonOptimizedSize,
 			string("Optimizer did not reduce bytecode size. Non-optimized size: ") +
-			std::to_string(nonOptimizedSize) + " - optimized size: " +
-			std::to_string(optimizedSize)
+			to_string(nonOptimizedSize) + " - optimized size: " +
+			to_string(optimizedSize)
 		);
 		m_optimizedContract = m_contractAddress;
 	}


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible): not necessary
- [x] README / documentation was extended, if necessary: not necessary
- [x] Changelog entry (if change is visible to the user): not visible
- [x] Used meaningful commit messages

### Description
Modifies the remaining code to use std::to_string instead of boost::lexical_cast<std::string>.
It implements #4752. 
