### PR TITLE
Disallow indexed reference types in events when using ABIEncoderV2 (backported)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.4.25 (unreleased)
 
 Bugfixes:
+ * Type Checker: Report error when using indexed structs in events with experimental ABIEncoderV2. This used to log wrong values.
  * Type Checker: Report error when using structs in events without experimental ABIEncoderV2. This used to crash or log the wrong values.
 
 ### 0.4.24 (2018-05-16)

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -4,7 +4,7 @@
 		"summary": "Using structs in events logged wrong data.",
 		"description": "If a struct is used in an event, the address of the struct is logged instead of the actual data.",
 		"introduced": "0.4.17",
-		"fixed": "0.5.0",
+		"fixed": "0.4.25",
 		"severity": "very low"
 	},
     {

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -1,4 +1,12 @@
 [
+	{
+		"name": "EventStructWrongData",
+		"summary": "Using structs in events logged wrong data.",
+		"description": "If a struct is used in an event, the address of the struct is logged instead of the actual data.",
+		"introduced": "0.4.17",
+		"fixed": "0.5.0",
+		"severity": "very low"
+	},
     {
         "name": "OneOfTwoConstructorsSkipped",
         "summary": "If a contract has both a new-style constructor (using the constructor keyword) and an old-style constructor (a function with the same name as the contract) at the same time, one of them will be ignored.",

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -389,16 +389,21 @@
     }, 
     "0.4.17": {
         "bugs": [
+            "EventStructWrongData", 
             "ZeroFunctionSelector"
         ], 
         "released": "2017-09-21"
     }, 
     "0.4.18": {
-        "bugs": [], 
+        "bugs": [
+            "EventStructWrongData"
+        ], 
         "released": "2017-10-18"
     }, 
     "0.4.19": {
-        "bugs": [], 
+        "bugs": [
+            "EventStructWrongData"
+        ], 
         "released": "2017-11-30"
     }, 
     "0.4.2": {
@@ -415,25 +420,34 @@
         "released": "2016-09-17"
     }, 
     "0.4.20": {
-        "bugs": [], 
+        "bugs": [
+            "EventStructWrongData"
+        ], 
         "released": "2018-02-14"
     }, 
     "0.4.21": {
-        "bugs": [], 
+        "bugs": [
+            "EventStructWrongData"
+        ], 
         "released": "2018-03-07"
     }, 
     "0.4.22": {
         "bugs": [
+            "EventStructWrongData", 
             "OneOfTwoConstructorsSkipped"
         ], 
         "released": "2018-04-16"
     }, 
     "0.4.23": {
-        "bugs": [], 
+        "bugs": [
+            "EventStructWrongData"
+        ], 
         "released": "2018-04-19"
     }, 
     "0.4.24": {
-        "bugs": [], 
+        "bugs": [
+            "EventStructWrongData"
+        ], 
         "released": "2018-05-16"
     }, 
     "0.4.3": {

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -869,7 +869,17 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 	for (ASTPointer<VariableDeclaration> const& var: _eventDef.parameters())
 	{
 		if (var->isIndexed())
+		{
 			numIndexed++;
+			if (
+				_eventDef.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2)
+				&& dynamic_cast<ReferenceType const*>(type(*var).get())
+			)
+				m_errorReporter.typeError(
+					var->location(),
+					"Reference types cannot be indexed."
+				);
+		}
 		if (!type(*var)->canLiveOutsideStorage())
 			m_errorReporter.typeError(var->location(), "Type is required to live outside storage.");
 		if (!type(*var)->interfaceType(false))

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -872,12 +872,12 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 		{
 			numIndexed++;
 			if (
-				_eventDef.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2)
-				&& dynamic_cast<ReferenceType const*>(type(*var).get())
+				_eventDef.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2) &&
+				dynamic_cast<ReferenceType const*>(type(*var).get())
 			)
 				m_errorReporter.typeError(
 					var->location(),
-					"Reference types cannot be indexed."
+					"Indexed reference types cannot yet be used with ABIEncoderV2."
 				);
 		}
 		if (!type(*var)->canLiveOutsideStorage())

--- a/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
@@ -1,0 +1,7 @@
+pragma experimental ABIEncoderV2;
+contract c {
+    event E(uint[] indexed);
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (59-65): Reference types cannot be indexed.

--- a/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
@@ -4,4 +4,4 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (59-65): Reference types cannot be indexed.
+// TypeError: (59-65): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_array_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_array_v2.sol
@@ -1,0 +1,6 @@
+pragma experimental ABIEncoderV2;
+contract c {
+    event E(uint[]);
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
@@ -4,4 +4,4 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (59-67): Reference types cannot be indexed.
+// TypeError: (59-67): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
@@ -1,0 +1,7 @@
+pragma experimental ABIEncoderV2;
+contract c {
+    event E(uint[][] indexed);
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (59-67): Reference types cannot be indexed.

--- a/test/libsolidity/syntaxTests/events/event_nested_array_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array_v2.sol
@@ -1,0 +1,6 @@
+pragma experimental ABIEncoderV2;
+contract c {
+    event E(uint[][]);
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
@@ -5,4 +5,4 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (85-86): Reference types cannot be indexed.
+// TypeError: (85-86): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
@@ -1,0 +1,8 @@
+pragma experimental ABIEncoderV2;
+contract c {
+    struct S { uint a ; }
+    event E(S indexed);
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (85-86): Reference types cannot be indexed.

--- a/test/libsolidity/syntaxTests/events/event_struct_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_v2.sol
@@ -1,0 +1,7 @@
+pragma experimental ABIEncoderV2;
+contract c {
+    struct S { uint a ; }
+    event E(S);
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.


### PR DESCRIPTION
Backported version of https://github.com/ethereum/solidity/pull/4820 with corrected "fixed" date.

Note that this PR merges into "develop_v0425"