### PR TITLE
Add Mojave to dependencies script

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -88,6 +88,7 @@ Language Features:
  * Parser: Accept the ``address payable`` type during parsing.
 
 Compiler Features:
+ * Build System: Support for Mojave version of macOS added.
  * C API (``libsolc``): Export the ``solidity_license``, ``solidity_version`` and ``solidity_compile`` methods.
  * Code Generator: ``CREATE2`` instruction has been updated to match EIP1014 (aka "Skinny CREATE2"). It also is accepted as part of Constantinople.
  * Type Checker: Nicer error message when trying to reference overloaded identifiers in inline assembly.

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -87,9 +87,12 @@ case $(uname -s) in
             10.13)
                 echo "Installing solidity dependencies on macOS 10.13 High Sierra."
                 ;;
+            10.14)
+                echo "Installing solidity dependencies on macOS 10.14 Mojave."
+                ;;
             *)
                 echo "Unsupported macOS version."
-                echo "We only support Mavericks, Yosemite, El Capitan, Sierra and High Sierra."
+                echo "We only support Mavericks, Yosemite, El Capitan, Sierra, High Sierra and Mojave."
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

While testing contribution guide I noticed that dependencies script doesn't support the newly release macOS version.

Not sure if this needs a changelog entry or tests? The code still builds on Mojave.