### PR TITLE
Add proper error reporting when invalid settings are provided in StandardJSON

### DIFF
--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -640,7 +640,7 @@ BOOST_AUTO_TEST_CASE(libraries_invalid_entry)
 	}
 	)";
 	Json::Value result = compile(input);
-	BOOST_CHECK(containsError(result, "JSONError", "library entry is not a JSON object."));
+	BOOST_CHECK(containsError(result, "JSONError", "Library entry is not a JSON object."));
 }
 
 BOOST_AUTO_TEST_CASE(libraries_invalid_hex)


### PR DESCRIPTION
The solfuzzer have found a lot of cases (but not all I have fixed here) which would result in a "JSON Logic error".