### PR TITLE
[WIP] CMake: Explicitly state which files to compile instead of relying on globbing

### DIFF
--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -1,7 +1,17 @@
-file(GLOB sources "*.cpp")
-file(GLOB headers "*.h")
+set(sources
+	CommonData.cpp
+	CommonIO.cpp
+	Exceptions.cpp
+	IndentedWriter.cpp
+	JSON.cpp
+	Keccak256.cpp
+	StringUtils.cpp
+	SwarmHash.cpp
+	UTF8.cpp
+	Whiskers.cpp
+)
 
-add_library(devcore ${sources} ${headers})
+add_library(devcore ${sources})
 target_link_libraries(devcore PRIVATE jsoncpp ${Boost_FILESYSTEM_LIBRARIES} ${Boost_REGEX_LIBRARIES} ${Boost_SYSTEM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
 target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})

--- a/libevmasm/CMakeLists.txt
+++ b/libevmasm/CMakeLists.txt
@@ -1,5 +1,21 @@
-file(GLOB sources "*.cpp")
-file(GLOB headers "*.h")
+set(sources
+	Assembly.cpp
+	AssemblyItem.cpp
+	BlockDeduplicator.cpp
+	CommonSubexpressionEliminator.cpp
+	ConstantOptimiser.cpp
+	ControlFlowGraph.cpp
+	ExpressionClasses.cpp
+	GasMeter.cpp
+	Instruction.cpp
+	JumpdestRemover.cpp
+	KnownState.cpp
+	LinkerObject.cpp
+	PathGasMeter.cpp
+	PeepholeOptimiser.cpp
+	SemanticInformation.cpp
+	SimplificationRules.cpp
+)
 
-add_library(evmasm ${sources} ${headers})
+add_library(evmasm ${sources})
 target_link_libraries(evmasm PUBLIC devcore)

--- a/liblangutil/CMakeLists.txt
+++ b/liblangutil/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Solidity Commons Library (Solidity related sharing bits between libsolidity and libyul)
-file(GLOB sources "*.cpp")
-file(GLOB headers "*.h")
+set(sources
+	CharStream.cpp
+	ErrorReporter.cpp
+	Exceptions.cpp
+	ParserBase.cpp
+	Scanner.cpp
+	Token.cpp
+)
 
-add_library(langutil ${sources} ${headers})
+add_library(langutil ${sources})
 target_link_libraries(langutil PUBLIC devcore)

--- a/liblll/CMakeLists.txt
+++ b/liblll/CMakeLists.txt
@@ -1,5 +1,9 @@
-file(GLOB sources "*.cpp")
-file(GLOB headers "*.h")
+set(sources
+	CodeFragment.cpp
+	Compiler.cpp
+	CompilerState.cpp
+	Parser.cpp
+)
 
-add_library(lll ${sources} ${headers})
+add_library(lll ${sources})
 target_link_libraries(lll PUBLIC evmasm devcore)

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -1,14 +1,60 @@
 # Until we have a clear separation, libyul has to be included here
-file(GLOB_RECURSE sources "*.cpp")
-file(GLOB_RECURSE headers "*.h")
+set(sources
+	analysis/ConstantEvaluator.cpp
+	analysis/ControlFlowAnalyzer.cpp
+	analysis/ControlFlowBuilder.cpp
+	analysis/ControlFlowGraph.cpp
+	analysis/DeclarationContainer.cpp
+	analysis/DocStringAnalyser.cpp
+	analysis/GlobalContext.cpp
+	analysis/NameAndTypeResolver.cpp
+	analysis/PostTypeChecker.cpp
+	analysis/ReferencesResolver.cpp
+	analysis/SemVerHandler.cpp
+	analysis/StaticAnalyzer.cpp
+	analysis/SyntaxChecker.cpp
+	analysis/TypeChecker.cpp
+	analysis/ViewPureChecker.cpp
+	ast/AST.cpp
+	ast/ASTAnnotations.cpp
+	ast/ASTJsonConverter.cpp
+	ast/ASTPrinter.cpp
+	ast/Types.cpp
+	codegen/ABIFunctions.cpp
+	codegen/ArrayUtils.cpp
+	codegen/Compiler.cpp
+	codegen/CompilerContext.cpp
+	codegen/CompilerUtils.cpp
+	codegen/ContractCompiler.cpp
+	codegen/ExpressionCompiler.cpp
+	codegen/LValue.cpp
+	formal/SMTChecker.cpp
+	formal/SMTLib2Interface.cpp
+	formal/SMTPortfolio.cpp
+	formal/SSAVariable.cpp
+	formal/SymbolicTypes.cpp
+	formal/SymbolicVariables.cpp
+	formal/VariableUsage.cpp
+	interface/ABI.cpp
+	interface/AssemblyStack.cpp
+	interface/CompilerStack.cpp
+	interface/GasEstimator.cpp
+	interface/Natspec.cpp
+	interface/SourceReferenceFormatter.cpp
+	interface/StandardCompiler.cpp
+	interface/Version.cpp
+	parsing/DocStringParser.cpp
+	parsing/Parser.cpp
+)
 
 find_package(Z3 QUIET)
 if (${Z3_FOUND})
   include_directories(${Z3_INCLUDE_DIR})
   add_definitions(-DHAVE_Z3)
   message("Z3 SMT solver found. This enables optional SMT checking with Z3.")
+  set(z3_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/formal/Z3Interface.cpp")
 else()
-  list(REMOVE_ITEM sources "${CMAKE_CURRENT_SOURCE_DIR}/formal/Z3Interface.cpp")
+  set(z3_SRCS)
 endif()
 
 find_package(CVC4 QUIET)
@@ -16,8 +62,9 @@ if (${CVC4_FOUND})
   include_directories(${CVC4_INCLUDE_DIR})
   add_definitions(-DHAVE_CVC4)
   message("CVC4 SMT solver found. This enables optional SMT checking with CVC4.")
+  set(cvc4_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/formal/CVC4Interface.cpp")
 else()
-  list(REMOVE_ITEM sources "${CMAKE_CURRENT_SOURCE_DIR}/formal/CVC4Interface.cpp")
+  set(cvc4_SRCS)
 endif()
 
 if (NOT (${Z3_FOUND} OR ${CVC4_FOUND}))
@@ -25,7 +72,7 @@ if (NOT (${Z3_FOUND} OR ${CVC4_FOUND}))
   \nPlease install Z3 or CVC4 or remove the option disabling them (USE_Z3, USE_CVC4).")
 endif()
 
-add_library(solidity ${sources} ${headers})
+add_library(solidity ${sources} ${z3_SRCS} ${cvc4_SRCS})
 target_link_libraries(solidity PUBLIC yul evmasm langutil devcore ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (${Z3_FOUND})


### PR DESCRIPTION
In another PR @chriseth expressed that we may finally now start consider using explicit file lists instead of using globbing, and I responded with "in another PR then".

Here we go.

(I've not finished it yet, esp. because one file will definitely cause a merge conflict that I'd like to avoid, resuming later).