### PR TITLE
Docs: Add content from old Solidity wiki

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,15 +6,18 @@ Solidity
     :alt: Solidity logo
     :align: center
 
-Solidity is a contract-oriented, high-level language for implementing smart contracts.
-It was influenced by C++, Python and JavaScript
-and is designed to target the Ethereum Virtual Machine (EVM).
+Solidity is an object-oriented, high-level language for implementing smart
+contracts. Smart contracts are programs which govern the behaviour of accounts
+within the Ethereum state.
+
+Solidity was influenced by C++, Python and JavaScript and is designed to target
+the Ethereum Virtual Machine (EVM).
 
 Solidity is statically typed, supports inheritance, libraries and complex
 user-defined types among other features.
 
-As you will see, it is possible to create contracts for voting,
-crowdfunding, blind auctions, multi-signature wallets and more.
+With Solidity you can create contracts for uses such as voting, crowdfunding, blind auctions,
+and multi-signature wallets.
 
 .. note::
     The best way to try out Solidity right now is using

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -8,8 +8,9 @@ Introduction to Smart Contracts
 A Simple Smart Contract
 ***********************
 
-Let us begin with the most basic example. It is fine if you do not understand everything
-right now, we will go into more detail later.
+Let us begin with a basic example that sets the value of a variable and exposes
+it for other contracts to access. It is fine if you do not understand
+everything right now, we will go into more detail later.
 
 Storage
 =======
@@ -34,7 +35,7 @@ The first line simply tells that the source code is written for
 Solidity version 0.4.0 or anything newer that does not break functionality
 (up to, but not including, version 0.5.0). This is to ensure that the
 contract is not compilable with a new (breaking) compiler version, where it could behave differently.
-So-called pragmas are common instrutions for compilers about how to treat the
+So-called pragmas are common instructions for compilers about how to treat the
 source code (e.g. `pragma once <https://en.wikipedia.org/wiki/Pragma_once>`_).
 
 A contract in the sense of Solidity is a collection of code (its *functions*) and


### PR DESCRIPTION
### Checklist
- [x] All tests are passing
- [x] README / documentation was extended, if necessary
- [x] Used meaningful commit messages

### Description

Closes #2180 that mentions several items missing from current docs that used to be present in the older Solidity Wiki. 

After reading through this older content I didn't find too much that wasn't covered in current docs, the language has depreciated, or was handled better in current docs (IMO). So this is a fairly small PR mentioning a couple of small things that clarify a couple of points.