### PR TITLE
On a yul switch, at least one case is required when there is no default statement

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -99,9 +99,11 @@ Grammar::
     If =
         'if' Expression Block
     Switch =
-        'switch' Expression Case* ( 'default' Block )?
+        'switch' Expression ( Case+ Default? | Default )
     Case =
         'case' Literal Block
+    Default =
+        'default' Block
     ForLoop =
         'for' Block Expression Block Block
     BreakContinue =


### PR DESCRIPTION
Change the `*` to `+` on the grammar for the switch statement, because there must be at least one case.

### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
Change the `*` to `+` on the grammar for the switch statement, because there must be at least one case.

Thank you for your help!
