### PR TITLE
Fix table css.

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -7,8 +7,8 @@ pre {
 }
 
 .wy-table-responsive table td, .wy-table-responsive table th {
-  white-space: pre-wrap;
+  white-space: normal;
 }
-.wy-table-responsive table td, .wy-table-responsive table th {
-  white-space: pre-wrap;
+.rst-content table.docutils td {
+  vertical-align: top;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
It looks like https://github.com/ethereum/solidity/pull/4367 actually never fixed the issue because the css file was not actually deployed (readthedocs provides a 404 document).

In addition to actually activating the stylesheet, I changed the word-wrap to `normal` which does not force linebreaks when there are `\n` in the source file and changed the vertical align to `top`.