### PR TITLE
Provide additional error messages during type checks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * Inline Assembly: Improve error messages around invalid function argument count.
  * Code Generator: Use binary search for dispatch function if more efficient. The size/speed tradeoff can be tuned using ``--optimize-runs``.
+ * Type Checker: Add an additional reason to be displayed when type conversion fails.
 
 
 Bugfixes:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1252,7 +1252,8 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 {
 	TypePointer const& leftType = type(_operation.leftExpression());
 	TypePointer const& rightType = type(_operation.rightExpression());
-	TypePointer commonType = leftType->binaryOperatorResult(_operation.getOperator(), rightType);
+	TypeResult result = leftType->binaryOperatorResult(_operation.getOperator(), rightType);
+	TypePointer commonType = result.get();
 	if (!commonType)
 	{
 		m_errorReporter.typeError(
@@ -1262,7 +1263,8 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 			" not compatible with types " +
 			leftType->toString() +
 			" and " +
-			rightType->toString()
+			rightType->toString() +
+			(!result.message().empty() ? ". " + result.message() : "")
 		);
 		commonType = leftType;
 	}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -513,7 +513,7 @@ TypeResult AddressType::unaryOperatorResult(Token _operator) const
 TypeResult AddressType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
 {
 	if (!TokenTraits::isCompareOp(_operator))
-		return TypeResult{"Addresses can only be compared"};
+		return TypeResult{"Arithmetic operations on addresses are not supported. Convert to integer first before using them."};
 
 	return Type::commonType(shared_from_this(), _other);
 }
@@ -678,7 +678,7 @@ TypeResult IntegerType::binaryOperatorResult(Token _operator, TypePointer const&
 	if (auto intType = dynamic_pointer_cast<IntegerType const>(commonType))
 	{
 		if (Token::Exp == _operator && intType->isSigned())
-			return TypeResult{"Signed exponentiation is not allowed"};
+			return TypeResult{"Exponentiation is not allowed for signed integer types."};
 	}
 	else if (auto fixType = dynamic_pointer_cast<FixedPointType const>(commonType))
 		if (Token::Exp == _operator)
@@ -1127,7 +1127,7 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 				uint32_t absExp = bigint(abs(exp)).convert_to<uint32_t>();
 
 				if (!fitsPrecisionExp(abs(m_value.numerator()), absExp) || !fitsPrecisionExp(abs(m_value.denominator()), absExp))
-					return TypeResult{"Precision is limited to 4096 bits"};
+					return TypeResult{"Precision of rational constants is limited to 4096 bits."};
 
 				static auto const optimizedPow = [](bigint const& _base, uint32_t _exponent) -> bigint {
 					if (_base == 1)
@@ -1208,7 +1208,7 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 
 		// verify that numerator and denominator fit into 4096 bit after every operation
 		if (value.numerator() != 0 && max(mostSignificantBit(abs(value.numerator())), mostSignificantBit(abs(value.denominator()))) > 4096)
-			return TypeResult{"Precision is limited to 4096 bits"};
+			return TypeResult{"Precision of rational constants is limited to 4096 bits."};
 
 		return TypeResult(make_shared<RationalNumberType>(value));
 	}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -512,9 +512,8 @@ TypeResult AddressType::unaryOperatorResult(Token _operator) const
 
 TypeResult AddressType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
 {
-	// Addresses can only be compared.
 	if (!TokenTraits::isCompareOp(_operator))
-		return TypePointer();
+		return TypeResult{"Addresses can only be compared"};
 
 	return Type::commonType(shared_from_this(), _other);
 }
@@ -678,9 +677,8 @@ TypeResult IntegerType::binaryOperatorResult(Token _operator, TypePointer const&
 		return TypePointer();
 	if (auto intType = dynamic_pointer_cast<IntegerType const>(commonType))
 	{
-		// Signed EXP is not allowed
 		if (Token::Exp == _operator && intType->isSigned())
-			return TypePointer();
+			return TypeResult{"Signed exponentiation is not allowed"};
 	}
 	else if (auto fixType = dynamic_pointer_cast<FixedPointType const>(commonType))
 		if (Token::Exp == _operator)
@@ -1128,9 +1126,8 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 
 				uint32_t absExp = bigint(abs(exp)).convert_to<uint32_t>();
 
-				// Limit size to 4096 bits
 				if (!fitsPrecisionExp(abs(m_value.numerator()), absExp) || !fitsPrecisionExp(abs(m_value.denominator()), absExp))
-					return TypePointer();
+					return TypeResult{"Precision is limited to 4096 bits"};
 
 				static auto const optimizedPow = [](bigint const& _base, uint32_t _exponent) -> bigint {
 					if (_base == 1)
@@ -1211,7 +1208,7 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 
 		// verify that numerator and denominator fit into 4096 bit after every operation
 		if (value.numerator() != 0 && max(mostSignificantBit(abs(value.numerator())), mostSignificantBit(abs(value.denominator()))) > 4096)
-			return TypePointer();
+			return TypeResult{"Precision is limited to 4096 bits"};
 
 		return TypeResult(make_shared<RationalNumberType>(value));
 	}

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/201_integer_signed_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/201_integer_signed_exp_signed.sol
@@ -1,3 +1,9 @@
-contract test { function() external { int x = -3; int y = -4; x ** y; } }
+contract test {
+    function f() public { int x = 3; int y = 4; x ** y; }
+    function g() public { int16 x = 3; uint8 y = 4; x ** y; }
+    function h() public { uint8 x = 3; int16 y = 4; x ** y; }
+}
 // ----
-// TypeError: (62-68): Operator ** not compatible with types int256 and int256. Signed exponentiation is not allowed
+// TypeError: (64-70): Operator ** not compatible with types int256 and int256. Exponentiation is not allowed for signed integer types.
+// TypeError: (126-132): Operator ** not compatible with types int16 and uint8. Exponentiation is not allowed for signed integer types.
+// TypeError: (188-194): Operator ** not compatible with types uint8 and int16. Exponentiation is not allowed for signed integer types.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/201_integer_signed_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/201_integer_signed_exp_signed.sol
@@ -1,3 +1,3 @@
 contract test { function() external { int x = -3; int y = -4; x ** y; } }
 // ----
-// TypeError: (62-68): Operator ** not compatible with types int256 and int256
+// TypeError: (62-68): Operator ** not compatible with types int256 and int256. Signed exponentiation is not allowed

--- a/test/libsolidity/syntaxTests/types/address/address_binary_operators.sol
+++ b/test/libsolidity/syntaxTests/types/address/address_binary_operators.sol
@@ -1,0 +1,15 @@
+contract C {
+    address a;
+    function f() public pure returns(bool) {
+        a = address(0) + address(0);
+        a = address(0) - address(0);
+        a = address(0) * address(0);
+        a = address(0) / address(0);
+        return address(0) == address(0);
+    }
+}
+// ----
+// TypeError: (85-108): Operator + not compatible with types address payable and address payable. Addresses can only be compared
+// TypeError: (122-145): Operator - not compatible with types address payable and address payable. Addresses can only be compared
+// TypeError: (159-182): Operator * not compatible with types address payable and address payable. Addresses can only be compared
+// TypeError: (196-219): Operator / not compatible with types address payable and address payable. Addresses can only be compared

--- a/test/libsolidity/syntaxTests/types/address/address_binary_operators.sol
+++ b/test/libsolidity/syntaxTests/types/address/address_binary_operators.sol
@@ -9,7 +9,7 @@ contract C {
     }
 }
 // ----
-// TypeError: (85-108): Operator + not compatible with types address payable and address payable. Addresses can only be compared
-// TypeError: (122-145): Operator - not compatible with types address payable and address payable. Addresses can only be compared
-// TypeError: (159-182): Operator * not compatible with types address payable and address payable. Addresses can only be compared
-// TypeError: (196-219): Operator / not compatible with types address payable and address payable. Addresses can only be compared
+// TypeError: (85-108): Operator + not compatible with types address payable and address payable. Arithmetic operations on addresses are not supported. Convert to integer first before using them.
+// TypeError: (122-145): Operator - not compatible with types address payable and address payable. Arithmetic operations on addresses are not supported. Convert to integer first before using them.
+// TypeError: (159-182): Operator * not compatible with types address payable and address payable. Arithmetic operations on addresses are not supported. Convert to integer first before using them.
+// TypeError: (196-219): Operator / not compatible with types address payable and address payable. Arithmetic operations on addresses are not supported. Convert to integer first before using them.

--- a/test/libsolidity/syntaxTests/types/rational_number_div_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_div_limit.sol
@@ -5,5 +5,5 @@ contract c {
     }
 }
 // ----
-// TypeError: (71-92): Operator / not compatible with types rational_const 1 / 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168
+// TypeError: (71-92): Operator / not compatible with types rational_const 1 / 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168. Precision is limited to 4096 bits
 // TypeError: (71-92): Type rational_const 1 / 5221...(1225 digits omitted)...5168 is not implicitly convertible to expected type int256. Try converting to type ufixed8x80 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/rational_number_div_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_div_limit.sol
@@ -5,5 +5,5 @@ contract c {
     }
 }
 // ----
-// TypeError: (71-92): Operator / not compatible with types rational_const 1 / 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168. Precision is limited to 4096 bits
+// TypeError: (71-92): Operator / not compatible with types rational_const 1 / 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168. Precision of rational constants is limited to 4096 bits.
 // TypeError: (71-92): Type rational_const 1 / 5221...(1225 digits omitted)...5168 is not implicitly convertible to expected type int256. Try converting to type ufixed8x80 or use an explicit conversion.

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_fail.sol
@@ -19,23 +19,23 @@ contract c {
     }
 }
 // ----
-// TypeError: (71-102): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision is limited to 4096 bits
+// TypeError: (71-102): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision of rational constants is limited to 4096 bits.
 // TypeError: (71-102): Type int_const 1797...(301 digits omitted)...7216 is not implicitly convertible to expected type int256.
-// TypeError: (116-148): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision is limited to 4096 bits
-// TypeError: (116-153): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision is limited to 4096 bits
+// TypeError: (116-148): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision of rational constants is limited to 4096 bits.
+// TypeError: (116-153): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision of rational constants is limited to 4096 bits.
 // TypeError: (116-153): Type int_const 1797...(301 digits omitted)...7216 is not implicitly convertible to expected type int256.
 // TypeError: (167-203): Operator ** not compatible with types int_const 4 and int_const -179...(302 digits omitted)...7216
 // TypeError: (217-228): Operator ** not compatible with types int_const 2 and int_const 1000...(1226 digits omitted)...0000
 // TypeError: (242-254): Operator ** not compatible with types int_const -2 and int_const 1000...(1226 digits omitted)...0000
 // TypeError: (268-280): Operator ** not compatible with types int_const 2 and int_const -100...(1227 digits omitted)...0000
 // TypeError: (294-307): Operator ** not compatible with types int_const -2 and int_const -100...(1227 digits omitted)...0000
-// TypeError: (321-332): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2. Precision is limited to 4096 bits
+// TypeError: (321-332): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2. Precision of rational constants is limited to 4096 bits.
 // TypeError: (321-332): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256.
-// TypeError: (346-358): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 2. Precision is limited to 4096 bits
+// TypeError: (346-358): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 2. Precision of rational constants is limited to 4096 bits.
 // TypeError: (346-358): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256.
-// TypeError: (372-384): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -2. Precision is limited to 4096 bits
+// TypeError: (372-384): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -2. Precision of rational constants is limited to 4096 bits.
 // TypeError: (372-384): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256.
-// TypeError: (398-411): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -2. Precision is limited to 4096 bits
+// TypeError: (398-411): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -2. Precision of rational constants is limited to 4096 bits.
 // TypeError: (398-411): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256.
 // TypeError: (425-441): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 1000...(1226 digits omitted)...0000
 // TypeError: (425-441): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256.

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_fail.sol
@@ -19,23 +19,23 @@ contract c {
     }
 }
 // ----
-// TypeError: (71-102): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4
+// TypeError: (71-102): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision is limited to 4096 bits
 // TypeError: (71-102): Type int_const 1797...(301 digits omitted)...7216 is not implicitly convertible to expected type int256.
-// TypeError: (116-148): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4
-// TypeError: (116-153): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4
+// TypeError: (116-148): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision is limited to 4096 bits
+// TypeError: (116-153): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4. Precision is limited to 4096 bits
 // TypeError: (116-153): Type int_const 1797...(301 digits omitted)...7216 is not implicitly convertible to expected type int256.
 // TypeError: (167-203): Operator ** not compatible with types int_const 4 and int_const -179...(302 digits omitted)...7216
 // TypeError: (217-228): Operator ** not compatible with types int_const 2 and int_const 1000...(1226 digits omitted)...0000
 // TypeError: (242-254): Operator ** not compatible with types int_const -2 and int_const 1000...(1226 digits omitted)...0000
 // TypeError: (268-280): Operator ** not compatible with types int_const 2 and int_const -100...(1227 digits omitted)...0000
 // TypeError: (294-307): Operator ** not compatible with types int_const -2 and int_const -100...(1227 digits omitted)...0000
-// TypeError: (321-332): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2
+// TypeError: (321-332): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2. Precision is limited to 4096 bits
 // TypeError: (321-332): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256.
-// TypeError: (346-358): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 2
+// TypeError: (346-358): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 2. Precision is limited to 4096 bits
 // TypeError: (346-358): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256.
-// TypeError: (372-384): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -2
+// TypeError: (372-384): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -2. Precision is limited to 4096 bits
 // TypeError: (372-384): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256.
-// TypeError: (398-411): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -2
+// TypeError: (398-411): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -2. Precision is limited to 4096 bits
 // TypeError: (398-411): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256.
 // TypeError: (425-441): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 1000...(1226 digits omitted)...0000
 // TypeError: (425-441): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256.

--- a/test/libsolidity/syntaxTests/types/rational_number_mul_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_mul_limit.sol
@@ -5,5 +5,5 @@ contract c {
     }
 }
 // ----
-// TypeError: (71-90): Operator * not compatible with types int_const 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168. Precision is limited to 4096 bits
+// TypeError: (71-90): Operator * not compatible with types int_const 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168. Precision of rational constants is limited to 4096 bits.
 // TypeError: (71-90): Type int_const 5221...(1225 digits omitted)...5168 is not implicitly convertible to expected type int256.

--- a/test/libsolidity/syntaxTests/types/rational_number_mul_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_mul_limit.sol
@@ -5,5 +5,5 @@ contract c {
     }
 }
 // ----
-// TypeError: (71-90): Operator * not compatible with types int_const 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168
+// TypeError: (71-90): Operator * not compatible with types int_const 5221...(1225 digits omitted)...5168 and int_const 5221...(1225 digits omitted)...5168. Precision is limited to 4096 bits
 // TypeError: (71-90): Type int_const 5221...(1225 digits omitted)...5168 is not implicitly convertible to expected type int256.


### PR DESCRIPTION
### Description

Fixes https://github.com/ethereum/solidity/issues/3879.

Based upon this PR we can hopefully evaluate if and where the creation of additional error messages during type conversion checks makes sense. In some of the places the seem to add value in others not. Overall this might be good starting point for working towards a more verbose error logging (cause, root cause, suggestion, etc...)
