### PR TITLE
Improve error message for lookup in function types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -99,6 +99,7 @@ Compiler Features:
  * Tests: Determine transaction status during IPC calls.
  * Code Generator: Allocate and free local variables according to their scope.
  * Removed ``pragma experimental "v0.5.0";``.
+ * Syntax Checker: Improved error message for lookup in function types.
 
 Bugfixes:
  * Build System: Support versions of CVC4 linked against CLN instead of GMP. In case of compilation issues due to the experimental SMT solver support, the solvers can be disabled when configuring the project with CMake using ``-DUSE_CVC4=OFF`` or ``-DUSE_Z3=OFF``.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2141,8 +2141,25 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				);
 		}
 		string errorMsg = "Member \"" + memberName + "\" not found or not visible "
-				"after argument-dependent lookup in " + exprType->toString() +
-				(memberName == "value" ? " - did you forget the \"payable\" modifier?" : ".");
+				"after argument-dependent lookup in " + exprType->toString() + ".";
+		if (memberName == "value")
+		{
+			errorMsg.pop_back();
+			errorMsg +=	" - did you forget the \"payable\" modifier?";
+		}
+		else if (exprType->category() == Type::Category::Function)
+		{
+			if (auto const& funType = dynamic_pointer_cast<FunctionType const>(exprType))
+			{
+				auto const& t = funType->returnParameterTypes();
+				if (t.size() == 1)
+					if (
+						t.front()->category() == Type::Category::Contract ||
+						t.front()->category() == Type::Category::Struct
+					)
+						errorMsg += " Did you intend to call the function?";
+			}
+		}
 		if (exprType->category() == Type::Category::Contract)
 			for (auto const& addressMember: AddressType::addressPayable().nativeMembers(nullptr))
 				if (addressMember.name == memberName)

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/575_member_member_getter_call_without_parentheses.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/575_member_member_getter_call_without_parentheses.sol
@@ -1,0 +1,19 @@
+contract A{
+    function f() public pure{
+
+    }
+}
+contract B{
+    A public a;
+}
+contract C{
+    B public b;
+}
+contract D{
+    C c;
+    function f() public view{
+        c.b.a.f();
+    }
+}
+// ----
+// TypeError: (170-175): Member "a" not found or not visible after argument-dependent lookup in function () view external returns (contract B). Did you intend to call the function?

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/576_member_getter_call_without_parentheses.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/576_member_getter_call_without_parentheses.sol
@@ -1,0 +1,17 @@
+contract A{
+    function f() public pure{
+
+    }
+}
+contract B{
+    A public a;
+}
+contract C{
+    B b;
+    function f() public view{
+        b.a.f();
+    }
+}
+
+// ----
+// TypeError: (140-145): Member "f" not found or not visible after argument-dependent lookup in function () view external returns (contract A). Did you intend to call the function?

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/577_member_getter_call_without_parentheses_missing_function.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/577_member_getter_call_without_parentheses_missing_function.sol
@@ -1,0 +1,15 @@
+contract A{
+
+}
+contract B{
+    A public a;
+}
+contract C{
+    B b;
+    function f() public view{
+        b.a.f();
+    }
+}
+
+// ----
+// TypeError: (104-109): Member "f" not found or not visible after argument-dependent lookup in function () view external returns (contract A). Did you intend to call the function?

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/578_private_member_getter_call_without_parentheses.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/578_private_member_getter_call_without_parentheses.sol
@@ -1,0 +1,17 @@
+contract A{
+    function f() public pure{
+
+    }
+}
+contract B{
+    A private a;
+}
+contract C{
+    B b;
+    function f() public view{
+        b.a.f();
+    }
+}
+
+// ----
+// TypeError: (141-144): Member "a" not found or not visible after argument-dependent lookup in contract B.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/579_member_getter_call_without_parentheses_private_function.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/579_member_getter_call_without_parentheses_private_function.sol
@@ -1,0 +1,17 @@
+contract A{
+    function f() private pure{
+
+    }
+}
+contract B{
+    A public a;
+}
+contract C{
+    B b;
+    function f() public view{
+        b.a.f();
+    }
+}
+
+// ----
+// TypeError: (141-146): Member "f" not found or not visible after argument-dependent lookup in function () view external returns (contract A). Did you intend to call the function?


### PR DESCRIPTION
Fixes #4066 

A new function was added in TypeChecker to improve the following message "member not found after argument-dependant lookup in type ..." when type is a function. 

when a.b.test() is called the compiler will suggest a.b().test()

