### PR TITLE
Fix cmake Z3 import issue for Fedora like distributions

### DIFF
--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -1,5 +1,5 @@
 if (USE_Z3)
-    find_path(Z3_INCLUDE_DIR z3++.h)
+    find_path(Z3_INCLUDE_DIR NAMES z3++.h PATH_SUFFIXES z3)
     find_library(Z3_LIBRARY NAMES z3 )
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(Z3 DEFAULT_MSG Z3_LIBRARY Z3_INCLUDE_DIR)


### PR DESCRIPTION
### Description

Fixes a Z3 detection problem when trying to compile with Z3 activated. Z3 is stored in `/usr/include/z3` in some distributions (like Fedora). Other distributions like Ubuntu directly store it in `/usr/include`.

The previous cmake FindZ3 script does not find Z3 that way on distributions like Fedora, even though it is installed correctly. This update includes searching for Z3 also in the `z3` subfolder.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
