### PR TITLE
Use YulString also in expectAsmIdentifier.

### DIFF
--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -78,7 +78,7 @@ protected:
 	FunctionDefinition parseFunctionDefinition();
 	Expression parseCall(ElementaryOperation&& _initialOp);
 	TypedName parseTypedName();
-	std::string expectAsmIdentifier();
+	YulString expectAsmIdentifier();
 
 	static bool isValidNumberLiteral(std::string const& _literal);
 


### PR DESCRIPTION
It does not seem to be that useful as of now to use YulString in expectAsmIdentifier, but eventually, also the instructions will move to YulStrings, so it makes sense after some other PRs.