### PR TITLE
[SMTChecker] Uninterpreted functions for blockhash()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ Language Features:
 Compiler Features:
  * Build System: LLL is not built anymore by default. Must configure it with CMake as `-DLLL=ON`.
  * Code generator: Do not perform redundant double cleanup on unsigned integers when loading from calldata.
+ * SMTChecker: Support ``msg``, ``tx`` and ``block`` member variables.
+ * SMTChecker: Support ``gasleft()`` and ``blockhash()`` functions.
 
 
 Bugfixes:

--- a/libsolidity/formal/CVC4Interface.cpp
+++ b/libsolidity/formal/CVC4Interface.cpp
@@ -50,7 +50,7 @@ void CVC4Interface::pop()
 	m_solver.pop();
 }
 
-void CVC4Interface::declareFunction(string _name, Sort _domain, Sort _codomain)
+void CVC4Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	if (!m_functions.count(_name))
 	{
@@ -200,4 +200,12 @@ CVC4::Type CVC4Interface::cvc4Sort(Sort _sort)
 	solAssert(false, "");
 	// Cannot be reached.
 	return m_context.integerType();
+}
+
+vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<Sort> const& _sorts)
+{
+	vector<CVC4::Type> cvc4Sorts;
+	for (auto const& _sort: _sorts)
+		cvc4Sorts.push_back(cvc4Sort(_sort));
+	return cvc4Sorts;
 }

--- a/libsolidity/formal/CVC4Interface.h
+++ b/libsolidity/formal/CVC4Interface.h
@@ -51,7 +51,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -61,6 +61,7 @@ public:
 private:
 	CVC4::Expr toCVC4Expr(Expression const& _expr);
 	CVC4::Type cvc4Sort(smt::Sort _sort);
+	std::vector<CVC4::Type> cvc4Sort(std::vector<smt::Sort> const& _sort);
 
 	CVC4::ExprManager m_context;
 	CVC4::SmtEngine m_solver;

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -83,6 +83,7 @@ private:
 	void inlineFunctionCall(FunctionCall const&);
 
 	void defineSpecialVariable(std::string const& _name, Expression const& _expr, bool _increaseIndex = false);
+	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::Sort> const& _domain, smt::Sort _codomain);
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -193,6 +194,11 @@ private:
 	std::unordered_map<Expression const*, std::shared_ptr<SymbolicVariable>> m_expressions;
 	std::unordered_map<VariableDeclaration const*, std::shared_ptr<SymbolicVariable>> m_variables;
 	std::unordered_map<std::string, std::shared_ptr<SymbolicVariable>> m_specialVariables;
+	/// Stores the declaration of an Uninterpreted Function.
+	std::unordered_map<std::string, smt::Expression> m_uninterpretedFunctions;
+	/// Stores the instances of an Uninterpreted Function applied to arguments.
+	/// Used to retrieve models.
+	std::vector<Expression const*> m_uninterpretedTerms;
 	std::vector<smt::Expression> m_pathConditions;
 	ErrorReporter& m_errorReporter;
 	std::shared_ptr<Scanner> m_scanner;

--- a/libsolidity/formal/SMTLib2Interface.cpp
+++ b/libsolidity/formal/SMTLib2Interface.cpp
@@ -64,9 +64,12 @@ void SMTLib2Interface::pop()
 	m_accumulatedOutput.pop_back();
 }
 
-void SMTLib2Interface::declareFunction(string _name, Sort _domain, Sort _codomain)
+void SMTLib2Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	// TODO Use domain and codomain as key as well
+	string domain("");
+	for (auto const& sort: _domain)
+		domain += toSmtLibSort(sort) + ' ';
 	if (!m_functions.count(_name))
 	{
 		m_functions.insert(_name);
@@ -74,7 +77,7 @@ void SMTLib2Interface::declareFunction(string _name, Sort _domain, Sort _codomai
 			"(declare-fun |" +
 			_name +
 			"| (" +
-			(_domain == Sort::Int ? "Int" : "Bool") +
+			domain +
 			") " +
 			(_codomain == Sort::Int ? "Int" : "Bool") +
 			")"
@@ -138,6 +141,19 @@ string SMTLib2Interface::toSExpr(Expression const& _expr)
 		sexpr += " " + toSExpr(arg);
 	sexpr += ")";
 	return sexpr;
+}
+
+string SMTLib2Interface::toSmtLibSort(Sort _sort)
+{
+	switch (_sort)
+	{
+	case Sort::Int:
+		return "Int";
+	case Sort::Bool:
+		return "Bool";
+	default:
+		solAssert(false, "Invalid SMT sort");
+	}
 }
 
 void SMTLib2Interface::write(string _data)

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -49,7 +49,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -58,6 +58,7 @@ public:
 
 private:
 	std::string toSExpr(Expression const& _expr);
+	std::string toSmtLibSort(Sort _sort);
 
 	void write(std::string _data);
 

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -64,7 +64,7 @@ void SMTPortfolio::pop()
 		s->pop();
 }
 
-void SMTPortfolio::declareFunction(string _name, Sort _domain, Sort _codomain)
+void SMTPortfolio::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	for (auto s : m_solvers)
 		s->declareFunction(_name, _domain, _codomain);

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -49,7 +49,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -24,6 +24,15 @@
 using namespace std;
 using namespace dev::solidity;
 
+smt::Sort dev::solidity::smtSort(Type::Category _category)
+{
+	if (isNumber(_category))
+		return smt::Sort::Int;
+	else if (isBool(_category))
+		return smt::Sort::Bool;
+	solAssert(false, "Invalid type");
+}
+
 bool dev::solidity::isSupportedType(Type::Category _category)
 {
 	return isNumber(_category) ||

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -28,6 +28,9 @@ namespace dev
 namespace solidity
 {
 
+/// Returns the SMT sort that models the Solidity type _type.
+smt::Sort smtSort(Type::Category _type);
+
 /// So far int, bool and address are supported.
 /// Returns true if type is supported.
 bool isSupportedType(Type::Category _category);

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -37,6 +37,11 @@ SymbolicVariable::SymbolicVariable(
 {
 }
 
+string SymbolicVariable::currentName() const
+{
+	return uniqueSymbol(m_ssa->index());
+}
+
 string SymbolicVariable::uniqueSymbol(unsigned _index) const
 {
 	return m_uniqueName + "_" + to_string(_index);

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -51,6 +51,8 @@ public:
 		return valueAtIndex(m_ssa->index());
 	}
 
+	std::string currentName() const;
+
 	virtual smt::Expression valueAtIndex(int _index) const = 0;
 
 	smt::Expression increaseIndex()

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -51,7 +51,7 @@ void Z3Interface::pop()
 	m_solver.pop();
 }
 
-void Z3Interface::declareFunction(string _name, Sort _domain, Sort _codomain)
+void Z3Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	if (!m_functions.count(_name))
 		m_functions.insert({_name, m_context.function(_name.c_str(), z3Sort(_domain), z3Sort(_codomain))});
@@ -182,4 +182,12 @@ z3::sort Z3Interface::z3Sort(Sort _sort)
 	solAssert(false, "");
 	// Cannot be reached.
 	return m_context.int_sort();
+}
+
+z3::sort_vector Z3Interface::z3Sort(vector<Sort> const& _sorts)
+{
+	z3::sort_vector z3Sorts(m_context);
+	for (auto const& _sort: _sorts)
+		z3Sorts.push_back(z3Sort(_sort));
+	return z3Sorts;
 }

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -40,7 +40,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -50,6 +50,7 @@ public:
 private:
 	z3::expr toZ3Expr(Expression const& _expr);
 	z3::sort z3Sort(smt::Sort _sort);
+	z3::sort_vector z3Sort(std::vector<smt::Sort> const& _sort);
 
 	z3::context m_context;
 	z3::solver m_solver;

--- a/test/libsolidity/smtCheckerTests/special/blockhash.sol
+++ b/test/libsolidity/smtCheckerTests/special/blockhash.sol
@@ -2,9 +2,13 @@ pragma experimental SMTChecker;
 
 contract C
 {
-	function f() public payable {
+	function f(uint x) public payable {
+		assert(blockhash(x) > 0);
 		assert(blockhash(2) > 0);
+		uint y = x;
+		assert(blockhash(x) == blockhash(y));
 	}
 }
 // ----
-// Warning: (79-103): Assertion violation happens here
+// Warning: (85-109): Assertion violation happens here
+// Warning: (113-137): Assertion violation happens here


### PR DESCRIPTION
Depends on #5398 

Uninterpreted functions should also be used for crypto&math, abi.