### PR TITLE
soltest: provides sane defaults for --testpath command line option

### DIFF
--- a/test/Options.cpp
+++ b/test/Options.cpp
@@ -25,9 +25,11 @@
 #include <libsolidity/interface/Exceptions.h>
 
 #include <boost/test/framework.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace std;
 using namespace dev::test;
+namespace fs = boost::filesystem;
 
 Options const& Options::get()
 {
@@ -70,6 +72,27 @@ Options::Options()
 	if (testPath.empty())
 		if (auto path = getenv("ETH_TEST_PATH"))
 			testPath = path;
+
+	if (testPath.empty())
+	{
+		auto const searchPath =
+		{
+			fs::current_path() / ".." / ".." / ".." / "test",
+			fs::current_path() / ".." / ".." / "test",
+			fs::current_path() / ".." / "test",
+			fs::current_path() / "test",
+			fs::current_path()
+		};
+		for (auto const& basePath : searchPath)
+		{
+			fs::path syntaxTestPath = basePath / "libsolidity" / "syntaxTests";
+			if (fs::exists(syntaxTestPath) && fs::is_directory(syntaxTestPath))
+			{
+				testPath = basePath;
+				break;
+			}
+		}
+	}
 }
 
 void Options::validate() const


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

This PR provides the ability to auto-infer the test directory, making the `--testpath` command line parameter to `soltest` executable optional (if inferred correctly).

The logic used is basically the same as in `isoltest`. However, the code block was duplicated because it's to simple to create a shared lib out of it.

I've also adjusted to `ETH_TEST_PATH` logic *a bit* because I believe that command line parameter flags should always be prioritized to environment variables (aligns well with standard UNIX tools).

(Implements #5129)