### PR TITLE
Refactor callable function

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -400,42 +400,42 @@ void TypeChecker::checkContractIllegalOverrides(ContractDefinition const& _contr
 	}
 }
 
-void TypeChecker::checkFunctionOverride(FunctionDefinition const& function, FunctionDefinition const& super)
+void TypeChecker::checkFunctionOverride(FunctionDefinition const& _function, FunctionDefinition const& _super)
 {
-	FunctionType functionType(function);
-	FunctionType superType(super);
+	FunctionType functionType(_function);
+	FunctionType superType(_super);
 
 	if (!functionType.hasEqualParameterTypes(superType))
 		return;
 
-	if (!function.annotation().superFunction)
-		function.annotation().superFunction = &super;
+	if (!_function.annotation().superFunction)
+		_function.annotation().superFunction = &_super;
 
-	if (function.visibility() != super.visibility())
+	if (_function.visibility() != _super.visibility())
 	{
 		// visibility is enforced to be external in interfaces, but a contract can override that with public
 		if (
-			super.inContractKind() == ContractDefinition::ContractKind::Interface &&
-			function.inContractKind() != ContractDefinition::ContractKind::Interface &&
-			function.visibility() == FunctionDefinition::Visibility::Public
+			_super.inContractKind() == ContractDefinition::ContractKind::Interface &&
+			_function.inContractKind() != ContractDefinition::ContractKind::Interface &&
+			_function.visibility() == FunctionDefinition::Visibility::Public
 		)
 			return;
-		overrideError(function, super, "Overriding function visibility differs.");
+		overrideError(_function, _super, "Overriding function visibility differs.");
 	}
 
-	else if (function.stateMutability() != super.stateMutability())
+	else if (_function.stateMutability() != _super.stateMutability())
 		overrideError(
-			function,
-			super,
+			_function,
+			_super,
 			"Overriding function changes state mutability from \"" +
-			stateMutabilityToString(super.stateMutability()) +
+			stateMutabilityToString(_super.stateMutability()) +
 			"\" to \"" +
-			stateMutabilityToString(function.stateMutability()) +
+			stateMutabilityToString(_function.stateMutability()) +
 			"\"."
 		);
 
 	else if (functionType != superType)
-		overrideError(function, super, "Overriding function return types differ.");
+		overrideError(_function, _super, "Overriding function return types differ.");
 }
 
 void TypeChecker::overrideError(FunctionDefinition const& function, FunctionDefinition const& super, string message)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -442,10 +442,11 @@ MemberList::MemberMap Type::boundFunctions(Type const& _type, ContractDefinition
 				if (!function->isVisibleAsLibraryMember() || seenFunctions.count(function))
 					continue;
 				seenFunctions.insert(function);
-				FunctionType funType(*function, false);
-				if (auto fun = funType.asCallableFunction(true, true))
-					if (_type.isImplicitlyConvertibleTo(*fun->selfType()))
-						members.push_back(MemberList::Member(function->name(), fun, function));
+				if (function->parameters().empty())
+					continue;
+				FunctionTypePointer fun = FunctionType(*function, false).asCallableFunction(true, true);
+				if (_type.isImplicitlyConvertibleTo(*fun->selfType()))
+					members.push_back(MemberList::Member(function->name(), fun, function));
 			}
 		}
 	return members;
@@ -3061,8 +3062,8 @@ TypePointer FunctionType::copyAndSetGasOrValue(bool _setGas, bool _setValue) con
 
 FunctionTypePointer FunctionType::asCallableFunction(bool _inLibrary, bool _bound) const
 {
-	if (_bound && m_parameterTypes.empty())
-		return FunctionTypePointer();
+	if (_bound)
+		solAssert(!m_parameterTypes.empty(), "");
 
 	TypePointers parameterTypes;
 	for (auto const& t: m_parameterTypes)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -443,7 +443,7 @@ MemberList::MemberMap Type::boundFunctions(Type const& _type, ContractDefinition
 					continue;
 				seenFunctions.insert(function);
 				FunctionType funType(*function, false);
-				if (auto fun = funType.asMemberFunction(true, true))
+				if (auto fun = funType.asCallableFunction(true, true))
 					if (_type.isImplicitlyConvertibleTo(*fun->selfType()))
 						members.push_back(MemberList::Member(function->name(), fun, function));
 			}
@@ -1970,7 +1970,7 @@ MemberList::MemberMap ContractType::nativeMembers(ContractDefinition const* _con
 		for (auto const& it: m_contract.interfaceFunctions())
 			members.push_back(MemberList::Member(
 				it.second->declaration().name(),
-				it.second->asMemberFunction(m_contract.isLibrary()),
+				it.second->asCallableFunction(m_contract.isLibrary()),
 				&it.second->declaration()
 			));
 	}
@@ -3059,7 +3059,7 @@ TypePointer FunctionType::copyAndSetGasOrValue(bool _setGas, bool _setValue) con
 	);
 }
 
-FunctionTypePointer FunctionType::asMemberFunction(bool _inLibrary, bool _bound) const
+FunctionTypePointer FunctionType::asCallableFunction(bool _inLibrary, bool _bound) const
 {
 	if (_bound && m_parameterTypes.empty())
 		return FunctionTypePointer();
@@ -3201,7 +3201,7 @@ MemberList::MemberMap TypeType::nativeMembers(ContractDefinition const* _current
 				if (function->isVisibleAsLibraryMember())
 					members.push_back(MemberList::Member(
 						function->name(),
-						FunctionType(*function).asMemberFunction(true),
+						FunctionType(*function).asCallableFunction(true),
 						function
 					));
 		if (isBase)

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1158,9 +1158,8 @@ public:
 	/// from CallData to Memory. This is the type that would be used when the function is
 	/// called, as opposed to the parameter types that are available inside the function body.
 	/// Also supports variants to be used for library or bound calls.
-	/// Returns empty shared pointer on a failure. Namely, if a bound function has no parameters.
 	/// @param _inLibrary if true, uses DelegateCall as location.
-	/// @param _bound if true, the arguments are placed as `arg1.functionName(arg2, ..., argn)`.
+	/// @param _bound if true, the function type is set to be bound.
 	FunctionTypePointer asCallableFunction(bool _inLibrary, bool _bound = false) const;
 
 private:

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1154,14 +1154,14 @@ public:
 	/// of the parameters to false.
 	TypePointer copyAndSetGasOrValue(bool _setGas, bool _setValue) const;
 
-	/// @returns a copy of this function type where all return parameters of dynamic size are
-	/// removed and the location of reference types is changed from CallData to Memory.
-	/// This is needed if external functions are called on other contracts, as they cannot return
-	/// dynamic values.
+	/// @returns a copy of this function type where the location of reference types is changed
+	/// from CallData to Memory. This is the type that would be used when the function is
+	/// called, as opposed to the parameter types that are available inside the function body.
+	/// Also supports variants to be used for library or bound calls.
 	/// Returns empty shared pointer on a failure. Namely, if a bound function has no parameters.
 	/// @param _inLibrary if true, uses DelegateCall as location.
 	/// @param _bound if true, the arguments are placed as `arg1.functionName(arg2, ..., argn)`.
-	FunctionTypePointer asMemberFunction(bool _inLibrary, bool _bound = false) const;
+	FunctionTypePointer asCallableFunction(bool _inLibrary, bool _bound = false) const;
 
 private:
 	static TypePointers parseElementaryTypeVector(strings const& _types);

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -415,7 +415,7 @@ FunctionDefinition const& CompilerContext::resolveVirtualFunction(
 			if (
 				function->name() == name &&
 				!function->isConstructor() &&
-				FunctionType(*function).hasEqualParameterTypes(functionType)
+				FunctionType(*function).asCallableFunction(false)->hasEqualParameterTypes(functionType)
 			)
 				return *function;
 	solAssert(false, "Super function " + name + " not found.");


### PR DESCRIPTION
This is in preparation for some bug fixes.

The `asMemberFunction` is refactored to be used also in other places where it is required to merge `calldata` and `memory` types.