### PR TITLE
Fixes invalid function calls to literals inside tuple assignment's LHS.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1444,8 +1444,12 @@ void TypeChecker::checkExpressionAssignment(Type const& _type, Expression const&
 		auto const* tupleType = dynamic_cast<TupleType const*>(&_type);
 		auto const& types = tupleType ? tupleType->components() : vector<TypePointer> { _type.shared_from_this() };
 
-		solAssert(tupleExpression->components().size() == types.size(), "");
-		for (size_t i = 0; i < types.size(); i++)
+		solAssert(
+			tupleExpression->components().size() == types.size() || m_errorReporter.hasErrors(),
+			"Array sizes don't match or no errors generated."
+		);
+
+		for (size_t i = 0; i < min(tupleExpression->components().size(), types.size()); i++)
 			if (types[i])
 			{
 				solAssert(!!tupleExpression->components()[i], "");

--- a/test/libsolidity/syntaxTests/types/function_call_fail.sol
+++ b/test/libsolidity/syntaxTests/types/function_call_fail.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(uint y) public pure {
+        (4(y)) = 2;
+    }
+}
+// ----
+// TypeError: (59-63): Type is not callable
+// TypeError: (59-63): Expression has to be an lvalue.
+// TypeError: (67-68): Type int_const 2 is not implicitly convertible to expected type tuple().

--- a/test/libsolidity/syntaxTests/types/function_call_fail2.sol
+++ b/test/libsolidity/syntaxTests/types/function_call_fail2.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(uint y) public pure returns (uint) {
+        (f(y)) = 2;
+    }
+}
+// ----
+// TypeError: (74-78): Expression has to be an lvalue.


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

This change fixes #5053. I did not adapt the Changelog as this bug was just recently introduced in the 0.5 branch.

FYI: I was first trying to not get a solution via making the typeError into a fatalTypeError, however, I didn't find a clean solution, as every follow-up-change did look more like a workaround, so I decided to go with promoting this error from non-fatal to fatal. I'd however like to have a post-0.5 discussion on when to go fatal and where we wanna change that (I believe we'd need a change in the AST to easily reflect whether some node is in invalid-state due to internal bug vs already-reported-user-bugs).