### PR TITLE
Improved Scanner error diagnostics.

### DIFF
--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -265,6 +265,15 @@ namespace langutil
 	T(Illegal, "ILLEGAL", 0)                                           \
 	/* Illegal hex token */                                            \
 	T(IllegalHex, "ILLEGAL_HEX", 0)                                    \
+	T(IllegalCommentTerminator, "ILLEGAL_COMMENT_TERMINATOR", 0)       \
+	T(IllegalStringEscape, "ILLEGAL_STRING_ESCAPE", 0)                 \
+	T(IllegalStringEndQuote, "ILLEGAL_STRING_END_QUOTE", 0)            \
+	T(IllegalNumberSeparator, "ILLEGAL_NUMER_SEPARATOR", 0)            \
+	T(IllegalHexDigit, "ILLEGAL_HEX_DIGIT", 0)                         \
+	T(IllegalOctalNotAllowed, "ILLEGAL_OCTAL_NOT_ALLOWED", 0)          \
+	T(IllegalExponent, "ILLEGAL_EXPONENT", 0)                          \
+	T(IllegalNumberEnd, "ILLEGAL_NUMBER_END", 0)                       \
+	T(IllegalEnd, NULL, 0) /* used as type Illegal enum end marker */  \
 	\
 	/* Scanner-internal use only. */                                   \
 	T(Whitespace, nullptr, 0)
@@ -311,6 +320,9 @@ namespace TokenTraits
 	constexpr bool isEtherSubdenomination(Token op) { return op == Token::SubWei || op == Token::SubSzabo || op == Token::SubFinney || op == Token::SubEther; }
 	constexpr bool isTimeSubdenomination(Token op) { return op == Token::SubSecond || op == Token::SubMinute || op == Token::SubHour || op == Token::SubDay || op == Token::SubWeek || op == Token::SubYear; }
 	constexpr bool isReservedKeyword(Token op) { return (Token::Abstract <= op && op <= Token::Unchecked); }
+
+	// @returns true if token is illegal
+	constexpr bool isIllegal(Token tok) { return Token::Illegal <= tok && tok < Token::IllegalEnd; };
 
 	inline Token AssignmentToBinaryOp(Token op)
 	{

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -263,17 +263,6 @@ namespace langutil
 	\
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \
-	/* Illegal hex token */                                            \
-	T(IllegalHex, "ILLEGAL_HEX", 0)                                    \
-	T(IllegalCommentTerminator, "ILLEGAL_COMMENT_TERMINATOR", 0)       \
-	T(IllegalStringEscape, "ILLEGAL_STRING_ESCAPE", 0)                 \
-	T(IllegalStringEndQuote, "ILLEGAL_STRING_END_QUOTE", 0)            \
-	T(IllegalNumberSeparator, "ILLEGAL_NUMER_SEPARATOR", 0)            \
-	T(IllegalHexDigit, "ILLEGAL_HEX_DIGIT", 0)                         \
-	T(IllegalOctalNotAllowed, "ILLEGAL_OCTAL_NOT_ALLOWED", 0)          \
-	T(IllegalExponent, "ILLEGAL_EXPONENT", 0)                          \
-	T(IllegalNumberEnd, "ILLEGAL_NUMBER_END", 0)                       \
-	T(IllegalEnd, NULL, 0) /* used as type Illegal enum end marker */  \
 	\
 	/* Scanner-internal use only. */                                   \
 	T(Whitespace, nullptr, 0)
@@ -320,9 +309,6 @@ namespace TokenTraits
 	constexpr bool isEtherSubdenomination(Token op) { return op == Token::SubWei || op == Token::SubSzabo || op == Token::SubFinney || op == Token::SubEther; }
 	constexpr bool isTimeSubdenomination(Token op) { return op == Token::SubSecond || op == Token::SubMinute || op == Token::SubHour || op == Token::SubDay || op == Token::SubWeek || op == Token::SubYear; }
 	constexpr bool isReservedKeyword(Token op) { return (Token::Abstract <= op && op <= Token::Unchecked); }
-
-	// @returns true if token is illegal
-	constexpr bool isIllegal(Token tok) { return Token::Illegal <= tok && tok < Token::IllegalEnd; };
 
 	inline Token AssignmentToBinaryOp(Token op)
 	{

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1558,6 +1558,30 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 	case Token::IllegalHex:
 		fatalParserError("Expected even number of hex-nibbles within double-quotes.");
 		break;
+	case Token::IllegalCommentTerminator:
+		fatalParserError("Expected multi-line comment-terminator.");
+		break;
+	case Token::IllegalStringEscape:
+		fatalParserError("Invalid String Escape.");
+		break;
+	case Token::IllegalStringEndQuote:
+		fatalParserError("Expected String end-quote.");
+		break;
+	case Token::IllegalNumberSeparator:
+		fatalParserError("Invalid use of Number Separator '_'.");
+		break;
+	case Token::IllegalHexDigit:
+		fatalParserError("Hex Digit missing or invalid.");
+		break;
+	case Token::IllegalOctalNotAllowed:
+		fatalParserError("Octal Numbers not allowed.");
+		break;
+	case Token::IllegalExponent:
+		fatalParserError("Invalid Exponent.");
+		break;
+	case Token::IllegalNumberEnd:
+		fatalParserError("Digit or Identifier-Start not allowed at end of Number.");
+		break;
 	default:
 		if (TokenTraits::isElementaryTypeName(token))
 		{

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1555,32 +1555,8 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 		expression = nodeFactory.createNode<TupleExpression>(components, isArray);
 		break;
 	}
-	case Token::IllegalHex:
-		fatalParserError("Expected even number of hex-nibbles within double-quotes.");
-		break;
-	case Token::IllegalCommentTerminator:
-		fatalParserError("Expected multi-line comment-terminator.");
-		break;
-	case Token::IllegalStringEscape:
-		fatalParserError("Invalid String Escape.");
-		break;
-	case Token::IllegalStringEndQuote:
-		fatalParserError("Expected String end-quote.");
-		break;
-	case Token::IllegalNumberSeparator:
-		fatalParserError("Invalid use of Number Separator '_'.");
-		break;
-	case Token::IllegalHexDigit:
-		fatalParserError("Hex Digit missing or invalid.");
-		break;
-	case Token::IllegalOctalNotAllowed:
-		fatalParserError("Octal Numbers not allowed.");
-		break;
-	case Token::IllegalExponent:
-		fatalParserError("Invalid Exponent.");
-		break;
-	case Token::IllegalNumberEnd:
-		fatalParserError("Digit or Identifier-Start not allowed at end of Number.");
+	case Token::Illegal:
+		fatalParserError(to_string(m_scanner->currentError()));
 		break;
 	default:
 		if (TokenTraits::isElementaryTypeName(token))

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/invalid_number.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/invalid_number.sol
@@ -7,4 +7,4 @@ contract C {
 }
 // ----
 // ParserError: (72-73): Literal, identifier or instruction expected.
-// ParserError: (72-73): Octal Numbers not allowed.
+// ParserError: (72-73): Octal numbers not allowed.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/invalid_number.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/invalid_number.sol
@@ -7,4 +7,4 @@ contract C {
 }
 // ----
 // ParserError: (72-73): Literal, identifier or instruction expected.
-// ParserError: (72-73): Expected primary expression.
+// ParserError: (72-73): Octal Numbers not allowed.

--- a/test/libsolidity/syntaxTests/parsing/invalid_fixed_conversion_leading_zeroes_check.sol
+++ b/test/libsolidity/syntaxTests/parsing/invalid_fixed_conversion_leading_zeroes_check.sol
@@ -4,4 +4,4 @@ contract test {
 	}
 }
 // ----
-// ParserError: (44-47): Digit or Identifier-Start not allowed at end of Number.
+// ParserError: (44-47): Identifier-start is not allowed at end of a number.

--- a/test/libsolidity/syntaxTests/parsing/invalid_fixed_conversion_leading_zeroes_check.sol
+++ b/test/libsolidity/syntaxTests/parsing/invalid_fixed_conversion_leading_zeroes_check.sol
@@ -4,4 +4,4 @@ contract test {
 	}
 }
 // ----
-// ParserError: (44-47): Expected primary expression.
+// ParserError: (44-47): Digit or Identifier-Start not allowed at end of Number.

--- a/test/libsolidity/syntaxTests/string/string_new_line.sol
+++ b/test/libsolidity/syntaxTests/string/string_new_line.sol
@@ -6,4 +6,4 @@ contract test {
     }
 }
 // ----
-// ParserError: (100-112): Expected primary expression.
+// ParserError: (100-112): Expected String end-quote.

--- a/test/libsolidity/syntaxTests/string/string_new_line.sol
+++ b/test/libsolidity/syntaxTests/string/string_new_line.sol
@@ -6,4 +6,4 @@ contract test {
     }
 }
 // ----
-// ParserError: (100-112): Expected String end-quote.
+// ParserError: (100-112): Expected string end-quote.

--- a/test/libsolidity/syntaxTests/string/string_terminated_by_backslash.sol
+++ b/test/libsolidity/syntaxTests/string/string_terminated_by_backslash.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// ParserError: (100-109): Expected primary expression.
+// ParserError: (100-109): Expected String end-quote.

--- a/test/libsolidity/syntaxTests/string/string_terminated_by_backslash.sol
+++ b/test/libsolidity/syntaxTests/string/string_terminated_by_backslash.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// ParserError: (100-109): Expected String end-quote.
+// ParserError: (100-109): Expected string end-quote.

--- a/test/libsolidity/syntaxTests/string/string_unterminated.sol
+++ b/test/libsolidity/syntaxTests/string/string_unterminated.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// ParserError: (100-112): Expected String end-quote.
+// ParserError: (100-112): Expected string end-quote.

--- a/test/libsolidity/syntaxTests/string/string_unterminated.sol
+++ b/test/libsolidity/syntaxTests/string/string_unterminated.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// ParserError: (100-112): Expected primary expression.
+// ParserError: (100-112): Expected String end-quote.

--- a/test/libsolidity/syntaxTests/string/string_unterminated_no_new_line.sol
+++ b/test/libsolidity/syntaxTests/string/string_unterminated_no_new_line.sol
@@ -1,4 +1,4 @@
 contract test {
     function f() pure public { "abc\
 // ----
-// ParserError: (47-53): Expected primary expression.
+// ParserError: (47-53): Expected String end-quote.

--- a/test/libsolidity/syntaxTests/string/string_unterminated_no_new_line.sol
+++ b/test/libsolidity/syntaxTests/string/string_unterminated_no_new_line.sol
@@ -1,4 +1,4 @@
 contract test {
     function f() pure public { "abc\
 // ----
-// ParserError: (47-53): Expected String end-quote.
+// ParserError: (47-53): Expected string end-quote.

--- a/test/libsolidity/syntaxTests/unicode_escape_literals.sol
+++ b/test/libsolidity/syntaxTests/unicode_escape_literals.sol
@@ -28,4 +28,4 @@ contract test {
 
 }
 // ----
-// ParserError: (678-681): Invalid String Escape.
+// ParserError: (678-681): Invalid escape sequence.

--- a/test/libsolidity/syntaxTests/unicode_escape_literals.sol
+++ b/test/libsolidity/syntaxTests/unicode_escape_literals.sol
@@ -28,4 +28,4 @@ contract test {
 
 }
 // ----
-// ParserError: (678-681): Expected primary expression.
+// ParserError: (678-681): Invalid String Escape.


### PR DESCRIPTION
This PR resurrects the idea that has been initially presented in PR #5335 with the changes proposed.

It also eliminates the magic `Token::IllegalHex`, i.e. `Token::Illegal` is the only illegal token, and you must use `Scanner::currentError()` to read the diagnostic error code.

No changelog entry has been provided. I am not sure it's actually worth mentioning.