### PR TITLE
keccak256 does not call an external contract

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -455,7 +455,7 @@ execution data (``msg.value`` or ``gasleft()``) or makes calls to external contr
 that might have a side-effect on memory allocation are allowed, but those that
 might have a side-effect on other memory objects are not. The built-in functions
 ``keccak256``, ``sha256``, ``ripemd160``, ``ecrecover``, ``addmod`` and ``mulmod``
-are allowed (even though they do call external contracts).
+are allowed (even though, with the exception of ``keccak256``, they do call external contracts).
 
 The reason behind allowing side-effects on the memory allocator is that it
 should be possible to construct complex objects like e.g. lookup-tables.


### PR DESCRIPTION
``keccak256`` will be compiled to the ``SHA3`` opcode and not call an external contract.

### Description

The current version of the description suggests that ``keccak256`` is an external contract which is not the case.

### Checklist
- [x] Used meaningful commit messages
