### PR TITLE
smt: added fallback type

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -779,20 +779,18 @@ void SMTChecker::mergeVariables(vector<VariableDeclaration const*> const& _varia
 
 bool SMTChecker::createVariable(VariableDeclaration const& _varDecl)
 {
-	if (SSAVariable::isSupportedType(_varDecl.type()->category()))
-	{
-		solAssert(m_variables.count(&_varDecl) == 0, "");
-		m_variables.emplace(&_varDecl, SSAVariable(_varDecl, *m_interface));
-		return true;
-	}
-	else
-	{
+	// Unconditionally add the variable. If the type is not supported
+	// SSAVariable will use the fallback which is an 256bits integer.
+	solAssert(m_variables.count(&_varDecl) == 0, "");
+	m_variables.emplace(&_varDecl, SSAVariable(_varDecl, *m_interface));
+
+	if (!SSAVariable::isSupportedType(_varDecl.type()->category()))
 		m_errorReporter.warning(
 			_varDecl.location(),
 			"Assertion checker does not yet support the type of this variable."
 		);
-		return false;
-	}
+
+	return true;
 }
 
 string SMTChecker::uniqueSymbol(Expression const& _expr)

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -209,16 +209,17 @@ void SMTChecker::endVisit(Assignment const& _assignment)
 			_assignment.location(),
 			"Assertion checker does not yet implement compound assignment."
 		);
-	else if (!SSAVariable::isSupportedType(_assignment.annotation().type->category()))
-		m_errorReporter.warning(
-			_assignment.location(),
-			"Assertion checker does not yet implement type " + _assignment.annotation().type->toString()
-		);
 	else if (Identifier const* identifier = dynamic_cast<Identifier const*>(&_assignment.leftHandSide()))
 	{
 		VariableDeclaration const& decl = dynamic_cast<VariableDeclaration const&>(*identifier->annotation().referencedDeclaration);
 		if (knownVariable(decl))
 		{
+			if (!SSAVariable::isSupportedType(_assignment.annotation().type->category()))
+				m_errorReporter.warning(
+					_assignment.location(),
+					"Assertion checker does not yet implement type " + _assignment.annotation().type->toString()
+				);
+
 			assignment(decl, _assignment.rightHandSide(), _assignment.location());
 			defineExpr(_assignment, expr(_assignment.rightHandSide()));
 		}
@@ -868,7 +869,8 @@ void SMTChecker::createExpr(Expression const& _e)
 			m_expressions.emplace(&_e, m_interface->newBool(uniqueSymbol(_e)));
 			break;
 		default:
-			solUnimplementedAssert(false, "Type not implemented.");
+			// Create an integer in the SMT solver, to match the fallback type
+			m_expressions.emplace(&_e, m_interface->newInteger(uniqueSymbol(_e)));
 		}
 	}
 }

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -19,6 +19,7 @@
 
 #include <libsolidity/formal/SymbolicBoolVariable.h>
 #include <libsolidity/formal/SymbolicIntVariable.h>
+#include <libsolidity/formal/SymbolicFallbackVariable.h>
 
 #include <libsolidity/ast/AST.h>
 
@@ -39,7 +40,10 @@ SSAVariable::SSAVariable(
 		m_symbolicVar = make_shared<SymbolicBoolVariable>(_decl, _interface);
 	else
 	{
-		solAssert(false, "");
+		// Use a fallback type. This allow the SMT checker to run on functions
+		// which use unsupported types. It may introduce false-positivies, but
+		// it will allows the checker to run on the known types.
+		m_symbolicVar = make_shared<SymbolicFallbackVariable>(_decl, _interface);
 	}
 }
 

--- a/libsolidity/formal/SymbolicFallbackVariable.cpp
+++ b/libsolidity/formal/SymbolicFallbackVariable.cpp
@@ -1,0 +1,58 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/formal/SymbolicFallbackVariable.h>
+
+#include <libsolidity/ast/AST.h>
+
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+SymbolicFallbackVariable::SymbolicFallbackVariable(
+	Declaration const& _decl,
+	smt::SolverInterface& _interface
+):
+	SymbolicVariable(_decl, _interface)
+{ }
+
+smt::Expression SymbolicFallbackVariable::valueAtSequence(int _seq) const
+{
+	return m_interface.newInteger(uniqueSymbol(_seq));
+}
+
+void SymbolicFallbackVariable::setZeroValue(int _seq)
+{
+	m_interface.addAssertion(valueAtSequence(_seq) == 0);
+}
+
+void SymbolicFallbackVariable::setUnknownValue(int _seq)
+{
+	auto const& intType = IntegerType(256);
+	m_interface.addAssertion(valueAtSequence(_seq) >= minValue(intType));
+	m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(intType));
+}
+
+smt::Expression SymbolicFallbackVariable::minValue(IntegerType const& _t)
+{
+	return smt::Expression(_t.minValue());
+}
+
+smt::Expression SymbolicFallbackVariable::maxValue(IntegerType const& _t)
+{
+	return smt::Expression(_t.maxValue());
+}

--- a/libsolidity/formal/SymbolicFallbackVariable.h
+++ b/libsolidity/formal/SymbolicFallbackVariable.h
@@ -1,0 +1,54 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolidity/formal/SymbolicVariable.h>
+
+#include <libsolidity/ast/Types.h>
+
+namespace dev
+{
+namespace solidity
+{
+
+/**
+ * Fallback variable based on Integers, used for types which are not
+ * implemented yet.
+ */
+class SymbolicFallbackVariable: public SymbolicVariable
+{
+public:
+	SymbolicFallbackVariable(
+		Declaration const& _decl,
+		smt::SolverInterface& _interface
+	);
+	//
+	/// Sets the var to 0.
+	void setZeroValue(int _seq);
+	/// Sets the variable to the full valid value range.
+	void setUnknownValue(int _seq);
+
+	static smt::Expression minValue(IntegerType const& _t);
+	static smt::Expression maxValue(IntegerType const& _t);
+
+protected:
+	smt::Expression valueAtSequence(int _seq) const;
+};
+
+}
+}

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -751,6 +751,21 @@ BOOST_AUTO_TEST_CASE(division_truncates_correctly)
 	)";
 	CHECK_SUCCESS_NO_WARNINGS(text);
 }
+BOOST_AUTO_TEST_CASE(regression_test)
+{
+	string text = R"(
+		library Test {
+			function test() {
+				bytes32 computedHash;
+				bytes32[] memory _proof;
+				for (;true;) {
+					computedHash = _proof[0];
+				}
+			}
+		}
+	)";
+	CHECK_SUCCESS(text);
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -765,6 +765,15 @@ BOOST_AUTO_TEST_CASE(regression_test)
 		}
 	)";
 	CHECK_SUCCESS(text);
+	text = R"(
+		library Test {
+			function test() internal pure {
+				bytes32[] memory _proof;
+				bytes32 proofElement = _proof[0];
+			}
+		}
+	)";
+	CHECK_SUCCESS(text);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change
- [ ] Changelog entry
- [x] Used meaningful commit messages (should be good enough)

### Description

~~Fixes~~ Partial fix for #4538 

The problem in short: Unsupported variables were not added to `m_variables` but the visitor callbacks expected it to be there.

The solution: Always define the variables, if it's unsupported use a fallback type (uint256)

Opening the PR for code review, then I can add the tests and changelog (if that is okay)