### PR TITLE
[Yul] Also substitute variables in Common Subexpression Eliminator

### DIFF
--- a/libjulia/optimiser/README.md
+++ b/libjulia/optimiser/README.md
@@ -97,6 +97,20 @@ of any function call or opcode execution, the transformation is not performed.
 Note that the component will not move the assigned value of a variable assignment
 or a variable that is referenced more than once.
 
+## Common Subexpression Eliminator
+
+This step replaces a subexpression by the value of a pre-existing variable
+that currently has the same value (only if the value is movable), based
+on a syntactic comparison.
+
+This can be used to compute a local value numbering, especially if the
+expression splitter is used before.
+
+The expression simplifier will be able to perform better replacements
+if the common subexpression eliminator was run right before it.
+
+Prerequisites: Disambiguator
+
 ## Full Function Inliner
 
 ## Rematerialisation

--- a/test/libjulia/yulOptimizerTests/commonSubexpressionEliminator/variable_for_variable.yul
+++ b/test/libjulia/yulOptimizerTests/commonSubexpressionEliminator/variable_for_variable.yul
@@ -1,0 +1,27 @@
+{
+
+    let a := mload(0)
+    let b := add(a, 7)
+    let c := a
+    let d := c
+    let x := add(a, b)
+    // CSE has to recognize equality with x here.
+    let y := add(d, add(c, 7))
+    // some reassignments
+    b := mload(a)
+    a := b
+    mstore(2, a)
+}
+// ----
+// commonSubexpressionEliminator
+// {
+//     let a := mload(0)
+//     let b := add(a, 7)
+//     let c := a
+//     let d := a
+//     let x := add(a, b)
+//     let y := x
+//     b := mload(a)
+//     a := b
+//     mstore(2, b)
+// }


### PR DESCRIPTION
This should enable the CSE to calculate a local value numbering.

Depends on #5203 