### PR TITLE
Revert "Disable covereage cmake option"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
       - image: buildpack-deps:artful
     environment:
       TERM: xterm
-      CMAKE_OPTIONS: -DCOVERAGE=OFF
+      CMAKE_OPTIONS: -DCOVERAGE=ON
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This reverts commit 5effc0eeb9cd5158b906facde69a3c4d52d95314.

Reverts #5342.

As agreed before the release.
