### PR TITLE
Do not crash on non-unsigned array index

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -125,6 +125,7 @@ Bugfixes:
  * Type Checker: Dynamic types as key for public mappings return error instead of assertion fail.
  * Type Checker: Fix internal error when array index value is too large.
  * Type Checker: Fix internal error for array type conversions.
+ * Type Checker: Fix internal error when array index is not an unsigned.
  * Type System: Allow arbitrary exponents for literals with a mantissa of zero.
  * Parser: Fix incorrect source location for nameless parameters.
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2299,7 +2299,8 @@ bool TypeChecker::visit(IndexAccess const& _access)
 			m_errorReporter.typeError(_access.location(), "Index expression cannot be omitted.");
 		else
 		{
-			expectType(*index, IntegerType(256));
+			if (!expectType(*index, IntegerType(256)))
+				m_errorReporter.fatalTypeError(_access.location(), "Index expression cannot be represented as an unsigned integer.");
 			if (auto integerType = dynamic_cast<RationalNumberType const*>(type(*index).get()))
 				if (bytesType.numBytes() <= integerType->literalValue(nullptr))
 					m_errorReporter.typeError(_access.location(), "Out of bounds array access.");
@@ -2470,7 +2471,7 @@ Declaration const& TypeChecker::dereference(UserDefinedTypeName const& _typeName
 	return *_typeName.annotation().referencedDeclaration;
 }
 
-void TypeChecker::expectType(Expression const& _expression, Type const& _expectedType)
+bool TypeChecker::expectType(Expression const& _expression, Type const& _expectedType)
 {
 	_expression.accept(*this);
 	if (!type(_expression)->isImplicitlyConvertibleTo(_expectedType))
@@ -2499,7 +2500,9 @@ void TypeChecker::expectType(Expression const& _expression, Type const& _expecte
 				_expectedType.toString() +
 				"."
 			);
+		return false;
 	}
+	return true;
 }
 
 void TypeChecker::requireLValue(Expression const& _expression)

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -143,7 +143,7 @@ private:
 
 	/// Runs type checks on @a _expression to infer its type and then checks that it is implicitly
 	/// convertible to @a _expectedType.
-	void expectType(Expression const& _expression, Type const& _expectedType);
+	bool expectType(Expression const& _expression, Type const& _expectedType);
 	/// Runs type checks on @a _expression to infer its type and then checks that it is an LValue.
 	void requireLValue(Expression const& _expression);
 

--- a/test/libsolidity/syntaxTests/indexing/array_multidim_rational.sol
+++ b/test/libsolidity/syntaxTests/indexing/array_multidim_rational.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public {
+    bytes[32] memory a;
+    a[8**90][8**90][8**90*0.1];
+  }
+}
+// ----
+// TypeError: (67-72): Type int_const 1897...(74 digits omitted)...1424 is not implicitly convertible to expected type uint256.
+// TypeError: (74-79): Type int_const 1897...(74 digits omitted)...1424 is not implicitly convertible to expected type uint256.
+// TypeError: (81-90): Type rational_const 9485...(73 digits omitted)...5712 / 5 is not implicitly convertible to expected type uint256.
+// TypeError: (65-91): Index expression cannot be represented as an unsigned integer.

--- a/test/libsolidity/syntaxTests/indexing/array_multim_overflow_index.sol
+++ b/test/libsolidity/syntaxTests/indexing/array_multim_overflow_index.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public {
+    bytes[32] memory a;
+    a[8**90][8**90][1 - 8**90];
+  }
+}
+// ----
+// TypeError: (67-72): Type int_const 1897...(74 digits omitted)...1424 is not implicitly convertible to expected type uint256.
+// TypeError: (74-79): Type int_const 1897...(74 digits omitted)...1424 is not implicitly convertible to expected type uint256.
+// TypeError: (81-90): Type int_const -189...(75 digits omitted)...1423 is not implicitly convertible to expected type uint256.
+// TypeError: (65-91): Index expression cannot be represented as an unsigned integer.

--- a/test/libsolidity/syntaxTests/indexing/fixedbytes_negative_index.sol
+++ b/test/libsolidity/syntaxTests/indexing/fixedbytes_negative_index.sol
@@ -1,0 +1,9 @@
+contract C {
+  function f() public {
+    bytes32 b;
+    b[-1];
+  }
+}
+// ----
+// TypeError: (58-60): Type int_const -1 is not implicitly convertible to expected type uint256.
+// TypeError: (56-61): Index expression cannot be represented as an unsigned integer.

--- a/test/libsolidity/syntaxTests/indexing/fixedbytes_noninteger_index.sol
+++ b/test/libsolidity/syntaxTests/indexing/fixedbytes_noninteger_index.sol
@@ -1,0 +1,9 @@
+contract C {
+  function f() public {
+    bytes32 b;
+    b[888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888];
+  }
+}
+// ----
+// TypeError: (58-169): Type int_const 8888...(103 digits omitted)...8888 is not implicitly convertible to expected type uint256.
+// TypeError: (56-170): Index expression cannot be represented as an unsigned integer.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5056.
Fixes https://github.com/ethereum/solidity/issues/5059.