### PR TITLE
DOCS: Add mapping guide to style docs

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -809,7 +809,23 @@ possible permutations for function declarations.
 Mappings
 ========
 
-TODO
+In variable declarations, do not separate the keyword ``mapping`` from its
+type by a space. Do not separate any nested ``mapping`` keyword from its type by
+whitespace.
+
+Yes::
+
+    mapping(uint => uint) map;
+    mapping(address => bool) registeredAddresses;
+    mapping(uint => mapping(bool => Data[])) public data;
+    mapping(uint => mapping(uint => s)) data;
+
+No::
+
+    mapping (uint => uint) map;
+    mapping( address => bool ) registeredAddresses;
+    mapping (uint => mapping (bool => Data[])) public data;
+    mapping(uint => mapping (uint => s)) data;
 
 Variable Declarations
 =====================


### PR DESCRIPTION
### Description

Thanks to @aupiff for the contribution this PR closes https://github.com/ethereum/solidity/issues/2917 by adding mapping details to style guide.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
