### PR TITLE
Fix tests for newer versions of aleth.

### DIFF
--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -122,9 +122,9 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 	if (!_isCreation)
 	{
 		d.to = dev::toString(m_contractAddress);
-		BOOST_REQUIRE(m_rpc.eth_getCode(d.to, "latest").size() > 2);
+		BOOST_REQUIRE(m_rpc.eth_getCode(d.to, "pending").size() > 2);
 		// Use eth_call to get the output
-		m_output = fromHex(m_rpc.eth_call(d, "latest"), WhenError::Throw);
+		m_output = fromHex(m_rpc.eth_call(d, "pending"), WhenError::Throw);
 	}
 
 	string txHash = m_rpc.eth_sendTransaction(d);


### PR DESCRIPTION
This fixes the test runs against newer versions of aleth, while maintaining backwards compatibility.

The blockhash test for constantinople is disabled, since older aleth versions will return zero, whereas newer aleth versions will return the correct hashes - this can be changed, once we switch to a newer aleth version for the tests.