### PR TITLE
Update tests.

### DIFF
--- a/test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
@@ -476,27 +476,27 @@
 //             abi_encode_i_69 := add(abi_encode_i_69, 1)
 //         }
 //         {
-//             let _922 := mload(abi_encode_srcPtr)
-//             let abi_encode_pos_71_1029 := abi_encode_pos
-//             let abi_encode_length_72_1030 := 0x3
-//             let abi_encode_srcPtr_73_1031 := _922
+//             let _931 := mload(abi_encode_srcPtr)
+//             let abi_encode_pos_71_1037 := abi_encode_pos
+//             let abi_encode_length_72_1038 := 0x3
+//             let abi_encode_srcPtr_73_1039 := _931
 //             for {
-//                 let abi_encode_i_74_1032 := _2
+//                 let abi_encode_i_74_1040 := _2
 //             }
-//             lt(abi_encode_i_74_1032, abi_encode_length_72_1030)
+//             lt(abi_encode_i_74_1040, abi_encode_length_72_1038)
 //             {
-//                 abi_encode_i_74_1032 := add(abi_encode_i_74_1032, 1)
+//                 abi_encode_i_74_1040 := add(abi_encode_i_74_1040, 1)
 //             }
 //             {
-//                 mstore(abi_encode_pos_71_1029, and(mload(abi_encode_srcPtr_73_1031), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
-//                 abi_encode_srcPtr_73_1031 := add(abi_encode_srcPtr_73_1031, _1)
-//                 abi_encode_pos_71_1029 := add(abi_encode_pos_71_1029, _1)
+//                 mstore(abi_encode_pos_71_1037, and(mload(abi_encode_srcPtr_73_1039), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+//                 abi_encode_srcPtr_73_1039 := add(abi_encode_srcPtr_73_1039, _1)
+//                 abi_encode_pos_71_1037 := add(abi_encode_pos_71_1037, _1)
 //             }
 //             abi_encode_srcPtr := add(abi_encode_srcPtr, _1)
 //             abi_encode_pos := add(abi_encode_pos, 0x60)
 //         }
-//         let _924 := 0x40
-//         let _487 := mload(_924)
+//         let _933 := 0x40
+//         let _487 := mload(_933)
 //         let _488 := mload(_1)
 //         let abi_decode_value0_60_618
 //         let abi_decode_value0_60 := abi_decode_value0_60_618
@@ -518,121 +518,121 @@
 //         }
 //         {
 //             let abi_decode_offset_64 := calldataload(add(_488, abi_encode_pos_590))
-//             let _931 := 0xffffffffffffffff
-//             if gt(abi_decode_offset_64, _931)
+//             let _940 := 0xffffffffffffffff
+//             if gt(abi_decode_offset_64, _940)
 //             {
 //                 revert(_2, _2)
 //             }
-//             let _933 := add(_488, abi_decode_offset_64)
-//             if iszero(slt(add(_933, 0x1f), _487))
+//             let _942 := add(_488, abi_decode_offset_64)
+//             if iszero(slt(add(_942, 0x1f), _487))
 //             {
 //                 revert(_2, _2)
 //             }
-//             let abi_decode_length_30_1038 := calldataload(_933)
-//             if gt(abi_decode_length_30_1038, _931)
+//             let abi_decode_length_30_1046 := calldataload(_942)
+//             if gt(abi_decode_length_30_1046, _940)
 //             {
 //                 revert(_2, _2)
 //             }
-//             let abi_decode_array_allo__561 := mul(abi_decode_length_30_1038, _1)
-//             let abi_decode_array_29_279_1039 := allocateMemory(add(abi_decode_array_allo__561, _1))
-//             let abi_decode_dst_31_1040 := abi_decode_array_29_279_1039
-//             mstore(abi_decode_array_29_279_1039, abi_decode_length_30_1038)
-//             let abi_decode_offset_27_281_1041 := add(_933, _1)
-//             abi_decode_dst_31_1040 := add(abi_decode_array_29_279_1039, _1)
-//             let abi_decode_src_32_1042 := abi_decode_offset_27_281_1041
-//             if gt(add(add(_933, abi_decode_array_allo__561), _1), _487)
+//             let abi_decode_array_allo__561 := mul(abi_decode_length_30_1046, _1)
+//             let abi_decode_array_29_279_1047 := allocateMemory(add(abi_decode_array_allo__561, _1))
+//             let abi_decode_dst_31_1048 := abi_decode_array_29_279_1047
+//             mstore(abi_decode_array_29_279_1047, abi_decode_length_30_1046)
+//             let abi_decode_offset_27_281_1049 := add(_942, _1)
+//             abi_decode_dst_31_1048 := add(abi_decode_array_29_279_1047, _1)
+//             let abi_decode_src_32_1050 := abi_decode_offset_27_281_1049
+//             if gt(add(add(_942, abi_decode_array_allo__561), _1), _487)
 //             {
 //                 revert(_2, _2)
 //             }
 //             for {
-//                 let abi_decode_i_33_1044 := _2
+//                 let abi_decode_i_33_1052 := _2
 //             }
-//             lt(abi_decode_i_33_1044, abi_decode_length_30_1038)
+//             lt(abi_decode_i_33_1052, abi_decode_length_30_1046)
 //             {
-//                 abi_decode_i_33_1044 := add(abi_decode_i_33_1044, 1)
+//                 abi_decode_i_33_1052 := add(abi_decode_i_33_1052, 1)
 //             }
 //             {
-//                 mstore(abi_decode_dst_31_1040, calldataload(abi_decode_src_32_1042))
-//                 abi_decode_dst_31_1040 := add(abi_decode_dst_31_1040, _1)
-//                 abi_decode_src_32_1042 := add(abi_decode_src_32_1042, _1)
+//                 mstore(abi_decode_dst_31_1048, calldataload(abi_decode_src_32_1050))
+//                 abi_decode_dst_31_1048 := add(abi_decode_dst_31_1048, _1)
+//                 abi_decode_src_32_1050 := add(abi_decode_src_32_1050, _1)
 //             }
-//             abi_decode_value2 := abi_decode_array_29_279_1039
+//             abi_decode_value2 := abi_decode_array_29_279_1047
 //         }
 //         {
 //             let abi_decode_offset_65 := calldataload(add(_488, 96))
-//             let _936 := 0xffffffffffffffff
-//             if gt(abi_decode_offset_65, _936)
+//             let _945 := 0xffffffffffffffff
+//             if gt(abi_decode_offset_65, _945)
 //             {
 //                 revert(_2, _2)
 //             }
-//             let _938 := add(_488, abi_decode_offset_65)
-//             let abi_decode__489_1048 := 0x1f
-//             if iszero(slt(add(_938, abi_decode__489_1048), _487))
+//             let _947 := add(_488, abi_decode_offset_65)
+//             let abi_decode__489_1056 := 0x1f
+//             if iszero(slt(add(_947, abi_decode__489_1056), _487))
 //             {
 //                 revert(_2, _2)
 //             }
-//             let abi_decode_length_6_1050 := calldataload(_938)
-//             if gt(abi_decode_length_6_1050, _936)
+//             let abi_decode_length_6_1058 := calldataload(_947)
+//             if gt(abi_decode_length_6_1058, _945)
 //             {
 //                 revert(_2, _2)
 //             }
-//             let abi_decode_array_5_254_1051 := allocateMemory(add(mul(abi_decode_length_6_1050, _1), _1))
-//             let abi_decode_dst_7_1052 := abi_decode_array_5_254_1051
-//             mstore(abi_decode_array_5_254_1051, abi_decode_length_6_1050)
-//             let abi_decode_offset_3_256_1053 := add(_938, _1)
-//             abi_decode_dst_7_1052 := add(abi_decode_array_5_254_1051, _1)
-//             let abi_decode_src_8_1054 := abi_decode_offset_3_256_1053
-//             if gt(add(add(_938, mul(abi_decode_length_6_1050, _924)), _1), _487)
+//             let abi_decode_array_5_254_1061 := allocateMemory(add(mul(abi_decode_length_6_1058, _1), _1))
+//             let abi_decode_dst_7_1062 := abi_decode_array_5_254_1061
+//             mstore(abi_decode_array_5_254_1061, abi_decode_length_6_1058)
+//             let abi_decode_offset_3_256_1063 := add(_947, _1)
+//             abi_decode_dst_7_1062 := add(abi_decode_array_5_254_1061, _1)
+//             let abi_decode_src_8_1064 := abi_decode_offset_3_256_1063
+//             if gt(add(add(_947, mul(abi_decode_length_6_1058, _933)), _1), _487)
 //             {
 //                 revert(_2, _2)
 //             }
 //             for {
-//                 let abi_decode_i_9_1058 := _2
+//                 let abi_decode_i_9_1068 := _2
 //             }
-//             lt(abi_decode_i_9_1058, abi_decode_length_6_1050)
+//             lt(abi_decode_i_9_1068, abi_decode_length_6_1058)
 //             {
-//                 abi_decode_i_9_1058 := add(abi_decode_i_9_1058, 1)
+//                 abi_decode_i_9_1068 := add(abi_decode_i_9_1068, 1)
 //             }
 //             {
-//                 if iszero(slt(add(abi_decode_src_8_1054, abi_decode__489_1048), _487))
+//                 if iszero(slt(add(abi_decode_src_8_1064, abi_decode__489_1056), _487))
 //                 {
 //                     revert(_2, _2)
 //                 }
-//                 let abi_decode_abi_decode_length_14 := 0x2
+//                 let abi_decode_abi_decode_length_14_1069 := 0x2
 //                 if _2
 //                 {
 //                     revert(_2, _2)
 //                 }
 //                 let allocateMe_memPtr_315 := mload(abi_encode_pos_590)
 //                 let allocateMe_newFreePtr := add(allocateMe_memPtr_315, abi_encode_pos_590)
-//                 if or(gt(allocateMe_newFreePtr, _936), lt(allocateMe_newFreePtr, allocateMe_memPtr_315))
+//                 if or(gt(allocateMe_newFreePtr, _945), lt(allocateMe_newFreePtr, allocateMe_memPtr_315))
 //                 {
 //                     revert(_2, _2)
 //                 }
 //                 mstore(abi_encode_pos_590, allocateMe_newFreePtr)
-//                 let abi_decode_abi_decode_dst_15 := allocateMe_memPtr_315
-//                 let abi_decode_abi_decode_src_16 := abi_decode_src_8_1054
-//                 if gt(add(abi_decode_src_8_1054, abi_encode_pos_590), _487)
+//                 let abi_decode_abi_decode_dst_15_1071 := allocateMe_memPtr_315
+//                 let abi_decode_abi_decode_src_16_1072 := abi_decode_src_8_1064
+//                 if gt(add(abi_decode_src_8_1064, abi_encode_pos_590), _487)
 //                 {
 //                     revert(_2, _2)
 //                 }
 //                 for {
-//                     let abi_decode_abi_decode_i_17 := _2
+//                     let abi_decode_abi_decode_i_17_1073 := _2
 //                 }
-//                 lt(abi_decode_abi_decode_i_17, abi_decode_abi_decode_length_14)
+//                 lt(abi_decode_abi_decode_i_17_1073, abi_decode_abi_decode_length_14_1069)
 //                 {
-//                     abi_decode_abi_decode_i_17 := add(abi_decode_abi_decode_i_17, 1)
+//                     abi_decode_abi_decode_i_17_1073 := add(abi_decode_abi_decode_i_17_1073, 1)
 //                 }
 //                 {
-//                     mstore(abi_decode_abi_decode_dst_15, calldataload(abi_decode_abi_decode_src_16))
-//                     abi_decode_abi_decode_dst_15 := add(abi_decode_abi_decode_dst_15, _1)
-//                     abi_decode_abi_decode_src_16 := add(abi_decode_abi_decode_src_16, _1)
+//                     mstore(abi_decode_abi_decode_dst_15_1071, calldataload(abi_decode_abi_decode_src_16_1072))
+//                     abi_decode_abi_decode_dst_15_1071 := add(abi_decode_abi_decode_dst_15_1071, _1)
+//                     abi_decode_abi_decode_src_16_1072 := add(abi_decode_abi_decode_src_16_1072, _1)
 //                 }
-//                 mstore(abi_decode_dst_7_1052, allocateMe_memPtr_315)
-//                 abi_decode_dst_7_1052 := add(abi_decode_dst_7_1052, _1)
-//                 abi_decode_src_8_1054 := add(abi_decode_src_8_1054, _924)
+//                 mstore(abi_decode_dst_7_1062, allocateMe_memPtr_315)
+//                 abi_decode_dst_7_1062 := add(abi_decode_dst_7_1062, _1)
+//                 abi_decode_src_8_1064 := add(abi_decode_src_8_1064, _933)
 //             }
-//             abi_decode_value3 := abi_decode_array_5_254_1051
+//             abi_decode_value3 := abi_decode_array_5_254_1061
 //         }
 //         sstore(abi_decode_value0_60, abi_decode_value1_61)
 //         sstore(abi_decode_value2, abi_decode_value3)


### PR DESCRIPTION
This inconsistency was caused by merging #5333 without rebasing it on top of #5392 , which changed the iteration order on yul strings.