### PR TITLE
[WIP] w.r.t. Yul's ExpressionJoiner

### DIFF
--- a/libyul/optimiser/ExpressionJoiner.h
+++ b/libyul/optimiser/ExpressionJoiner.h
@@ -73,29 +73,29 @@ class NameCollector;
 class ExpressionJoiner: public ASTModifier
 {
 public:
-	virtual void operator()(FunctionalInstruction&) override;
-	virtual void operator()(FunctionCall&) override;
-	virtual void operator()(If&) override;
-	virtual void operator()(Switch&) override;
-	virtual void operator()(Block& _block) override;
-
-	using ASTModifier::visit;
-	virtual void visit(Expression& _e) override;
-
 	static void run(Block& _ast);
+
 private:
 	explicit ExpressionJoiner(Block& _ast);
+
+	void operator()(Block& _block) override;
+	void operator()(FunctionalInstruction&) override;
+	void operator()(FunctionCall&) override;
+
+	using ASTModifier::visit;
+	void visit(Expression& _e) override;
 
 	void handleArguments(std::vector<Expression>& _arguments);
 
 	void decrementLatestStatementPointer();
 	void resetLatestStatementPointer();
 	Statement* latestStatement();
-	bool isLatestStatementVarDeclOf(Identifier const& _identifier);
+	bool isLatestStatementVarDeclJoinable(Identifier const& _identifier);
 
-	Block* m_currentBlock = nullptr;
-	size_t m_latestStatementInBlock = 0;
-	std::map<std::string, size_t> m_references;
+private:
+	Block* m_currentBlock = nullptr;            ///< Pointer to currently block holding the visiting statement.
+	size_t m_latestStatementInBlock = 0;        ///< Offset to m_currentBlock's statements of the last visited statement.
+	std::map<std::string, size_t> m_references; ///< Holds reference counts to all variable declarations in current block.
 };
 
 }


### PR DESCRIPTION
[Yul] ExpressionJoiner: cleanup (and ideally soon-be-fixing #5244)

### Changes
* ensure public API is only containing `run(Block&)`, all the rest is private API / implementation details
* adding some comments to class data members to quicker understand their meaning
* eliminate unnecessary `operator()(If&)` as it's not changing default behaviour of `ASTModifier`
* simplify readability of `visit(Expression&)`'s impl, also moving assert's into "isLatestStatementVarDeclOf", as this one is already ensuring exactly that.
* ctor impl's use of ReferenceCounter use shortened.
* renamed and improved `isLatestStatementVarDeclOf` to better match its meaning (especially since it's only used once)
* eliminate `operator()(Switch&)`: We can also safely remove the this override because it's not changing behavior. I know the override is not running through the `Case.value`, but that's of type `Literal`, which is a no-op in the base class.

### Open Questions
Of course, the actual motivation of working on `ExpressionJoiner` is to eliminate the need of having to run it twice(+), which at least is the case for the `"fullInliner"` test.

While going through the code, I first had to understand it, and found some oddities which I addressed in the prior commit[s] so far.

@chriseth  I believe that we could rewrite the `Block* m_currentBlock` / `size_t m_latestStatementInBlock` logic into a single `vector<Statement>::iterator m_latestStatementInBlock`, which should further simplify the code.

Lastly, I don't find a "definite" yul code example that proofs that the ExpressionJoiner requires more than one run. I know that in the `"fullInliner"` tests we have 2 tests that rely on ExpressionInliner to run twice at the end of the chain, but whenever I try extracting this test case to only run this one pass, it's working as it should (I'll give it a further look).