### PR TITLE
Add syntax tests to fix #4627

### DIFF
--- a/test/libsolidity/syntaxTests/multiline_comments.sol
+++ b/test/libsolidity/syntaxTests/multiline_comments.sol
@@ -1,0 +1,13 @@
+/*
+ * This is a multi-line comment
+ * it should create no problems
+ *
+*/
+
+contract test {
+    /*
+    * this is another multi-line comment
+    *
+    */
+}
+// ----

--- a/test/libsolidity/syntaxTests/string/string_escapes.sol
+++ b/test/libsolidity/syntaxTests/string/string_escapes.sol
@@ -1,0 +1,7 @@
+contract test {
+    function f() public pure returns (bytes32) {
+        bytes32 escapeCharacters = "\t\b\n\r\f\'\"\\\b";
+        return escapeCharacters;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/string/string_new_line.sol
+++ b/test/libsolidity/syntaxTests/string/string_new_line.sol
@@ -1,0 +1,9 @@
+contract test {
+    function f() public pure returns (bytes32) {
+        bytes32 escapeCharacters = "This a test
+        ";
+        return escapeCharacters;
+    }
+}
+// ----
+// ParserError: (100-112): Expected primary expression.

--- a/test/libsolidity/syntaxTests/string/string_terminated_by_backslash.sol
+++ b/test/libsolidity/syntaxTests/string/string_terminated_by_backslash.sol
@@ -1,0 +1,8 @@
+contract test {
+    function f() public pure returns (bytes32) {
+        bytes32 escapeCharacters = "text \";
+        return escapeCharacters;
+    }
+}
+// ----
+// ParserError: (100-109): Expected primary expression.

--- a/test/libsolidity/syntaxTests/string/string_unterminated.sol
+++ b/test/libsolidity/syntaxTests/string/string_unterminated.sol
@@ -1,0 +1,7 @@
+contract test {
+    function f() public pure returns (bytes32) {
+        bytes32 escapeCharacters = "This a test
+    }
+}
+// ----
+// ParserError: (100-112): Expected primary expression.

--- a/test/libsolidity/syntaxTests/string/string_unterminated_no_new_line.sol
+++ b/test/libsolidity/syntaxTests/string/string_unterminated_no_new_line.sol
@@ -1,0 +1,4 @@
+contract test {
+    function f() pure public { "abc\
+// ----
+// ParserError: (47-53): Expected primary expression.

--- a/test/libsolidity/syntaxTests/unicode_escape_literals.sol
+++ b/test/libsolidity/syntaxTests/unicode_escape_literals.sol
@@ -1,0 +1,31 @@
+contract test {
+
+    function oneByteUTF8() public pure returns (bytes32) {
+        bytes32 usdollar = "aaa\u0024aaa";
+        return usdollar;
+    }
+
+    function twoBytesUTF8() public pure returns (bytes32) {
+        bytes32 cent = "aaa\u00A2aaa";
+        return cent;
+    }
+
+    function threeBytesUTF8() public pure returns (bytes32) {
+        bytes32 eur = "aaa\u20ACaaa";
+        return  eur;
+    }
+
+    function together() public pure returns (bytes32) {
+        bytes32 res = "\u0024\u00A2\u20AC";
+        return res;
+    }
+
+    // this function returns an invalid unicode character
+    function invalidLiteral() public pure returns(bytes32) {
+        bytes32 invalid = "\u00xx";
+        return invalid;
+    }
+
+}
+// ----
+// ParserError: (678-681): Expected primary expression.

--- a/test/libsolidity/syntaxTests/unterminatedBlocks/one_dot.sol
+++ b/test/libsolidity/syntaxTests/unterminatedBlocks/one_dot.sol
@@ -1,0 +1,4 @@
+contract c {
+    function f() pure public { 1.
+// ----
+// ParserError: (47-47): Expected identifier but got end of source

--- a/test/libsolidity/syntaxTests/unterminatedBlocks/one_dot_x.sol
+++ b/test/libsolidity/syntaxTests/unterminatedBlocks/one_dot_x.sol
@@ -1,0 +1,5 @@
+contract test {
+    function f() pure public { 1.x; }
+}
+// ----
+// TypeError: (47-50): Member "x" not found or not visible after argument-dependent lookup in int_const 1.

--- a/test/libsolidity/syntaxTests/unterminatedBlocks/zero_dot.sol
+++ b/test/libsolidity/syntaxTests/unterminatedBlocks/zero_dot.sol
@@ -1,0 +1,4 @@
+contract c {
+    function f() pure public { 0.
+// ----
+// ParserError: (47-47): Expected identifier but got end of source

--- a/test/libsolidity/syntaxTests/unterminatedBlocks/zero_dot_x.sol
+++ b/test/libsolidity/syntaxTests/unterminatedBlocks/zero_dot_x.sol
@@ -1,0 +1,5 @@
+contract test {
+    function f() pure public { 0.x; }
+}
+// ----
+// TypeError: (47-50): Member "x" not found or not visible after argument-dependent lookup in int_const 0.

--- a/test/libsolidity/syntaxTests/upper_case_hex_literals.sol
+++ b/test/libsolidity/syntaxTests/upper_case_hex_literals.sol
@@ -1,0 +1,9 @@
+contract test {
+
+    function f() public pure returns (uint256) {
+        uint256 a = 0x1234aAbcC;
+        uint256 b = 0x1234ABCDEF;
+        return a + b;
+    }
+}
+// ----


### PR DESCRIPTION
1. Add multiline comment test
2. Add upper case hex literal test
3. Add test for unicode escapes

### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

### Description
I added some syntax tests to augment the test coverage of Scanner as described here #4627. This issue should fix #4627.



Thank you for your help!
