### PR TITLE
Change terminology used for input output parameters pt 2

### DIFF
--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -276,7 +276,7 @@ functions, annotate conditions for formal verification, and provide a
 function.
 
 In the following example we document the title of the contract, the explanation
-for the two input parameters and two returned values.
+for the two function parameters and two return variables.
 
 ::
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -253,7 +253,7 @@ Send is the low-level counterpart of ``transfer``. If the execution fails, the c
 In order to interface with contracts that do not adhere to the ABI,
 or to get more direct control over the encoding,
 the functions ``call``, ``delegatecall`` and ``staticcall`` are provided.
-They all take a single ``bytes memory`` argument as input and
+They all take a single ``bytes memory`` parameter and
 return the success condition (as a ``bool``) and the returned data
 (``bytes memory``).
 The functions ``abi.encode``, ``abi.encodePacked``, ``abi.encodeWithSelector``

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -43,8 +43,8 @@ library has to be updated by an external oracle.
 .. note::
     The suffix ``years`` has been removed in version 0.5.0 due to the reasons above.
 
-These suffixes cannot be applied to variables. If you want to
-interpret some input variable in e.g. days, you can do it in the following way::
+These suffixes cannot be applied to variables. For example, if you want to
+interpret a function parameter in days, you can in the following way::
 
     function f(uint start, uint daysAfter) public {
         if (now >= start + daysAfter * 1 days) {
@@ -125,7 +125,7 @@ ABI Encoding and Decoding Functions
     These encoding functions can be used to craft data for external function calls without actually
     calling an external function. Furthermore, ``keccak256(abi.encodePacked(a, b))`` is a way
     to compute the hash of structured data (although be aware that it is possible to
-    craft a "hash collision" using different inputs types).
+    craft a "hash collision" using different function parameter types).
 
 See the documentation about the :ref:`ABI <ABI>` and the
 :ref:`tightly packed encoding <abi_packed_mode>` for details about the encoding.
@@ -240,4 +240,3 @@ Furthermore, all functions of the current contract are callable directly includi
 .. note::
     Prior to version 0.5.0, there was a function called ``suicide`` with the same
     semantics as ``selfdestruct``.
-


### PR DESCRIPTION
### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Description

As discussed here https://github.com/ethereum/solidity/pull/4859#discussion_r214986820 this first PR changes the terminology previously used for input and output parameters. Hopefully, I got the semantics, explanations and usage correct. Part 1 is here https://github.com/ethereum/solidity/pull/5323.