### PR TITLE
Removed unused "FunctionType::Kind::CallCode"

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2496,7 +2496,7 @@ TypePointers FunctionType::returnParameterTypesWithoutDynamicTypes() const
 {
 	TypePointers returnParameterTypes = m_returnParameterTypes;
 
-	if (m_kind == Kind::External || m_kind == Kind::CallCode || m_kind == Kind::DelegateCall)
+	if (m_kind == Kind::External || m_kind == Kind::DelegateCall)
 		for (auto& param: returnParameterTypes)
 			if (param->isDynamicallySized() && !param->dataStoredIn(DataLocation::Storage))
 				param = make_shared<InaccessibleDynamicType>();
@@ -2518,7 +2518,6 @@ string FunctionType::richIdentifier() const
 	{
 	case Kind::Internal: id += "internal"; break;
 	case Kind::External: id += "external"; break;
-	case Kind::CallCode: id += "callcode"; break;
 	case Kind::DelegateCall: id += "delegatecall"; break;
 	case Kind::BareCall: id += "barecall"; break;
 	case Kind::BareCallCode: id += "barecallcode"; break;
@@ -2700,7 +2699,6 @@ unsigned FunctionType::sizeOnStack() const
 	switch(kind)
 	{
 	case Kind::External:
-	case Kind::CallCode:
 	case Kind::DelegateCall:
 		size = 2;
 		break;
@@ -2933,7 +2931,6 @@ string FunctionType::externalSignature() const
 	{
 	case Kind::Internal:
 	case Kind::External:
-	case Kind::CallCode:
 	case Kind::DelegateCall:
 	case Kind::Event:
 		break;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -899,7 +899,6 @@ public:
 	{
 		Internal, ///< stack-call using plain JUMP
 		External, ///< external call using CALL
-		CallCode, ///< external call using CALLCODE, i.e. not exchanging the storage
 		DelegateCall, ///< external call using DELEGATECALL, i.e. not exchanging the storage
 		BareCall, ///< CALL without function hash
 		BareCallCode, ///< CALLCODE without function hash

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -566,7 +566,6 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			break;
 		}
 		case FunctionType::Kind::External:
-		case FunctionType::Kind::CallCode:
 		case FunctionType::Kind::DelegateCall:
 		case FunctionType::Kind::BareCall:
 		case FunctionType::Kind::BareCallCode:
@@ -1169,7 +1168,6 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					_memberAccess.expression().accept(*this);
 					m_context << funType->externalIdentifier();
 					break;
-				case FunctionType::Kind::CallCode:
 				case FunctionType::Kind::External:
 				case FunctionType::Kind::Creation:
 				case FunctionType::Kind::Send:
@@ -1831,7 +1829,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	solAssert(funKind != FunctionType::Kind::BareStaticCall || m_context.evmVersion().hasStaticCall(), "");
 	
 	bool returnSuccessCondition = funKind == FunctionType::Kind::BareCall || funKind == FunctionType::Kind::BareCallCode || funKind == FunctionType::Kind::BareDelegateCall || funKind == FunctionType::Kind::BareStaticCall;
-	bool isCallCode = funKind == FunctionType::Kind::BareCallCode || funKind == FunctionType::Kind::CallCode;
+	bool isCallCode = funKind == FunctionType::Kind::BareCallCode;
 	bool isDelegateCall = funKind == FunctionType::Kind::BareDelegateCall || funKind == FunctionType::Kind::DelegateCall;
 	bool useStaticCall = funKind == FunctionType::Kind::BareStaticCall || (_functionType.stateMutability() <= StateMutability::View && m_context.evmVersion().hasStaticCall());
 
@@ -1959,7 +1957,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 
 	bool existenceChecked = false;
 	// Check the the target contract exists (has code) for non-low-level calls.
-	if (funKind == FunctionType::Kind::External || funKind == FunctionType::Kind::CallCode || funKind == FunctionType::Kind::DelegateCall)
+	if (funKind == FunctionType::Kind::External || funKind == FunctionType::Kind::DelegateCall)
 	{
 		m_context << Instruction::DUP1 << Instruction::EXTCODESIZE << Instruction::ISZERO;
 		// TODO: error message?


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
Please explain the changes you made here.
Removed unused "FunctionType::Kind::CallCode" from Types.h and its usage from Types.cpp and ExpressionCompiler.cpp

Thank you for your help!
