### PR TITLE
Disallow event overloading if only difference is indexed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -111,6 +111,7 @@ Bugfixes:
  * Type Checker: Report error when using structs in events without experimental ABIEncoderV2. This used to crash or log the wrong values.
  * Type Checker: Report error when using indexed structs in events with experimental ABIEncoderV2. This used to log wrong values.
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
+ * Type Checker: Overloading events where the only difference are indexed parameters is disallowed.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
 
 ### 0.4.24 (2018-05-16)

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -71,6 +71,8 @@ private:
 	/// Reports a type error with an appropriate message if overridden function signature differs.
 	/// Also stores the direct super function in the AST annotations.
 	void checkFunctionOverride(FunctionDefinition const& function, FunctionDefinition const& super);
+	/// Reports a type error with an appropriate message if overridden event is duplicate or overloading event does not extend parameter list.
+	void checkEventOverride(EventDefinition const& function, EventDefinition const& super);
 	void overrideError(FunctionDefinition const& function, FunctionDefinition const& super, std::string message);
 	void checkContractAbstractFunctions(ContractDefinition const& _contract);
 	void checkContractBaseConstructorArguments(ContractDefinition const& _contract);

--- a/test/libsolidity/syntaxTests/inheritance/event_overload_function.sol
+++ b/test/libsolidity/syntaxTests/inheritance/event_overload_function.sol
@@ -1,0 +1,9 @@
+contract IFoo {
+    function Approve(address a, address b) public;
+}
+contract Foo is IFoo {
+    event Approve(address a, address b);
+}
+// ----
+// DeclarationError: (96-132): Identifier already declared.
+// TypeError: (96-132): Override changes function to event.

--- a/test/libsolidity/syntaxTests/inheritance/event_overload_indexed_1.sol
+++ b/test/libsolidity/syntaxTests/inheritance/event_overload_indexed_1.sol
@@ -1,0 +1,8 @@
+contract IFoo {
+    event Approve(address a, address b);
+}
+contract Foo is IFoo {
+    event Approve(address indexed a, address b);
+}
+// ----
+// TypeError: (86-130): Event overload must extend parameter list or have different types.

--- a/test/libsolidity/syntaxTests/inheritance/event_overload_indexed_2.sol
+++ b/test/libsolidity/syntaxTests/inheritance/event_overload_indexed_2.sol
@@ -1,0 +1,8 @@
+contract IFoo {
+    event Approve(address indexed a, address b);
+}
+contract Foo is IFoo {
+    event Approve(address a, address b);
+}
+// ----
+// TypeError: (94-130): Event overload must extend parameter list or have different types.

--- a/test/libsolidity/syntaxTests/inheritance/event_overload_indexed_3.sol
+++ b/test/libsolidity/syntaxTests/inheritance/event_overload_indexed_3.sol
@@ -1,0 +1,8 @@
+contract IFoo {
+    event Approve(address a, address b);
+}
+contract Foo is IFoo {
+    event Approve(address indexed a, address indexed b);
+}
+// ----
+// TypeError: (86-138): Event overload must extend parameter list or have different types.

--- a/test/libsolidity/syntaxTests/inheritance/event_overload_modifier.sol
+++ b/test/libsolidity/syntaxTests/inheritance/event_overload_modifier.sol
@@ -1,0 +1,9 @@
+contract IFoo {
+    modifier Approve { _; }
+}
+contract Foo is IFoo {
+    event Approve(address a, address b);
+}
+// ----
+// DeclarationError: (73-109): Identifier already declared.
+// TypeError: (73-109): Override changes modifier to event.

--- a/test/libsolidity/syntaxTests/inheritance/function_overload_event.sol
+++ b/test/libsolidity/syntaxTests/inheritance/function_overload_event.sol
@@ -1,0 +1,9 @@
+contract IFoo {
+    event Approve(address a, address b);
+}
+contract Foo is IFoo {
+    function Approve(address a, address b) public;
+}
+// ----
+// DeclarationError: (86-132): Identifier already declared.
+// TypeError: (86-132): Override changes event to function.

--- a/test/libsolidity/syntaxTests/inheritance/modifier_overload_event.sol
+++ b/test/libsolidity/syntaxTests/inheritance/modifier_overload_event.sol
@@ -1,0 +1,9 @@
+contract IFoo {
+    event Approve(address a, address b);
+}
+contract Foo is IFoo {
+    modifier Approve { _; }
+}
+// ----
+// DeclarationError: (86-109): Identifier already declared.
+// TypeError: (86-109): Override changes event to modifier.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/087_double_event_declaration.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/087_double_event_declaration.sol
@@ -4,3 +4,4 @@ contract test {
 }
 // ----
 // DeclarationError: (20-36): Event with same name and arguments defined twice.
+// TypeError: (20-36): Event overload must extend parameter list or have different types.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/088_double_event_declaration_ignores_anonymous.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/088_double_event_declaration_ignores_anonymous.sol
@@ -4,3 +4,4 @@ contract test {
 }
 // ----
 // DeclarationError: (20-36): Event with same name and arguments defined twice.
+// TypeError: (20-36): Event overload must extend parameter list or have different types.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/089_double_event_declaration_ignores_indexed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/089_double_event_declaration_ignores_indexed.sol
@@ -4,3 +4,4 @@ contract test {
 }
 // ----
 // DeclarationError: (20-36): Event with same name and arguments defined twice.
+// TypeError: (20-36): Event overload must extend parameter list or have different types.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/091_event_function_inheritance_clash.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/091_event_function_inheritance_clash.sol
@@ -10,3 +10,4 @@ contract C is A, B {
 }
 // ----
 // DeclarationError: (99-111): Identifier already declared.
+// TypeError: (99-111): Override changes function to event.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/092_function_event_inheritance_clash.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/092_function_event_inheritance_clash.sol
@@ -10,3 +10,4 @@ contract C is B, A {
 }
 // ----
 // DeclarationError: (49-111): Identifier already declared.
+// TypeError: (49-111): Override changes event to function.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/093_function_event_in_contract_clash.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/093_function_event_in_contract_clash.sol
@@ -6,3 +6,4 @@ contract A {
 }
 // ----
 // DeclarationError: (34-96): Identifier already declared.
+// TypeError: (34-96): Override changes event to function.


### PR DESCRIPTION
Fixes #4803 

This code reports an error if two events have the same number of parameters and same types across contracts.