### PR TITLE
Detect Fedora properly in install_deps.sh

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -55,7 +55,7 @@ detect_linux_distro() {
         DISTRO=$(lsb_release -is)
     elif [ -f /etc/os-release ]; then
         # extract 'foo' from NAME=foo, only on the line with NAME=foo
-        DISTRO=$(sed -n -e 's/^NAME="\(.*\)\"/\1/p' /etc/os-release)
+        DISTRO=$(sed -n -e 's/^NAME="\?\([^"]*\)"\?$/\1/p' /etc/os-release)
     elif [ -f /etc/centos-release ]; then
         DISTRO=CentOS
     else


### PR DESCRIPTION
### Description

Make the double quotes around the distro name optional so it matches properly in Fedora (`NAME=Fedora`)

Fixes https://github.com/ethereum/solidity/issues/5512

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
