### PR TITLE
Remove code generation for Throw statement

### DIFF
--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -779,11 +779,9 @@ bool ContractCompiler::visit(Return const& _return)
 	return false;
 }
 
-bool ContractCompiler::visit(Throw const& _throw)
+bool ContractCompiler::visit(Throw const&)
 {
-	CompilerContext::LocationSetter locationSetter(m_context, _throw);
-	// Do not send back an error detail.
-	m_context.appendRevert();
+	solAssert(false, "Throw statement is disallowed.");
 	return false;
 }
 


### PR DESCRIPTION
It is disallowed in the type system.

I am not fully sure about this, but my reasoning is that if we reintroduce the `Throw` statement, it likely will operate differently, and this will force us to implement it properly.