### PR TITLE
Fix internal compiler error for unimplemented base contract function.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@ Bugfixes:
  * Type Checker: Disallow struct return types for getters of public state variables unless the new ABI encoder is active.
  * Type Checker: Fix internal compiler error when a field of a struct used as a parameter in a function type has a non-existent type.
  * Type Checker: Disallow functions ``sha3`` and ``suicide`` also without a function call.
+ * Type Checker: Fix internal compiler error with ``super`` when base contract function is not implemented.
  * Type Checker: Fixed internal error when trying to create abstract contract in some cases.
  * Type Checker: Fixed internal error related to double declaration of events.
  * Type Checker: Disallow inline arrays of mapping type.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1943,8 +1943,9 @@ MemberList::MemberMap ContractType::nativeMembers(ContractDefinition const* _con
 		for (ContractDefinition const* base: bases | boost::adaptors::sliced(1, bases.size()))
 			for (FunctionDefinition const* function: base->definedFunctions())
 			{
-				if (!function->isVisibleInDerivedContracts())
+				if (!function->isVisibleInDerivedContracts() || !function->isImplemented())
 					continue;
+
 				auto functionType = make_shared<FunctionType>(*function, true);
 				bool functionWithEqualArgumentsFound = false;
 				for (auto const& member: members)

--- a/test/libsolidity/syntaxTests/unimplemented_super_function.sol
+++ b/test/libsolidity/syntaxTests/unimplemented_super_function.sol
@@ -1,0 +1,8 @@
+contract a {
+    function f() public;
+}
+contract b is a {
+    function f() public { super.f(); }
+}
+// ----
+// TypeError: (84-91): Member "f" not found or not visible after argument-dependent lookup in contract super b.

--- a/test/libsolidity/syntaxTests/unimplemented_super_function_derived.sol
+++ b/test/libsolidity/syntaxTests/unimplemented_super_function_derived.sol
@@ -1,0 +1,12 @@
+contract a {
+    function f() public;
+}
+contract b is a {
+    function f() public { super.f(); }
+}
+contract c is a,b {
+    // No error here.
+    function f() public { super.f(); }
+}
+// ----
+// TypeError: (84-91): Member "f" not found or not visible after argument-dependent lookup in contract super b.


### PR DESCRIPTION
### Description
This pull request fixes the internal compiler error for super function by ignoring the super functions which doesn't have implementation.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

Fixes #5130 