### PR TITLE
CREATE2 opcode has been moved from 0xfb to 0xf5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -87,6 +87,7 @@ Language Features:
 
 Compiler Features:
  * C API (``libsolc``): Export the ``solidity_license``, ``solidity_version`` and ``solidity_compile`` methods.
+ * Code Generator: ``CREATE2`` instruction has been updated to match EIP1014 (aka "Skinny CREATE2").
  * Type Checker: Nicer error message when trying to reference overloaded identifiers in inline assembly.
  * Type Checker: Show named argument in case of error.
  * Type System: IntegerType is split into IntegerType and AddressType internally.

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -192,8 +192,8 @@ enum class Instruction: uint8_t
 	CALLCODE,			///< message-call with another account's code only
 	RETURN,				///< halt execution returning output data
 	DELEGATECALL,		///< like CALLCODE but keeps caller's value and sender
+	CREATE2 = 0xf5,		///< create new account with associated code at address `sha3(0xff + sender + salt + init code) % 2**160`
 	STATICCALL = 0xfa,	///< like CALL but disallow state modifications
-	CREATE2 = 0xfb,		///< create new account with associated code at address `sha3(sender + salt + sha3(init code)) % 2**160`
 
 	REVERT = 0xfd,		///< halt execution, revert state and return output data
 	INVALID = 0xfe,		///< invalid instruction for expressing runtime errors (e.g., division-by-zero)


### PR DESCRIPTION
I think this is fairly stable now given tests are created for it.