### PR TITLE
Split IntegerType into IntegerType and AddressType.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -86,6 +86,7 @@ Compiler Features:
  * C API (``libsolc``): Export the ``solidity_license``, ``solidity_version`` and ``solidity_compile`` methods.
  * Type Checker: Nicer error message when trying to reference overloaded identifiers in inline assembly.
  * Type Checker: Show named argument in case of error.
+ * Type System: IntegerType is split into IntegerType and AddressType internally.
  * Tests: Determine transaction status during IPC calls.
  * Code Generator: Allocate and free local variables according to their scope.
  * Removed ``pragma experimental "v0.5.0";``.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2103,7 +2103,7 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				"after argument-dependent lookup in " + exprType->toString() +
 				(memberName == "value" ? " - did you forget the \"payable\" modifier?" : ".");
 		if (exprType->category() == Type::Category::Contract)
-			for (auto const& addressMember: IntegerType(160, IntegerType::Modifier::Address).nativeMembers(nullptr))
+			for (auto const& addressMember: AddressType().nativeMembers(nullptr))
 				if (addressMember.name == memberName)
 				{
 					Identifier const* var = dynamic_cast<Identifier const*>(&_memberAccess.expression());
@@ -2353,7 +2353,7 @@ void TypeChecker::endVisit(Literal const& _literal)
 	if (_literal.looksLikeAddress())
 	{
 		// Assign type here if it even looks like an address. This prevents double errors for invalid addresses
-		_literal.annotation().type = make_shared<IntegerType>(160, IntegerType::Modifier::Address);
+		_literal.annotation().type = make_shared<AddressType>();
 
 		string msg;
 		if (_literal.value().length() != 42) // "0x" + 40 hex digits

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -323,7 +323,7 @@ void ViewPureChecker::endVisit(MemberAccess const& _memberAccess)
 	ASTString const& member = _memberAccess.memberName();
 	switch (_memberAccess.expression().annotation().type->category())
 	{
-	case Type::Category::Integer:
+	case Type::Category::Address:
 		if (member == "balance")
 			mutability = StateMutability::View;
 		break;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1259,7 +1259,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 				identifier = FunctionType(*function).externalIdentifier();
 			else
 				solAssert(false, "Contract member is neither variable nor function.");
-			utils().convertType(type, IntegerType(160, IntegerType::Modifier::Address), true);
+			utils().convertType(type, AddressType(), true);
 			m_context << identifier;
 		}
 		else
@@ -1268,11 +1268,16 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 	}
 	case Type::Category::Integer:
 	{
+		solAssert(false, "Invalid member access to integer");
+		break;
+	}
+	case Type::Category::Address:
+	{
 		if (member == "balance")
 		{
 			utils().convertType(
 				*_memberAccess.expression().annotation().type,
-				IntegerType(160, IntegerType::Modifier::Address),
+				AddressType(),
 				true
 			);
 			m_context << Instruction::BALANCE;
@@ -1280,11 +1285,11 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		else if ((set<string>{"send", "transfer", "call", "callcode", "delegatecall", "staticcall"}).count(member))
 			utils().convertType(
 				*_memberAccess.expression().annotation().type,
-				IntegerType(160, IntegerType::Modifier::Address),
+				AddressType(),
 				true
 			);
 		else
-			solAssert(false, "Invalid member access to integer");
+			solAssert(false, "Invalid member access to address");
 		break;
 	}
 	case Type::Category::Function:
@@ -1578,7 +1583,7 @@ void ExpressionCompiler::endVisit(Literal const& _literal)
 	{
 	case Type::Category::RationalNumber:
 	case Type::Category::Bool:
-	case Type::Category::Integer:
+	case Type::Category::Address:
 		m_context << type->literalValue(&_literal);
 		break;
 	case Type::Category::StringLiteral:

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -394,7 +394,7 @@ void SMTChecker::endVisit(Identifier const& _identifier)
 void SMTChecker::endVisit(Literal const& _literal)
 {
 	Type const& type = *_literal.annotation().type;
-	if (type.category() == Type::Category::Integer || type.category() == Type::Category::RationalNumber)
+	if (type.category() == Type::Category::Integer || type.category() == Type::Category::Address || type.category() == Type::Category::RationalNumber)
 	{
 		if (RationalNumberType const* rational = dynamic_cast<RationalNumberType const*>(&type))
 			solAssert(!rational->isFractional(), "");
@@ -540,6 +540,8 @@ void SMTChecker::assignment(VariableDeclaration const& _variable, smt::Expressio
 	TypePointer type = _variable.type();
 	if (auto const* intType = dynamic_cast<IntegerType const*>(type.get()))
 		checkUnderOverflow(_value, *intType, _location);
+	else if (dynamic_cast<AddressType const*>(type.get()))
+		checkUnderOverflow(_value, IntegerType(160), _location);
 	m_interface->addAssertion(newValue(_variable) == _value);
 }
 
@@ -862,6 +864,7 @@ void SMTChecker::createExpr(Expression const& _e)
 			m_expressions.emplace(&_e, m_interface->newInteger(uniqueSymbol(_e)));
 			break;
 		}
+		case Type::Category::Address:
 		case Type::Category::Integer:
 			m_expressions.emplace(&_e, m_interface->newInteger(uniqueSymbol(_e)));
 			break;

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -50,7 +50,7 @@ bool SSAVariable::isSupportedType(Type::Category _category)
 
 bool SSAVariable::isInteger(Type::Category _category)
 {
-	return _category == Type::Category::Integer;
+	return _category == Type::Category::Integer || _category == Type::Category::Address;
 }
 
 bool SSAVariable::isBool(Type::Category _category)

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -29,7 +29,11 @@ SymbolicIntVariable::SymbolicIntVariable(
 ):
 	SymbolicVariable(_decl, _interface)
 {
-	solAssert(m_declaration.type()->category() == Type::Category::Integer, "");
+	solAssert(
+		m_declaration.type()->category() == Type::Category::Integer ||
+		m_declaration.type()->category() == Type::Category::Address,
+		""
+	);
 }
 
 smt::Expression SymbolicIntVariable::valueAtSequence(int _seq) const
@@ -44,9 +48,11 @@ void SymbolicIntVariable::setZeroValue(int _seq)
 
 void SymbolicIntVariable::setUnknownValue(int _seq)
 {
-	auto const& intType = dynamic_cast<IntegerType const&>(*m_declaration.type());
-	m_interface.addAssertion(valueAtSequence(_seq) >= minValue(intType));
-	m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(intType));
+	auto intType = dynamic_pointer_cast<IntegerType const>(m_declaration.type());
+	if (!intType)
+		intType = make_shared<IntegerType>(160);
+	m_interface.addAssertion(valueAtSequence(_seq) >= minValue(*intType));
+	m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(*intType));
 }
 
 smt::Expression SymbolicIntVariable::minValue(IntegerType const& _t)

--- a/test/compilationTests/zeppelin/token/VestedToken.sol
+++ b/test/compilationTests/zeppelin/token/VestedToken.sol
@@ -53,7 +53,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
 
     uint256 count = grants[_to].push(
                 TokenGrant(
-                  _revokable ? msg.sender : 0, // avoid storing an extra 20 bytes when it is non-revokable
+                  _revokable ? msg.sender : 0x0000000000000000000000000000000000000000, // avoid storing an extra 20 bytes when it is non-revokable
                   _value,
                   _cliff,
                   _vesting,
@@ -84,7 +84,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
       revert();
     }
 
-    address receiver = grant.burnsOnRevoke ? 0xdead : msg.sender;
+    address receiver = grant.burnsOnRevoke ? 0x000000000000000000000000000000000000dEaD : msg.sender;
 
     uint256 nonVested = nonVestedTokens(grant, uint64(now));
 


### PR DESCRIPTION
As a prerequisite for #4552, ``IntegerType`` is split into ``IntegerType`` and ``AddressType``.
Code generation and SMT checker continue to treat ``AddressType`` in the same way as ``IntegerType(160)``.