### PR TITLE
Fix: Disallow structs in getters for old encoder.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,8 +17,9 @@ Compiler Features:
 Bugfixes:
  * Assembly output: Do not mix in/out jump annotations with arguments.
  * Code Generator: Annotate jump from calldata decoder to function as "jump in".
- * Type Checker: Properly detect different return types when overriding an external interface function with a public contract function.
  * Optimizer: Fix nondeterminism bug related to the boost version and constants representation. The bug only resulted in less optimal but still correct code because the generated routine is always verified to be correct.
+ * Type Checker: Properly detect different return types when overriding an external interface function with a public contract function.
+ * Type Checker: Disallow struct return types for getters of public state variables unless the new ABI encoder is active.
 
 Build System:
  * Emscripten: Upgrade to Emscripten SDK 1.37.21 and boost 1.67.

--- a/test/libsolidity/syntaxTests/getter/complex_struct.sol
+++ b/test/libsolidity/syntaxTests/getter/complex_struct.sol
@@ -1,0 +1,7 @@
+contract C {
+    struct Y {
+        uint a;
+        uint b;
+    }
+    mapping(uint256 => Y) public m;
+}

--- a/test/libsolidity/syntaxTests/getter/nested_structs.sol
+++ b/test/libsolidity/syntaxTests/getter/nested_structs.sol
@@ -1,0 +1,11 @@
+contract C {
+    struct Y {
+        uint b;
+    }
+    struct X {
+        Y a;
+    }
+    mapping(uint256 => X) public m;
+}
+// ----
+// TypeError: (88-118): The following types are only supported for getters in the new experimental ABI encoder: struct C.Y memory. Either remove "public" or use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/getter/recursive_struct.sol
+++ b/test/libsolidity/syntaxTests/getter/recursive_struct.sol
@@ -1,0 +1,8 @@
+contract C {
+    struct Y {
+        Y[] x;
+    }
+    mapping(uint256 => Y) public m;
+}
+// ----
+// TypeError: (53-83): Internal or recursive type is not allowed for public state variables.

--- a/test/libsolidity/syntaxTests/getter/simple_struct.sol
+++ b/test/libsolidity/syntaxTests/getter/simple_struct.sol
@@ -1,0 +1,6 @@
+contract C {
+    struct Y {
+        uint b;
+    }
+    mapping(uint256 => Y) public m;
+}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5520