### PR TITLE
Refactored bool TypeChecker::visit(FunctionCall const& _functionCall).

### DIFF
--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -94,7 +94,33 @@ private:
 	/// Performs type checks for ``abi.decode(bytes memory, (...))`` and returns the
 	/// vector of return types (which is basically the second argument) if successful. It returns
 	/// the empty vector on error.
-	TypePointers typeCheckABIDecodeAndRetrieveReturnType(FunctionCall const& _functionCall, bool _abiEncoderV2);
+	TypePointers typeCheckABIDecodeAndRetrieveReturnType(
+		FunctionCall const& _functionCall,
+		bool _abiEncoderV2
+	);
+
+	/// Performs type checks and determines result types for type conversion FunctionCall nodes.
+	TypePointer typeCheckTypeConversionAndRetrieveReturnType(
+		FunctionCall const& _functionCall
+	);
+
+	/// Performs type checks on function call and struct ctor FunctionCall nodes (except for kind ABIDecode).
+	void typeCheckFunctionCall(
+		FunctionCall const& _functionCall,
+		FunctionTypePointer _functionType
+	);
+
+	/// Performs general number and type checks of arguments against function call and struct ctor FunctionCall node parameters.
+	void typeCheckFunctionGeneralChecks(
+		FunctionCall const& _functionCall,
+		FunctionTypePointer _functionType
+	);
+
+	/// Performs general checks and checks specific to ABI encode functions
+	void typeCheckABIEncodeFunctions(
+		FunctionCall const& _functionCall,
+		FunctionTypePointer _functionType
+	);
 
 	virtual void endVisit(InheritanceSpecifier const& _inheritance) override;
 	virtual void endVisit(UsingForDirective const& _usingFor) override;

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/102_duplicate_parameter_names_in_named_args.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/102_duplicate_parameter_names_in_named_args.sol
@@ -8,4 +8,4 @@ contract test {
 }
 // ----
 // Warning: (31-37): This declaration shadows an existing declaration.
-// TypeError: (159-160): Duplicate named argument.
+// TypeError: (159-160): Duplicate named argument "a".

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/583_abi_encode_packed_with_rational_number_constant.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/583_abi_encode_packed_with_rational_number_constant.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() pure public { abi.encodePacked(0/1); }
+}
+// ----
+// TypeError: (61-64): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/584_abi_decode_with_tuple_of_other_than_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/584_abi_decode_with_tuple_of_other_than_types.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() pure public { abi.decode("", (0)); }
+}
+// ----
+// TypeError: (60-61): Argument has to be a type name.


### PR DESCRIPTION
Logic is now split into the following methods:
- TypeChecker::typeCheckABIDecodeAndRetrieveReturnType (unchanged)
- TypeChecker::typeCheckTypeConversionAndRetrieveReturnType (added)
- TypeChecker::typeCheckFunctionLikeAndRetrieveReturnType (added)
- TypeChecker::typeCheckNonABIDecodeFunctionLike (added)

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

### Description
FunctionCall AST nodes can represent type conversion, struct construction and function call expressions, each of which require different type check and annotation logic and which was handled in a single large and unwieldy method.

Logic common to all FunctionCall nodes such as visiting descendent AST nodes, evaluating argument types for positional funciton expressions, assignment of annotations and initial determinination of FunctionCall sub-type (i.e. type conversion, function call, etc.) was left in TypeChecker::visit(FunctionCall const&).

Error checking and return type determination logic was moved to distinct methods and for function call/struct ctors return type determiniation was separated from the rather more lengthy error checking logic.

Function calls of kind ABIDecode were already delegated to a separate method TypeChecker::typeCheckABIDecodeAndRetrieveReturnType(...) which was left unchanged.
 <!--
Please explain the changes you made here.

Thank you for your help!
-->