### PR TITLE
Add error reporting script and use in check_style script

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+. scripts/report_errors.sh
+
 (
 REPO_ROOT="$(dirname "$0")"/..
 cd $REPO_ROOT
@@ -8,8 +10,8 @@ WHITESPACE=$(git grep -n -I -E "^.*[[:space:]]+$" | grep -v "test/libsolidity/AS
 
 if [[ "$WHITESPACE" != "" ]]
 then
-	echo "Error: Trailing whitespace found:" >&2
-	echo "$WHITESPACE" >&2
+	echo "Error: Trailing whitespace found:" | tee -a $ERROR_LOG
+	echo "$WHITESPACE" | tee -a $ERROR_LOG
 	exit 1
 fi
 
@@ -22,8 +24,8 @@ git grep -nIE "\<if\>\s*\(.*\)\s*\{\s*$" -- '*.h' '*.cpp'
 
 if [[ "$FORMATERROR" != "" ]]
 then
-	echo "Error: Format error for if/for:" >&2
-	echo "$FORMATERROR" >&2
+	echo "Error: Format error for if/for:" | tee -a $ERROR_LOG
+	echo "$FORMATERROR" | tee -a $ERROR_LOG
 	exit 1
 fi
 )

--- a/scripts/report_errors.sh
+++ b/scripts/report_errors.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+export ERROR_LOG="/tmp/error.log"
+
+function report_error_to_github
+{
+    if [ $? -eq 0 ]
+    then
+        exit 0
+    fi
+
+    if [ -z $CIRCLE_PR_NUMBER ]
+    then
+        CIRCLE_PR_NUMBER="${CIRCLE_PULL_REQUEST//[^0-9]/}"
+    fi
+
+    ERROR_MSG=$(cat $ERROR_LOG)
+
+    echo $ERROR_MSG
+
+    if [ ! -z $CI ]
+    then
+        echo "posting error message to github"
+        post_error_to_github
+    fi
+}
+
+function post_error_to_github
+{
+    if [ -z $CIRCLE_PR_NUMBER ]
+    then
+        CIRCLE_PR_NUMBER="${CIRCLE_PULL_REQUEST//[^0-9]/}"
+    fi
+
+    GITHUB_API_URL="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$CIRCLE_PR_NUMBER/comments"
+
+    ESCAPED_ERROR_MSG=$(cat -e $ERROR_LOG | sed 's/\\/\\\\/g' | sed 's/"/\\\"/g')
+
+    FORMATTED_ERROR_MSG=$(echo $ESCAPED_ERROR_MSG | sed 's/\$/\\n/g' | tr -d '\n')
+
+    curl --request POST \
+      --url $GITHUB_API_URL \
+      --header 'accept: application/vnd.github.v3+json' \
+      --header 'content-type: application/json' \
+      -u stackenbotten:$GITHUB_ACCESS_TOKEN \
+      --data "{\"body\": \"There was an error when running \`$CIRCLE_JOB\` for commit \`$CIRCLE_SHA1\`:\n\`\`\`\n$FORMATTED_ERROR_MSG\n\`\`\`\nPlease check that your changes are working as intended.\"}"
+}
+
+trap report_error_to_github EXIT


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

### Description

Adding an error reporting script that will take any errors from scripts and post those as comments to an associated pull request. In order to use this script in any other scripts used by CircleCI it will need to be imported by the testing script and trap any exit with the `report_error_to_github` function. It also requires that any errors are written to the scripts `ERROR_LOG` file. This is perhaps one of the cleaner way to trap any errors encountered in testing scripts and report them to github. 

This will require that a github access token be created for the bot and that will need to be stored in CircleCI's private environment variables. Currently my username is being used in the script and will need to be updated to the bot's username. 