### PR TITLE
ossfuzz: Added solc target

### DIFF
--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,5 +1,7 @@
+if (DEFINED ENV{OSSFUZZ})
 add_executable(solc_target solc_target.cpp)
 target_link_libraries(solc_target PRIVATE libsolc evmasm FuzzingEngine.a)
+endif()
 
 add_executable(solfuzzer fuzzer.cpp)
 target_link_libraries(solfuzzer PRIVATE libsolc evmasm ${Boost_PROGRAM_OPTIONS_LIBRARIES} ${Boost_SYSTEM_LIBRARIES})

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_executable(solc_target solc_target.cpp)
+target_link_libraries(solc_target PRIVATE libsolc evmasm FuzzingEngine.a)
+
 add_executable(solfuzzer fuzzer.cpp)
 target_link_libraries(solfuzzer PRIVATE libsolc evmasm ${Boost_PROGRAM_OPTIONS_LIBRARIES} ${Boost_SYSTEM_LIBRARIES})
 

--- a/test/tools/solc_target.cpp
+++ b/test/tools/solc_target.cpp
@@ -26,6 +26,45 @@ namespace
         return "";
     }
 
+    void testConstantOptimizer(string const& input)
+    {
+	if (!quiet)
+		cout << "Testing constant optimizer" << endl;
+	vector<u256> numbers;
+	stringstream sin(input);
+
+	while (!sin.eof())
+	{
+		h256 data;
+		sin.read(reinterpret_cast<char*>(data.data()), 32);
+		numbers.push_back(u256(data));
+	}
+	if (!quiet)
+		cout << "Got " << numbers.size() << " inputs:" << endl;
+
+	Assembly assembly;
+	for (u256 const& n: numbers)
+	{
+		if (!quiet)
+			cout << n << endl;
+		assembly.append(n);
+	}
+	for (bool isCreation: {false, true})
+	{
+		for (unsigned runs: {1, 2, 3, 20, 40, 100, 200, 400, 1000})
+		{
+			ConstantOptimisationMethod::optimiseConstants(
+				isCreation,
+				runs,
+				EVMVersion{},
+				assembly,
+				const_cast<AssemblyItems&>(assembly.items())
+			);
+		}
+	}
+    }
+
+
     void runCompiler(string input)
     {
         string outputString(compileStandard(input.c_str(), nullptr));
@@ -78,6 +117,12 @@ namespace
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     string input(reinterpret_cast<const char*>(data), size);
-    testCompiler(input, true);
+
+    if (size % 3 == 0)
+        testCompiler(input, true);
+    else if (size % 3 == 1)
+	testConstantOptimizer(input);
+    else
+	testCompiler(input, false);
     return 0;
 }

--- a/test/tools/solc_target.cpp
+++ b/test/tools/solc_target.cpp
@@ -1,0 +1,83 @@
+#include <libdevcore/CommonIO.h>
+#include <libevmasm/Assembly.h>
+#include <libevmasm/ConstantOptimiser.h>
+#include <libsolc/libsolc.h>
+
+#include <libdevcore/JSON.h>
+
+#include <string>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+using namespace dev;
+using namespace dev::eth;
+
+namespace
+{
+
+    bool quiet = true;
+
+    string contains(string const& _haystack, vector<string> const& _needles)
+    {
+        for (string const& needle: _needles)
+            if (_haystack.find(needle) != string::npos)
+                return needle;
+        return "";
+    }
+
+    void runCompiler(string input)
+    {
+        string outputString(compileStandard(input.c_str(), nullptr));
+        Json::Value output;
+        if (!jsonParseStrict(outputString, output))
+        {
+            cout << "Compiler produced invalid JSON output." << endl;
+            abort();
+        }
+        if (output.isMember("errors"))
+            for (auto const& error: output["errors"])
+            {
+                string invalid = contains(error["type"].asString(), vector<string>{
+                        "Exception",
+                        "InternalCompilerError"
+                });
+                if (!invalid.empty())
+                {
+                    cout << "Invalid error: \"" << error["type"].asString() << "\"" << endl;
+                    abort();
+                }
+            }
+    }
+
+    void testCompiler(string const& input, bool optimize)
+    {
+        if (!quiet)
+            cout << "Testing compiler " << (optimize ? "with" : "without") << " optimizer." << endl;
+
+        Json::Value config = Json::objectValue;
+        config["language"] = "Solidity";
+        config["sources"] = Json::objectValue;
+        config["sources"][""] = Json::objectValue;
+        config["sources"][""]["content"] = input;
+        config["settings"] = Json::objectValue;
+        config["settings"]["optimizer"] = Json::objectValue;
+        config["settings"]["optimizer"]["enabled"] = optimize;
+        config["settings"]["optimizer"]["runs"] = 200;
+
+        // Enable all SourceUnit-level outputs.
+        config["settings"]["outputSelection"]["*"][""][0] = "*";
+        // Enable all Contract-level outputs.
+        config["settings"]["outputSelection"]["*"]["*"][0] = "*";
+
+        runCompiler(jsonCompactPrint(config));
+    }
+
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    string input(reinterpret_cast<const char*>(data), size);
+    testCompiler(input, true);
+    return 0;
+}


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

Hello,

This PR (CC #5212 ):
  - adds a libfuzzer fuzzer test harness
  - a corresponding entry in `test/tools/CMakeLists.txt`

~~I wouldn't know how to have the upstream CI not complain about `libFuzzingEngine.a` which is only relevant for the fuzzing build.~~
To keep CI bots happy, the fuzzer harness is compiled only when an environment variable called `OSSFUZZ` is set. This variable is expected to be set in the oss-fuzz build script.

Once this PR is correctly merged, the plan is to issue another PR to upstream google oss-fuzz repo to start fuzzing solidity continuously.

At the moment, I have a PR waiting in line to this effect that works quite well (achieves a coverage of over 3000 CFG edges). But before we proceed further, it is important to streamline this harness upstream so that it can be maintained along side code.

Hope this helps, looking forward to questions and a smooth oss-fuzz integration.

P.S. First issue found here #5279 