### PR TITLE
Fix negative denominator in ``boost::rational`` during exponentiation.

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1144,10 +1144,10 @@ TypePointer RationalNumberType::binaryOperatorResult(Token _operator, TypePointe
 				bigint denominator = optimizedPow(m_value.denominator(), absExp);
 
 				if (exp >= 0)
-					value = rational(numerator, denominator);
+					value = makeRational(numerator, denominator);
 				else
 					// invert
-					value = rational(denominator, numerator);
+					value = makeRational(denominator, numerator);
 			}
 			break;
 		}

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -51,6 +51,15 @@ using FunctionTypePointer = std::shared_ptr<FunctionType const>;
 using TypePointers = std::vector<TypePointer>;
 using rational = boost::rational<dev::bigint>;
 
+inline rational makeRational(bigint const& _numerator, bigint const& _denominator)
+{
+	solAssert(_denominator != 0, "division by zero");
+	// due to a bug in certain versions of boost the denominator has to be positive
+	if (_denominator < 0)
+		return rational(-_numerator, -_denominator);
+	else
+		return rational(_numerator, _denominator);
+}
 
 enum class DataLocation { Storage, CallData, Memory };
 

--- a/test/libsolidity/syntaxTests/types/rational_negative_numerator_negative_exp.sol
+++ b/test/libsolidity/syntaxTests/types/rational_negative_numerator_negative_exp.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() public pure returns (int) {
+        return (-1 / 2) ** -1;
+    }
+}


### PR DESCRIPTION
Actual fix for the problem in #5347.
During exponentiation negative denominators may occur, resulting in boost 1.68 throwing an exception.