### PR TITLE
Crash when array index value is too large

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -111,6 +111,7 @@ Bugfixes:
  * Type Checker: Report error when using structs in events without experimental ABIEncoderV2. This used to crash or log the wrong values.
  * Type Checker: Report error when using indexed structs in events with experimental ABIEncoderV2. This used to log wrong values.
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
+ * Type Checker: Fix internal error when array index value is too large.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 
 ### 0.4.24 (2018-05-16)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2211,12 +2211,13 @@ bool TypeChecker::visit(IndexAccess const& _access)
 		else
 		{
 			expectType(*index, IntegerType(256));
-			if (auto numberType = dynamic_cast<RationalNumberType const*>(type(*index).get()))
-			{
-				if (!numberType->isFractional()) // error is reported above
+			if (!m_errorReporter.hasErrors())
+				if (auto numberType = dynamic_cast<RationalNumberType const*>(type(*index).get()))
+				{
+					solAssert(!numberType->isFractional(), "");
 					if (!actualType.isDynamicallySized() && actualType.length() <= numberType->literalValue(nullptr))
 						m_errorReporter.typeError(_access.location(), "Out of bounds array access.");
-			}
+				}
 		}
 		resultType = actualType.baseType();
 		isLValue = actualType.location() != DataLocation::CallData;

--- a/test/libsolidity/syntaxTests/types/array_index_too_large.sol
+++ b/test/libsolidity/syntaxTests/types/array_index_too_large.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public returns (string memory) {
+        // this used to cause an internal error
+        return (["zeppelin"][123456789012345678901234567890123456789012345678901234567890123456789012345678]);
+    }
+}
+// ----
+// TypeError: (140-218): Type int_const 1234...(70 digits omitted)...5678 is not implicitly convertible to expected type uint256.


### PR DESCRIPTION
Fix #4716

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
Add some check to report error instead of crash
