### PR TITLE
[1/3] SourceLocation related refactoring.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -114,10 +114,10 @@ namespace
 
 string locationFromSources(StringMap const& _sourceCodes, SourceLocation const& _location)
 {
-	if (_location.isEmpty() || _sourceCodes.empty() || _location.start >= _location.end || _location.start < 0)
+	if (_location.isEmpty() || !_location.source.get() || _sourceCodes.empty() || _location.start >= _location.end || _location.start < 0)
 		return "";
 
-	auto it = _sourceCodes.find(*_location.sourceName);
+	auto it = _sourceCodes.find(_location.source->name());
 	if (it == _sourceCodes.end())
 		return "";
 
@@ -186,11 +186,11 @@ public:
 
 	void printLocation()
 	{
-		if (!m_location.sourceName && m_location.isEmpty())
+		if (!m_location.source && m_location.isEmpty())
 			return;
 		m_out << m_prefix << "    /*";
-		if (m_location.sourceName)
-			m_out << " \"" + *m_location.sourceName + "\"";
+		if (m_location.source)
+			m_out << " \"" + m_location.source->name() + "\"";
 		if (!m_location.isEmpty())
 			m_out << ":" << to_string(m_location.start) + ":" + to_string(m_location.end);
 		m_out << "  " << locationFromSources(m_sourceCodes, m_location);

--- a/liblangutil/CharStream.h
+++ b/liblangutil/CharStream.h
@@ -68,7 +68,8 @@ class CharStream
 {
 public:
 	CharStream(): m_position(0) {}
-	explicit CharStream(std::string const& _source): m_source(_source), m_position(0) {}
+	explicit CharStream(std::string const& _source, std::string const& name):
+		m_source(_source), m_name(name), m_position(0) {}
 
 	int position() const { return m_position; }
 	bool isPastEndOfInput(size_t _charsForward = 0) const { return (m_position + _charsForward) >= m_source.size(); }
@@ -80,6 +81,7 @@ public:
 	void reset() { m_position = 0; }
 
 	std::string const& source() const { return m_source; }
+	std::string const& name() const noexcept { return m_name; }
 
 	///@{
 	///@name Error printing helper functions
@@ -91,6 +93,7 @@ public:
 
 private:
 	std::string m_source;
+	std::string m_name;
 	size_t m_position;
 };
 

--- a/liblangutil/CharStream.h
+++ b/liblangutil/CharStream.h
@@ -80,7 +80,7 @@ public:
 
 	void reset() { m_position = 0; }
 
-	std::string const& source() const { return m_source; }
+	std::string const& source() const noexcept { return m_source; }
 	std::string const& name() const noexcept { return m_name; }
 
 	///@{

--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -105,10 +105,10 @@ void ParserBase::decreaseRecursionDepth()
 
 void ParserBase::parserError(string const& _description)
 {
-	m_errorReporter.parserError(SourceLocation(position(), endPosition(), sourceName()), _description);
+	m_errorReporter.parserError(SourceLocation(position(), endPosition(), source()), _description);
 }
 
 void ParserBase::fatalParserError(string const& _description)
 {
-	m_errorReporter.fatalParserError(SourceLocation(position(), endPosition(), sourceName()), _description);
+	m_errorReporter.fatalParserError(SourceLocation(position(), endPosition(), source()), _description);
 }

--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -27,11 +27,6 @@
 using namespace std;
 using namespace langutil;
 
-std::shared_ptr<string const> const& ParserBase::sourceName() const
-{
-	return m_scanner->sourceName();
-}
-
 int ParserBase::position() const
 {
 	return m_scanner->currentLocation().start;

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -39,7 +39,7 @@ public:
 	explicit ParserBase(ErrorReporter& errorReporter): m_errorReporter(errorReporter) {}
 
 	std::shared_ptr<std::string const> const& sourceName() const;
-	CharStream const* charStream() const { return &m_scanner->charStream(); }
+	std::shared_ptr<CharStream> source() const { return m_scanner->charStream(); }
 
 protected:
 	/// Utility class that creates an error and throws an exception if the

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <liblangutil/Token.h>
+#include <liblangutil/Scanner.h>
 #include <memory>
 #include <string>
 
@@ -38,6 +39,7 @@ public:
 	explicit ParserBase(ErrorReporter& errorReporter): m_errorReporter(errorReporter) {}
 
 	std::shared_ptr<std::string const> const& sourceName() const;
+	CharStream const* charStream() const { return &m_scanner->charStream(); }
 
 protected:
 	/// Utility class that creates an error and throws an exception if the

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -38,7 +38,6 @@ class ParserBase
 public:
 	explicit ParserBase(ErrorReporter& errorReporter): m_errorReporter(errorReporter) {}
 
-	std::shared_ptr<std::string const> const& sourceName() const;
 	std::shared_ptr<CharStream> source() const { return m_scanner->charStream(); }
 
 protected:

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -167,10 +167,9 @@ private:
 }; // end of LiteralScope class
 
 
-void Scanner::reset(CharStream _source, string _sourceName)
+void Scanner::reset(CharStream _source)
 {
 	m_source = make_shared<CharStream>(std::move(_source));
-	m_sourceName = make_shared<string const>(std::move(_sourceName));
 	reset();
 }
 

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -91,14 +91,14 @@ class Scanner
 	friend class LiteralScope;
 public:
 	explicit Scanner(std::shared_ptr<CharStream> _source) { reset(std::move(_source)); }
-	explicit Scanner(CharStream _source = CharStream(), std::string _sourceName = "") { reset(std::move(_source), std::move(_sourceName)); }
+	explicit Scanner(CharStream _source = CharStream()) { reset(std::move(_source)); }
 
 	std::string source() const { return m_source->source(); }
 
 	std::shared_ptr<CharStream> charStream() noexcept { return m_source; }
 
-	/// Resets the scanner as if newly constructed with _source and _sourceName as input.
-	void reset(CharStream _source, std::string _sourceName);
+	/// Resets the scanner as if newly constructed with _source as input.
+	void reset(CharStream _source);
 	void reset(std::shared_ptr<CharStream> _source);
 	/// Resets scanner to the start of input.
 	void reset();
@@ -149,8 +149,6 @@ public:
 	SourceLocation peekLocation() const { return m_nextToken.location; }
 	std::string const& peekLiteral() const { return m_nextToken.literal; }
 	///@}
-
-	std::shared_ptr<std::string const> const& sourceName() const { return m_sourceName; }
 
 	///@{
 	///@name Error printing helper functions
@@ -242,7 +240,6 @@ private:
 	TokenDesc m_nextToken;     // desc for next token (one token look-ahead)
 
 	std::shared_ptr<CharStream> m_source;
-	std::shared_ptr<std::string const> m_sourceName;
 
 	/// one character look-ahead, equals 0 at end of input
 	char m_char;

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -93,7 +93,7 @@ public:
 	explicit Scanner(std::shared_ptr<CharStream> _source) { reset(std::move(_source)); }
 	explicit Scanner(CharStream _source = CharStream()) { reset(std::move(_source)); }
 
-	std::string source() const { return m_source->source(); }
+	std::string const& source() const noexcept { return m_source->source(); }
 
 	std::shared_ptr<CharStream> charStream() noexcept { return m_source; }
 

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -94,6 +94,8 @@ public:
 
 	std::string source() const { return m_source.source(); }
 
+	CharStream const& charStream() const noexcept { return m_source; }
+
 	/// Resets the scanner as if newly constructed with _source and _sourceName as input.
 	void reset(CharStream _source, std::string _sourceName);
 	/// Resets scanner to the start of input.

--- a/liblangutil/SourceLocation.h
+++ b/liblangutil/SourceLocation.h
@@ -44,9 +44,7 @@ struct SourceLocation
 
 	bool operator==(SourceLocation const& _other) const
 	{
-		return start == _other.start && end == _other.end &&
-			((!source.get() && !_other.source.get()) ||
-			  (source.get() && _other.source.get() && source->name() == _other.source->name()));
+		return source.get() == _other.source.get() && start == _other.start && end == _other.end;
 	}
 	bool operator!=(SourceLocation const& _other) const { return !operator==(_other); }
 	inline bool operator<(SourceLocation const& _other) const;
@@ -84,14 +82,14 @@ bool SourceLocation::operator<(SourceLocation const& _other) const
 
 bool SourceLocation::contains(SourceLocation const& _other) const
 {
-	if (isEmpty() || _other.isEmpty() || ((!source || !_other.source || source->name() != _other.source->name()) && (source || _other.source)))
+	if (isEmpty() || _other.isEmpty() || source.get() != _other.source.get())
 		return false;
 	return start <= _other.start && _other.end <= end;
 }
 
 bool SourceLocation::intersects(SourceLocation const& _other) const
 {
-	if (isEmpty() || _other.isEmpty() || ((!source || !_other.source || source->name() != _other.source->name()) && (source || _other.source)))
+	if (isEmpty() || _other.isEmpty() || source.get() != _other.source.get())
 		return false;
 	return _other.start < end && start < _other.end;
 }

--- a/liblangutil/SourceLocation.h
+++ b/liblangutil/SourceLocation.h
@@ -41,20 +41,6 @@ struct SourceLocation
 	SourceLocation(): start(-1), end(-1), source{nullptr} { }
 	SourceLocation(int _start, int _end, std::shared_ptr<CharStream> _source):
 		start(_start), end(_end), source{std::move(_source)} { }
-	SourceLocation(SourceLocation&& _other) noexcept:
-		start(_other.start),
-		end(_other.end),
-		source{std::move(_other.source)}
-	{}
-	SourceLocation(SourceLocation const&) = default;
-	SourceLocation& operator=(SourceLocation const&) = default;
-	SourceLocation& operator=(SourceLocation&& _other) noexcept
-	{
-		start = _other.start;
-		end = _other.end;
-		source = std::move(_other.source);
-		return *this;
-	}
 
 	bool operator==(SourceLocation const& _other) const
 	{

--- a/liblangutil/SourceReferenceFormatter.cpp
+++ b/liblangutil/SourceReferenceFormatter.cpp
@@ -30,9 +30,9 @@ using namespace langutil;
 
 void SourceReferenceFormatter::printSourceLocation(SourceLocation const* _location)
 {
-	if (!_location || !_location->sourceName)
+	if (!_location || !_location->source)
 		return; // Nothing we can print here
-	auto const& scanner = m_scannerFromSourceName(*_location->sourceName);
+	auto const& scanner = m_scannerFromSourceName(_location->source->name());
 	int startLine;
 	int startColumn;
 	tie(startLine, startColumn) = scanner.translatePositionToLineColumn(_location->start);
@@ -89,13 +89,13 @@ void SourceReferenceFormatter::printSourceLocation(SourceLocation const* _locati
 
 void SourceReferenceFormatter::printSourceName(SourceLocation const* _location)
 {
-	if (!_location || !_location->sourceName)
+	if (!_location || !_location->source)
 		return; // Nothing we can print here
-	auto const& scanner = m_scannerFromSourceName(*_location->sourceName);
+	auto const& scanner = m_scannerFromSourceName(_location->source->name());
 	int startLine;
 	int startColumn;
 	tie(startLine, startColumn) = scanner.translatePositionToLineColumn(_location->start);
-	m_stream << *_location->sourceName << ":" << (startLine + 1) << ":" << (startColumn + 1) << ": ";
+	m_stream << _location->source->name() << ":" << (startLine + 1) << ":" << (startColumn + 1) << ": ";
 }
 
 void SourceReferenceFormatter::printExceptionInformation(

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -492,9 +492,9 @@ bool DeclarationRegistrationHelper::registerDeclaration(
 		Declaration const* conflictingDeclaration = _container.conflictingDeclaration(_declaration, _name);
 		solAssert(conflictingDeclaration, "");
 		bool const comparable =
-			_errorLocation->sourceName &&
-			conflictingDeclaration->location().sourceName &&
-			*_errorLocation->sourceName == *conflictingDeclaration->location().sourceName;
+			_errorLocation->source &&
+			conflictingDeclaration->location().source &&
+			_errorLocation->source->name() == conflictingDeclaration->location().source->name();
 		if (comparable && _errorLocation->start < conflictingDeclaration->location().start)
 		{
 			firstDeclarationLocation = *_errorLocation;

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -122,8 +122,8 @@ void ASTJsonConverter::setJsonNode(
 string ASTJsonConverter::sourceLocationToString(SourceLocation const& _location) const
 {
 	int sourceIndex{-1};
-	if (_location.sourceName && m_sourceIndices.count(*_location.sourceName))
-		sourceIndex = m_sourceIndices.at(*_location.sourceName);
+	if (_location.source && m_sourceIndices.count(_location.source->name()))
+		sourceIndex = m_sourceIndices.at(_location.source->name());
 	int length = -1;
 	if (_location.start >= 0 && _location.end >= 0)
 		length = _location.end - _location.start;

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -360,7 +360,7 @@ void CompilerContext::appendInlineAssembly(
 
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<langutil::Scanner>(langutil::CharStream(_assembly), "--CODEGEN--");
+	auto scanner = make_shared<langutil::Scanner>(langutil::CharStream(_assembly, "--CODEGEN--"), "--CODEGEN--");
 	auto parserResult = yul::Parser(errorReporter, yul::AsmFlavour::Strict).parse(scanner, false);
 #ifdef SOL_OUTPUT_ASM
 	cout << yul::AsmPrinter()(*parserResult) << endl;

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -360,7 +360,7 @@ void CompilerContext::appendInlineAssembly(
 
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<langutil::Scanner>(langutil::CharStream(_assembly, "--CODEGEN--"), "--CODEGEN--");
+	auto scanner = make_shared<langutil::Scanner>(langutil::CharStream(_assembly, "--CODEGEN--"));
 	auto parserResult = yul::Parser(errorReporter, yul::AsmFlavour::Strict).parse(scanner, false);
 #ifdef SOL_OUTPUT_ASM
 	cout << yul::AsmPrinter()(*parserResult) << endl;

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -69,7 +69,7 @@ bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string 
 {
 	m_errors.clear();
 	m_analysisSuccessful = false;
-	m_scanner = make_shared<Scanner>(CharStream(_source), _sourceName);
+	m_scanner = make_shared<Scanner>(CharStream(_source, _sourceName), _sourceName);
 	m_parserResult = yul::ObjectParser(m_errorReporter, languageToAsmFlavour(m_language)).parse(m_scanner, false);
 	if (!m_errorReporter.errors().empty())
 		return false;

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -69,7 +69,7 @@ bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string 
 {
 	m_errors.clear();
 	m_analysisSuccessful = false;
-	m_scanner = make_shared<Scanner>(CharStream(_source, _sourceName), _sourceName);
+	m_scanner = make_shared<Scanner>(CharStream(_source, _sourceName));
 	m_parserResult = yul::ObjectParser(m_errorReporter, languageToAsmFlavour(m_language)).parse(m_scanner, false);
 	if (!m_errorReporter.errors().empty())
 		return false;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -598,8 +598,8 @@ tuple<int, int, int, int> CompilerStack::positionFromSourceLocation(SourceLocati
 	int startColumn;
 	int endLine;
 	int endColumn;
-	tie(startLine, startColumn) = scanner(*_sourceLocation.sourceName).translatePositionToLineColumn(_sourceLocation.start);
-	tie(endLine, endColumn) = scanner(*_sourceLocation.sourceName).translatePositionToLineColumn(_sourceLocation.end);
+	tie(startLine, startColumn) = scanner(_sourceLocation.source->name()).translatePositionToLineColumn(_sourceLocation.start);
+	tie(endLine, endColumn) = scanner(_sourceLocation.source->name()).translatePositionToLineColumn(_sourceLocation.end);
 
 	return make_tuple(++startLine, ++startColumn, ++endLine, ++endColumn);
 }
@@ -922,8 +922,8 @@ string CompilerStack::computeSourceMapping(eth::AssemblyItems const& _items) con
 		SourceLocation const& location = item.location();
 		int length = location.start != -1 && location.end != -1 ? location.end - location.start : -1;
 		int sourceIndex =
-			location.sourceName && sourceIndicesMap.count(*location.sourceName) ?
-			sourceIndicesMap.at(*location.sourceName) :
+			location.source && sourceIndicesMap.count(location.source->name()) ?
+			sourceIndicesMap.at(location.source->name()) :
 			-1;
 		char jump = '-';
 		if (item.getJumpType() == eth::AssemblyItem::JumpType::IntoFunction)

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -125,7 +125,7 @@ bool CompilerStack::addSource(string const& _name, string const& _content, bool 
 {
 	bool existed = m_sources.count(_name) != 0;
 	reset(true);
-	m_sources[_name].scanner = make_shared<Scanner>(CharStream(_content, _name), _name);
+	m_sources[_name].scanner = make_shared<Scanner>(CharStream(_content, _name));
 	m_sources[_name].isLibrary = _isLibrary;
 	m_stackState = SourcesSet;
 	return existed;
@@ -160,7 +160,7 @@ bool CompilerStack::parse()
 			{
 				string const& newPath = newSource.first;
 				string const& newContents = newSource.second;
-				m_sources[newPath].scanner = make_shared<Scanner>(CharStream(newContents, newPath), newPath);
+				m_sources[newPath].scanner = make_shared<Scanner>(CharStream(newContents, newPath));
 				sourcesToParse.push_back(newPath);
 			}
 		}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -125,7 +125,7 @@ bool CompilerStack::addSource(string const& _name, string const& _content, bool 
 {
 	bool existed = m_sources.count(_name) != 0;
 	reset(true);
-	m_sources[_name].scanner = make_shared<Scanner>(CharStream(_content), _name);
+	m_sources[_name].scanner = make_shared<Scanner>(CharStream(_content, _name), _name);
 	m_sources[_name].isLibrary = _isLibrary;
 	m_stackState = SourcesSet;
 	return existed;
@@ -160,7 +160,7 @@ bool CompilerStack::parse()
 			{
 				string const& newPath = newSource.first;
 				string const& newContents = newSource.second;
-				m_sources[newPath].scanner = make_shared<Scanner>(CharStream(newContents), newPath);
+				m_sources[newPath].scanner = make_shared<Scanner>(CharStream(newContents, newPath), newPath);
 				sourcesToParse.push_back(newPath);
 			}
 		}

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -85,9 +85,9 @@ Json::Value formatErrorWithException(
 		message = _message;
 
 	Json::Value sourceLocation;
-	if (location && location->sourceName)
+	if (location && location->source && location->source->name() != "")
 	{
-		sourceLocation["file"] = *location->sourceName;
+		sourceLocation["file"] = location->source->name();
 		sourceLocation["start"] = location->start;
 		sourceLocation["end"] = location->end;
 	}

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -42,7 +42,7 @@ class Parser::ASTNodeFactory
 {
 public:
 	explicit ASTNodeFactory(Parser const& _parser):
-		m_parser(_parser), m_location(_parser.position(), -1, _parser.sourceName()) {}
+		m_parser(_parser), m_location(_parser.position(), -1, _parser.source()) {}
 	ASTNodeFactory(Parser const& _parser, ASTPointer<ASTNode> const& _childNode):
 		m_parser(_parser), m_location(_childNode->location()) {}
 
@@ -55,7 +55,7 @@ public:
 	template <class NodeType, typename... Args>
 	ASTPointer<NodeType> createNode(Args&& ... _args)
 	{
-		solAssert(m_location.sourceName, "");
+		solAssert(m_location.source, "");
 		if (m_location.end < 0)
 			markEndPosition();
 		return make_shared<NodeType>(m_location, std::forward<Args>(_args)...);

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -56,11 +56,11 @@ protected:
 			r.location.start = position();
 			r.location.end = endPosition();
 		}
-		if (!r.location.sourceName)
-			r.location.sourceName = sourceName();
+		if (!r.location.source)
+			r.location.source = m_scanner->charStream();
 		return r;
 	}
-	langutil::SourceLocation location() const { return {position(), endPosition(), sourceName()}; }
+	langutil::SourceLocation location() const { return {position(), endPosition(), m_scanner->charStream()}; }
 
 	Block parseBlock();
 	Statement parseStatement();

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -55,10 +55,12 @@ BOOST_AUTO_TEST_SUITE(Assembler)
 BOOST_AUTO_TEST_CASE(all_assembly_items)
 {
 	Assembly _assembly;
-	_assembly.setSourceLocation(SourceLocation(1, 3, make_shared<string>("root.asm")));
+	auto root_asm = make_shared<CharStream>("", "root.asm");
+	_assembly.setSourceLocation(SourceLocation(1, 3, root_asm));
 
 	Assembly _subAsm;
-	_subAsm.setSourceLocation(SourceLocation(6, 8, make_shared<string>("sub.asm")));
+	auto sub_asm = make_shared<CharStream>("", "sub.asm");
+	_subAsm.setSourceLocation(SourceLocation(6, 8, sub_asm));
 	_subAsm.append(Instruction::INVALID);
 	shared_ptr<Assembly> _subAsmPtr = make_shared<Assembly>(_subAsm);
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -53,7 +53,7 @@ namespace
 		// add dummy locations to each item so that we can check that they are not deleted
 		AssemblyItems input = _input;
 		for (AssemblyItem& item: input)
-			item.setLocation(SourceLocation(1, 3, make_shared<string>("")));
+			item.setLocation(SourceLocation(1, 3, nullptr));
 		return input;
 	}
 

--- a/test/liblangutil/SourceLocation.cpp
+++ b/test/liblangutil/SourceLocation.cpp
@@ -33,12 +33,16 @@ BOOST_AUTO_TEST_SUITE(SourceLocationTest)
 
 BOOST_AUTO_TEST_CASE(test_fail)
 {
+	auto const source = std::make_shared<CharStream>("", "source");
+	auto const sourceA = std::make_shared<CharStream>("", "sourceA");
+	auto const sourceB = std::make_shared<CharStream>("", "sourceB");
+
 	BOOST_CHECK(SourceLocation() == SourceLocation());
-	BOOST_CHECK(SourceLocation(0, 3, std::make_shared<std::string>("sourceA")) != SourceLocation(0, 3, std::make_shared<std::string>("sourceB")));
-	BOOST_CHECK(SourceLocation(0, 3, std::make_shared<std::string>("source")) == SourceLocation(0, 3, std::make_shared<std::string>("source")));
-	BOOST_CHECK(SourceLocation(3, 7, std::make_shared<std::string>("source")).contains(SourceLocation(4, 6, std::make_shared<std::string>("source"))));
-	BOOST_CHECK(!SourceLocation(3, 7, std::make_shared<std::string>("sourceA")).contains(SourceLocation(4, 6, std::make_shared<std::string>("sourceB"))));
-	BOOST_CHECK(SourceLocation(3, 7, std::make_shared<std::string>("sourceA")) < SourceLocation(4, 6, std::make_shared<std::string>("sourceB")));
+	BOOST_CHECK(SourceLocation(0, 3, sourceA) != SourceLocation(0, 3, sourceB));
+	BOOST_CHECK(SourceLocation(0, 3, source) == SourceLocation(0, 3, source));
+	BOOST_CHECK(SourceLocation(3, 7, source).contains(SourceLocation(4, 6, source)));
+	BOOST_CHECK(!SourceLocation(3, 7, sourceA).contains(SourceLocation(4, 6, sourceB)));
+	BOOST_CHECK(SourceLocation(3, 7, sourceA) < SourceLocation(4, 6, sourceB));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -52,13 +52,13 @@ namespace test
 namespace
 {
 
-eth::AssemblyItems compileContract(string const& _sourceCode)
+eth::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	Parser parser(errorReporter);
 	ASTPointer<SourceUnit> sourceUnit;
-	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(make_shared<Scanner>(CharStream(_sourceCode, ""))));
+	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(make_shared<Scanner>(_sourceCode)));
 	BOOST_CHECK(!!sourceUnit);
 
 	map<ASTNode const*, shared_ptr<DeclarationContainer>> scopes;
@@ -104,7 +104,7 @@ void printAssemblyLocations(AssemblyItems const& _items)
 			", " <<
 			_loc.end <<
 			", make_shared<string>(\"" <<
-			*_loc.sourceName <<
+			_loc.source->name() <<
 			"\"))) +" << endl;
 	};
 
@@ -151,29 +151,32 @@ BOOST_AUTO_TEST_SUITE(Assembly)
 
 BOOST_AUTO_TEST_CASE(location_test)
 {
-	char const* sourceCode = R"(
+	auto sourceCode = make_shared<CharStream>(R"(
 	contract test {
 		function f() public returns (uint256 a) {
 			return 16;
 		}
 	}
-	)";
+	)", "");
 	AssemblyItems items = compileContract(sourceCode);
 	bool hasShifts = dev::test::Options::get().evmVersion().hasBitwiseShifting();
+
+	auto codegenCharStream = make_shared<CharStream>("", "--CODEGEN--");
+
 	vector<SourceLocation> locations =
-		vector<SourceLocation>(hasShifts ? 21 : 22, SourceLocation(2, 82, make_shared<string>(""))) +
-		vector<SourceLocation>(2, SourceLocation(20, 79, make_shared<string>(""))) +
-		vector<SourceLocation>(1, SourceLocation(8, 17, make_shared<string>("--CODEGEN--"))) +
-		vector<SourceLocation>(3, SourceLocation(5, 7, make_shared<string>("--CODEGEN--"))) +
-		vector<SourceLocation>(1, SourceLocation(30, 31, make_shared<string>("--CODEGEN--"))) +
-		vector<SourceLocation>(1, SourceLocation(27, 28, make_shared<string>("--CODEGEN--"))) +
-		vector<SourceLocation>(1, SourceLocation(20, 32, make_shared<string>("--CODEGEN--"))) +
-		vector<SourceLocation>(1, SourceLocation(5, 7, make_shared<string>("--CODEGEN--"))) +
-		vector<SourceLocation>(24, SourceLocation(20, 79, make_shared<string>(""))) +
-		vector<SourceLocation>(1, SourceLocation(49, 58, make_shared<string>(""))) +
-		vector<SourceLocation>(1, SourceLocation(72, 74, make_shared<string>(""))) +
-		vector<SourceLocation>(2, SourceLocation(65, 74, make_shared<string>(""))) +
-		vector<SourceLocation>(2, SourceLocation(20, 79, make_shared<string>("")));
+		vector<SourceLocation>(hasShifts ? 21 : 22, SourceLocation(2, 82, sourceCode)) +
+		vector<SourceLocation>(2, SourceLocation(20, 79, sourceCode)) +
+		vector<SourceLocation>(1, SourceLocation(8, 17,  codegenCharStream)) +
+		vector<SourceLocation>(3, SourceLocation(5, 7,   codegenCharStream)) +
+		vector<SourceLocation>(1, SourceLocation(30, 31, codegenCharStream)) +
+		vector<SourceLocation>(1, SourceLocation(27, 28, codegenCharStream)) +
+		vector<SourceLocation>(1, SourceLocation(20, 32, codegenCharStream)) +
+		vector<SourceLocation>(1, SourceLocation(5, 7,   codegenCharStream)) +
+		vector<SourceLocation>(24, SourceLocation(20, 79, sourceCode)) +
+		vector<SourceLocation>(1, SourceLocation(49, 58, sourceCode)) +
+		vector<SourceLocation>(1, SourceLocation(72, 74, sourceCode)) +
+		vector<SourceLocation>(2, SourceLocation(65, 74, sourceCode)) +
+		vector<SourceLocation>(2, SourceLocation(20, 79, sourceCode));
 	checkAssemblyLocations(items, locations);
 }
 

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -135,7 +135,8 @@ void checkAssemblyLocations(AssemblyItems const& _items, vector<SourceLocation> 
 	BOOST_CHECK_EQUAL(_items.size(), _locations.size());
 	for (size_t i = 0; i < min(_items.size(), _locations.size()); ++i)
 	{
-		if (_items[i].location() != _locations[i])
+		if (_items[i].location().start != _locations[i].start ||
+			_items[i].location().end != _locations[i].end)
 		{
 			BOOST_CHECK_MESSAGE(false, "Location mismatch for item " + to_string(i) + ". Found the following locations:");
 			printAssemblyLocations(_items);

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -58,7 +58,7 @@ eth::AssemblyItems compileContract(string const& _sourceCode)
 	ErrorReporter errorReporter(errors);
 	Parser parser(errorReporter);
 	ASTPointer<SourceUnit> sourceUnit;
-	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(make_shared<Scanner>(CharStream(_sourceCode))));
+	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(make_shared<Scanner>(CharStream(_sourceCode, ""))));
 	BOOST_CHECK(!!sourceUnit);
 
 	map<ASTNode const*, shared_ptr<DeclarationContainer>> scopes;

--- a/test/libsolidity/SemVerMatcher.cpp
+++ b/test/libsolidity/SemVerMatcher.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_SUITE(SemVerMatcher)
 
 SemVerMatchExpression parseExpression(string const& _input)
 {
-	Scanner scanner{CharStream(_input)};
+	Scanner scanner{CharStream(_input, "")};
 	vector<string> literals;
 	vector<Token> tokens;
 	while (scanner.currentToken() != Token::EOS)

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -101,7 +101,7 @@ bytes compileFirstExpression(
 	{
 		ErrorList errors;
 		ErrorReporter errorReporter(errors);
-		sourceUnit = Parser(errorReporter).parse(make_shared<Scanner>(CharStream(_sourceCode)));
+		sourceUnit = Parser(errorReporter).parse(make_shared<Scanner>(CharStream(_sourceCode, "")));
 		if (!sourceUnit)
 			return bytes();
 	}

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -43,7 +43,7 @@ namespace
 ASTPointer<ContractDefinition> parseText(std::string const& _source, ErrorList& _errors)
 {
 	ErrorReporter errorReporter(_errors);
-	ASTPointer<SourceUnit> sourceUnit = Parser(errorReporter).parse(std::make_shared<Scanner>(CharStream(_source)));
+	ASTPointer<SourceUnit> sourceUnit = Parser(errorReporter).parse(std::make_shared<Scanner>(CharStream(_source, "")));
 	if (!sourceUnit)
 		return ASTPointer<ContractDefinition>();
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -107,10 +107,10 @@ BOOST_AUTO_TEST_CASE(hex_numbers)
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0x765432536763762734623472346");
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream("0x1234", ""), "");
+	scanner.reset(CharStream("0x1234", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0x1234");
-	scanner.reset(CharStream("0X1234", ""), "");
+	scanner.reset(CharStream("0X1234", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 }
 
@@ -118,17 +118,17 @@ BOOST_AUTO_TEST_CASE(octal_numbers)
 {
 	Scanner scanner(CharStream("07", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-	scanner.reset(CharStream("007", ""), "");
+	scanner.reset(CharStream("007", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-	scanner.reset(CharStream("-07", ""), "");
+	scanner.reset(CharStream("-07", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Sub);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-	scanner.reset(CharStream("-.07", ""), "");
+	scanner.reset(CharStream("-.07", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Sub);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	scanner.reset(CharStream("0", ""), "");
+	scanner.reset(CharStream("0", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
-	scanner.reset(CharStream("0.1", ""), "");
+	scanner.reset(CharStream("0.1", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 }
 
@@ -149,16 +149,16 @@ BOOST_AUTO_TEST_CASE(trailing_dot)
 	Scanner scanner(CharStream("2.5", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream("2.5e10", ""), "");
+	scanner.reset(CharStream("2.5e10", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream(".5", ""), "");
+	scanner.reset(CharStream(".5", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream(".5e10", ""), "");
+	scanner.reset(CharStream(".5e10", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream("2.", ""), "");
+	scanner.reset(CharStream("2.", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Period);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(leading_underscore_decimal_after_dot_illegal)
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-	scanner.reset(CharStream("1._", ""), "");
+	scanner.reset(CharStream("1._", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
@@ -225,11 +225,11 @@ BOOST_AUTO_TEST_CASE(number_literals_with_trailing_underscore_at_eos)
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-	scanner.reset(CharStream("123_", ""), "");
+	scanner.reset(CharStream("123_", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-	scanner.reset(CharStream("12.34_", ""), "");
+	scanner.reset(CharStream("12.34_", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -37,13 +37,13 @@ BOOST_AUTO_TEST_SUITE(SolidityScanner)
 
 BOOST_AUTO_TEST_CASE(test_empty)
 {
-	Scanner scanner(CharStream(""));
+	Scanner scanner(CharStream{});
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(smoke_test)
 {
-	Scanner scanner(CharStream("function break;765  \t  \"string1\",'string2'\nidentifier1"));
+	Scanner scanner(CharStream("function break;765  \t  \"string1\",'string2'\nidentifier1", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Function);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Break);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(smoke_test)
 
 BOOST_AUTO_TEST_CASE(string_escapes)
 {
-	Scanner scanner(CharStream("  { \"a\\x61\""));
+	Scanner scanner(CharStream("  { \"a\\x61\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "aa");
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(string_escapes)
 
 BOOST_AUTO_TEST_CASE(string_escapes_all)
 {
-	Scanner scanner(CharStream("  { \"a\\x61\\b\\f\\n\\r\\t\\v\""));
+	Scanner scanner(CharStream("  { \"a\\x61\\b\\f\\n\\r\\t\\v\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "aa\b\f\n\r\t\v");
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(string_escapes_all)
 
 BOOST_AUTO_TEST_CASE(string_escapes_with_zero)
 {
-	Scanner scanner(CharStream("  { \"a\\x61\\x00abc\""));
+	Scanner scanner(CharStream("  { \"a\\x61\\x00abc\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("aa\0abc", 6));
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(string_escapes_with_zero)
 
 BOOST_AUTO_TEST_CASE(string_escape_illegal)
 {
-	Scanner scanner(CharStream(" bla \"\\x6rf\" (illegalescape)"));
+	Scanner scanner(CharStream(" bla \"\\x6rf\" (illegalescape)", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalEscapeSequence);
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(string_escape_illegal)
 
 BOOST_AUTO_TEST_CASE(hex_numbers)
 {
-	Scanner scanner(CharStream("var x = 0x765432536763762734623472346;"));
+	Scanner scanner(CharStream("var x = 0x765432536763762734623472346;", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
@@ -107,34 +107,34 @@ BOOST_AUTO_TEST_CASE(hex_numbers)
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0x765432536763762734623472346");
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Semicolon);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream("0x1234"), "");
+	scanner.reset(CharStream("0x1234", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "0x1234");
-	scanner.reset(CharStream("0X1234"), "");
+	scanner.reset(CharStream("0X1234", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 }
 
 BOOST_AUTO_TEST_CASE(octal_numbers)
 {
-	Scanner scanner(CharStream("07"));
+	Scanner scanner(CharStream("07", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-	scanner.reset(CharStream("007"), "");
+	scanner.reset(CharStream("007", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-	scanner.reset(CharStream("-07"), "");
+	scanner.reset(CharStream("-07", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Sub);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
-	scanner.reset(CharStream("-.07"), "");
+	scanner.reset(CharStream("-.07", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Sub);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
-	scanner.reset(CharStream("0"), "");
+	scanner.reset(CharStream("0", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
-	scanner.reset(CharStream("0.1"), "");
+	scanner.reset(CharStream("0.1", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 }
 
 BOOST_AUTO_TEST_CASE(scientific_notation)
 {
-	Scanner scanner(CharStream("var x = 2e10;"));
+	Scanner scanner(CharStream("var x = 2e10;", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
@@ -146,19 +146,19 @@ BOOST_AUTO_TEST_CASE(scientific_notation)
 
 BOOST_AUTO_TEST_CASE(trailing_dot)
 {
-	Scanner scanner(CharStream("2.5"));
+	Scanner scanner(CharStream("2.5", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream("2.5e10"), "");
+	scanner.reset(CharStream("2.5e10", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream(".5"), "");
+	scanner.reset(CharStream(".5", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream(".5e10"), "");
+	scanner.reset(CharStream(".5e10", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
-	scanner.reset(CharStream("2."), "");
+	scanner.reset(CharStream("2.", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Period);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(trailing_dot)
 BOOST_AUTO_TEST_CASE(leading_underscore_decimal_is_identifier)
 {
 	// Actual error is cought by SyntaxChecker.
-	Scanner scanner(CharStream("_1.2"));
+	Scanner scanner(CharStream("_1.2", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
@@ -176,11 +176,11 @@ BOOST_AUTO_TEST_CASE(leading_underscore_decimal_is_identifier)
 BOOST_AUTO_TEST_CASE(leading_underscore_decimal_after_dot_illegal)
 {
 	// Actual error is cought by SyntaxChecker.
-	Scanner scanner(CharStream("1._2"));
+	Scanner scanner(CharStream("1._2", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-	scanner.reset(CharStream("1._"), "");
+	scanner.reset(CharStream("1._", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(leading_underscore_decimal_after_dot_illegal)
 BOOST_AUTO_TEST_CASE(leading_underscore_exp_are_identifier)
 {
 	// Actual error is cought by SyntaxChecker.
-	Scanner scanner(CharStream("_1e2"));
+	Scanner scanner(CharStream("_1e2", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(leading_underscore_exp_are_identifier)
 BOOST_AUTO_TEST_CASE(leading_underscore_exp_after_e_illegal)
 {
 	// Actual error is cought by SyntaxChecker.
-	Scanner scanner(CharStream("1e_2"));
+	Scanner scanner(CharStream("1e_2", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "1e_2");
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(leading_underscore_exp_after_e_illegal)
 
 BOOST_AUTO_TEST_CASE(leading_underscore_hex_illegal)
 {
-	Scanner scanner(CharStream("0x_abc"));
+	Scanner scanner(CharStream("0x_abc", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(leading_underscore_hex_illegal)
 BOOST_AUTO_TEST_CASE(fixed_number_invalid_underscore_front)
 {
 	// Actual error is cought by SyntaxChecker.
-	Scanner scanner(CharStream("12._1234_1234"));
+	Scanner scanner(CharStream("12._1234_1234", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
@@ -221,22 +221,22 @@ BOOST_AUTO_TEST_CASE(fixed_number_invalid_underscore_front)
 BOOST_AUTO_TEST_CASE(number_literals_with_trailing_underscore_at_eos)
 {
 	// Actual error is cought by SyntaxChecker.
-	Scanner scanner(CharStream("0x123_"));
+	Scanner scanner(CharStream("0x123_", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-	scanner.reset(CharStream("123_"), "");
+	scanner.reset(CharStream("123_", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 
-	scanner.reset(CharStream("12.34_"), "");
+	scanner.reset(CharStream("12.34_", ""), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Number);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(negative_numbers)
 {
-	Scanner scanner(CharStream("var x = -.2 + -0x78 + -7.3 + 8.9 + 2e-2;"));
+	Scanner scanner(CharStream("var x = -.2 + -0x78 + -7.3 + 8.9 + 2e-2;", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Var);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Assign);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(negative_numbers)
 
 BOOST_AUTO_TEST_CASE(locations)
 {
-	Scanner scanner(CharStream("function_identifier has ; -0x743/*comment*/\n ident //comment"));
+	Scanner scanner(CharStream("function_identifier has ; -0x743/*comment*/\n ident //comment", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.currentLocation().start, 0);
 	BOOST_CHECK_EQUAL(scanner.currentLocation().end, 19);
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(locations)
 BOOST_AUTO_TEST_CASE(ambiguities)
 {
 	// test scanning of some operators which need look-ahead
-	Scanner scanner(CharStream("<=" "<" "+ +=a++ =>" "<<" ">>" " >>=" ">>>" ">>>=" " >>>>>=><<="));
+	Scanner scanner(CharStream("<=" "<" "+ +=a++ =>" "<<" ">>" " >>=" ">>>" ">>>=" " >>>>>=><<=", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LessThanOrEqual);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::LessThan);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Add);
@@ -308,21 +308,21 @@ BOOST_AUTO_TEST_CASE(ambiguities)
 
 BOOST_AUTO_TEST_CASE(documentation_comments_parsed_begin)
 {
-	Scanner scanner(CharStream("/// Send $(value / 1000) chocolates to the user"));
+	Scanner scanner(CharStream("/// Send $(value / 1000) chocolates to the user", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "Send $(value / 1000) chocolates to the user");
 }
 
 BOOST_AUTO_TEST_CASE(multiline_documentation_comments_parsed_begin)
 {
-	Scanner scanner(CharStream("/** Send $(value / 1000) chocolates to the user*/"));
+	Scanner scanner(CharStream("/** Send $(value / 1000) chocolates to the user*/", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "Send $(value / 1000) chocolates to the user");
 }
 
 BOOST_AUTO_TEST_CASE(documentation_comments_parsed)
 {
-	Scanner scanner(CharStream("some other tokens /// Send $(value / 1000) chocolates to the user"));
+	Scanner scanner(CharStream("some other tokens /// Send $(value / 1000) chocolates to the user", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(multiline_documentation_comments_parsed)
 {
 	Scanner scanner(CharStream("some other tokens /**\n"
 							   "* Send $(value / 1000) chocolates to the user\n"
-							   "*/"));
+							   "*/", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
@@ -346,7 +346,7 @@ BOOST_AUTO_TEST_CASE(multiline_documentation_no_stars)
 {
 	Scanner scanner(CharStream("some other tokens /**\n"
 							   " Send $(value / 1000) chocolates to the user\n"
-							   "*/"));
+							   "*/", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(multiline_documentation_whitespace_hell)
 {
 	Scanner scanner(CharStream("some other tokens /** \t \r \n"
 							   "\t \r  * Send $(value / 1000) chocolates to the user\n"
-							   "*/"));
+							   "*/", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
@@ -368,28 +368,28 @@ BOOST_AUTO_TEST_CASE(multiline_documentation_whitespace_hell)
 
 BOOST_AUTO_TEST_CASE(comment_before_eos)
 {
-	Scanner scanner(CharStream("//"));
+	Scanner scanner(CharStream("//", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 }
 
 BOOST_AUTO_TEST_CASE(documentation_comment_before_eos)
 {
-	Scanner scanner(CharStream("///"));
+	Scanner scanner(CharStream("///", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 }
 
 BOOST_AUTO_TEST_CASE(empty_multiline_comment)
 {
-	Scanner scanner(CharStream("/**/"));
+	Scanner scanner(CharStream("/**/", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 }
 
 BOOST_AUTO_TEST_CASE(empty_multiline_documentation_comment_before_eos)
 {
-	Scanner scanner(CharStream("/***/"));
+	Scanner scanner(CharStream("/***/", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::EOS);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 }
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(comments_mixed_in_sequence)
 {
 	Scanner scanner(CharStream("hello_world ///documentation comment \n"
 							   "//simple comment \n"
-							   "<<"));
+							   "<<", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::SHL);
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "documentation comment ");
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(comments_mixed_in_sequence)
 
 BOOST_AUTO_TEST_CASE(ether_subdenominations)
 {
-	Scanner scanner(CharStream("wei szabo finney ether"));
+	Scanner scanner(CharStream("wei szabo finney ether", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::SubWei);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::SubSzabo);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::SubFinney);
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(ether_subdenominations)
 
 BOOST_AUTO_TEST_CASE(time_subdenominations)
 {
-	Scanner scanner(CharStream("seconds minutes hours days weeks years"));
+	Scanner scanner(CharStream("seconds minutes hours days weeks years", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::SubSecond);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::SubMinute);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::SubHour);
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(time_subdenominations)
 
 BOOST_AUTO_TEST_CASE(empty_comment)
 {
-	Scanner scanner(CharStream("//\ncontract{}"));
+	Scanner scanner(CharStream("//\ncontract{}", ""));
 	BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Contract);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::LBrace);
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(empty_comment)
 
 BOOST_AUTO_TEST_CASE(valid_unicode_string_escape)
 {
-	Scanner scanner(CharStream("{ \"\\u00DAnicode\""));
+	Scanner scanner(CharStream("{ \"\\u00DAnicode\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("\xC3\x9Anicode", 8));
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(valid_unicode_string_escape)
 
 BOOST_AUTO_TEST_CASE(valid_unicode_string_escape_7f)
 {
-	Scanner scanner(CharStream("{ \"\\u007Fnicode\""));
+	Scanner scanner(CharStream("{ \"\\u007Fnicode\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("\x7Fnicode", 7));
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(valid_unicode_string_escape_7f)
 
 BOOST_AUTO_TEST_CASE(valid_unicode_string_escape_7ff)
 {
-	Scanner scanner(CharStream("{ \"\\u07FFnicode\""));
+	Scanner scanner(CharStream("{ \"\\u07FFnicode\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("\xDF\xBFnicode", 8));
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(valid_unicode_string_escape_7ff)
 
 BOOST_AUTO_TEST_CASE(valid_unicode_string_escape_ffff)
 {
-	Scanner scanner(CharStream("{ \"\\uFFFFnicode\""));
+	Scanner scanner(CharStream("{ \"\\uFFFFnicode\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("\xEF\xBF\xBFnicode", 9));
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(valid_unicode_string_escape_ffff)
 
 BOOST_AUTO_TEST_CASE(invalid_short_unicode_string_escape)
 {
-	Scanner scanner(CharStream("{ \"\\uFFnicode\""));
+	Scanner scanner(CharStream("{ \"\\uFFnicode\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 }
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(invalid_short_unicode_string_escape)
 
 BOOST_AUTO_TEST_CASE(valid_hex_literal)
 {
-	Scanner scanner(CharStream("{ hex\"00112233FF\""));
+	Scanner scanner(CharStream("{ hex\"00112233FF\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
 	BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string("\x00\x11\x22\x33\xFF", 5));
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(valid_hex_literal)
 
 BOOST_AUTO_TEST_CASE(invalid_short_hex_literal)
 {
-	Scanner scanner(CharStream("{ hex\"00112233F\""));
+	Scanner scanner(CharStream("{ hex\"00112233F\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalHexString);
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(invalid_short_hex_literal)
 
 BOOST_AUTO_TEST_CASE(invalid_hex_literal_with_space)
 {
-	Scanner scanner(CharStream("{ hex\"00112233FF \""));
+	Scanner scanner(CharStream("{ hex\"00112233FF \"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalHexString);
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE(invalid_hex_literal_with_space)
 
 BOOST_AUTO_TEST_CASE(invalid_hex_literal_with_wrong_quotes)
 {
-	Scanner scanner(CharStream("{ hex\"00112233FF'"));
+	Scanner scanner(CharStream("{ hex\"00112233FF'", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalHexString);
@@ -509,7 +509,7 @@ BOOST_AUTO_TEST_CASE(invalid_hex_literal_with_wrong_quotes)
 
 BOOST_AUTO_TEST_CASE(invalid_hex_literal_nonhex_string)
 {
-	Scanner scanner(CharStream("{ hex\"hello\""));
+	Scanner scanner(CharStream("{ hex\"hello\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalHexString);
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(invalid_hex_literal_nonhex_string)
 BOOST_AUTO_TEST_CASE(invalid_multiline_comment_close)
 {
 	// This used to parse as "comment", "identifier"
-	Scanner scanner(CharStream("/** / x"));
+	Scanner scanner(CharStream("/** / x", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
@@ -528,14 +528,14 @@ BOOST_AUTO_TEST_CASE(invalid_multiline_comment_close)
 BOOST_AUTO_TEST_CASE(multiline_doc_comment_at_eos)
 {
 	// This used to parse as "whitespace"
-	Scanner scanner(CharStream("/**"));
+	Scanner scanner(CharStream("/**", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
 BOOST_AUTO_TEST_CASE(multiline_comment_at_eos)
 {
-	Scanner scanner(CharStream("/*"));
+	Scanner scanner(CharStream("/*", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE(regular_line_break_in_single_line_comment)
 {
 	for (auto const& nl: {"\r", "\n"})
 	{
-		Scanner scanner(CharStream("// abc " + string(nl) + " def "));
+		Scanner scanner(CharStream("// abc " + string(nl) + " def ", ""));
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_single_line_comment)
 {
 	for (auto const& nl: {"\v", "\f", "\xE2\x80\xA8", "\xE2\x80\xA9"})
 	{
-		Scanner scanner(CharStream("// abc " + string(nl) + " def "));
+		Scanner scanner(CharStream("// abc " + string(nl) + " def ", ""));
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 		for (size_t i = 0; i < string(nl).size() - 1; i++)
@@ -571,7 +571,7 @@ BOOST_AUTO_TEST_CASE(regular_line_breaks_in_single_line_doc_comment)
 {
 	for (auto const& nl: {"\r", "\n"})
 	{
-		Scanner scanner(CharStream("/// abc " + string(nl) + " def "));
+		Scanner scanner(CharStream("/// abc " + string(nl) + " def ", ""));
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "abc ");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_single_line_doc_comment)
 {
 	for (auto const& nl: {"\v", "\f", "\xE2\x80\xA8", "\xE2\x80\xA9"})
 	{
-		Scanner scanner(CharStream("/// abc " + string(nl) + " def "));
+		Scanner scanner(CharStream("/// abc " + string(nl) + " def ", ""));
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "abc ");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 		for (size_t i = 0; i < string(nl).size() - 1; i++)
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(regular_line_breaks_in_strings)
 {
 	for (auto const& nl: {"\n", "\r"})
 	{
-		Scanner scanner(CharStream("\"abc " + string(nl) + " def\""));
+		Scanner scanner(CharStream("\"abc " + string(nl) + " def\"", ""));
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 		BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_strings)
 {
 	for (auto const& nl: {"\v", "\f", "\xE2\x80\xA8", "\xE2\x80\xA9"})
 	{
-		Scanner scanner(CharStream("\"abc " + string(nl) + " def\""));
+		Scanner scanner(CharStream("\"abc " + string(nl) + " def\"", ""));
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
 		for (size_t i = 0; i < string(nl).size(); i++)
 			BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -57,7 +57,7 @@ pair<shared_ptr<Block>, shared_ptr<yul::AsmAnalysisInfo>> yul::test::parse(strin
 	auto flavour = _yul ? yul::AsmFlavour::Yul : yul::AsmFlavour::Strict;
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<Scanner>(CharStream(_source), "");
+	auto scanner = make_shared<Scanner>(CharStream(_source, ""), "");
 	auto parserResult = yul::Parser(errorReporter, flavour).parse(scanner, false);
 	if (parserResult)
 	{

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -57,7 +57,7 @@ pair<shared_ptr<Block>, shared_ptr<yul::AsmAnalysisInfo>> yul::test::parse(strin
 	auto flavour = _yul ? yul::AsmFlavour::Yul : yul::AsmFlavour::Strict;
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<Scanner>(CharStream(_source, ""), "");
+	auto scanner = make_shared<Scanner>(CharStream(_source, ""));
 	auto parserResult = yul::Parser(errorReporter, flavour).parse(scanner, false);
 	if (parserResult)
 	{

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -51,7 +51,7 @@ bool parse(string const& _source, ErrorReporter& errorReporter)
 {
 	try
 	{
-		auto scanner = make_shared<Scanner>(CharStream(_source));
+		auto scanner = make_shared<Scanner>(CharStream(_source, ""));
 		auto parserResult = yul::Parser(errorReporter, yul::AsmFlavour::Yul).parse(scanner, false);
 		if (parserResult)
 		{

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -259,7 +259,7 @@ bool YulOptimizerTest::parse(ostream& _stream, string const& _linePrefix, bool c
 	yul::AsmFlavour flavour = m_yul ? yul::AsmFlavour::Yul : yul::AsmFlavour::Strict;
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(m_source), "");
+	shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(m_source, ""), "");
 	m_ast = yul::Parser(errorReporter, flavour).parse(scanner, false);
 	if (!m_ast || !errorReporter.errors().empty())
 	{

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -259,7 +259,7 @@ bool YulOptimizerTest::parse(ostream& _stream, string const& _linePrefix, bool c
 	yul::AsmFlavour flavour = m_yul ? yul::AsmFlavour::Yul : yul::AsmFlavour::Strict;
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(m_source, ""), "");
+	shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(m_source, ""));
 	m_ast = yul::Parser(errorReporter, flavour).parse(scanner, false);
 	if (!m_ast || !errorReporter.errors().empty())
 	{

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -81,7 +81,7 @@ public:
 	bool parse(string const& _input)
 	{
 		ErrorReporter errorReporter(m_errors);
-		shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(_input), "");
+		shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(_input, ""), "");
 		m_ast = yul::Parser(errorReporter, yul::AsmFlavour::Strict).parse(scanner, false);
 		if (!m_ast || !errorReporter.errors().empty())
 		{

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -81,7 +81,7 @@ public:
 	bool parse(string const& _input)
 	{
 		ErrorReporter errorReporter(m_errors);
-		shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(_input, ""), "");
+		shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(_input, ""));
 		m_ast = yul::Parser(errorReporter, yul::AsmFlavour::Strict).parse(scanner, false);
 		if (!m_ast || !errorReporter.errors().empty())
 		{


### PR DESCRIPTION
This pr is the earliest in the series of PRs that needs to be merged "in order" :-).

**Motivation:** I noticed, that we pass (CharStream, filename) almost always as pair to Scanner, and then use complex ways (via callback functions) to get back to some functions that can extract the source code fragments (duplicated API from CharStream into Scanner) inside the SourceReferenceFormatter.

**Gains**:
* So the idea now is, to not pass CharStream **and** a source name to the scanner, but to simply pass a CharStream, that already knows the source name, to the Scanner.
* This should eliminate the callback workaround as SourceLocation will have access to the CharStream already.

Prerequisite of: #5535 (is based on top of this PR)