### PR TITLE
docs(bug_report.md): Small grammar fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,12 +6,12 @@ about: Bug reports about the Solidity Compiler.
 ## Prerequisites
 
 - First, many thanks for taking part in the community. We really appreciate that.
-- We realize there is a lot of data requested here. We ask only that you do your best to provide as much information as possible so we can better help you.
+- We realize there is a lot of information requested here. We ask only that you do your best to provide as much information as possible so we can better help you.
 - Support questions are better asked in one of the following locations:
 	- [Solidity chat](https://gitter.im/ethereum/solidity)
 	- [Stack Overflow](https://ethereum.stackexchange.com/)
 - Ensure the issue isn't already reported.
-- The issue should be reproducible with the latest solidity version , however, this isn't a hard requirement and being reproducible with an older version is sufficient.
+- The issue should be reproducible with the latest solidity version; however, this isn't a hard requirement and being reproducible with an older version is sufficient.
 
 *Delete the above section and the instructions in the sections below before submitting*
 


### PR DESCRIPTION
### Checklist
- [N/A] Code compiles correctly
- [N/A] All tests are passing
- [N/A] New tests have been created which fail without the change (if possible)
- [N/A] README / documentation was extended, if necessary
- [N/A] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

This is only a small documentation fix.

- Data is plural, but 'there are a lot of data' sounds odd to most readers. I used the word information, instead. 'There is a lot of data' isn't grammatical.
- There was an errant space before a comma. I've substituted in a semicolon for readability.

These are small changes, almost pathetically so. But they make the bug report easier to read, thus reducing some friction at scale.