### PR TITLE
Allow external public override

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.5.1 (unreleased)
 
 Language Features:
+ * Allow public functions to override external functions.
 
 
 Compiler Features:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -413,16 +413,14 @@ void TypeChecker::checkFunctionOverride(FunctionDefinition const& _function, Fun
 
 	if (_function.visibility() != _super.visibility())
 	{
-		// visibility is enforced to be external in interfaces, but a contract can override that with public
-		if (
-			_super.inContractKind() == ContractDefinition::ContractKind::Interface &&
-			_function.inContractKind() != ContractDefinition::ContractKind::Interface &&
+		// Visibility change from external to public is fine.
+		// Any other change is disallowed.
+		if (!(
+			_super.visibility() == FunctionDefinition::Visibility::External &&
 			_function.visibility() == FunctionDefinition::Visibility::Public
-		)
-			return;
-		overrideError(_function, _super, "Overriding function visibility differs.");
+		))
+			overrideError(_function, _super, "Overriding function visibility differs.");
 	}
-
 	else if (_function.stateMutability() != _super.stateMutability())
 		overrideError(
 			_function,
@@ -433,7 +431,6 @@ void TypeChecker::checkFunctionOverride(FunctionDefinition const& _function, Fun
 			stateMutabilityToString(_function.stateMutability()) +
 			"\"."
 		);
-
 	else if (functionType != superType)
 		overrideError(_function, _super, "Overriding function return types differ.");
 }

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -14062,6 +14062,21 @@ BOOST_AUTO_TEST_CASE(flipping_sign_tests)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(true));
 }
 
+BOOST_AUTO_TEST_CASE(external_public_override)
+{
+	char const* sourceCode = R"(
+		contract A {
+			function f() external returns (uint) { return 1; }
+		}
+		contract B is A {
+			function f() public returns (uint) { return 2; }
+			function g() public returns (uint) { return f(); }
+		}
+	)";
+	compileAndRun(sourceCode);
+	ABI_CHECK(callContractFunction("f()"), encodeArgs(2));
+	ABI_CHECK(callContractFunction("g()"), encodeArgs(2));
+}
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/libsolidity/syntaxTests/inheritance/override/external_turns_public_no_params.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/external_turns_public_no_params.sol
@@ -1,0 +1,7 @@
+contract A {
+    function f() external pure {}
+}
+contract B is A {
+    function f() public pure {
+    }
+}

--- a/test/libsolidity/syntaxTests/inheritance/super_on_external.sol
+++ b/test/libsolidity/syntaxTests/inheritance/super_on_external.sol
@@ -1,0 +1,10 @@
+contract A {
+    function f() external pure {}
+}
+contract B is A {
+    function f() public pure {
+        super.f();
+    }
+}
+// ----
+// TypeError: (106-113): Member "f" not found or not visible after argument-dependent lookup in contract super B.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/182_equal_overload.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/182_equal_overload.sol
@@ -4,4 +4,3 @@ contract C {
 }
 // ----
 // DeclarationError: (17-66): Function with same name and arguments defined twice.
-// TypeError: (17-66): Overriding function visibility differs.


### PR DESCRIPTION
Allow external functions to be overridden by public functions.

Depends on https://github.com/ethereum/solidity/pull/5485