### PR TITLE
Fix compiler warning

### DIFF
--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -62,8 +62,6 @@ public:
 
 	Expression(Expression const&) = default;
 	Expression(Expression&&) = default;
-	Expression& operator=(Expression const&) = default;
-	Expression& operator=(Expression&&) = default;
 
 	bool hasCorrectArity() const
 	{

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -62,6 +62,8 @@ public:
 
 	Expression(Expression const&) = default;
 	Expression(Expression&&) = default;
+	Expression& operator=(Expression const&) = default;
+	Expression& operator=(Expression&&) = default;
 
 	bool hasCorrectArity() const
 	{
@@ -169,8 +171,8 @@ public:
 		}
 	}
 
-	std::string const name;
-	std::vector<Expression> const arguments;
+	std::string name;
+	std::vector<Expression> arguments;
 	Sort sort;
 
 private:


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

### Description

This PR fixes a compiler warning that stalls the solidity build via clang version 8. Although g++ may not issue this warning, this fix may be generally useful.

The problem is that clang-8 complains that the following explicitly defined copy and move constructors for the Expression object in `libsolidity/formal/SolverInterface.h` are implicitly deleted. Although I do not fully understand this piece of code, I think the following is happening:

- Expression object explicitly asks the compiler to create move and copy constructors for the Expression object
- Expression object can be constructed using a `std::string` data type that does **not** have a copy/move constructor
  - I believe `std::copy` and `std::move` are used for this purpose

So, the compiler is caught between obeying the explicit definition and not being able to create one?