### PR TITLE
Mention in docs that standard json url files need --allow-paths

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -83,6 +83,8 @@ Input Description
           [
             "bzzr://56ab...",
             "ipfs://Qma...",
+            // If files are used, their directories should be added to the command line via
+            // `--allow-paths <path>`.
             "file:///tmp/path/to/file.sol"
           ]
         },


### PR DESCRIPTION
Clarifies #4688 