### PR TITLE
Properly truncate referenced src

### DIFF
--- a/libsolidity/interface/SourceReferenceFormatter.cpp
+++ b/libsolidity/interface/SourceReferenceFormatter.cpp
@@ -55,8 +55,14 @@ void SourceReferenceFormatter::printSourceLocation(SourceLocation const* _locati
 		}
 		if (line.length() > 150)
 		{
-			line = " ... " + line.substr(startColumn, locationLength) + " ... ";
-			startColumn = 5;
+			int len = line.length();
+			line = line.substr(max(0, startColumn - 35), min(startColumn, 35) + min(locationLength + 35, len - startColumn));
+			if (startColumn + locationLength + 35 < len)
+				line += " ...";
+			if (startColumn > 35) {
+				line = " ... " + line;
+				startColumn = 40;
+			}
 			endColumn = startColumn + locationLength;
 		}
 

--- a/test/cmdlineErrorReports/too_long_line.sol
+++ b/test/cmdlineErrorReports/too_long_line.sol
@@ -1,0 +1,4 @@
+contract C {
+   function ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(announcementType Type, string Announcement, string Link, bool Oppositable, string _str, uint256 _uint, address _addr) onlyOwner external {
+}
+}

--- a/test/cmdlineErrorReports/too_long_line.sol.ref
+++ b/test/cmdlineErrorReports/too_long_line.sol.ref
@@ -1,0 +1,7 @@
+
+too_long_line.sol:1:1: Warning: Source file does not specify required compiler version!
+contract C {
+^ (Relevant source part starts here and spans across multiple lines).
+too_long_line.sol:2:164: Error: Identifier not found or not unique.
+ ... ffffffffffffffffffffffffffffffffff(announcementType Type, string Announcement, string  ...
+                                        ^--------------^

--- a/test/cmdlineErrorReports/too_long_line_both_sides_short.sol
+++ b/test/cmdlineErrorReports/too_long_line_both_sides_short.sol
@@ -1,0 +1,5 @@
+contract C {
+   function f(announcementTypeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Type,
+       string Announcement, string Link, bool Oppositable, string _str, uint256 _uint, address _addr) onlyOwner external {
+}
+}

--- a/test/cmdlineErrorReports/too_long_line_both_sides_short.sol.ref
+++ b/test/cmdlineErrorReports/too_long_line_both_sides_short.sol.ref
@@ -1,0 +1,7 @@
+
+too_long_line_both_sides_short.sol:1:1: Warning: Source file does not specify required compiler version!
+contract C {
+^ (Relevant source part starts here and spans across multiple lines).
+too_long_line_both_sides_short.sol:2:15: Error: Identifier not found or not unique.
+   function f(announcementTypeXXXXXXXXXXXXXXXXXXX ... XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Type,
+              ^-------------------------------------------------------------------------^

--- a/test/cmdlineErrorReports/too_long_line_edge_in.sol
+++ b/test/cmdlineErrorReports/too_long_line_edge_in.sol
@@ -1,0 +1,4 @@
+contract C {
+   function ffffffffffffffffffffff(announcementTypeTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT Ty, string A) onlyOwner external {
+}
+}

--- a/test/cmdlineErrorReports/too_long_line_edge_in.sol.ref
+++ b/test/cmdlineErrorReports/too_long_line_edge_in.sol.ref
@@ -1,0 +1,7 @@
+
+too_long_line_edge_in.sol:1:1: Warning: Source file does not specify required compiler version!
+contract C {
+^ (Relevant source part starts here and spans across multiple lines).
+too_long_line_edge_in.sol:2:36: Error: Identifier not found or not unique.
+   function ffffffffffffffffffffff(announcementTypeTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT Ty, string A) onlyOwner external {
+                                   ^----------------------------------------------------------------------------------------------^

--- a/test/cmdlineErrorReports/too_long_line_edge_out.sol
+++ b/test/cmdlineErrorReports/too_long_line_edge_out.sol
@@ -1,0 +1,4 @@
+contract C {
+   function fffffffffffffffffffffff(announcementTypeTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT Typ, string A) onlyOwner external {
+}
+}

--- a/test/cmdlineErrorReports/too_long_line_edge_out.sol.ref
+++ b/test/cmdlineErrorReports/too_long_line_edge_out.sol.ref
@@ -1,0 +1,7 @@
+
+too_long_line_edge_out.sol:1:1: Warning: Source file does not specify required compiler version!
+contract C {
+^ (Relevant source part starts here and spans across multiple lines).
+too_long_line_edge_out.sol:2:37: Error: Identifier not found or not unique.
+ ...   function fffffffffffffffffffffff(announcementTypeTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT Typ, string A) onlyOwner external  ...
+                                        ^----------------------------------------------------------------------------------------------^

--- a/test/cmdlineErrorReports/too_long_line_left_short.sol
+++ b/test/cmdlineErrorReports/too_long_line_left_short.sol
@@ -1,0 +1,4 @@
+contract C {
+   function f(announcementType Type, string Announcement, string Link, bool Oppositable, string _str, uint256 _uint, address _addr) onlyOwner external {
+}
+}

--- a/test/cmdlineErrorReports/too_long_line_left_short.sol.ref
+++ b/test/cmdlineErrorReports/too_long_line_left_short.sol.ref
@@ -1,0 +1,7 @@
+
+too_long_line_left_short.sol:1:1: Warning: Source file does not specify required compiler version!
+contract C {
+^ (Relevant source part starts here and spans across multiple lines).
+too_long_line_left_short.sol:2:15: Error: Identifier not found or not unique.
+   function f(announcementType Type, string Announcement, string  ...
+              ^--------------^

--- a/test/cmdlineErrorReports/too_long_line_right_short.sol
+++ b/test/cmdlineErrorReports/too_long_line_right_short.sol
@@ -1,0 +1,5 @@
+contract C {
+   function ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff(announcementType Type,
+       string Announcement, string Link, bool Oppositable, string _str, uint256 _uint, address _addr) onlyOwner external {
+}
+}

--- a/test/cmdlineErrorReports/too_long_line_right_short.sol.ref
+++ b/test/cmdlineErrorReports/too_long_line_right_short.sol.ref
@@ -1,0 +1,7 @@
+
+too_long_line_right_short.sol:1:1: Warning: Source file does not specify required compiler version!
+contract C {
+^ (Relevant source part starts here and spans across multiple lines).
+too_long_line_right_short.sol:2:164: Error: Identifier not found or not unique.
+ ... ffffffffffffffffffffffffffffffffff(announcementType Type,
+                                        ^--------------^


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] Used meaningful commit messages

### Description

This PR fixes the issue #4741 by trying to give more information for too long lines.
Basically, the solution gives at most 35 chars before and after the string we want to print if the line is too long. The previous solution simply prints the string out which is lack of the context of the problem we want to show to a user.

This PR is tested with 4 possible situations, i.e. no side, left side, right side, or both sides are shorter than 35 chars. Two more edge tests are also added to test that it prints "..." when the corresponding edge has more than 35 chars.
