### PR TITLE
[SMTChecker] Refactoring types

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -257,14 +257,14 @@ void SMTChecker::endVisit(TupleExpression const& _tuple)
 void SMTChecker::checkUnderOverflow(smt::Expression _value, IntegerType const& _type, SourceLocation const& _location)
 {
 	checkCondition(
-		_value < SymbolicIntVariable::minValue(_type),
+		_value < minValue(_type),
 		_location,
 		"Underflow (resulting value less than " + formatNumber(_type.minValue()) + ")",
 		"<result>",
 		&_value
 	);
 	checkCondition(
-		_value > SymbolicIntVariable::maxValue(_type),
+		_value > maxValue(_type),
 		_location,
 		"Overflow (resulting value larger than " + formatNumber(_type.maxValue()) + ")",
 		"<result>",
@@ -570,7 +570,7 @@ void SMTChecker::compareOperation(BinaryOperation const& _op)
 		smt::Expression right(expr(_op.rightExpression()));
 		Token::Value op = _op.getOperator();
 		shared_ptr<smt::Expression> value;
-		if (isInteger(_op.annotation().commonType->category()))
+		if (isNumber(_op.annotation().commonType->category()))
 		{
 			value = make_shared<smt::Expression>(
 				op == Token::Equal ? (left == right) :

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -86,13 +86,13 @@ private:
 	void assignment(VariableDeclaration const& _variable, smt::Expression const& _value, SourceLocation const& _location);
 
 	/// Maps a variable to an SSA index.
-	using VariableSequenceCounters = std::unordered_map<VariableDeclaration const*, int>;
+	using VariableIndices = std::unordered_map<VariableDeclaration const*, int>;
 
 	/// Visits the branch given by the statement, pushes and pops the current path conditions.
 	/// @param _condition if present, asserts that this condition is true within the branch.
-	/// @returns the variable sequence counter after visiting the branch.
-	VariableSequenceCounters visitBranch(Statement const& _statement, smt::Expression const* _condition = nullptr);
-	VariableSequenceCounters visitBranch(Statement const& _statement, smt::Expression _condition);
+	/// @returns the variable indices after visiting the branch.
+	VariableIndices visitBranch(Statement const& _statement, smt::Expression const* _condition = nullptr);
+	VariableIndices visitBranch(Statement const& _statement, smt::Expression _condition);
 
 	/// Check that a condition can be satisfied.
 	void checkCondition(
@@ -125,7 +125,7 @@ private:
 	/// Given two different branches and the touched variables,
 	/// merge the touched variables into after-branch ite variables
 	/// using the branch condition as guard.
-	void mergeVariables(std::vector<VariableDeclaration const*> const& _variables, smt::Expression const& _condition, VariableSequenceCounters const& _countersEndTrue, VariableSequenceCounters const& _countersEndFalse);
+	void mergeVariables(std::vector<VariableDeclaration const*> const& _variables, smt::Expression const& _condition, VariableIndices const& _indicesEndTrue, VariableIndices const& _indicesEndFalse);
 	/// Tries to create an uninitialized variable and returns true on success.
 	/// This fails if the type is not supported.
 	bool createVariable(VariableDeclaration const& _varDecl);
@@ -133,16 +133,16 @@ private:
 	static std::string uniqueSymbol(Expression const& _expr);
 
 	/// @returns true if _delc is a variable that is known at the current point, i.e.
-	/// has a valid sequence number
+	/// has a valid index
 	bool knownVariable(VariableDeclaration const& _decl);
 	/// @returns an expression denoting the value of the variable declared in @a _decl
 	/// at the current point.
 	smt::Expression currentValue(VariableDeclaration const& _decl);
 	/// @returns an expression denoting the value of the variable declared in @a _decl
-	/// at the given sequence point. Does not ensure that this sequence point exists.
-	smt::Expression valueAtSequence(VariableDeclaration const& _decl, int _sequence);
-	/// Allocates a new sequence number for the declaration, updates the current
-	/// sequence number to this value and returns the expression.
+	/// at the given index. Does not ensure that this index exists.
+	smt::Expression valueAtIndex(VariableDeclaration const& _decl, int _index);
+	/// Allocates a new index for the declaration, updates the current
+	/// index to this value and returns the expression.
 	smt::Expression newValue(VariableDeclaration const& _decl);
 
 	/// Sets the value of the declaration to zero.
@@ -177,9 +177,9 @@ private:
 	bool hasVariable(VariableDeclaration const& _e) const;
 
 	/// Copy the SSA indices of m_variables.
-	VariableSequenceCounters copyVariableSequenceCounters();
-	/// Resets the variable counters.
-	void resetVariableCounters(VariableSequenceCounters const& _counters); 
+	VariableIndices copyVariableIndices();
+	/// Resets the variable indices.
+	void resetVariableIndices(VariableIndices const& _indices);
 
 	std::shared_ptr<smt::SolverInterface> m_interface;
 	std::shared_ptr<VariableUsage> m_variableUsage;

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -19,14 +19,14 @@
 
 
 #include <libsolidity/formal/SolverInterface.h>
-
-#include <libsolidity/formal/SSAVariable.h>
+#include <libsolidity/formal/SymbolicVariable.h>
 
 #include <libsolidity/ast/ASTVisitor.h>
 
 #include <libsolidity/interface/ReadFile.h>
 
 #include <map>
+#include <unordered_map>
 #include <string>
 #include <vector>
 
@@ -86,7 +86,7 @@ private:
 	void assignment(VariableDeclaration const& _variable, smt::Expression const& _value, SourceLocation const& _location);
 
 	/// Maps a variable to an SSA index.
-	using VariableSequenceCounters = std::map<VariableDeclaration const*, SSAVariable>;
+	using VariableSequenceCounters = std::unordered_map<VariableDeclaration const*, int>;
 
 	/// Visits the branch given by the statement, pushes and pops the current path conditions.
 	/// @param _condition if present, asserts that this condition is true within the branch.
@@ -176,13 +176,18 @@ private:
 	/// Checks if VariableDeclaration was seen.
 	bool hasVariable(VariableDeclaration const& _e) const;
 
+	/// Copy the SSA indices of m_variables.
+	VariableSequenceCounters copyVariableSequenceCounters();
+	/// Resets the variable counters.
+	void resetVariableCounters(VariableSequenceCounters const& _counters); 
+
 	std::shared_ptr<smt::SolverInterface> m_interface;
 	std::shared_ptr<VariableUsage> m_variableUsage;
 	bool m_loopExecutionHappened = false;
 	/// An Expression may have multiple smt::Expression due to
 	/// repeated calls to the same function.
 	std::multimap<Expression const*, smt::Expression> m_expressions;
-	std::map<VariableDeclaration const*, SSAVariable> m_variables;
+	std::unordered_map<VariableDeclaration const*, std::shared_ptr<SymbolicVariable>> m_variables;
 	std::vector<smt::Expression> m_pathConditions;
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -17,46 +17,12 @@
 
 #include <libsolidity/formal/SSAVariable.h>
 
-#include <libsolidity/formal/SymbolicBoolVariable.h>
-#include <libsolidity/formal/SymbolicIntVariable.h>
-
-#include <libsolidity/ast/AST.h>
-
 using namespace std;
-using namespace dev;
 using namespace dev::solidity;
 
-SSAVariable::SSAVariable(
-	Type const& _type,
-	string const& _uniqueName,
-	smt::SolverInterface& _interface
-)
+SSAVariable::SSAVariable()
 {
 	resetIndex();
-
-	if (isInteger(_type.category()))
-		m_symbolicVar = make_shared<SymbolicIntVariable>(_type, _uniqueName, _interface);
-	else if (isBool(_type.category()))
-		m_symbolicVar = make_shared<SymbolicBoolVariable>(_type, _uniqueName, _interface);
-	else
-	{
-		solAssert(false, "");
-	}
-}
-
-bool SSAVariable::isSupportedType(Type::Category _category)
-{
-	return isInteger(_category) || isBool(_category);
-}
-
-bool SSAVariable::isInteger(Type::Category _category)
-{
-	return _category == Type::Category::Integer || _category == Type::Category::Address;
-}
-
-bool SSAVariable::isBool(Type::Category _category)
-{
-	return _category == Type::Category::Bool;
 }
 
 void SSAVariable::resetIndex()
@@ -64,24 +30,4 @@ void SSAVariable::resetIndex()
 	m_currentSequenceCounter = 0;
 	m_nextFreeSequenceCounter.reset (new int);
 	*m_nextFreeSequenceCounter = 1;
-}
-
-int SSAVariable::index() const
-{
-	return m_currentSequenceCounter;
-}
-
-int SSAVariable::next() const
-{
-	return *m_nextFreeSequenceCounter;
-}
-
-void SSAVariable::setZeroValue()
-{
-	m_symbolicVar->setZeroValue(index());
-}
-
-void SSAVariable::setUnknownValue()
-{
-	m_symbolicVar->setUnknownValue(index());
 }

--- a/libsolidity/formal/SSAVariable.cpp
+++ b/libsolidity/formal/SSAVariable.cpp
@@ -27,7 +27,7 @@ SSAVariable::SSAVariable()
 
 void SSAVariable::resetIndex()
 {
-	m_currentSequenceCounter = 0;
-	m_nextFreeSequenceCounter.reset (new int);
-	*m_nextFreeSequenceCounter = 1;
+	m_currentIndex = 0;
+	m_nextFreeIndex.reset (new int);
+	*m_nextFreeIndex = 1;
 }

--- a/libsolidity/formal/SSAVariable.h
+++ b/libsolidity/formal/SSAVariable.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include <libsolidity/formal/SymbolicVariable.h>
-
 #include <memory>
 
 namespace dev
@@ -32,53 +30,19 @@ namespace solidity
 class SSAVariable
 {
 public:
-	/// @param _type Forwarded to the symbolic var.
-	/// @param _interface Forwarded to the symbolic var such that it can give constraints to the solver.
-	SSAVariable(
-		Type const& _type,
-		std::string const& _uniqueName,
-		smt::SolverInterface& _interface
-	);
-
+	SSAVariable();
 	void resetIndex();
 
 	/// This function returns the current index of this SSA variable.
-	int index() const;
-	/// This function returns the next free index of this SSA variable.
-	int next() const;
+	int index() const { return m_currentSequenceCounter; }
+	int& index() { return m_currentSequenceCounter; }
 
 	int operator++()
 	{
 		return m_currentSequenceCounter = (*m_nextFreeSequenceCounter)++;
 	}
 
-	smt::Expression operator()() const
-	{
-		return valueAtSequence(index());
-	}
-
-	smt::Expression operator()(int _seq) const
-	{
-		return valueAtSequence(_seq);
-	}
-
-	/// These two functions forward the call to the symbolic var
-	/// which generates the constraints according to the type.
-	void setZeroValue();
-	void setUnknownValue();
-
-	/// So far Int and Bool are supported.
-	static bool isSupportedType(Type::Category _category);
-	static bool isInteger(Type::Category _category);
-	static bool isBool(Type::Category _category);
-
 private:
-	smt::Expression valueAtSequence(int _seq) const
-	{
-		return (*m_symbolicVar)(_seq);
-	}
-
-	std::shared_ptr<SymbolicVariable> m_symbolicVar = nullptr;
 	int m_currentSequenceCounter;
 	/// The next free sequence counter is a shared pointer because we want
 	/// the copy and the copied to share it.

--- a/libsolidity/formal/SSAVariable.h
+++ b/libsolidity/formal/SSAVariable.h
@@ -34,19 +34,19 @@ public:
 	void resetIndex();
 
 	/// This function returns the current index of this SSA variable.
-	int index() const { return m_currentSequenceCounter; }
-	int& index() { return m_currentSequenceCounter; }
+	int index() const { return m_currentIndex; }
+	int& index() { return m_currentIndex; }
 
 	int operator++()
 	{
-		return m_currentSequenceCounter = (*m_nextFreeSequenceCounter)++;
+		return m_currentIndex = (*m_nextFreeIndex)++;
 	}
 
 private:
-	int m_currentSequenceCounter;
-	/// The next free sequence counter is a shared pointer because we want
+	int m_currentIndex;
+	/// The next free index is a shared pointer because we want
 	/// the copy and the copied to share it.
-	std::shared_ptr<int> m_nextFreeSequenceCounter;
+	std::shared_ptr<int> m_nextFreeIndex;
 };
 
 }

--- a/libsolidity/formal/SymbolicAddressVariable.cpp
+++ b/libsolidity/formal/SymbolicAddressVariable.cpp
@@ -15,35 +15,27 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include <libsolidity/formal/SymbolicAddressVariable.h>
 
-#include <libsolidity/formal/SymbolicVariable.h>
+#include <libsolidity/formal/SymbolicTypes.h>
 
-namespace dev
+using namespace std;
+using namespace dev;
+using namespace dev::solidity;
+
+SymbolicAddressVariable::SymbolicAddressVariable(
+	Type const& _type,
+	string const& _uniqueName,
+	smt::SolverInterface& _interface
+):
+	SymbolicIntVariable(_type, _uniqueName, _interface)
 {
-namespace solidity
-{
-
-/**
- * Specialization of SymbolicVariable for Integers
- */
-class SymbolicIntVariable: public SymbolicVariable
-{
-public:
-	SymbolicIntVariable(
-		Type const& _type,
-		std::string const& _uniqueName,
-		smt::SolverInterface& _interface
-	);
-
-	/// Sets the var to 0.
-	void setZeroValue();
-	/// Sets the variable to the full valid value range.
-	virtual void setUnknownValue();
-
-protected:
-	smt::Expression valueAtIndex(int _index) const;
-};
-
+	solAssert(isAddress(_type.category()), "");
 }
+
+void SymbolicAddressVariable::setUnknownValue()
+{
+	IntegerType intType{160};
+	m_interface.addAssertion(currentValue() >= minValue(intType));
+	m_interface.addAssertion(currentValue() <= maxValue(intType));
 }

--- a/libsolidity/formal/SymbolicAddressVariable.h
+++ b/libsolidity/formal/SymbolicAddressVariable.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <libsolidity/formal/SymbolicVariable.h>
+#include <libsolidity/formal/SymbolicIntVariable.h>
 
 namespace dev
 {
@@ -25,24 +25,19 @@ namespace solidity
 {
 
 /**
- * Specialization of SymbolicVariable for Integers
+ * Specialization of SymbolicVariable for Address
  */
-class SymbolicIntVariable: public SymbolicVariable
+class SymbolicAddressVariable: public SymbolicIntVariable
 {
 public:
-	SymbolicIntVariable(
+	SymbolicAddressVariable(
 		Type const& _type,
 		std::string const& _uniqueName,
 		smt::SolverInterface& _interface
 	);
 
-	/// Sets the var to 0.
-	void setZeroValue();
 	/// Sets the variable to the full valid value range.
-	virtual void setUnknownValue();
-
-protected:
-	smt::Expression valueAtIndex(int _index) const;
+	void setUnknownValue();
 };
 
 }

--- a/libsolidity/formal/SymbolicBoolVariable.cpp
+++ b/libsolidity/formal/SymbolicBoolVariable.cpp
@@ -17,8 +17,6 @@
 
 #include <libsolidity/formal/SymbolicBoolVariable.h>
 
-#include <libsolidity/ast/AST.h>
-
 using namespace std;
 using namespace dev;
 using namespace dev::solidity;
@@ -38,11 +36,11 @@ smt::Expression SymbolicBoolVariable::valueAtSequence(int _seq) const
 	return m_interface.newBool(uniqueSymbol(_seq));
 }
 
-void SymbolicBoolVariable::setZeroValue(int _seq)
+void SymbolicBoolVariable::setZeroValue()
 {
-	m_interface.addAssertion(valueAtSequence(_seq) == smt::Expression(false));
+	m_interface.addAssertion(current() == smt::Expression(false));
 }
 
-void SymbolicBoolVariable::setUnknownValue(int)
+void SymbolicBoolVariable::setUnknownValue()
 {
 }

--- a/libsolidity/formal/SymbolicBoolVariable.cpp
+++ b/libsolidity/formal/SymbolicBoolVariable.cpp
@@ -31,14 +31,14 @@ SymbolicBoolVariable::SymbolicBoolVariable(
 	solAssert(_type.category() == Type::Category::Bool, "");
 }
 
-smt::Expression SymbolicBoolVariable::valueAtSequence(int _seq) const
+smt::Expression SymbolicBoolVariable::valueAtIndex(int _index) const
 {
-	return m_interface.newBool(uniqueSymbol(_seq));
+	return m_interface.newBool(uniqueSymbol(_index));
 }
 
 void SymbolicBoolVariable::setZeroValue()
 {
-	m_interface.addAssertion(current() == smt::Expression(false));
+	m_interface.addAssertion(currentValue() == smt::Expression(false));
 }
 
 void SymbolicBoolVariable::setUnknownValue()

--- a/libsolidity/formal/SymbolicBoolVariable.h
+++ b/libsolidity/formal/SymbolicBoolVariable.h
@@ -37,9 +37,9 @@ public:
 	);
 
 	/// Sets the var to false.
-	void setZeroValue(int _seq);
-	/// Does nothing since the SMT solver already knows the valid values.
-	void setUnknownValue(int _seq);
+	void setZeroValue();
+	/// Does nothing since the SMT solver already knows the valid values for Bool.
+	void setUnknownValue();
 
 protected:
 	smt::Expression valueAtSequence(int _seq) const;

--- a/libsolidity/formal/SymbolicBoolVariable.h
+++ b/libsolidity/formal/SymbolicBoolVariable.h
@@ -42,7 +42,7 @@ public:
 	void setUnknownValue();
 
 protected:
-	smt::Expression valueAtSequence(int _seq) const;
+	smt::Expression valueAtIndex(int _index) const;
 };
 
 }

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -17,6 +17,8 @@
 
 #include <libsolidity/formal/SymbolicIntVariable.h>
 
+#include <libsolidity/formal/SymbolicTypes.h>
+
 using namespace std;
 using namespace dev;
 using namespace dev::solidity;
@@ -28,11 +30,7 @@ SymbolicIntVariable::SymbolicIntVariable(
 ):
 	SymbolicVariable(_type, _uniqueName, _interface)
 {
-	solAssert(
-		_type.category() == Type::Category::Integer ||
-		_type.category() == Type::Category::Address,
-		""
-	);
+	solAssert(isNumber(_type.category()), "");
 }
 
 smt::Expression SymbolicIntVariable::valueAtIndex(int _index) const
@@ -47,28 +45,8 @@ void SymbolicIntVariable::setZeroValue()
 
 void SymbolicIntVariable::setUnknownValue()
 {
-	if (m_type.category() == Type::Category::Integer)
-	{
-		auto intType = dynamic_cast<IntegerType const*>(&m_type);
-		solAssert(intType, "");
-		m_interface.addAssertion(currentValue() >= minValue(*intType));
-		m_interface.addAssertion(currentValue() <= maxValue(*intType));
-	}
-	else
-	{
-		solAssert(m_type.category() == Type::Category::Address, "");
-		IntegerType addrType{160};
-		m_interface.addAssertion(currentValue() >= minValue(addrType));
-		m_interface.addAssertion(currentValue() <= maxValue(addrType));
-	}
-}
-
-smt::Expression SymbolicIntVariable::minValue(IntegerType const& _t)
-{
-	return smt::Expression(_t.minValue());
-}
-
-smt::Expression SymbolicIntVariable::maxValue(IntegerType const& _t)
-{
-	return smt::Expression(_t.maxValue());
+	auto intType = dynamic_cast<IntegerType const*>(&m_type);
+	solAssert(intType, "");
+	m_interface.addAssertion(currentValue() >= minValue(*intType));
+	m_interface.addAssertion(currentValue() <= maxValue(*intType));
 }

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -35,14 +35,14 @@ SymbolicIntVariable::SymbolicIntVariable(
 	);
 }
 
-smt::Expression SymbolicIntVariable::valueAtSequence(int _seq) const
+smt::Expression SymbolicIntVariable::valueAtIndex(int _index) const
 {
-	return m_interface.newInteger(uniqueSymbol(_seq));
+	return m_interface.newInteger(uniqueSymbol(_index));
 }
 
 void SymbolicIntVariable::setZeroValue()
 {
-	m_interface.addAssertion(current() == 0);
+	m_interface.addAssertion(currentValue() == 0);
 }
 
 void SymbolicIntVariable::setUnknownValue()
@@ -51,15 +51,15 @@ void SymbolicIntVariable::setUnknownValue()
 	{
 		auto intType = dynamic_cast<IntegerType const*>(&m_type);
 		solAssert(intType, "");
-		m_interface.addAssertion(current() >= minValue(*intType));
-		m_interface.addAssertion(current() <= maxValue(*intType));
+		m_interface.addAssertion(currentValue() >= minValue(*intType));
+		m_interface.addAssertion(currentValue() <= maxValue(*intType));
 	}
 	else
 	{
 		solAssert(m_type.category() == Type::Category::Address, "");
 		IntegerType addrType{160};
-		m_interface.addAssertion(current() >= minValue(addrType));
-		m_interface.addAssertion(current() <= maxValue(addrType));
+		m_interface.addAssertion(currentValue() >= minValue(addrType));
+		m_interface.addAssertion(currentValue() <= maxValue(addrType));
 	}
 }
 

--- a/libsolidity/formal/SymbolicIntVariable.cpp
+++ b/libsolidity/formal/SymbolicIntVariable.cpp
@@ -40,26 +40,26 @@ smt::Expression SymbolicIntVariable::valueAtSequence(int _seq) const
 	return m_interface.newInteger(uniqueSymbol(_seq));
 }
 
-void SymbolicIntVariable::setZeroValue(int _seq)
+void SymbolicIntVariable::setZeroValue()
 {
-	m_interface.addAssertion(valueAtSequence(_seq) == 0);
+	m_interface.addAssertion(current() == 0);
 }
 
-void SymbolicIntVariable::setUnknownValue(int _seq)
+void SymbolicIntVariable::setUnknownValue()
 {
 	if (m_type.category() == Type::Category::Integer)
 	{
 		auto intType = dynamic_cast<IntegerType const*>(&m_type);
 		solAssert(intType, "");
-		m_interface.addAssertion(valueAtSequence(_seq) >= minValue(*intType));
-		m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(*intType));
+		m_interface.addAssertion(current() >= minValue(*intType));
+		m_interface.addAssertion(current() <= maxValue(*intType));
 	}
 	else
 	{
 		solAssert(m_type.category() == Type::Category::Address, "");
 		IntegerType addrType{160};
-		m_interface.addAssertion(valueAtSequence(_seq) >= minValue(addrType));
-		m_interface.addAssertion(valueAtSequence(_seq) <= maxValue(addrType));
+		m_interface.addAssertion(current() >= minValue(addrType));
+		m_interface.addAssertion(current() <= maxValue(addrType));
 	}
 }
 

--- a/libsolidity/formal/SymbolicIntVariable.h
+++ b/libsolidity/formal/SymbolicIntVariable.h
@@ -37,9 +37,9 @@ public:
 	);
 
 	/// Sets the var to 0.
-	void setZeroValue(int _seq);
+	void setZeroValue();
 	/// Sets the variable to the full valid value range.
-	void setUnknownValue(int _seq);
+	void setUnknownValue();
 
 	static smt::Expression minValue(IntegerType const& _t);
 	static smt::Expression maxValue(IntegerType const& _t);

--- a/libsolidity/formal/SymbolicIntVariable.h
+++ b/libsolidity/formal/SymbolicIntVariable.h
@@ -45,7 +45,7 @@ public:
 	static smt::Expression maxValue(IntegerType const& _t);
 
 protected:
-	smt::Expression valueAtSequence(int _seq) const;
+	smt::Expression valueAtIndex(int _index) const;
 };
 
 }

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -1,0 +1,72 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/formal/SymbolicTypes.h>
+
+#include <libsolidity/formal/SymbolicBoolVariable.h>
+#include <libsolidity/formal/SymbolicIntVariable.h>
+
+#include <libsolidity/ast/Types.h>
+
+#include <memory>
+
+using namespace std;
+using namespace dev::solidity;
+
+bool dev::solidity::isSupportedType(Type::Category _category)
+{
+	return isInteger(_category) || isBool(_category);
+}
+
+bool dev::solidity::isSupportedType(Type const& _type)
+{
+	return isSupportedType(_type.category());
+}
+
+bool dev::solidity::isInteger(Type::Category _category)
+{
+	return _category == Type::Category::Integer || _category == Type::Category::Address;
+}
+
+bool dev::solidity::isInteger(Type const& _type)
+{
+	return isInteger(_type.category());
+}
+
+bool dev::solidity::isBool(Type::Category _category)
+{
+	return _category == Type::Category::Bool;
+}
+
+bool dev::solidity::isBool(Type const& _type)
+{
+	return isBool(_type.category());
+}
+
+shared_ptr<SymbolicVariable> dev::solidity::newSymbolicVariable(Type const& _type, std::string const& _uniqueName, smt::SolverInterface& _solver)
+{
+	if (!isSupportedType(_type))
+		return nullptr;
+	if (isBool(_type.category()))
+		return make_shared<SymbolicBoolVariable>(_type, _uniqueName, _solver);
+	else if (isInteger(_type.category()))
+		return make_shared<SymbolicIntVariable>(_type, _uniqueName, _solver);
+	else
+		solAssert(false, "");
+}
+
+

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -19,6 +19,7 @@
 
 #include <libsolidity/formal/SymbolicBoolVariable.h>
 #include <libsolidity/formal/SymbolicIntVariable.h>
+#include <libsolidity/formal/SymbolicAddressVariable.h>
 
 #include <libsolidity/ast/Types.h>
 
@@ -29,7 +30,27 @@ using namespace dev::solidity;
 
 bool dev::solidity::isSupportedType(Type::Category _category)
 {
-	return isInteger(_category) || isBool(_category);
+	return isInteger(_category) ||
+		isAddress(_category) ||
+		isBool(_category);
+}
+
+shared_ptr<SymbolicVariable> dev::solidity::newSymbolicVariable(
+	Type const& _type,
+	std::string const& _uniqueName,
+	smt::SolverInterface& _solver
+)
+{
+	if (!isSupportedType(_type))
+		return nullptr;
+	if (isBool(_type.category()))
+		return make_shared<SymbolicBoolVariable>(_type, _uniqueName, _solver);
+	else if (isInteger(_type.category()))
+		return make_shared<SymbolicIntVariable>(_type, _uniqueName, _solver);
+	else if (isAddress(_type.category()))
+		return make_shared<SymbolicAddressVariable>(_type, _uniqueName, _solver);
+	else
+		solAssert(false, "");
 }
 
 bool dev::solidity::isSupportedType(Type const& _type)
@@ -39,12 +60,33 @@ bool dev::solidity::isSupportedType(Type const& _type)
 
 bool dev::solidity::isInteger(Type::Category _category)
 {
-	return _category == Type::Category::Integer || _category == Type::Category::Address;
+	return _category == Type::Category::Integer;
 }
 
 bool dev::solidity::isInteger(Type const& _type)
 {
 	return isInteger(_type.category());
+}
+
+bool dev::solidity::isAddress(Type::Category _category)
+{
+	return _category == Type::Category::Address;
+}
+
+bool dev::solidity::isAddress(Type const& _type)
+{
+	return isAddress(_type.category());
+}
+
+bool dev::solidity::isNumber(Type::Category _category)
+{
+	return isInteger(_category) ||
+		isAddress(_category);
+}
+
+bool dev::solidity::isNumber(Type const& _type)
+{
+	return isNumber(_type.category());
 }
 
 bool dev::solidity::isBool(Type::Category _category)
@@ -57,16 +99,12 @@ bool dev::solidity::isBool(Type const& _type)
 	return isBool(_type.category());
 }
 
-shared_ptr<SymbolicVariable> dev::solidity::newSymbolicVariable(Type const& _type, std::string const& _uniqueName, smt::SolverInterface& _solver)
+smt::Expression dev::solidity::minValue(IntegerType const& _type)
 {
-	if (!isSupportedType(_type))
-		return nullptr;
-	if (isBool(_type.category()))
-		return make_shared<SymbolicBoolVariable>(_type, _uniqueName, _solver);
-	else if (isInteger(_type.category()))
-		return make_shared<SymbolicIntVariable>(_type, _uniqueName, _solver);
-	else
-		solAssert(false, "");
+	return smt::Expression(_type.minValue());
 }
 
-
+smt::Expression dev::solidity::maxValue(IntegerType const& _type)
+{
+	return smt::Expression(_type.maxValue());
+}

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -36,10 +36,19 @@ bool isSupportedType(Type const& _type);
 bool isInteger(Type::Category _category);
 bool isInteger(Type const& _type);
 
+bool isAddress(Type::Category _category);
+bool isAddress(Type const& _type);
+
+bool isNumber(Type::Category _category);
+bool isNumber(Type const& _type);
+
 bool isBool(Type::Category _category);
 bool isBool(Type const& _type);
 
 std::shared_ptr<SymbolicVariable> newSymbolicVariable(Type const& _type, std::string const& _uniqueName, smt::SolverInterface& _solver);
+
+smt::Expression minValue(IntegerType const& _type);
+smt::Expression maxValue(IntegerType const& _type);
 
 }
 }

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -15,29 +15,31 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#pragma once
+
+#include <libsolidity/formal/SolverInterface.h>
 #include <libsolidity/formal/SymbolicVariable.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/Types.h>
 
-using namespace std;
-using namespace dev;
-using namespace dev::solidity;
-
-SymbolicVariable::SymbolicVariable(
-	Type const& _type,
-	string const& _uniqueName,
-	smt::SolverInterface& _interface
-):
-	m_type(_type),
-	m_uniqueName(_uniqueName),
-	m_interface(_interface),
-	m_ssa(make_shared<SSAVariable>())
+namespace dev
 {
-}
-
-string SymbolicVariable::uniqueSymbol(int _seq) const
+namespace solidity
 {
-	return m_uniqueName + "_" + to_string(_seq);
+
+/// So far int, bool and address are supported.
+/// Returns true if type is supported.
+bool isSupportedType(Type::Category _category);
+bool isSupportedType(Type const& _type);
+
+bool isInteger(Type::Category _category);
+bool isInteger(Type const& _type);
+
+bool isBool(Type::Category _category);
+bool isBool(Type const& _type);
+
+std::shared_ptr<SymbolicVariable> newSymbolicVariable(Type const& _type, std::string const& _uniqueName, smt::SolverInterface& _solver);
+
 }
-
-
+}

--- a/libsolidity/formal/SymbolicVariable.cpp
+++ b/libsolidity/formal/SymbolicVariable.cpp
@@ -35,9 +35,9 @@ SymbolicVariable::SymbolicVariable(
 {
 }
 
-string SymbolicVariable::uniqueSymbol(int _seq) const
+string SymbolicVariable::uniqueSymbol(int _index) const
 {
-	return m_uniqueName + "_" + to_string(_seq);
+	return m_uniqueName + "_" + to_string(_index);
 }
 
 

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -62,10 +62,11 @@ public:
 	int& index() { return m_ssa->index(); }
 
 	/// Sets the var to the default value of its type.
+	/// Inherited types must implement.
 	virtual void setZeroValue() = 0;
-	/// The unknown value is the full range of valid values,
-	/// and that's sub-type dependent.
-	virtual void setUnknownValue() = 0;
+	/// The unknown value is the full range of valid values.
+	/// It is sub-type dependent, but not mandatory.
+	virtual void setUnknownValue() {}
 
 protected:
 	std::string uniqueSymbol(int _index) const;

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <libsolidity/formal/SSAVariable.h>
+
 #include <libsolidity/formal/SolverInterface.h>
 
 #include <libsolidity/ast/Types.h>
@@ -43,25 +45,35 @@ public:
 	);
 	virtual ~SymbolicVariable() = default;
 
-	smt::Expression operator()(int _seq) const
+	smt::Expression current() const
 	{
-		return valueAtSequence(_seq);
+		return valueAtSequence(m_ssa->index());
 	}
 
-	std::string uniqueSymbol(int _seq) const;
+	virtual smt::Expression valueAtSequence(int _seq) const = 0;
+
+	smt::Expression increase()
+	{
+		++(*m_ssa);
+		return current();
+	}
+
+	int index() const { return m_ssa->index(); }
+	int& index() { return m_ssa->index(); }
 
 	/// Sets the var to the default value of its type.
-	virtual void setZeroValue(int _seq) = 0;
+	virtual void setZeroValue() = 0;
 	/// The unknown value is the full range of valid values,
 	/// and that's sub-type dependent.
-	virtual void setUnknownValue(int _seq) = 0;
+	virtual void setUnknownValue() = 0;
 
 protected:
-	virtual smt::Expression valueAtSequence(int _seq) const = 0;
+	std::string uniqueSymbol(int _seq) const;
 
 	Type const& m_type;
 	std::string m_uniqueName;
 	smt::SolverInterface& m_interface;
+	std::shared_ptr<SSAVariable> m_ssa = nullptr;
 };
 
 }

--- a/libsolidity/formal/SymbolicVariable.h
+++ b/libsolidity/formal/SymbolicVariable.h
@@ -45,17 +45,17 @@ public:
 	);
 	virtual ~SymbolicVariable() = default;
 
-	smt::Expression current() const
+	smt::Expression currentValue() const
 	{
-		return valueAtSequence(m_ssa->index());
+		return valueAtIndex(m_ssa->index());
 	}
 
-	virtual smt::Expression valueAtSequence(int _seq) const = 0;
+	virtual smt::Expression valueAtIndex(int _index) const = 0;
 
-	smt::Expression increase()
+	smt::Expression increaseIndex()
 	{
 		++(*m_ssa);
-		return current();
+		return currentValue();
 	}
 
 	int index() const { return m_ssa->index(); }
@@ -68,7 +68,7 @@ public:
 	virtual void setUnknownValue() = 0;
 
 protected:
-	std::string uniqueSymbol(int _seq) const;
+	std::string uniqueSymbol(int _index) const;
 
 	Type const& m_type;
 	std::string m_uniqueName;


### PR DESCRIPTION
Before this PR, SSAVariable contained a SymbolicVariable. In order to handle types better and remove this responsibility from SSAVariable, this PR swaps this relation such that now SymbolicVariable contains an SSAVariable that simply manages indices.
A lib of type utils was also created to reason about Solidity types in the SMT encoding context.