### PR TITLE
DOCS: Add check for whether voter has right to vote

### DIFF
--- a/docs/solidity-by-example.rst
+++ b/docs/solidity-by-example.rst
@@ -152,6 +152,7 @@ of votes.
         /// to proposal `proposals[proposal].name`.
         function vote(uint proposal) public {
             Voter storage sender = voters[msg.sender];
+            require(sender.weight != 0, "Has no right to vote");
             require(!sender.voted, "Already voted.");
             sender.voted = true;
             sender.vote = proposal;


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->
In the voting example: in vote method, if a voter does not have right to vote, it can still vote because there is no check for check for it. I added a require method call to check if a voter has given right to vote previously.