### PR TITLE
Add archlinux run on circleci for testing against current versions of deps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ jobs:
       TERM: xterm
       CC: /usr/bin/clang-7
       CXX: /usr/bin/clang++-7
-      IPC_ENABLED: false
     steps:
       - checkout
       - run:
@@ -291,13 +290,12 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            pacman --noconfirm -Syu --noprogressbar --needed boost python2 wget perl z3 cvc4 leveldb git openssh tar
-            ln -sf /usr/bin/core_perl/shasum /usr/bin
+            pacman --noconfirm -Syu --noprogressbar --needed boost z3 cvc4 git openssh tar
       - checkout
       - attach_workspace:
           at: build
       - run: mkdir -p test_results
-      - run: *run_tests
+      - run: build/test/soltest --logger=JUNIT,test_suite,test_results/result.xml -- --no-ipc --testpath test
       - store_test_results:
           path: test_results/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,27 @@ jobs:
           paths:
             - "*"
 
+  build_x86_archlinux:
+    docker:
+      - image: archlinux/base
+    environment:
+      TERM: xterm
+    steps:
+      - run:
+          name: Install build dependencies
+          command: |
+            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake z3 cvc4 git openssh tar
+      - checkout
+      - run: *setup_prerelease_commit_hash
+      - run: *run_build
+      - store_artifacts: *solc_artifact
+      - persist_to_workspace:
+          root: build
+          paths:
+            - solc/solc
+            - test/soltest
+            - test/tools/solfuzzer
+
   build_x86_clang7:
     docker:
       - image: buildpack-deps:cosmic
@@ -146,6 +167,7 @@ jobs:
       TERM: xterm
       CC: /usr/bin/clang-7
       CXX: /usr/bin/clang++-7
+      IPC_ENABLED: false
     steps:
       - checkout
       - run:
@@ -260,6 +282,28 @@ jobs:
           path: test_results/
           destination: test_results/
 
+  test_x86_archlinux:
+    docker:
+      - image: archlinux/base
+    environment:
+      TERM: xterm
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            pacman --noconfirm -Syu --noprogressbar --needed boost python2 wget perl z3 cvc4 leveldb git openssh tar
+            ln -sf /usr/bin/core_perl/shasum /usr/bin
+      - checkout
+      - attach_workspace:
+          at: build
+      - run: mkdir -p test_results
+      - run: *run_tests
+      - store_test_results:
+          path: test_results/
+      - store_artifacts:
+          path: test_results/
+          destination: test_results/
+
   test_x86_mac:
     macos:
       xcode: "10.0.0"
@@ -330,3 +374,8 @@ workflows:
           requires:
             - build_x86_mac
       - docs: *build_on_tags
+      - build_x86_archlinux: *build_on_tags
+      - test_x86_archlinux:
+          <<: *build_on_tags
+          requires:
+            - build_x86_archlinux


### PR DESCRIPTION
I think it makes sense to not only test on current ubuntu versions, but also to test against the (close to) most recent versions of our dependencies (i.e. mainly boost, gcc, z3, cvc4). Since Archlinux is rolling-release and provides docker images and there were several issues with build failures on Archlinux and Manjaro in the past, I think adding another test run makes sense.