### PR TITLE
Changelog for reference conversion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -116,6 +116,7 @@ Bugfixes:
  * Type Checker: Fix freeze for negative fixed-point literals very close to ``0``, such as ``-1e-100``.
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
  * Type Checker: Fix internal error when array index value is too large.
+ * Type Checker: Fix internal error for array type conversions.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
  * Parser: Fix incorrect source location for nameless parameters.
 


### PR DESCRIPTION
We missed that in https://github.com/ethereum/solidity/pull/4904