### PR TITLE
delay the lib option parse after assemble because it is not used by the assembler

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -760,11 +760,6 @@ bool CommandLineInterface::processInput()
 	if (!readInputFilesAndConfigureRemappings())
 		return false;
 
-	if (m_args.count(g_argLibraries))
-		for (string const& library: m_args[g_argLibraries].as<vector<string>>())
-			if (!parseLibraryOption(library))
-				return false;
-
 	if (m_args.count(g_strEVMVersion))
 	{
 		string versionOptionStr = m_args[g_strEVMVersion].as<string>();
@@ -802,6 +797,12 @@ bool CommandLineInterface::processInput()
 		}
 		return assemble(inputLanguage, targetMachine);
 	}
+
+	if (m_args.count(g_argLibraries))
+		for (string const& library: m_args[g_argLibraries].as<vector<string>>())
+			if (!parseLibraryOption(library))
+				return false;
+
 	if (m_args.count(g_argLink))
 	{
 		// switch to linker mode


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
Please explain the changes you made here.

The library option is never used by the assembler in Solidity. So, we do not need to parse it if the user only wants to call the assembler.

This PR delay the parse for library option after the assembler code.

Thank you for your help!
