### PR TITLE
[WIP] Fixes issue where computing storage size for a number would take too long (or even cause a crash).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -94,6 +94,7 @@ Bugfixes:
  * Type Checker: Allow assignments to local variables of mapping types.
  * Type Checker: Consider fixed size arrays when checking for recursive structs.
  * Type Checker: Fix crashes in erroneous tuple assignments in which the type of the right hand side cannot be determined.
+ * Type Checker: Fix freeze for negative fixed-point literals very close to ``0``, such as ``-1e-100``.
  * Type Checker: Report error when using structs in events without experimental ABIEncoderV2. This used to crash or log the wrong values.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1263,7 +1263,8 @@ shared_ptr<FixedPointType const> RationalNumberType::fixedPointType() const
 		return shared_ptr<FixedPointType const>();
 	// This means we round towards zero for positive and negative values.
 	bigint v = value.numerator() / value.denominator();
-	if (negative)
+
+	if (negative && v != 0)
 		// modify value to satisfy bit requirements for negative numbers:
 		// add one bit for sign and decrement because negative numbers can be larger
 		v = (v - 1) << 1;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -446,7 +446,8 @@ public:
 
 	/// @returns the smallest integer type that can hold the value or an empty pointer if not possible.
 	std::shared_ptr<IntegerType const> integerType() const;
-	/// @returns the smallest fixed type that can  hold the value or incurs the least precision loss.
+	/// @returns the smallest fixed type that can  hold the value or incurs the least precision loss,
+	/// unless the value was truncated, then a suitable type will be chosen to indicate such event.
 	/// If the integer part does not fit, returns an empty pointer.
 	std::shared_ptr<FixedPointType const> fixedPointType() const;
 

--- a/test/libsolidity/syntaxTests/types/too_small_negative_numbers.sol
+++ b/test/libsolidity/syntaxTests/types/too_small_negative_numbers.sol
@@ -1,0 +1,4 @@
+contract C {
+  fixed8x80 a = -1e-100;
+}
+// ----


### PR DESCRIPTION
Fixes #4673.

### TODO
* [x] create a test case for `fixed8x80 a = -1 / (1e9 ** 10);`
* [x] check if it could also fix #4717.
