### PR TITLE
Use boost 1.67 as ppa dependency.

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -69,6 +69,12 @@ else
     Z3DEPENDENCY="libz3-dev,
                "
 fi
+if [ $distribution = trusty ]
+then
+    BOOSTDEPENDENCY="libboost1.67-dev"
+else
+    BOOSTDEPENDENCY="libboost-all-dev"
+fi
 
 # Fetch source
 git clone --depth 2 --recursive https://github.com/ethereum/solidity.git -b "$branch"
@@ -117,7 +123,7 @@ Build-Depends: ${Z3DEPENDENCY}debhelper (>= 9.0.0),
                g++-8,
                git,
                libgmp-dev,
-               libboost-all-dev,
+               ${BOOSTDEPENDENCY},
                automake,
                libtool,
                scons

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -174,7 +174,7 @@ override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DINSTALL_LLLC=Off -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8
+	dh_auto_configure -- -DINSTALL_LLLC=Off -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DBoost_USE_STATIC_LIBS=OFF
 EOF
 cat <<EOF > debian/copyright
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/


### PR DESCRIPTION
I'm still no expert in PPA builds, but I guess this should be all that's needed?
We probably need to have some equivalent of ``add-apt-repository -y ppa:mhier/libboost-latest`` in the travis build, but that may have to be using the web interface (to which I don't have access)?
See https://help.launchpad.net/Packaging/PPA/BuildingASourcePackage#Depending_on_other_PPAs:
``
If you want Launchpad to satisfy your package dependencies using one or more other PPAs, follow the Edit dependencies link on your PPA or the team's overview page.
``

For reference: this is what needs to be fixed:
https://launchpadlibrarian.net/401162227/buildlog_ubuntu-trusty-amd64.solc_1%3A0.5.2-develop-2018-12-12-1476acb8-1ubuntu1~trusty_BUILDING.txt.gz