### PR TITLE
Disallow uppercase X in hex number literals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,7 @@ Breaking Changes:
  * Optimizer: Remove the no-op ``PUSH1 0 NOT AND`` sequence.
  * Parser: Disallow trailing dots that are not followed by a number.
  * Parser: Remove ``constant`` as function state mutability modifier.
+ * Parser: Disallow uppercase X in hex number literals
  * Type Checker: Disallow assignments between tuples with different numbers of components. This was already the case in the experimental 0.5.0 mode.
  * Type Checker: Disallow values for constants that are not compile-time constants. This was already the case in the experimental 0.5.0 mode.
  * Type Checker: Disallow arithmetic operations for boolean variables.

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -132,7 +132,7 @@ HexLiteral = 'hex' ('"' ([0-9a-fA-F]{2})* '"' | '\'' ([0-9a-fA-F]{2})* '\'')
 StringLiteral = '"' ([^"\r\n\\] | '\\' .)* '"'
 Identifier = [a-zA-Z_$] [a-zA-Z_$0-9]*
 
-HexNumber = '0' [xX] [0-9a-fA-F]+
+HexNumber = '0x' [0-9a-fA-F]+
 DecimalNumber = [0-9]+ ( '.' [0-9]* )? ( [eE] [0-9]+ )?
 
 TupleExpression = '(' ( Expression? ( ',' Expression? )*  )? ')'

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -780,13 +780,13 @@ Token::Value Scanner::scanNumber(char _charSeen)
 		{
 			addLiteralCharAndAdvance();
 			// either 0, 0exxx, 0Exxx, 0.xxx or a hex number
-			if (m_char == 'x' || m_char == 'X')
+			if (m_char == 'x')
 			{
 				// hex number
 				kind = HEX;
 				addLiteralCharAndAdvance();
 				if (!isHexDigit(m_char))
-					return Token::Illegal; // we must have at least one hex digit after 'x'/'X'
+					return Token::Illegal; // we must have at least one hex digit after 'x'
 
 				while (isHexDigit(m_char) || m_char == '_') // We keep the underscores for later validation
 					addLiteralCharAndAdvance();

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -105,6 +105,11 @@ BOOST_AUTO_TEST_CASE(hex_numbers)
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0x765432536763762734623472346");
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+	scanner.reset(CharStream("0x1234"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0x1234");
+	scanner.reset(CharStream("0X1234"), "");
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 }
 
 BOOST_AUTO_TEST_CASE(octal_numbers)


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description
This PR closes #4899. I remove "0X" condition in parser and add one test case to verify it.