### PR TITLE
[Yul] Proper recursion in ForLoopInitRewriter.

### DIFF
--- a/libyul/optimiser/ForLoopInitRewriter.cpp
+++ b/libyul/optimiser/ForLoopInitRewriter.cpp
@@ -27,17 +27,24 @@ void ForLoopInitRewriter::operator()(Block& _block)
 {
 	iterateReplacing(
 		_block.statements,
-		[](Statement& _stmt) -> boost::optional<vector<Statement>>
+		[&](Statement& _stmt) -> boost::optional<vector<Statement>>
 		{
 			if (_stmt.type() == typeid(ForLoop))
 			{
 				auto& forLoop = boost::get<ForLoop>(_stmt);
+				(*this)(forLoop.pre);
+				(*this)(forLoop.body);
+				(*this)(forLoop.post);
 				vector<Statement> rewrite;
 				swap(rewrite, forLoop.pre.statements);
 				rewrite.emplace_back(move(forLoop));
 				return rewrite;
 			}
-			return {};
+			else
+			{
+				visit(_stmt);
+				return {};
+			}
 		}
 	);
 }

--- a/test/libyul/yulOptimizerTests/forLoopInitRewriter/nested.yul
+++ b/test/libyul/yulOptimizerTests/forLoopInitRewriter/nested.yul
@@ -1,0 +1,48 @@
+{
+  let random := 42
+  for {
+    for { let a := 1} iszero(eq(a,10)) {} {
+      a := add(a, 1)
+    }
+	let b := 1
+  } iszero(eq(b, 10)) {
+    for { let c := 1 } iszero(eq(c,2)) { c := add(c, 1) } {
+      b := add(b, 1)
+    }
+  } {
+    mstore(b,b)
+  }
+}
+// ----
+// forLoopInitRewriter
+// {
+//     let random := 42
+//     let a := 1
+//     for {
+//     }
+//     iszero(eq(a, 10))
+//     {
+//     }
+//     {
+//         a := add(a, 1)
+//     }
+//     let b := 1
+//     for {
+//     }
+//     iszero(eq(b, 10))
+//     {
+//         let c := 1
+//         for {
+//         }
+//         iszero(eq(c, 2))
+//         {
+//             c := add(c, 1)
+//         }
+//         {
+//             b := add(b, 1)
+//         }
+//     }
+//     {
+//         mstore(b, b)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
@@ -468,8 +468,8 @@
 //         let abi_encode_pos_590 := 64
 //         abi_encode_pos := abi_encode_pos_590
 //         let abi_encode_srcPtr := add(_485, _1)
+//         let abi_encode_i_69 := _2
 //         for {
-//             let abi_encode_i_69 := _2
 //         }
 //         lt(abi_encode_i_69, abi_encode_length_68)
 //         {
@@ -480,8 +480,8 @@
 //             let abi_encode_pos_71_1037 := abi_encode_pos
 //             let abi_encode_length_72_1038 := 0x3
 //             let abi_encode_srcPtr_73_1039 := _931
+//             let abi_encode_i_74_1040 := _2
 //             for {
-//                 let abi_encode_i_74_1040 := _2
 //             }
 //             lt(abi_encode_i_74_1040, abi_encode_length_72_1038)
 //             {
@@ -544,8 +544,8 @@
 //             {
 //                 revert(_2, _2)
 //             }
+//             let abi_decode_i_33_1052 := _2
 //             for {
-//                 let abi_decode_i_33_1052 := _2
 //             }
 //             lt(abi_decode_i_33_1052, abi_decode_length_30_1046)
 //             {
@@ -586,8 +586,8 @@
 //             {
 //                 revert(_2, _2)
 //             }
+//             let abi_decode_i_9_1068 := _2
 //             for {
-//                 let abi_decode_i_9_1068 := _2
 //             }
 //             lt(abi_decode_i_9_1068, abi_decode_length_6_1058)
 //             {
@@ -616,8 +616,8 @@
 //                 {
 //                     revert(_2, _2)
 //                 }
+//                 let abi_decode_abi_decode_i_17_1073 := _2
 //                 for {
-//                     let abi_decode_abi_decode_i_17_1073 := _2
 //                 }
 //                 lt(abi_decode_abi_decode_i_17_1073, abi_decode_abi_decode_length_14_1069)
 //                 {


### PR DESCRIPTION
While working on #5584 I noticed that the for loop init rewriter does not properly recurse and because of that doesn't rewrite all for pre's.

This PR therefore adds the required recursion, adjusts the fullSuite test and adds a new test with nested for's.