### PR TITLE
Fixes crash on empty runtime code.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Compiler Features:
 
 Bugfixes:
  * Assembly output: Do not mix in/out jump annotations with arguments.
+ * Commandline interface: Fix crash when using ``--ast`` on empty runtime code.
  * Code Generator: Annotate jump from calldata decoder to function as "jump in".
  * Type Checker: Properly detect different return types when overriding an external interface function with a public contract function.
  * Optimizer: Fix nondeterminism bug related to the boost version and constants representation. The bug only resulted in less optimal but still correct code because the generated routine is always verified to be correct.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1022,12 +1022,16 @@ void CommandLineInterface::handleAst(string const& _argStr)
 		map<ASTNode const*, eth::GasMeter::GasConsumption> gasCosts;
 		for (auto const& contract : m_compiler->contractNames())
 		{
-			auto ret = GasEstimator::breakToStatementLevel(
-				GasEstimator(m_evmVersion).structuralEstimation(*m_compiler->runtimeAssemblyItems(contract), asts),
-				asts
-			);
-			for (auto const& it: ret)
-				gasCosts[it.first] += it.second;
+			if (auto const* assemblyItems = m_compiler->runtimeAssemblyItems(contract))
+			{
+				auto ret = GasEstimator::breakToStatementLevel(
+					GasEstimator(m_evmVersion).structuralEstimation(*assemblyItems, asts),
+					asts
+				);
+				for (auto const& it: ret)
+					gasCosts[it.first] += it.second;
+			}
+
 		}
 
 		bool legacyFormat = !m_args.count(g_argAstCompactJson);


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5501.

Apparently, the crash was not caused by the Heisenbug, but by an illegal memory access if no runtime assembly items were returned (as is it the case for the contract that seg-faulted on the users machine).