### PR TITLE
Relax type equality requirement of function types during conversion in code generation.

### DIFF
--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1014,12 +1014,24 @@ void CompilerUtils::convertType(
 			// stack: <address> <function_id>
 			m_context << Instruction::POP;
 		}
-		else if (stackTypeCategory == Type::Category::Function && targetTypeCategory == Type::Category::Function)
-			solAssert(_typeOnStack.isImplicitlyConvertibleTo(_targetType), "Invalid function type conversion requested.");
 		else
 		{
-			// All other types should not be convertible to non-equal types.
-			solAssert(_typeOnStack == _targetType, "Invalid type conversion requested.");
+			if (stackTypeCategory == Type::Category::Function && targetTypeCategory == Type::Category::Function)
+			{
+				FunctionType const& typeOnStack = dynamic_cast<FunctionType const&>(_typeOnStack);
+				FunctionType const& targetType = dynamic_cast<FunctionType const&>(_targetType);
+				solAssert(
+					typeOnStack.isImplicitlyConvertibleTo(targetType) &&
+					typeOnStack.sizeOnStack() == targetType.sizeOnStack() &&
+					(typeOnStack.kind() == FunctionType::Kind::Internal || typeOnStack.kind() == FunctionType::Kind::External) &&
+					typeOnStack.kind() == targetType.kind(),
+					"Invalid function type conversion requested."
+				);
+			}
+			else
+				// All other types should not be convertible to non-equal types.
+				solAssert(_typeOnStack == _targetType, "Invalid type conversion requested.");
+
 			if (_cleanupNeeded && _targetType.canBeStored() && _targetType.storageBytes() < 32)
 				m_context
 					<< ((u256(1) << (8 * _targetType.storageBytes())) - 1)

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1014,6 +1014,8 @@ void CompilerUtils::convertType(
 			// stack: <address> <function_id>
 			m_context << Instruction::POP;
 		}
+		else if (stackTypeCategory == Type::Category::Function && targetTypeCategory == Type::Category::Function)
+			solAssert(_typeOnStack.isImplicitlyConvertibleTo(_targetType), "Invalid function type conversion requested.");
 		else
 		{
 			// All other types should not be convertible to non-equal types.

--- a/test/libsolidity/syntaxTests/conversion/function_type_nonpayable_payable.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_nonpayable_payable.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() external {
+    }
+    function f() view external returns (bytes4) {
+        function () payable external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (105-144): Type function () external is not implicitly convertible to expected type function () payable external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_nonpayable_pure.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_nonpayable_pure.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() external {
+    }
+    function f() view external returns (bytes4) {
+        function () pure external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (105-141): Type function () external is not implicitly convertible to expected type function () pure external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_nonpayable_view.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_nonpayable_view.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() external {
+    }
+    function f() view external returns (bytes4) {
+        function () view external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (105-141): Type function () external is not implicitly convertible to expected type function () view external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_payable_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_payable_nonpayable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() payable external {
+    }
+    function f() view external returns (bytes4) {
+        function () external g = this.h;
+        return g.selector;
+    }
+}

--- a/test/libsolidity/syntaxTests/conversion/function_type_payable_pure.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_payable_pure.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() payable external {
+    }
+    function f() view external returns (bytes4) {
+        function () pure external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (113-149): Type function () payable external is not implicitly convertible to expected type function () pure external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_payable_view.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_payable_view.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() payable external {
+    }
+    function f() view external returns (bytes4) {
+        function () view external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (113-149): Type function () payable external is not implicitly convertible to expected type function () view external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_pure_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_pure_nonpayable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() pure external {
+    }
+    function f() view external returns (bytes4) {
+        function () external g = this.h;
+        return g.selector;
+    }
+}

--- a/test/libsolidity/syntaxTests/conversion/function_type_pure_payable.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_pure_payable.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() pure external {
+    }
+    function f() view external returns (bytes4) {
+        function () payable external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (110-149): Type function () pure external is not implicitly convertible to expected type function () payable external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_pure_view.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_pure_view.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() pure external {
+    }
+    function f() view external returns (bytes4) {
+        function () view external g = this.h;
+        return g.selector;
+    }
+}

--- a/test/libsolidity/syntaxTests/conversion/function_type_same.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_same.sol
@@ -1,0 +1,14 @@
+contract C {
+	int dummy;
+    function h_nonpayable() external { dummy = 1; }
+    function h_payable() payable external {}
+    function h_view() view external { dummy; }
+    function h_pure() pure external {}
+    function f() view external {
+        function () external g_nonpayable = this.h_nonpayable; g_nonpayable;
+        function () payable external g_payable = this.h_payable; g_payable;
+        function () view external g_view = this.h_view; g_view;
+        function () pure external g_pure = this.h_pure; g_pure;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/conversion/function_type_view_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_view_nonpayable.sol
@@ -1,0 +1,10 @@
+contract C {
+	int dummy;
+    function h() view external {
+		dummy;
+    }
+    function f() view external returns (bytes4) {
+        function () external g = this.h;
+        return g.selector;
+    }
+}

--- a/test/libsolidity/syntaxTests/conversion/function_type_view_payable.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_view_payable.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() view external {
+    }
+    function f() view external returns (bytes4) {
+        function () payable external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (110-149): Type function () view external is not implicitly convertible to expected type function () payable external.

--- a/test/libsolidity/syntaxTests/conversion/function_type_view_pure.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_view_pure.sol
@@ -1,0 +1,10 @@
+contract C {
+    function h() view external {
+    }
+    function f() view external returns (bytes4) {
+        function () pure external g = this.h;
+        return g.selector;
+    }
+}
+// ----
+// TypeError: (110-146): Type function () view external is not implicitly convertible to expected type function () pure external.


### PR DESCRIPTION
Fixes #5279.