### PR TITLE
Fix bug in memory non-value parameter overriding external calldata

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -111,6 +111,7 @@ Bugfixes:
  * Type Checker: Report error when using structs in events without experimental ABIEncoderV2. This used to crash or log the wrong values.
  * Type Checker: Report error when using indexed structs in events with experimental ABIEncoderV2. This used to log wrong values.
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
+ * Type Checker: Allow memory non-value types as parameters of public functions that override external interface functions.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 
 ### 0.4.24 (2018-05-16)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -458,7 +458,7 @@ void TypeChecker::checkContractExternalTypeClashes(ContractDefinition const& _co
 				// under non error circumstances this should be true
 				if (functionType->interfaceFunctionType())
 					externalDeclarations[functionType->externalSignature()].push_back(
-						make_pair(f, functionType)
+						make_pair(f, functionType->interfaceFunctionType(true))
 					);
 			}
 		for (VariableDeclaration const* v: contract->stateVariables())
@@ -468,7 +468,7 @@ void TypeChecker::checkContractExternalTypeClashes(ContractDefinition const& _co
 				// under non error circumstances this should be true
 				if (functionType->interfaceFunctionType())
 					externalDeclarations[functionType->externalSignature()].push_back(
-						make_pair(v, functionType)
+						make_pair(v, functionType->interfaceFunctionType(true))
 					);
 			}
 	}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2727,11 +2727,11 @@ unsigned FunctionType::sizeOnStack() const
 	return size;
 }
 
-FunctionTypePointer FunctionType::interfaceFunctionType() const
+FunctionTypePointer FunctionType::interfaceFunctionType(bool _isLib) const
 {
 	// Note that m_declaration might also be a state variable!
 	solAssert(m_declaration, "Declaration needed to determine interface function type.");
-	bool isLibraryFunction = dynamic_cast<ContractDefinition const&>(*m_declaration->scope()).isLibrary();
+	bool isLibraryFunction = dynamic_cast<ContractDefinition const&>(*m_declaration->scope()).isLibrary() || _isLib;
 
 	TypePointers paramTypes;
 	TypePointers retParamTypes;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1038,7 +1038,8 @@ public:
 	/// current function.
 	/// @returns an empty shared pointer if one of the input/return parameters does not have an
 	/// external type.
-	FunctionTypePointer interfaceFunctionType() const;
+	/// @param _isLib allows the caller to retrieve the type emulating a library in order to separate the types from their encoding type, while keeping the interface parts.
+	FunctionTypePointer interfaceFunctionType(bool _isLib = false) const;
 
 	/// @returns true if this function can take the given argument types (possibly
 	/// after implicit conversion).

--- a/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_1.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_1.sol
@@ -1,0 +1,14 @@
+interface FooI {
+    function fooNum(uint num) external;
+    function fooNums(uint[] calldata nums) external;
+    function fooNums2(uint[] calldata nums) external;
+}
+
+contract Foo is FooI {
+    function fooNum(uint num) public {}
+    function fooNums(uint[] memory nums) public {}
+}
+// ----
+// Warning: (210-218): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (251-269): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (234-280): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_2.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_2.sol
@@ -1,0 +1,10 @@
+interface FooI {
+    function fooNums(string calldata nums) external;
+}
+
+contract Foo is FooI {
+    function fooNums(string memory nums) public {}
+}
+// ----
+// Warning: (117-135): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (100-146): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_3.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_3.sol
@@ -1,0 +1,14 @@
+pragma experimental ABIEncoderV2;
+
+interface FooI {
+	struct S { uint x; }
+    function fooNums(S calldata nums) external;
+}
+
+contract Foo is FooI {
+    function fooNums(S memory nums) public {}
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (169-182): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (152-193): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_4.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_4.sol
@@ -1,0 +1,14 @@
+pragma experimental ABIEncoderV2;
+
+interface FooI {
+	struct S { uint[] x; }
+    function fooNums(S calldata nums) external;
+}
+
+contract Foo is FooI {
+    function fooNums(S memory nums) public {}
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (171-184): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (154-195): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_5.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_5.sol
@@ -1,0 +1,13 @@
+pragma experimental ABIEncoderV2;
+
+interface FooI {
+    function fooNums(uint[][] calldata nums) external;
+}
+
+contract Foo is FooI {
+    function fooNums(uint[][] memory nums) public {}
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (154-174): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (137-185): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_6.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_nonvalue_types_6.sol
@@ -1,0 +1,13 @@
+pragma experimental ABIEncoderV2;
+
+interface FooI {
+    function fooNums(uint[][] calldata nums) external;
+}
+
+contract Foo is FooI {
+    function fooNums(uint[][] memory nums) internal {}
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (154-174): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (137-187): Function state mutability can be restricted to pure


### PR DESCRIPTION
Fixes #4832 

Using `interfaceFunctionType` allows us to ignore the `location` for that check.