### PR TITLE
[WIP] [SMTChecker] Refactor smt sorts and add Array

### DIFF
--- a/libsolidity/formal/CVC4Interface.cpp
+++ b/libsolidity/formal/CVC4Interface.cpp
@@ -33,8 +33,7 @@ CVC4Interface::CVC4Interface():
 
 void CVC4Interface::reset()
 {
-	m_constants.clear();
-	m_functions.clear();
+	m_variables.clear();
 	m_solver.reset();
 	m_solver.setOption("produce-models", true);
 	m_solver.setTimeLimit(queryTimeout);
@@ -52,17 +51,8 @@ void CVC4Interface::pop()
 
 void CVC4Interface::declareVariable(string const& _name, Sort const& _sort)
 {
-	if (!m_constants.count(_name))
-		m_constants.insert({_name, m_context.mkVar(_name.c_str(), cvc4Sort(_sort))});
-}
-
-void CVC4Interface::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
-{
-	if (!m_functions.count(_name))
-	{
-		CVC4::Type fType = m_context.mkFunctionType(cvc4Sort(_domain), cvc4Sort(_codomain));
-		m_functions.insert({_name, m_context.mkVar(_name.c_str(), fType)});
-	}
+	if (!m_variables.count(_name))
+		m_variables.insert({_name, m_context.mkVar(_name.c_str(), cvc4Sort(_sort))});
 }
 
 void CVC4Interface::addAssertion(Expression const& _expr)
@@ -123,20 +113,19 @@ pair<CheckResult, vector<string>> CVC4Interface::check(vector<Expression> const&
 
 CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 {
-	if (_expr.arguments.empty() && m_constants.count(_expr.name))
-		return m_constants.at(_expr.name);
+	// Variable
+	if (_expr.arguments.empty() && m_variables.count(_expr.name))
+		return m_variables.at(_expr.name);
+
 	vector<CVC4::Expr> arguments;
 	for (auto const& arg: _expr.arguments)
 		arguments.push_back(toCVC4Expr(arg));
 
 	string const& n = _expr.name;
-	if (m_functions.count(n))
-		return m_context.mkExpr(CVC4::kind::APPLY_UF, m_functions[n], arguments);
-	else if (m_constants.count(n))
-	{
-		solAssert(arguments.empty(), "");
-		return m_constants.at(n);
-	}
+	// Function application
+	if (!arguments.empty() && m_variables.count(_expr.name))
+		return m_context.mkExpr(CVC4::kind::APPLY_UF, m_variables.at(n), arguments);
+	// Literal
 	else if (arguments.empty())
 	{
 		if (n == "true")
@@ -181,7 +170,6 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 		return m_context.mkExpr(CVC4::kind::STORE, arguments[0], arguments[1], arguments[2]);
 	// Cannot reach here.
 	solAssert(false, "");
-	return arguments[0];
 }
 
 CVC4::Type CVC4Interface::cvc4Sort(Sort const& _sort)
@@ -194,15 +182,18 @@ CVC4::Type CVC4Interface::cvc4Sort(Sort const& _sort)
 		return m_context.integerType();
 	case Kind::Array:
 	{
-		auto const& arraySort = dynamic_cast<ArraySort const&>(_sort);
+		ArraySort const& arraySort = dynamic_cast<ArraySort const&>(_sort);
 		return m_context.mkArrayType(cvc4Sort(*arraySort.domain), cvc4Sort(*arraySort.range));
+	}
+	case Kind::Function:
+	{
+		FunctionSort const& fSort = dynamic_cast<FunctionSort const&>(_sort);
+		return m_context.mkFunctionType(cvc4Sort(fSort.domain), cvc4Sort(*fSort.codomain));
 	}
 	default:
 		break;
 	}
 	solAssert(false, "");
-	// Cannot be reached.
-	return m_context.integerType();
 }
 
 vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<SortPointer> const& _sorts)

--- a/libsolidity/formal/CVC4Interface.cpp
+++ b/libsolidity/formal/CVC4Interface.cpp
@@ -50,25 +50,19 @@ void CVC4Interface::pop()
 	m_solver.pop();
 }
 
-void CVC4Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void CVC4Interface::declareVariable(string const& _name, Sort const& _sort)
+{
+	if (!m_constants.count(_name))
+		m_constants.insert({_name, m_context.mkVar(_name.c_str(), cvc4Sort(_sort))});
+}
+
+void CVC4Interface::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	if (!m_functions.count(_name))
 	{
 		CVC4::Type fType = m_context.mkFunctionType(cvc4Sort(_domain), cvc4Sort(_codomain));
 		m_functions.insert({_name, m_context.mkVar(_name.c_str(), fType)});
 	}
-}
-
-void CVC4Interface::declareInteger(string _name)
-{
-	if (!m_constants.count(_name))
-		m_constants.insert({_name, m_context.mkVar(_name.c_str(), m_context.integerType())});
-}
-
-void CVC4Interface::declareBool(string _name)
-{
-	if (!m_constants.count(_name))
-		m_constants.insert({_name, m_context.mkVar(_name.c_str(), m_context.booleanType())});
 }
 
 void CVC4Interface::addAssertion(Expression const& _expr)
@@ -181,19 +175,28 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 		return m_context.mkExpr(CVC4::kind::MULT, arguments[0], arguments[1]);
 	else if (n == "/")
 		return m_context.mkExpr(CVC4::kind::INTS_DIVISION_TOTAL, arguments[0], arguments[1]);
+	else if (n == "select")
+		return m_context.mkExpr(CVC4::kind::SELECT, arguments[0], arguments[1]);
+	else if (n == "store")
+		return m_context.mkExpr(CVC4::kind::STORE, arguments[0], arguments[1], arguments[2]);
 	// Cannot reach here.
 	solAssert(false, "");
 	return arguments[0];
 }
 
-CVC4::Type CVC4Interface::cvc4Sort(Sort _sort)
+CVC4::Type CVC4Interface::cvc4Sort(Sort const& _sort)
 {
-	switch (_sort)
+	switch (_sort.kind)
 	{
-	case Sort::Bool:
+	case Kind::Bool:
 		return m_context.booleanType();
-	case Sort::Int:
+	case Kind::Int:
 		return m_context.integerType();
+	case Kind::Array:
+	{
+		auto const& arraySort = dynamic_cast<ArraySort const&>(_sort);
+		return m_context.mkArrayType(cvc4Sort(*arraySort.domain), cvc4Sort(*arraySort.range));
+	}
 	default:
 		break;
 	}
@@ -202,10 +205,10 @@ CVC4::Type CVC4Interface::cvc4Sort(Sort _sort)
 	return m_context.integerType();
 }
 
-vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<Sort> const& _sorts)
+vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<SortPointer> const& _sorts)
 {
 	vector<CVC4::Type> cvc4Sorts;
 	for (auto const& _sort: _sorts)
-		cvc4Sorts.push_back(cvc4Sort(_sort));
+		cvc4Sorts.push_back(cvc4Sort(*_sort));
 	return cvc4Sorts;
 }

--- a/libsolidity/formal/CVC4Interface.h
+++ b/libsolidity/formal/CVC4Interface.h
@@ -51,17 +51,16 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareVariable(std::string const&, Sort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
 	CVC4::Expr toCVC4Expr(Expression const& _expr);
-	CVC4::Type cvc4Sort(smt::Sort _sort);
-	std::vector<CVC4::Type> cvc4Sort(std::vector<smt::Sort> const& _sort);
+	CVC4::Type cvc4Sort(smt::Sort const& _sort);
+	std::vector<CVC4::Type> cvc4Sort(std::vector<SortPointer> const& _sort);
 
 	CVC4::ExprManager m_context;
 	CVC4::SmtEngine m_solver;

--- a/libsolidity/formal/CVC4Interface.h
+++ b/libsolidity/formal/CVC4Interface.h
@@ -52,7 +52,6 @@ public:
 	void pop() override;
 
 	void declareVariable(std::string const&, Sort const&) override;
-	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
@@ -64,8 +63,7 @@ private:
 
 	CVC4::ExprManager m_context;
 	CVC4::SmtEngine m_solver;
-	std::map<std::string, CVC4::Expr> m_constants;
-	std::map<std::string, CVC4::Expr> m_functions;
+	std::map<std::string, CVC4::Expr> m_variables;
 };
 
 }

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -416,7 +416,7 @@ void SMTChecker::visitGasLeft(FunctionCall const& _funCall)
 void SMTChecker::visitBlockHash(FunctionCall const& _funCall)
 {
 	string blockHash = "blockhash";
-	defineUninterpretedFunction(blockHash, {smt::Sort::Int}, smt::Sort::Int);
+	defineUninterpretedFunction(blockHash, {make_shared<smt::Sort>(smt::Kind::Int)}, make_shared<smt::Sort>(smt::Kind::Int));
 	auto const& arguments = _funCall.arguments();
 	solAssert(arguments.size() == 1, "");
 	defineExpr(_funCall, m_uninterpretedFunctions.at(blockHash)({expr(*arguments[0])}));
@@ -593,7 +593,7 @@ void SMTChecker::defineSpecialVariable(string const& _name, Expression const& _e
 	defineExpr(_expr, m_specialVariables.at(_name)->currentValue());
 }
 
-void SMTChecker::defineUninterpretedFunction(string const& _name, vector<smt::Sort> const& _domain, smt::Sort _codomain)
+void SMTChecker::defineUninterpretedFunction(string const& _name, vector<smt::SortPointer> const& _domain, smt::SortPointer _codomain)
 {
 	if (!m_uninterpretedFunctions.count(_name))
 		m_uninterpretedFunctions.emplace(_name, m_interface->newFunction(_name, _domain, _codomain));

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -81,9 +81,9 @@ private:
 	/// Visits the FunctionDefinition of the called function
 	/// if available and inlines the return value.
 	void inlineFunctionCall(FunctionCall const&);
-
+	
 	void defineSpecialVariable(std::string const& _name, Expression const& _expr, bool _increaseIndex = false);
-	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::Sort> const& _domain, smt::Sort _codomain);
+	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::SortPointer> const& _domain, smt::SortPointer _codomain);
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -192,7 +192,9 @@ private:
 	/// An Expression may have multiple smt::Expression due to
 	/// repeated calls to the same function.
 	std::unordered_map<Expression const*, std::shared_ptr<SymbolicVariable>> m_expressions;
+	/// Stores the declaration of symbolic variables of all types.
 	std::unordered_map<VariableDeclaration const*, std::shared_ptr<SymbolicVariable>> m_variables;
+	/// Stores the symbolic representation of special variables.
 	std::unordered_map<std::string, std::shared_ptr<SymbolicVariable>> m_specialVariables;
 	/// Stores the declaration of an Uninterpreted Function.
 	std::unordered_map<std::string, smt::Expression> m_uninterpretedFunctions;

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -81,9 +81,9 @@ private:
 	/// Visits the FunctionDefinition of the called function
 	/// if available and inlines the return value.
 	void inlineFunctionCall(FunctionCall const&);
-	
+
 	void defineSpecialVariable(std::string const& _name, Expression const& _expr, bool _increaseIndex = false);
-	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::SortPointer> const& _domain, smt::SortPointer _codomain);
+	void defineUninterpretedFunction(std::string const& _name, smt::SortPointer _sort);
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -152,8 +152,10 @@ private:
 
 	/// Sets the value of the declaration to zero.
 	void setZeroValue(VariableDeclaration const& _decl);
+	void setZeroValue(SymbolicVariable& _variable);
 	/// Resets the variable to an unknown value (in its range).
 	void setUnknownValue(VariableDeclaration const& decl);
+	void setUnknownValue(SymbolicVariable& _variable);
 
 	/// Returns the expression corresponding to the AST node. Throws if the expression does not exist.
 	smt::Expression expr(Expression const& _e);
@@ -197,7 +199,7 @@ private:
 	/// Stores the symbolic representation of special variables.
 	std::unordered_map<std::string, std::shared_ptr<SymbolicVariable>> m_specialVariables;
 	/// Stores the declaration of an Uninterpreted Function.
-	std::unordered_map<std::string, smt::Expression> m_uninterpretedFunctions;
+	std::unordered_map<std::string, SymbolicFunctionDeclaration> m_uninterpretedFunctions;
 	/// Stores the instances of an Uninterpreted Function applied to arguments.
 	/// Used to retrieve models.
 	std::vector<Expression const*> m_uninterpretedTerms;

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -50,14 +50,15 @@ public:
 	void pop() override;
 
 	void declareVariable(std::string const&, Sort const&) override;
-	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
+	void declareFunction(std::string const&, Sort const&);
 	std::string toSExpr(Expression const& _expr);
 	std::string toSmtLibSort(Sort _sort);
+	std::string toSmtLibSort(std::vector<SortPointer> const& _sort);
 
 	void write(std::string _data);
 
@@ -69,8 +70,7 @@ private:
 
 	ReadCallback::Callback m_queryCallback;
 	std::vector<std::string> m_accumulatedOutput;
-	std::set<std::string> m_constants;
-	std::set<std::string> m_functions;
+	std::set<std::string> m_variables;
 };
 
 }

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -49,9 +49,8 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareVariable(std::string const&, Sort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -64,22 +64,16 @@ void SMTPortfolio::pop()
 		s->pop();
 }
 
-void SMTPortfolio::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void SMTPortfolio::declareVariable(string const& _name, Sort const& _sort)
+{
+	for (auto s : m_solvers)
+		s->declareVariable(_name, _sort);
+}
+
+void SMTPortfolio::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	for (auto s : m_solvers)
 		s->declareFunction(_name, _domain, _codomain);
-}
-
-void SMTPortfolio::declareInteger(string _name)
-{
-	for (auto s : m_solvers)
-		s->declareInteger(_name);
-}
-
-void SMTPortfolio::declareBool(string _name)
-{
-	for (auto s : m_solvers)
-		s->declareBool(_name);
 }
 
 void SMTPortfolio::addAssertion(Expression const& _expr)

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -70,12 +70,6 @@ void SMTPortfolio::declareVariable(string const& _name, Sort const& _sort)
 		s->declareVariable(_name, _sort);
 }
 
-void SMTPortfolio::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
-{
-	for (auto s : m_solvers)
-		s->declareFunction(_name, _domain, _codomain);
-}
-
 void SMTPortfolio::addAssertion(Expression const& _expr)
 {
 	for (auto s : m_solvers)

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -50,7 +50,6 @@ public:
 	void pop() override;
 
 	void declareVariable(std::string const&, Sort const&) override;
-	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -49,9 +49,8 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareVariable(std::string const&, Sort const&) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -42,21 +42,45 @@ enum class CheckResult
 	SATISFIABLE, UNSATISFIABLE, UNKNOWN, CONFLICTING, ERROR
 };
 
-enum class Sort
+enum class Kind
 {
 	Int,
-	Bool
+	Bool,
+	Array
 };
+
+struct Sort
+{
+	Sort(Kind _kind):
+		kind(_kind) {}
+	virtual ~Sort() = default;
+	Kind const kind;
+	bool operator==(Sort const& _other) const { return kind == _other.kind; }
+};
+using SortPointer = std::shared_ptr<Sort>;
+
+struct ArraySort: public Sort
+{
+	ArraySort(SortPointer _domain, SortPointer _range):
+		Sort(Kind::Array), domain(std::move(_domain)), range(std::move(_range)) {}
+	SortPointer domain = nullptr;
+	SortPointer range = nullptr;
+	bool operator==(ArraySort const& _other) const
+	{
+		return Sort::operator==(_other) && *domain == *_other.domain && *range == *_other.range;
+	}
+};
+using ArraySortPointer = std::shared_ptr<ArraySort>;
 
 /// C++ representation of an SMTLIB2 expression.
 class Expression
 {
 	friend class SolverInterface;
 public:
-	explicit Expression(bool _v): name(_v ? "true" : "false"), sort(Sort::Bool) {}
-	Expression(size_t _number): name(std::to_string(_number)), sort(Sort::Int) {}
-	Expression(u256 const& _number): name(_number.str()), sort(Sort::Int) {}
-	Expression(bigint const& _number): name(_number.str()), sort(Sort::Int) {}
+	explicit Expression(bool _v): Expression(_v ? "true" : "false", Kind::Bool) {}
+	Expression(size_t _number): Expression(std::to_string(_number), Kind::Int) {}
+	Expression(u256 const& _number): Expression(_number.str(), Kind::Int) {}
+	Expression(bigint const& _number): Expression(_number.str(), Kind::Int) {}
 
 	Expression(Expression const&) = default;
 	Expression(Expression&&) = default;
@@ -78,14 +102,16 @@ public:
 			{"+", 2},
 			{"-", 2},
 			{"*", 2},
-			{"/", 2}
+			{"/", 2},
+			{"select", 2},
+			{"store", 3}
 		};
 		return operatorsArity.count(name) && operatorsArity.at(name) == arguments.size();
 	}
 
 	static Expression ite(Expression _condition, Expression _trueValue, Expression _falseValue)
 	{
-		solAssert(_trueValue.sort == _falseValue.sort, "");
+		solAssert(*_trueValue.sort == *_falseValue.sort, "");
 		return Expression("ite", std::vector<Expression>{
 			std::move(_condition), std::move(_trueValue), std::move(_falseValue)
 		}, _trueValue.sort);
@@ -96,21 +122,44 @@ public:
 		return !std::move(_a) || std::move(_b);
 	}
 
+	static Expression select(Expression _array, Expression _index)
+	{
+		solAssert(_array.sort->kind == Kind::Array, "");
+		auto const& arraySort = dynamic_cast<ArraySort const*>(_array.sort.get());
+		solAssert(arraySort, "");
+		solAssert(*arraySort->domain == *_index.sort, "");
+		return Expression("select", std::vector<Expression>{
+			std::move(_array), std::move(_index)
+		}, arraySort->range);
+	}
+
+	static Expression store(Expression _array, Expression _index, Expression _element)
+	{
+		solAssert(_array.sort->kind == Kind::Array, "");
+		auto const& arraySort = dynamic_cast<ArraySort const*>(_array.sort.get());
+		solAssert(arraySort, "");
+		solAssert(*arraySort->domain == *_index.sort, "");
+		solAssert(*arraySort->range == *_element.sort, "");
+		return Expression("store", std::vector<Expression>{
+			std::move(_array), std::move(_index), std::move(_element)
+		}, _array.sort);
+	}
+
 	friend Expression operator!(Expression _a)
 	{
-		return Expression("not", std::move(_a), Sort::Bool);
+		return Expression("not", std::move(_a), Kind::Bool);
 	}
 	friend Expression operator&&(Expression _a, Expression _b)
 	{
-		return Expression("and", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("and", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator||(Expression _a, Expression _b)
 	{
-		return Expression("or", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("or", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator==(Expression _a, Expression _b)
 	{
-		return Expression("=", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("=", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator!=(Expression _a, Expression _b)
 	{
@@ -118,35 +167,35 @@ public:
 	}
 	friend Expression operator<(Expression _a, Expression _b)
 	{
-		return Expression("<", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("<", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator<=(Expression _a, Expression _b)
 	{
-		return Expression("<=", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression("<=", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator>(Expression _a, Expression _b)
 	{
-		return Expression(">", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression(">", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator>=(Expression _a, Expression _b)
 	{
-		return Expression(">=", std::move(_a), std::move(_b), Sort::Bool);
+		return Expression(">=", std::move(_a), std::move(_b), Kind::Bool);
 	}
 	friend Expression operator+(Expression _a, Expression _b)
 	{
-		return Expression("+", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("+", std::move(_a), std::move(_b), Kind::Int);
 	}
 	friend Expression operator-(Expression _a, Expression _b)
 	{
-		return Expression("-", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("-", std::move(_a), std::move(_b), Kind::Int);
 	}
 	friend Expression operator*(Expression _a, Expression _b)
 	{
-		return Expression("*", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("*", std::move(_a), std::move(_b), Kind::Int);
 	}
 	friend Expression operator/(Expression _a, Expression _b)
 	{
-		return Expression("/", std::move(_a), std::move(_b), Sort::Int);
+		return Expression("/", std::move(_a), std::move(_b), Kind::Int);
 	}
 	Expression operator()(std::vector<Expression> _arguments) const
 	{
@@ -154,7 +203,7 @@ public:
 			arguments.empty(),
 			"Attempted function application to non-function."
 		);
-		switch (sort)
+		switch (sort->kind)
 		{
 		case Sort::Int:
 			return Expression(name, std::move(_arguments), Sort::Int);
@@ -171,19 +220,21 @@ public:
 
 	std::string name;
 	std::vector<Expression> arguments;
-	Sort sort;
+	SortPointer sort = nullptr;
 
 private:
-	/// Manual constructor, should only be used by SolverInterface and this class itself.
-	Expression(std::string _name, std::vector<Expression> _arguments, Sort _sort):
+	/// Manual constructors, should only be used by SolverInterface and this class itself.
+	Expression(std::string _name, std::vector<Expression> _arguments, SortPointer _sort):
 		name(std::move(_name)), arguments(std::move(_arguments)), sort(_sort) {}
+	Expression(std::string _name, std::vector<Expression> _arguments, Kind _kind):
+		Expression(std::move(_name), std::move(_arguments), std::make_shared<Sort>(_kind)) {}
 
-	explicit Expression(std::string _name, Sort _sort):
-		Expression(std::move(_name), std::vector<Expression>{}, _sort) {}
-	Expression(std::string _name, Expression _arg, Sort _sort):
-		Expression(std::move(_name), std::vector<Expression>{std::move(_arg)}, _sort) {}
-	Expression(std::string _name, Expression _arg1, Expression _arg2, Sort _sort):
-		Expression(std::move(_name), std::vector<Expression>{std::move(_arg1), std::move(_arg2)}, _sort) {}
+	explicit Expression(std::string _name, Kind _kind):
+		Expression(std::move(_name), std::vector<Expression>{}, _kind) {}
+	Expression(std::string _name, Expression _arg, Kind _kind):
+		Expression(std::move(_name), std::vector<Expression>{std::move(_arg)}, _kind) {}
+	Expression(std::string _name, Expression _arg1, Expression _arg2, Kind _kind):
+		Expression(std::move(_name), std::vector<Expression>{std::move(_arg1), std::move(_arg2)}, _kind) {}
 };
 
 DEV_SIMPLE_EXCEPTION(SolverError);
@@ -197,39 +248,20 @@ public:
 	virtual void push() = 0;
 	virtual void pop() = 0;
 
-	virtual void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) = 0;
-	void declareFunction(std::string _name, Sort _domain, Sort _codomain)
-	{
-		declareFunction(std::move(_name), std::vector<Sort>{std::move(_domain)}, std::move(_codomain));
-	}
-	Expression newFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain)
-	{
-		declareFunction(_name, _domain, _codomain);
-		// Subclasses should do something here
-		switch (_codomain)
-		{
-		case Sort::Int:
-			return Expression(std::move(_name), {}, Sort::Int);
-		case Sort::Bool:
-			return Expression(std::move(_name), {}, Sort::Bool);
-		default:
-			solAssert(false, "Function sort not supported.");
-			break;
-		}
-	}
-	virtual void declareInteger(std::string _name) = 0;
-	Expression newInteger(std::string _name)
+	virtual void declareVariable(std::string const& _name, Sort const& _sort) = 0;
+	Expression newVariable(std::string _name, SortPointer _sort)
 	{
 		// Subclasses should do something here
-		declareInteger(_name);
-		return Expression(std::move(_name), {}, Sort::Int);
+		declareVariable(_name, *_sort);
+		return Expression(std::move(_name), {}, std::move(_sort));
 	}
-	virtual void declareBool(std::string _name) = 0;
-	Expression newBool(std::string _name)
+
+	virtual void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) = 0;
+	Expression newFunction(std::string _name, std::vector<SortPointer> const& _domain, SortPointer _codomain)
 	{
 		// Subclasses should do something here
-		declareBool(_name);
-		return Expression(std::move(_name), {}, Sort::Bool);
+		declareFunction(_name, _domain, *_codomain);
+		return Expression(std::move(_name), {}, _codomain);
 	}
 
 	virtual void addAssertion(Expression const& _expr) = 0;

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -24,18 +24,37 @@
 using namespace std;
 using namespace dev::solidity;
 
-smt::Sort dev::solidity::smtSort(Type::Category _category)
+shared_ptr<smt::Sort> dev::solidity::smtSort(Type const& _type)
+{
+	auto const& category = _type.category();
+	if (isNumber(category))
+		return make_shared<smt::Sort>(smt::Kind::Int);
+	else if (isBool(category))
+		return make_shared<smt::Sort>(smt::Kind::Bool);
+	else if (isMapping(category))
+	{
+		auto mapType = dynamic_cast<MappingType const*>(&_type);
+		solAssert(mapType, "");
+		return make_shared<smt::ArraySort>(smtSort(*mapType->keyType()), smtSort(*mapType->valueType()));
+	}
+	solAssert(false, "Invalid type");
+}
+
+smt::Kind dev::solidity::smtKind(Type::Category _category)
 {
 	if (isNumber(_category))
-		return smt::Sort::Int;
+		return smt::Kind::Int;
 	else if (isBool(_category))
-		return smt::Sort::Bool;
+		return smt::Kind::Bool;
+	else if (isMapping(_category))
+		return smt::Kind::Array;
 	solAssert(false, "Invalid type");
 }
 
 bool dev::solidity::isSupportedType(Type::Category _category)
 {
 	return isNumber(_category) ||
+		isArray(_category) ||
 		isBool(_category) ||
 		isFunction(_category);
 }
@@ -54,6 +73,8 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 		abstract = true;
 		var = make_shared<SymbolicIntVariable>(make_shared<IntegerType>(256), _uniqueName, _solver);
 	}
+	else if (isMapping(_type.category()))
+		var = make_shared<SymbolicMappingVariable>(type, _uniqueName, _solver);
 	else if (isBool(_type.category()))
 		var = make_shared<SymbolicBoolVariable>(type, _uniqueName, _solver);
 	else if (isFunction(_type.category()))
@@ -123,6 +144,17 @@ bool dev::solidity::isBool(Type::Category _category)
 bool dev::solidity::isFunction(Type::Category _category)
 {
 	return _category == Type::Category::Function;
+}
+
+bool dev::solidity::isMapping(Type::Category _category)
+{
+	return _category == Type::Category::Mapping;
+}
+
+bool dev::solidity::isArray(Type::Category _category)
+{
+	// In the future will also support arrays.
+	return isMapping(_category);
 }
 
 smt::Expression dev::solidity::minValue(IntegerType const& _type)

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -28,8 +28,12 @@ namespace dev
 namespace solidity
 {
 
-/// Returns the SMT sort that models the Solidity type _type.
-smt::Sort smtSort(Type::Category _type);
+/// Returns the SMT sort that models the Solidity type _type,
+/// including sub sorts (for Array, for example).
+std::shared_ptr<smt::Sort> smtSort(Type const& _type);
+/// Returns the SMT kind that models the Solidity type type category _category.
+smt::Kind smtKind(Type::Category _category);
+
 
 /// So far int, bool and address are supported.
 /// Returns true if type is supported.
@@ -43,6 +47,8 @@ bool isAddress(Type::Category _category);
 bool isNumber(Type::Category _category);
 bool isBool(Type::Category _category);
 bool isFunction(Type::Category _category);
+bool isMapping(Type::Category _category);
+bool isArray(Type::Category _category);
 
 /// Returns a new symbolic variable, according to _type.
 /// Also returns whether the type is abstract or not,

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -30,7 +30,8 @@ namespace solidity
 
 /// Returns the SMT sort that models the Solidity type _type,
 /// including sub sorts (for Array, for example).
-std::shared_ptr<smt::Sort> smtSort(Type const& _type);
+smt::SortPointer smtSort(Type const& _type);
+std::vector<smt::SortPointer> smtSort(std::vector<TypePointer> const& _types);
 /// Returns the SMT kind that models the Solidity type type category _category.
 smt::Kind smtKind(Type::Category _category);
 
@@ -57,6 +58,13 @@ std::pair<bool, std::shared_ptr<SymbolicVariable>> newSymbolicVariable(Type cons
 
 smt::Expression minValue(IntegerType const& _type);
 smt::Expression maxValue(IntegerType const& _type);
+
+void setZeroValue(SymbolicVariable const& _variable, smt::SolverInterface& _interface);
+void setZeroValue(smt::Expression _expr, TypePointer const& _type, smt::SolverInterface& _interface);
+
+void setUnknownValue(SymbolicVariable const& _variable, smt::SolverInterface& _interface);
+void setUnknownValue(smt::Expression _expr, TypePointer const& _type, smt::SolverInterface& _interface);
+
 
 }
 }

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -47,6 +47,35 @@ string SymbolicVariable::uniqueSymbol(unsigned _index) const
 	return m_uniqueName + "_" + to_string(_index);
 }
 
+SymbolicMappingVariable::SymbolicMappingVariable(
+	TypePointer _type,
+	string const& _uniqueName,
+	smt::SolverInterface& _interface
+):
+	SymbolicVariable(move(_type), _uniqueName, _interface)
+{
+	solAssert(isMapping(m_type->category()), "");
+}
+
+smt::Expression SymbolicMappingVariable::valueAtIndex(int _index) const
+{
+	auto mapType = dynamic_cast<MappingType const*>(m_type.get());
+	solAssert(mapType, "");
+	auto domain = smtSort(*mapType->keyType());
+	auto range = smtSort(*mapType->valueType());
+	return m_interface.newVariable(uniqueSymbol(_index), make_shared<smt::ArraySort>(domain, range));
+}
+
+void SymbolicMappingVariable::setZeroValue()
+{
+}
+
+void SymbolicMappingVariable::setUnknownValue()
+{
+	// TODO
+	// \forall d \in D . (select m d) == UNKNOWN (apply type restrictions)
+}
+
 SymbolicBoolVariable::SymbolicBoolVariable(
 	TypePointer _type,
 	string const& _uniqueName,
@@ -59,7 +88,7 @@ SymbolicBoolVariable::SymbolicBoolVariable(
 
 smt::Expression SymbolicBoolVariable::valueAtIndex(int _index) const
 {
-	return m_interface.newBool(uniqueSymbol(_index));
+	return m_interface.newVariable(uniqueSymbol(_index), make_shared<smt::Sort>(smt::Kind::Bool));
 }
 
 void SymbolicBoolVariable::setZeroValue()
@@ -83,7 +112,7 @@ SymbolicIntVariable::SymbolicIntVariable(
 
 smt::Expression SymbolicIntVariable::valueAtIndex(int _index) const
 {
-	return m_interface.newInteger(uniqueSymbol(_index));
+	return m_interface.newVariable(uniqueSymbol(_index), make_shared<smt::Sort>(smt::Kind::Int));
 }
 
 void SymbolicIntVariable::setZeroValue()

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -81,6 +81,27 @@ protected:
 };
 
 /**
+ * Specialization of SymbolicVariable for Mapping
+ */
+class SymbolicMappingVariable: public SymbolicVariable
+{
+public:
+	SymbolicMappingVariable(
+		TypePointer _type,
+		std::string const& _uniqueName,
+		smt::SolverInterface& _interface
+	);
+
+	/// Sets all the elements to 0.
+	void setZeroValue();
+	/// Sets the valid range for all elements.
+	void setUnknownValue();
+
+protected:
+	smt::Expression valueAtIndex(int _index) const;
+};
+
+/**
  * Specialization of SymbolicVariable for Bool
  */
 class SymbolicBoolVariable: public SymbolicVariable

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -64,20 +64,15 @@ public:
 	unsigned index() const { return m_ssa->index(); }
 	unsigned& index() { return m_ssa->index(); }
 
-	/// Sets the var to the default value of its type.
-	/// Inherited types must implement.
-	virtual void setZeroValue() = 0;
-	/// The unknown value is the full range of valid values.
-	/// It is sub-type dependent, but not mandatory.
-	virtual void setUnknownValue() {}
+	TypePointer const& type() const { return m_type; }
 
 protected:
 	std::string uniqueSymbol(unsigned _index) const;
 
-	TypePointer m_type = nullptr;
+	TypePointer m_type;
 	std::string m_uniqueName;
 	smt::SolverInterface& m_interface;
-	std::shared_ptr<SSAVariable> m_ssa = nullptr;
+	std::shared_ptr<SSAVariable> m_ssa;
 };
 
 /**
@@ -91,11 +86,6 @@ public:
 		std::string const& _uniqueName,
 		smt::SolverInterface& _interface
 	);
-
-	/// Sets all the elements to 0.
-	void setZeroValue();
-	/// Sets the valid range for all elements.
-	void setUnknownValue();
 
 protected:
 	smt::Expression valueAtIndex(int _index) const;
@@ -113,11 +103,6 @@ public:
 		smt::SolverInterface& _interface
 	);
 
-	/// Sets the var to false.
-	void setZeroValue();
-	/// Does nothing since the SMT solver already knows the valid values for Bool.
-	void setUnknownValue();
-
 protected:
 	smt::Expression valueAtIndex(int _index) const;
 };
@@ -133,11 +118,6 @@ public:
 		std::string const& _uniqueName,
 		smt::SolverInterface& _interface
 	);
-
-	/// Sets the var to 0.
-	void setZeroValue();
-	/// Sets the variable to the full valid value range.
-	void setUnknownValue();
 
 protected:
 	smt::Expression valueAtIndex(int _index) const;
@@ -166,6 +146,27 @@ public:
 		std::string const& _uniqueName,
 		smt::SolverInterface& _interface
 	);
+};
+
+class SymbolicFunctionDeclaration
+{
+public:
+	SymbolicFunctionDeclaration(
+		smt::SortPointer const& _sort,
+		std::string const& _uniqueName,
+		smt::SolverInterface& _interface
+	);
+	SymbolicFunctionDeclaration(
+		FunctionTypePointer const& _type,
+		std::string const& _uniqueName,
+		smt::SolverInterface& _interface
+	);
+
+	// Applies the function to the given arguments.
+	smt::Expression operator()(std::vector<smt::Expression> _arguments);
+
+private:
+	smt::Expression m_declaration;
 };
 
 }

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -51,22 +51,16 @@ void Z3Interface::pop()
 	m_solver.pop();
 }
 
-void Z3Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void Z3Interface::declareVariable(string const& _name, Sort const& _sort)
+{
+	if (!m_constants.count(_name))
+		m_constants.insert({_name, m_context.constant(_name.c_str(), z3Sort(_sort))});
+}
+
+void Z3Interface::declareFunction(string const& _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	if (!m_functions.count(_name))
 		m_functions.insert({_name, m_context.function(_name.c_str(), z3Sort(_domain), z3Sort(_codomain))});
-}
-
-void Z3Interface::declareInteger(string _name)
-{
-	if (!m_constants.count(_name))
-		m_constants.insert({_name, m_context.int_const(_name.c_str())});
-}
-
-void Z3Interface::declareBool(string _name)
-{
-	if (!m_constants.count(_name))
-		m_constants.insert({_name, m_context.bool_const(_name.c_str())});
 }
 
 void Z3Interface::addAssertion(Expression const& _expr)
@@ -163,31 +157,38 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 		return arguments[0] * arguments[1];
 	else if (n == "/")
 		return arguments[0] / arguments[1];
+	else if (n == "select")
+		return z3::select(arguments[0], arguments[1]);
+	else if (n == "store")
+		return z3::store(arguments[0], arguments[1], arguments[2]);
 	// Cannot reach here.
 	solAssert(false, "");
 	return arguments[0];
 }
 
-z3::sort Z3Interface::z3Sort(Sort _sort)
+z3::sort Z3Interface::z3Sort(Sort const& _sort)
 {
-	switch (_sort)
+	switch (_sort.kind)
 	{
-	case Sort::Bool:
+	case Kind::Bool:
 		return m_context.bool_sort();
-	case Sort::Int:
+	case Kind::Int:
 		return m_context.int_sort();
+	case Kind::Array:
+	{
+		auto const& arraySort = dynamic_cast<ArraySort const&>(_sort);
+		return m_context.array_sort(z3Sort(*arraySort.domain), z3Sort(*arraySort.range));
+	}
 	default:
 		break;
 	}
 	solAssert(false, "");
-	// Cannot be reached.
-	return m_context.int_sort();
 }
 
-z3::sort_vector Z3Interface::z3Sort(vector<Sort> const& _sorts)
+z3::sort_vector Z3Interface::z3Sort(vector<SortPointer> const& _sorts)
 {
 	z3::sort_vector z3Sorts(m_context);
 	for (auto const& _sort: _sorts)
-		z3Sorts.push_back(z3Sort(_sort));
+		z3Sorts.push_back(z3Sort(*_sort));
 	return z3Sorts;
 }

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -40,17 +40,16 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
-	void declareInteger(std::string _name) override;
-	void declareBool(std::string _name) override;
+	void declareVariable(std::string const& _name, Sort const& _sort) override;
+	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
 	z3::expr toZ3Expr(Expression const& _expr);
-	z3::sort z3Sort(smt::Sort _sort);
-	z3::sort_vector z3Sort(std::vector<smt::Sort> const& _sort);
+	z3::sort z3Sort(smt::Sort const& _sort);
+	z3::sort_vector z3Sort(std::vector<SortPointer> const& _sort);
 
 	z3::context m_context;
 	z3::solver m_solver;

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -41,12 +41,12 @@ public:
 	void pop() override;
 
 	void declareVariable(std::string const& _name, Sort const& _sort) override;
-	void declareFunction(std::string const& _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 
 	void addAssertion(Expression const& _expr) override;
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 private:
+	void declareFunction(std::string const& _name, Sort const& _sort);
 	z3::expr toZ3Expr(Expression const& _expr);
 	z3::sort z3Sort(smt::Sort const& _sort);
 	z3::sort_vector z3Sort(std::vector<SortPointer> const& _sort);


### PR DESCRIPTION
Depends on #5307 

This PR refactors the way SMT sorts are created/used in the SMTChecker.

`ArraySort` has two recursive subsorts: `domain` is the type of the indices and `range` is the type of the values.

`FunctionSort` has a vector of sorts `domain` for its parameters and a return sort `codomain`.

This PR is being split into smaller ones.