### PR TITLE
Jumps with annotations cannot be functional.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Assembly output: Do not mix in/out jump annotations with arguments.
 
 Build System:
  * Emscripten: Upgrade to Emscripten SDK 1.37.21 and boost 1.67.

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -117,6 +117,8 @@ int AssemblyItem::returnValues() const
 
 bool AssemblyItem::canBeFunctional() const
 {
+	if (m_jumpType != JumpType::Ordinary)
+		return false;
 	switch (m_type)
 	{
 	case Operation:


### PR DESCRIPTION
Split out from https://github.com/ethereum/solidity/pull/5404/files

Did not add tests because this component has zero tests and is not fully specified anyway.