### PR TITLE
Calculate the dataGas correctly in the constant optimiser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -92,6 +92,7 @@ Bugfixes:
  * Code Generator: Properly handle negative number literals in ABIEncoderV2.
  * Commandline Interface: Correctly handle paths with backslashes on windows.
  * Fix NatSpec json output for `@notice` and `@dev` tags on contract definitions.
+ * Optimizer: Correctly estimate gas costs of constants for special cases.
  * References Resolver: Do not crash on using ``_slot`` and ``_offset`` suffixes on their own.
  * References Resolver: Enforce ``storage`` as data location for mappings.
  * References Resolver: Properly handle invalid references used together with ``_slot`` and ``_offset``.

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -93,6 +93,7 @@ bigint ConstantOptimisationMethod::simpleRunGas(AssemblyItems const& _items)
 
 bigint ConstantOptimisationMethod::dataGas(bytes const& _data) const
 {
+	assertThrow(_data.size() > 0, OptimizerException, "Empty bytecode generated.");
 	if (m_params.isCreation)
 	{
 		bigint gas;
@@ -101,7 +102,7 @@ bigint ConstantOptimisationMethod::dataGas(bytes const& _data) const
 		return gas;
 	}
 	else
-		return GasCosts::createDataGas * dataSize();
+		return GasCosts::createDataGas * _data.size();
 }
 
 size_t ConstantOptimisationMethod::bytesRequired(AssemblyItems const& _items)

--- a/libevmasm/ConstantOptimiser.h
+++ b/libevmasm/ConstantOptimiser.h
@@ -75,8 +75,6 @@ public:
 	virtual AssemblyItems execute(Assembly& _assembly) const = 0;
 
 protected:
-	size_t dataSize() const { return std::max<size_t>(1, dev::bytesRequired(m_value)); }
-
 	/// @returns the run gas for the given items ignoring special gas costs
 	static bigint simpleRunGas(AssemblyItems const& _items);
 	/// @returns the gas needed to store the given data literally


### PR DESCRIPTION
This may cause a wrong decision about cost (and as a result choosing the least efficient code),
but will not cause any miscompilation or invalid output.
