### PR TITLE
Eliminate `byte`-typedef and use `uint8_t` in all their places instead.

### DIFF
--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -64,15 +64,13 @@
 #include <functional>
 #include <string>
 
-using byte = uint8_t;
-
 namespace dev
 {
 
 // Binary data types.
-using bytes = std::vector<byte>;
-using bytesRef = vector_ref<byte>;
-using bytesConstRef = vector_ref<byte const>;
+using bytes = std::vector<uint8_t>;
+using bytesRef = vector_ref<uint8_t>;
+using bytesConstRef = vector_ref<uint8_t const>;
 
 // Numeric types.
 using bigint = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>>;

--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -64,7 +64,7 @@ bytes dev::fromHex(std::string const& _s, WhenError _throw)
 		int h = fromHex(_s[i], WhenError::DontThrow);
 		int l = fromHex(_s[i + 1], WhenError::DontThrow);
 		if (h != -1 && l != -1)
-			ret.push_back((byte)(h * 16 + l));
+			ret.push_back((uint8_t)(h * 16 + l));
 		else if (_throw == WhenError::Throw)
 			BOOST_THROW_EXCEPTION(BadHexCharacter());
 		else

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -88,7 +88,7 @@ inline std::string asString(bytesConstRef _b)
 /// Converts a string to a byte array containing the string's (byte) data.
 inline bytes asBytes(std::string const& _b)
 {
-	return bytes((byte const*)_b.data(), (byte const*)(_b.data() + _b.size()));
+	return bytes((uint8_t const*)_b.data(), (uint8_t const*)(_b.data() + _b.size()));
 }
 
 // Big-endian to/from host endian conversion functions.
@@ -117,7 +117,7 @@ inline T fromBigEndian(_In const& _bytes)
 {
 	T ret = (T)0;
 	for (auto i: _bytes)
-		ret = (T)((ret << 8) | (byte)(typename std::make_unsigned<typename _In::value_type>::type)i);
+		ret = (T)((ret << 8) | (uint8_t)(typename std::make_unsigned<typename _In::value_type>::type)i);
 	return ret;
 }
 inline bytes toBigEndian(u256 _val) { bytes ret(32); toBigEndian(_val, ret); return ret; }
@@ -135,7 +135,7 @@ inline bytes toCompactBigEndian(T _val, unsigned _min = 0)
 	toBigEndian(_val, ret);
 	return ret;
 }
-inline bytes toCompactBigEndian(byte _val, unsigned _min = 0)
+inline bytes toCompactBigEndian(uint8_t _val, unsigned _min = 0)
 {
 	return (_min || _val) ? bytes{ _val } : bytes{};
 }

--- a/libdevcore/FixedHash.h
+++ b/libdevcore/FixedHash.h
@@ -79,7 +79,7 @@ public:
 	operator Arith() const { return fromBigEndian<Arith>(m_data); }
 
 	/// @returns true iff this is the empty hash.
-	explicit operator bool() const { return std::any_of(m_data.begin(), m_data.end(), [](byte _b) { return _b != 0; }); }
+	explicit operator bool() const { return std::any_of(m_data.begin(), m_data.end(), [](uint8_t _b) { return _b != 0; }); }
 
 	// The obvious comparison operators.
 	bool operator==(FixedHash const& _c) const { return m_data == _c.m_data; }
@@ -90,9 +90,9 @@ public:
 	FixedHash operator~() const { FixedHash ret; for (unsigned i = 0; i < N; ++i) ret[i] = ~m_data[i]; return ret; }
 
 	/// @returns a particular byte from the hash.
-	byte& operator[](unsigned _i) { return m_data[_i]; }
+	uint8_t& operator[](unsigned _i) { return m_data[_i]; }
 	/// @returns a particular byte from the hash.
-	byte operator[](unsigned _i) const { return m_data[_i]; }
+	uint8_t operator[](unsigned _i) const { return m_data[_i]; }
 
 	/// @returns the hash as a user-readable hex string.
 	std::string hex() const { return toHex(ref()); }
@@ -104,19 +104,19 @@ public:
 	bytesConstRef ref() const { return bytesConstRef(m_data.data(), N); }
 
 	/// @returns a mutable byte pointer to the object's data.
-	byte* data() { return m_data.data(); }
+	uint8_t* data() { return m_data.data(); }
 
 	/// @returns a constant byte pointer to the object's data.
-	byte const* data() const { return m_data.data(); }
+	uint8_t const* data() const { return m_data.data(); }
 
 	/// @returns a copy of the object's data as a byte vector.
 	bytes asBytes() const { return bytes(data(), data() + N); }
 
 	/// @returns a mutable reference to the object's data as an STL array.
-	std::array<byte, N>& asArray() { return m_data; }
+	std::array<uint8_t, N>& asArray() { return m_data; }
 
 	/// @returns a constant reference to the object's data as an STL array.
-	std::array<byte, N> const& asArray() const { return m_data; }
+	std::array<uint8_t, N> const& asArray() const { return m_data; }
 
 	/// Returns the index of the first bit set to one, or size() * 8 if no bits are set.
 	inline unsigned firstBitSet() const
@@ -137,7 +137,7 @@ public:
 	void clear() { m_data.fill(0); }
 
 private:
-	std::array<byte, N> m_data;		///< The binary data.
+	std::array<uint8_t, N> m_data;		///< The binary data.
 };
 
 /// Stream I/O for the FixedHash class.

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -525,14 +525,14 @@ LinkerObject const& Assembly::assemble() const
 	multimap<size_t, size_t> subRef;
 	vector<unsigned> sizeRef; ///< Pointers to code locations where the size of the program is inserted
 	unsigned bytesPerTag = dev::bytesRequired(bytesRequiredForCode);
-	byte tagPush = (byte)Instruction::PUSH1 - 1 + bytesPerTag;
+	uint8_t tagPush = (uint8_t)Instruction::PUSH1 - 1 + bytesPerTag;
 
 	unsigned bytesRequiredIncludingData = bytesRequiredForCode + 1 + m_auxiliaryData.size();
 	for (auto const& sub: m_subs)
 		bytesRequiredIncludingData += sub->assemble().bytecode.size();
 
 	unsigned bytesPerDataRef = dev::bytesRequired(bytesRequiredIncludingData);
-	byte dataRefPush = (byte)Instruction::PUSH1 - 1 + bytesPerDataRef;
+	uint8_t dataRefPush = (uint8_t)Instruction::PUSH1 - 1 + bytesPerDataRef;
 	ret.bytecode.reserve(bytesRequiredIncludingData);
 
 	for (AssemblyItem const& i: m_items)
@@ -544,25 +544,25 @@ LinkerObject const& Assembly::assemble() const
 		switch (i.type())
 		{
 		case Operation:
-			ret.bytecode.push_back((byte)i.instruction());
+			ret.bytecode.push_back((uint8_t)i.instruction());
 			break;
 		case PushString:
 		{
-			ret.bytecode.push_back((byte)Instruction::PUSH32);
+			ret.bytecode.push_back((uint8_t)Instruction::PUSH32);
 			unsigned ii = 0;
 			for (auto j: m_strings.at((h256)i.data()))
 				if (++ii > 32)
 					break;
 				else
-					ret.bytecode.push_back((byte)j);
+					ret.bytecode.push_back((uint8_t)j);
 			while (ii++ < 32)
 				ret.bytecode.push_back(0);
 			break;
 		}
 		case Push:
 		{
-			byte b = max<unsigned>(1, dev::bytesRequired(i.data()));
-			ret.bytecode.push_back((byte)Instruction::PUSH1 - 1 + b);
+			uint8_t b = max<unsigned>(1, dev::bytesRequired(i.data()));
+			ret.bytecode.push_back((uint8_t)Instruction::PUSH1 - 1 + b);
 			ret.bytecode.resize(ret.bytecode.size() + b);
 			bytesRef byr(&ret.bytecode.back() + 1 - b, b);
 			toBigEndian(i.data(), byr);
@@ -589,8 +589,8 @@ LinkerObject const& Assembly::assemble() const
 		{
 			auto s = m_subs.at(size_t(i.data()))->assemble().bytecode.size();
 			i.setPushedValue(u256(s));
-			byte b = max<unsigned>(1, dev::bytesRequired(s));
-			ret.bytecode.push_back((byte)Instruction::PUSH1 - 1 + b);
+			uint8_t b = max<unsigned>(1, dev::bytesRequired(s));
+			ret.bytecode.push_back((uint8_t)Instruction::PUSH1 - 1 + b);
 			ret.bytecode.resize(ret.bytecode.size() + b);
 			bytesRef byr(&ret.bytecode.back() + 1 - b, b);
 			toBigEndian(s, byr);
@@ -604,12 +604,12 @@ LinkerObject const& Assembly::assemble() const
 			break;
 		}
 		case PushLibraryAddress:
-			ret.bytecode.push_back(byte(Instruction::PUSH20));
+			ret.bytecode.push_back(uint8_t(Instruction::PUSH20));
 			ret.linkReferences[ret.bytecode.size()] = m_libraries.at(i.data());
 			ret.bytecode.resize(ret.bytecode.size() + 20);
 			break;
 		case PushDeployTimeAddress:
-			ret.bytecode.push_back(byte(Instruction::PUSH20));
+			ret.bytecode.push_back(uint8_t(Instruction::PUSH20));
 			ret.bytecode.resize(ret.bytecode.size() + 20);
 			break;
 		case Tag:
@@ -618,7 +618,7 @@ LinkerObject const& Assembly::assemble() const
 			assertThrow(ret.bytecode.size() < 0xffffffffL, AssemblyException, "Tag too large.");
 			assertThrow(m_tagPositionsInBytecode[size_t(i.data())] == size_t(-1), AssemblyException, "Duplicate tag position.");
 			m_tagPositionsInBytecode[size_t(i.data())] = ret.bytecode.size();
-			ret.bytecode.push_back((byte)Instruction::JUMPDEST);
+			ret.bytecode.push_back((uint8_t)Instruction::JUMPDEST);
 			break;
 		default:
 			BOOST_THROW_EXCEPTION(InvalidOpcode());
@@ -627,7 +627,7 @@ LinkerObject const& Assembly::assemble() const
 
 	if (!m_subs.empty() || !m_data.empty() || !m_auxiliaryData.empty())
 		// Append an INVALID here to help tests find miscompilation.
-		ret.bytecode.push_back(byte(Instruction::INVALID));
+		ret.bytecode.push_back(uint8_t(Instruction::INVALID));
 
 	for (size_t i = 0; i < m_subs.size(); ++i)
 	{

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -69,7 +69,7 @@ public:
 		m_location(_location)
 	{
 		if (m_type == Operation)
-			m_instruction = Instruction(byte(_data));
+			m_instruction = Instruction(uint8_t(_data));
 		else
 			m_data = std::make_shared<u256>(_data);
 	}

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -228,25 +228,25 @@ inline bool isLogInstruction(Instruction _inst)
 /// @returns the number of PUSH Instruction _inst
 inline unsigned getPushNumber(Instruction _inst)
 {
-	return (byte)_inst - unsigned(Instruction::PUSH1) + 1;
+	return (uint8_t)_inst - unsigned(Instruction::PUSH1) + 1;
 }
 
 /// @returns the number of DUP Instruction _inst
 inline unsigned getDupNumber(Instruction _inst)
 {
-	return (byte)_inst - unsigned(Instruction::DUP1) + 1;
+	return (uint8_t)_inst - unsigned(Instruction::DUP1) + 1;
 }
 
 /// @returns the number of SWAP Instruction _inst
 inline unsigned getSwapNumber(Instruction _inst)
 {
-	return (byte)_inst - unsigned(Instruction::SWAP1) + 1;
+	return (uint8_t)_inst - unsigned(Instruction::SWAP1) + 1;
 }
 
 /// @returns the number of LOG Instruction _inst
 inline unsigned getLogNumber(Instruction _inst)
 {
-	return (byte)_inst - unsigned(Instruction::LOG0);
+	return (uint8_t)_inst - unsigned(Instruction::LOG0);
 }
 
 /// @returns the PUSH<_number> instruction

--- a/libevmasm/SimplificationRules.cpp
+++ b/libevmasm/SimplificationRules.cpp
@@ -48,7 +48,7 @@ SimplificationRule<Pattern> const* Rules::findFirstMatch(
 	resetMatchGroups();
 
 	assertThrow(_expr.item, OptimizerException, "");
-	for (auto const& rule: m_rules[byte(_expr.item->instruction())])
+	for (auto const& rule: m_rules[uint8_t(_expr.item->instruction())])
 	{
 		if (rule.pattern.matches(_expr, _classes))
 			return &rule;
@@ -59,7 +59,7 @@ SimplificationRule<Pattern> const* Rules::findFirstMatch(
 
 bool Rules::isInitialized() const
 {
-	return !m_rules[byte(Instruction::ADD)].empty();
+	return !m_rules[uint8_t(Instruction::ADD)].empty();
 }
 
 void Rules::addRules(std::vector<SimplificationRule<Pattern>> const& _rules)
@@ -70,7 +70,7 @@ void Rules::addRules(std::vector<SimplificationRule<Pattern>> const& _rules)
 
 void Rules::addRule(SimplificationRule<Pattern> const& _rule)
 {
-	m_rules[byte(_rule.pattern.instruction())].push_back(_rule);
+	m_rules[uint8_t(_rule.pattern.instruction())].push_back(_rule);
 }
 
 Rules::Rules()

--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -348,7 +348,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 				else if (i.which() == sp::utree_type::string_type)
 				{
 					auto sr = i.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>();
-					data.insert(data.end(), (byte const *)sr.begin(), (byte const*)sr.end());
+					data.insert(data.end(), (uint8_t const *)sr.begin(), (uint8_t const*)sr.end());
 				}
 				else if (i.which() == sp::utree_type::any_type)
 				{

--- a/libsolidity/interface/Version.cpp
+++ b/libsolidity/interface/Version.cpp
@@ -55,13 +55,13 @@ bytes dev::solidity::binaryVersion()
 			ret = ret * 10 + (VersionString[i] - '0');
 		return ret;
 	};
-	ret.push_back(byte(parseDecimal()));
+	ret.push_back(uint8_t(parseDecimal()));
 	solAssert(i < VersionString.size() && VersionString[i] == '.', "");
 	++i;
-	ret.push_back(byte(parseDecimal()));
+	ret.push_back(uint8_t(parseDecimal()));
 	solAssert(i < VersionString.size() && VersionString[i] == '.', "");
 	++i;
-	ret.push_back(byte(parseDecimal()));
+	ret.push_back(uint8_t(parseDecimal()));
 	solAssert(i < VersionString.size() && (VersionString[i] == '-' || VersionString[i] == '+'), "");
 	++i;
 	size_t commitpos = VersionString.find("commit.");

--- a/libyul/backends/evm/EVMAssembly.cpp
+++ b/libyul/backends/evm/EVMAssembly.cpp
@@ -44,7 +44,7 @@ void EVMAssembly::setSourceLocation(SourceLocation const&)
 
 void EVMAssembly::appendInstruction(solidity::Instruction _instr)
 {
-	m_bytecode.push_back(byte(_instr));
+	m_bytecode.push_back(uint8_t(_instr));
 	m_stackHeight += solidity::instructionInfo(_instr).ret - solidity::instructionInfo(_instr).args;
 }
 
@@ -101,7 +101,7 @@ void EVMAssembly::appendJumpTo(LabelID _labelId, int _stackDiffAfter)
 {
 	if (m_evm15)
 	{
-		m_bytecode.push_back(byte(solidity::Instruction::JUMPTO));
+		m_bytecode.push_back(uint8_t(solidity::Instruction::JUMPTO));
 		appendLabelReferenceInternal(_labelId);
 		m_stackHeight += _stackDiffAfter;
 	}
@@ -116,7 +116,7 @@ void EVMAssembly::appendJumpToIf(LabelID _labelId)
 {
 	if (m_evm15)
 	{
-		m_bytecode.push_back(byte(solidity::Instruction::JUMPIF));
+		m_bytecode.push_back(uint8_t(solidity::Instruction::JUMPIF));
 		appendLabelReferenceInternal(_labelId);
 		m_stackHeight--;
 	}
@@ -132,7 +132,7 @@ void EVMAssembly::appendBeginsub(LabelID _labelId, int _arguments)
 	solAssert(m_evm15, "BEGINSUB used for EVM 1.0");
 	solAssert(_arguments >= 0, "");
 	setLabelToCurrentPosition(_labelId);
-	m_bytecode.push_back(byte(solidity::Instruction::BEGINSUB));
+	m_bytecode.push_back(uint8_t(solidity::Instruction::BEGINSUB));
 	m_stackHeight += _arguments;
 }
 
@@ -140,7 +140,7 @@ void EVMAssembly::appendJumpsub(LabelID _labelId, int _arguments, int _returns)
 {
 	solAssert(m_evm15, "JUMPSUB used for EVM 1.0");
 	solAssert(_arguments >= 0 && _returns >= 0, "");
-	m_bytecode.push_back(byte(solidity::Instruction::JUMPSUB));
+	m_bytecode.push_back(uint8_t(solidity::Instruction::JUMPSUB));
 	appendLabelReferenceInternal(_labelId);
 	m_stackHeight += _returns - _arguments;
 }
@@ -149,7 +149,7 @@ void EVMAssembly::appendReturnsub(int _returns, int _stackDiffAfter)
 {
 	solAssert(m_evm15, "RETURNSUB used for EVM 1.0");
 	solAssert(_returns >= 0, "");
-	m_bytecode.push_back(byte(solidity::Instruction::RETURNSUB));
+	m_bytecode.push_back(uint8_t(solidity::Instruction::RETURNSUB));
 	m_stackHeight += _stackDiffAfter - _returns;
 }
 
@@ -198,5 +198,5 @@ void EVMAssembly::updateReference(size_t pos, size_t size, u256 value)
 	solAssert(m_bytecode.size() >= size && pos <= m_bytecode.size() - size, "");
 	solAssert(value < (u256(1) << (8 * size)), "");
 	for (size_t i = 0; i < size; i++)
-		m_bytecode[pos + i] = byte((value >> (8 * (size - i - 1))) & 0xff);
+		m_bytecode[pos + i] = uint8_t((value >> (8 * (size - i - 1))) & 0xff);
 }

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -46,7 +46,7 @@ SimplificationRule<Pattern> const* SimplificationRules::findFirstMatch(
 	assertThrow(rules.isInitialized(), OptimizerException, "Rule list not properly initialized.");
 
 	FunctionalInstruction const& instruction = boost::get<FunctionalInstruction>(_expr);
-	for (auto const& rule: rules.m_rules[byte(instruction.instruction)])
+	for (auto const& rule: rules.m_rules[uint8_t(instruction.instruction)])
 	{
 		rules.resetMatchGroups();
 		if (rule.pattern.matches(_expr, _ssaValues))
@@ -57,7 +57,7 @@ SimplificationRule<Pattern> const* SimplificationRules::findFirstMatch(
 
 bool SimplificationRules::isInitialized() const
 {
-	return !m_rules[byte(solidity::Instruction::ADD)].empty();
+	return !m_rules[uint8_t(solidity::Instruction::ADD)].empty();
 }
 
 void SimplificationRules::addRules(vector<SimplificationRule<Pattern>> const& _rules)
@@ -68,7 +68,7 @@ void SimplificationRules::addRules(vector<SimplificationRule<Pattern>> const& _r
 
 void SimplificationRules::addRule(SimplificationRule<Pattern> const& _rule)
 {
-	m_rules[byte(_rule.pattern.instruction())].push_back(_rule);
+	m_rules[uint8_t(_rule.pattern.instruction())].push_back(_rule);
 }
 
 SimplificationRules::SimplificationRules()

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -147,11 +147,11 @@ public:
 
 	static std::pair<bool, std::string> compareAndCreateMessage(bytes const& _result, bytes const& _expectation);
 
-	static bytes encode(bool _value) { return encode(byte(_value)); }
+	static bytes encode(bool _value) { return encode(uint8_t(_value)); }
 	static bytes encode(int _value) { return encode(u256(_value)); }
 	static bytes encode(size_t _value) { return encode(u256(_value)); }
 	static bytes encode(char const* _value) { return encode(std::string(_value)); }
-	static bytes encode(byte _value) { return bytes(31, 0) + bytes{_value}; }
+	static bytes encode(uint8_t _value) { return bytes(31, 0) + bytes{_value}; }
 	static bytes encode(u256 const& _value) { return toBigEndian(_value); }
 	/// @returns the fixed-point encoding of a rational number with a given
 	/// number of fractional bits.

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -1259,14 +1259,14 @@ BOOST_AUTO_TEST_CASE(state_smoke_test)
 		}
 	)";
 	compileAndRun(sourceCode);
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x00)), encodeArgs(0));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x01)), encodeArgs(0));
-	ABI_CHECK(callContractFunction("set(uint8,uint256)", byte(0x00), 0x1234), encodeArgs());
-	ABI_CHECK(callContractFunction("set(uint8,uint256)", byte(0x01), 0x8765), encodeArgs());
-	ABI_CHECK(callContractFunction("get(uint8)", byte( 0x00)), encodeArgs(0x1234));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x01)), encodeArgs(0x8765));
-	ABI_CHECK(callContractFunction("set(uint8,uint256)", byte(0x00), 0x3), encodeArgs());
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x00)), encodeArgs(0x3));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x00)), encodeArgs(0));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x01)), encodeArgs(0));
+	ABI_CHECK(callContractFunction("set(uint8,uint256)", uint8_t(0x00), 0x1234), encodeArgs());
+	ABI_CHECK(callContractFunction("set(uint8,uint256)", uint8_t(0x01), 0x8765), encodeArgs());
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t( 0x00)), encodeArgs(0x1234));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x01)), encodeArgs(0x8765));
+	ABI_CHECK(callContractFunction("set(uint8,uint256)", uint8_t(0x00), 0x3), encodeArgs());
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x00)), encodeArgs(0x3));
 }
 
 BOOST_AUTO_TEST_CASE(compound_assign)
@@ -1321,21 +1321,21 @@ BOOST_AUTO_TEST_CASE(simple_mapping)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0)), encodeArgs(byte(0x00)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x01)), encodeArgs(byte(0x00)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0xa7)), encodeArgs(byte(0x00)));
-	callContractFunction("set(uint8,uint8)", byte(0x01), byte(0xa1));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x00)), encodeArgs(byte(0x00)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x01)), encodeArgs(byte(0xa1)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0xa7)), encodeArgs(byte(0x00)));
-	callContractFunction("set(uint8,uint8)", byte(0x00), byte(0xef));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x00)), encodeArgs(byte(0xef)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x01)), encodeArgs(byte(0xa1)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0xa7)), encodeArgs(byte(0x00)));
-	callContractFunction("set(uint8,uint8)", byte(0x01), byte(0x05));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x00)), encodeArgs(byte(0xef)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0x01)), encodeArgs(byte(0x05)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(0xa7)), encodeArgs(byte(0x00)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0)), encodeArgs(uint8_t(0x00)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x01)), encodeArgs(uint8_t(0x00)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0xa7)), encodeArgs(uint8_t(0x00)));
+	callContractFunction("set(uint8,uint8)", uint8_t(0x01), uint8_t(0xa1));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x00)), encodeArgs(uint8_t(0x00)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x01)), encodeArgs(uint8_t(0xa1)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0xa7)), encodeArgs(uint8_t(0x00)));
+	callContractFunction("set(uint8,uint8)", uint8_t(0x00), uint8_t(0xef));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x00)), encodeArgs(uint8_t(0xef)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x01)), encodeArgs(uint8_t(0xa1)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0xa7)), encodeArgs(uint8_t(0x00)));
+	callContractFunction("set(uint8,uint8)", uint8_t(0x01), uint8_t(0x05));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x00)), encodeArgs(uint8_t(0xef)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0x01)), encodeArgs(uint8_t(0x05)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(0xa7)), encodeArgs(uint8_t(0x00)));
 }
 
 BOOST_AUTO_TEST_CASE(mapping_state)
@@ -1496,7 +1496,7 @@ BOOST_AUTO_TEST_CASE(mapping_local_assignment)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("f()"), encodeArgs(byte(42), byte(0), byte(0), byte(21)));
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(uint8_t(42), uint8_t(0), uint8_t(0), uint8_t(21)));
 }
 
 BOOST_AUTO_TEST_CASE(mapping_local_tuple_assignment)
@@ -1519,7 +1519,7 @@ BOOST_AUTO_TEST_CASE(mapping_local_tuple_assignment)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("f()"), encodeArgs(byte(42), byte(0), byte(0), byte(21)));
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(uint8_t(42), uint8_t(0), uint8_t(0), uint8_t(21)));
 }
 
 BOOST_AUTO_TEST_CASE(mapping_local_compound_assignment)
@@ -1540,7 +1540,7 @@ BOOST_AUTO_TEST_CASE(mapping_local_compound_assignment)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("f()"), encodeArgs(byte(42), byte(0), byte(0), byte(21)));
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(uint8_t(42), uint8_t(0), uint8_t(0), uint8_t(21)));
 }
 
 BOOST_AUTO_TEST_CASE(mapping_internal_argument)
@@ -1565,10 +1565,10 @@ BOOST_AUTO_TEST_CASE(mapping_internal_argument)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8)", byte(1), byte(21), byte(42)), encodeArgs(byte(0), byte(0)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(1)), encodeArgs(byte(21), byte(42)));
-	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8)", byte(1), byte(10), byte(11)), encodeArgs(byte(21), byte(42)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(1)), encodeArgs(byte(10), byte(11)));
+	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8)", uint8_t(1), uint8_t(21), uint8_t(42)), encodeArgs(uint8_t(0), uint8_t(0)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(1)), encodeArgs(uint8_t(21), uint8_t(42)));
+	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8)", uint8_t(1), uint8_t(10), uint8_t(11)), encodeArgs(uint8_t(21), uint8_t(42)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(1)), encodeArgs(uint8_t(10), uint8_t(11)));
 }
 
 BOOST_AUTO_TEST_CASE(mapping_array_internal_argument)
@@ -1595,10 +1595,10 @@ BOOST_AUTO_TEST_CASE(mapping_array_internal_argument)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8,uint8,uint8)", byte(1), byte(21), byte(22), byte(42), byte(43)), encodeArgs(byte(0), byte(0), byte(0), byte(0)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(1)), encodeArgs(byte(21), byte(22), byte(42), byte(43)));
-	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8,uint8,uint8)", byte(1), byte(10), byte(30), byte(11), byte(31)), encodeArgs(byte(21), byte(22), byte(42), byte(43)));
-	ABI_CHECK(callContractFunction("get(uint8)", byte(1)), encodeArgs(byte(10), byte(30), byte(11), byte(31)));
+	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8,uint8,uint8)", uint8_t(1), uint8_t(21), uint8_t(22), uint8_t(42), uint8_t(43)), encodeArgs(uint8_t(0), uint8_t(0), uint8_t(0), uint8_t(0)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(1)), encodeArgs(uint8_t(21), uint8_t(22), uint8_t(42), uint8_t(43)));
+	ABI_CHECK(callContractFunction("set(uint8,uint8,uint8,uint8,uint8)", uint8_t(1), uint8_t(10), uint8_t(30), uint8_t(11), uint8_t(31)), encodeArgs(uint8_t(21), uint8_t(22), uint8_t(42), uint8_t(43)));
+	ABI_CHECK(callContractFunction("get(uint8)", uint8_t(1)), encodeArgs(uint8_t(10), uint8_t(30), uint8_t(11), uint8_t(31)));
 }
 
 BOOST_AUTO_TEST_CASE(mapping_internal_return)
@@ -1626,8 +1626,8 @@ BOOST_AUTO_TEST_CASE(mapping_internal_return)
 	)";
 	compileAndRun(sourceCode);
 
-	ABI_CHECK(callContractFunction("g()"), encodeArgs(byte(0), byte(42), byte(0), byte(0), byte(84), byte (21)));
-	ABI_CHECK(callContractFunction("h()"), encodeArgs(byte(0), byte(42), byte(0), byte(0), byte(84), byte (17)));
+	ABI_CHECK(callContractFunction("g()"), encodeArgs(uint8_t(0), uint8_t(42), uint8_t(0), uint8_t(0), uint8_t(84), uint8_t (21)));
+	ABI_CHECK(callContractFunction("h()"), encodeArgs(uint8_t(0), uint8_t(42), uint8_t(0), uint8_t(0), uint8_t(84), uint8_t (17)));
 }
 
 BOOST_AUTO_TEST_CASE(structs)
@@ -1819,7 +1819,7 @@ BOOST_AUTO_TEST_CASE(constructor)
 		}
 	)";
 	compileAndRun(sourceCode);
-	map<u256, byte> data;
+	map<u256, uint8_t> data;
 	data[7] = 8;
 	auto get = [&](u256 const& _x) -> u256
 	{
@@ -2624,7 +2624,7 @@ BOOST_AUTO_TEST_CASE(ecrecover)
 	)";
 	compileAndRun(sourceCode);
 	u256 h("0x18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c");
-	byte v = 28;
+	uint8_t v = 28;
 	u256 r("0x73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75f");
 	u256 s("0xeeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549");
 	u160 addr("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b");

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(literal_true)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH1), 0x1});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x1});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(literal_false)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH1), 0x0});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x0});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(int_literal)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH10), 0x12, 0x34, 0x56, 0x78, 0x90,
+	bytes expectation({uint8_t(Instruction::PUSH10), 0x12, 0x34, 0x56, 0x78, 0x90,
 													   0x12, 0x34, 0x56, 0x78, 0x90});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(int_with_wei_ether_subdenomination)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH1), 0x1});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x1});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(int_with_szabo_ether_subdenomination)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH5), 0xe8, 0xd4, 0xa5, 0x10, 0x00});
+	bytes expectation({uint8_t(Instruction::PUSH5), 0xe8, 0xd4, 0xa5, 0x10, 0x00});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(int_with_finney_ether_subdenomination)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH7), 0x3, 0x8d, 0x7e, 0xa4, 0xc6, 0x80, 0x00});
+	bytes expectation({uint8_t(Instruction::PUSH7), 0x3, 0x8d, 0x7e, 0xa4, 0xc6, 0x80, 0x00});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(int_with_ether_ether_subdenomination)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH8), 0xd, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00});
+	bytes expectation({uint8_t(Instruction::PUSH8), 0xd, 0xe0, 0xb6, 0xb3, 0xa7, 0x64, 0x00, 0x00});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -281,12 +281,12 @@ BOOST_AUTO_TEST_CASE(comparison)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH1), 0x1, byte(Instruction::ISZERO), byte(Instruction::ISZERO),
-					   byte(Instruction::PUSH2), 0x11, 0xaa,
-					   byte(Instruction::PUSH2), 0x10, 0xaa,
-					   byte(Instruction::LT), byte(Instruction::ISZERO), byte(Instruction::ISZERO),
-					   byte(Instruction::EQ),
-					   byte(Instruction::ISZERO)});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x1, uint8_t(Instruction::ISZERO), uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::PUSH2), 0x11, 0xaa,
+					   uint8_t(Instruction::PUSH2), 0x10, 0xaa,
+					   uint8_t(Instruction::LT), uint8_t(Instruction::ISZERO), uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::EQ),
+					   uint8_t(Instruction::ISZERO)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -299,23 +299,23 @@ BOOST_AUTO_TEST_CASE(short_circuiting)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation({byte(Instruction::PUSH1), 0x12, // 8 + 10
-					   byte(Instruction::PUSH1), 0x4,
-					   byte(Instruction::GT),
-					   byte(Instruction::ISZERO), // after this we have 4 <= 8 + 10
-					   byte(Instruction::DUP1),
-					   byte(Instruction::PUSH1), 0x11,
-					   byte(Instruction::JUMPI), // short-circuit if it is true
-					   byte(Instruction::POP),
-					   byte(Instruction::PUSH1), 0x2,
-					   byte(Instruction::PUSH1), 0x9,
-					   byte(Instruction::EQ),
-					   byte(Instruction::ISZERO), // after this we have 9 != 2
-					   byte(Instruction::JUMPDEST),
-					   byte(Instruction::ISZERO), byte(Instruction::ISZERO),
-					   byte(Instruction::PUSH1), 0x1, byte(Instruction::ISZERO), byte(Instruction::ISZERO),
-					   byte(Instruction::EQ),
-					   byte(Instruction::ISZERO)});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x12, // 8 + 10
+					   uint8_t(Instruction::PUSH1), 0x4,
+					   uint8_t(Instruction::GT),
+					   uint8_t(Instruction::ISZERO), // after this we have 4 <= 8 + 10
+					   uint8_t(Instruction::DUP1),
+					   uint8_t(Instruction::PUSH1), 0x11,
+					   uint8_t(Instruction::JUMPI), // short-circuit if it is true
+					   uint8_t(Instruction::POP),
+					   uint8_t(Instruction::PUSH1), 0x2,
+					   uint8_t(Instruction::PUSH1), 0x9,
+					   uint8_t(Instruction::EQ),
+					   uint8_t(Instruction::ISZERO), // after this we have 9 != 2
+					   uint8_t(Instruction::JUMPDEST),
+					   uint8_t(Instruction::ISZERO), uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::PUSH1), 0x1, uint8_t(Instruction::ISZERO), uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::EQ),
+					   uint8_t(Instruction::ISZERO)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -327,37 +327,37 @@ BOOST_AUTO_TEST_CASE(arithmetic)
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}});
-	bytes expectation({byte(Instruction::PUSH1), 0x1,
-					   byte(Instruction::PUSH1), 0x2,
-					   byte(Instruction::PUSH1), 0x3,
-					   byte(Instruction::PUSH1), 0x4,
-					   byte(Instruction::PUSH1), 0x5,
-					   byte(Instruction::PUSH1), 0x6,
-					   byte(Instruction::PUSH1), 0x7,
-					   byte(Instruction::PUSH1), 0x8,
-					   byte(Instruction::DUP9),
-					   byte(Instruction::XOR),
-					   byte(Instruction::AND),
-					   byte(Instruction::OR),
-					   byte(Instruction::SUB),
-					   byte(Instruction::ADD),
-					   byte(Instruction::DUP2),
-					   byte(Instruction::ISZERO),
-					   byte(Instruction::ISZERO),
-					   byte(Instruction::PUSH1), 0x1d,
-					   byte(Instruction::JUMPI),
-					   byte(Instruction::INVALID),
-					   byte(Instruction::JUMPDEST),
-					   byte(Instruction::MOD),
-					   byte(Instruction::DUP2),
-					   byte(Instruction::ISZERO),
-					   byte(Instruction::ISZERO),
-					   byte(Instruction::PUSH1), 0x26,
-					   byte(Instruction::JUMPI),
-					   byte(Instruction::INVALID),
-					   byte(Instruction::JUMPDEST),
-					   byte(Instruction::DIV),
-					   byte(Instruction::MUL)});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x1,
+					   uint8_t(Instruction::PUSH1), 0x2,
+					   uint8_t(Instruction::PUSH1), 0x3,
+					   uint8_t(Instruction::PUSH1), 0x4,
+					   uint8_t(Instruction::PUSH1), 0x5,
+					   uint8_t(Instruction::PUSH1), 0x6,
+					   uint8_t(Instruction::PUSH1), 0x7,
+					   uint8_t(Instruction::PUSH1), 0x8,
+					   uint8_t(Instruction::DUP9),
+					   uint8_t(Instruction::XOR),
+					   uint8_t(Instruction::AND),
+					   uint8_t(Instruction::OR),
+					   uint8_t(Instruction::SUB),
+					   uint8_t(Instruction::ADD),
+					   uint8_t(Instruction::DUP2),
+					   uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::PUSH1), 0x1d,
+					   uint8_t(Instruction::JUMPI),
+					   uint8_t(Instruction::INVALID),
+					   uint8_t(Instruction::JUMPDEST),
+					   uint8_t(Instruction::MOD),
+					   uint8_t(Instruction::DUP2),
+					   uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::ISZERO),
+					   uint8_t(Instruction::PUSH1), 0x26,
+					   uint8_t(Instruction::JUMPI),
+					   uint8_t(Instruction::INVALID),
+					   uint8_t(Instruction::JUMPDEST),
+					   uint8_t(Instruction::DIV),
+					   uint8_t(Instruction::MUL)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -370,13 +370,13 @@ BOOST_AUTO_TEST_CASE(unary_operators)
 	)";
 	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}});
 
-	bytes expectation({byte(Instruction::PUSH1), 0x2,
-					   byte(Instruction::DUP2),
-					   byte(Instruction::PUSH1), 0x0,
-					   byte(Instruction::SUB),
-					   byte(Instruction::NOT),
-					   byte(Instruction::EQ),
-					   byte(Instruction::ISZERO)});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x2,
+					   uint8_t(Instruction::DUP2),
+					   uint8_t(Instruction::PUSH1), 0x0,
+					   uint8_t(Instruction::SUB),
+					   uint8_t(Instruction::NOT),
+					   uint8_t(Instruction::EQ),
+					   uint8_t(Instruction::ISZERO)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -390,47 +390,47 @@ BOOST_AUTO_TEST_CASE(unary_inc_dec)
 	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "a"}, {"test", "f", "x"}});
 
 	// Stack: a, x
-	bytes expectation({byte(Instruction::DUP2),
-					   byte(Instruction::DUP1),
-					   byte(Instruction::PUSH1), 0x1,
-					   byte(Instruction::ADD),
+	bytes expectation({uint8_t(Instruction::DUP2),
+					   uint8_t(Instruction::DUP1),
+					   uint8_t(Instruction::PUSH1), 0x1,
+					   uint8_t(Instruction::ADD),
 					   // Stack here: a x a (a+1)
-					   byte(Instruction::SWAP3),
-					   byte(Instruction::POP), // first ++
+					   uint8_t(Instruction::SWAP3),
+					   uint8_t(Instruction::POP), // first ++
 					   // Stack here: (a+1) x a
-					   byte(Instruction::DUP3),
-					   byte(Instruction::PUSH1), 0x1,
-					   byte(Instruction::ADD),
+					   uint8_t(Instruction::DUP3),
+					   uint8_t(Instruction::PUSH1), 0x1,
+					   uint8_t(Instruction::ADD),
 					   // Stack here: (a+1) x a (a+2)
-					   byte(Instruction::SWAP3),
-					   byte(Instruction::POP),
+					   uint8_t(Instruction::SWAP3),
+					   uint8_t(Instruction::POP),
 					   // Stack here: (a+2) x a
-					   byte(Instruction::DUP3), // second ++
-					   byte(Instruction::XOR),
+					   uint8_t(Instruction::DUP3), // second ++
+					   uint8_t(Instruction::XOR),
 					   // Stack here: (a+2) x a^(a+2)
-					   byte(Instruction::DUP3),
-					   byte(Instruction::DUP1),
-					   byte(Instruction::PUSH1), 0x1,
-					   byte(Instruction::SWAP1),
-					   byte(Instruction::SUB),
+					   uint8_t(Instruction::DUP3),
+					   uint8_t(Instruction::DUP1),
+					   uint8_t(Instruction::PUSH1), 0x1,
+					   uint8_t(Instruction::SWAP1),
+					   uint8_t(Instruction::SUB),
 					   // Stack here: (a+2) x a^(a+2) (a+2) (a+1)
-					   byte(Instruction::SWAP4),
-					   byte(Instruction::POP), // first --
-					   byte(Instruction::XOR),
+					   uint8_t(Instruction::SWAP4),
+					   uint8_t(Instruction::POP), // first --
+					   uint8_t(Instruction::XOR),
 					   // Stack here: (a+1) x a^(a+2)^(a+2)
-					   byte(Instruction::DUP3),
-					   byte(Instruction::PUSH1), 0x1,
-					   byte(Instruction::SWAP1),
-					   byte(Instruction::SUB),
+					   uint8_t(Instruction::DUP3),
+					   uint8_t(Instruction::PUSH1), 0x1,
+					   uint8_t(Instruction::SWAP1),
+					   uint8_t(Instruction::SUB),
 					   // Stack here: (a+1) x a^(a+2)^(a+2) a
-					   byte(Instruction::SWAP3),
-					   byte(Instruction::POP), // second ++
+					   uint8_t(Instruction::SWAP3),
+					   uint8_t(Instruction::POP), // second ++
 					   // Stack here: a x a^(a+2)^(a+2)
-					   byte(Instruction::DUP3), // will change
-					   byte(Instruction::XOR),
-					   byte(Instruction::SWAP1),
-					   byte(Instruction::POP),
-					   byte(Instruction::DUP1)});
+					   uint8_t(Instruction::DUP3), // will change
+					   uint8_t(Instruction::XOR),
+					   uint8_t(Instruction::SWAP1),
+					   uint8_t(Instruction::POP),
+					   uint8_t(Instruction::DUP1)});
 					   // Stack here: a x a^(a+2)^(a+2)^a
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
@@ -445,16 +445,16 @@ BOOST_AUTO_TEST_CASE(assignment)
 	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "a"}, {"test", "f", "b"}});
 
 	// Stack: a, b
-	bytes expectation({byte(Instruction::PUSH1), 0x2,
-					   byte(Instruction::DUP2),
-					   byte(Instruction::DUP4),
-					   byte(Instruction::ADD),
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x2,
+					   uint8_t(Instruction::DUP2),
+					   uint8_t(Instruction::DUP4),
+					   uint8_t(Instruction::ADD),
 					   // Stack here: a b 2 a+b
-					   byte(Instruction::SWAP3),
-					   byte(Instruction::POP),
-					   byte(Instruction::DUP3),
+					   uint8_t(Instruction::SWAP3),
+					   uint8_t(Instruction::POP),
+					   uint8_t(Instruction::DUP3),
 					   // Stack here: a+b b 2 a+b
-					   byte(Instruction::MUL)});
+					   uint8_t(Instruction::MUL)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(negative_literals_8bits)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation(bytes({byte(Instruction::PUSH32)}) + bytes(31, 0xff) + bytes(1, 0x80));
+	bytes expectation(bytes({uint8_t(Instruction::PUSH32)}) + bytes(31, 0xff) + bytes(1, 0x80));
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(negative_literals_16bits)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation(bytes({byte(Instruction::PUSH32)}) + bytes(30, 0xff) + bytes{0xf5, 0x43});
+	bytes expectation(bytes({uint8_t(Instruction::PUSH32)}) + bytes(30, 0xff) + bytes{0xf5, 0x43});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -495,7 +495,7 @@ BOOST_AUTO_TEST_CASE(intermediately_overflowing_literals)
 	)";
 	bytes code = compileFirstExpression(sourceCode);
 
-	bytes expectation(bytes({byte(Instruction::PUSH1), 0xbf}));
+	bytes expectation(bytes({uint8_t(Instruction::PUSH1), 0xbf}));
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -514,8 +514,8 @@ BOOST_AUTO_TEST_CASE(blockhash)
 
 	bytes code = compileFirstExpression(sourceCode, {}, {}, {make_shared<MagicVariableDeclaration>("blockhash", blockhashFun)});
 
-	bytes expectation({byte(Instruction::PUSH1), 0x03,
-					   byte(Instruction::BLOCKHASH)});
+	bytes expectation({uint8_t(Instruction::PUSH1), 0x03,
+					   uint8_t(Instruction::BLOCKHASH)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 
@@ -533,7 +533,7 @@ BOOST_AUTO_TEST_CASE(gas_left)
 		{make_shared<MagicVariableDeclaration>("gasleft", make_shared<FunctionType>(strings(), strings{"uint256"}, FunctionType::Kind::GasLeft))}
 	);
 
-	bytes expectation = bytes({byte(Instruction::GAS)});
+	bytes expectation = bytes({uint8_t(Instruction::GAS)});
 	BOOST_CHECK_EQUAL_COLLECTIONS(code.begin(), code.end(), expectation.begin(), expectation.end());
 }
 


### PR DESCRIPTION
Closes #5357 

    Eliminate `byte`-typedef and use `uint8_t` in all their places instead.

    This change is made to (easily) be forward compatible with future C++
    standards, in order to allow compiling the code with newer standards at
    some point in the future.

    * Removed the global namespace's `using byte = uint8_t;` line from Common.h
    * Mechanically change all uses of `byte` to `uint8_t`.

    Tested with GCC 7.3 in C++11/14/17 modes :-)
