### PR TITLE
Removed default case from "ExpressionCompiler::visit(FunctionCall...)".

### DIFF
--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -311,8 +311,6 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 			return make_shared<FunctionType>(*this, _internal);
 		case Declaration::Visibility::External:
 			return {};
-		default:
-			solAssert(false, "visibility() should return a Visibility");
 		}
 	}
 	else
@@ -327,8 +325,6 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 		case Declaration::Visibility::Public:
 		case Declaration::Visibility::External:
 			return make_shared<FunctionType>(*this, _internal);
-		default:
-			solAssert(false, "visibility() should return a Visibility");
 		}
 	}
 
@@ -568,8 +564,6 @@ FunctionTypePointer VariableDeclaration::functionType(bool _internal) const
 	case Declaration::Visibility::Public:
 	case Declaration::Visibility::External:
 		return make_shared<FunctionType>(*this);
-	default:
-		solAssert(false, "visibility() should not return a Visibility");
 	}
 
 	// To make the compiler happy

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -747,9 +747,9 @@ string ASTJsonConverter::location(VariableDeclaration::Location _location)
 		return "memory";
 	case VariableDeclaration::Location::CallData:
 		return "calldata";
-	default:
-		solAssert(false, "Unknown declaration location.");
 	}
+	// To make the compiler happy
+	return {};
 }
 
 string ASTJsonConverter::contractKind(ContractDefinition::ContractKind _kind)
@@ -762,9 +762,10 @@ string ASTJsonConverter::contractKind(ContractDefinition::ContractKind _kind)
 		return "contract";
 	case ContractDefinition::ContractKind::Library:
 		return "library";
-	default:
-		solAssert(false, "Unknown kind of contract.");
 	}
+
+	// To make the compiler happy
+	return {};
 }
 
 string ASTJsonConverter::functionCallKind(FunctionCallKind _kind)

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -1108,8 +1108,6 @@ void ArrayUtils::accessIndex(ArrayType const& _arrayType, bool _doBoundsCheck) c
 		m_context << endTag;
 		break;
 	}
-	default:
-		solAssert(false, "");
 	}
 }
 

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -895,15 +895,6 @@ void CompilerUtils::convertType(
 					typeOnStack.location() == DataLocation::CallData,
 				"Invalid conversion to calldata type.");
 			break;
-		default:
-			solAssert(
-				false,
-				"Invalid type conversion " +
-				_typeOnStack.toString(false) +
-				" to " +
-				_targetType.toString(false) +
-				" requested."
-			);
 		}
 		break;
 	}

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1098,8 +1098,6 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::GasLeft:
 			m_context << Instruction::GAS;
 			break;
-		default:
-			solAssert(false, "Invalid function type.");
 		}
 	}
 	return false;

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -639,8 +639,6 @@ void SMTChecker::checkCondition(
 	case smt::CheckResult::ERROR:
 		m_errorReporter.warning(_location, "Error trying to invoke SMT solver.");
 		break;
-	default:
-		solAssert(false, "");
 	}
 	m_interface->pop();
 }

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -91,8 +91,6 @@ pair<CheckResult, vector<string>> Z3Interface::check(vector<Expression> const& _
 		case z3::check_result::unknown:
 			result = CheckResult::UNKNOWN;
 			break;
-		default:
-			solAssert(false, "");
 		}
 
 		if (result == CheckResult::SATISFIABLE && !_expressionsToEvaluate.empty())

--- a/libsolidity/interface/Exceptions.cpp
+++ b/libsolidity/interface/Exceptions.cpp
@@ -49,9 +49,6 @@ Error::Error(Type _type, SourceLocation const& _location, string const& _descrip
 	case Type::Warning:
 		m_typeName = "Warning";
 		break;
-	default:
-		solAssert(false, "");
-		break;
 	}
 
 	if (!_location.isEmpty())


### PR DESCRIPTION
Fixes #3667.

### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
Please explain the changes you made here.
Removed default case from "ExpressionCompiler::visit(FunctionCall...)".
Couldn't remove default case from few other places due to compilation error, hence didn't investigate further.

Let me know if I need to look at those default cases as well.
Thank you for your help!
