### PR TITLE
[WIP] Allow natspec documentation for non-public functions

### DIFF
--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -91,17 +91,12 @@ Json::Value Natspec::devDocumentation(ContractDefinition const& _contractDef)
 			methods["constructor"] = constructor;
 	}
 
-	for (auto const& it: _contractDef.interfaceFunctions())
+	for (auto const& it: _contractDef.definedFunctions())
 	{
-		if (!it.second->hasDeclaration())
-			continue;
-		if (auto fun = dynamic_cast<FunctionDefinition const*>(&it.second->declaration()))
-		{
-			Json::Value method(devDocumentation(fun->annotation().docTags));
-			if (!method.empty())
-				// add the function, only if we have any documentation to add
-				methods[it.second->externalSignature()] = method;
-		}
+		Json::Value method(devDocumentation(it->annotation().docTags));
+		if (!method.empty())
+			// add the function, only if we have any documentation to add
+			methods[it->externalSignature()] = method;
 	}
 	doc["methods"] = methods;
 


### PR DESCRIPTION
### Description

Make natspec extract information from all functions, not just public/interface ones by iterating over all defined functions instead of just the interface ones.
I haven't modified Natspec::userDocumentation to have the same behavior as natspec comments on private functions are not relevant for users.
This PR fixes issue #3097 

### Checklist
- [x] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
