### PR TITLE
Defaul data location for type conversions is memory.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -91,6 +91,7 @@ Bugfixes:
  * References Resolver: Enforce ``storage`` as data location for mappings.
  * References Resolver: Properly handle invalid references used together with ``_slot`` and ``_offset``.
  * References Resolver: Report error instead of assertion fail when FunctionType has an undeclared type as parameter.
+ * Type Checker: Default data location for type conversions (e.g. from literals) is memory and not storage.
  * Type Checker: Disallow assignments to mappings within tuple assignments as well.
  * Type Checker: Allow assignments to local variables of mapping types.
  * Type Checker: Consider fixed size arrays when checking for recursive structs.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1626,10 +1626,13 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 		else
 		{
 			TypePointer const& argType = type(*arguments.front());
+			// Resulting data location is memory unless we are converting from a reference
+			// type with a different data location.
+			// (data location cannot yet be specified for type conversions)
+			DataLocation dataLoc = DataLocation::Memory;
 			if (auto argRefType = dynamic_cast<ReferenceType const*>(argType.get()))
-				// do not change the data location when converting
-				// (data location cannot yet be specified for type conversions)
-				resultType = ReferenceType::copyForLocationIfReference(argRefType->location(), resultType);
+				dataLoc = argRefType->location();
+			resultType = ReferenceType::copyForLocationIfReference(dataLoc, resultType);
 			if (!argType->isExplicitlyConvertibleTo(*resultType))
 				m_errorReporter.typeError(
 					_functionCall.location(),

--- a/test/libsolidity/syntaxTests/conversion/conversion_to_bytes.sol
+++ b/test/libsolidity/syntaxTests/conversion/conversion_to_bytes.sol
@@ -1,0 +1,5 @@
+contract test {
+  function f() public pure returns (bytes) {
+    return bytes("abc");
+  }
+}

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/186_invalid_utf8_explicit.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/186_invalid_utf8_explicit.sol
@@ -2,4 +2,4 @@ contract C {
     string s = string("\xa0\x00");
 }
 // ----
-// TypeError: (28-46): Explicit type conversion not allowed from "literal_string (contains invalid UTF-8 sequence at position 0)" to "string storage pointer".
+// TypeError: (28-46): Explicit type conversion not allowed from "literal_string (contains invalid UTF-8 sequence at position 0)" to "string memory".

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/482_explicit_literal_to_unspecified_string.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/482_explicit_literal_to_unspecified_string.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (52-65): Explicit type conversion not allowed from "literal_string "abc"" to "string storage pointer".
+// Warning: (52-65): Statement has no effect.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/4535