### PR TITLE
Do not crash when trying to encode too large arrays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -128,6 +128,7 @@ Bugfixes:
  * Type Checker: Fix freeze for negative fixed-point literals very close to ``0``, such as ``-1e-100``.
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
  * Type Checker: Fix internal error when array index value is too large.
+ * Type Checker: Fix internal error when fixed-size array is too large to be encoded.
  * Type Checker: Fix internal error for array type conversions.
  * Type Checker: Fix internal error when array index is not an unsigned.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1698,6 +1698,9 @@ bool ArrayType::operator==(Type const& _other) const
 
 bool ArrayType::validForCalldata() const
 {
+	if (auto arrayBaseType = dynamic_cast<ArrayType const*>(baseType().get()))
+        if (!arrayBaseType->validForCalldata())
+            return false;
 	return unlimitedCalldataEncodedSize(true) <= numeric_limits<unsigned>::max();
 }
 

--- a/test/libsolidity/syntaxTests/array/length/parameter_too_large.sol
+++ b/test/libsolidity/syntaxTests/array/length/parameter_too_large.sol
@@ -1,0 +1,5 @@
+contract C {
+  function f(bytes32[1263941234127518272] memory) public pure {}
+}
+// ----
+// TypeError: (26-61): Array is too large to be encoded.

--- a/test/libsolidity/syntaxTests/array/length/parameter_too_large_multidim.sol
+++ b/test/libsolidity/syntaxTests/array/length/parameter_too_large_multidim.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f(bytes32[1263941234127518272][500] memory) public pure {}
+  function f(uint[2**30][] memory) public pure {}
+  function f(uint[2**30][2**30][] memory) public pure {}
+  function f(uint[2**16][2**16][] memory) public pure {}
+}
+// ----
+// TypeError: (26-66): Array is too large to be encoded.
+// TypeError: (96-116): Array is too large to be encoded.
+// TypeError: (146-173): Array is too large to be encoded.
+// TypeError: (203-230): Array is too large to be encoded.

--- a/test/libsolidity/syntaxTests/array/length/parameter_too_large_multidim_ABIv2.sol
+++ b/test/libsolidity/syntaxTests/array/length/parameter_too_large_multidim_ABIv2.sol
@@ -1,0 +1,10 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+  function f(bytes32[1263941234127518272][500] memory) public pure {}
+  function f(uint[2**30][2**30][][] memory) public pure {}
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (61-101): Array is too large to be encoded.
+// TypeError: (131-160): Array is too large to be encoded.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5058.