### PR TITLE
[Yul] Split constants too

### DIFF
--- a/libjulia/optimiser/ExpressionSplitter.cpp
+++ b/libjulia/optimiser/ExpressionSplitter.cpp
@@ -89,7 +89,7 @@ void ExpressionSplitter::operator()(Block& _block)
 
 void ExpressionSplitter::outlineExpression(Expression& _expr)
 {
-	if (_expr.type() != typeid(FunctionalInstruction) && _expr.type() != typeid(FunctionCall))
+	if (_expr.type() == typeid(Identifier))
 		return;
 
 	visit(_expr);

--- a/test/libjulia/yulOptimizerTests/expressionSplitter/control_flow.yul
+++ b/test/libjulia/yulOptimizerTests/expressionSplitter/control_flow.yul
@@ -10,24 +10,31 @@
 // ----
 // expressionSplitter
 // {
-//     let x := calldataload(0)
-//     let _1 := add(x, 2)
-//     let _2 := mul(_1, 3)
-//     if _2
+//     let _1 := 0
+//     let x := calldataload(_1)
+//     let _2 := 3
+//     let _3 := 2
+//     let _4 := add(x, _3)
+//     let _5 := mul(_4, _2)
+//     if _5
 //     {
 //         for {
 //             let a := 2
 //         }
 //         lt(a, mload(a))
 //         {
-//             let _3 := mul(a, 2)
-//             a := add(a, _3)
+//             let _6 := 2
+//             let _7 := mul(a, _6)
+//             a := add(a, _7)
 //         }
 //         {
-//             let _4 := add(a, 2)
-//             let b := mul(_4, 4)
-//             let _5 := mul(b, 2)
-//             sstore(b, _5)
+//             let _8 := 4
+//             let _9 := 2
+//             let _10 := add(a, _9)
+//             let b := mul(_10, _8)
+//             let _11 := 2
+//             let _12 := mul(b, _11)
+//             sstore(b, _12)
 //         }
 //     }
 // }

--- a/test/libjulia/yulOptimizerTests/expressionSplitter/inside_function.yul
+++ b/test/libjulia/yulOptimizerTests/expressionSplitter/inside_function.yul
@@ -8,17 +8,22 @@
 // ----
 // expressionSplitter
 // {
-//     let _1 := mload(7)
-//     let _2 := f(0, _1)
-//     let x := mul(_2, 3)
+//     let _1 := 3
+//     let _2 := 7
+//     let _3 := mload(_2)
+//     let _4 := 0
+//     let _5 := f(_4, _3)
+//     let x := mul(_5, _1)
 //     function f(a, b) -> c
 //     {
-//         let _3 := add(b, c)
-//         let _4 := mload(_3)
-//         c := mul(a, _4)
+//         let _6 := add(b, c)
+//         let _7 := mload(_6)
+//         c := mul(a, _7)
 //     }
-//     let _5 := mload(2)
-//     let _6 := mload(2)
-//     let _7 := f(_6, _5)
-//     sstore(x, _7)
+//     let _8 := 2
+//     let _9 := mload(_8)
+//     let _10 := 2
+//     let _11 := mload(_10)
+//     let _12 := f(_11, _9)
+//     sstore(x, _12)
 // }

--- a/test/libjulia/yulOptimizerTests/expressionSplitter/switch.yul
+++ b/test/libjulia/yulOptimizerTests/expressionSplitter/switch.yul
@@ -9,17 +9,25 @@
 // expressionSplitter
 // {
 //     let x := 8
-//     let _1 := calldataload(0)
-//     let _2 := add(2, _1)
-//     switch _2
+//     let _1 := 0
+//     let _2 := calldataload(_1)
+//     let _3 := 2
+//     let _4 := add(_3, _2)
+//     switch _4
 //     case 0 {
-//         let _3 := mload(2)
-//         sstore(0, _3)
+//         let _5 := 2
+//         let _6 := mload(_5)
+//         let _7 := 0
+//         sstore(_7, _6)
 //     }
 //     default {
-//         let _4 := mload(3)
-//         mstore(0, _4)
+//         let _8 := 3
+//         let _9 := mload(_8)
+//         let _10 := 0
+//         mstore(_10, _9)
 //     }
-//     let _5 := mload(3)
-//     x := add(_5, 4)
+//     let _11 := 4
+//     let _12 := 3
+//     let _13 := mload(_12)
+//     x := add(_13, _11)
 // }

--- a/test/libjulia/yulOptimizerTests/expressionSplitter/trivial.yul
+++ b/test/libjulia/yulOptimizerTests/expressionSplitter/trivial.yul
@@ -4,8 +4,11 @@
 // ----
 // expressionSplitter
 // {
-//     let _1 := mload(3)
-//     let _2 := calldataload(2)
-//     let _3 := add(_2, _1)
-//     mstore(_3, 8)
+//     let _1 := 8
+//     let _2 := 3
+//     let _3 := mload(_2)
+//     let _4 := 2
+//     let _5 := calldataload(_4)
+//     let _6 := add(_5, _3)
+//     mstore(_6, _1)
 // }


### PR DESCRIPTION
Change the expression splitter to also extract constants.

Required for #5147 