### PR TITLE
[Yul] Limit name length created by dispenser

### DIFF
--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -47,9 +47,8 @@ public:
 		solidity::assembly::AsmAnalysisInfo const& _analysisInfo,
 		std::set<std::string> const& _externallyUsedIdentifiers = {}
 	):
-		m_info(_analysisInfo), m_externallyUsedIdentifiers(_externallyUsedIdentifiers)
+		m_info(_analysisInfo), m_externallyUsedIdentifiers(_externallyUsedIdentifiers), m_nameDispenser(m_externallyUsedIdentifiers)
 	{
-		m_nameDispenser.m_usedNames = m_externallyUsedIdentifiers;
 	}
 
 protected:

--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -106,8 +106,6 @@ private:
 	boost::optional<std::vector<Statement>> tryInlineStatement(Statement& _statement);
 	std::vector<Statement> performInline(Statement& _statement, FunctionCall& _funCall);
 
-	std::string newName(std::string const& _prefix);
-
 	std::string m_currentFunction;
 	FullInliner& m_driver;
 	NameDispenser& m_nameDispenser;

--- a/libyul/optimiser/NameDispenser.h
+++ b/libyul/optimiser/NameDispenser.h
@@ -19,6 +19,8 @@
  */
 #pragma once
 
+#include <libyul/ASTDataForward.h>
+
 #include <set>
 #include <string>
 
@@ -27,9 +29,29 @@ namespace dev
 namespace yul
 {
 
-struct NameDispenser
+/**
+ * Optimizer component that can be used to generate new names that
+ * do not conflict with existing names.
+ *
+ * Tries to keep names short and appends decimals to disambiguate.
+ */
+class NameDispenser
 {
-	std::string newName(std::string const& _prefix);
+public:
+	/// Initialize the name dispenser with all the names used in the given AST.
+	explicit NameDispenser(Block const& _ast);
+	/// Initialize the name dispenser with the given used names.
+	explicit NameDispenser(std::set<std::string> _usedNames);
+
+	/// @returns a currently unused name that should be similar to _nameHint
+	/// and prefixed by _context if present.
+	/// If the resulting name would be too long, trims the context at the end
+	/// and the name hint at the start.
+	std::string newName(std::string const& _nameHint, std::string const& _context = {});
+
+private:
+	std::string newNameInternal(std::string const& _nameHint);
+
 	std::set<std::string> m_usedNames;
 };
 

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -106,8 +106,7 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 	}
 	else if (m_optimizerStep == "expressionSplitter")
 	{
-		NameDispenser nameDispenser;
-		nameDispenser.m_usedNames = NameCollector(*m_ast).names();
+		NameDispenser nameDispenser(*m_ast);
 		ExpressionSplitter{nameDispenser}(*m_ast);
 	}
 	else if (m_optimizerStep == "functionGrouper")
@@ -130,8 +129,7 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 		disambiguate();
 		(FunctionHoister{})(*m_ast);
 		(FunctionGrouper{})(*m_ast);
-		NameDispenser nameDispenser;
-		nameDispenser.m_usedNames = NameCollector(*m_ast).names();
+		NameDispenser nameDispenser(*m_ast);
 		ExpressionSplitter{nameDispenser}(*m_ast);
 		FullInliner(*m_ast).run();
 		ExpressionJoiner::run(*m_ast);
@@ -155,8 +153,7 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 	else if (m_optimizerStep == "fullSimplify")
 	{
 		disambiguate();
-		NameDispenser nameDispenser;
-		nameDispenser.m_usedNames = NameCollector(*m_ast).names();
+		NameDispenser nameDispenser(*m_ast);
 		ExpressionSplitter{nameDispenser}(*m_ast);
 		CommonSubexpressionEliminator{}(*m_ast);
 		ExpressionSimplifier::run(*m_ast);

--- a/test/libyul/yulOptimizerTests/disambiguator/long_names.yul
+++ b/test/libyul/yulOptimizerTests/disambiguator/long_names.yul
@@ -1,0 +1,12 @@
+// yul
+{ { let aanteuhdaoneudbrgkjiuaothduiathudaoeuh:u256 } { let aanteuhdaoneudbrgkjiuaothduiathudaoeuh:u256 } }
+// ----
+// disambiguator
+// {
+//     {
+//         let aanteuhdaoneudbrgkjiuaothduiathudaoeuh:u256
+//     }
+//     {
+//         let aanteuhdaoneudbrgkjiuaothduiathudaoeuh_1:u256
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/fullInliner/long_names.yul
+++ b/test/libyul/yulOptimizerTests/fullInliner/long_names.yul
@@ -1,0 +1,25 @@
+{
+	function verylongfunctionname(verylongvariablename) -> verylongvariablename2 {
+		verylongvariablename2 := add(verylongvariablename, verylongvariablename)
+	}
+	// same long name
+	let verylongvariablename2 := 3
+	mstore(0, verylongfunctionname(verylongvariablename2))
+	mstore(1, verylongvariablename2)
+}
+// ----
+// fullInliner
+// {
+//     {
+//         let verylongvariablename2_1 := 3
+//         let verylongfu_verylongvariablename := verylongvariablename2_1
+//         let verylongfu_verylongvariablename2
+//         verylongfu_verylongvariablename2 := add(verylongfu_verylongvariablename, verylongfu_verylongvariablename)
+//         mstore(0, verylongfu_verylongvariablename2)
+//         mstore(1, verylongvariablename2_1)
+//     }
+//     function verylongfunctionname(verylongvariablename) -> verylongvariablename2
+//     {
+//         verylongvariablename2 := add(verylongvariablename, verylongvariablename)
+//     }
+// }


### PR DESCRIPTION
If multiple functions are inlined, this gets messy quickly.

Depends on https://github.com/ethereum/solidity/pull/5232 and https://github.com/ethereum/solidity/pull/5227