### PR TITLE
[BACKPORT] Use wildcards for MSVC version in scripts/release.bat.

### DIFF
--- a/scripts/release.bat
+++ b/scripts/release.bat
@@ -32,12 +32,9 @@ set VERSION=%2
 IF "%VERSION%"=="2015" (
     set "DLLS=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvc*.dll"
 ) ELSE (
-
-    IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.13.26020\x86\Microsoft.VC141.CRT\" (
-        set "DLLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.13.26020\x86\Microsoft.VC141.CRT\msvc*.dll"
-		) ELSE (
-        set "DLLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Redist\MSVC\14.13.26020\x86\Microsoft.VC141.CRT\msvc*.dll"
-    )
+    set "DLLS=MSVC_DLLS_NOT_FOUND"
+    FOR /d %%d IN ("C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Redist\MSVC\*"
+                   "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\*") DO set "DLLS=%%d\x86\Microsoft.VC141.CRT\msvc*.dll"
 )
 
 7z a solidity-windows.zip ^


### PR DESCRIPTION
Backport of #4890 to develop_v0425.
Fixes  #4919.

Note that this will be merged to the develop_v0425 branch.