### PR TITLE
Rename `Location::Default` to `Location::Unspecified`

### DIFF
--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -332,7 +332,7 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 			case Location::Memory: return "\"memory\"";
 			case Location::Storage: return "\"storage\"";
 			case Location::CallData: return "\"calldata\"";
-			case Location::Default: return "none";
+			case Location::Unspecified: return "none";
 			}
 			return {};
 		};
@@ -368,12 +368,12 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 	// Find correct data location.
 	if (_variable.isEventParameter())
 	{
-		solAssert(varLoc == Location::Default, "");
+		solAssert(varLoc == Location::Unspecified, "");
 		typeLoc = DataLocation::Memory;
 	}
 	else if (_variable.isStateVariable())
 	{
-		solAssert(varLoc == Location::Default, "");
+		solAssert(varLoc == Location::Unspecified, "");
 		typeLoc = _variable.isConstant() ? DataLocation::Memory : DataLocation::Storage;
 	}
 	else if (
@@ -394,7 +394,7 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 		case Location::CallData:
 			typeLoc = DataLocation::CallData;
 			break;
-		case Location::Default:
+		case Location::Unspecified:
 			solAssert(!_variable.hasReferenceOrMappingType(), "Data location not properly set.");
 		}
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1217,7 +1217,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 			if (ref->dataStoredIn(DataLocation::Storage))
 			{
 				string errorText{"Uninitialized storage pointer."};
-				if (varDecl.referenceLocation() == VariableDeclaration::Location::Default)
+				if (varDecl.referenceLocation() == VariableDeclaration::Location::Unspecified)
 					errorText += " Did you mean '<type> memory " + varDecl.name() + "'?";
 				solAssert(m_scope, "");
 				m_errorReporter.declarationError(varDecl.location(), errorText);

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -517,7 +517,7 @@ set<VariableDeclaration::Location> VariableDeclaration::allowedDataLocations() c
 	using Location = VariableDeclaration::Location;
 
 	if (!hasReferenceOrMappingType() || isStateVariable() || isEventParameter())
-		return set<Location>{ Location::Default };
+		return set<Location>{ Location::Unspecified };
 	else if (isStateVariable() && isConstant())
 		return set<Location>{ Location::Memory };
 	else if (isExternalCallableParameter())
@@ -546,7 +546,7 @@ set<VariableDeclaration::Location> VariableDeclaration::allowedDataLocations() c
 	}
 	else
 		// Struct members etc.
-		return set<Location>{ Location::Default };
+		return set<Location>{ Location::Unspecified };
 }
 
 TypePointer VariableDeclaration::type() const

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -655,7 +655,7 @@ private:
 class VariableDeclaration: public Declaration
 {
 public:
-	enum Location { Default, Storage, Memory, CallData };
+	enum Location { Unspecified, Storage, Memory, CallData };
 
 	VariableDeclaration(
 		SourceLocation const& _sourceLocation,
@@ -666,7 +666,7 @@ public:
 		bool _isStateVar = false,
 		bool _isIndexed = false,
 		bool _isConstant = false,
-		Location _referenceLocation = Location::Default
+		Location _referenceLocation = Location::Unspecified
 	):
 		Declaration(_sourceLocation, _name, _visibility),
 		m_typeName(_type),

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -739,7 +739,7 @@ string ASTJsonConverter::location(VariableDeclaration::Location _location)
 {
 	switch (_location)
 	{
-	case VariableDeclaration::Location::Default:
+	case VariableDeclaration::Location::Unspecified:
 		return "default";
 	case VariableDeclaration::Location::Storage:
 		return "storage";

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -564,7 +564,7 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 	bool isIndexed = false;
 	bool isDeclaredConst = false;
 	Declaration::Visibility visibility(Declaration::Visibility::Default);
-	VariableDeclaration::Location location = VariableDeclaration::Location::Default;
+	VariableDeclaration::Location location = VariableDeclaration::Location::Unspecified;
 	ASTPointer<ASTString> identifier;
 
 	while (true)
@@ -592,7 +592,7 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 				isDeclaredConst = true;
 			else if (_options.allowLocationSpecifier && Token::isLocationSpecifier(token))
 			{
-				if (location != VariableDeclaration::Location::Default)
+				if (location != VariableDeclaration::Location::Unspecified)
 					parserError(string("Location already specified."));
 				else if (!type)
 					parserError(string("Location specifier needs explicit type name."));


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/4633. Changes `Location::Default` to `Location::Unspecified`.
