### PR TITLE
Return note taken from metadata and reorder

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -93,14 +93,15 @@ explanatory purposes.
       }
     }
 
+.. warning::
+  Since the bytecode of the resulting contract contains the metadata hash, any
+  change to the metadata results in a change of the bytecode. This includes
+  changes to a filename or path, and since the metadata includes a hash of all the
+  sources used, a single whitespace change results in different metadata, and
+  different bytecode.
+
 .. note::
     Note the ABI definition above has no fixed order. It can change with compiler versions.
-
-Since the bytecode of the resulting contract contains the metadata hash, any
-change to the metadata results in a change of the bytecode. This includes
-changes to a filename or path, and since the metadata includes a hash of all the
-sources used, a single whitespace change results in different metadata, and
-different bytecode.
 
 Encoding of the Metadata Hash in the Bytecode
 =============================================


### PR DESCRIPTION
### Checklist
- [x] All tests are passing
- [x] README / documentation was extended, if necessary
- [x] Used meaningful commit messages

### Description

As discussed in https://github.com/ethereum/solidity/pull/4844#discussion_r220599885

While this is passing information, as it's fairly important to know (as mentioned in original issue 
https://github.com/ethereum/solidity/issues/1644) I thought it needed more prominence, so reformatted as a warning and moved above the other note.