### PR TITLE
type conversion checker for array should be stronger

### DIFF
--- a/test/libsolidity/syntaxTests/conversion/allowed_conversion_to_bytes_array.sol
+++ b/test/libsolidity/syntaxTests/conversion/allowed_conversion_to_bytes_array.sol
@@ -1,0 +1,9 @@
+contract C {
+	bytes a;
+	bytes b;
+	function f() public view {
+		bytes storage c = a;
+		bytes memory d = b;
+		d = bytes(c);
+	}
+}

--- a/test/libsolidity/syntaxTests/conversion/allowed_conversion_to_string.sol
+++ b/test/libsolidity/syntaxTests/conversion/allowed_conversion_to_string.sol
@@ -1,0 +1,9 @@
+contract C {
+	string a;
+	string b;
+	function f() public view {
+		string storage c = a;
+		string memory d = b;
+		d = string(c);
+	}
+}

--- a/test/libsolidity/syntaxTests/conversion/explicit_conversion_from_storage_array_ref.sol
+++ b/test/libsolidity/syntaxTests/conversion/explicit_conversion_from_storage_array_ref.sol
@@ -1,0 +1,10 @@
+contract C {
+	int[10] x;
+	function f() public view {
+		int[](x);
+		int(x);
+	}
+}
+// ----
+// TypeError: (55-63): Explicit type conversion not allowed from "int256[10] storage ref" to "int256[] storage pointer".
+// TypeError: (67-73): Explicit type conversion not allowed from "int256[10] storage ref" to "int256".

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_storage_array_ref.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_storage_array_ref.sol
@@ -1,0 +1,7 @@
+contract C {
+	int[10] x;
+	int[] y;
+	function f() public {
+		y = x;
+	}
+}

--- a/test/libsolidity/syntaxTests/conversion/not_allowed_conversion_to_int_array_pointer1.sol
+++ b/test/libsolidity/syntaxTests/conversion/not_allowed_conversion_to_int_array_pointer1.sol
@@ -1,0 +1,10 @@
+contract C {
+	uint[] a;
+	uint[] b;
+	function f() public view {
+		uint[] storage c = a;
+		uint[] storage d = b;
+		d = uint[](c);
+	}
+}
+// ----

--- a/test/libsolidity/syntaxTests/conversion/not_allowed_conversion_to_int_array_pointer2.sol
+++ b/test/libsolidity/syntaxTests/conversion/not_allowed_conversion_to_int_array_pointer2.sol
@@ -1,0 +1,10 @@
+contract C {
+	uint[] a;
+	uint[] b;
+	function f() public view {
+		uint[] storage c = a;
+		uint[] memory d = b;
+		d = uint[](c);
+	}
+}
+// ----

--- a/test/libsolidity/syntaxTests/dataLocations/memory_storage_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/memory_storage_data_location.sol
@@ -1,0 +1,12 @@
+contract C {
+	int[] x;
+	function f() public {
+		int[] storage a = x;
+		int[] memory b;
+		a = b;
+		a = int[](b);
+	}
+}
+// ----
+// TypeError: (93-94): Type int256[] memory is not implicitly convertible to expected type int256[] storage pointer.
+// TypeError: (102-110): Type int256[] memory is not implicitly convertible to expected type int256[] storage pointer.


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

This fix is for the issue #4901.
The type conversion checker for array should be stronger.
