### PR TITLE
Make full inliner more flexible.

### DIFF
--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -71,7 +71,7 @@ class NameCollector;
 class FullInliner: public ASTModifier
 {
 public:
-	explicit FullInliner(Block& _ast);
+	explicit FullInliner(Block& _ast, NameDispenser& _dispenser);
 
 	void run();
 
@@ -94,7 +94,7 @@ private:
 	/// Variables that are constants (used for inlining heuristic)
 	std::set<std::string> m_constants;
 	std::map<std::string, size_t> m_functionSizes;
-	NameDispenser m_nameDispenser;
+	NameDispenser& m_nameDispenser;
 };
 
 /**

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -131,7 +131,7 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 		(FunctionGrouper{})(*m_ast);
 		NameDispenser nameDispenser(*m_ast);
 		ExpressionSplitter{nameDispenser}(*m_ast);
-		FullInliner(*m_ast).run();
+		FullInliner(*m_ast, nameDispenser).run();
 		ExpressionJoiner::run(*m_ast);
 	}
 	else if (m_optimizerStep == "mainFunction")


### PR DESCRIPTION
This allows the full inliner to be used with source in the wrong format - it will not throw an exception, it will just not be effective.