### PR TITLE
Docs: Added order of layout to style guide

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -874,6 +874,28 @@ No::
     x = y+z;
     x +=1;
 
+***************
+Order of Layout
+***************
+
+Layout contract elements in the following order:
+
+1. Import statements
+2. Interfaces
+3. Libraries
+4. Contracts
+
+Inside each contract, library or interface, use the following order:
+
+1. Type declarations
+2. State variables
+3. Events
+4. Functions
+
+.. note::
+
+    It might be clearer to declare types close to their use in events or state
+    variables.
 
 ******************
 Naming Conventions


### PR DESCRIPTION
### Checklist
- [x] All tests are passing
- [x] README / documentation was extended, if necessary
- [x] Used meaningful commit messages

### Description

Adds order of code layout to style guide, closes https://github.com/ethereum/solidity/issues/1444