### PR TITLE
build.sh bash script cleanup

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,28 +1,26 @@
 #!/usr/bin/env bash
+set -e
 
-if [ -z "$1" ]; then
+ROOTDIR="$(dirname "$0")/.."
+BUILDDIR="${ROOTDIR}/build"
+
+if [[ $# -eq 0 ]]; then
     BUILD_TYPE=Release
 else
     BUILD_TYPE="$1"
 fi
 
-cd $(dirname "$0")/.. &&
-
 if [[ "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]; then
-	touch prerelease.txt
+	touch "${ROOTDIR}/prerelease.txt"
 fi
 
-mkdir -p build &&
-cd build &&
-cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE" &&
+mkdir -p "${BUILDDIR}"
+cd "${BUILDDIR}"
+
+cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${@:2}"
 make -j2
 
-if [ $? -ne 0 ]; then
-	echo "Failed to build"
-	exit 1
-fi
-
-if [ -z $CI ]; then
-	echo "Installing solc and soltest"
-	install solc/solc /usr/local/bin && install test/soltest /usr/local/bin
+if [[ "${CI}" == "" ]]; then
+	echo "Installing ..."
+	sudo make install
 fi


### PR DESCRIPTION
Not sure if there's interest in all of those changes, but here they are:

* use `set -e` to abort script execution when error codes fail (and haven't been checked)
* use [[ ]] instead of [ ] or test.
* use ROOTDIR/BUILDDIR variables for better readability
* use mktemp in order to avoid accidental name clashes.
* use `make install` instead of `install ...` as cleaner installation process
  * this however doesn't install soltest anymore, which I believe is
    right, as normal users should not need it installed in their system.
    Those who want to run the test suite, can do so manually
* allow optional passing of more additional custom args to cmake
