### PR TITLE
Add a missing tests for yul inliner optimization

### DIFF
--- a/test/libjulia/Inliner.cpp
+++ b/test/libjulia/Inliner.cpp
@@ -116,6 +116,9 @@ BOOST_AUTO_TEST_CASE(negative)
 	BOOST_CHECK_EQUAL(inlinableFunctions("{ function f() -> x:u256 { x := f() } }"), "");
 	BOOST_CHECK_EQUAL(inlinableFunctions("{ function f() -> x:u256 { x := x } }"), "");
 	BOOST_CHECK_EQUAL(inlinableFunctions("{ function f() -> x:u256, y:u256 { x := 2:u256 } }"), "");
+  BOOST_CHECK_EQUAL(inlinableFunctions(
+    "{ function g() -> x:u256, y:u256 {} function f(y:u256) -> x:u256 { x,y := g() } }"), "");
+	BOOST_CHECK_EQUAL(inlinableFunctions("{ function f(y:u256) -> x:u256 { y := 2:u256 } }"), "");
 }
 
 


### PR DESCRIPTION
When the statement has two return values, the function is not inlinable.

When the function has one statement but it is not an assignment to the
return variable, the function is not inlinable.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
This should increase the unit test coverage of the InlinableExpressionFunctionFinder.cpp to 100%.
