### PR TITLE
Moving SourceReferenceFormatter into langutil namespace.

### DIFF
--- a/liblangutil/SourceReferenceFormatter.cpp
+++ b/liblangutil/SourceReferenceFormatter.cpp
@@ -20,17 +20,13 @@
  * Formatting functions for errors referencing positions and locations in the source.
  */
 
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 #include <liblangutil/Scanner.h>
 #include <liblangutil/Exceptions.h>
 
 using namespace std;
+using namespace dev;
 using namespace langutil;
-
-namespace dev
-{
-namespace solidity
-{
 
 void SourceReferenceFormatter::printSourceLocation(SourceLocation const* _location)
 {
@@ -103,7 +99,7 @@ void SourceReferenceFormatter::printSourceName(SourceLocation const* _location)
 }
 
 void SourceReferenceFormatter::printExceptionInformation(
-	Exception const& _exception,
+	dev::Exception const& _exception,
 	string const& _name
 )
 {
@@ -130,7 +126,4 @@ void SourceReferenceFormatter::printExceptionInformation(
 		}
 		m_stream << endl;
 	}
-}
-
-}
 }

--- a/liblangutil/SourceReferenceFormatter.h
+++ b/liblangutil/SourceReferenceFormatter.h
@@ -26,21 +26,15 @@
 #include <sstream>
 #include <functional>
 
+namespace dev
+{
+struct Exception; // forward
+}
+
 namespace langutil
 {
 struct SourceLocation;
 class Scanner;
-}
-
-namespace dev
-{
-
-struct Exception; // forward
-
-namespace solidity
-{
-
-class CompilerStack; // forward
 
 class SourceReferenceFormatter
 {
@@ -57,10 +51,10 @@ public:
 
 	/// Prints source location if it is given.
 	void printSourceLocation(langutil::SourceLocation const* _location);
-	void printExceptionInformation(Exception const& _exception, std::string const& _name);
+	void printExceptionInformation(dev::Exception const& _exception, std::string const& _name);
 
 	static std::string formatExceptionInformation(
-		Exception const& _exception,
+		dev::Exception const& _exception,
 		std::string const& _name,
 		ScannerFromSourceNameFun const& _scannerFromSourceName
 	)
@@ -79,5 +73,4 @@ private:
 	ScannerFromSourceNameFun m_scannerFromSourceName;
 };
 
-}
 }

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -25,7 +25,7 @@
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/codegen/Compiler.h>
 #include <libsolidity/interface/Version.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmCodeGen.h>
 #include <libyul/AsmAnalysis.h>

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <libsolidity/interface/StandardCompiler.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 #include <libsolidity/ast/ASTJsonConverter.h>
 #include <libevmasm/Instruction.h>
 #include <libdevcore/JSON.h>

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -34,7 +34,7 @@
 #include <liblangutil/Exceptions.h>
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/StandardCompiler.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 #include <libsolidity/interface/GasEstimator.h>
 #include <libsolidity/interface/AssemblyStack.h>
 

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -23,7 +23,7 @@
 #include <test/Options.h>
 
 #include <libsolidity/interface/CompilerStack.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 #include <libsolidity/ast/AST.h>
 

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -26,7 +26,7 @@
 #include <libevmasm/PathGasMeter.h>
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/interface/GasEstimator.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 using namespace std;
 using namespace langutil;

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -28,7 +28,7 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 #include <liblangutil/Exceptions.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 namespace dev
 {
@@ -73,7 +73,7 @@ public:
 		if (!m_compiler.compile())
 		{
 			auto scannerFromSourceName = [&](std::string const& _sourceName) -> langutil::Scanner const& { return m_compiler.scanner(_sourceName); };
-			SourceReferenceFormatter formatter(std::cerr, scannerFromSourceName);
+			langutil::SourceReferenceFormatter formatter(std::cerr, scannerFromSourceName);
 
 			for (auto const& error: m_compiler.errors())
 				formatter.printExceptionInformation(

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -23,7 +23,7 @@
 
 #include <test/Options.h>
 
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 #include <libyul/optimiser/Disambiguator.h>
 #include <libyul/AsmParser.h>

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -43,7 +43,7 @@
 #include <libyul/AsmPrinter.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmAnalysis.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Scanner.h>

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -27,7 +27,7 @@
 #include <libyul/AsmData.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmPrinter.h>
-#include <libsolidity/interface/SourceReferenceFormatter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 #include <libyul/optimiser/BlockFlattener.h>
 #include <libyul/optimiser/Disambiguator.h>


### PR DESCRIPTION
As @chriseth proposed, this PR moves the `SourceReferenceFormatter` from libsolidity into liblangutil, as this API is not Solidity specific.

Many thanks,
Christian.