### PR TITLE
Bug fix: Add missing include in test/Options.h

### DIFF
--- a/test/Options.h
+++ b/test/Options.h
@@ -24,7 +24,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/version.hpp>
-
+#include <boost/core/noncopyable.hpp>
 #include <functional>
 
 namespace dev


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

### Description

The `test/Options.h` header file does not include `boost/core/noncopyable.hpp` that is necessary for the compiler to understand the definition of the `boost::noncopyable` object. This PR includes the said file.