### PR TITLE
Annotate jump from calldata decode to function as "jump in".

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Compiler Features:
 
 Bugfixes:
  * Assembly output: Do not mix in/out jump annotations with arguments.
+ * Code Generator: Annotate jump from calldata decoder to function as "jump in".
 
 Build System:
  * Emscripten: Upgrade to Emscripten SDK 1.37.21 and boost 1.67.

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -167,7 +167,10 @@ public:
 	/// the data.
 	CompilerContext& appendConditionalRevert(bool _forwardReturnData = false);
 	/// Appends a JUMP to a specific tag
-	CompilerContext& appendJumpTo(eth::AssemblyItem const& _tag) { m_asm->appendJump(_tag); return *this; }
+	CompilerContext& appendJumpTo(
+		eth::AssemblyItem const& _tag,
+		eth::AssemblyItem::JumpType _jumpType = eth::AssemblyItem::JumpType::Ordinary
+	) { *m_asm << _tag.pushTag(); return appendJump(_jumpType); }
 	/// Appends pushing of a new tag and @returns the new tag.
 	eth::AssemblyItem pushNewTag() { return m_asm->append(m_asm->newPushTag()).tag(); }
 	/// @returns a new tag without pushing any opcodes or data

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -344,7 +344,10 @@ void ContractCompiler::appendFunctionSelector(ContractDefinition const& _contrac
 			m_context << Instruction::DUP1 << Instruction::CALLDATASIZE << Instruction::SUB;
 			CompilerUtils(m_context).abiDecode(functionType->parameterTypes());
 		}
-		m_context.appendJumpTo(m_context.functionEntryLabel(functionType->declaration()));
+		m_context.appendJumpTo(
+			m_context.functionEntryLabel(functionType->declaration()),
+			eth::AssemblyItem::JumpType::IntoFunction
+		);
 		m_context << returnTag;
 		// Return tag and input parameters get consumed.
 		m_context.adjustStackOffset(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5403

Depends on https://github.com/ethereum/solidity/pull/5472