### PR TITLE
Allow mapping arguments for public and external library functions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.5.1 (unreleased)
 
 Language Features:
+ * Allow mapping type for parameters and return variables of public and external library functions.
  * Allow public functions to override external functions.
 
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1873,6 +1873,8 @@ void ExpressionCompiler::appendExternalFunctionCall(
 				retSize = 0;
 				break;
 			}
+			else if (retType->decodingType())
+				retSize += retType->decodingType()->calldataEncodedSize();
 			else
 				retSize += retType->calldataEncodedSize();
 	}

--- a/test/libsolidity/syntaxTests/types/mapping/library_argument_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_argument_external.sol
@@ -3,4 +3,3 @@ library L {
     }
 }
 // ----
-// TypeError: (27-56): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_argument_public.sol
@@ -3,4 +3,3 @@ library L {
     }
 }
 // ----
-// TypeError: (27-56): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_return_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_return_external.sol
@@ -5,6 +5,3 @@ library L
     }
 }
 // ----
-// TypeError: (27-58): Type is required to live outside storage.
-// TypeError: (60-91): Type is required to live outside storage.
-// TypeError: (123-152): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/library_return_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_return_public.sol
@@ -5,6 +5,3 @@ library L
     }
 }
 // ----
-// TypeError: (27-58): Type is required to live outside storage.
-// TypeError: (60-91): Type is required to live outside storage.
-// TypeError: (121-150): Type is required to live outside storage.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_external.sol
@@ -2,5 +2,5 @@ contract c {
     function f1(mapping(uint => uint) calldata) pure external returns (mapping(uint => uint) memory) {}
 }
 // ----
-// TypeError: (29-59): Type is required to live outside storage.
-// TypeError: (29-59): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (29-59): Mapping types for parameters or return variables can only be used in internal or library functions.
+// TypeError: (84-112): Mapping types for parameters or return variables can only be used in internal or library functions.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_public.sol
@@ -2,5 +2,4 @@ contract c {
     function f3(mapping(uint => uint) memory) view public {}
 }
 // ----
-// TypeError: (29-57): Type is required to live outside storage.
-// TypeError: (29-57): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (29-57): Mapping types for parameters or return variables can only be used in internal or library functions.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_return_public_memory.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_return_public_memory.sol
@@ -3,5 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (51-79): Type is required to live outside storage.
-// TypeError: (51-79): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (51-79): Mapping types for parameters or return variables can only be used in internal or library functions.


### PR DESCRIPTION
Fixes #4635.

I may be missing something here, since the description in the issue predicts more changes to be necessary.

Also: the issue is restricted to public library functions - no reason to exclude external ones, though, is there?
Also: do we want to support *returning* mappings from public/external library functions as well? It seems like that would be more involved, but I could think of use cases for that as well (e.g. selecting a mapping from an argument that is a mapping to mappings).