### PR TITLE
Disallow inline arrays of mapping type.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Bugfixes:
  * Type Checker: Disallow struct return types for getters of public state variables unless the new ABI encoder is active.
  * Type Checker: Fix internal compiler error when a field of a struct used as a parameter in a function type has a non-existent type.
  * Type Checker: Disallow functions ``sha3`` and ``suicide`` also without a function call.
+ * Type Checker: Disallow inline arrays of mapping type.
 
 Build System:
  * Emscripten: Upgrade to Emscripten SDK 1.37.21 and boost 1.67.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1608,6 +1608,9 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 		{
 			if (!inlineArrayType)
 				m_errorReporter.fatalTypeError(_tuple.location(), "Unable to deduce common type for array elements.");
+			else if (!inlineArrayType->canLiveOutsideStorage())
+				m_errorReporter.fatalTypeError(_tuple.location(), "Type " + inlineArrayType->toString() + " is only valid in storage.");
+
 			_tuple.annotation().type = make_shared<ArrayType>(DataLocation::Memory, inlineArrayType, types.size());
 		}
 		else

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_of_mapping_type.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_of_mapping_type.sol
@@ -1,0 +1,8 @@
+contract C {
+  mapping(int => int) a;
+  function f() public {
+    [a];
+  }
+}
+// ----
+// TypeError: (66-69): Type mapping(int256 => int256) is only valid in storage.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5518