### PR TITLE
Removing redundant virtual from override function declaration

### DIFF
--- a/libevmasm/ConstantOptimiser.h
+++ b/libevmasm/ConstantOptimiser.h
@@ -109,8 +109,8 @@ class LiteralMethod: public ConstantOptimisationMethod
 public:
 	explicit LiteralMethod(Params const& _params, u256 const& _value):
 		ConstantOptimisationMethod(_params, _value) {}
-	virtual bigint gasNeeded() const override;
-	virtual AssemblyItems execute(Assembly&) const override { return AssemblyItems{}; }
+	bigint gasNeeded() const override;
+	AssemblyItems execute(Assembly&) const override { return AssemblyItems{}; }
 };
 
 /**
@@ -120,8 +120,8 @@ class CodeCopyMethod: public ConstantOptimisationMethod
 {
 public:
 	explicit CodeCopyMethod(Params const& _params, u256 const& _value);
-	virtual bigint gasNeeded() const override;
-	virtual AssemblyItems execute(Assembly& _assembly) const override;
+	bigint gasNeeded() const override;
+	AssemblyItems execute(Assembly& _assembly) const override;
 
 protected:
 	static AssemblyItems const& copyRoutine();
@@ -144,8 +144,8 @@ public:
 		);
 	}
 
-	virtual bigint gasNeeded() const override { return gasNeeded(m_routine); }
-	virtual AssemblyItems execute(Assembly&) const override
+	bigint gasNeeded() const override { return gasNeeded(m_routine); }
+	AssemblyItems execute(Assembly&) const override
 	{
 		return m_routine;
 	}

--- a/libsolidity/analysis/ControlFlowAnalyzer.h
+++ b/libsolidity/analysis/ControlFlowAnalyzer.h
@@ -34,7 +34,7 @@ public:
 
 	bool analyze(ASTNode const& _astRoot);
 
-	virtual bool visit(FunctionDefinition const& _function) override;
+	bool visit(FunctionDefinition const& _function) override;
 
 private:
 	static std::set<VariableDeclaration const*> variablesAssignedInNode(CFGNode const *node);

--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -46,19 +46,19 @@ public:
 private:
 	explicit ControlFlowBuilder(CFG::NodeContainer& _nodeContainer, FunctionFlow const& _functionFlow);
 
-	virtual bool visit(BinaryOperation const& _operation) override;
-	virtual bool visit(Conditional const& _conditional) override;
-	virtual bool visit(IfStatement const& _ifStatement) override;
-	virtual bool visit(ForStatement const& _forStatement) override;
-	virtual bool visit(WhileStatement const& _whileStatement) override;
-	virtual bool visit(Break const&) override;
-	virtual bool visit(Continue const&) override;
-	virtual bool visit(Throw const&) override;
-	virtual bool visit(Block const&) override;
-	virtual void endVisit(Block const&) override;
-	virtual bool visit(Return const& _return) override;
-	virtual bool visit(PlaceholderStatement const&) override;
-	virtual bool visit(FunctionCall const& _functionCall) override;
+	bool visit(BinaryOperation const& _operation) override;
+	bool visit(Conditional const& _conditional) override;
+	bool visit(IfStatement const& _ifStatement) override;
+	bool visit(ForStatement const& _forStatement) override;
+	bool visit(WhileStatement const& _whileStatement) override;
+	bool visit(Break const&) override;
+	bool visit(Continue const&) override;
+	bool visit(Throw const&) override;
+	bool visit(Block const&) override;
+	void endVisit(Block const&) override;
+	bool visit(Return const& _return) override;
+	bool visit(PlaceholderStatement const&) override;
+	bool visit(FunctionCall const& _functionCall) override;
 
 
 	/// Appends the control flow of @a _node to the current control flow.
@@ -74,7 +74,7 @@ private:
 
 
 protected:
-	virtual bool visitNode(ASTNode const& node) override;
+	bool visitNode(ASTNode const& node) override;
 
 private:
 

--- a/libsolidity/analysis/ControlFlowGraph.h
+++ b/libsolidity/analysis/ControlFlowGraph.h
@@ -105,8 +105,8 @@ public:
 
 	bool constructFlow(ASTNode const& _astRoot);
 
-	virtual bool visit(ModifierDefinition const& _modifier) override;
-	virtual bool visit(FunctionDefinition const& _function) override;
+	bool visit(ModifierDefinition const& _modifier) override;
+	bool visit(FunctionDefinition const& _function) override;
 
 	FunctionFlow const& functionFlow(FunctionDefinition const& _function) const;
 

--- a/libsolidity/analysis/DocStringAnalyser.h
+++ b/libsolidity/analysis/DocStringAnalyser.h
@@ -43,10 +43,10 @@ public:
 	bool analyseDocStrings(SourceUnit const& _sourceUnit);
 
 private:
-	virtual bool visit(ContractDefinition const& _contract) override;
-	virtual bool visit(FunctionDefinition const& _function) override;
-	virtual bool visit(ModifierDefinition const& _modifier) override;
-	virtual bool visit(EventDefinition const& _event) override;
+	bool visit(ContractDefinition const& _contract) override;
+	bool visit(FunctionDefinition const& _function) override;
+	bool visit(ModifierDefinition const& _modifier) override;
+	bool visit(EventDefinition const& _event) override;
 
 	void checkParameters(
 		CallableDeclaration const& _callable,

--- a/libsolidity/analysis/PostTypeChecker.h
+++ b/libsolidity/analysis/PostTypeChecker.h
@@ -47,13 +47,13 @@ private:
 	/// Adds a new error to the list of errors.
 	void typeError(SourceLocation const& _location, std::string const& _description);
 
-	virtual bool visit(ContractDefinition const& _contract) override;
-	virtual void endVisit(ContractDefinition const& _contract) override;
+	bool visit(ContractDefinition const& _contract) override;
+	void endVisit(ContractDefinition const& _contract) override;
 
-	virtual bool visit(VariableDeclaration const& _variable) override;
-	virtual void endVisit(VariableDeclaration const& _variable) override;
+	bool visit(VariableDeclaration const& _variable) override;
+	void endVisit(VariableDeclaration const& _variable) override;
 
-	virtual bool visit(Identifier const& _identifier) override;
+	bool visit(Identifier const& _identifier) override;
 
 	VariableDeclaration const* findCycle(VariableDeclaration const& _startingFrom);
 

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -57,24 +57,24 @@ public:
 	bool resolve(ASTNode const& _root);
 
 private:
-	virtual bool visit(Block const& _block) override;
-	virtual void endVisit(Block const& _block) override;
-	virtual bool visit(ForStatement const& _for) override;
-	virtual void endVisit(ForStatement const& _for) override;
-	virtual void endVisit(VariableDeclarationStatement const& _varDeclStatement) override;
-	virtual bool visit(Identifier const& _identifier) override;
-	virtual bool visit(ElementaryTypeName const& _typeName) override;
-	virtual bool visit(FunctionDefinition const& _functionDefinition) override;
-	virtual void endVisit(FunctionDefinition const& _functionDefinition) override;
-	virtual bool visit(ModifierDefinition const& _modifierDefinition) override;
-	virtual void endVisit(ModifierDefinition const& _modifierDefinition) override;
-	virtual void endVisit(UserDefinedTypeName const& _typeName) override;
-	virtual void endVisit(FunctionTypeName const& _typeName) override;
-	virtual void endVisit(Mapping const& _typeName) override;
-	virtual void endVisit(ArrayTypeName const& _typeName) override;
-	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
-	virtual bool visit(Return const& _return) override;
-	virtual void endVisit(VariableDeclaration const& _variable) override;
+	bool visit(Block const& _block) override;
+	void endVisit(Block const& _block) override;
+	bool visit(ForStatement const& _for) override;
+	void endVisit(ForStatement const& _for) override;
+	void endVisit(VariableDeclarationStatement const& _varDeclStatement) override;
+	bool visit(Identifier const& _identifier) override;
+	bool visit(ElementaryTypeName const& _typeName) override;
+	bool visit(FunctionDefinition const& _functionDefinition) override;
+	void endVisit(FunctionDefinition const& _functionDefinition) override;
+	bool visit(ModifierDefinition const& _modifierDefinition) override;
+	void endVisit(ModifierDefinition const& _modifierDefinition) override;
+	void endVisit(UserDefinedTypeName const& _typeName) override;
+	void endVisit(FunctionTypeName const& _typeName) override;
+	void endVisit(Mapping const& _typeName) override;
+	void endVisit(ArrayTypeName const& _typeName) override;
+	bool visit(InlineAssembly const& _inlineAssembly) override;
+	bool visit(Return const& _return) override;
+	void endVisit(VariableDeclaration const& _variable) override;
 
 	/// Adds a new error to the list of errors.
 	void typeError(SourceLocation const& _location, std::string const& _description);

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -52,20 +52,20 @@ public:
 
 private:
 
-	virtual bool visit(ContractDefinition const& _contract) override;
-	virtual void endVisit(ContractDefinition const& _contract) override;
+	bool visit(ContractDefinition const& _contract) override;
+	void endVisit(ContractDefinition const& _contract) override;
 
-	virtual bool visit(FunctionDefinition const& _function) override;
-	virtual void endVisit(FunctionDefinition const& _function) override;
+	bool visit(FunctionDefinition const& _function) override;
+	void endVisit(FunctionDefinition const& _function) override;
 
-	virtual bool visit(ExpressionStatement const& _statement) override;
-	virtual bool visit(VariableDeclaration const& _variable) override;
-	virtual bool visit(Identifier const& _identifier) override;
-	virtual bool visit(Return const& _return) override;
-	virtual bool visit(MemberAccess const& _memberAccess) override;
-	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
-	virtual bool visit(BinaryOperation const& _operation) override;
-	virtual bool visit(FunctionCall const& _functionCall) override;
+	bool visit(ExpressionStatement const& _statement) override;
+	bool visit(VariableDeclaration const& _variable) override;
+	bool visit(Identifier const& _identifier) override;
+	bool visit(Return const& _return) override;
+	bool visit(MemberAccess const& _memberAccess) override;
+	bool visit(InlineAssembly const& _inlineAssembly) override;
+	bool visit(BinaryOperation const& _operation) override;
+	bool visit(FunctionCall const& _functionCall) override;
 
 	/// @returns the size of this type in storage, including all sub-types.
 	static bigint structureSizeEstimate(Type const& _type, std::set<StructDefinition const*>& _structsSeen);

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -45,41 +45,41 @@ public:
 
 private:
 
-	virtual bool visit(SourceUnit const& _sourceUnit) override;
-	virtual void endVisit(SourceUnit const& _sourceUnit) override;
-	virtual bool visit(PragmaDirective const& _pragma) override;
+	bool visit(SourceUnit const& _sourceUnit) override;
+	void endVisit(SourceUnit const& _sourceUnit) override;
+	bool visit(PragmaDirective const& _pragma) override;
 
-	virtual bool visit(ModifierDefinition const& _modifier) override;
-	virtual void endVisit(ModifierDefinition const& _modifier) override;
+	bool visit(ModifierDefinition const& _modifier) override;
+	void endVisit(ModifierDefinition const& _modifier) override;
 
 	/// Reports an error if _statement is a VariableDeclarationStatement.
 	/// Used by if/while/for to check for single statement variable declarations
 	/// without a block.
 	void checkSingleStatementVariableDeclaration(ASTNode const& _statement);
 
-	virtual bool visit(IfStatement const& _ifStatement) override;
-	virtual bool visit(WhileStatement const& _whileStatement) override;
-	virtual void endVisit(WhileStatement const& _whileStatement) override;
-	virtual bool visit(ForStatement const& _forStatement) override;
-	virtual void endVisit(ForStatement const& _forStatement) override;
+	bool visit(IfStatement const& _ifStatement) override;
+	bool visit(WhileStatement const& _whileStatement) override;
+	void endVisit(WhileStatement const& _whileStatement) override;
+	bool visit(ForStatement const& _forStatement) override;
+	void endVisit(ForStatement const& _forStatement) override;
 
-	virtual bool visit(Continue const& _continueStatement) override;
-	virtual bool visit(Break const& _breakStatement) override;
+	bool visit(Continue const& _continueStatement) override;
+	bool visit(Break const& _breakStatement) override;
 
-	virtual bool visit(Throw const& _throwStatement) override;
+	bool visit(Throw const& _throwStatement) override;
 
-	virtual bool visit(UnaryOperation const& _operation) override;
+	bool visit(UnaryOperation const& _operation) override;
 
-	virtual bool visit(PlaceholderStatement const& _placeholderStatement) override;
+	bool visit(PlaceholderStatement const& _placeholderStatement) override;
 
-	virtual bool visit(ContractDefinition const& _contract) override;
-	virtual bool visit(FunctionDefinition const& _function) override;
-	virtual bool visit(FunctionTypeName const& _node) override;
+	bool visit(ContractDefinition const& _contract) override;
+	bool visit(FunctionDefinition const& _function) override;
+	bool visit(FunctionTypeName const& _node) override;
 
-	virtual bool visit(VariableDeclarationStatement const& _statement) override;
+	bool visit(VariableDeclarationStatement const& _statement) override;
 
-	virtual bool visit(StructDefinition const& _struct) override;
-	virtual bool visit(Literal const& _literal) override;
+	bool visit(StructDefinition const& _struct) override;
+	bool visit(Literal const& _literal) override;
 
 	ErrorReporter& m_errorReporter;
 

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -62,7 +62,7 @@ public:
 
 private:
 
-	virtual bool visit(ContractDefinition const& _contract) override;
+	bool visit(ContractDefinition const& _contract) override;
 	/// Checks that two functions defined in this contract with the same name have different
 	/// arguments and that there is at most one constructor.
 	void checkContractDuplicateFunctions(ContractDefinition const& _contract);
@@ -122,37 +122,37 @@ private:
 		FunctionTypePointer _functionType
 	);
 
-	virtual void endVisit(InheritanceSpecifier const& _inheritance) override;
-	virtual void endVisit(UsingForDirective const& _usingFor) override;
-	virtual bool visit(StructDefinition const& _struct) override;
-	virtual bool visit(FunctionDefinition const& _function) override;
-	virtual bool visit(VariableDeclaration const& _variable) override;
+	void endVisit(InheritanceSpecifier const& _inheritance) override;
+	void endVisit(UsingForDirective const& _usingFor) override;
+	bool visit(StructDefinition const& _struct) override;
+	bool visit(FunctionDefinition const& _function) override;
+	bool visit(VariableDeclaration const& _variable) override;
 	/// We need to do this manually because we want to pass the bases of the current contract in
 	/// case this is a base constructor call.
 	void visitManually(ModifierInvocation const& _modifier, std::vector<ContractDefinition const*> const& _bases);
-	virtual bool visit(EventDefinition const& _eventDef) override;
-	virtual void endVisit(FunctionTypeName const& _funType) override;
-	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
-	virtual bool visit(IfStatement const& _ifStatement) override;
-	virtual bool visit(WhileStatement const& _whileStatement) override;
-	virtual bool visit(ForStatement const& _forStatement) override;
-	virtual void endVisit(Return const& _return) override;
-	virtual bool visit(EmitStatement const&) override { m_insideEmitStatement = true; return true; }
-	virtual void endVisit(EmitStatement const& _emit) override;
-	virtual bool visit(VariableDeclarationStatement const& _variable) override;
-	virtual void endVisit(ExpressionStatement const& _statement) override;
-	virtual bool visit(Conditional const& _conditional) override;
-	virtual bool visit(Assignment const& _assignment) override;
-	virtual bool visit(TupleExpression const& _tuple) override;
-	virtual void endVisit(BinaryOperation const& _operation) override;
-	virtual bool visit(UnaryOperation const& _operation) override;
-	virtual bool visit(FunctionCall const& _functionCall) override;
-	virtual void endVisit(NewExpression const& _newExpression) override;
-	virtual bool visit(MemberAccess const& _memberAccess) override;
-	virtual bool visit(IndexAccess const& _indexAccess) override;
-	virtual bool visit(Identifier const& _identifier) override;
-	virtual void endVisit(ElementaryTypeNameExpression const& _expr) override;
-	virtual void endVisit(Literal const& _literal) override;
+	bool visit(EventDefinition const& _eventDef) override;
+	void endVisit(FunctionTypeName const& _funType) override;
+	bool visit(InlineAssembly const& _inlineAssembly) override;
+	bool visit(IfStatement const& _ifStatement) override;
+	bool visit(WhileStatement const& _whileStatement) override;
+	bool visit(ForStatement const& _forStatement) override;
+	void endVisit(Return const& _return) override;
+	bool visit(EmitStatement const&) override { m_insideEmitStatement = true; return true; }
+	void endVisit(EmitStatement const& _emit) override;
+	bool visit(VariableDeclarationStatement const& _variable) override;
+	void endVisit(ExpressionStatement const& _statement) override;
+	bool visit(Conditional const& _conditional) override;
+	bool visit(Assignment const& _assignment) override;
+	bool visit(TupleExpression const& _tuple) override;
+	void endVisit(BinaryOperation const& _operation) override;
+	bool visit(UnaryOperation const& _operation) override;
+	bool visit(FunctionCall const& _functionCall) override;
+	void endVisit(NewExpression const& _newExpression) override;
+	bool visit(MemberAccess const& _memberAccess) override;
+	bool visit(IndexAccess const& _indexAccess) override;
+	bool visit(Identifier const& _identifier) override;
+	void endVisit(ElementaryTypeNameExpression const& _expr) override;
+	void endVisit(Literal const& _literal) override;
 
 	template <class T>
 	void findDuplicateDefinitions(std::map<std::string, std::vector<T>> const& _definitions, std::string _message);

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -46,17 +46,17 @@ private:
 		SourceLocation location;
 	};
 
-	virtual bool visit(FunctionDefinition const& _funDef) override;
-	virtual void endVisit(FunctionDefinition const& _funDef) override;
-	virtual bool visit(ModifierDefinition const& _modifierDef) override;
-	virtual void endVisit(ModifierDefinition const& _modifierDef) override;
-	virtual void endVisit(Identifier const& _identifier) override;
-	virtual bool visit(MemberAccess const& _memberAccess) override;
-	virtual void endVisit(MemberAccess const& _memberAccess) override;
-	virtual void endVisit(IndexAccess const& _indexAccess) override;
-	virtual void endVisit(ModifierInvocation const& _modifier) override;
-	virtual void endVisit(FunctionCall const& _functionCall) override;
-	virtual void endVisit(InlineAssembly const& _inlineAssembly) override;
+	bool visit(FunctionDefinition const& _funDef) override;
+	void endVisit(FunctionDefinition const& _funDef) override;
+	bool visit(ModifierDefinition const& _modifierDef) override;
+	void endVisit(ModifierDefinition const& _modifierDef) override;
+	void endVisit(Identifier const& _identifier) override;
+	bool visit(MemberAccess const& _memberAccess) override;
+	void endVisit(MemberAccess const& _memberAccess) override;
+	void endVisit(IndexAccess const& _indexAccess) override;
+	void endVisit(ModifierInvocation const& _modifier) override;
+	void endVisit(FunctionCall const& _functionCall) override;
+	void endVisit(InlineAssembly const& _inlineAssembly) override;
 
 	/// Called when an element of mutability @a _mutability is encountered.
 	/// Creates appropriate warnings and errors and sets @a m_currentBestMutability.

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -126,9 +126,9 @@ public:
 	SourceUnit(SourceLocation const& _location, std::vector<ASTPointer<ASTNode>> const& _nodes):
 		ASTNode(_location), m_nodes(_nodes) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
-	virtual SourceUnitAnnotation& annotation() const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+	SourceUnitAnnotation& annotation() const override;
 
 	std::vector<ASTPointer<ASTNode>> nodes() const { return m_nodes; }
 
@@ -242,8 +242,8 @@ public:
 	): ASTNode(_location), m_tokens(_tokens), m_literals(_literals)
 	{}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<Token> const& tokens() const { return m_tokens; }
 	std::vector<ASTString> const& literals() const { return m_literals; }
@@ -279,17 +279,17 @@ public:
 		m_symbolAliases(_symbolAliases)
 	{ }
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	ASTString const& path() const { return *m_path; }
 	std::vector<std::pair<ASTPointer<Identifier>, ASTPointer<ASTString>>> const& symbolAliases() const
 	{
 		return m_symbolAliases;
 	}
-	virtual ImportAnnotation& annotation() const override;
+	ImportAnnotation& annotation() const override;
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
 private:
 	ASTPointer<ASTString> m_path;
@@ -375,8 +375,8 @@ public:
 		m_contractKind(_contractKind)
 	{}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<InheritanceSpecifier>> const& baseContracts() const { return m_baseContracts; }
 	std::vector<ASTPointer<ASTNode>> const& subNodes() const { return m_subNodes; }
@@ -407,9 +407,9 @@ public:
 
 	std::string fullyQualifiedName() const { return sourceUnitName() + ":" + name(); }
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
-	virtual ContractDefinitionAnnotation& annotation() const override;
+	ContractDefinitionAnnotation& annotation() const override;
 
 	ContractKind contractKind() const { return m_contractKind; }
 
@@ -434,8 +434,8 @@ public:
 	):
 		ASTNode(_location), m_baseName(_baseName), m_arguments(std::move(_arguments)) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	UserDefinedTypeName const& name() const { return *m_baseName; }
 	// Returns nullptr if no argument list was given (``C``).
@@ -463,8 +463,8 @@ public:
 	):
 		ASTNode(_location), m_libraryName(_libraryName), m_typeName(_typeName) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	UserDefinedTypeName const& libraryName() const { return *m_libraryName; }
 	/// @returns the type name the library is attached to, null for `*`.
@@ -485,14 +485,14 @@ public:
 	):
 		Declaration(_location, _name), m_members(_members) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<VariableDeclaration>> const& members() const { return m_members; }
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
-	virtual TypeDeclarationAnnotation& annotation() const override;
+	TypeDeclarationAnnotation& annotation() const override;
 
 private:
 	std::vector<ASTPointer<VariableDeclaration>> m_members;
@@ -507,14 +507,14 @@ public:
 		std::vector<ASTPointer<EnumValue>> const& _members
 	):
 		Declaration(_location, _name), m_members(_members) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<EnumValue>> const& members() const { return m_members; }
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
-	virtual TypeDeclarationAnnotation& annotation() const override;
+	TypeDeclarationAnnotation& annotation() const override;
 
 private:
 	std::vector<ASTPointer<EnumValue>> m_members;
@@ -529,10 +529,10 @@ public:
 	EnumValue(SourceLocation const& _location, ASTPointer<ASTString> const& _name):
 		Declaration(_location, _name) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 };
 
 /**
@@ -548,8 +548,8 @@ public:
 		std::vector<ASTPointer<VariableDeclaration>> const& _parameters
 	):
 		ASTNode(_location), m_parameters(_parameters) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<VariableDeclaration>> const& parameters() const { return m_parameters; }
 
@@ -610,8 +610,8 @@ public:
 		m_body(_body)
 	{}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	StateMutability stateMutability() const { return m_stateMutability; }
 	bool isConstructor() const { return m_isConstructor; }
@@ -620,11 +620,11 @@ public:
 	std::vector<ASTPointer<ModifierInvocation>> const& modifiers() const { return m_functionModifiers; }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameters() const { return m_returnParameters->parameters(); }
 	Block const& body() const { solAssert(m_body, ""); return *m_body; }
-	virtual bool isVisibleInContract() const override
+	bool isVisibleInContract() const override
 	{
 		return Declaration::isVisibleInContract() && !isConstructor() && !isFallback();
 	}
-	virtual bool isPartOfExternalInterface() const override { return isPublic() && !isConstructor() && !isFallback(); }
+	bool isPartOfExternalInterface() const override { return isPublic() && !isConstructor() && !isFallback(); }
 
 	/// @returns the external signature of the function
 	/// That consists of the name of the function followed by the types of the
@@ -633,13 +633,13 @@ public:
 
 	ContractDefinition::ContractKind inContractKind() const;
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.
 	/// @returns null when it is not accessible as a function.
-	virtual FunctionTypePointer functionType(bool /*_internal*/) const override;
+	FunctionTypePointer functionType(bool /*_internal*/) const override;
 
-	virtual FunctionDefinitionAnnotation& annotation() const override;
+	FunctionDefinitionAnnotation& annotation() const override;
 
 private:
 	StateMutability m_stateMutability;
@@ -676,14 +676,14 @@ public:
 		m_isConstant(_isConstant),
 		m_location(_referenceLocation) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	TypeName* typeName() const { return m_typeName.get(); }
 	ASTPointer<Expression> const& value() const { return m_value; }
 
-	virtual bool isLValue() const override;
-	virtual bool isPartOfExternalInterface() const override { return isPublic(); }
+	bool isLValue() const override;
+	bool isPartOfExternalInterface() const override { return isPublic(); }
 
 	/// @returns true iff this variable is the parameter (or return parameter) of a function
 	/// (or function type name or event) or declared inside a function body.
@@ -717,13 +717,13 @@ public:
 	/// @returns a set of allowed storage locations for the variable.
 	std::set<Location> allowedDataLocations() const;
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.
 	/// @returns null when it is not accessible as a function.
-	virtual FunctionTypePointer functionType(bool /*_internal*/) const override;
+	FunctionTypePointer functionType(bool /*_internal*/) const override;
 
-	virtual VariableDeclarationAnnotation& annotation() const override;
+	VariableDeclarationAnnotation& annotation() const override;
 
 protected:
 	Visibility defaultVisibility() const override { return Visibility::Internal; }
@@ -758,14 +758,14 @@ public:
 	{
 	}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Block const& body() const { return *m_body; }
 
-	virtual TypePointer type() const override;
+	TypePointer type() const override;
 
-	virtual ModifierDefinitionAnnotation& annotation() const override;
+	ModifierDefinitionAnnotation& annotation() const override;
 
 private:
 	ASTPointer<Block> m_body;
@@ -784,8 +784,8 @@ public:
 	):
 		ASTNode(_location), m_modifierName(_name), m_arguments(std::move(_arguments)) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	ASTPointer<Identifier> const& name() const { return m_modifierName; }
 	// Returns nullptr if no argument list was given (``mod``).
@@ -817,15 +817,15 @@ public:
 	{
 	}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	bool isAnonymous() const { return m_anonymous; }
 
-	virtual TypePointer type() const override;
-	virtual FunctionTypePointer functionType(bool /*_internal*/) const override;
+	TypePointer type() const override;
+	FunctionTypePointer functionType(bool /*_internal*/) const override;
 
-	virtual EventDefinitionAnnotation& annotation() const override;
+	EventDefinitionAnnotation& annotation() const override;
 
 private:
 	bool m_anonymous = false;
@@ -840,21 +840,21 @@ class MagicVariableDeclaration: public Declaration
 public:
 	MagicVariableDeclaration(ASTString const& _name, std::shared_ptr<Type const> const& _type):
 		Declaration(SourceLocation(), std::make_shared<ASTString>(_name)), m_type(_type) {}
-	virtual void accept(ASTVisitor&) override
+	void accept(ASTVisitor&) override
 	{
 		solAssert(false, "MagicVariableDeclaration used inside real AST.");
 	}
-	virtual void accept(ASTConstVisitor&) const override
+	void accept(ASTConstVisitor&) const override
 	{
 		solAssert(false, "MagicVariableDeclaration used inside real AST.");
 	}
 
-	virtual FunctionTypePointer functionType(bool) const override
+	FunctionTypePointer functionType(bool) const override
 	{
 		solAssert(m_type->category() == Type::Category::Function, "");
 		return std::dynamic_pointer_cast<FunctionType const>(m_type);
 	}
-	virtual TypePointer type() const override { return m_type; }
+	TypePointer type() const override { return m_type; }
 
 private:
 	std::shared_ptr<Type const> m_type;
@@ -872,7 +872,7 @@ protected:
 	explicit TypeName(SourceLocation const& _location): ASTNode(_location) {}
 
 public:
-	virtual TypeNameAnnotation& annotation() const override;
+	TypeNameAnnotation& annotation() const override;
 };
 
 /**
@@ -891,8 +891,8 @@ public:
 		solAssert(!_stateMutability.is_initialized() || _elem.token() == Token::Address, "");
 	}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	ElementaryTypeNameToken const& typeName() const { return m_type; }
 
@@ -911,12 +911,12 @@ class UserDefinedTypeName: public TypeName
 public:
 	UserDefinedTypeName(SourceLocation const& _location, std::vector<ASTString> const& _namePath):
 		TypeName(_location), m_namePath(_namePath) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTString> const& namePath() const { return m_namePath; }
 
-	virtual UserDefinedTypeNameAnnotation& annotation() const override;
+	UserDefinedTypeNameAnnotation& annotation() const override;
 
 private:
 	std::vector<ASTString> m_namePath;
@@ -938,8 +938,8 @@ public:
 		TypeName(_location), m_parameterTypes(_parameterTypes), m_returnTypes(_returnTypes),
 		m_visibility(_visibility), m_stateMutability(_stateMutability)
 	{}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<VariableDeclaration>> const& parameterTypes() const { return m_parameterTypes->parameters(); }
 	std::vector<ASTPointer<VariableDeclaration>> const& returnParameterTypes() const { return m_returnTypes->parameters(); }
@@ -972,8 +972,8 @@ public:
 		ASTPointer<TypeName> const& _valueType
 	):
 		TypeName(_location), m_keyType(_keyType), m_valueType(_valueType) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	ElementaryTypeName const& keyType() const { return *m_keyType; }
 	TypeName const& valueType() const { return *m_valueType; }
@@ -995,8 +995,8 @@ public:
 		ASTPointer<Expression> const& _length
 	):
 		TypeName(_location), m_baseType(_baseType), m_length(_length) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	TypeName const& baseType() const { return *m_baseType; }
 	Expression const* length() const { return m_length.get(); }
@@ -1023,7 +1023,7 @@ public:
 		ASTPointer<ASTString> const& _docString
 	): ASTNode(_location), Documented(_docString) {}
 
-	virtual StatementAnnotation& annotation() const override;
+	StatementAnnotation& annotation() const override;
 };
 
 namespace assembly
@@ -1044,12 +1044,12 @@ public:
 		std::shared_ptr<assembly::Block> const& _operations
 	):
 		Statement(_location, _docString), m_operations(_operations) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	assembly::Block const& operations() const { return *m_operations; }
 
-	virtual InlineAssemblyAnnotation& annotation() const override;
+	InlineAssemblyAnnotation& annotation() const override;
 
 private:
 	std::shared_ptr<assembly::Block> m_operations;
@@ -1067,8 +1067,8 @@ public:
 		std::vector<ASTPointer<Statement>> const& _statements
 	):
 		Statement(_location, _docString), m_statements(_statements) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<Statement>> const& statements() const { return m_statements; }
 
@@ -1088,8 +1088,8 @@ public:
 		ASTPointer<ASTString> const& _docString
 	): Statement(_location, _docString) {}
 
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 };
 
 /**
@@ -1111,8 +1111,8 @@ public:
 		m_trueBody(_trueBody),
 		m_falseBody(_falseBody)
 	{}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& condition() const { return *m_condition; }
 	Statement const& trueStatement() const { return *m_trueBody; }
@@ -1149,8 +1149,8 @@ public:
 	):
 		BreakableStatement(_location, _docString), m_condition(_condition), m_body(_body),
 		m_isDoWhile(_isDoWhile) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& condition() const { return *m_condition; }
 	Statement const& body() const { return *m_body; }
@@ -1182,8 +1182,8 @@ public:
 		m_loopExpression(_loopExpression),
 		m_body(_body)
 	{}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Statement const* initializationExpression() const { return m_initExpression.get(); }
 	Expression const* condition() const { return m_condExpression.get(); }
@@ -1206,8 +1206,8 @@ class Continue: public Statement
 public:
 	explicit Continue(SourceLocation const& _location, 	ASTPointer<ASTString> const& _docString):
 		Statement(_location, _docString) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 };
 
 class Break: public Statement
@@ -1215,8 +1215,8 @@ class Break: public Statement
 public:
 	explicit Break(SourceLocation const& _location, ASTPointer<ASTString> const& _docString):
 		Statement(_location, _docString) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 };
 
 class Return: public Statement
@@ -1227,12 +1227,12 @@ public:
 		ASTPointer<ASTString> const& _docString,
 		ASTPointer<Expression> _expression
 	): Statement(_location, _docString), m_expression(_expression) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const* expression() const { return m_expression.get(); }
 
-	virtual ReturnAnnotation& annotation() const override;
+	ReturnAnnotation& annotation() const override;
 
 private:
 	ASTPointer<Expression> m_expression; ///< value to return, optional
@@ -1246,8 +1246,8 @@ class Throw: public Statement
 public:
 	explicit Throw(SourceLocation const& _location, ASTPointer<ASTString> const& _docString):
 		Statement(_location, _docString) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 };
 
 /**
@@ -1262,8 +1262,8 @@ public:
 		ASTPointer<FunctionCall> const& _functionCall
 	):
 		Statement(_location, _docString), m_eventCall(_functionCall) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	FunctionCall const& eventCall() const { return *m_eventCall; }
 
@@ -1289,8 +1289,8 @@ public:
 		ASTPointer<Expression> const& _initialValue
 	):
 		Statement(_location, _docString), m_variables(_variables), m_initialValue(_initialValue) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<VariableDeclaration>> const& declarations() const { return m_variables; }
 	Expression const* initialValue() const { return m_initialValue.get(); }
@@ -1317,8 +1317,8 @@ public:
 		ASTPointer<Expression> _expression
 	):
 		Statement(_location, _docString), m_expression(_expression) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& expression() const { return *m_expression; }
 
@@ -1358,8 +1358,8 @@ public:
 		m_trueExpression(_trueExpression),
 		m_falseExpression(_falseExpression)
 	{}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& condition() const { return *m_condition; }
 	Expression const& trueExpression() const { return *m_trueExpression; }
@@ -1389,8 +1389,8 @@ public:
 	{
 		solAssert(TokenTraits::isAssignmentOp(_assignmentOperator), "");
 	}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& leftHandSide() const { return *m_leftHandSide; }
 	Token assignmentOperator() const { return m_assigmentOperator; }
@@ -1421,8 +1421,8 @@ public:
 		Expression(_location),
 		m_components(_components),
 		m_isArray(_isArray) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	std::vector<ASTPointer<Expression>> const& components() const { return m_components; }
 	bool isInlineArray() const { return m_isArray; }
@@ -1452,8 +1452,8 @@ public:
 	{
 		solAssert(TokenTraits::isUnaryOp(_operator), "");
 	}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Token getOperator() const { return m_operator; }
 	bool isPrefixOperation() const { return m_isPrefix; }
@@ -1482,8 +1482,8 @@ public:
 	{
 		solAssert(TokenTraits::isBinaryOp(_operator) || TokenTraits::isCompareOp(_operator), "");
 	}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& leftExpression() const { return *m_left; }
 	Expression const& rightExpression() const { return *m_right; }
@@ -1510,14 +1510,14 @@ public:
 		std::vector<ASTPointer<ASTString>> const& _names
 	):
 		Expression(_location), m_expression(_expression), m_arguments(_arguments), m_names(_names) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& expression() const { return *m_expression; }
 	std::vector<ASTPointer<Expression const>> arguments() const { return {m_arguments.begin(), m_arguments.end()}; }
 	std::vector<ASTPointer<ASTString>> const& names() const { return m_names; }
 
-	virtual FunctionCallAnnotation& annotation() const override;
+	FunctionCallAnnotation& annotation() const override;
 
 private:
 	ASTPointer<Expression> m_expression;
@@ -1537,8 +1537,8 @@ public:
 		ASTPointer<TypeName> const& _typeName
 	):
 		Expression(_location), m_typeName(_typeName) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	TypeName const& typeName() const { return *m_typeName; }
 
@@ -1558,12 +1558,12 @@ public:
 		ASTPointer<ASTString> const& _memberName
 	):
 		Expression(_location), m_expression(_expression), m_memberName(_memberName) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 	Expression const& expression() const { return *m_expression; }
 	ASTString const& memberName() const { return *m_memberName; }
 
-	virtual MemberAccessAnnotation& annotation() const override;
+	MemberAccessAnnotation& annotation() const override;
 
 private:
 	ASTPointer<Expression> m_expression;
@@ -1582,8 +1582,8 @@ public:
 		ASTPointer<Expression> const& _index
 	):
 		Expression(_location), m_base(_base), m_index(_index) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Expression const& baseExpression() const { return *m_base; }
 	Expression const* indexExpression() const { return m_index.get(); }
@@ -1614,12 +1614,12 @@ public:
 		ASTPointer<ASTString> const& _name
 	):
 		PrimaryExpression(_location), m_name(_name) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	ASTString const& name() const { return *m_name; }
 
-	virtual IdentifierAnnotation& annotation() const override;
+	IdentifierAnnotation& annotation() const override;
 
 private:
 	ASTPointer<ASTString> m_name;
@@ -1636,8 +1636,8 @@ public:
 	ElementaryTypeNameExpression(SourceLocation const& _location, ElementaryTypeNameToken const& _type):
 		PrimaryExpression(_location), m_typeToken(_type)
 	{}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	ElementaryTypeNameToken const& typeName() const { return m_typeToken; }
 
@@ -1672,8 +1672,8 @@ public:
 		SubDenomination _sub = SubDenomination::None
 	):
 		PrimaryExpression(_location), m_token(_token), m_value(_value), m_subDenomination(_sub) {}
-	virtual void accept(ASTVisitor& _visitor) override;
-	virtual void accept(ASTConstVisitor& _visitor) const override;
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
 
 	Token token() const { return m_token; }
 	/// @returns the non-parsed value of the literal

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -262,8 +262,8 @@ public:
 	): m_onVisit(_onVisit), m_onEndVisit(_onEndVisit) {}
 
 protected:
-	virtual bool visitNode(ASTNode const& _n) override { return m_onVisit ? m_onVisit(_n) : true; }
-	virtual void endVisitNode(ASTNode const& _n) override { m_onEndVisit(_n); }
+	bool visitNode(ASTNode const& _n) override { return m_onVisit ? m_onVisit(_n) : true; }
+	void endVisitNode(ASTNode const& _n) override { m_onEndVisit(_n); }
 
 private:
 	std::function<bool(ASTNode const&)> m_onVisit;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -331,31 +331,31 @@ public:
     static AddressType& address() { static std::shared_ptr<AddressType> addr(std::make_shared<AddressType>(StateMutability::NonPayable)); return *addr; }
     static AddressType& addressPayable() { static std::shared_ptr<AddressType> addr(std::make_shared<AddressType>(StateMutability::Payable)); return *addr; }
 
-	virtual Category category() const override { return Category::Address; }
+	Category category() const override { return Category::Address; }
 
 	explicit AddressType(StateMutability _stateMutability);
 
-	virtual std::string richIdentifier() const override;
-	virtual bool isImplicitlyConvertibleTo(Type const& _other) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
+	std::string richIdentifier() const override;
+	bool isImplicitlyConvertibleTo(Type const& _other) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
-	virtual bool operator==(Type const& _other) const override;
+	bool operator==(Type const& _other) const override;
 
-	virtual unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : 160 / 8; }
-	virtual unsigned storageBytes() const override { return 160 / 8; }
-	virtual bool isValueType() const override { return true; }
+	unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : 160 / 8; }
+	unsigned storageBytes() const override { return 160 / 8; }
+	bool isValueType() const override { return true; }
 
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
+	MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
 
-	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName() const override;
+	std::string toString(bool _short) const override;
+	std::string canonicalName() const override;
 
-	virtual u256 literalValue(Literal const* _literal) const override;
+	u256 literalValue(Literal const* _literal) const override;
 
-	virtual TypePointer encodingType() const override { return shared_from_this(); }
-	virtual TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypePointer encodingType() const override { return shared_from_this(); }
+	TypePointer interfaceType(bool) const override { return shared_from_this(); }
 
 	StateMutability stateMutability(void) const { return m_stateMutability; }
 
@@ -374,26 +374,26 @@ public:
 		Unsigned, Signed
 	};
 
-	virtual Category category() const override { return Category::Integer; }
+	Category category() const override { return Category::Integer; }
 
 	explicit IntegerType(unsigned _bits, Modifier _modifier = Modifier::Unsigned);
 
-	virtual std::string richIdentifier() const override;
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
+	std::string richIdentifier() const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
-	virtual bool operator==(Type const& _other) const override;
+	bool operator==(Type const& _other) const override;
 
-	virtual unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : m_bits / 8; }
-	virtual unsigned storageBytes() const override { return m_bits / 8; }
-	virtual bool isValueType() const override { return true; }
+	unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : m_bits / 8; }
+	unsigned storageBytes() const override { return m_bits / 8; }
+	bool isValueType() const override { return true; }
 
-	virtual std::string toString(bool _short) const override;
+	std::string toString(bool _short) const override;
 
-	virtual TypePointer encodingType() const override { return shared_from_this(); }
-	virtual TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypePointer encodingType() const override { return shared_from_this(); }
+	TypePointer interfaceType(bool) const override { return shared_from_this(); }
 
 	unsigned numBits() const { return m_bits; }
 	bool isSigned() const { return m_modifier == Modifier::Signed; }
@@ -416,26 +416,26 @@ public:
 	{
 		Unsigned, Signed
 	};
-	virtual Category category() const override { return Category::FixedPoint; }
+	Category category() const override { return Category::FixedPoint; }
 
 	explicit FixedPointType(unsigned _totalBits, unsigned _fractionalDigits, Modifier _modifier = Modifier::Unsigned);
 
-	virtual std::string richIdentifier() const override;
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
+	std::string richIdentifier() const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
-	virtual bool operator==(Type const& _other) const override;
+	bool operator==(Type const& _other) const override;
 
-	virtual unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : m_totalBits / 8; }
-	virtual unsigned storageBytes() const override { return m_totalBits / 8; }
-	virtual bool isValueType() const override { return true; }
+	unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : m_totalBits / 8; }
+	unsigned storageBytes() const override { return m_totalBits / 8; }
+	bool isValueType() const override { return true; }
 
-	virtual std::string toString(bool _short) const override;
+	std::string toString(bool _short) const override;
 
-	virtual TypePointer encodingType() const override { return shared_from_this(); }
-	virtual TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypePointer encodingType() const override { return shared_from_this(); }
+	TypePointer interfaceType(bool) const override { return shared_from_this(); }
 
 	/// Number of bits used for this type in total.
 	unsigned numBits() const { return m_totalBits; }
@@ -467,7 +467,7 @@ class RationalNumberType: public Type
 {
 public:
 
-	virtual Category category() const override { return Category::RationalNumber; }
+	Category category() const override { return Category::RationalNumber; }
 
 	static TypePointer forLiteral(Literal const& _literal);
 
@@ -475,20 +475,20 @@ public:
 		m_value(_value), m_compatibleBytesType(_compatibleBytesType)
 	{}
 
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
 
-	virtual bool canBeStored() const override { return false; }
-	virtual bool canLiveOutsideStorage() const override { return false; }
+	bool canBeStored() const override { return false; }
+	bool canLiveOutsideStorage() const override { return false; }
 
-	virtual std::string toString(bool _short) const override;
-	virtual u256 literalValue(Literal const* _literal) const override;
-	virtual TypePointer mobileType() const override;
+	std::string toString(bool _short) const override;
+	u256 literalValue(Literal const* _literal) const override;
+	TypePointer mobileType() const override;
 
 	/// @returns the smallest integer type that can hold the value or an empty pointer if not possible.
 	std::shared_ptr<IntegerType const> integerType() const;
@@ -530,25 +530,25 @@ private:
 class StringLiteralType: public Type
 {
 public:
-	virtual Category category() const override { return Category::StringLiteral; }
+	Category category() const override { return Category::StringLiteral; }
 
 	explicit StringLiteralType(Literal const& _literal);
 
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override
 	{
 		return TypePointer();
 	}
 
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
 
-	virtual bool canBeStored() const override { return false; }
-	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual unsigned sizeOnStack() const override { return 0; }
+	bool canBeStored() const override { return false; }
+	bool canLiveOutsideStorage() const override { return false; }
+	unsigned sizeOnStack() const override { return 0; }
 
-	virtual std::string toString(bool) const override;
-	virtual TypePointer mobileType() const override;
+	std::string toString(bool) const override;
+	TypePointer mobileType() const override;
 
 	bool isValidUTF8() const;
 
@@ -564,25 +564,25 @@ private:
 class FixedBytesType: public Type
 {
 public:
-	virtual Category category() const override { return Category::FixedBytes; }
+	Category category() const override { return Category::FixedBytes; }
 
 	explicit FixedBytesType(unsigned _bytes);
 
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
-	virtual unsigned calldataEncodedSize(bool _padded) const override { return _padded && m_bytes > 0 ? 32 : m_bytes; }
-	virtual unsigned storageBytes() const override { return m_bytes; }
-	virtual bool isValueType() const override { return true; }
+	unsigned calldataEncodedSize(bool _padded) const override { return _padded && m_bytes > 0 ? 32 : m_bytes; }
+	unsigned storageBytes() const override { return m_bytes; }
+	bool isValueType() const override { return true; }
 
-	virtual std::string toString(bool) const override { return "bytes" + dev::toString(m_bytes); }
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
-	virtual TypePointer encodingType() const override { return shared_from_this(); }
-	virtual TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	std::string toString(bool) const override { return "bytes" + dev::toString(m_bytes); }
+	MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
+	TypePointer encodingType() const override { return shared_from_this(); }
+	TypePointer interfaceType(bool) const override { return shared_from_this(); }
 
 	unsigned numBytes() const { return m_bytes; }
 
@@ -597,19 +597,19 @@ class BoolType: public Type
 {
 public:
 	BoolType() {}
-	virtual Category category() const override { return Category::Bool; }
-	virtual std::string richIdentifier() const override { return "t_bool"; }
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
+	Category category() const override { return Category::Bool; }
+	std::string richIdentifier() const override { return "t_bool"; }
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token _operator, TypePointer const& _other) const override;
 
-	virtual unsigned calldataEncodedSize(bool _padded) const override{ return _padded ? 32 : 1; }
-	virtual unsigned storageBytes() const override { return 1; }
-	virtual bool isValueType() const override { return true; }
+	unsigned calldataEncodedSize(bool _padded) const override{ return _padded ? 32 : 1; }
+	unsigned storageBytes() const override { return 1; }
+	bool isValueType() const override { return true; }
 
-	virtual std::string toString(bool) const override { return "bool"; }
-	virtual u256 literalValue(Literal const* _literal) const override;
-	virtual TypePointer encodingType() const override { return shared_from_this(); }
-	virtual TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	std::string toString(bool) const override { return "bool"; }
+	u256 literalValue(Literal const* _literal) const override;
+	TypePointer encodingType() const override { return shared_from_this(); }
+	TypePointer interfaceType(bool) const override { return shared_from_this(); }
 };
 
 /**
@@ -622,20 +622,20 @@ public:
 	explicit ReferenceType(DataLocation _location): m_location(_location) {}
 	DataLocation location() const { return m_location; }
 
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override
 	{
 		return TypePointer();
 	}
-	virtual unsigned memoryHeadSize() const override { return 32; }
+	unsigned memoryHeadSize() const override { return 32; }
 
 	/// @returns a copy of this type with location (recursively) changed to @a _location,
 	/// whereas isPointer is only shallowly changed - the deep copy is always a bound reference.
 	virtual TypePointer copyForLocation(DataLocation _location, bool _isPointer) const = 0;
 
-	virtual TypePointer mobileType() const override { return copyForLocation(m_location, true); }
-	virtual bool dataStoredIn(DataLocation _location) const override { return m_location == _location; }
-	virtual bool hasSimpleZeroValueInMemory() const override { return false; }
+	TypePointer mobileType() const override { return copyForLocation(m_location, true); }
+	bool dataStoredIn(DataLocation _location) const override { return m_location == _location; }
+	bool hasSimpleZeroValueInMemory() const override { return false; }
 
 	/// Storage references can be pointers or bound references. In general, local variables are of
 	/// pointer type, state variables are bound references. Assignments to pointers or deleting
@@ -677,7 +677,7 @@ public:
 	static ArrayType& bytesMemory() { static std::shared_ptr<ArrayType> addr(std::make_shared<ArrayType>(DataLocation::Memory)); return *addr; }
 	static ArrayType& stringMemory() { static std::shared_ptr<ArrayType> addr(std::make_shared<ArrayType>(DataLocation::Memory, true)); return *addr; }
 
-	virtual Category category() const override { return Category::Array; }
+	Category category() const override { return Category::Array; }
 
 	/// Constructor for a byte array ("bytes") and string.
 	explicit ArrayType(DataLocation _location, bool _isString = false):
@@ -700,24 +700,24 @@ public:
 		m_length(_length)
 	{}
 
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(const Type& _other) const override;
-	virtual unsigned calldataEncodedSize(bool _padded) const override;
-	virtual bool isDynamicallySized() const override { return m_hasDynamicLength; }
-	virtual bool isDynamicallyEncoded() const override;
-	virtual u256 storageSize() const override;
-	virtual bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
-	virtual unsigned sizeOnStack() const override;
-	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName() const override;
-	virtual std::string signatureInExternalFunction(bool _structsByName) const override;
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
-	virtual TypePointer encodingType() const override;
-	virtual TypePointer decodingType() const override;
-	virtual TypePointer interfaceType(bool _inLibrary) const override;
-	virtual bool canBeUsedExternally(bool _inLibrary) const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	std::string richIdentifier() const override;
+	bool operator==(const Type& _other) const override;
+	unsigned calldataEncodedSize(bool _padded) const override;
+	bool isDynamicallySized() const override { return m_hasDynamicLength; }
+	bool isDynamicallyEncoded() const override;
+	u256 storageSize() const override;
+	bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
+	unsigned sizeOnStack() const override;
+	std::string toString(bool _short) const override;
+	std::string canonicalName() const override;
+	std::string signatureInExternalFunction(bool _structsByName) const override;
+	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
+	TypePointer encodingType() const override;
+	TypePointer decodingType() const override;
+	TypePointer interfaceType(bool _inLibrary) const override;
+	bool canBeUsedExternally(bool _inLibrary) const override;
 
 	/// @returns true if this is valid to be stored in calldata
 	bool validForCalldata() const;
@@ -751,36 +751,36 @@ private:
 class ContractType: public Type
 {
 public:
-	virtual Category category() const override { return Category::Contract; }
+	Category category() const override { return Category::Contract; }
 	explicit ContractType(ContractDefinition const& _contract, bool _super = false):
 		m_contract(_contract), m_super(_super) {}
 	/// Contracts can be implicitly converted only to base contracts.
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	/// Contracts can only be explicitly converted to address types and base contracts.
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual unsigned calldataEncodedSize(bool _padded ) const override
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	unsigned calldataEncodedSize(bool _padded ) const override
 	{
 		solAssert(!isSuper(), "");
 		return encodingType()->calldataEncodedSize(_padded);
 	}
-	virtual unsigned storageBytes() const override { solAssert(!isSuper(), ""); return 20; }
-	virtual bool canLiveOutsideStorage() const override { return !isSuper(); }
-	virtual unsigned sizeOnStack() const override { return m_super ? 0 : 1; }
-	virtual bool isValueType() const override { return !isSuper(); }
-	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName() const override;
+	unsigned storageBytes() const override { solAssert(!isSuper(), ""); return 20; }
+	bool canLiveOutsideStorage() const override { return !isSuper(); }
+	unsigned sizeOnStack() const override { return m_super ? 0 : 1; }
+	bool isValueType() const override { return !isSuper(); }
+	std::string toString(bool _short) const override;
+	std::string canonicalName() const override;
 
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
-	virtual TypePointer encodingType() const override
+	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
+	TypePointer encodingType() const override
 	{
 		if (isSuper())
 			return TypePointer{};
 		return std::make_shared<AddressType>(isPayable() ? StateMutability::Payable : StateMutability::NonPayable);
 	}
-	virtual TypePointer interfaceType(bool _inLibrary) const override
+	TypePointer interfaceType(bool _inLibrary) const override
 	{
 		if (isSuper())
 			return TypePointer{};
@@ -816,31 +816,31 @@ private:
 class StructType: public ReferenceType
 {
 public:
-	virtual Category category() const override { return Category::Struct; }
+	Category category() const override { return Category::Struct; }
 	explicit StructType(StructDefinition const& _struct, DataLocation _location = DataLocation::Storage):
 		ReferenceType(_location), m_struct(_struct) {}
-	virtual bool isImplicitlyConvertibleTo(const Type& _convertTo) const override;
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual unsigned calldataEncodedSize(bool _padded) const override;
-	virtual bool isDynamicallyEncoded() const override;
+	bool isImplicitlyConvertibleTo(const Type& _convertTo) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	unsigned calldataEncodedSize(bool _padded) const override;
+	bool isDynamicallyEncoded() const override;
 	u256 memorySize() const;
-	virtual u256 storageSize() const override;
-	virtual bool canLiveOutsideStorage() const override { return true; }
-	virtual std::string toString(bool _short) const override;
+	u256 storageSize() const override;
+	bool canLiveOutsideStorage() const override { return true; }
+	std::string toString(bool _short) const override;
 
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
-	virtual TypePointer encodingType() const override
+	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
+	TypePointer encodingType() const override
 	{
 		return location() == DataLocation::Storage ? std::make_shared<IntegerType>(256) : shared_from_this();
 	}
-	virtual TypePointer interfaceType(bool _inLibrary) const override;
-	virtual bool canBeUsedExternally(bool _inLibrary) const override;
+	TypePointer interfaceType(bool _inLibrary) const override;
+	bool canBeUsedExternally(bool _inLibrary) const override;
 
 	TypePointer copyForLocation(DataLocation _location, bool _isPointer) const override;
 
-	virtual std::string canonicalName() const override;
-	virtual std::string signatureInExternalFunction(bool _structsByName) const override;
+	std::string canonicalName() const override;
+	std::string signatureInExternalFunction(bool _structsByName) const override;
 
 	/// @returns a function that performs the type conversion between a list of struct members
 	/// and a memory struct of this type.
@@ -872,27 +872,27 @@ private:
 class EnumType: public Type
 {
 public:
-	virtual Category category() const override { return Category::Enum; }
+	Category category() const override { return Category::Enum; }
 	explicit EnumType(EnumDefinition const& _enum): m_enum(_enum) {}
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual unsigned calldataEncodedSize(bool _padded) const override
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	unsigned calldataEncodedSize(bool _padded) const override
 	{
 		return encodingType()->calldataEncodedSize(_padded);
 	}
-	virtual unsigned storageBytes() const override;
-	virtual bool canLiveOutsideStorage() const override { return true; }
-	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName() const override;
-	virtual bool isValueType() const override { return true; }
+	unsigned storageBytes() const override;
+	bool canLiveOutsideStorage() const override { return true; }
+	std::string toString(bool _short) const override;
+	std::string canonicalName() const override;
+	bool isValueType() const override { return true; }
 
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer encodingType() const override
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer encodingType() const override
 	{
 		return std::make_shared<IntegerType>(8 * int(storageBytes()));
 	}
-	virtual TypePointer interfaceType(bool _inLibrary) const override
+	TypePointer interfaceType(bool _inLibrary) const override
 	{
 		return _inLibrary ? shared_from_this() : encodingType();
 	}
@@ -913,21 +913,21 @@ private:
 class TupleType: public Type
 {
 public:
-	virtual Category category() const override { return Category::Tuple; }
+	Category category() const override { return Category::Tuple; }
 	explicit TupleType(std::vector<TypePointer> const& _types = std::vector<TypePointer>()): m_components(_types) {}
-	virtual bool isImplicitlyConvertibleTo(Type const& _other) const override;
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
-	virtual std::string toString(bool) const override;
-	virtual bool canBeStored() const override { return false; }
-	virtual u256 storageSize() const override;
-	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual unsigned sizeOnStack() const override;
-	virtual bool hasSimpleZeroValueInMemory() const override { return false; }
-	virtual TypePointer mobileType() const override;
+	bool isImplicitlyConvertibleTo(Type const& _other) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
+	std::string toString(bool) const override;
+	bool canBeStored() const override { return false; }
+	u256 storageSize() const override;
+	bool canLiveOutsideStorage() const override { return false; }
+	unsigned sizeOnStack() const override;
+	bool hasSimpleZeroValueInMemory() const override { return false; }
+	TypePointer mobileType() const override;
 	/// Converts components to their temporary types and performs some wildcard matching.
-	virtual TypePointer closestTemporaryType(TypePointer const& _targetType) const override;
+	TypePointer closestTemporaryType(TypePointer const& _targetType) const override;
 
 	std::vector<TypePointer> const& components() const { return m_components; }
 
@@ -987,7 +987,7 @@ public:
 		GasLeft, ///< gasleft()
 	};
 
-	virtual Category category() const override { return Category::Function; }
+	Category category() const override { return Category::Function; }
 
 	/// Creates the type of a function.
 	explicit FunctionType(FunctionDefinition const& _function, bool _isInternal = true);
@@ -1061,25 +1061,25 @@ public:
 	/// @returns the "self" parameter type for a bound function
 	TypePointer const& selfType() const;
 
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
-	virtual TypePointer unaryOperatorResult(Token _operator) const override;
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override;
-	virtual std::string canonicalName() const override;
-	virtual std::string toString(bool _short) const override;
-	virtual unsigned calldataEncodedSize(bool _padded) const override;
-	virtual bool canBeStored() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
-	virtual u256 storageSize() const override;
-	virtual unsigned storageBytes() const override;
-	virtual bool isValueType() const override { return true; }
-	virtual bool canLiveOutsideStorage() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
-	virtual unsigned sizeOnStack() const override;
-	virtual bool hasSimpleZeroValueInMemory() const override { return false; }
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
-	virtual TypePointer encodingType() const override;
-	virtual TypePointer interfaceType(bool _inLibrary) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	bool isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+	bool isExplicitlyConvertibleTo(Type const& _convertTo) const override;
+	TypePointer unaryOperatorResult(Token _operator) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override;
+	std::string canonicalName() const override;
+	std::string toString(bool _short) const override;
+	unsigned calldataEncodedSize(bool _padded) const override;
+	bool canBeStored() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
+	u256 storageSize() const override;
+	unsigned storageBytes() const override;
+	bool isValueType() const override { return true; }
+	bool canLiveOutsideStorage() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
+	unsigned sizeOnStack() const override;
+	bool hasSimpleZeroValueInMemory() const override { return false; }
+	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
+	TypePointer encodingType() const override;
+	TypePointer interfaceType(bool _inLibrary) const override;
 
 	/// @returns TypePointer of a new FunctionType object. All input/return parameters are an
 	/// appropriate external types (i.e. the interfaceType()s) of input/return parameters of
@@ -1187,27 +1187,27 @@ private:
 class MappingType: public Type
 {
 public:
-	virtual Category category() const override { return Category::Mapping; }
+	Category category() const override { return Category::Mapping; }
 	MappingType(TypePointer const& _keyType, TypePointer const& _valueType):
 		m_keyType(_keyType), m_valueType(_valueType) {}
 
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual std::string toString(bool _short) const override;
-	virtual std::string canonicalName() const override;
-	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
-	virtual TypePointer encodingType() const override
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	std::string toString(bool _short) const override;
+	std::string canonicalName() const override;
+	bool canLiveOutsideStorage() const override { return false; }
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
+	TypePointer encodingType() const override
 	{
 		return std::make_shared<IntegerType>(256);
 	}
-	virtual TypePointer interfaceType(bool _inLibrary) const override
+	TypePointer interfaceType(bool _inLibrary) const override
 	{
 		return _inLibrary ? shared_from_this() : TypePointer();
 	}
-	virtual bool dataStoredIn(DataLocation _location) const override { return _location == DataLocation::Storage; }
+	bool dataStoredIn(DataLocation _location) const override { return _location == DataLocation::Storage; }
 	/// Cannot be stored in memory, but just in case.
-	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
+	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 
 	TypePointer const& keyType() const { return m_keyType; }
 	TypePointer const& valueType() const { return m_valueType; }
@@ -1225,20 +1225,20 @@ private:
 class TypeType: public Type
 {
 public:
-	virtual Category category() const override { return Category::TypeType; }
+	Category category() const override { return Category::TypeType; }
 	explicit TypeType(TypePointer const& _actualType): m_actualType(_actualType) {}
 	TypePointer const& actualType() const { return m_actualType; }
 
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual bool canBeStored() const override { return false; }
-	virtual u256 storageSize() const override;
-	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual unsigned sizeOnStack() const override;
-	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
-	virtual std::string toString(bool _short) const override { return "type(" + m_actualType->toString(_short) + ")"; }
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	bool canBeStored() const override { return false; }
+	u256 storageSize() const override;
+	bool canLiveOutsideStorage() const override { return false; }
+	unsigned sizeOnStack() const override;
+	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
+	std::string toString(bool _short) const override { return "type(" + m_actualType->toString(_short) + ")"; }
+	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 
 private:
 	TypePointer m_actualType;
@@ -1251,18 +1251,18 @@ private:
 class ModifierType: public Type
 {
 public:
-	virtual Category category() const override { return Category::Modifier; }
+	Category category() const override { return Category::Modifier; }
 	explicit ModifierType(ModifierDefinition const& _modifier);
 
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
-	virtual bool canBeStored() const override { return false; }
-	virtual u256 storageSize() const override;
-	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual unsigned sizeOnStack() const override { return 0; }
-	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual std::string toString(bool _short) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
+	bool canBeStored() const override { return false; }
+	u256 storageSize() const override;
+	bool canLiveOutsideStorage() const override { return false; }
+	unsigned sizeOnStack() const override { return 0; }
+	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	std::string toString(bool _short) const override;
 
 private:
 	TypePointers m_parameterTypes;
@@ -1276,20 +1276,20 @@ private:
 class ModuleType: public Type
 {
 public:
-	virtual Category category() const override { return Category::Module; }
+	Category category() const override { return Category::Module; }
 
 	explicit ModuleType(SourceUnit const& _source): m_sourceUnit(_source) {}
 
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual bool canBeStored() const override { return false; }
-	virtual bool canLiveOutsideStorage() const override { return true; }
-	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
-	virtual unsigned sizeOnStack() const override { return 0; }
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	bool canBeStored() const override { return false; }
+	bool canLiveOutsideStorage() const override { return true; }
+	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
+	unsigned sizeOnStack() const override { return 0; }
+	MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
 
-	virtual std::string toString(bool _short) const override;
+	std::string toString(bool _short) const override;
 
 private:
 	SourceUnit const& m_sourceUnit;
@@ -1303,24 +1303,24 @@ class MagicType: public Type
 {
 public:
 	enum class Kind { Block, Message, Transaction, ABI };
-	virtual Category category() const override { return Category::Magic; }
+	Category category() const override { return Category::Magic; }
 
 	explicit MagicType(Kind _kind): m_kind(_kind) {}
 
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override
 	{
 		return TypePointer();
 	}
 
-	virtual std::string richIdentifier() const override;
-	virtual bool operator==(Type const& _other) const override;
-	virtual bool canBeStored() const override { return false; }
-	virtual bool canLiveOutsideStorage() const override { return true; }
-	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
-	virtual unsigned sizeOnStack() const override { return 0; }
-	virtual MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	bool canBeStored() const override { return false; }
+	bool canLiveOutsideStorage() const override { return true; }
+	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
+	unsigned sizeOnStack() const override { return 0; }
+	MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
 
-	virtual std::string toString(bool _short) const override;
+	std::string toString(bool _short) const override;
 
 	Kind kind() const { return m_kind; }
 
@@ -1335,20 +1335,20 @@ private:
 class InaccessibleDynamicType: public Type
 {
 public:
-	virtual Category category() const override { return Category::InaccessibleDynamic; }
+	Category category() const override { return Category::InaccessibleDynamic; }
 
-	virtual std::string richIdentifier() const override { return "t_inaccessible"; }
-	virtual bool isImplicitlyConvertibleTo(Type const&) const override { return false; }
-	virtual bool isExplicitlyConvertibleTo(Type const&) const override { return false; }
-	virtual TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
-	virtual unsigned calldataEncodedSize(bool _padded) const override { (void)_padded; return 32; }
-	virtual bool canBeStored() const override { return false; }
-	virtual bool canLiveOutsideStorage() const override { return false; }
-	virtual bool isValueType() const override { return true; }
-	virtual unsigned sizeOnStack() const override { return 1; }
-	virtual bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
-	virtual std::string toString(bool) const override { return "inaccessible dynamic type"; }
-	virtual TypePointer decodingType() const override { return std::make_shared<IntegerType>(256); }
+	std::string richIdentifier() const override { return "t_inaccessible"; }
+	bool isImplicitlyConvertibleTo(Type const&) const override { return false; }
+	bool isExplicitlyConvertibleTo(Type const&) const override { return false; }
+	TypePointer binaryOperatorResult(Token, TypePointer const&) const override { return TypePointer(); }
+	unsigned calldataEncodedSize(bool _padded) const override { (void)_padded; return 32; }
+	bool canBeStored() const override { return false; }
+	bool canLiveOutsideStorage() const override { return false; }
+	bool isValueType() const override { return true; }
+	unsigned sizeOnStack() const override { return 1; }
+	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
+	std::string toString(bool) const override { return "inaccessible dynamic type"; }
+	TypePointer decodingType() const override { return std::make_shared<IntegerType>(256); }
 };
 
 }

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -88,22 +88,22 @@ private:
 	void registerStateVariables(ContractDefinition const& _contract);
 	void initializeStateVariables(ContractDefinition const& _contract);
 
-	virtual bool visit(VariableDeclaration const& _variableDeclaration) override;
-	virtual bool visit(FunctionDefinition const& _function) override;
-	virtual bool visit(InlineAssembly const& _inlineAssembly) override;
-	virtual bool visit(IfStatement const& _ifStatement) override;
-	virtual bool visit(WhileStatement const& _whileStatement) override;
-	virtual bool visit(ForStatement const& _forStatement) override;
-	virtual bool visit(Continue const& _continueStatement) override;
-	virtual bool visit(Break const& _breakStatement) override;
-	virtual bool visit(Return const& _return) override;
-	virtual bool visit(Throw const& _throw) override;
-	virtual bool visit(EmitStatement const& _emit) override;
-	virtual bool visit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
-	virtual bool visit(ExpressionStatement const& _expressionStatement) override;
-	virtual bool visit(PlaceholderStatement const&) override;
-	virtual bool visit(Block const& _block) override;
-	virtual void endVisit(Block const& _block) override;
+	bool visit(VariableDeclaration const& _variableDeclaration) override;
+	bool visit(FunctionDefinition const& _function) override;
+	bool visit(InlineAssembly const& _inlineAssembly) override;
+	bool visit(IfStatement const& _ifStatement) override;
+	bool visit(WhileStatement const& _whileStatement) override;
+	bool visit(ForStatement const& _forStatement) override;
+	bool visit(Continue const& _continueStatement) override;
+	bool visit(Break const& _breakStatement) override;
+	bool visit(Return const& _return) override;
+	bool visit(Throw const& _throw) override;
+	bool visit(EmitStatement const& _emit) override;
+	bool visit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
+	bool visit(ExpressionStatement const& _expressionStatement) override;
+	bool visit(PlaceholderStatement const&) override;
+	bool visit(Block const& _block) override;
+	void endVisit(Block const& _block) override;
 
 	/// Repeatedly visits all function which are referenced but which are not compiled yet.
 	void appendMissingFunctions();

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -71,17 +71,17 @@ public:
 	void appendConstStateVariableAccessor(const VariableDeclaration& _varDecl);
 
 private:
-	virtual bool visit(Conditional const& _condition) override;
-	virtual bool visit(Assignment const& _assignment) override;
-	virtual bool visit(TupleExpression const& _tuple) override;
-	virtual bool visit(UnaryOperation const& _unaryOperation) override;
-	virtual bool visit(BinaryOperation const& _binaryOperation) override;
-	virtual bool visit(FunctionCall const& _functionCall) override;
-	virtual bool visit(NewExpression const& _newExpression) override;
-	virtual bool visit(MemberAccess const& _memberAccess) override;
-	virtual bool visit(IndexAccess const& _indexAccess) override;
-	virtual void endVisit(Identifier const& _identifier) override;
-	virtual void endVisit(Literal const& _literal) override;
+	bool visit(Conditional const& _condition) override;
+	bool visit(Assignment const& _assignment) override;
+	bool visit(TupleExpression const& _tuple) override;
+	bool visit(UnaryOperation const& _unaryOperation) override;
+	bool visit(BinaryOperation const& _binaryOperation) override;
+	bool visit(FunctionCall const& _functionCall) override;
+	bool visit(NewExpression const& _newExpression) override;
+	bool visit(MemberAccess const& _memberAccess) override;
+	bool visit(IndexAccess const& _indexAccess) override;
+	void endVisit(Identifier const& _identifier) override;
+	void endVisit(Literal const& _literal) override;
 
 	///@{
 	///@name Append code for various operator types

--- a/libsolidity/codegen/LValue.h
+++ b/libsolidity/codegen/LValue.h
@@ -82,8 +82,8 @@ class StackVariable: public LValue
 public:
 	StackVariable(CompilerContext& _compilerContext, VariableDeclaration const& _declaration);
 
-	virtual unsigned sizeOnStack() const override { return 0; }
-	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
+	unsigned sizeOnStack() const override { return 0; }
+	void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
 		SourceLocation const& _location = SourceLocation(),
@@ -108,8 +108,8 @@ class MemoryItem: public LValue
 {
 public:
 	MemoryItem(CompilerContext& _compilerContext, Type const& _type, bool _padded = true);
-	virtual unsigned sizeOnStack() const override { return 1; }
-	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
+	unsigned sizeOnStack() const override { return 1; }
+	void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
 		SourceLocation const& _location = SourceLocation(),
@@ -136,8 +136,8 @@ public:
 	StorageItem(CompilerContext& _compilerContext, VariableDeclaration const& _declaration);
 	/// Constructs the LValue and assumes that the storage reference is already on the stack.
 	StorageItem(CompilerContext& _compilerContext, Type const& _type);
-	virtual unsigned sizeOnStack() const override { return 2; }
-	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
+	unsigned sizeOnStack() const override { return 2; }
+	void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
 		SourceLocation const& _location = SourceLocation(),
@@ -158,8 +158,8 @@ class StorageByteArrayElement: public LValue
 public:
 	/// Constructs the LValue and assumes that the storage reference is already on the stack.
 	StorageByteArrayElement(CompilerContext& _compilerContext);
-	virtual unsigned sizeOnStack() const override { return 2; }
-	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
+	unsigned sizeOnStack() const override { return 2; }
+	void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
 		SourceLocation const& _location = SourceLocation(),
@@ -181,7 +181,7 @@ class StorageArrayLength: public LValue
 public:
 	/// Constructs the LValue, assumes that the reference to the array head is already on the stack.
 	StorageArrayLength(CompilerContext& _compilerContext, ArrayType const& _arrayType);
-	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
+	void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
 		SourceLocation const& _location = SourceLocation(),
@@ -205,8 +205,8 @@ public:
 	/// Constructs the LValue assuming that the other LValues are present on the stack.
 	/// Empty unique_ptrs are possible if e.g. some values should be ignored during assignment.
 	TupleObject(CompilerContext& _compilerContext, std::vector<std::unique_ptr<LValue>>&& _lvalues);
-	virtual unsigned sizeOnStack() const override;
-	virtual void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
+	unsigned sizeOnStack() const override;
+	void retrieveValue(SourceLocation const& _location, bool _remove = false) const override;
 	virtual void storeValue(
 		Type const& _sourceType,
 		SourceLocation const& _location = SourceLocation(),

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -51,24 +51,24 @@ private:
 	// because the order of expression evaluation is undefined
 	// TODO: or just force a certain order, but people might have a different idea about that.
 
-	virtual bool visit(ContractDefinition const& _node) override;
-	virtual void endVisit(ContractDefinition const& _node) override;
-	virtual void endVisit(VariableDeclaration const& _node) override;
-	virtual bool visit(FunctionDefinition const& _node) override;
-	virtual void endVisit(FunctionDefinition const& _node) override;
-	virtual bool visit(IfStatement const& _node) override;
-	virtual bool visit(WhileStatement const& _node) override;
-	virtual bool visit(ForStatement const& _node) override;
-	virtual void endVisit(VariableDeclarationStatement const& _node) override;
-	virtual void endVisit(Assignment const& _node) override;
-	virtual void endVisit(TupleExpression const& _node) override;
-	virtual void endVisit(UnaryOperation const& _node) override;
-	virtual void endVisit(BinaryOperation const& _node) override;
-	virtual void endVisit(FunctionCall const& _node) override;
-	virtual void endVisit(Identifier const& _node) override;
-	virtual void endVisit(Literal const& _node) override;
-	virtual void endVisit(Return const& _node) override;
-	virtual bool visit(MemberAccess const& _node) override;
+	bool visit(ContractDefinition const& _node) override;
+	void endVisit(ContractDefinition const& _node) override;
+	void endVisit(VariableDeclaration const& _node) override;
+	bool visit(FunctionDefinition const& _node) override;
+	void endVisit(FunctionDefinition const& _node) override;
+	bool visit(IfStatement const& _node) override;
+	bool visit(WhileStatement const& _node) override;
+	bool visit(ForStatement const& _node) override;
+	void endVisit(VariableDeclarationStatement const& _node) override;
+	void endVisit(Assignment const& _node) override;
+	void endVisit(TupleExpression const& _node) override;
+	void endVisit(UnaryOperation const& _node) override;
+	void endVisit(BinaryOperation const& _node) override;
+	void endVisit(FunctionCall const& _node) override;
+	void endVisit(Identifier const& _node) override;
+	void endVisit(Literal const& _node) override;
+	void endVisit(Return const& _node) override;
+	bool visit(MemberAccess const& _node) override;
 
 	void arithmeticOperation(BinaryOperation const& _op);
 	void compareOperation(BinaryOperation const& _op);

--- a/libyul/backends/evm/EVMAssembly.h
+++ b/libyul/backends/evm/EVMAssembly.h
@@ -38,42 +38,42 @@ public:
 	virtual ~EVMAssembly() {}
 
 	/// Set a new source location valid starting from the next instruction.
-	virtual void setSourceLocation(SourceLocation const& _location) override;
+	void setSourceLocation(SourceLocation const& _location) override;
 	/// Retrieve the current height of the stack. This does not have to be zero
 	/// at the beginning.
-	virtual int stackHeight() const override { return m_stackHeight; }
+	int stackHeight() const override { return m_stackHeight; }
 	/// Append an EVM instruction.
-	virtual void appendInstruction(solidity::Instruction _instruction) override;
+	void appendInstruction(solidity::Instruction _instruction) override;
 	/// Append a constant.
-	virtual void appendConstant(u256 const& _constant) override;
+	void appendConstant(u256 const& _constant) override;
 	/// Append a label.
-	virtual void appendLabel(LabelID _labelId) override;
+	void appendLabel(LabelID _labelId) override;
 	/// Append a label reference.
-	virtual void appendLabelReference(LabelID _labelId) override;
+	void appendLabelReference(LabelID _labelId) override;
 	/// Generate a new unique label.
-	virtual LabelID newLabelId() override;
+	LabelID newLabelId() override;
 	/// Returns a label identified by the given name. Creates it if it does not yet exist.
-	virtual LabelID namedLabel(std::string const& _name) override;
+	LabelID namedLabel(std::string const& _name) override;
 	/// Append a reference to a to-be-linked symbol.
 	/// Currently, we assume that the value is always a 20 byte number.
-	virtual void appendLinkerSymbol(std::string const& _name) override;
+	void appendLinkerSymbol(std::string const& _name) override;
 
 	/// Append a jump instruction.
 	/// @param _stackDiffAfter the stack adjustment after this instruction.
-	virtual void appendJump(int _stackDiffAfter) override;
+	void appendJump(int _stackDiffAfter) override;
 	/// Append a jump-to-immediate operation.
-	virtual void appendJumpTo(LabelID _labelId, int _stackDiffAfter) override;
+	void appendJumpTo(LabelID _labelId, int _stackDiffAfter) override;
 	/// Append a jump-to-if-immediate operation.
-	virtual void appendJumpToIf(LabelID _labelId) override;
+	void appendJumpToIf(LabelID _labelId) override;
 	/// Start a subroutine.
-	virtual void appendBeginsub(LabelID _labelId, int _arguments) override;
+	void appendBeginsub(LabelID _labelId, int _arguments) override;
 	/// Call a subroutine.
-	virtual void appendJumpsub(LabelID _labelId, int _arguments, int _returns) override;
+	void appendJumpsub(LabelID _labelId, int _arguments, int _returns) override;
 	/// Return from a subroutine.
-	virtual void appendReturnsub(int _returns, int _stackDiffAfter) override;
+	void appendReturnsub(int _returns, int _stackDiffAfter) override;
 
 	/// Append the assembled size as a constant.
-	virtual void appendAssemblySize() override;
+	void appendAssemblySize() override;
 
 	/// Resolves references inside the bytecode and returns the linker object.
 	eth::LinkerObject finalize();

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -71,21 +71,21 @@ class ASTCopier: public ExpressionCopier, public StatementCopier
 {
 public:
 	virtual ~ASTCopier() = default;
-	virtual Expression operator()(Literal const& _literal) override;
-	virtual Statement operator()(Instruction const& _instruction) override;
-	virtual Expression operator()(Identifier const& _identifier) override;
-	virtual Expression operator()(FunctionalInstruction const& _instr) override;
-	virtual Expression operator()(FunctionCall const&) override;
-	virtual Statement operator()(ExpressionStatement const& _statement) override;
-	virtual Statement operator()(Label const& _label) override;
-	virtual Statement operator()(StackAssignment const& _assignment) override;
-	virtual Statement operator()(Assignment const& _assignment) override;
-	virtual Statement operator()(VariableDeclaration const& _varDecl) override;
-	virtual Statement operator()(If const& _if) override;
-	virtual Statement operator()(Switch const& _switch) override;
-	virtual Statement operator()(FunctionDefinition const&) override;
-	virtual Statement operator()(ForLoop const&) override;
-	virtual Statement operator()(Block const& _block) override;
+	Expression operator()(Literal const& _literal) override;
+	Statement operator()(Instruction const& _instruction) override;
+	Expression operator()(Identifier const& _identifier) override;
+	Expression operator()(FunctionalInstruction const& _instr) override;
+	Expression operator()(FunctionCall const&) override;
+	Statement operator()(ExpressionStatement const& _statement) override;
+	Statement operator()(Label const& _label) override;
+	Statement operator()(StackAssignment const& _assignment) override;
+	Statement operator()(Assignment const& _assignment) override;
+	Statement operator()(VariableDeclaration const& _varDecl) override;
+	Statement operator()(If const& _if) override;
+	Statement operator()(Switch const& _switch) override;
+	Statement operator()(FunctionDefinition const&) override;
+	Statement operator()(ForLoop const&) override;
+	Statement operator()(Block const& _block) override;
 
 	virtual Expression translate(Expression const& _expression);
 	virtual Statement translate(Statement const& _statement);

--- a/libyul/optimiser/CommonSubexpressionEliminator.h
+++ b/libyul/optimiser/CommonSubexpressionEliminator.h
@@ -38,7 +38,7 @@ class CommonSubexpressionEliminator: public DataFlowAnalyzer
 {
 protected:
 	using ASTModifier::visit;
-	virtual void visit(Expression& _e) override;
+	void visit(Expression& _e) override;
 };
 
 }

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -45,13 +45,13 @@ class DataFlowAnalyzer: public ASTModifier
 {
 public:
 	using ASTModifier::operator();
-	virtual void operator()(Assignment& _assignment) override;
-	virtual void operator()(VariableDeclaration& _varDecl) override;
-	virtual void operator()(If& _if) override;
-	virtual void operator()(Switch& _switch) override;
-	virtual void operator()(FunctionDefinition&) override;
-	virtual void operator()(ForLoop&) override;
-	virtual void operator()(Block& _block) override;
+	void operator()(Assignment& _assignment) override;
+	void operator()(VariableDeclaration& _varDecl) override;
+	void operator()(If& _if) override;
+	void operator()(Switch& _switch) override;
+	void operator()(FunctionDefinition&) override;
+	void operator()(ForLoop&) override;
+	void operator()(Block& _block) override;
 
 protected:
 	/// Registers the assignment.

--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -52,11 +52,11 @@ public:
 	}
 
 protected:
-	virtual void enterScope(Block const& _block) override;
-	virtual void leaveScope(Block const& _block) override;
-	virtual void enterFunction(FunctionDefinition const& _function) override;
-	virtual void leaveFunction(FunctionDefinition const& _function) override;
-	virtual YulString translateIdentifier(YulString _name) override;
+	void enterScope(Block const& _block) override;
+	void leaveScope(Block const& _block) override;
+	void enterFunction(FunctionDefinition const& _function) override;
+	void leaveFunction(FunctionDefinition const& _function) override;
+	YulString translateIdentifier(YulString _name) override;
 
 	void enterScopeInternal(solidity::assembly::Scope& _scope);
 	void leaveScopeInternal(solidity::assembly::Scope& _scope);

--- a/libyul/optimiser/ExpressionInliner.h
+++ b/libyul/optimiser/ExpressionInliner.h
@@ -54,9 +54,9 @@ public:
 	void run();
 
 	using ASTModifier::operator();
-	virtual void operator()(FunctionDefinition& _fun) override;
+	void operator()(FunctionDefinition& _fun) override;
 
-	virtual void visit(Expression& _expression) override;
+	void visit(Expression& _expression) override;
 
 private:
 	std::map<YulString, FunctionDefinition const*> m_inlinableFunctions;

--- a/libyul/optimiser/ExpressionSplitter.h
+++ b/libyul/optimiser/ExpressionSplitter.h
@@ -63,12 +63,12 @@ public:
 		m_nameDispenser(_nameDispenser)
 	{ }
 
-	virtual void operator()(FunctionalInstruction&) override;
-	virtual void operator()(FunctionCall&) override;
-	virtual void operator()(If&) override;
-	virtual void operator()(Switch&) override;
-	virtual void operator()(ForLoop&) override;
-	virtual void operator()(Block& _block) override;
+	void operator()(FunctionalInstruction&) override;
+	void operator()(FunctionCall&) override;
+	void operator()(If&) override;
+	void operator()(Switch&) override;
+	void operator()(ForLoop&) override;
+	void operator()(Block& _block) override;
 
 private:
 	/// Replaces the expression by a variable if it is a function call or functional

--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -110,7 +110,7 @@ public:
 		m_nameDispenser(_nameDispenser)
 	{ }
 
-	virtual void operator()(Block& _block) override;
+	void operator()(Block& _block) override;
 
 private:
 	boost::optional<std::vector<Statement>> tryInlineStatement(Statement& _statement);
@@ -141,10 +141,10 @@ public:
 
 	using ASTCopier::operator ();
 
-	virtual Statement operator()(VariableDeclaration const& _varDecl) override;
-	virtual Statement operator()(FunctionDefinition const& _funDef) override;
+	Statement operator()(VariableDeclaration const& _varDecl) override;
+	Statement operator()(FunctionDefinition const& _funDef) override;
 
-	virtual YulString translateIdentifier(YulString _name) override;
+	YulString translateIdentifier(YulString _name) override;
 
 	NameDispenser& m_nameDispenser;
 	YulString m_varNamePrefix;

--- a/libyul/optimiser/InlinableExpressionFunctionFinder.h
+++ b/libyul/optimiser/InlinableExpressionFunctionFinder.h
@@ -49,9 +49,9 @@ public:
 	}
 
 	using ASTWalker::operator();
-	virtual void operator()(Identifier const& _identifier) override;
-	virtual void operator()(FunctionCall const& _funCall) override;
-	virtual void operator()(FunctionDefinition const& _function) override;
+	void operator()(Identifier const& _identifier) override;
+	void operator()(FunctionCall const& _funCall) override;
+	void operator()(FunctionDefinition const& _function) override;
 
 private:
 	void checkAllowed(YulString _name)

--- a/libyul/optimiser/Metrics.h
+++ b/libyul/optimiser/Metrics.h
@@ -41,8 +41,8 @@ public:
 	static size_t codeSize(Block const& _block);
 
 private:
-	virtual void visit(Statement const& _statement) override;
-	virtual void visit(Expression const& _expression) override;
+	void visit(Statement const& _statement) override;
+	void visit(Expression const& _expression) override;
 
 private:
 	size_t m_size = 0;

--- a/libyul/optimiser/NameCollector.h
+++ b/libyul/optimiser/NameCollector.h
@@ -42,8 +42,8 @@ public:
 	}
 
 	using ASTWalker::operator ();
-	virtual void operator()(VariableDeclaration const& _varDecl) override;
-	virtual void operator()(FunctionDefinition const& _funDef) override;
+	void operator()(VariableDeclaration const& _varDecl) override;
+	void operator()(FunctionDefinition const& _funDef) override;
 
 	std::set<YulString> names() const { return m_names; }
 private:
@@ -75,7 +75,7 @@ class Assignments: public ASTWalker
 {
 public:
 	using ASTWalker::operator ();
-	virtual void operator()(Assignment const& _assignment) override;
+	void operator()(Assignment const& _assignment) override;
 
 	std::set<YulString> const& names() const { return m_names; }
 private:

--- a/libyul/optimiser/Rematerialiser.h
+++ b/libyul/optimiser/Rematerialiser.h
@@ -36,7 +36,7 @@ class Rematerialiser: public DataFlowAnalyzer
 {
 protected:
 	using ASTModifier::visit;
-	virtual void visit(Expression& _e) override;
+	void visit(Expression& _e) override;
 
 };
 

--- a/libyul/optimiser/SSAValueTracker.h
+++ b/libyul/optimiser/SSAValueTracker.h
@@ -41,8 +41,8 @@ class SSAValueTracker: public ASTWalker
 {
 public:
 	using ASTWalker::operator();
-	virtual void operator()(VariableDeclaration const& _varDecl) override;
-	virtual void operator()(Assignment const& _assignment) override;
+	void operator()(VariableDeclaration const& _varDecl) override;
+	void operator()(Assignment const& _assignment) override;
 
 	std::map<YulString, Expression const*> const& values() const { return m_values; }
 	Expression const* value(YulString _name) const { return m_values.at(_name); }

--- a/libyul/optimiser/Semantics.h
+++ b/libyul/optimiser/Semantics.h
@@ -38,12 +38,12 @@ public:
 	MovableChecker() = default;
 	explicit MovableChecker(Expression const& _expression);
 
-	virtual void operator()(Identifier const& _identifier) override;
-	virtual void operator()(FunctionalInstruction const& _functionalInstruction) override;
-	virtual void operator()(FunctionCall const& _functionCall) override;
+	void operator()(Identifier const& _identifier) override;
+	void operator()(FunctionalInstruction const& _functionalInstruction) override;
+	void operator()(FunctionCall const& _functionCall) override;
 
 	/// Disallow visiting anything apart from Expressions (this throws).
-	virtual void visit(Statement const&) override;
+	void visit(Statement const&) override;
 	using ASTWalker::visit;
 
 	bool movable() const { return m_movable; }

--- a/libyul/optimiser/Substitution.h
+++ b/libyul/optimiser/Substitution.h
@@ -40,7 +40,7 @@ public:
 	Substitution(std::map<YulString, Expression const*> const& _substitutions):
 		m_substitutions(_substitutions)
 	{}
-	virtual Expression translate(Expression const& _expression) override;
+	Expression translate(Expression const& _expression) override;
 
 private:
 	std::map<YulString, Expression const*> const& m_substitutions;

--- a/libyul/optimiser/UnusedPruner.h
+++ b/libyul/optimiser/UnusedPruner.h
@@ -45,7 +45,7 @@ public:
 	explicit UnusedPruner(Block& _ast, std::set<YulString> const& _externallyUsedFunctions = {});
 
 	using ASTModifier::operator();
-	virtual void operator()(Block& _block) override;
+	void operator()(Block& _block) override;
 
 	// @returns true iff the code changed in the previous run.
 	bool shouldRunAgain() const { return m_shouldRunAgain; }

--- a/test/libsolidity/ASTJSONTest.h
+++ b/test/libsolidity/ASTJSONTest.h
@@ -39,10 +39,10 @@ public:
 	{ return std::unique_ptr<TestCase>(new ASTJSONTest(_filename)); }
 	ASTJSONTest(std::string const& _filename);
 
-	virtual bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 
-	virtual void printSource(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
-	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
+	void printSource(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
+	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
 private:
 	std::vector<std::pair<std::string, std::string>> m_sources;
 	std::string m_expectation;

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -57,10 +57,10 @@ public:
 	{ return std::unique_ptr<TestCase>(new SyntaxTest(_filename)); }
 	SyntaxTest(std::string const& _filename);
 
-	virtual bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 
-	virtual void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool const _formatted = false) const override;
-	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override
+	void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool const _formatted = false) const override;
+	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override
 	{
 		if (!m_errorList.empty())
 			printErrorList(_stream, m_errorList, _linePrefix, false);


### PR DESCRIPTION
Part of issue #5168.
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description
Removed redundant `virtual` declaration from functions that already have `override` stated. As always, let me know if I missed anything.
<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
