### PR TITLE
[SMTChecker] Refactor smt::Sort and its usage

### DIFF
--- a/libsolidity/formal/CVC4Interface.cpp
+++ b/libsolidity/formal/CVC4Interface.cpp
@@ -50,7 +50,7 @@ void CVC4Interface::pop()
 	m_solver.pop();
 }
 
-void CVC4Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void CVC4Interface::declareFunction(string _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	if (!m_functions.count(_name))
 	{
@@ -186,13 +186,13 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 	return arguments[0];
 }
 
-CVC4::Type CVC4Interface::cvc4Sort(Sort _sort)
+CVC4::Type CVC4Interface::cvc4Sort(Sort const& _sort)
 {
-	switch (_sort)
+	switch (_sort.kind)
 	{
-	case Sort::Bool:
+	case Kind::Bool:
 		return m_context.booleanType();
-	case Sort::Int:
+	case Kind::Int:
 		return m_context.integerType();
 	default:
 		break;
@@ -202,10 +202,10 @@ CVC4::Type CVC4Interface::cvc4Sort(Sort _sort)
 	return m_context.integerType();
 }
 
-vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<Sort> const& _sorts)
+vector<CVC4::Type> CVC4Interface::cvc4Sort(vector<SortPointer> const& _sorts)
 {
 	vector<CVC4::Type> cvc4Sorts;
 	for (auto const& _sort: _sorts)
-		cvc4Sorts.push_back(cvc4Sort(_sort));
+		cvc4Sorts.push_back(cvc4Sort(*_sort));
 	return cvc4Sorts;
 }

--- a/libsolidity/formal/CVC4Interface.h
+++ b/libsolidity/formal/CVC4Interface.h
@@ -51,7 +51,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -60,8 +60,8 @@ public:
 
 private:
 	CVC4::Expr toCVC4Expr(Expression const& _expr);
-	CVC4::Type cvc4Sort(smt::Sort _sort);
-	std::vector<CVC4::Type> cvc4Sort(std::vector<smt::Sort> const& _sort);
+	CVC4::Type cvc4Sort(smt::Sort const& _sort);
+	std::vector<CVC4::Type> cvc4Sort(std::vector<smt::SortPointer> const& _sorts);
 
 	CVC4::ExprManager m_context;
 	CVC4::SmtEngine m_solver;

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -416,7 +416,7 @@ void SMTChecker::visitGasLeft(FunctionCall const& _funCall)
 void SMTChecker::visitBlockHash(FunctionCall const& _funCall)
 {
 	string blockHash = "blockhash";
-	defineUninterpretedFunction(blockHash, {smt::Sort::Int}, smt::Sort::Int);
+	defineUninterpretedFunction(blockHash, {make_shared<smt::Sort>(smt::Kind::Int)}, smt::Kind::Int);
 	auto const& arguments = _funCall.arguments();
 	solAssert(arguments.size() == 1, "");
 	defineExpr(_funCall, m_uninterpretedFunctions.at(blockHash)({expr(*arguments[0])}));
@@ -605,7 +605,7 @@ void SMTChecker::defineSpecialVariable(string const& _name, Expression const& _e
 	defineExpr(_expr, m_specialVariables.at(_name)->currentValue());
 }
 
-void SMTChecker::defineUninterpretedFunction(string const& _name, vector<smt::Sort> const& _domain, smt::Sort _codomain)
+void SMTChecker::defineUninterpretedFunction(string const& _name, vector<smt::SortPointer> const& _domain, smt::Sort const& _codomain)
 {
 	if (!m_uninterpretedFunctions.count(_name))
 		m_uninterpretedFunctions.emplace(_name, m_interface->newFunction(_name, _domain, _codomain));

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -83,7 +83,7 @@ private:
 	void inlineFunctionCall(FunctionCall const&);
 
 	void defineSpecialVariable(std::string const& _name, Expression const& _expr, bool _increaseIndex = false);
-	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::Sort> const& _domain, smt::Sort _codomain);
+	void defineUninterpretedFunction(std::string const& _name, std::vector<smt::SortPointer> const& _domain, smt::Sort const& _codomain);
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.

--- a/libsolidity/formal/SMTLib2Interface.cpp
+++ b/libsolidity/formal/SMTLib2Interface.cpp
@@ -64,12 +64,12 @@ void SMTLib2Interface::pop()
 	m_accumulatedOutput.pop_back();
 }
 
-void SMTLib2Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void SMTLib2Interface::declareFunction(string _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	// TODO Use domain and codomain as key as well
 	string domain("");
 	for (auto const& sort: _domain)
-		domain += toSmtLibSort(sort) + ' ';
+		domain += toSmtLibSort(*sort) + ' ';
 	if (!m_functions.count(_name))
 	{
 		m_functions.insert(_name);
@@ -79,7 +79,7 @@ void SMTLib2Interface::declareFunction(string _name, vector<Sort> const& _domain
 			"| (" +
 			domain +
 			") " +
-			(_codomain == Sort::Int ? "Int" : "Bool") +
+			(_codomain.kind == Kind::Int ? "Int" : "Bool") +
 			")"
 		);
 	}
@@ -143,13 +143,13 @@ string SMTLib2Interface::toSExpr(Expression const& _expr)
 	return sexpr;
 }
 
-string SMTLib2Interface::toSmtLibSort(Sort _sort)
+string SMTLib2Interface::toSmtLibSort(Sort const& _sort)
 {
-	switch (_sort)
+	switch (_sort.kind)
 	{
-	case Sort::Int:
+	case Kind::Int:
 		return "Int";
-	case Sort::Bool:
+	case Kind::Bool:
 		return "Bool";
 	default:
 		solAssert(false, "Invalid SMT sort");
@@ -173,8 +173,8 @@ string SMTLib2Interface::checkSatAndGetValuesCommand(vector<Expression> const& _
 		for (size_t i = 0; i < _expressionsToEvaluate.size(); i++)
 		{
 			auto const& e = _expressionsToEvaluate.at(i);
-			solAssert(e.sort == Sort::Int || e.sort == Sort::Bool, "Invalid sort for expression to evaluate.");
-			command += "(declare-const |EVALEXPR_" + to_string(i) + "| " + (e.sort == Sort::Int ? "Int" : "Bool") + ")\n";
+			solAssert(e.sort->kind == Kind::Int || e.sort->kind == Kind::Bool, "Invalid sort for expression to evaluate.");
+			command += "(declare-const |EVALEXPR_" + to_string(i) + "| " + (e.sort->kind == Kind::Int ? "Int" : "Bool") + ")\n";
 			command += "(assert (= |EVALEXPR_" + to_string(i) + "| " + toSExpr(e) + "))\n";
 		}
 		command += "(check-sat)\n";

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -49,7 +49,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -58,7 +58,7 @@ public:
 
 private:
 	std::string toSExpr(Expression const& _expr);
-	std::string toSmtLibSort(Sort _sort);
+	std::string toSmtLibSort(Sort const& _sort);
 
 	void write(std::string _data);
 

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -64,7 +64,7 @@ void SMTPortfolio::pop()
 		s->pop();
 }
 
-void SMTPortfolio::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void SMTPortfolio::declareFunction(string _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	for (auto s : m_solvers)
 		s->declareFunction(_name, _domain, _codomain);

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -49,7 +49,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -24,12 +24,24 @@
 using namespace std;
 using namespace dev::solidity;
 
-smt::Sort dev::solidity::smtSort(Type::Category _category)
+smt::SortPointer dev::solidity::smtSort(Type const& _type)
+{
+	switch (smtKind(_type.category()))
+	{
+	case smt::Kind::Int:
+		return make_shared<smt::Sort>(smt::Kind::Int);
+	case smt::Kind::Bool:
+		return make_shared<smt::Sort>(smt::Kind::Bool);
+	}
+	solAssert(false, "Invalid type");
+}
+
+smt::Kind dev::solidity::smtKind(Type::Category _category)
 {
 	if (isNumber(_category))
-		return smt::Sort::Int;
+		return smt::Kind::Int;
 	else if (isBool(_category))
-		return smt::Sort::Bool;
+		return smt::Kind::Bool;
 	solAssert(false, "Invalid type");
 }
 

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -29,7 +29,9 @@ namespace solidity
 {
 
 /// Returns the SMT sort that models the Solidity type _type.
-smt::Sort smtSort(Type::Category _type);
+smt::SortPointer smtSort(Type const& _type);
+/// Returns the SMT kind that models the Solidity type type category _category.
+smt::Kind smtKind(Type::Category _category);
 
 /// So far int, bool and address are supported.
 /// Returns true if type is supported.

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -51,7 +51,7 @@ void Z3Interface::pop()
 	m_solver.pop();
 }
 
-void Z3Interface::declareFunction(string _name, vector<Sort> const& _domain, Sort _codomain)
+void Z3Interface::declareFunction(string _name, vector<SortPointer> const& _domain, Sort const& _codomain)
 {
 	if (!m_functions.count(_name))
 		m_functions.insert({_name, m_context.function(_name.c_str(), z3Sort(_domain), z3Sort(_codomain))});
@@ -168,13 +168,13 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 	return arguments[0];
 }
 
-z3::sort Z3Interface::z3Sort(Sort _sort)
+z3::sort Z3Interface::z3Sort(Sort const& _sort)
 {
-	switch (_sort)
+	switch (_sort.kind)
 	{
-	case Sort::Bool:
+	case Kind::Bool:
 		return m_context.bool_sort();
-	case Sort::Int:
+	case Kind::Int:
 		return m_context.int_sort();
 	default:
 		break;
@@ -184,10 +184,10 @@ z3::sort Z3Interface::z3Sort(Sort _sort)
 	return m_context.int_sort();
 }
 
-z3::sort_vector Z3Interface::z3Sort(vector<Sort> const& _sorts)
+z3::sort_vector Z3Interface::z3Sort(vector<SortPointer> const& _sorts)
 {
 	z3::sort_vector z3Sorts(m_context);
 	for (auto const& _sort: _sorts)
-		z3Sorts.push_back(z3Sort(_sort));
+		z3Sorts.push_back(z3Sort(*_sort));
 	return z3Sorts;
 }

--- a/libsolidity/formal/Z3Interface.h
+++ b/libsolidity/formal/Z3Interface.h
@@ -40,7 +40,7 @@ public:
 	void push() override;
 	void pop() override;
 
-	void declareFunction(std::string _name, std::vector<Sort> const& _domain, Sort _codomain) override;
+	void declareFunction(std::string _name, std::vector<SortPointer> const& _domain, Sort const& _codomain) override;
 	void declareInteger(std::string _name) override;
 	void declareBool(std::string _name) override;
 
@@ -49,8 +49,8 @@ public:
 
 private:
 	z3::expr toZ3Expr(Expression const& _expr);
-	z3::sort z3Sort(smt::Sort _sort);
-	z3::sort_vector z3Sort(std::vector<smt::Sort> const& _sort);
+	z3::sort z3Sort(smt::Sort const& _sort);
+	z3::sort_vector z3Sort(std::vector<smt::SortPointer> const& _sorts);
 
 	z3::context m_context;
 	z3::solver m_solver;


### PR DESCRIPTION
Split from #5387 

The reason why it's now a pointer inside `smt::Expression` is the preparation to the derived struct `ArraySort`.