### PR TITLE
refactor `libsolidity::Token` into a strongly typed enum

### DIFF
--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -46,7 +46,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 			m_errorReporter.fatalTypeError(
 				_operation.location(),
 				"Operator " +
-				string(Token::toString(_operation.getOperator())) +
+				string(TokenTraits::toString(_operation.getOperator())) +
 				" not compatible with types " +
 				left->toString() +
 				" and " +
@@ -54,7 +54,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 			);
 		setType(
 			_operation,
-			Token::isCompareOp(_operation.getOperator()) ?
+			TokenTraits::isCompareOp(_operation.getOperator()) ?
 			make_shared<BoolType>() :
 			commonType
 		);

--- a/libsolidity/analysis/SemVerHandler.cpp
+++ b/libsolidity/analysis/SemVerHandler.cpp
@@ -199,7 +199,7 @@ void SemVerMatchExpressionParser::parseMatchExpression()
 SemVerMatchExpression::MatchComponent SemVerMatchExpressionParser::parseMatchComponent()
 {
 	SemVerMatchExpression::MatchComponent component;
-	Token::Value token = currentToken();
+	Token token = currentToken();
 
 	switch (token)
 	{
@@ -280,7 +280,7 @@ char SemVerMatchExpressionParser::nextChar()
 	return currentChar();
 }
 
-Token::Value SemVerMatchExpressionParser::currentToken() const
+Token SemVerMatchExpressionParser::currentToken() const
 {
 	if (m_pos < m_tokens.size())
 		return m_tokens[m_pos];

--- a/libsolidity/analysis/SemVerHandler.h
+++ b/libsolidity/analysis/SemVerHandler.h
@@ -61,7 +61,7 @@ struct SemVerMatchExpression
 	struct MatchComponent
 	{
 		/// Prefix from < > <= >= ~ ^
-		Token::Value prefix = Token::Illegal;
+		Token prefix = Token::Illegal;
 		/// Version, where unsigned(-1) in major, minor or patch denotes '*', 'x' or 'X'
 		SemVerVersion version;
 		/// Whether we have 1, 1.2 or 1.2.4
@@ -81,7 +81,7 @@ struct SemVerMatchExpression
 class SemVerMatchExpressionParser
 {
 public:
-	SemVerMatchExpressionParser(std::vector<Token::Value> const& _tokens, std::vector<std::string> const& _literals):
+	SemVerMatchExpressionParser(std::vector<Token> const& _tokens, std::vector<std::string> const& _literals):
 		m_tokens(_tokens), m_literals(_literals)
 	{}
 	SemVerMatchExpression parse();
@@ -95,10 +95,10 @@ private:
 
 	char currentChar() const;
 	char nextChar();
-	Token::Value currentToken() const;
+	Token currentToken() const;
 	void nextToken();
 
-	std::vector<Token::Value> m_tokens;
+	std::vector<Token> m_tokens;
 	std::vector<std::string> m_literals;
 
 	unsigned m_pos = 0;

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -106,7 +106,7 @@ bool SyntaxChecker::visit(PragmaDirective const& _pragma)
 	}
 	else if (_pragma.literals()[0] == "solidity")
 	{
-		vector<Token::Value> tokens(_pragma.tokens().begin() + 1, _pragma.tokens().end());
+		vector<Token> tokens(_pragma.tokens().begin() + 1, _pragma.tokens().end());
 		vector<string> literals(_pragma.literals().begin() + 1, _pragma.literals().end());
 		SemVerMatchExpressionParser parser(tokens, literals);
 		auto matchExpression = parser.parse();

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1499,14 +1499,14 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		// compound assignment
 		_assignment.rightHandSide().accept(*this);
 		TypePointer resultType = t->binaryOperatorResult(
-			Token::AssignmentToBinaryOp(_assignment.assignmentOperator()),
+			TokenTraits::AssignmentToBinaryOp(_assignment.assignmentOperator()),
 			type(_assignment.rightHandSide())
 		);
 		if (!resultType || *resultType != *t)
 			m_errorReporter.typeError(
 				_assignment.location(),
 				"Operator " +
-				string(Token::toString(_assignment.assignmentOperator())) +
+				string(TokenTraits::toString(_assignment.assignmentOperator())) +
 				" not compatible with types " +
 				t->toString() +
 				" and " +
@@ -1607,8 +1607,8 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 bool TypeChecker::visit(UnaryOperation const& _operation)
 {
 	// Inc, Dec, Add, Sub, Not, BitNot, Delete
-	Token::Value op = _operation.getOperator();
-	bool const modifying = (op == Token::Value::Inc || op == Token::Value::Dec || op == Token::Value::Delete);
+	Token op = _operation.getOperator();
+	bool const modifying = (op == Token::Inc || op == Token::Dec || op == Token::Delete);
 	if (modifying)
 		requireLValue(_operation.subExpression());
 	else
@@ -1620,7 +1620,7 @@ bool TypeChecker::visit(UnaryOperation const& _operation)
 		m_errorReporter.typeError(
 			_operation.location(),
 			"Unary operator " +
-			string(Token::toString(op)) +
+			string(TokenTraits::toString(op)) +
 			" cannot be applied to type " +
 			subExprType->toString()
 		);
@@ -1641,7 +1641,7 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 		m_errorReporter.typeError(
 			_operation.location(),
 			"Operator " +
-			string(Token::toString(_operation.getOperator())) +
+			string(TokenTraits::toString(_operation.getOperator())) +
 			" not compatible with types " +
 			leftType->toString() +
 			" and " +
@@ -1651,7 +1651,7 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 	}
 	_operation.annotation().commonType = commonType;
 	_operation.annotation().type =
-		Token::isCompareOp(_operation.getOperator()) ?
+		TokenTraits::isCompareOp(_operation.getOperator()) ?
 		make_shared<BoolType>() :
 		commonType;
 	_operation.annotation().isPure =

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -237,7 +237,7 @@ class PragmaDirective: public ASTNode
 public:
 	PragmaDirective(
 		SourceLocation const& _location,
-		std::vector<Token::Value> const& _tokens,
+		std::vector<Token> const& _tokens,
 		std::vector<ASTString> const& _literals
 	): ASTNode(_location), m_tokens(_tokens), m_literals(_literals)
 	{}
@@ -245,13 +245,13 @@ public:
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	std::vector<Token::Value> const& tokens() const { return m_tokens; }
+	std::vector<Token> const& tokens() const { return m_tokens; }
 	std::vector<ASTString> const& literals() const { return m_literals; }
 
 private:
 
 	/// Sequence of tokens following the "pragma" keyword.
-	std::vector<Token::Value> m_tokens;
+	std::vector<Token> m_tokens;
 	/// Sequence of literals following the "pragma" keyword.
 	std::vector<ASTString> m_literals;
 };
@@ -1379,7 +1379,7 @@ public:
 	Assignment(
 		SourceLocation const& _location,
 		ASTPointer<Expression> const& _leftHandSide,
-		Token::Value _assignmentOperator,
+		Token _assignmentOperator,
 		ASTPointer<Expression> const& _rightHandSide
 	):
 		Expression(_location),
@@ -1387,18 +1387,18 @@ public:
 		m_assigmentOperator(_assignmentOperator),
 		m_rightHandSide(_rightHandSide)
 	{
-		solAssert(Token::isAssignmentOp(_assignmentOperator), "");
+		solAssert(TokenTraits::isAssignmentOp(_assignmentOperator), "");
 	}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& leftHandSide() const { return *m_leftHandSide; }
-	Token::Value assignmentOperator() const { return m_assigmentOperator; }
+	Token assignmentOperator() const { return m_assigmentOperator; }
 	Expression const& rightHandSide() const { return *m_rightHandSide; }
 
 private:
 	ASTPointer<Expression> m_leftHandSide;
-	Token::Value m_assigmentOperator;
+	Token m_assigmentOperator;
 	ASTPointer<Expression> m_rightHandSide;
 };
 
@@ -1441,7 +1441,7 @@ class UnaryOperation: public Expression
 public:
 	UnaryOperation(
 		SourceLocation const& _location,
-		Token::Value _operator,
+		Token _operator,
 		ASTPointer<Expression> const& _subExpression,
 		bool _isPrefix
 	):
@@ -1450,17 +1450,17 @@ public:
 		m_subExpression(_subExpression),
 		m_isPrefix(_isPrefix)
 	{
-		solAssert(Token::isUnaryOp(_operator), "");
+		solAssert(TokenTraits::isUnaryOp(_operator), "");
 	}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	Token::Value getOperator() const { return m_operator; }
+	Token getOperator() const { return m_operator; }
 	bool isPrefixOperation() const { return m_isPrefix; }
 	Expression const& subExpression() const { return *m_subExpression; }
 
 private:
-	Token::Value m_operator;
+	Token m_operator;
 	ASTPointer<Expression> m_subExpression;
 	bool m_isPrefix;
 };
@@ -1475,25 +1475,25 @@ public:
 	BinaryOperation(
 		SourceLocation const& _location,
 		ASTPointer<Expression> const& _left,
-		Token::Value _operator,
+		Token _operator,
 		ASTPointer<Expression> const& _right
 	):
 		Expression(_location), m_left(_left), m_operator(_operator), m_right(_right)
 	{
-		solAssert(Token::isBinaryOp(_operator) || Token::isCompareOp(_operator), "");
+		solAssert(TokenTraits::isBinaryOp(_operator) || TokenTraits::isCompareOp(_operator), "");
 	}
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& leftExpression() const { return *m_left; }
 	Expression const& rightExpression() const { return *m_right; }
-	Token::Value getOperator() const { return m_operator; }
+	Token getOperator() const { return m_operator; }
 
 	BinaryOperationAnnotation& annotation() const override;
 
 private:
 	ASTPointer<Expression> m_left;
-	Token::Value m_operator;
+	Token m_operator;
 	ASTPointer<Expression> m_right;
 };
 
@@ -1653,21 +1653,21 @@ class Literal: public PrimaryExpression
 public:
 	enum class SubDenomination
 	{
-		None = Token::Illegal,
-		Wei = Token::SubWei,
-		Szabo = Token::SubSzabo,
-		Finney = Token::SubFinney,
-		Ether = Token::SubEther,
-		Second = Token::SubSecond,
-		Minute = Token::SubMinute,
-		Hour = Token::SubHour,
-		Day = Token::SubDay,
-		Week = Token::SubWeek,
-		Year = Token::SubYear
+		None = static_cast<int>(Token::Illegal),
+		Wei = static_cast<int>(Token::SubWei),
+		Szabo = static_cast<int>(Token::SubSzabo),
+		Finney = static_cast<int>(Token::SubFinney),
+		Ether = static_cast<int>(Token::SubEther),
+		Second = static_cast<int>(Token::SubSecond),
+		Minute = static_cast<int>(Token::SubMinute),
+		Hour = static_cast<int>(Token::SubHour),
+		Day = static_cast<int>(Token::SubDay),
+		Week = static_cast<int>(Token::SubWeek),
+		Year = static_cast<int>(Token::SubYear)
 	};
 	Literal(
 		SourceLocation const& _location,
-		Token::Value _token,
+		Token _token,
 		ASTPointer<ASTString> const& _value,
 		SubDenomination _sub = SubDenomination::None
 	):
@@ -1675,7 +1675,7 @@ public:
 	virtual void accept(ASTVisitor& _visitor) override;
 	virtual void accept(ASTConstVisitor& _visitor) const override;
 
-	Token::Value token() const { return m_token; }
+	Token token() const { return m_token; }
 	/// @returns the non-parsed value of the literal
 	ASTString const& value() const { return *m_value; }
 
@@ -1694,7 +1694,7 @@ public:
 	std::string getChecksummedAddress() const;
 
 private:
-	Token::Value m_token;
+	Token m_token;
 	ASTPointer<ASTString> m_value;
 	SubDenomination m_subDenomination;
 };

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -589,7 +589,7 @@ bool ASTJsonConverter::visit(Conditional const& _node)
 bool ASTJsonConverter::visit(Assignment const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
-		make_pair("operator", Token::toString(_node.assignmentOperator())),
+		make_pair("operator", TokenTraits::toString(_node.assignmentOperator())),
 		make_pair("leftHandSide", toJson(_node.leftHandSide())),
 		make_pair("rightHandSide", toJson(_node.rightHandSide()))
 	};
@@ -613,7 +613,7 @@ bool ASTJsonConverter::visit(UnaryOperation const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("prefix", _node.isPrefixOperation()),
-		make_pair("operator", Token::toString(_node.getOperator())),
+		make_pair("operator", TokenTraits::toString(_node.getOperator())),
 		make_pair("subExpression", toJson(_node.subExpression()))
 	};
 	appendExpressionAttributes(attributes, _node.annotation());
@@ -624,7 +624,7 @@ bool ASTJsonConverter::visit(UnaryOperation const& _node)
 bool ASTJsonConverter::visit(BinaryOperation const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
-		make_pair("operator", Token::toString(_node.getOperator())),
+		make_pair("operator", TokenTraits::toString(_node.getOperator())),
 		make_pair("leftExpression", toJson(_node.leftExpression())),
 		make_pair("rightExpression", toJson(_node.rightExpression())),
 		make_pair("commonType", typePointerToJson(_node.annotation().commonType)),
@@ -719,7 +719,7 @@ bool ASTJsonConverter::visit(Literal const& _node)
 	Json::Value value{_node.value()};
 	if (!dev::validateUTF8(_node.value()))
 		value = Json::nullValue;
-	Token::Value subdenomination = Token::Value(_node.subDenomination());
+	Token subdenomination = Token(_node.subDenomination());
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair(m_legacy ? "token" : "kind", literalTokenKind(_node.token())),
 		make_pair("value", value),
@@ -728,7 +728,7 @@ bool ASTJsonConverter::visit(Literal const& _node)
 			"subdenomination",
 			subdenomination == Token::Illegal ?
 			Json::nullValue :
-			Json::Value{Token::toString(subdenomination)}
+			Json::Value{TokenTraits::toString(subdenomination)}
 		)
 	};
 	appendExpressionAttributes(attributes, _node.annotation());
@@ -790,7 +790,7 @@ string ASTJsonConverter::functionCallKind(FunctionCallKind _kind)
 	}
 }
 
-string ASTJsonConverter::literalTokenKind(Token::Value _token)
+string ASTJsonConverter::literalTokenKind(Token _token)
 {
 	switch (_token)
 	{

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -134,7 +134,7 @@ private:
 	static std::string location(VariableDeclaration::Location _location);
 	static std::string contractKind(ContractDefinition::ContractKind _kind);
 	static std::string functionCallKind(FunctionCallKind _kind);
-	static std::string literalTokenKind(Token::Value _token);
+	static std::string literalTokenKind(Token _token);
 	static std::string type(Expression const& _expression);
 	static std::string type(VariableDeclaration const& _varDecl);
 	static int nodeId(ASTNode const& _node)

--- a/libsolidity/ast/ASTPrinter.cpp
+++ b/libsolidity/ast/ASTPrinter.cpp
@@ -289,7 +289,7 @@ bool ASTPrinter::visit(Conditional const& _node)
 
 bool ASTPrinter::visit(Assignment const& _node)
 {
-	writeLine(string("Assignment using operator ") + Token::toString(_node.assignmentOperator()));
+	writeLine(string("Assignment using operator ") + TokenTraits::toString(_node.assignmentOperator()));
 	printType(_node);
 	printSourcePart(_node);
 	return goDeeper();
@@ -306,7 +306,7 @@ bool ASTPrinter::visit(TupleExpression const& _node)
 bool ASTPrinter::visit(UnaryOperation const& _node)
 {
 	writeLine(string("UnaryOperation (") + (_node.isPrefixOperation() ? "prefix" : "postfix") +
-			  ") " + Token::toString(_node.getOperator()));
+			  ") " + TokenTraits::toString(_node.getOperator()));
 	printType(_node);
 	printSourcePart(_node);
 	return goDeeper();
@@ -314,7 +314,7 @@ bool ASTPrinter::visit(UnaryOperation const& _node)
 
 bool ASTPrinter::visit(BinaryOperation const& _node)
 {
-	writeLine(string("BinaryOperation using operator ") + Token::toString(_node.getOperator()));
+	writeLine(string("BinaryOperation using operator ") + TokenTraits::toString(_node.getOperator()));
 	printType(_node);
 	printSourcePart(_node);
 	return goDeeper();
@@ -370,7 +370,7 @@ bool ASTPrinter::visit(ElementaryTypeNameExpression const& _node)
 
 bool ASTPrinter::visit(Literal const& _node)
 {
-	char const* tokenString = Token::toString(_node.token());
+	char const* tokenString = TokenTraits::toString(_node.token());
 	if (!tokenString)
 		tokenString = "[no token]";
 	writeLine(string("Literal, token: ") + tokenString + " value: " + _node.value());

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -188,13 +188,13 @@ public:
 	/// @returns the resulting type of applying the given unary operator or an empty pointer if
 	/// this is not possible.
 	/// The default implementation does not allow any unary operator.
-	virtual TypePointer unaryOperatorResult(Token::Value) const { return TypePointer(); }
+	virtual TypePointer unaryOperatorResult(Token) const { return TypePointer(); }
 	/// @returns the resulting type of applying the given binary operator or an empty pointer if
 	/// this is not possible.
 	/// The default implementation allows comparison operators if a common type exists
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const
 	{
-		return Token::isCompareOp(_operator) ? commonType(shared_from_this(), _other) : TypePointer();
+		return TokenTraits::isCompareOp(_operator) ? commonType(shared_from_this(), _other) : TypePointer();
 	}
 
 	virtual bool operator==(Type const& _other) const { return category() == _other.category(); }
@@ -329,8 +329,8 @@ public:
 	virtual std::string richIdentifier() const override;
 	virtual bool isImplicitlyConvertibleTo(Type const& _other) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
 	virtual bool operator==(Type const& _other) const override;
 
@@ -372,8 +372,8 @@ public:
 	virtual std::string richIdentifier() const override;
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
 	virtual bool operator==(Type const& _other) const override;
 
@@ -414,8 +414,8 @@ public:
 	virtual std::string richIdentifier() const override;
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
 	virtual bool operator==(Type const& _other) const override;
 
@@ -468,8 +468,8 @@ public:
 
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
@@ -526,7 +526,7 @@ public:
 	explicit StringLiteralType(Literal const& _literal);
 
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override
 	{
 		return TypePointer();
 	}
@@ -563,8 +563,8 @@ public:
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
 	virtual unsigned calldataEncodedSize(bool _padded) const override { return _padded && m_bytes > 0 ? 32 : m_bytes; }
 	virtual unsigned storageBytes() const override { return m_bytes; }
@@ -590,8 +590,8 @@ public:
 	BoolType() {}
 	virtual Category category() const override { return Category::Bool; }
 	virtual std::string richIdentifier() const override { return "t_bool"; }
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
 	virtual unsigned calldataEncodedSize(bool _padded) const override{ return _padded ? 32 : 1; }
 	virtual unsigned storageBytes() const override { return 1; }
@@ -613,8 +613,8 @@ public:
 	explicit ReferenceType(DataLocation _location): m_location(_location) {}
 	DataLocation location() const { return m_location; }
 
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override
 	{
 		return TypePointer();
 	}
@@ -749,7 +749,7 @@ public:
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	/// Contracts can only be explicitly converted to address types and base contracts.
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded ) const override
@@ -865,7 +865,7 @@ class EnumType: public Type
 public:
 	virtual Category category() const override { return Category::Enum; }
 	explicit EnumType(EnumDefinition const& _enum): m_enum(_enum) {}
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override
@@ -909,7 +909,7 @@ public:
 	virtual bool isImplicitlyConvertibleTo(Type const& _other) const override;
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
 	virtual std::string toString(bool) const override;
 	virtual bool canBeStored() const override { return false; }
 	virtual u256 storageSize() const override;
@@ -1056,8 +1056,8 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token::Value _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override;
+	virtual TypePointer unaryOperatorResult(Token _operator) const override;
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override;
 	virtual std::string canonicalName() const override;
 	virtual std::string toString(bool _short) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
@@ -1187,7 +1187,7 @@ public:
 	virtual std::string toString(bool _short) const override;
 	virtual std::string canonicalName() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
 	virtual TypePointer encodingType() const override
 	{
 		return std::make_shared<IntegerType>(256);
@@ -1220,7 +1220,7 @@ public:
 	explicit TypeType(TypePointer const& _actualType): m_actualType(_actualType) {}
 	TypePointer const& actualType() const { return m_actualType; }
 
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
@@ -1245,7 +1245,7 @@ public:
 	virtual Category category() const override { return Category::Modifier; }
 	explicit ModifierType(ModifierDefinition const& _modifier);
 
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
 	virtual bool canBeStored() const override { return false; }
 	virtual u256 storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
@@ -1271,7 +1271,7 @@ public:
 
 	explicit ModuleType(SourceUnit const& _source): m_sourceUnit(_source) {}
 
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
@@ -1298,7 +1298,7 @@ public:
 
 	explicit MagicType(Kind _kind): m_kind(_kind) {}
 
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override
 	{
 		return TypePointer();
 	}
@@ -1331,7 +1331,7 @@ public:
 	virtual std::string richIdentifier() const override { return "t_inaccessible"; }
 	virtual bool isImplicitlyConvertibleTo(Type const&) const override { return false; }
 	virtual bool isExplicitlyConvertibleTo(Type const&) const override { return false; }
-	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
+	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
 	virtual unsigned calldataEncodedSize(bool _padded) const override { (void)_padded; return 32; }
 	virtual bool canBeStored() const override { return false; }
 	virtual bool canLiveOutsideStorage() const override { return false; }

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -86,12 +86,12 @@ private:
 	///@{
 	///@name Append code for various operator types
 	void appendAndOrOperatorCode(BinaryOperation const& _binaryOperation);
-	void appendCompareOperatorCode(Token::Value _operator, Type const& _type);
-	void appendOrdinaryBinaryOperatorCode(Token::Value _operator, Type const& _type);
+	void appendCompareOperatorCode(Token _operator, Type const& _type);
+	void appendOrdinaryBinaryOperatorCode(Token _operator, Type const& _type);
 
-	void appendArithmeticOperatorCode(Token::Value _operator, Type const& _type);
-	void appendBitOperatorCode(Token::Value _operator);
-	void appendShiftOperatorCode(Token::Value _operator, Type const& _valueType, Type const& _shiftAmountType);
+	void appendArithmeticOperatorCode(Token _operator, Type const& _type);
+	void appendBitOperatorCode(Token _operator);
+	void appendShiftOperatorCode(Token _operator, Type const& _valueType, Type const& _shiftAmountType);
 	/// @}
 
 	/// Appends code to call a function of the given type with the given arguments.
@@ -119,7 +119,7 @@ private:
 
 	/// @returns true if the operator applied to the given type requires a cleanup prior to the
 	/// operation.
-	static bool cleanupNeededForOp(Type::Category _type, Token::Value _op);
+	static bool cleanupNeededForOp(Type::Category _type, Token _op);
 
 	/// @returns the CompilerUtils object containing the current context.
 	CompilerUtils utils();

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -212,7 +212,7 @@ void SMTChecker::endVisit(VariableDeclarationStatement const& _varDecl)
 
 void SMTChecker::endVisit(Assignment const& _assignment)
 {
-	if (_assignment.assignmentOperator() != Token::Value::Assign)
+	if (_assignment.assignmentOperator() != Token::Assign)
 		m_errorReporter.warning(
 			_assignment.location(),
 			"Assertion checker does not yet implement compound assignment."
@@ -331,11 +331,11 @@ void SMTChecker::endVisit(UnaryOperation const& _op)
 
 void SMTChecker::endVisit(BinaryOperation const& _op)
 {
-	if (Token::isArithmeticOp(_op.getOperator()))
+	if (TokenTraits::isArithmeticOp(_op.getOperator()))
 		arithmeticOperation(_op);
-	else if (Token::isCompareOp(_op.getOperator()))
+	else if (TokenTraits::isCompareOp(_op.getOperator()))
 		compareOperation(_op);
-	else if (Token::isBooleanOp(_op.getOperator()))
+	else if (TokenTraits::isBooleanOp(_op.getOperator()))
 		booleanOperation(_op);
 	else
 		m_errorReporter.warning(
@@ -530,7 +530,7 @@ void SMTChecker::arithmeticOperation(BinaryOperation const& _op)
 		auto const& intType = dynamic_cast<IntegerType const&>(*_op.annotation().commonType);
 		smt::Expression left(expr(_op.leftExpression()));
 		smt::Expression right(expr(_op.rightExpression()));
-		Token::Value op = _op.getOperator();
+		Token op = _op.getOperator();
 		smt::Expression value(
 			op == Token::Add ? left + right :
 			op == Token::Sub ? left - right :
@@ -564,7 +564,7 @@ void SMTChecker::compareOperation(BinaryOperation const& _op)
 	{
 		smt::Expression left(expr(_op.leftExpression()));
 		smt::Expression right(expr(_op.rightExpression()));
-		Token::Value op = _op.getOperator();
+		Token op = _op.getOperator();
 		shared_ptr<smt::Expression> value;
 		if (isNumber(_op.annotation().commonType->category()))
 		{

--- a/libsolidity/parsing/ParserBase.cpp
+++ b/libsolidity/parsing/ParserBase.cpp
@@ -43,12 +43,12 @@ int ParserBase::endPosition() const
 	return m_scanner->currentLocation().end;
 }
 
-Token::Value ParserBase::currentToken() const
+Token ParserBase::currentToken() const
 {
 	return m_scanner->currentToken();
 }
 
-Token::Value ParserBase::peekNextToken() const
+Token ParserBase::peekNextToken() const
 {
 	return m_scanner->peekNextToken();
 }
@@ -58,31 +58,31 @@ std::string ParserBase::currentLiteral() const
 	return m_scanner->currentLiteral();
 }
 
-Token::Value ParserBase::advance()
+Token ParserBase::advance()
 {
 	return m_scanner->next();
 }
 
-void ParserBase::expectToken(Token::Value _value, bool _advance)
+void ParserBase::expectToken(Token _value, bool _advance)
 {
-	Token::Value tok = m_scanner->currentToken();
+	Token tok = m_scanner->currentToken();
 	if (tok != _value)
 	{
-		auto tokenName = [this](Token::Value _token)
+		auto tokenName = [this](Token _token)
 		{
 			if (_token == Token::Identifier)
 				return string("identifier");
 			else if (_token == Token::EOS)
 				return string("end of source");
-			else if (Token::isReservedKeyword(_token))
-				return string("reserved keyword '") + Token::friendlyName(_token) + "'";
-			else if (Token::isElementaryTypeName(_token)) //for the sake of accuracy in reporting
+			else if (TokenTraits::isReservedKeyword(_token))
+				return string("reserved keyword '") + TokenTraits::friendlyName(_token) + "'";
+			else if (TokenTraits::isElementaryTypeName(_token)) //for the sake of accuracy in reporting
 			{
 				ElementaryTypeNameToken elemTypeName = m_scanner->currentElementaryTypeNameToken();
 				return string("'") + elemTypeName.toString() + "'";
 			}
 			else
-				return string("'") + Token::friendlyName(_token) + "'";
+				return string("'") + TokenTraits::friendlyName(_token) + "'";
 		};
 
 		fatalParserError(string("Expected ") + tokenName(_value) + string(" but got ") + tokenName(tok));

--- a/libsolidity/parsing/ParserBase.h
+++ b/libsolidity/parsing/ParserBase.h
@@ -63,11 +63,11 @@ protected:
 	///@{
 	///@name Helper functions
 	/// If current token value is not _value, throw exception otherwise advance token.
-	void expectToken(Token::Value _value, bool _advance = true);
-	Token::Value currentToken() const;
-	Token::Value peekNextToken() const;
+	void expectToken(Token _value, bool _advance = true);
+	Token currentToken() const;
+	Token peekNextToken() const;
 	std::string currentLiteral() const;
-	Token::Value advance();
+	Token advance();
 	///@}
 
 	/// Increases the recursion depth and throws an exception if it is too deep.

--- a/libsolidity/parsing/Scanner.cpp
+++ b/libsolidity/parsing/Scanner.cpp
@@ -214,9 +214,9 @@ void Scanner::addUnicodeAsUTF8(unsigned codepoint)
 }
 
 // Ensure that tokens can be stored in a byte.
-BOOST_STATIC_ASSERT(Token::NUM_TOKENS <= 0x100);
+BOOST_STATIC_ASSERT(TokenTraits::count() <= 0x100);
 
-Token::Value Scanner::next()
+Token Scanner::next()
 {
 	m_currentToken = m_nextToken;
 	m_skippedComment = m_nextSkippedComment;
@@ -225,7 +225,7 @@ Token::Value Scanner::next()
 	return m_currentToken.token;
 }
 
-Token::Value Scanner::selectToken(char _next, Token::Value _then, Token::Value _else)
+Token Scanner::selectToken(char _next, Token _then, Token _else)
 {
 	advance();
 	if (m_char == _next)
@@ -249,7 +249,7 @@ void Scanner::skipWhitespaceExceptUnicodeLinebreak()
 		advance();
 }
 
-Token::Value Scanner::skipSingleLineComment()
+Token Scanner::skipSingleLineComment()
 {
 	// Line terminator is not part of the comment. If it is a
 	// non-ascii line terminator, it will result in a parser error.
@@ -259,7 +259,7 @@ Token::Value Scanner::skipSingleLineComment()
 	return Token::Whitespace;
 }
 
-Token::Value Scanner::scanSingleLineDocComment()
+Token Scanner::scanSingleLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
 	advance(); //consume the last '/' at ///
@@ -295,7 +295,7 @@ Token::Value Scanner::scanSingleLineDocComment()
 	return Token::CommentLiteral;
 }
 
-Token::Value Scanner::skipMultiLineComment()
+Token Scanner::skipMultiLineComment()
 {
 	advance();
 	while (!isSourcePastEndOfInput())
@@ -316,7 +316,7 @@ Token::Value Scanner::skipMultiLineComment()
 	return Token::Illegal;
 }
 
-Token::Value Scanner::scanMultiLineDocComment()
+Token Scanner::scanMultiLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
 	bool endFound = false;
@@ -369,7 +369,7 @@ Token::Value Scanner::scanMultiLineDocComment()
 		return Token::CommentLiteral;
 }
 
-Token::Value Scanner::scanSlash()
+Token Scanner::scanSlash()
 {
 	int firstSlashPosition = sourcePos();
 	advance();
@@ -380,7 +380,7 @@ Token::Value Scanner::scanSlash()
 		else if (m_char == '/')
 		{
 			// doxygen style /// comment
-			Token::Value comment;
+			Token comment;
 			m_nextSkippedComment.location.start = firstSlashPosition;
 			comment = scanSingleLineDocComment();
 			m_nextSkippedComment.location.end = sourcePos();
@@ -406,7 +406,7 @@ Token::Value Scanner::scanSlash()
 				return Token::Whitespace;
 			}
 			// we actually have a multiline documentation comment
-			Token::Value comment;
+			Token comment;
 			m_nextSkippedComment.location.start = firstSlashPosition;
 			comment = scanMultiLineDocComment();
 			m_nextSkippedComment.location.end = sourcePos();
@@ -432,7 +432,7 @@ void Scanner::scanToken()
 	m_nextSkippedComment.literal.clear();
 	m_nextSkippedComment.extendedTokenInfo = make_tuple(0, 0);
 
-	Token::Value token;
+	Token token;
 	// M and N are for the purposes of grabbing different type sizes
 	unsigned m;
 	unsigned n;
@@ -703,7 +703,7 @@ bool Scanner::isUnicodeLinebreak()
 		return false;
 }
 
-Token::Value Scanner::scanString()
+Token Scanner::scanString()
 {
 	char const quote = m_char;
 	advance();  // consume quote
@@ -727,7 +727,7 @@ Token::Value Scanner::scanString()
 	return Token::StringLiteral;
 }
 
-Token::Value Scanner::scanHexString()
+Token Scanner::scanHexString()
 {
 	char const quote = m_char;
 	advance();  // consume quote
@@ -760,7 +760,7 @@ void Scanner::scanDecimalDigits()
 	// Defer further validation of underscore to SyntaxChecker.
 }
 
-Token::Value Scanner::scanNumber(char _charSeen)
+Token Scanner::scanNumber(char _charSeen)
 {
 	enum { DECIMAL, HEX, BINARY } kind = DECIMAL;
 	LiteralScope literal(this, LITERAL_TYPE_NUMBER);
@@ -854,7 +854,7 @@ Token::Value Scanner::scanNumber(char _charSeen)
 	return Token::Number;
 }
 
-tuple<Token::Value, unsigned, unsigned> Scanner::scanIdentifierOrKeyword()
+tuple<Token, unsigned, unsigned> Scanner::scanIdentifierOrKeyword()
 {
 	solAssert(isIdentifierStart(m_char), "");
 	LiteralScope literal(this, LITERAL_TYPE_STRING);
@@ -863,7 +863,7 @@ tuple<Token::Value, unsigned, unsigned> Scanner::scanIdentifierOrKeyword()
 	while (isIdentifierPart(m_char)) //get full literal
 		addLiteralCharAndAdvance();
 	literal.complete();
-	return Token::fromIdentifierOrKeyword(m_nextToken.literal);
+	return TokenTraits::fromIdentifierOrKeyword(m_nextToken.literal);
 }
 
 char CharStream::advanceAndGet(size_t _chars)

--- a/libsolidity/parsing/Scanner.h
+++ b/libsolidity/parsing/Scanner.h
@@ -112,13 +112,13 @@ public:
 	void reset();
 
 	/// @returns the next token and advances input
-	Token::Value next();
+	Token next();
 
 	///@{
 	///@name Information about the current token
 
 	/// @returns the current token
-	Token::Value currentToken() const
+	Token currentToken() const
 	{
 		return m_currentToken.token;
 	}
@@ -149,7 +149,7 @@ public:
 	///@name Information about the next token
 
 	/// @returns the next token without advancing input.
-	Token::Value peekNextToken() const { return m_nextToken.token; }
+	Token peekNextToken() const { return m_nextToken.token; }
 	SourceLocation peekLocation() const { return m_nextToken.location; }
 	std::string const& peekLiteral() const { return m_nextToken.literal; }
 	///@}
@@ -168,7 +168,7 @@ private:
 	/// Used for the current and look-ahead token and comments
 	struct TokenDesc
 	{
-		Token::Value token;
+		Token token;
 		SourceLocation location;
 		std::string literal;
 		std::tuple<unsigned, unsigned> extendedTokenInfo;
@@ -185,9 +185,9 @@ private:
 	bool advance() { m_char = m_source.advanceAndGet(); return !m_source.isPastEndOfInput(); }
 	void rollback(int _amount) { m_char = m_source.rollback(_amount); }
 
-	inline Token::Value selectToken(Token::Value _tok) { advance(); return _tok; }
+	inline Token selectToken(Token _tok) { advance(); return _tok; }
 	/// If the next character is _next, advance and return _then, otherwise return _else.
-	inline Token::Value selectToken(char _next, Token::Value _then, Token::Value _else);
+	inline Token selectToken(char _next, Token _then, Token _else);
 
 	bool scanHexByte(char& o_scannedByte);
 	bool scanUnicode(unsigned& o_codepoint);
@@ -199,19 +199,19 @@ private:
 	bool skipWhitespace();
 	/// Skips all whitespace that are neither '\r' nor '\n'.
 	void skipWhitespaceExceptUnicodeLinebreak();
-	Token::Value skipSingleLineComment();
-	Token::Value skipMultiLineComment();
+	Token skipSingleLineComment();
+	Token skipMultiLineComment();
 
 	void scanDecimalDigits();
-	Token::Value scanNumber(char _charSeen = 0);
-	std::tuple<Token::Value, unsigned, unsigned> scanIdentifierOrKeyword();
+	Token scanNumber(char _charSeen = 0);
+	std::tuple<Token, unsigned, unsigned> scanIdentifierOrKeyword();
 
-	Token::Value scanString();
-	Token::Value scanHexString();
-	Token::Value scanSingleLineDocComment();
-	Token::Value scanMultiLineDocComment();
+	Token scanString();
+	Token scanHexString();
+	Token scanSingleLineDocComment();
+	Token scanMultiLineDocComment();
 	/// Scans a slash '/' and depending on the characters returns the appropriate token
-	Token::Value scanSlash();
+	Token scanSlash();
 
 	/// Scans an escape-sequence which is part of a string and adds the
 	/// decoded character to the current literal. Returns true if a pattern

--- a/libsolidity/parsing/Token.cpp
+++ b/libsolidity/parsing/Token.cpp
@@ -51,9 +51,9 @@ namespace dev
 namespace solidity
 {
 
-void ElementaryTypeNameToken::assertDetails(Token::Value _baseType, unsigned const& _first, unsigned const& _second)
+void ElementaryTypeNameToken::assertDetails(Token _baseType, unsigned const& _first, unsigned const& _second)
 {
-	solAssert(Token::isElementaryTypeName(_baseType), "Expected elementary type name: " + string(Token::toString(_baseType)));
+	solAssert(TokenTraits::isElementaryTypeName(_baseType), "Expected elementary type name: " + string(TokenTraits::toString(_baseType)));
 	if (_baseType == Token::BytesM)
 	{
 		solAssert(_second == 0, "There should not be a second size argument to type bytesM.");
@@ -61,17 +61,17 @@ void ElementaryTypeNameToken::assertDetails(Token::Value _baseType, unsigned con
 	}
 	else if (_baseType == Token::UIntM || _baseType == Token::IntM)
 	{
-		solAssert(_second == 0, "There should not be a second size argument to type " + string(Token::toString(_baseType)) + ".");
+		solAssert(_second == 0, "There should not be a second size argument to type " + string(TokenTraits::toString(_baseType)) + ".");
 		solAssert(
 			_first <= 256 && _first % 8 == 0,
-			"No elementary type " + string(Token::toString(_baseType)) + to_string(_first) + "."
+			"No elementary type " + string(TokenTraits::toString(_baseType)) + to_string(_first) + "."
 		);
 	}
 	else if (_baseType == Token::UFixedMxN || _baseType == Token::FixedMxN)
 	{
 		solAssert(
 			_first >= 8 && _first <= 256 && _first % 8 == 0 && _second <= 80,
-			"No elementary type " + string(Token::toString(_baseType)) + to_string(_first) + "x" + to_string(_second) + "."
+			"No elementary type " + string(TokenTraits::toString(_baseType)) + to_string(_first) + "x" + to_string(_second) + "."
 		);
 	}
 	m_token = _baseType;
@@ -79,38 +79,54 @@ void ElementaryTypeNameToken::assertDetails(Token::Value _baseType, unsigned con
 	m_secondNumber = _second;
 }
 
+namespace TokenTraits
+{
+
+char const* toString(Token tok)
+{
+	switch (tok)
+	{
+#define T(name, string, precedence) case Token::name: return string;
+		TOKEN_LIST(T, T)
+#undef T
+		default: // Token::NUM_TOKENS:
+			return "";
+	}
+}
+
+char const* name(Token tok)
+{
 #define T(name, string, precedence) #name,
-char const* const Token::m_name[NUM_TOKENS] =
-{
-	TOKEN_LIST(T, T)
-};
+	static char const* const names[TokenTraits::count()] = { TOKEN_LIST(T, T) };
 #undef T
 
+	solAssert(static_cast<size_t>(tok) < TokenTraits::count(), "");
+	return names[static_cast<size_t>(tok)];
+}
 
-#define T(name, string, precedence) string,
-char const* const Token::m_string[NUM_TOKENS] =
+std::string friendlyName(Token tok)
 {
-	TOKEN_LIST(T, T)
-};
-#undef T
+	char const* ret = toString(tok);
+	if (ret)
+		return std::string(ret);
 
+	ret = name(tok);
+	solAssert(ret != nullptr, "");
+	return std::string(ret);
+}
 
 #define T(name, string, precedence) precedence,
-int8_t const Token::m_precedence[NUM_TOKENS] =
+int precedence(Token tok)
 {
-	TOKEN_LIST(T, T)
-};
+	int8_t const static precs[TokenTraits::count()] =
+	{
+		TOKEN_LIST(T, T)
+	};
+	return precs[static_cast<size_t>(tok)];
+}
 #undef T
 
-
-#define KT(a, b, c) 'T',
-#define KK(a, b, c) 'K',
-char const Token::m_tokenType[] =
-{
-	TOKEN_LIST(KT, KK)
-};
-
-int Token::parseSize(string::const_iterator _begin, string::const_iterator _end)
+int parseSize(string::const_iterator _begin, string::const_iterator _end)
 {
 	try
 	{
@@ -123,7 +139,20 @@ int Token::parseSize(string::const_iterator _begin, string::const_iterator _end)
 	}
 }
 
-tuple<Token::Value, unsigned int, unsigned int> Token::fromIdentifierOrKeyword(string const& _literal)
+static Token keywordByName(string const& _name)
+{
+	// The following macros are used inside TOKEN_LIST and cause non-keyword tokens to be ignored
+	// and keywords to be put inside the keywords variable.
+#define KEYWORD(name, string, precedence) {string, Token::name},
+#define TOKEN(name, string, precedence)
+	static const map<string, Token> keywords({TOKEN_LIST(TOKEN, KEYWORD)});
+#undef KEYWORD
+#undef TOKEN
+	auto it = keywords.find(_name);
+	return it == keywords.end() ? Token::Identifier : it->second;
+}
+
+tuple<Token, unsigned int, unsigned int> fromIdentifierOrKeyword(string const& _literal)
 {
 	auto positionM = find_if(_literal.begin(), _literal.end(), ::isdigit);
 	if (positionM != _literal.end())
@@ -131,7 +160,7 @@ tuple<Token::Value, unsigned int, unsigned int> Token::fromIdentifierOrKeyword(s
 		string baseType(_literal.begin(), positionM);
 		auto positionX = find_if_not(positionM, _literal.end(), ::isdigit);
 		int m = parseSize(positionM, positionX);
-		Token::Value keyword = keywordByName(baseType);
+		Token keyword = keywordByName(baseType);
 		if (keyword == Token::Bytes)
 		{
 			if (0 < m && m <= 32 && positionX == _literal.end())
@@ -172,20 +201,7 @@ tuple<Token::Value, unsigned int, unsigned int> Token::fromIdentifierOrKeyword(s
 
 	return make_tuple(keywordByName(_literal), 0, 0);
 }
-Token::Value Token::keywordByName(string const& _name)
-{
-	// The following macros are used inside TOKEN_LIST and cause non-keyword tokens to be ignored
-	// and keywords to be put inside the keywords variable.
-#define KEYWORD(name, string, precedence) {string, Token::name},
-#define TOKEN(name, string, precedence)
-	static const map<string, Token::Value> keywords({TOKEN_LIST(TOKEN, KEYWORD)});
-#undef KEYWORD
-#undef TOKEN
-	auto it = keywords.find(_name);
-	return it == keywords.end() ? Token::Identifier : it->second;
-}
 
-#undef KT
-#undef KK
+}
 }
 }

--- a/libsolidity/parsing/Token.h
+++ b/libsolidity/parsing/Token.h
@@ -45,6 +45,7 @@
 #include <libdevcore/Common.h>
 #include <libsolidity/interface/Exceptions.h>
 #include <libsolidity/parsing/UndefMacros.h>
+#include <iosfwd>
 
 namespace dev
 {
@@ -267,119 +268,95 @@ namespace solidity
 	/* Scanner-internal use only. */                                   \
 	T(Whitespace, NULL, 0)
 
-
-class Token
-{
-public:
-	// All token values.
-	// attention! msvc issue:
-	// http://stackoverflow.com/questions/9567868/compile-errors-after-adding-v8-to-my-project-c2143-c2059
-	// @todo: avoid TOKEN_LIST macro
+// All token values.
+// attention! msvc issue:
+// http://stackoverflow.com/questions/9567868/compile-errors-after-adding-v8-to-my-project-c2143-c2059
+// @todo: avoid TOKEN_LIST macro
+enum class Token : unsigned int {
 #define T(name, string, precedence) name,
-	enum Value
-	{
-		TOKEN_LIST(T, T)
-		NUM_TOKENS
-	};
+	TOKEN_LIST(T, T)
+	NUM_TOKENS
 #undef T
+};
 
-	// @returns a string corresponding to the C++ token name
-	// (e.g. "LT" for the token LT).
-	static char const* name(Value tok)
-	{
-		solAssert(tok < NUM_TOKENS, "");
-		return m_name[tok];
-	}
+namespace TokenTraits
+{
+	constexpr size_t count() { return static_cast<size_t>(Token::NUM_TOKENS); }
 
 	// Predicates
-	static bool isElementaryTypeName(Value tok) { return Int <= tok && tok < TypesEnd; }
-	static bool isAssignmentOp(Value tok) { return Assign <= tok && tok <= AssignMod; }
-	static bool isBinaryOp(Value op) { return Comma <= op && op <= Exp; }
-	static bool isCommutativeOp(Value op) { return op == BitOr || op == BitXor || op == BitAnd ||
-				op == Add || op == Mul || op == Equal || op == NotEqual; }
-	static bool isArithmeticOp(Value op) { return Add <= op && op <= Exp; }
-	static bool isCompareOp(Value op) { return Equal <= op && op <= GreaterThanOrEqual; }
+	constexpr bool isElementaryTypeName(Token tok) { return Token::Int <= tok && tok < Token::TypesEnd; }
+	constexpr bool isAssignmentOp(Token tok) { return Token::Assign <= tok && tok <= Token::AssignMod; }
+	constexpr bool isBinaryOp(Token op) { return Token::Comma <= op && op <= Token::Exp; }
+	constexpr bool isCommutativeOp(Token op) { return op == Token::BitOr || op == Token::BitXor || op == Token::BitAnd ||
+		 op == Token::Add || op == Token::Mul || op == Token::Equal || op == Token::NotEqual; }
+	constexpr bool isArithmeticOp(Token op) { return Token::Add <= op && op <= Token::Exp; }
+	constexpr bool isCompareOp(Token op) { return Token::Equal <= op && op <= Token::GreaterThanOrEqual; }
 
-	static Value AssignmentToBinaryOp(Value op)
+	constexpr bool isBitOp(Token op) { return (Token::BitOr <= op && op <= Token::BitAnd) || op == Token::BitNot; }
+	constexpr bool isBooleanOp(Token op) { return (Token::Or <= op && op <= Token::And) || op == Token::Not; }
+	constexpr bool isUnaryOp(Token op) { return (Token::Not <= op && op <= Token::Delete) || op == Token::Add || op == Token::Sub; }
+	constexpr bool isCountOp(Token op) { return op == Token::Inc || op == Token::Dec; }
+	constexpr bool isShiftOp(Token op) { return (Token::SHL <= op) && (op <= Token::SHR); }
+	constexpr bool isVariableVisibilitySpecifier(Token op) { return op == Token::Public || op == Token::Private || op == Token::Internal; }
+	constexpr bool isVisibilitySpecifier(Token op) { return isVariableVisibilitySpecifier(op) || op == Token::External; }
+	constexpr bool isLocationSpecifier(Token op) { return op == Token::Memory || op == Token::Storage || op == Token::CallData; }
+
+	constexpr bool isStateMutabilitySpecifier(Token op, bool _allowConstant = true)
 	{
-		solAssert(isAssignmentOp(op) && op != Assign, "");
-		return Value(op + (BitOr - AssignBitOr));
+		return (op == Token::Constant && _allowConstant)
+			|| op == Token::Pure || op == Token::View || op == Token::Payable;
 	}
 
-	static bool isBitOp(Value op) { return (BitOr <= op && op <= BitAnd) || op == BitNot; }
-	static bool isBooleanOp(Value op) { return (Or <= op && op <= And) || op == Not; }
-	static bool isUnaryOp(Value op) { return (Not <= op && op <= Delete) || op == Add || op == Sub; }
-	static bool isCountOp(Value op) { return op == Inc || op == Dec; }
-	static bool isShiftOp(Value op) { return (SHL <= op) && (op <= SHR); }
-	static bool isVisibilitySpecifier(Value op) { return isVariableVisibilitySpecifier(op) || op == External; }
-	static bool isVariableVisibilitySpecifier(Value op) { return op == Public || op == Private || op == Internal; }
-	static bool isLocationSpecifier(Value op) { return op == Memory || op == Storage || op == CallData; }
-	static bool isStateMutabilitySpecifier(Value op, bool _allowConstant = true)
-	{
-		if (op == Constant && _allowConstant)
-			return true;
-		return op == Pure || op == View || op == Payable;
-	}
-	static bool isEtherSubdenomination(Value op) { return op == SubWei || op == SubSzabo || op == SubFinney || op == SubEther; }
-	static bool isTimeSubdenomination(Value op) { return op == SubSecond || op == SubMinute || op == SubHour || op == SubDay || op == SubWeek || op == SubYear; }
-	static bool isReservedKeyword(Value op) { return (Abstract <= op && op <= Unchecked); }
+	constexpr bool isEtherSubdenomination(Token op) { return op == Token::SubWei || op == Token::SubSzabo || op == Token::SubFinney || op == Token::SubEther; }
+	constexpr bool isTimeSubdenomination(Token op) { return op == Token::SubSecond || op == Token::SubMinute || op == Token::SubHour || op == Token::SubDay || op == Token::SubWeek || op == Token::SubYear; }
+	constexpr bool isReservedKeyword(Token op) { return (Token::Abstract <= op && op <= Token::Unchecked); }
 
-	// @returns a string corresponding to the JS token string
-	// (.e., "<" for the token LT) or NULL if the token doesn't
-	// have a (unique) string (e.g. an IDENTIFIER).
-	static char const* toString(Value tok)
+	inline Token AssignmentToBinaryOp(Token op)
 	{
-		solAssert(tok < NUM_TOKENS, "");
-		return m_string[tok];
-	}
-
-	static std::string friendlyName(Value tok)
-	{
-		char const* ret = toString(tok);
-		if (ret == nullptr)
-		{
-			ret = name(tok);
-			solAssert(ret != nullptr, "");
-		}
-		return std::string(ret);
+		solAssert(isAssignmentOp(op) && op != Token::Assign, "");
+		return static_cast<Token>(static_cast<int>(op) + (static_cast<int>(Token::BitOr) - static_cast<int>(Token::AssignBitOr)));
 	}
 
 	// @returns the precedence > 0 for binary and compare
 	// operators; returns 0 otherwise.
-	static int precedence(Value tok)
-	{
-		solAssert(tok < NUM_TOKENS, "");
-		return m_precedence[tok];
-	}
+	int precedence(Token tok);
 
-	static std::tuple<Token::Value, unsigned int, unsigned int> fromIdentifierOrKeyword(std::string const& _literal);
+	std::tuple<Token, unsigned int, unsigned int> fromIdentifierOrKeyword(std::string const& _literal);
 
-private:
-	// @returns -1 on error (invalid digit or number too large)
-	static int parseSize(std::string::const_iterator _begin, std::string::const_iterator _end);
-	// @returns the keyword with name @a _name or Token::Identifier of no such keyword exists.
-	static Token::Value keywordByName(std::string const& _name);
-	static char const* const m_name[NUM_TOKENS];
-	static char const* const m_string[NUM_TOKENS];
-	static int8_t const m_precedence[NUM_TOKENS];
-	static char const m_tokenType[NUM_TOKENS];
-};
+	// @returns a string corresponding to the C++ token name
+	// (e.g. "LT" for the token LT).
+	char const* name(Token tok);
+
+	// @returns a string corresponding to the JS token string
+	// (.e., "<" for the token LT) or NULL if the token doesn't
+	// have a (unique) string (e.g. an IDENTIFIER).
+	char const* toString(Token tok);
+
+	std::string friendlyName(Token tok);
+}
+
+inline std::ostream& operator<<(std::ostream& os, Token token)
+{
+	os << TokenTraits::friendlyName(token);
+	return os;
+}
 
 class ElementaryTypeNameToken
 {
 public:
-	ElementaryTypeNameToken(Token::Value _token, unsigned const& _firstNumber, unsigned const& _secondNumber)
+	ElementaryTypeNameToken(Token _token, unsigned const& _firstNumber, unsigned const& _secondNumber)
 	{
 		assertDetails(_token, _firstNumber, _secondNumber);
 	}
 
 	unsigned int firstNumber() const { return m_firstNumber; }
 	unsigned int secondNumber() const { return m_secondNumber; }
-	Token::Value token() const { return m_token; }
+	Token token() const { return m_token; }
+
 	///if tokValue is set to true, then returns the actual token type name, otherwise, returns full type
 	std::string toString(bool const& tokenValue = false) const
 	{
-		std::string name = Token::toString(m_token);
+		std::string name = TokenTraits::toString(m_token);
 		if (tokenValue || (firstNumber() == 0 && secondNumber() == 0))
 			return name;
 		solAssert(name.size() >= 3, "Token name size should be greater than 3. Should not reach here.");
@@ -390,11 +367,11 @@ public:
 	}
 
 private:
-	Token::Value m_token;
+	Token m_token;
 	unsigned int m_firstNumber;
 	unsigned int m_secondNumber;
 	/// throws if type is not properly sized
-	void assertDetails(Token::Value _baseType, unsigned const& _first, unsigned const& _second);
+	void assertDetails(Token _baseType, unsigned const& _first, unsigned const& _second);
 };
 
 }

--- a/test/libsolidity/SemVerMatcher.cpp
+++ b/test/libsolidity/SemVerMatcher.cpp
@@ -42,13 +42,13 @@ SemVerMatchExpression parseExpression(string const& _input)
 {
 	Scanner scanner{CharStream(_input)};
 	vector<string> literals;
-	vector<Token::Value> tokens;
+	vector<Token> tokens;
 	while (scanner.currentToken() != Token::EOS)
 	{
 		auto token = scanner.currentToken();
 		string literal = scanner.currentLiteral();
-		if (literal.empty() && Token::toString(token))
-			literal = Token::toString(token);
+		if (literal.empty() && TokenTraits::toString(token))
+			literal = TokenTraits::toString(token);
 		literals.push_back(literal);
 		tokens.push_back(token);
 		scanner.next();


### PR DESCRIPTION
Refactor `solidity::Token` into an `enum class` with `TokenTraits` heler namespace

### Patch includes:

* avoiding the hack of `Token::Value` to represent a scoped `Token` type
* moved all Token trait helper into `TokenTraits` namespace
* made all helpers `constexpr` where possible (ALL the rest could be made constexpr with C++14/17).
* eliminated some dead code inside Token.cpp

I hope that this makes the code a bit more readable, safe, and more "modern".
