### PR TITLE
DOCS: Move undefined FAQ item

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -143,44 +143,6 @@ arguments for you.
 See `ping.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_ping.sol>`_ and
 `pong.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_pong.sol>`_.
 
-When returning a value of say ``uint`` type, is it possible to return an ``undefined`` or "null"-like value?
-============================================================================================================
-
-This is not possible, because all types use up the full value range.
-
-You have the option to ``throw`` on error, which will also revert the whole
-transaction, which might be a good idea if you ran into an unexpected
-situation.
-
-If you do not want to throw, you can return a pair::
-
-    pragma solidity >0.4.23 <0.6.0;
-
-    contract C {
-        uint[] counters;
-
-        function getCounter(uint index)
-            public
-            view
-            returns (uint counter, bool error) {
-                if (index >= counters.length)
-                    return (0, true);
-                else
-                    return (counters[index], false);
-        }
-
-        function checkCounter(uint index) public view {
-            (uint counter, bool error) = getCounter(index);
-            if (error) {
-                // Handle the error
-            } else {
-                // Do something with counter.
-                require(counter > 7, "Invalid counter value");
-            }
-        }
-    }
-
-
 Are comments included with deployed contracts and do they increase deployment gas?
 ==================================================================================
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -13,7 +13,7 @@ Solidity provides several elementary types which can be combined to form complex
 In addition, types can interact with each other in expressions containing
 operators. For a quick reference of the various operators, see :ref:`order`.
 
-The concept of "undefined" or "null" values do not exist in Solidity, but newly
+The concept of "undefined" or "null" values does not exist in Solidity, but newly
 declared variables always have a :ref:`default value<default-value>` dependent
 on its type. To handle any unexpected values, you should use the :ref:`revert function<assert-and-require>` to revert the whole transaction, or return a
 tuple with a second `bool` value denoting success.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -13,7 +13,10 @@ Solidity provides several elementary types which can be combined to form complex
 In addition, types can interact with each other in expressions containing
 operators. For a quick reference of the various operators, see :ref:`order`.
 
-The concept of "undefined" or "null" values do not exist in Solidity. To handle any unexpected values, you should use the :ref:`revert function<assert-and-require>` to revert the whole transaction, or return a tuple with a second `bool` value denoting success.
+The concept of "undefined" or "null" values do not exist in Solidity, but newly
+declared variables always have a :ref:`default value<default-value>` dependent
+on its type. To handle any unexpected values, you should use the :ref:`revert function<assert-and-require>` to revert the whole transaction, or return a
+tuple with a second `bool` value denoting success.
 
 .. index:: ! value type, ! type;value
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -13,6 +13,8 @@ Solidity provides several elementary types which can be combined to form complex
 In addition, types can interact with each other in expressions containing
 operators. For a quick reference of the various operators, see :ref:`order`.
 
+The concept of "undefined" or "null" values do not exist in Solidity. To handle any unexpected values, you should use the :ref:`revert function<assert-and-require>` to revert the whole transaction.
+
 .. index:: ! value type, ! type;value
 
 Value Types

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -13,7 +13,7 @@ Solidity provides several elementary types which can be combined to form complex
 In addition, types can interact with each other in expressions containing
 operators. For a quick reference of the various operators, see :ref:`order`.
 
-The concept of "undefined" or "null" values do not exist in Solidity. To handle any unexpected values, you should use the :ref:`revert function<assert-and-require>` to revert the whole transaction.
+The concept of "undefined" or "null" values do not exist in Solidity. To handle any unexpected values, you should use the :ref:`revert function<assert-and-require>` to revert the whole transaction, or return a tuple with a second `bool` value denoting success.
 
 .. index:: ! value type, ! type;value
 


### PR DESCRIPTION
### Description

Move undefined FAQ item into main docs, breaking https://github.com/ethereum/solidity/pull/4499/files

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
