### PR TITLE
Clarify docs around reserved memory byte ranges

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -64,7 +64,7 @@ The position of ``data[4][9].b`` is at ``keccak256(uint256(9) . keccak256(uint25
 Layout in Memory
 ****************
 
-Solidity reserves four 32 byte slots:
+Solidity reserves four 32-byte slots, with specific byte ranges (inclusive of endpoints) being used as follows:
 
 - ``0x00`` - ``0x3f`` (64 bytes): scratch space for hashing methods
 - ``0x40`` - ``0x5f`` (32 bytes): currently allocated memory size (aka. free memory pointer)


### PR DESCRIPTION
Minor documentation issue to improve reading flow as it goes from talking about a specified number of 32-byte slots being reserved to giving numbers which refer to byte ranges within the space of memory resulting from the union of those slots.
