### PR TITLE
[SMTChecker] Unroll loops once

### DIFF
--- a/test/libsolidity/smtCheckerTests/loops/do_while_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_1_fail.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) public pure {
+		require(x < 100);
+		do {
+			// Overflows due to resetting x.
+			x = x + 1;
+		} while (x < 10);
+		assert(x < 14);
+	}
+}
+// ----
+// Warning: (150-155): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (146-155): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (179-193): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/do_while_1_false_positives.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_1_false_positives.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) public pure {
+		require(x < 100);
+		do {
+			// Overflows due to resetting x.
+			x = x + 1;
+		} while (x < 1000);
+		// The assertion is true but we can't infer so
+		// because x is touched in the loop.
+		assert(x > 0);
+	}
+}
+// ----
+// Warning: (150-155): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (146-155): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (269-282): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_fail.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) public pure {
+		require(x < 100);
+		for(uint i = 0; i < 10; ++i) {
+			// Overflows due to resetting x.
+			x = x + 1;
+		}
+		assert(x < 14);
+	}
+}
+// ----
+// Warning: (176-181): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (172-181): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (189-203): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) public pure {
+		require(x < 100);
+		for(uint i = 0; i < 10; ++i) {
+			// Overflows due to resetting x.
+			x = x + 1;
+		}
+		// The assertion is true but x is touched and reset.
+		assert(x > 0);
+	}
+}
+// ----
+// Warning: (176-181): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (172-181): Overflow (resulting value larger than 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) happens here
+// Warning: (244-257): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_5.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_5.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// Warning: (167-181): Assertion violation happens here\nNote that some information is erased after the execution of loops.\nYou can re-introduce information using require().
+// Warning: (167-181): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_6.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_6.sol
@@ -5,8 +5,9 @@ contract C {
         for (y = 2; x < 10; ) {
             y = 3;
         }
-        assert(y == 2);
+        // False positive due to resetting y.
+        assert(y < 4);
     }
 }
 // ----
-// Warning: (167-181): Assertion violation happens here\nNote that some information is erased after the execution of loops.\nYou can re-introduce information using require().
+// Warning: (213-226): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_1.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(uint x) public pure {
+        require(x == 2);
+        for (; x == 2;) {}
+        assert(x == 2);
+    }
+}
+// ----
+// Warning: (122-128): For loop condition is always true.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_2.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(uint x) public pure {
+        require(x == 2);
+        uint y;
+        for (; x == 2;) {
+            y = 7;
+        }
+        assert(x == 2);
+    }
+}
+// ----
+// Warning: (138-144): For loop condition is always true.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_3.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(uint x) public pure {
+        require(x == 2);
+        uint y;
+        // The loop condition is always true,
+        // but since x is touched in the body
+        // we can't infer that.
+        for (; x == 2;) {
+            x = 2;
+        }
+        // False positive due to resetting x.
+        assert(x == 2);
+    }
+}
+// ----
+// Warning: (115-121): Unused local variable.
+// Warning: (356-370): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_unreachable_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_unreachable_1.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(uint x) public pure {
+        require(x == 2);
+        for (; x > 2;) {}
+        assert(x == 2);
+    }
+}
+// ----
+// Warning: (122-127): For loop condition is always false.

--- a/test/libsolidity/smtCheckerTests/loops/while_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x, bool b) public pure {
+		require(x < 100);
+		while (x < 10) {
+			if (b)
+				x = x + 1;
+			else
+				x = 0;
+		}
+		assert(x > 0);
+	}
+}
+// ----
+// Warning: (177-190): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1_fail.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) public pure {
+		require(x < 100);
+		while (x < 10) {
+			x = x + 1;
+		}
+		assert(x < 14);
+	}
+}
+// ----
+// Warning: (139-153): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_2_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_2_fail.sol
@@ -1,0 +1,15 @@
+pragma experimental SMTChecker;
+contract C {
+	function f(uint x) public pure {
+		x = 2;
+		while (x > 1) {
+			if (x > 10)
+				x = 2;
+			else
+				x = 10;
+		}
+		assert(x == 2);
+	}
+}
+// ----
+// Warning: (158-172): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_simple_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_simple_1.sol
@@ -4,10 +4,10 @@ contract C {
     function f(uint x) public pure {
         x = 2;
         while (x > 1) {
-            x = 2;
+            x = 1;
         }
         assert(x == 2);
     }
 }
 // ----
-// Warning: (194-208): Assertion violation happens here\nNote that some information is erased after the execution of loops.\nYou can re-introduce information using require().
+// Warning: (194-208): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_simple_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_simple_3.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// Warning: (187-201): Assertion violation happens here\nNote that some information is erased after the execution of loops.\nYou can re-introduce information using require().
+// Warning: (187-201): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_simple_4.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_simple_4.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// Warning: (199-213): Assertion violation happens here\nNote that some information is erased after the execution of loops.\nYou can re-introduce information using require().
+// Warning: (199-213): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_simple_5.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_simple_5.sol
@@ -9,4 +9,4 @@ contract C {
     }
 }
 // ----
-// Warning: (216-230): Assertion violation happens here\nNote that some information is erased after the execution of loops.\nYou can re-introduce information using require().
+// Warning: (216-230): Assertion violation happens here


### PR DESCRIPTION
Currently the SMT checker unrolls the loop once and resets knowledge.
This PR:
- Keeps that as an execution branch (one unroll) which merges with the branch that skips the loop and does not clear previous knowledge.
- Moves the loop comment regarding knowledge erasing to a `SecondarySourceLocation` (does not show in tests).
- Adds more tests.