### PR TITLE
[Yul] Codegen for objects access

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
  * Code Generator: Use binary search for dispatch function if more efficient. The size/speed tradeoff can be tuned using ``--optimize-runs``.
  * SMTChecker: Support mathematical and cryptographic functions in an uninterpreted way.
  * Type Checker: Add an additional reason to be displayed when type conversion fails.
+ * Yul: Support object access via ``datasize``, ``dataoffset`` and ``datacopy`` in standalone assembly mode.
 
 
 Bugfixes:

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -27,6 +27,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/AsmData.h>
+#include <libyul/backends/evm/EVMDialect.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Exceptions.h>
 
@@ -321,7 +322,7 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 		errorsIgnored,
 		EVMVersion(),
 		errorTypeForLoose,
-		yul::Dialect::looseAssemblyForEVM(),
+		yul::EVMDialect::looseAssemblyForEVM(),
 		resolver
 	).analyze(_inlineAssembly.operations());
 	return false;

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -27,6 +27,8 @@
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/AsmData.h>
 
+#include <libyul/backends/evm/EVMDialect.h>
+
 #include <liblangutil/ErrorReporter.h>
 
 #include <libdevcore/Algorithms.h>
@@ -658,7 +660,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 		m_errorReporter,
 		m_evmVersion,
 		Error::Type::SyntaxError,
-		yul::Dialect::looseAssemblyForEVM(),
+		yul::EVMDialect::looseAssemblyForEVM(),
 		identifierAccess
 	);
 	if (!analyzer.analyze(_inlineAssembly.operations()))

--- a/libsolidity/codegen/AsmCodeGen.cpp
+++ b/libsolidity/codegen/AsmCodeGen.cpp
@@ -188,8 +188,8 @@ void CodeGenerator::assemble(
 		assemblyAdapter,
 		_analysisInfo,
 		_parsedData,
+		*EVMDialect::strictAssemblyForEVM(),
 		_optimize,
-		Dialect::strictAssemblyForEVM(),
 		false,
 		_identifierAccess,
 		_useNamedLabelsForFunctions

--- a/libsolidity/codegen/AsmCodeGen.cpp
+++ b/libsolidity/codegen/AsmCodeGen.cpp
@@ -189,7 +189,7 @@ void CodeGenerator::assemble(
 		_analysisInfo,
 		_parsedData,
 		_optimize,
-		false,
+		Dialect::strictAssemblyForEVM(),
 		false,
 		_identifierAccess,
 		_useNamedLabelsForFunctions

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -31,6 +31,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/YulString.h>
+#include <libyul/backends/evm/EVMDialect.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Scanner.h>
 
@@ -361,7 +362,7 @@ void CompilerContext::appendInlineAssembly(
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	auto scanner = make_shared<langutil::Scanner>(langutil::CharStream(_assembly, "--CODEGEN--"));
-	auto parserResult = yul::Parser(errorReporter, yul::Dialect::strictAssemblyForEVM()).parse(scanner, false);
+	auto parserResult = yul::Parser(errorReporter, yul::EVMDialect::strictAssemblyForEVM()).parse(scanner, false);
 #ifdef SOL_OUTPUT_ASM
 	cout << yul::AsmPrinter()(*parserResult) << endl;
 #endif
@@ -373,7 +374,7 @@ void CompilerContext::appendInlineAssembly(
 			errorReporter,
 			m_evmVersion,
 			boost::none,
-			yul::Dialect::strictAssemblyForEVM(),
+			yul::EVMDialect::strictAssemblyForEVM(),
 			identifierAccess.resolve
 		).analyze(*parserResult);
 	if (!parserResult || !errorReporter.errors().empty() || !analyzerResult)

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -136,7 +136,7 @@ MachineAssemblyObject AssemblyStack::assemble(Machine _machine, bool _optimize) 
 		MachineAssemblyObject object;
 		eth::Assembly assembly;
 		EthAssemblyAdapter adapter(assembly);
-		yul::EVMObjectCompiler::compile(*m_parserResult, adapter, m_language == Language::Yul, false, _optimize);
+		yul::EVMObjectCompiler::compile(*m_parserResult, adapter, languageToDialect(m_language), false, _optimize);
 		object.bytecode = make_shared<eth::LinkerObject>(assembly.assemble());
 		object.assembly = assembly.assemblyString();
 		return object;
@@ -145,7 +145,7 @@ MachineAssemblyObject AssemblyStack::assemble(Machine _machine, bool _optimize) 
 	{
 		MachineAssemblyObject object;
 		yul::EVMAssembly assembly(true);
-		yul::EVMObjectCompiler::compile(*m_parserResult, assembly, m_language == Language::Yul, true, _optimize);
+		yul::EVMObjectCompiler::compile(*m_parserResult, assembly, languageToDialect(m_language), true, _optimize);
 		object.bytecode = make_shared<eth::LinkerObject>(assembly.finalize());
 		/// TODO: fill out text representation
 		return object;

--- a/libsolidity/interface/AssemblyStack.h
+++ b/libsolidity/interface/AssemblyStack.h
@@ -36,6 +36,10 @@ namespace langutil
 {
 class Scanner;
 }
+namespace yul
+{
+class AbstractAssembly;
+}
 
 namespace dev
 {
@@ -85,6 +89,8 @@ public:
 private:
 	bool analyzeParsed();
 	bool analyzeParsed(yul::Object& _object);
+
+	void compileEVM(yul::AbstractAssembly& _assembly, bool _evm15, bool _optimize) const;
 
 	void optimize(yul::Object& _object);
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <libsolidity/parsing/Parser.h>
 #include <libyul/AsmParser.h>
+#include <libyul/backends/evm/EVMDialect.h>
 #include <liblangutil/SourceLocation.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Scanner.h>
@@ -1012,7 +1013,7 @@ ASTPointer<InlineAssembly> Parser::parseInlineAssembly(ASTPointer<ASTString> con
 		m_scanner->next();
 	}
 
-	yul::Parser asmParser(m_errorReporter);
+	yul::Parser asmParser(m_errorReporter, yul::EVMDialect::looseAssemblyForEVM());
 	shared_ptr<yul::Block> block = asmParser.parse(m_scanner, true);
 	nodeFactory.markEndPosition();
 	return nodeFactory.createNode<InlineAssembly>(_docString, block);

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -101,7 +101,7 @@ bool AsmAnalyzer::operator()(Literal const& _literal)
 	}
 	else if (_literal.kind == LiteralKind::Boolean)
 	{
-		solAssert(m_dialect.flavour == AsmFlavour::Yul, "");
+		solAssert(m_dialect->flavour == AsmFlavour::Yul, "");
 		solAssert(_literal.value == YulString{string("true")} || _literal.value == YulString{string("false")}, "");
 	}
 	m_info.stackHeightInfo[&_literal] = m_stackHeight;
@@ -164,7 +164,7 @@ bool AsmAnalyzer::operator()(Identifier const& _identifier)
 
 bool AsmAnalyzer::operator()(FunctionalInstruction const& _instr)
 {
-	solAssert(m_dialect.flavour != AsmFlavour::Yul, "");
+	solAssert(m_dialect->flavour != AsmFlavour::Yul, "");
 	bool success = true;
 	for (auto const& arg: _instr.arguments | boost::adaptors::reversed)
 		if (!expectExpression(arg))
@@ -182,9 +182,9 @@ bool AsmAnalyzer::operator()(ExpressionStatement const& _statement)
 {
 	int initialStackHeight = m_stackHeight;
 	bool success = boost::apply_visitor(*this, _statement.expression);
-	if (m_stackHeight != initialStackHeight && (m_dialect.flavour != AsmFlavour::Loose || m_errorTypeForLoose))
+	if (m_stackHeight != initialStackHeight && (m_dialect->flavour != AsmFlavour::Loose || m_errorTypeForLoose))
 	{
-		Error::Type errorType = m_dialect.flavour == AsmFlavour::Loose ? *m_errorTypeForLoose : Error::Type::TypeError;
+		Error::Type errorType = m_dialect->flavour == AsmFlavour::Loose ? *m_errorTypeForLoose : Error::Type::TypeError;
 		string msg =
 			"Top-level expressions are not supposed to return values (this expression returns " +
 			to_string(m_stackHeight - initialStackHeight) +
@@ -299,7 +299,7 @@ bool AsmAnalyzer::operator()(FunctionCall const& _funCall)
 	bool success = true;
 	size_t parameters = 0;
 	size_t returns = 0;
-	if (BuiltinFunction const* f = m_dialect.builtins->query(_funCall.functionName.name))
+	if (BuiltinFunction const* f = m_dialect->builtin(_funCall.functionName.name))
 	{
 		// TODO: compare types, too
 		parameters = f->parameters.size();
@@ -569,7 +569,7 @@ Scope& AsmAnalyzer::scope(Block const* _block)
 }
 void AsmAnalyzer::expectValidType(string const& type, SourceLocation const& _location)
 {
-	if (m_dialect.flavour != AsmFlavour::Yul)
+	if (m_dialect->flavour != AsmFlavour::Yul)
 		return;
 
 	if (!builtinTypes.count(type))
@@ -629,7 +629,7 @@ void AsmAnalyzer::warnOnInstructions(solidity::Instruction _instr, SourceLocatio
 
 	if (_instr == solidity::Instruction::JUMP || _instr == solidity::Instruction::JUMPI || _instr == solidity::Instruction::JUMPDEST)
 	{
-		if (m_dialect.flavour != AsmFlavour::Loose)
+		if (m_dialect->flavour != AsmFlavour::Loose)
 			solAssert(m_errorTypeForLoose && *m_errorTypeForLoose != Error::Type::Warning, "");
 
 		m_errorReporter.error(
@@ -644,7 +644,7 @@ void AsmAnalyzer::warnOnInstructions(solidity::Instruction _instr, SourceLocatio
 
 void AsmAnalyzer::checkLooseFeature(SourceLocation const& _location, string const& _description)
 {
-	if (m_dialect.flavour != AsmFlavour::Loose)
+	if (m_dialect->flavour != AsmFlavour::Loose)
 		solAssert(false, _description);
 	else if (m_errorTypeForLoose)
 		m_errorReporter.error(*m_errorTypeForLoose, _location, _description);

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -59,7 +59,7 @@ public:
 		langutil::ErrorReporter& _errorReporter,
 		dev::solidity::EVMVersion _evmVersion,
 		boost::optional<langutil::Error::Type> _errorTypeForLoose,
-		Dialect _dialect = Dialect::looseAssemblyForEVM(),
+		std::shared_ptr<Dialect> _dialect,
 		ExternalIdentifierAccess::Resolver const& _resolver = ExternalIdentifierAccess::Resolver()
 	):
 		m_resolver(_resolver),
@@ -115,7 +115,7 @@ private:
 	AsmAnalysisInfo& m_info;
 	langutil::ErrorReporter& m_errorReporter;
 	dev::solidity::EVMVersion m_evmVersion;
-	Dialect m_dialect = Dialect::looseAssemblyForEVM();
+	std::shared_ptr<Dialect> m_dialect;
 	boost::optional<langutil::Error::Type> m_errorTypeForLoose;
 };
 

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -38,7 +38,7 @@ namespace yul
 class Parser: public langutil::ParserBase
 {
 public:
-	explicit Parser(langutil::ErrorReporter& _errorReporter, Dialect _dialect = Dialect::looseAssemblyForEVM()):
+	explicit Parser(langutil::ErrorReporter& _errorReporter, std::shared_ptr<Dialect> _dialect):
 		ParserBase(_errorReporter), m_dialect(std::move(_dialect)) {}
 
 	/// Parses an inline assembly block starting with `{` and ending with `}`.
@@ -86,7 +86,7 @@ protected:
 	static bool isValidNumberLiteral(std::string const& _literal);
 
 private:
-	Dialect m_dialect = Dialect::looseAssemblyForEVM();
+	std::shared_ptr<Dialect> m_dialect;
 };
 
 }

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(yul
 	ObjectParser.cpp
 	backends/evm/EVMAssembly.cpp
 	backends/evm/EVMCodeTransform.cpp
+	backends/evm/EVMDialect.cpp
 	backends/evm/EVMObjectCompiler.cpp
 	optimiser/ASTCopier.cpp
 	optimiser/ASTWalker.cpp

--- a/libyul/Dialect.cpp
+++ b/libyul/Dialect.cpp
@@ -20,57 +20,10 @@
 
 #include <libyul/Dialect.h>
 
+#include <libyul/Object.h>
+#include <libyul/backends/evm/AbstractAssembly.h>
+
 #include <map>
 
 using namespace yul;
 using namespace std;
-
-namespace
-{
-
-void addFunction(
-	map<YulString, BuiltinFunction>& _repository,
-	string const& _name,
-	size_t _params,
-	size_t _returns,
-	bool _movable
-)
-{
-	_repository[YulString{_name}] = BuiltinFunction{
-		YulString{_name},
-		vector<Type>(_params),
-		vector<Type>(_returns),
-		_movable
-	};
-}
-
-class GenericBuiltins: public Builtins
-{
-public:
-	GenericBuiltins(map<YulString, BuiltinFunction> const& _functions): m_functions(_functions) {}
-	BuiltinFunction const* query(YulString _name) const
-	{
-		auto it = m_functions.find(_name);
-		if (it != end(m_functions))
-			return &it->second;
-		else
-			return nullptr;
-	}
-private:
-	map<YulString, BuiltinFunction> const& m_functions;
-};
-
-}
-
-Dialect Dialect::strictAssemblyForEVMObjects()
-{
-	static map<YulString, BuiltinFunction> functions;
-	if (functions.empty())
-	{
-		addFunction(functions, "datasize", 1, 1, true);
-		addFunction(functions, "dataoffset", 1, 1, true);
-		addFunction(functions, "datacopy", 3, 0, false);
-	}
-	// The EVM instructions will be moved to builtins at some point.
-	return Dialect{AsmFlavour::Strict, std::make_shared<GenericBuiltins>(functions)};
-}

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -22,7 +22,9 @@
 
 #include <libyul/YulString.h>
 
-#include <memory>
+#include <boost/noncopyable.hpp>
+
+#include <vector>
 
 namespace yul
 {
@@ -45,38 +47,19 @@ struct BuiltinFunction
 	bool movable;
 };
 
-/**
- * Class to query for builtin functions and their semantics.
- */
-struct Builtins
+struct Dialect: boost::noncopyable
 {
-	virtual ~Builtins() = default;
+	AsmFlavour const flavour = AsmFlavour::Loose;
 	/// @returns the builtin function of the given name or a nullptr if it is not a builtin function.
-	virtual BuiltinFunction const* query(YulString /*_name*/) const { return nullptr; }
-};
+	virtual BuiltinFunction const* builtin(YulString /*_name*/) const { return nullptr; }
 
-struct Dialect
-{
-	AsmFlavour flavour = AsmFlavour::Loose;
-	std::shared_ptr<Builtins> builtins;
+	Dialect(AsmFlavour _flavour): flavour(_flavour) {}
+	virtual ~Dialect() {}
 
-	Dialect(AsmFlavour _flavour, std::shared_ptr<Builtins> _builtins):
-		flavour(_flavour), builtins(std::move(_builtins))
-	{}
-	static Dialect looseAssemblyForEVM()
-	{
-		return Dialect{AsmFlavour::Loose, std::make_shared<Builtins>()};
-	}
-	static Dialect strictAssemblyForEVM()
-	{
-		// The EVM instructions will be moved to builtins at some point.
-		return Dialect{AsmFlavour::Strict, std::make_shared<Builtins>()};
-	}
-	static Dialect strictAssemblyForEVMObjects();
-	static Dialect yul()
+	static std::shared_ptr<Dialect> yul()
 	{
 		// Will have to add builtins later.
-		return Dialect{AsmFlavour::Yul, std::make_shared<Builtins>()};
+		return std::make_shared<Dialect>(AsmFlavour::Yul);
 	}
 };
 

--- a/libyul/ObjectParser.h
+++ b/libyul/ObjectParser.h
@@ -47,7 +47,7 @@ class ObjectParser: public langutil::ParserBase
 public:
 	explicit ObjectParser(
 		langutil::ErrorReporter& _errorReporter,
-		Dialect _dialect = Dialect::looseAssemblyForEVM()
+		std::shared_ptr<Dialect> _dialect
 	):
 		ParserBase(_errorReporter), m_dialect(std::move(_dialect)) {}
 
@@ -67,7 +67,7 @@ private:
 	YulString parseUniqueName(Object const* _containingObject);
 	void addNamedSubObject(Object& _container, YulString _name, std::shared_ptr<ObjectNode> _subObject);
 
-	Dialect m_dialect;
+	std::shared_ptr<Dialect> m_dialect;
 };
 
 }

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -506,7 +506,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 		m_info,
 		_function.body,
 		m_allowStackOpt,
-		m_yul,
+		m_dialect,
 		m_evm15,
 		m_identifierAccess,
 		m_useNamedLabelsForFunctions,

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -22,8 +22,8 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/AsmDataForward.h>
-
 #include <libyul/AsmScope.h>
+#include <libyul/Dialect.h>
 
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
@@ -88,7 +88,7 @@ public:
 		AsmAnalysisInfo& _analysisInfo,
 		Block const& _block,
 		bool _allowStackOpt = false,
-		bool _yul = false,
+		Dialect const& _dialect,
 		bool _evm15 = false,
 		ExternalIdentifierAccess const& _identifierAccess = ExternalIdentifierAccess(),
 		bool _useNamedLabelsForFunctions = false
@@ -97,7 +97,7 @@ public:
 		_analysisInfo,
 		_block,
 		_allowStackOpt,
-		_yul,
+		_dialect,
 		_evm15,
 		_identifierAccess,
 		_useNamedLabelsForFunctions,
@@ -115,7 +115,7 @@ protected:
 		AsmAnalysisInfo& _analysisInfo,
 		Block const& _block,
 		bool _allowStackOpt,
-		bool _yul,
+		Dialect const& _dialect,
 		bool _evm15,
 		ExternalIdentifierAccess const& _identifierAccess,
 		bool _useNamedLabelsForFunctions,
@@ -180,7 +180,7 @@ private:
 	AsmAnalysisInfo& m_info;
 	Scope* m_scope = nullptr;
 	bool const m_allowStackOpt = true;
-	bool m_yul = false;
+	Dialect const& m_dialect;
 	bool m_evm15 = false;
 	bool m_useNamedLabelsForFunctions = false;
 	ExternalIdentifierAccess m_identifierAccess;

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -20,10 +20,10 @@
 
 #include <libyul/backends/evm/EVMAssembly.h>
 
+#include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/AsmDataForward.h>
 #include <libyul/AsmScope.h>
-#include <libyul/Dialect.h>
 
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
@@ -87,8 +87,8 @@ public:
 		AbstractAssembly& _assembly,
 		AsmAnalysisInfo& _analysisInfo,
 		Block const& _block,
+		EVMDialect const& _dialect,
 		bool _allowStackOpt = false,
-		Dialect const& _dialect,
 		bool _evm15 = false,
 		ExternalIdentifierAccess const& _identifierAccess = ExternalIdentifierAccess(),
 		bool _useNamedLabelsForFunctions = false
@@ -115,7 +115,7 @@ protected:
 		AsmAnalysisInfo& _analysisInfo,
 		Block const& _block,
 		bool _allowStackOpt,
-		Dialect const& _dialect,
+		EVMDialect const& _dialect,
 		bool _evm15,
 		ExternalIdentifierAccess const& _identifierAccess,
 		bool _useNamedLabelsForFunctions,
@@ -179,10 +179,10 @@ private:
 	AbstractAssembly& m_assembly;
 	AsmAnalysisInfo& m_info;
 	Scope* m_scope = nullptr;
+	EVMDialect const& m_dialect;
 	bool const m_allowStackOpt = true;
-	Dialect const& m_dialect;
-	bool m_evm15 = false;
-	bool m_useNamedLabelsForFunctions = false;
+	bool const m_evm15 = false;
+	bool const m_useNamedLabelsForFunctions = false;
 	ExternalIdentifierAccess m_identifierAccess;
 	/// Adjustment between the stack height as determined during the analysis phase
 	/// and the stack height in the assembly. This is caused by an initial stack being present

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -1,0 +1,141 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Yul dialects for EVM.
+ */
+
+#include <libyul/backends/evm/EVMDialect.h>
+
+#include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AsmData.h>
+#include <libyul/Object.h>
+#include <libyul/backends/evm/AbstractAssembly.h>
+
+#include <liblangutil/Exceptions.h>
+
+#include <libyul/Exceptions.h>
+
+#include <boost/range/adaptor/reversed.hpp>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+using namespace dev::solidity;
+
+
+EVMDialect::EVMDialect(AsmFlavour _flavour, bool _objectAccess):
+	Dialect(_flavour), m_objectAccess(_objectAccess)
+{
+	// The EVM instructions will be moved to builtins at some point.
+	if (!m_objectAccess)
+		return;
+
+	addFunction("datasize", 1, 1, true, [this](
+		FunctionCall const& _call,
+		AbstractAssembly& _assembly,
+		std::function<void()>
+	) {
+		yulAssert(m_currentObject, "No object available.");
+		yulAssert(_call.arguments.size() == 1, "");
+		Expression const& arg = _call.arguments.front();
+		YulString dataName = boost::get<Literal>(arg).value;
+		if (m_currentObject->name == dataName)
+			_assembly.appendAssemblySize();
+		else
+			_assembly.appendDataSize(m_subIDs.at(dataName));
+	});
+	addFunction("dataoffset", 1, 1, true, [this](
+		FunctionCall const& _call,
+		AbstractAssembly& _assembly,
+		std::function<void()>
+	) {
+		yulAssert(m_currentObject, "No object available.");
+		yulAssert(_call.arguments.size() == 1, "");
+		Expression const& arg = _call.arguments.front();
+		YulString dataName = boost::get<Literal>(arg).value;
+		if (m_currentObject->name == dataName)
+			_assembly.appendConstant(0);
+		else
+			_assembly.appendDataOffset(m_subIDs.at(dataName));
+	});
+	addFunction("datacopy", 3, 0, false, [](
+		FunctionCall const&,
+		AbstractAssembly& _assembly,
+		std::function<void()> _visitArguments
+	) {
+		_visitArguments();
+		_assembly.appendInstruction(solidity::Instruction::CODECOPY);
+	});
+}
+
+BuiltinFunctionForEVM const* EVMDialect::builtin(YulString _name) const
+{
+	auto it = m_functions.find(_name);
+	if (it != m_functions.end())
+		return &it->second;
+	else
+		return nullptr;
+}
+
+shared_ptr<EVMDialect> EVMDialect::looseAssemblyForEVM()
+{
+	return make_shared<EVMDialect>(AsmFlavour::Loose, false);
+}
+
+shared_ptr<EVMDialect> EVMDialect::strictAssemblyForEVM()
+{
+	return make_shared<EVMDialect>(AsmFlavour::Strict, false);
+}
+
+shared_ptr<EVMDialect> EVMDialect::strictAssemblyForEVMObjects()
+{
+	return make_shared<EVMDialect>(AsmFlavour::Strict, true);
+}
+
+shared_ptr<yul::EVMDialect> EVMDialect::yulForEVM()
+{
+	return make_shared<EVMDialect>(AsmFlavour::Yul, false);
+}
+
+void EVMDialect::setSubIDs(map<YulString, AbstractAssembly::SubID> _subIDs)
+{
+	yulAssert(m_objectAccess, "Sub IDs set with dialect that does not support object access.");
+	m_subIDs = std::move(_subIDs);
+}
+
+void EVMDialect::setCurrentObject(Object const* _object)
+{
+	yulAssert(m_objectAccess, "Current object set with dialect that does not support object access.");
+	m_currentObject = _object;
+}
+
+void EVMDialect::addFunction(
+	string _name,
+	size_t _params,
+	size_t _returns,
+	bool _movable,
+	std::function<void(FunctionCall const&, AbstractAssembly&, std::function<void()>)> _generateCode
+)
+{
+	YulString name{std::move(_name)};
+	BuiltinFunctionForEVM& f = m_functions[name];
+	f.name = name;
+	f.parameters.resize(_params);
+	f.returns.resize(_returns);
+	f.movable = _movable;
+	f.generateCode = std::move(_generateCode);
+}

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -1,0 +1,85 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Yul dialects for EVM.
+ */
+
+#pragma once
+
+#include <libyul/Dialect.h>
+
+#include <libyul/backends/evm/AbstractAssembly.h>
+
+#include <map>
+
+namespace yul
+{
+
+class YulString;
+using Type = YulString;
+struct FunctionCall;
+struct Object;
+
+struct BuiltinFunctionForEVM: BuiltinFunction
+{
+	/// Function to generate code for the given function call and append it to the abstract
+	/// assembly. The third parameter is called to visit (and generate code for) the arguments
+	/// from right to left.
+	std::function<void(FunctionCall const&, AbstractAssembly&, std::function<void()>)> generateCode;
+};
+
+/**
+ * Yul dialect for EVM as a backend.
+ * The main difference is that the builtin functions take an AbstractAssembly for the
+ * code generation.
+ */
+struct EVMDialect: public Dialect
+{
+	EVMDialect(AsmFlavour _flavour, bool _objectAccess);
+
+	/// @returns the builtin function of the given name or a nullptr if it is not a builtin function.
+	BuiltinFunctionForEVM const* builtin(YulString _name) const override;
+
+	static std::shared_ptr<EVMDialect> looseAssemblyForEVM();
+	static std::shared_ptr<EVMDialect> strictAssemblyForEVM();
+	static std::shared_ptr<EVMDialect> strictAssemblyForEVMObjects();
+	static std::shared_ptr<EVMDialect> yulForEVM();
+
+	bool providesObjectAccess() const { return m_objectAccess; }
+
+	/// Sets the mapping of current sub assembly IDs. Used during code generation.
+	void setSubIDs(std::map<YulString, AbstractAssembly::SubID> _subIDs);
+	/// Sets the current object. Used during code generation.
+	void setCurrentObject(Object const* _object);
+
+private:
+	void addFunction(
+		std::string _name,
+		size_t _params,
+		size_t _returns,
+		bool _movable,
+		std::function<void(FunctionCall const&, AbstractAssembly&, std::function<void()>)> _generateCode
+	);
+
+	bool m_objectAccess;
+	Object const* m_currentObject = nullptr;
+	/// Mapping from named objects to abstract assembly sub IDs.
+	std::map<YulString, AbstractAssembly::SubID> m_subIDs;
+	std::map<YulString, BuiltinFunctionForEVM> m_functions;
+};
+
+}

--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -21,13 +21,15 @@
 #include <libyul/backends/evm/EVMObjectCompiler.h>
 
 #include <libyul/backends/evm/EVMCodeTransform.h>
+#include <libyul/backends/evm/EVMDialect.h>
+
 #include <libyul/Object.h>
 #include <libyul/Exceptions.h>
 
 using namespace yul;
 using namespace std;
 
-void EVMObjectCompiler::compile(Object& _object, AbstractAssembly& _assembly, Dialect const& _dialect, bool _evm15, bool _optimize)
+void EVMObjectCompiler::compile(Object& _object, AbstractAssembly& _assembly, EVMDialect& _dialect, bool _evm15, bool _optimize)
 {
 	EVMObjectCompiler compiler(_assembly, _dialect, _evm15);
 	compiler.run(_object, _optimize);
@@ -50,7 +52,13 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 			subIDs[data.name] = m_assembly.appendData(data.data);
 		}
 
+	if (m_dialect.providesObjectAccess())
+	{
+		m_dialect.setSubIDs(std::move(subIDs));
+		m_dialect.setCurrentObject(&_object);
+	}
+
 	yulAssert(_object.analysisInfo, "No analysis info.");
 	yulAssert(_object.code, "No code.");
-	CodeTransform{m_assembly, *_object.analysisInfo, *_object.code, _optimize, m_yul, m_evm15, _optimize}(*_object.code);
+	CodeTransform{m_assembly, *_object.analysisInfo, *_object.code, m_dialect, _optimize, m_evm15}(*_object.code);
 }

--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -27,9 +27,9 @@
 using namespace yul;
 using namespace std;
 
-void EVMObjectCompiler::compile(Object& _object, AbstractAssembly& _assembly, bool _yul, bool _evm15, bool _optimize)
+void EVMObjectCompiler::compile(Object& _object, AbstractAssembly& _assembly, Dialect const& _dialect, bool _evm15, bool _optimize)
 {
-	EVMObjectCompiler compiler(_assembly, _yul, _evm15);
+	EVMObjectCompiler compiler(_assembly, _dialect, _evm15);
 	compiler.run(_object, _optimize);
 }
 
@@ -42,7 +42,7 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 		{
 			auto subAssemblyAndID = m_assembly.createSubAssembly();
 			subIDs[subObject->name] = subAssemblyAndID.second;
-			compile(*subObject, *subAssemblyAndID.first, m_yul, m_evm15, _optimize);
+			compile(*subObject, *subAssemblyAndID.first, m_dialect, m_evm15, _optimize);
 		}
 		else
 		{
@@ -52,5 +52,5 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 
 	yulAssert(_object.analysisInfo, "No analysis info.");
 	yulAssert(_object.code, "No code.");
-	CodeTransform{m_assembly, *_object.analysisInfo, *_object.code, _optimize, m_yul, m_evm15}(*_object.code);
+	CodeTransform{m_assembly, *_object.analysisInfo, *_object.code, _optimize, m_yul, m_evm15, _optimize}(*_object.code);
 }

--- a/libyul/backends/evm/EVMObjectCompiler.h
+++ b/libyul/backends/evm/EVMObjectCompiler.h
@@ -23,21 +23,21 @@ namespace yul
 {
 struct Object;
 class AbstractAssembly;
-struct Dialect;
+struct EVMDialect;
 
 class EVMObjectCompiler
 {
 public:
-	static void compile(Object& _object, AbstractAssembly& _assembly, Dialect const& _dialect, bool _evm15, bool _optimize);
+	static void compile(Object& _object, AbstractAssembly& _assembly, EVMDialect& _dialect, bool _evm15, bool _optimize);
 private:
-	EVMObjectCompiler(AbstractAssembly& _assembly, Dialect const& _dialect, bool _evm15):
+	EVMObjectCompiler(AbstractAssembly& _assembly, EVMDialect& _dialect, bool _evm15):
 		m_assembly(_assembly), m_dialect(_dialect), m_evm15(_evm15)
 	{}
 
 	void run(Object& _object, bool _optimize);
 
 	AbstractAssembly& m_assembly;
-	Dialect const& m_dialect;
+	EVMDialect& m_dialect;
 	bool m_evm15 = false;
 };
 

--- a/libyul/backends/evm/EVMObjectCompiler.h
+++ b/libyul/backends/evm/EVMObjectCompiler.h
@@ -23,20 +23,21 @@ namespace yul
 {
 struct Object;
 class AbstractAssembly;
+struct Dialect;
 
 class EVMObjectCompiler
 {
 public:
-	static void compile(Object& _object, AbstractAssembly& _assembly, bool _yul, bool _evm15, bool _optimize);
+	static void compile(Object& _object, AbstractAssembly& _assembly, Dialect const& _dialect, bool _evm15, bool _optimize);
 private:
-	EVMObjectCompiler(AbstractAssembly& _assembly, bool _yul, bool _evm15):
-		m_assembly(_assembly), m_yul(_yul), m_evm15(_evm15)
+	EVMObjectCompiler(AbstractAssembly& _assembly, Dialect const& _dialect, bool _evm15):
+		m_assembly(_assembly), m_dialect(_dialect), m_evm15(_evm15)
 	{}
 
 	void run(Object& _object, bool _optimize);
 
 	AbstractAssembly& m_assembly;
-	bool m_yul = false;
+	Dialect const& m_dialect;
 	bool m_evm15 = false;
 };
 

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -29,6 +29,7 @@
 #include <libyul/AsmParser.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmPrinter.h>
+#include <libyul/backends/evm/EVMDialect.h>
 
 #include <liblangutil/Scanner.h>
 #include <liblangutil/ErrorReporter.h>
@@ -54,7 +55,7 @@ void yul::test::printErrors(ErrorList const& _errors)
 
 pair<shared_ptr<Block>, shared_ptr<yul::AsmAnalysisInfo>> yul::test::parse(string const& _source, bool _yul)
 {
-	Dialect dialect = _yul ? yul::Dialect::yul() : yul::Dialect::strictAssemblyForEVM();
+	shared_ptr<Dialect> dialect = _yul ? yul::Dialect::yul() : yul::EVMDialect::strictAssemblyForEVM();
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	auto scanner = make_shared<Scanner>(CharStream(_source, ""));

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -41,6 +41,7 @@
 #include <libyul/optimiser/RedundantAssignEliminator.h>
 #include <libyul/optimiser/StructuralSimplifier.h>
 #include <libyul/optimiser/Suite.h>
+#include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmAnalysis.h>
@@ -262,7 +263,7 @@ void YulOptimizerTest::printIndented(ostream& _stream, string const& _output, st
 
 bool YulOptimizerTest::parse(ostream& _stream, string const& _linePrefix, bool const _formatted)
 {
-	yul::Dialect dialect = m_yul ? yul::Dialect::yul() : yul::Dialect::strictAssemblyForEVM();
+	shared_ptr<yul::Dialect> dialect = m_yul ? yul::Dialect::yul() : yul::EVMDialect::strictAssemblyForEVM();
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(m_source, ""));

--- a/test/libyul/objectCompiler/datacopy.yul
+++ b/test/libyul/objectCompiler/datacopy.yul
@@ -1,0 +1,48 @@
+object "a" {
+  code {
+    datacopy(0, dataoffset("sub"), datasize("sub"))
+    return(0, datasize("sub"))
+  }
+  object "sub" {
+    code {
+      sstore(0, dataoffset("sub"))
+      mstore(0, datasize("data1"))
+    }
+    data "data1" "Hello, World!"
+  }
+}
+// ----
+// Assembly:
+//     /* "source":26:73   */
+//   dataSize(sub_0)
+//   dataOffset(sub_0)
+//     /* "source":35:36   */
+//   0x00
+//     /* "source":26:73   */
+//   codecopy
+//     /* "source":78:104   */
+//   dataSize(sub_0)
+//     /* "source":85:86   */
+//   0x00
+//     /* "source":78:104   */
+//   return
+// stop
+//
+// sub_0: assembly {
+//         /* "source":143:171   */
+//       0x00
+//         /* "source":150:151   */
+//       0x00
+//         /* "source":143:171   */
+//       sstore
+//         /* "source":178:206   */
+//       0x0d
+//         /* "source":185:186   */
+//       0x00
+//         /* "source":178:206   */
+//       mstore
+//     stop
+//     data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// }
+// Bytecode: 600b600d600039600b6000f3fe6000600055600d600052fe
+// Opcodes: PUSH1 0xB PUSH1 0xD PUSH1 0x0 CODECOPY PUSH1 0xB PUSH1 0x0 RETURN INVALID PUSH1 0x0 PUSH1 0x0 SSTORE PUSH1 0xD PUSH1 0x0 MSTORE INVALID

--- a/test/libyul/objectCompiler/dataoffset_code.yul
+++ b/test/libyul/objectCompiler/dataoffset_code.yul
@@ -1,0 +1,29 @@
+object "a" {
+  code { sstore(0, dataoffset("sub")) }
+  object "sub" {
+    code { sstore(0, 8) }
+    data "data1" "Hello, World!"
+  }
+}
+// ----
+// Assembly:
+//     /* "source":22:50   */
+//   dataOffset(sub_0)
+//     /* "source":29:30   */
+//   0x00
+//     /* "source":22:50   */
+//   sstore
+// stop
+//
+// sub_0: assembly {
+//         /* "source":91:92   */
+//       0x08
+//         /* "source":88:89   */
+//       0x00
+//         /* "source":81:93   */
+//       sstore
+//     stop
+//     data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// }
+// Bytecode: 6006600055fe6008600055fe
+// Opcodes: PUSH1 0x6 PUSH1 0x0 SSTORE INVALID PUSH1 0x8 PUSH1 0x0 SSTORE INVALID

--- a/test/libyul/objectCompiler/dataoffset_data.yul
+++ b/test/libyul/objectCompiler/dataoffset_data.yul
@@ -1,0 +1,16 @@
+object "a" {
+  code { sstore(0, dataoffset("data1")) }
+  data "data1" "Hello, World!"
+}
+// ----
+// Assembly:
+//     /* "source":22:52   */
+//   data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f
+//     /* "source":29:30   */
+//   0x00
+//     /* "source":22:52   */
+//   sstore
+// stop
+// data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// Bytecode: 6006600055fe48656c6c6f2c20576f726c6421
+// Opcodes: PUSH1 0x6 PUSH1 0x0 SSTORE INVALID 0x48 PUSH6 0x6C6C6F2C2057 PUSH16 0x726C6421000000000000000000000000

--- a/test/libyul/objectCompiler/dataoffset_self.yul
+++ b/test/libyul/objectCompiler/dataoffset_self.yul
@@ -1,0 +1,16 @@
+object "a" {
+  code { sstore(0, dataoffset("a")) }
+  data "data1" "Hello, World!"
+}
+// ----
+// Assembly:
+//     /* "source":22:48   */
+//   0x00
+//     /* "source":29:30   */
+//   0x00
+//     /* "source":22:48   */
+//   sstore
+// stop
+// data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// Bytecode: 6000600055fe
+// Opcodes: PUSH1 0x0 PUSH1 0x0 SSTORE INVALID

--- a/test/libyul/objectCompiler/datasize_code.yul
+++ b/test/libyul/objectCompiler/datasize_code.yul
@@ -1,0 +1,29 @@
+object "a" {
+  code { sstore(0, datasize("sub")) }
+  object "sub" {
+    code { sstore(0, 8) }
+    data "data1" "Hello, World!"
+  }
+}
+// ----
+// Assembly:
+//     /* "source":22:48   */
+//   dataSize(sub_0)
+//     /* "source":29:30   */
+//   0x00
+//     /* "source":22:48   */
+//   sstore
+// stop
+//
+// sub_0: assembly {
+//         /* "source":89:90   */
+//       0x08
+//         /* "source":86:87   */
+//       0x00
+//         /* "source":79:91   */
+//       sstore
+//     stop
+//     data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// }
+// Bytecode: 6006600055fe
+// Opcodes: PUSH1 0x6 PUSH1 0x0 SSTORE INVALID

--- a/test/libyul/objectCompiler/datasize_data.yul
+++ b/test/libyul/objectCompiler/datasize_data.yul
@@ -1,0 +1,16 @@
+object "a" {
+  code { sstore(0, datasize("data1")) }
+  data "data1" "Hello, World!"
+}
+// ----
+// Assembly:
+//     /* "source":22:50   */
+//   0x0d
+//     /* "source":29:30   */
+//   0x00
+//     /* "source":22:50   */
+//   sstore
+// stop
+// data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// Bytecode: 600d600055fe
+// Opcodes: PUSH1 0xD PUSH1 0x0 SSTORE INVALID

--- a/test/libyul/objectCompiler/datasize_self.yul
+++ b/test/libyul/objectCompiler/datasize_self.yul
@@ -1,0 +1,16 @@
+object "a" {
+  code { sstore(0, datasize("a")) }
+  data "data1" "Hello, World!"
+}
+// ----
+// Assembly:
+//     /* "source":22:46   */
+//   bytecodeSize
+//     /* "source":29:30   */
+//   0x00
+//     /* "source":22:46   */
+//   sstore
+// stop
+// data_acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f 48656c6c6f2c20576f726c6421
+// Bytecode: 6006600055fe
+// Opcodes: PUSH1 0x6 PUSH1 0x0 SSTORE INVALID

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -49,6 +49,8 @@
 #include <libyul/optimiser/StructuralSimplifier.h>
 #include <libyul/optimiser/VarDeclPropagator.h>
 
+#include <libyul/backends/evm/EVMDialect.h>
+
 #include <libdevcore/JSON.h>
 
 #include <boost/program_options.hpp>
@@ -83,7 +85,7 @@ public:
 	{
 		ErrorReporter errorReporter(m_errors);
 		shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(_input, ""));
-		m_ast = yul::Parser(errorReporter, yul::Dialect::strictAssemblyForEVM()).parse(scanner, false);
+		m_ast = yul::Parser(errorReporter, yul::EVMDialect::strictAssemblyForEVM()).parse(scanner, false);
 		if (!m_ast || !errorReporter.errors().empty())
 		{
 			cout << "Error parsing source." << endl;
@@ -96,7 +98,7 @@ public:
 			errorReporter,
 			EVMVersion::byzantium(),
 			langutil::Error::Type::SyntaxError,
-			Dialect::strictAssemblyForEVM()
+			EVMDialect::strictAssemblyForEVM()
 		);
 		if (!analyzer.analyze(*m_ast) || !errorReporter.errors().empty())
 		{


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3334
Fixes https://github.com/ethereum/solidity/issues/5510

This re-attaches the builtin function query function directly to the dialect and gets rid of the intermediate Builtins struct.

It also splits the Dialect into Dialect and EVMDialect. The latter returns a different BuiltinFuncitonForEVM (which derives from BuiltinFunction), which takes an AbstractAssembly for code generation.

After this change and relevant changes to the optimizer, we can turn all EVM instructions into builtin functions.