### PR TITLE
Fix#4743: Incorrect source location for nameless parameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -112,6 +112,7 @@ Bugfixes:
  * Type Checker: Report error when using indexed structs in events with experimental ABIEncoderV2. This used to log wrong values.
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
+ * Parser: Fix incorrect source location for nameless parameters.
 
 ### 0.4.24 (2018-05-16)
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -572,6 +572,7 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 		Token::Value token = m_scanner->currentToken();
 		if (_options.isStateVariable && Token::isVariableVisibilitySpecifier(token))
 		{
+			nodeFactory.markEndPosition();
 			if (visibility != Declaration::Visibility::Default)
 			{
 				parserError(string(
@@ -616,21 +617,21 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 			}
 			else
 				break;
+			nodeFactory.markEndPosition();
 			m_scanner->next();
 		}
 	}
-	nodeFactory.markEndPosition();
 
 	if (_options.allowEmptyName && m_scanner->currentToken() != Token::Identifier)
 	{
 		identifier = make_shared<ASTString>("");
 		solAssert(!_options.allowVar, ""); // allowEmptyName && allowVar makes no sense
-		if (type)
-			nodeFactory.setEndPositionFromNode(type);
-		// if type is null this has already caused an error
 	}
 	else
+	{
+		nodeFactory.markEndPosition();
 		identifier = expectIdentifierToken();
+	}
 	ASTPointer<Expression> value;
 	if (_options.allowInitialValue)
 	{

--- a/test/libsolidity/syntaxTests/controlFlow/mappingReturn/unnamed_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/mappingReturn/unnamed_err.sol
@@ -2,4 +2,4 @@ contract C {
     function f() internal pure returns (mapping(uint=>uint) storage) {}
 }
 // ----
-// TypeError: (53-72): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.
+// TypeError: (53-80): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly_err.sol
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (87-88): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.
+// TypeError: (87-96): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/modifier_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/modifier_err.sol
@@ -18,5 +18,5 @@ contract C {
     }
 }
 // ----
-// TypeError: (249-250): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.
-// TypeError: (367-368): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.
+// TypeError: (249-258): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.
+// TypeError: (367-376): This variable is of storage pointer type and might be returned without assignment and could be used uninitialized. Assign the variable (potentially from itself) to fix this error.

--- a/test/libsolidity/syntaxTests/dataLocations/data_location_in_function_type_fail.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/data_location_in_function_type_fail.sol
@@ -5,5 +5,5 @@ library L {
 }
 
 // ----
-// TypeError: (66-72): Data location must be "memory" for parameter in function, but "calldata" was given.
-// TypeError: (159-165): Data location must be "memory" for parameter in function, but "storage" was given.
+// TypeError: (66-81): Data location must be "memory" for parameter in function, but "calldata" was given.
+// TypeError: (159-173): Data location must be "memory" for parameter in function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_memory.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_memory.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes memory) external;
 }
 // ----
-// TypeError: (31-36): Data location must be "calldata" for parameter in external function, but "memory" was given.
+// TypeError: (31-43): Data location must be "calldata" for parameter in external function, but "memory" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_storage.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_storage.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes storage) external;
 }
 // ----
-// TypeError: (31-36): Data location must be "calldata" for parameter in external function, but "storage" was given.
+// TypeError: (31-44): Data location must be "calldata" for parameter in external function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/function_argument_location_specifier_test_non_reference_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/function_argument_location_specifier_test_non_reference_type.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes4 memory) public;
 }
 // ----
-// TypeError: (31-37): Data location can only be specified for array, struct or mapping types, but "memory" was given.
+// TypeError: (31-44): Data location can only be specified for array, struct or mapping types, but "memory" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/function_argument_location_specifier_test_internal_calldata.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/function_argument_location_specifier_test_internal_calldata.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes calldata) internal;
 }
 // ----
-// TypeError: (31-36): Data location must be "storage" or "memory" for parameter in function, but "calldata" was given.
+// TypeError: (31-45): Data location must be "storage" or "memory" for parameter in function, but "calldata" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraryExternalFunction/function_argument_location_specifier_test_external_memory.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraryExternalFunction/function_argument_location_specifier_test_external_memory.sol
@@ -2,4 +2,4 @@ library test {
     function f(bytes memory) external;
 }
 // ----
-// TypeError: (30-35): Data location must be "storage" or "calldata" for parameter in external function, but "memory" was given.
+// TypeError: (30-42): Data location must be "storage" or "calldata" for parameter in external function, but "memory" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraryInternalFunction/function_argument_location_specifier_test_internal_calldata.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraryInternalFunction/function_argument_location_specifier_test_internal_calldata.sol
@@ -2,4 +2,4 @@ library test {
     function f(bytes calldata) internal pure {}
 }
 // ----
-// TypeError: (30-35): Data location must be "storage" or "memory" for parameter in function, but "calldata" was given.
+// TypeError: (30-44): Data location must be "storage" or "memory" for parameter in function, but "calldata" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_calldata.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_calldata.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes calldata) public;
 }
 // ----
-// TypeError: (31-36): Data location must be "memory" for parameter in function, but "calldata" was given.
+// TypeError: (31-45): Data location must be "memory" for parameter in function, but "calldata" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_storage.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_storage.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes storage) public;
 }
 // ----
-// TypeError: (31-36): Data location must be "memory" for parameter in function, but "storage" was given.
+// TypeError: (31-44): Data location must be "memory" for parameter in function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
@@ -4,4 +4,4 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (59-65): Indexed reference types cannot yet be used with ABIEncoderV2.
+// TypeError: (59-73): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
@@ -4,4 +4,4 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (59-67): Indexed reference types cannot yet be used with ABIEncoderV2.
+// TypeError: (59-75): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_struct_indexed.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_indexed.sol
@@ -3,4 +3,4 @@ contract c {
     event E(S indexed);
 }
 // ----
-// TypeError: (51-52): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
+// TypeError: (51-60): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
@@ -5,4 +5,4 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (85-86): Indexed reference types cannot yet be used with ABIEncoderV2.
+// TypeError: (85-94): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
@@ -6,4 +6,4 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (103-104): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (103-111): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
@@ -6,4 +6,4 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (105-106): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (105-113): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
@@ -7,4 +7,4 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (132-133): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (132-140): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
@@ -2,4 +2,4 @@ contract C {
     function f() public pure returns (string[][] memory) {}
 }
 // ----
-// TypeError: (51-61): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
+// TypeError: (51-68): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
@@ -2,4 +2,4 @@ contract C {
     function f() public pure returns (uint[][2] memory) {}
 }
 // ----
-// TypeError: (51-60): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
+// TypeError: (51-67): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (91-92): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (91-99): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (94-95): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (94-102): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/types/mapping/argument_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/argument_external.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (28-49): Data location must be "calldata" for parameter in external function, but "storage" was given.
+// TypeError: (28-57): Data location must be "calldata" for parameter in external function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/argument_public.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (28-49): Data location must be "memory" for parameter in function, but "storage" was given.
+// TypeError: (28-57): Data location must be "memory" for parameter in function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/array_argument_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/array_argument_external.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (28-51): Data location must be "calldata" for parameter in external function, but "storage" was given.
+// TypeError: (28-59): Data location must be "calldata" for parameter in external function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/array_argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/array_argument_public.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (28-51): Data location must be "memory" for parameter in function, but "storage" was given.
+// TypeError: (28-59): Data location must be "memory" for parameter in function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/function_type_argument_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/function_type_argument_external.sol
@@ -3,5 +3,5 @@ contract C {
     }
 }
 // ----
-// TypeError: (37-56): Data location must be "memory" for parameter in function, but "storage" was given.
-// TypeError: (37-56): Internal type cannot be used for external function type.
+// TypeError: (37-64): Data location must be "memory" for parameter in function, but "storage" was given.
+// TypeError: (37-64): Internal type cannot be used for external function type.

--- a/test/libsolidity/syntaxTests/types/mapping/function_type_return_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/function_type_return_external.sol
@@ -3,5 +3,5 @@ contract C {
     }
 }
 // ----
-// TypeError: (57-76): Data location must be "memory" for return parameter in function, but "storage" was given.
-// TypeError: (57-76): Internal type cannot be used for external function type.
+// TypeError: (57-84): Data location must be "memory" for return parameter in function, but "storage" was given.
+// TypeError: (57-84): Internal type cannot be used for external function type.

--- a/test/libsolidity/syntaxTests/types/mapping/library_argument_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_argument_external.sol
@@ -3,4 +3,4 @@ library L {
     }
 }
 // ----
-// TypeError: (27-48): Type is required to live outside storage.
+// TypeError: (27-56): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_argument_public.sol
@@ -3,4 +3,4 @@ library L {
     }
 }
 // ----
-// TypeError: (27-48): Type is required to live outside storage.
+// TypeError: (27-56): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_array_argument_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_array_argument_external.sol
@@ -3,4 +3,4 @@ library L {
     }
 }
 // ----
-// TypeError: (27-50): Type is required to live outside storage.
+// TypeError: (27-58): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_array_argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_array_argument_public.sol
@@ -3,4 +3,4 @@ library L {
     }
 }
 // ----
-// TypeError: (27-50): Type is required to live outside storage.
+// TypeError: (27-58): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_return_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_return_external.sol
@@ -7,4 +7,4 @@ library L
 // ----
 // TypeError: (27-58): Type is required to live outside storage.
 // TypeError: (60-91): Type is required to live outside storage.
-// TypeError: (123-144): Type is required to live outside storage.
+// TypeError: (123-152): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_return_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_return_public.sol
@@ -7,4 +7,4 @@ library L
 // ----
 // TypeError: (27-58): Type is required to live outside storage.
 // TypeError: (60-91): Type is required to live outside storage.
-// TypeError: (121-142): Type is required to live outside storage.
+// TypeError: (121-150): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_array_data_location_function_param_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_array_data_location_function_param_external.sol
@@ -2,5 +2,5 @@ contract c {
     function f1(mapping(uint => uint)[] calldata) pure external {}
 }
 // ----
-// TypeError: (29-52): Type is required to live outside storage.
-// TypeError: (29-52): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (29-61): Type is required to live outside storage.
+// TypeError: (29-61): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_external.sol
@@ -2,5 +2,5 @@ contract c {
     function f1(mapping(uint => uint) calldata) pure external returns (mapping(uint => uint) memory) {}
 }
 // ----
-// TypeError: (29-50): Type is required to live outside storage.
-// TypeError: (29-50): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (29-59): Type is required to live outside storage.
+// TypeError: (29-59): Internal or recursive type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_public.sol
@@ -2,5 +2,5 @@ contract c {
     function f3(mapping(uint => uint) memory) view public {}
 }
 // ----
-// TypeError: (29-50): Type is required to live outside storage.
-// TypeError: (29-50): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (29-57): Type is required to live outside storage.
+// TypeError: (29-57): Internal or recursive type is not allowed for public or external functions.


### PR DESCRIPTION
Fix #4743 

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
My solution is don't call `nodeFactory.markEndPosition()` if the loop break at https://github.com/ethereum/solidity/blob/develop/libsolidity/parsing/Parser.cpp#L618.

It breaks a lot of tests since nameless parameters is now contain location. Should i change all the test to match the change?