### PR TITLE
Remove unary + from the type system

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -612,10 +612,9 @@ TypeResult IntegerType::unaryOperatorResult(Token _operator) const
 	// "delete" is ok for all integer types
 	if (_operator == Token::Delete)
 		return TypeResult{make_shared<TupleType>()};
-	// we allow +, -, ++ and --
-	else if (_operator == Token::Add || _operator == Token::Sub ||
-			_operator == Token::Inc || _operator == Token::Dec ||
-			_operator == Token::BitNot)
+	// we allow -, ++ and --
+	else if (_operator == Token::Sub || _operator == Token::Inc ||
+		_operator == Token::Dec || _operator == Token::BitNot)
 		return TypeResult{shared_from_this()};
 	else
 		return TypeResult{""};

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(unary_operators)
 {
 	char const* sourceCode = R"(
 		contract test {
-			function f(int y) { !(~+- y == 2); }
+			function f(int y) { !(~- y == 2); }
 		}
 	)";
 	bytes code = compileFirstExpression(sourceCode, {}, {{"test", "f", "y"}});

--- a/test/libsolidity/syntaxTests/parsing/unary_plus_expression.sol
+++ b/test/libsolidity/syntaxTests/parsing/unary_plus_expression.sol
@@ -6,3 +6,4 @@ contract test {
 }
 // ----
 // SyntaxError: (70-72): Use of unary + is disallowed.
+// TypeError: (70-72): Unary operator + cannot be applied to type uint256


### PR DESCRIPTION
### Description

Remove unary + from the type system, as requested in  #5470 

Fixes #5470 

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

Not sure if any new test is needed, feedback would be appreciated.