### PR TITLE
add more vim temp files to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ docs/utils/*.pyc
 /deps/downloads/
 
 # vim stuff
-.*.sw?
+[._]*.sw[a-p]
+[._]sw[a-p]
 
 # IDE files
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ docs/utils/*.pyc
 /deps/downloads/
 
 # vim stuff
-*.swp
+.*.sw?
 
 # IDE files
 .idea


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
Please explain the changes you made here.

When we edit one file multiple times, we may get other temporary files from vim, e.g. .*.swo.
So, this PR changes it from "swp" to "sw?".

Thank you for your help!
