### PR TITLE
[WIP] [SMTChecker] Support to mapping

### DIFF
--- a/libsolidity/formal/CVC4Interface.cpp
+++ b/libsolidity/formal/CVC4Interface.cpp
@@ -50,7 +50,7 @@ void CVC4Interface::pop()
 	m_solver.pop();
 }
 
-void CVC4Interface::declareFunction(string _name, Sort _domain, Sort _codomain)
+void CVC4Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	if (!m_functions.count(_name))
 	{
@@ -200,4 +200,12 @@ CVC4::Type CVC4Interface::cvc4Sort(Sort _sort)
 	solAssert(false, "");
 	// Cannot be reached.
 	return m_context.integerType();
+}
+
+vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<Sort> const& _sorts)
+{
+	vector<CVC4::Type> cvc4Sorts;
+	for (auto const& _sort: _sorts)
+		cvc4Sorts.push_back(cvc4Sort(_sort));
+	return cvc4Sorts;
 }

--- a/libsolidity/formal/CVC4Interface.h
+++ b/libsolidity/formal/CVC4Interface.h
@@ -51,7 +51,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -61,6 +61,7 @@ public:
 private:
 	CVC4::Expr toCVC4Expr(Expression const& _expr);
 	CVC4::Type cvc4Sort(smt::Sort _sort);
+	std::vector<CVC4::Type> cvc4Sort(std::vector<smt::Sort> const& _sort);
 
 	CVC4::ExprManager m_context;
 	CVC4::SmtEngine m_solver;

--- a/libsolidity/formal/CVC4Interface.h
+++ b/libsolidity/formal/CVC4Interface.h
@@ -51,17 +51,18 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareArray(std::string const&, ArraySort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
+	void declareInteger(std::string const& _name) override;
+	void declareBool(std::string const& _name) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
 	CVC4::Expr toCVC4Expr(Expression const& _expr);
-	CVC4::Type cvc4Sort(smt::Sort _sort);
-	std::vector<CVC4::Type> cvc4Sort(std::vector<smt::Sort> const& _sort);
+	CVC4::Type cvc4Sort(smt::Sort const& _sort);
+	std::vector<CVC4::Type> cvc4Sort(std::vector<SortPointer> const& _sort);
 
 	CVC4::ExprManager m_context;
 	CVC4::SmtEngine m_solver;

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -457,6 +457,14 @@ void SMTChecker::inlineFunctionCall(FunctionCall const& _funCall)
 	else if (_funDef && _funDef->isImplemented())
 	{
 		vector<smt::Expression> funArgs;
+		auto const& funType = dynamic_cast<FunctionType const*>(_funCall.expression().annotation().type.get());
+		solAssert(funType, "");
+		if (funType->bound())
+		{
+			auto const& boundFunction = dynamic_cast<MemberAccess const*>(&_funCall.expression());
+			solAssert(boundFunction, "");
+			funArgs.push_back(expr(boundFunction->expression()));
+		}
 		for (auto arg: _funCall.arguments())
 			funArgs.push_back(expr(*arg));
 		initializeFunctionCallParameters(*_funDef, funArgs);
@@ -548,6 +556,10 @@ void SMTChecker::endVisit(Return const& _return)
 
 bool SMTChecker::visit(MemberAccess const& _memberAccess)
 {
+	auto const& accessType = _memberAccess.annotation().type;
+	if (accessType->category() == Type::Category::Function)
+		return true;
+
 	auto const& exprType = _memberAccess.expression().annotation().type;
 	solAssert(exprType, "");
 	if (exprType->category() == Type::Category::Magic)

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -81,6 +81,7 @@ private:
 	void inlineFunctionCall(FunctionCall const&);
 
 	void defineSpecialVariable(std::string const& _name, Expression const& _expr, bool _increaseIndex = false);
+	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::Sort> const& _domain, smt::Sort _codomain);
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -191,6 +192,11 @@ private:
 	std::unordered_map<Expression const*, std::shared_ptr<SymbolicVariable>> m_expressions;
 	std::unordered_map<VariableDeclaration const*, std::shared_ptr<SymbolicVariable>> m_variables;
 	std::unordered_map<std::string, std::shared_ptr<SymbolicVariable>> m_specialVariables;
+	/// Stores the declaration of an Uninterpreted Function.
+	std::unordered_map<std::string, smt::Expression> m_uFunctions;
+	/// Stores the instances of an UF applied to arguments.
+	/// Used to retrieve models.
+	std::vector<smt::Expression> m_uTerms;
 	std::vector<smt::Expression> m_pathConditions;
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -67,6 +67,7 @@ private:
 	virtual void endVisit(Literal const& _node) override;
 	virtual void endVisit(Return const& _node) override;
 	virtual bool visit(MemberAccess const& _node) override;
+	virtual void endVisit(IndexAccess const& _node) override;
 
 	void arithmeticOperation(BinaryOperation const& _op);
 	void compareOperation(BinaryOperation const& _op);
@@ -79,9 +80,12 @@ private:
 	/// Visits the FunctionDefinition of the called function
 	/// if available and inlines the return value.
 	void inlineFunctionCall(FunctionCall const&);
+	
+	/// Handles assignment to mapping/array
+	void arrayAssignment(Assignment const&);
 
 	void defineSpecialVariable(std::string const& _name, Expression const& _expr, bool _increaseIndex = false);
-	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::Sort> const& _domain, smt::Sort _codomain);
+	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::SortPointer> const& _domain, smt::SortPointer _codomain);
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -190,13 +194,18 @@ private:
 	/// An Expression may have multiple smt::Expression due to
 	/// repeated calls to the same function.
 	std::unordered_map<Expression const*, std::shared_ptr<SymbolicVariable>> m_expressions;
+	/// Stores the declaration of symbolic variables of all types.
 	std::unordered_map<VariableDeclaration const*, std::shared_ptr<SymbolicVariable>> m_variables;
+	/// Stores the symbolic representation of special variables.
 	std::unordered_map<std::string, std::shared_ptr<SymbolicVariable>> m_specialVariables;
 	/// Stores the declaration of an Uninterpreted Function.
 	std::unordered_map<std::string, smt::Expression> m_uFunctions;
 	/// Stores the instances of an UF applied to arguments.
 	/// Used to retrieve models.
 	std::vector<smt::Expression> m_uTerms;
+	/// Stores the instances of array access.
+	/// Used to retrieve models.
+	std::vector<std::pair<VariableDeclaration const*, smt::Expression>> m_arrayTerms;
 	std::vector<smt::Expression> m_pathConditions;
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -205,7 +205,7 @@ private:
 	std::vector<smt::Expression> m_uTerms;
 	/// Stores the instances of array access.
 	/// Used to retrieve models.
-	std::vector<std::pair<VariableDeclaration const*, smt::Expression>> m_arrayTerms;
+	std::vector<std::pair<IndexAccess const*, smt::Expression>> m_arrayTerms;
 	std::vector<smt::Expression> m_pathConditions;
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/formal/SMTLib2Interface.cpp
+++ b/libsolidity/formal/SMTLib2Interface.cpp
@@ -64,9 +64,12 @@ void SMTLib2Interface::pop()
 	m_accumulatedOutput.pop_back();
 }
 
-void SMTLib2Interface::declareFunction(string _name, Sort _domain, Sort _codomain)
+void SMTLib2Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	// TODO Use domain and codomain as key as well
+	string domain("");
+	for (auto const& _sort: _domain)
+		domain += toSSort(_sort) + ' ';
 	if (!m_functions.count(_name))
 	{
 		m_functions.insert(_name);
@@ -74,7 +77,7 @@ void SMTLib2Interface::declareFunction(string _name, Sort _domain, Sort _codomai
 			"(declare-fun |" +
 			_name +
 			"| (" +
-			(_domain == Sort::Int ? "Int" : "Bool") +
+			domain +
 			") " +
 			(_codomain == Sort::Int ? "Int" : "Bool") +
 			")"
@@ -138,6 +141,19 @@ string SMTLib2Interface::toSExpr(Expression const& _expr)
 		sexpr += " " + toSExpr(arg);
 	sexpr += ")";
 	return sexpr;
+}
+
+string SMTLib2Interface::toSSort(Sort _sort)
+{
+	switch (_sort)
+	{
+	case Sort::Int:
+		return "Int";
+	case Sort::Bool:
+		return "Bool";
+	default:
+		solAssert(false, "Invalid SMT sort");
+	}
 }
 
 void SMTLib2Interface::write(string _data)

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -49,7 +49,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -58,6 +58,7 @@ public:
 
 private:
 	std::string toSExpr(Expression const& _expr);
+	std::string toSSort(Sort _sort);
 
 	void write(std::string _data);
 

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -49,16 +49,17 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareArray(std::string const&, ArraySort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
+	void declareInteger(std::string const& _name) override;
+	void declareBool(std::string const& _name) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
 	std::string toSExpr(Expression const& _expr);
-	std::string toSSort(Sort _sort);
+	std::string toSSort(Sort const& _sort);
 
 	void write(std::string _data);
 

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -64,7 +64,7 @@ void SMTPortfolio::pop()
 		s->pop();
 }
 
-void SMTPortfolio::declareFunction(string _name, Sort _domain, Sort _codomain)
+void SMTPortfolio::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	for (auto s : m_solvers)
 		s->declareFunction(_name, _domain, _codomain);

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -64,19 +64,25 @@ void SMTPortfolio::pop()
 		s->pop();
 }
 
-void SMTPortfolio::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void SMTPortfolio::declareArray(string const& _name, ArraySort const& _arraySort)
+{
+	for (auto s : m_solvers)
+		s->declareArray(_name, _arraySort);
+}
+
+void SMTPortfolio::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	for (auto s : m_solvers)
 		s->declareFunction(_name, _domain, _codomain);
 }
 
-void SMTPortfolio::declareInteger(string _name)
+void SMTPortfolio::declareInteger(string const& _name)
 {
 	for (auto s : m_solvers)
 		s->declareInteger(_name);
 }
 
-void SMTPortfolio::declareBool(string _name)
+void SMTPortfolio::declareBool(string const& _name)
 {
 	for (auto s : m_solvers)
 		s->declareBool(_name);

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -49,7 +49,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -49,9 +49,10 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareArray(std::string const&, ArraySort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
+	void declareInteger(std::string const& _name) override;
+	void declareBool(std::string const& _name) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -45,9 +45,7 @@ enum class CheckResult
 enum class Sort
 {
 	Int,
-	Bool,
-	IntIntFun, // Function of one Int returning a single Int
-	IntBoolFun // Function of one Int returning a single Bool
+	Bool
 };
 
 /// C++ representation of an SMTLIB2 expression.
@@ -158,9 +156,9 @@ public:
 		);
 		switch (sort)
 		{
-		case Sort::IntIntFun:
+		case Sort::Int:
 			return Expression(name, _a, Sort::Int);
-		case Sort::IntBoolFun:
+		case Sort::Bool:
 			return Expression(name, _a, Sort::Bool);
 		default:
 			solAssert(
@@ -199,18 +197,21 @@ public:
 	virtual void push() = 0;
 	virtual void pop() = 0;
 
-	virtual void declareFunction(std::string _name, Sort _domain, Sort _codomain) = 0;
-	Expression newFunction(std::string _name, Sort _domain, Sort _codomain)
+	virtual void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) = 0;
+	void declareFunction(std::string _name, Sort _domain, Sort _codomain)
+	{
+		declareFunction(std::move(_name), std::vector<Sort>{std::move(_domain)}, std::move(_codomain));
+	}
+	Expression newFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain)
 	{
 		declareFunction(_name, _domain, _codomain);
-		solAssert(_domain == Sort::Int, "Function sort not supported.");
 		// Subclasses should do something here
 		switch (_codomain)
 		{
 		case Sort::Int:
-			return Expression(std::move(_name), {}, Sort::IntIntFun);
+			return Expression(std::move(_name), {}, Sort::Int);
 		case Sort::Bool:
-			return Expression(std::move(_name), {}, Sort::IntBoolFun);
+			return Expression(std::move(_name), {}, Sort::Bool);
 		default:
 			solAssert(false, "Function sort not supported.");
 			break;

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -42,21 +42,45 @@ enum class CheckResult
 	SATISFIABLE, UNSATISFIABLE, UNKNOWN, CONFLICTING, ERROR
 };
 
-enum class Sort
+enum class Kind
 {
 	Int,
-	Bool
+	Bool,
+	Array
 };
+
+struct Sort
+{
+	Sort(Kind _kind):
+		kind(_kind) {}
+	virtual ~Sort() = default;
+	Kind const kind;
+	bool operator==(Sort const& _other) const { return kind == _other.kind; }
+};
+using SortPointer = std::shared_ptr<Sort>;
+
+struct ArraySort: public Sort
+{
+	ArraySort(SortPointer _domain, SortPointer _range):
+		Sort(Kind::Array), domain(std::move(_domain)), range(std::move(_range)) {}
+	SortPointer domain = nullptr;
+	SortPointer range = nullptr;
+	bool operator==(ArraySort const& _other) const
+	{
+		return Sort::operator==(_other) && *domain == *_other.domain && *range == *_other.range;
+	}
+};
+using ArraySortPointer = std::shared_ptr<ArraySort>;
 
 /// C++ representation of an SMTLIB2 expression.
 class Expression
 {
 	friend class SolverInterface;
 public:
-	explicit Expression(bool _v): name(_v ? "true" : "false"), sort(Sort::Bool) {}
-	Expression(size_t _number): name(std::to_string(_number)), sort(Sort::Int) {}
-	Expression(u256 const& _number): name(_number.str()), sort(Sort::Int) {}
-	Expression(bigint const& _number): name(_number.str()), sort(Sort::Int) {}
+	explicit Expression(bool _v): Expression(_v ? "true" : "false", Kind::Bool) {}
+	Expression(size_t _number): Expression(std::to_string(_number), Kind::Int) {}
+	Expression(u256 const& _number): Expression(_number.str(), Kind::Int) {}
+	Expression(bigint const& _number): Expression(_number.str(), Kind::Int) {}
 
 	Expression(Expression const&) = default;
 	Expression(Expression&&) = default;
@@ -78,14 +102,16 @@ public:
 			{"+", 2},
 			{"-", 2},
 			{"*", 2},
-			{"/", 2}
+			{"/", 2},
+			{"select", 2},
+			{"store", 3}
 		};
 		return operatorsArity.count(name) && operatorsArity.at(name) == arguments.size();
 	}
 
 	static Expression ite(Expression _condition, Expression _trueValue, Expression _falseValue)
 	{
-		solAssert(_trueValue.sort == _falseValue.sort, "");
+		solAssert(*_trueValue.sort == *_falseValue.sort, "");
 		return Expression("ite", std::vector<Expression>{
 			std::move(_condition), std::move(_trueValue), std::move(_falseValue)
 		}, _trueValue.sort);
@@ -96,21 +122,44 @@ public:
 		return !std::move(_a) || std::move(_b);
 	}
 
+	static Expression select(Expression _array, Expression _index)
+	{
+		solAssert(_array.sort->kind == Kind::Array, "");
+		auto const& arraySort = dynamic_cast<ArraySort const*>(_array.sort.get());
+		solAssert(arraySort, "");
+		solAssert(*arraySort->domain == *_index.sort, "");
+		return Expression("select", std::vector<Expression>{
+			std::move(_array), std::move(_index)
+		}, arraySort->range);
+	}
+
+	static Expression store(Expression _array, Expression _index, Expression _element)
+	{
+		solAssert(_array.sort->kind == Kind::Array, "");
+		auto const& arraySort = dynamic_cast<ArraySort const*>(_array.sort.get());
+		solAssert(arraySort, "");
+		solAssert(*arraySort->domain == *_index.sort, "");
+		solAssert(*arraySort->range == *_element.sort, "");
+		return Expression("store", std::vector<Expression>{
+			std::move(_array), std::move(_index), std::move(_element)
+		}, _array.sort);
+	}
+
 	friend Expression operator!(Expression _a)
 	{
-		return Expression("not", std::move(_a), Sort::Bool);
+		return Expression("not", std::move(_a), Kind::Bool);
 	}
 	friend Expression operator&&(Expression _a, Expression _b)
 	{
-		return Expression("and", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("and", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator||(Expression _a, Expression _b)
 	{
-		return Expression("or", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("or", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator==(Expression _a, Expression _b)
 	{
-		return Expression("=", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("=", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator!=(Expression _a, Expression _b)
 	{
@@ -118,35 +167,35 @@ public:
 	}
 	friend Expression operator<(Expression _a, Expression _b)
 	{
-		return Expression("<", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("<", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator<=(Expression _a, Expression _b)
 	{
-		return Expression("<=", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("<=", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator>(Expression _a, Expression _b)
 	{
-		return Expression(">", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression(">", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator>=(Expression _a, Expression _b)
 	{
-		return Expression(">=", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression(">=", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator+(Expression _a, Expression _b)
 	{
-		return Expression("+", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("+", std::move(_a), std::move(_b), Kind::Int);
 	}
 	friend Expression operator-(Expression _a, Expression _b)
 	{
-		return Expression("-", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("-", std::move(_a), std::move(_b), Kind::Int);
 	}
 	friend Expression operator*(Expression _a, Expression _b)
 	{
-		return Expression("*", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("*", std::move(_a), std::move(_b), Kind::Int);
 	}
 	friend Expression operator/(Expression _a, Expression _b)
 	{
-		return Expression("/", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("/", std::move(_a), std::move(_b), Kind::Int);
 	}
 	Expression operator()(Expression _a) const
 	{
@@ -154,12 +203,12 @@ public:
 			arguments.empty(),
 			"Attempted function application to non-function."
 		);
-		switch (sort)
+		switch (sort->kind)
 		{
-		case Sort::Int:
-			return Expression(name, _a, Sort::Int);
-		case Sort::Bool:
-			return Expression(name, _a, Sort::Bool);
+		case Kind::Int:
+			return Expression(name, _a, Kind::Int);
+		case Kind::Bool:
+			return Expression(name, _a, Kind::Bool);
 		default:
 			solAssert(
 				false,
@@ -171,19 +220,21 @@ public:
 
 	std::string name;
 	std::vector<Expression> arguments;
-	Sort sort;
+	SortPointer sort = nullptr;
 
 private:
-	/// Manual constructor, should only be used by SolverInterface and this class itself.
-	Expression(std::string _name, std::vector<Expression> _arguments, Sort _sort):
+	/// Manual constructors, should only be used by SolverInterface and this class itself.
+	Expression(std::string _name, std::vector<Expression> _arguments, SortPointer _sort):
 		name(std::move(_name)), arguments(std::move(_arguments)), sort(_sort) {}
+	Expression(std::string _name, std::vector<Expression> _arguments, Kind _kind):
+		Expression(std::move(_name), std::move(_arguments), std::make_shared<Sort>(_kind)) {}
 
-	explicit Expression(std::string _name, Sort _sort):
-		Expression(std::move(_name), std::vector<Expression>{}, _sort) {}
-	Expression(std::string _name, Expression _arg, Sort _sort):
-		Expression(std::move(_name), std::vector<Expression>{std::move(_arg)}, _sort) {}
-	Expression(std::string _name, Expression _arg1, Expression _arg2, Sort _sort):
-		Expression(std::move(_name), std::vector<Expression>{std::move(_arg1), std::move(_arg2)}, _sort) {}
+	explicit Expression(std::string _name, Kind _kind):
+		Expression(std::move(_name), std::vector<Expression>{}, _kind) {}
+	Expression(std::string _name, Expression _arg, Kind _kind):
+		Expression(std::move(_name), std::vector<Expression>{std::move(_arg)}, _kind) {}
+	Expression(std::string _name, Expression _arg1, Expression _arg2, Kind _kind):
+		Expression(std::move(_name), std::vector<Expression>{std::move(_arg1), std::move(_arg2)}, _kind) {}
 };
 
 DEV_SIMPLE_EXCEPTION(SolverError);
@@ -197,39 +248,34 @@ public:
 	virtual void push() = 0;
 	virtual void pop() = 0;
 
-	virtual void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) = 0;
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain)
+	virtual void declareArray(std::string const& _name, ArraySort const& _arraySort) = 0;
+	Expression newArray(std::string _name, ArraySortPointer _arraySort)
 	{
-		declareFunction(std::move(_name), std::vector<Sort>{std::move(_domain)}, std::move(_codomain));
-	}
-	Expression newFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain)
-	{
-		declareFunction(_name, _domain, _codomain);
 		// Subclasses should do something here
-		switch (_codomain)
-		{
-		case Sort::Int:
-			return Expression(std::move(_name), {}, Sort::Int);
-		case Sort::Bool:
-			return Expression(std::move(_name), {}, Sort::Bool);
-		default:
-			solAssert(false, "Function sort not supported.");
-			break;
-		}
+		declareArray(_name, *_arraySort);
+		return Expression(std::move(_name), {}, _arraySort);
 	}
-	virtual void declareInteger(std::string _name) = 0;
+
+	virtual void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) = 0;
+	Expression newFunction(std::string _name, std::vector<SortPointer> const& _domain, SortPointer _codomain)
+	{
+		declareFunction(_name, _domain, *_codomain);
+		// Subclasses should do something here
+		return Expression(std::move(_name), {}, _codomain);
+	}
+	virtual void declareInteger(std::string const& _name) = 0;
 	Expression newInteger(std::string _name)
 	{
 		// Subclasses should do something here
 		declareInteger(_name);
-		return Expression(std::move(_name), {}, Sort::Int);
+		return Expression(std::move(_name), {}, Kind::Int);
 	}
-	virtual void declareBool(std::string _name) = 0;
+	virtual void declareBool(std::string const& _name) = 0;
 	Expression newBool(std::string _name)
 	{
 		// Subclasses should do something here
 		declareBool(_name);
-		return Expression(std::move(_name), {}, Sort::Bool);
+		return Expression(std::move(_name), {}, Kind::Bool);
 	}
 
 	virtual void addAssertion(Expression const& _expr) = 0;

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -24,6 +24,15 @@
 using namespace std;
 using namespace dev::solidity;
 
+smt::Sort smtSort(Type::Category _category)
+{
+	if (isNumber(_category))
+		return smt::Sort::Int;
+	else if (isBool(_category))
+		return smt::Sort::Bool;
+	solAssert(false, "Invalid type");
+}
+
 bool dev::solidity::isSupportedType(Type::Category _category)
 {
 	return isNumber(_category) ||

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -28,6 +28,9 @@ namespace dev
 namespace solidity
 {
 
+/// Returns the SMT sort that models the Solidity type _type.
+smt::Sort smtSort(Type::Category _type);
+
 /// So far int, bool and address are supported.
 /// Returns true if type is supported.
 bool isSupportedType(Type::Category _category);

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -28,8 +28,12 @@ namespace dev
 namespace solidity
 {
 
-/// Returns the SMT sort that models the Solidity type _type.
-smt::Sort smtSort(Type::Category _type);
+/// Returns the SMT sort that models the Solidity type _type,
+/// including sub sorts (for Array, for example).
+std::shared_ptr<smt::Sort> smtSort(Type const& _type);
+/// Returns the SMT kind that models the Solidity type type category _category.
+smt::Kind smtKind(Type::Category _category);
+
 
 /// So far int, bool and address are supported.
 /// Returns true if type is supported.
@@ -43,6 +47,8 @@ bool isAddress(Type::Category _category);
 bool isNumber(Type::Category _category);
 bool isBool(Type::Category _category);
 bool isFunction(Type::Category _category);
+bool isMapping(Type::Category _category);
+bool isArray(Type::Category _category);
 
 /// Returns a new symbolic variable, according to _type.
 /// Also returns whether the type is abstract or not,

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -37,6 +37,11 @@ SymbolicVariable::SymbolicVariable(
 {
 }
 
+string SymbolicVariable::currentName() const
+{
+	return uniqueSymbol(m_ssa->index());
+}
+
 string SymbolicVariable::uniqueSymbol(unsigned _index) const
 {
 	return m_uniqueName + "_" + to_string(_index);

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -47,6 +47,35 @@ string SymbolicVariable::uniqueSymbol(unsigned _index) const
 	return m_uniqueName + "_" + to_string(_index);
 }
 
+SymbolicMappingVariable::SymbolicMappingVariable(
+	TypePointer _type,
+	string const& _uniqueName,
+	smt::SolverInterface& _interface
+):
+	SymbolicVariable(move(_type), _uniqueName, _interface)
+{
+	solAssert(isMapping(m_type->category()), "");
+}
+
+smt::Expression SymbolicMappingVariable::valueAtIndex(int _index) const
+{
+	auto mapType = dynamic_cast<MappingType const*>(m_type.get());
+	solAssert(mapType, "");
+	auto domain = smtSort(*mapType->keyType());
+	auto range = smtSort(*mapType->valueType());
+	return m_interface.newArray(uniqueSymbol(_index), make_shared<smt::ArraySort>(domain, range));
+}
+
+void SymbolicMappingVariable::setZeroValue()
+{
+}
+
+void SymbolicMappingVariable::setUnknownValue()
+{
+	// TODO
+	// \forall d \in D . (select m d) == UNKNOWN (apply type restrictions)
+}
+
 SymbolicBoolVariable::SymbolicBoolVariable(
 	TypePointer _type,
 	string const& _uniqueName,

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -51,6 +51,8 @@ public:
 		return valueAtIndex(m_ssa->index());
 	}
 
+	std::string currentName() const;
+
 	virtual smt::Expression valueAtIndex(int _index) const = 0;
 
 	smt::Expression increaseIndex()

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -81,6 +81,27 @@ protected:
 };
 
 /**
+ * Specialization of SymbolicVariable for Mapping
+ */
+class SymbolicMappingVariable: public SymbolicVariable
+{
+public:
+	SymbolicMappingVariable(
+		TypePointer _type,
+		std::string const& _uniqueName,
+		smt::SolverInterface& _interface
+	);
+
+	/// Sets all the elements to 0.
+	void setZeroValue();
+	/// Sets the valid range for all elements.
+	void setUnknownValue();
+
+protected:
+	smt::Expression valueAtIndex(int _index) const;
+};
+
+/**
  * Specialization of SymbolicVariable for Bool
  */
 class SymbolicBoolVariable: public SymbolicVariable

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -51,7 +51,7 @@ void Z3Interface::pop()
 	m_solver.pop();
 }
 
-void Z3Interface::declareFunction(string _name, Sort _domain, Sort _codomain)
+void Z3Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
 {
 	if (!m_functions.count(_name))
 		m_functions.insert({_name, m_context.function(_name.c_str(), z3Sort(_domain), z3Sort(_codomain))});
@@ -182,4 +182,12 @@ z3::sort Z3Interface::z3Sort(Sort _sort)
 	solAssert(false, "");
 	// Cannot be reached.
 	return m_context.int_sort();
+}
+
+z3::sort_vector Z3Interface::z3Sort(vector<Sort> const& _sorts)
+{
+	z3::sort_vector z3Sorts(m_context);
+	for (auto const& _sort: _sorts)
+		z3Sorts.push_back(z3Sort(_sort));
+	return z3Sorts;
 }

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -51,19 +51,25 @@ void Z3Interface::pop()
 	m_solver.pop();
 }
 
-void Z3Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void Z3Interface::declareArray(string const& _name, ArraySort const& _arraySort)
+{
+	if (!m_constants.count(_name))
+		m_constants.insert({_name, m_context.constant(_name.c_str(), z3Sort(_arraySort))});
+}
+
+void Z3Interface::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	if (!m_functions.count(_name))
 		m_functions.insert({_name, m_context.function(_name.c_str(), z3Sort(_domain), z3Sort(_codomain))});
 }
 
-void Z3Interface::declareInteger(string _name)
+void Z3Interface::declareInteger(string const& _name)
 {
 	if (!m_constants.count(_name))
 		m_constants.insert({_name, m_context.int_const(_name.c_str())});
 }
 
-void Z3Interface::declareBool(string _name)
+void Z3Interface::declareBool(string const& _name)
 {
 	if (!m_constants.count(_name))
 		m_constants.insert({_name, m_context.bool_const(_name.c_str())});
@@ -163,31 +169,38 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 		return arguments[0] * arguments[1];
 	else if (n == "/")
 		return arguments[0] / arguments[1];
+	else if (n == "select")
+		return z3::select(arguments[0], arguments[1]);
+	else if (n == "store")
+		return z3::store(arguments[0], arguments[1], arguments[2]);
 	// Cannot reach here.
 	solAssert(false, "");
 	return arguments[0];
 }
 
-z3::sort Z3Interface::z3Sort(Sort _sort)
+z3::sort Z3Interface::z3Sort(Sort const& _sort)
 {
-	switch (_sort)
+	switch (_sort.kind)
 	{
-	case Sort::Bool:
+	case Kind::Bool:
 		return m_context.bool_sort();
-	case Sort::Int:
+	case Kind::Int:
 		return m_context.int_sort();
+	case Kind::Array:
+	{
+		auto const& arraySort = dynamic_cast<ArraySort const&>(_sort);
+		return m_context.array_sort(z3Sort(*arraySort.domain), z3Sort(*arraySort.range));
+	}
 	default:
 		break;
 	}
 	solAssert(false, "");
-	// Cannot be reached.
-	return m_context.int_sort();
 }
 
-z3::sort_vector Z3Interface::z3Sort(vector<Sort> const& _sorts)
+z3::sort_vector Z3Interface::z3Sort(vector<SortPointer> const& _sorts)
 {
 	z3::sort_vector z3Sorts(m_context);
 	for (auto const& _sort: _sorts)
-		z3Sorts.push_back(z3Sort(_sort));
+		z3Sorts.push_back(z3Sort(*_sort));
 	return z3Sorts;
 }

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -40,7 +40,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -50,6 +50,7 @@ public:
 private:
 	z3::expr toZ3Expr(Expression const& _expr);
 	z3::sort z3Sort(smt::Sort _sort);
+	z3::sort_vector z3Sort(std::vector<smt::Sort> const& _sort);
 
 	z3::context m_context;
 	z3::solver m_solver;

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -40,17 +40,18 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareArray(std::string const&, ArraySort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
+	void declareInteger(std::string const& _name) override;
+	void declareBool(std::string const& _name) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
 	z3::expr toZ3Expr(Expression const& _expr);
-	z3::sort z3Sort(smt::Sort _sort);
-	z3::sort_vector z3Sort(std::vector<smt::Sort> const& _sort);
+	z3::sort z3Sort(smt::Sort const& _sort);
+	z3::sort_vector z3Sort(std::vector<SortPointer> const& _sort);
 
 	z3::context m_context;
 	z3::solver m_solver;

--- a/test/libsolidity/smtCheckerTests/functions/functions_bound_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_bound_1.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+library L
+{
+	function add(uint x, uint y) internal pure returns (uint) {
+		require(x < 1000);
+		require(y < 1000);
+		return x + y;
+	}
+}
+
+contract C
+{
+	using L for uint;
+	function f(uint x) public pure {
+		uint y = x.add(999);
+		assert(y < 10000);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/functions/functions_bound_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_bound_1_fail.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+library L
+{
+	function add(uint x, uint y) internal pure returns (uint) {
+		require(x < 1000);
+		require(y < 1000);
+		return x + y;
+	}
+}
+
+contract C
+{
+	using L for uint;
+	function f(uint x) public pure {
+		uint y = x.add(999);
+		assert(y < 1000);
+	}
+}
+// ----
+// Warning: (261-277): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/functions/functions_library_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_library_1.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+
+library L
+{
+	function add(uint x, uint y) internal pure returns (uint) {
+		require(x < 1000);
+		require(y < 1000);
+		return x + y;
+	}
+}
+
+contract C
+{
+	function f(uint x) public pure {
+		uint y = L.add(x, 999);
+		assert(y < 10000);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/functions/functions_library_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_library_1_fail.sol
@@ -1,0 +1,20 @@
+pragma experimental SMTChecker;
+
+library L
+{
+	function add(uint x, uint y) internal pure returns (uint) {
+		require(x < 1000);
+		require(y < 1000);
+		return x + y;
+	}
+}
+
+contract C
+{
+	function f(uint x) public pure {
+		uint y = L.add(x, 999);
+		assert(y < 1000);
+	}
+}
+// ----
+// Warning: (245-261): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/special/blockhash.sol
+++ b/test/libsolidity/smtCheckerTests/special/blockhash.sol
@@ -2,9 +2,13 @@ pragma experimental SMTChecker;
 
 contract C
 {
-	function f() public payable {
+	function f(uint x) public payable {
+		assert(blockhash(x) > 0);
 		assert(blockhash(2) > 0);
+		uint y = x;
+		assert(blockhash(x) == blockhash(y));
 	}
 }
 // ----
-// Warning: (79-103): Assertion violation happens here
+// Warning: (85-109): Assertion violation happens here
+// Warning: (113-137): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_1.sol
@@ -7,3 +7,5 @@ contract C
 		assert(x != map[2]);
 	}
 }
+// ----
+// Warning: (111-130): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_1.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (uint => uint) map;
+	function f(uint x) public view {
+		assert(x != map[2]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_1_fail.sol
@@ -5,7 +5,9 @@ contract C
 	mapping (uint => uint) map;
 	function f(uint x) public {
 		map[2] = x;
-		assert(x == map[2]);
+		map[2] = 3;
+		assert(x != map[2]);
 	}
 }
 // ----
+// Warning: (134-153): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_2.sol
@@ -7,3 +7,5 @@ contract C
 		assert(x != map[2]);
 	}
 }
+// ----
+// Warning: (111-130): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_2.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (uint => bool) map;
+	function f(bool x) public view {
+		assert(x != map[2]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_2d_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_2d_1.sol
@@ -3,9 +3,9 @@ pragma experimental SMTChecker;
 contract C
 {
 	mapping (uint => mapping (uint => uint)) map;
-	function f(uint x) public view {
+	function f(uint x) public {
 		x = 42;
-		require(map[13][14] == 42);
+		map[13][14] = 42;
 		assert(x == map[13][14]);
 	}
 }

--- a/test/libsolidity/smtCheckerTests/types/mapping_2d_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_2d_1.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (uint => mapping (uint => uint)) map;
+	function f(uint x) public view {
+		x = 42;
+		require(map[13][14] == 42);
+		assert(x == map[13][14]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_2d_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_2d_1_fail.sol
@@ -3,11 +3,11 @@ pragma experimental SMTChecker;
 contract C
 {
 	mapping (uint => mapping (uint => uint)) map;
-	function f(uint x) public view {
-		x = 42;
-		require(map[13][14] == 42);
-		assert(x != map[13][14]);
+	function f(uint x) public {
+		x = 41;
+		map[13][14] = 42;
+		assert(x == map[13][14]);
 	}
 }
 // ----
-// Warning: (169-193): Assertion violation happens here
+// Warning: (154-178): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_2d_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_2d_1_fail.sol
@@ -9,3 +9,5 @@ contract C
 		assert(x != map[13][14]);
 	}
 }
+// ----
+// Warning: (169-193): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_3.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (bool => uint) map;
+	function f(uint x) public view {
+		assert(x != map[true]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_3.sol
@@ -7,3 +7,5 @@ contract C
 		assert(x != map[true]);
 	}
 }
+// ----
+// Warning: (111-133): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_3d_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_3d_1.sol
@@ -3,9 +3,9 @@ pragma experimental SMTChecker;
 contract C
 {
 	mapping (uint => mapping (uint => mapping (uint => uint))) map;
-	function f(uint x) public view {
+	function f(uint x) public {
 		x = 42;
-		require(map[13][14][15] == 42);
+		map[13][14][15] = 42;
 		assert(x == map[13][14][15]);
 	}
 }

--- a/test/libsolidity/smtCheckerTests/types/mapping_3d_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_3d_1.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (uint => mapping (uint => mapping (uint => uint))) map;
+	function f(uint x) public view {
+		x = 42;
+		require(map[13][14][15] == 42);
+		assert(x == map[13][14][15]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_3d_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_3d_1_fail.sol
@@ -3,11 +3,11 @@ pragma experimental SMTChecker;
 contract C
 {
 	mapping (uint => mapping (uint => mapping (uint => uint))) map;
-	function f(uint x) public view {
-		x = 42;
-		require(map[13][14][15] == 42);
-		assert(x != map[13][14][15]);
+	function f(uint x) public {
+		x = 41;
+		map[13][14][15] = 42;
+		assert(x == map[13][14][15]);
 	}
 }
 // ----
-// Warning: (191-219): Assertion violation happens here
+// Warning: (176-204): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_3d_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_3d_1_fail.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (uint => mapping (uint => mapping (uint => uint))) map;
+	function f(uint x) public view {
+		x = 42;
+		require(map[13][14][15] == 42);
+		assert(x != map[13][14][15]);
+	}
+}
+// ----
+// Warning: (191-219): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_4.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_4.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (bool => bool) map;
+	function f(bool x) public view {
+		assert(x != map[true]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_4.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_4.sol
@@ -7,3 +7,5 @@ contract C
 		assert(x != map[true]);
 	}
 }
+// ----
+// Warning: (111-133): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_5.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_5.sol
@@ -7,3 +7,5 @@ contract C
 		assert(x != map[a]);
 	}
 }
+// ----
+// Warning: (125-144): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/mapping_5.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_5.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (address => uint) map;
+	function f(address a, uint x) public view {
+		assert(x != map[a]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/mapping_6.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_6.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	mapping (uint => mapping (uint => uint)) map;
+	function f(uint x) public view {
+		x = 42;
+		require(map[13][14] == 42);
+		assert(x != map[13][14]);
+	}
+}


### PR DESCRIPTION
Depends on #5307 

This PR refactors `smt::Sort` adding `Array` and also adds support to `mapping`.

TODO:
- [x] 1-d mapping
- [x] M-d mapping access
- [x] M-d mapping model - currently it gives a lambda for the outer access
- [x] M-d mapping assignment
- [ ] setZeroValue and setUnknownValue (depends on `forall`)