### PR TITLE
[DOCS] Document disallowed explicit conversions between unrelated contract types.

### DIFF
--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -101,6 +101,14 @@ For most of the topics the compiler will provide suggestions.
   ``c.transfer(...)`` to ``address(c).transfer(...)``,
   and ``c.balance`` to ``address(c).balance``.
 
+* Explicit conversions between unrelated contract types are now disallowed. You can only
+  convert from a contract type to one of its base or ancestor types. If you are sure that
+  a contract is compatible with the contract type you want to convert to, although it does not
+  inherit from it, you can work around this by converting to ``address`` first.
+  Example: if ``A`` and ``B`` are contract types, ``B`` does not inherit from ``A`` and
+  ``b`` is a contract of type ``B``, you can still convert ``b`` to type ``A`` using ``A(address(b))``.
+  Note that you still need to watch out for matching payable fallback functions, as explained below.
+
 * The ``address`` type  was split into ``address`` and ``address payable``,
   where only ``address payable`` provides the ``transfer`` function.  An
   ``address payable`` can be directly converted to an ``address``, but the


### PR DESCRIPTION
Came up on gitter.
I just quickly wrote something up to track this - we may want to reformulate and maybe we want to include this elsewhere as well or I missed it being mentioned elsewhere already...