### PR TITLE
[Yul] Fix compilation for certain combinations of boost and gcc.

### DIFF
--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -55,7 +55,7 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 			if (expressionAlwaysTrue(*_ifStmt.condition))
 				return {std::move(_ifStmt.body.statements)};
 			else if (expressionAlwaysFalse(*_ifStmt.condition))
-				return {{}};
+				return {vector<Statement>{}};
 			return {};
 		},
 		[](Switch& _switchStmt) -> OptionalStatements {


### PR DESCRIPTION
Some combinations of older versions of boost and gcc have problems with the optional vector of variants without giving them explicit types.