### PR TITLE
[Yul] Use C++ user-defined literals for creating YulString constants.

### DIFF
--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -102,7 +102,7 @@ bool AsmAnalyzer::operator()(Literal const& _literal)
 	else if (_literal.kind == LiteralKind::Boolean)
 	{
 		solAssert(m_dialect->flavour == AsmFlavour::Yul, "");
-		solAssert(_literal.value == YulString{string("true")} || _literal.value == YulString{string("false")}, "");
+		solAssert(_literal.value == "true"_yulstring || _literal.value == "false"_yulstring, "");
 	}
 	m_info.stackHeightInfo[&_literal] = m_stackHeight;
 	return true;

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -354,11 +354,11 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 	{
 		YulString literal;
 		if (currentToken() == Token::Return)
-			literal = YulString{"return"};
+			literal = "return"_yulstring;
 		else if (currentToken() == Token::Byte)
-			literal = YulString{"byte"};
+			literal = "byte"_yulstring;
 		else if (currentToken() == Token::Address)
-			literal = YulString{"address"};
+			literal = "address"_yulstring;
 		else
 			literal = YulString{currentLiteral()};
 		// first search the set of builtins, then the instructions.

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -55,8 +55,8 @@ string AsmPrinter::operator()(Literal const& _literal)
 		solAssert(isValidDecimal(_literal.value.str()) || isValidHex(_literal.value.str()), "Invalid number literal");
 		return _literal.value.str() + appendTypeName(_literal.type);
 	case LiteralKind::Boolean:
-		solAssert(_literal.value.str() == "true" || _literal.value.str() == "false", "Invalid bool literal.");
-		return ((_literal.value.str() == "true") ? "true" : "false") + appendTypeName(_literal.type);
+		solAssert(_literal.value == "true"_yulstring || _literal.value == "false"_yulstring, "Invalid bool literal.");
+		return ((_literal.value == "true"_yulstring) ? "true" : "false") + appendTypeName(_literal.type);
 	case LiteralKind::String:
 		break;
 	}

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -42,7 +42,7 @@ shared_ptr<Object> ObjectParser::parse(shared_ptr<Scanner> const& _scanner, bool
 		{
 			// Special case: Code-only form.
 			object = make_shared<Object>();
-			object->name = YulString{"object"};
+			object->name = "object"_yulstring;
 			object->code = parseBlock();
 			if (!object->code)
 				return nullptr;

--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -127,4 +127,9 @@ private:
 	YulStringRepository::Handle m_handle{ 0, YulStringRepository::emptyHash() };
 };
 
+inline YulString operator "" _yulstring(const char *_string, std::size_t _size)
+{
+	return YulString(std::string(_string, _size));
+}
+
 }

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -387,7 +387,7 @@ void CodeTransform::operator()(Literal const& _literal)
 		m_assembly.appendConstant(u256(_literal.value.str()));
 	else if (_literal.kind == LiteralKind::Boolean)
 	{
-		if (_literal.value.str() == "true")
+		if (_literal.value == "true"_yulstring)
 			m_assembly.appendConstant(u256(1));
 		else
 			m_assembly.appendConstant(u256(0));

--- a/libyul/optimiser/MainFunction.cpp
+++ b/libyul/optimiser/MainFunction.cpp
@@ -40,12 +40,12 @@ void MainFunction::operator()(Block& _block)
 	for (size_t i = 1; i < _block.statements.size(); ++i)
 		assertThrow(_block.statements.at(i).type() == typeid(FunctionDefinition), OptimizerException, "");
 	/// @todo this should handle scopes properly and instead of an assertion it should rename the conflicting function
-	assertThrow(NameCollector(_block).names().count(YulString{"main"}) == 0, OptimizerException, "");
+	assertThrow(NameCollector(_block).names().count("main"_yulstring) == 0, OptimizerException, "");
 
 	Block& block = boost::get<Block>(_block.statements[0]);
 	FunctionDefinition main{
 		block.location,
-		YulString{"main"},
+		"main"_yulstring,
 		{},
 		{},
 		std::move(block)

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(builtins_parser)
 		SimpleDialect(): Dialect(AsmFlavour::Strict) {}
 		BuiltinFunction const* builtin(YulString _name) const override
 		{
-			return _name == YulString{"builtin"} ? &f : nullptr;
+			return _name == "builtin"_yulstring ? &f : nullptr;
 		}
 		BuiltinFunction f;
 	};
@@ -329,9 +329,9 @@ BOOST_AUTO_TEST_CASE(builtins_analysis)
 		SimpleDialect(): Dialect(AsmFlavour::Strict) {}
 		BuiltinFunction const* builtin(YulString _name) const override
 		{
-			return _name == YulString{"builtin"} ? &f : nullptr;
+			return _name == "builtin"_yulstring ? &f : nullptr;
 		}
-		BuiltinFunction f{YulString{"builtin"}, vector<Type>(2), vector<Type>(3), false};
+		BuiltinFunction f{"builtin"_yulstring, vector<Type>(2), vector<Type>(3), false};
 	};
 
 	shared_ptr<Dialect> dialect = make_shared<SimpleDialect>();


### PR DESCRIPTION
I think this is a good middle ground between the convenience of implicit construction from strings and the verbosity of the full constructor.

@chriseth What do you think?