### PR TITLE
[DOCS] Add missing backtick for inline code syntax.

### DIFF
--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -53,7 +53,7 @@ Semantic and Syntactic Changes
 
 This section highlights changes that affect syntax and semantics.
 
-* The functions ``.call()``, ``.delegatecall()`, ``staticcall()``,
+* The functions ``.call()``, ``.delegatecall()``, ``staticcall()``,
   ``keccak256()``, ``sha256()`` and ``ripemd160()`` now accept only a single
   ``bytes`` argument. Moreover, the argument is not padded. This was changed to
   make more explicit and clear how the arguments are concatenated. Change every


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

Just add missing backtick for https://solidity.readthedocs.io/en/develop/050-breaking-changes.html?highlight=callcode#semantic-and-syntactic-changes after `.delegatecall()`.