### PR TITLE
Parser cleanup.

### DIFF
--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -69,11 +69,11 @@ private:
 	///@name Parsing functions for the AST nodes
 	ASTPointer<PragmaDirective> parsePragmaDirective();
 	ASTPointer<ImportDirective> parseImportDirective();
-	ContractDefinition::ContractKind tokenToContractKind(Token::Value _token);
-	ASTPointer<ContractDefinition> parseContractDefinition(Token::Value _expectedKind);
+	ContractDefinition::ContractKind parseContractKind();
+	ASTPointer<ContractDefinition> parseContractDefinition();
 	ASTPointer<InheritanceSpecifier> parseInheritanceSpecifier();
-	Declaration::Visibility parseVisibilitySpecifier(Token::Value _token);
-	StateMutability parseStateMutability(Token::Value _token);
+	Declaration::Visibility parseVisibilitySpecifier();
+	StateMutability parseStateMutability();
 	FunctionHeaderParserResult parseFunctionHeader(bool _forceEmptyName, bool _allowModifiers);
 	ASTPointer<ASTNode> parseFunctionDefinitionOrFunctionTypeStateVariable();
 	ASTPointer<FunctionDefinition> parseFunctionDefinition(ASTString const* _contractName);


### PR DESCRIPTION
Came up during #4911.

Most parser functions are of the form ``parse*()``. They take no arguments, but instead use ``m_scanner->currentToken()``, they assert that this token is valid and they call ``m_scanner->next()`` inside the body.

However, this schema is not always adhered to, which is fixed in this PR.