### PR TITLE
[RFC] C++ `=default` ctors/dtors and the use of non-static member initializer syntax.

### DIFF
--- a/libdevcore/IndentedWriter.h
+++ b/libdevcore/IndentedWriter.h
@@ -34,8 +34,6 @@ DEV_SIMPLE_EXCEPTION(IndentedWriterError);
 class IndentedWriter
 {
 public:
-	explicit IndentedWriter(): m_lines(std::vector<Line>{{std::string(), 0}}) {}
-
 	// Returns the formatted output.
 	std::string format() const;
 
@@ -61,7 +59,7 @@ private:
 		unsigned indentation;
 	};
 
-	std::vector<Line> m_lines;
+	std::vector<Line> m_lines{{std::string(), 0}};
 };
 
 }

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -45,8 +45,6 @@ using AssemblyPointer = std::shared_ptr<Assembly>;
 class Assembly
 {
 public:
-	Assembly() {}
-
 	AssemblyItem newTag() { assertThrow(m_usedTags < 0xffffffff, AssemblyException, ""); return AssemblyItem(Tag, m_usedTags++); }
 	AssemblyItem newPushTag() { assertThrow(m_usedTags < 0xffffffff, AssemblyException, ""); return AssemblyItem(PushTag, m_usedTags++); }
 	/// Returns a tag identified by the given name. Creates it if it does not yet exist.

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -304,7 +304,7 @@ KnownState::StoreOperation KnownState::storeInStorage(
 
 	AssemblyItem item(Instruction::SSTORE, _location);
 	Id id = m_expressionClasses->find(item, {_slot, _value}, true, m_sequenceNumber);
-	StoreOperation operation(StoreOperation::Storage, _slot, m_sequenceNumber, id);
+	StoreOperation operation{StoreOperation::Storage, _slot, m_sequenceNumber, id};
 	m_storageContent[_slot] = _value;
 	// increment a second time so that we get unique sequence numbers for writes
 	m_sequenceNumber++;
@@ -336,7 +336,7 @@ KnownState::StoreOperation KnownState::storeInMemory(Id _slot, Id _value, Source
 
 	AssemblyItem item(Instruction::MSTORE, _location);
 	Id id = m_expressionClasses->find(item, {_slot, _value}, true, m_sequenceNumber);
-	StoreOperation operation(StoreOperation(StoreOperation::Memory, _slot, m_sequenceNumber, id));
+	StoreOperation operation{StoreOperation::Memory, _slot, m_sequenceNumber, id};
 	m_memoryContent[_slot] = _value;
 	// increment a second time so that we get unique sequence numbers for writes
 	m_sequenceNumber++;

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -74,18 +74,13 @@ public:
 	struct StoreOperation
 	{
 		enum Target { Invalid, Memory, Storage };
-		StoreOperation(): target(Invalid), sequenceNumber(-1) {}
-		StoreOperation(
-			Target _target,
-			Id _slot,
-			unsigned _sequenceNumber,
-			Id _expression
-		): target(_target), slot(_slot), sequenceNumber(_sequenceNumber), expression(_expression) {}
+
 		bool isValid() const { return target != Invalid; }
-		Target target;
-		Id slot;
-		unsigned sequenceNumber;
-		Id expression;
+
+		Target target{Invalid};
+		Id slot{std::numeric_limits<Id>::max()};
+		unsigned sequenceNumber{std::numeric_limits<unsigned>::max()};
+		Id expression{std::numeric_limits<Id>::max()};
 	};
 
 	explicit KnownState(

--- a/liblangutil/CharStream.h
+++ b/liblangutil/CharStream.h
@@ -67,9 +67,9 @@ namespace langutil
 class CharStream
 {
 public:
-	CharStream(): m_position(0) {}
+	CharStream() = default;
 	explicit CharStream(std::string const& _source, std::string const& name):
-		m_source(_source), m_name(name), m_position(0) {}
+		m_source(_source), m_name(name) {}
 
 	int position() const { return m_position; }
 	bool isPastEndOfInput(size_t _charsForward = 0) const { return (m_position + _charsForward) >= m_source.size(); }
@@ -94,7 +94,7 @@ public:
 private:
 	std::string m_source;
 	std::string m_name;
-	size_t m_position;
+	size_t m_position{0};
 };
 
 }

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -39,7 +39,7 @@ class EVMVersion:
 	boost::equality_comparable<EVMVersion>
 {
 public:
-	EVMVersion() {}
+	EVMVersion() = default;
 
 	static EVMVersion homestead() { return {Version::Homestead}; }
 	static EVMVersion tangerineWhistle() { return {Version::TangerineWhistle}; }

--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -100,10 +100,10 @@ void ParserBase::decreaseRecursionDepth()
 
 void ParserBase::parserError(string const& _description)
 {
-	m_errorReporter.parserError(SourceLocation(position(), endPosition(), source()), _description);
+	m_errorReporter.parserError(SourceLocation{position(), endPosition(), source()}, _description);
 }
 
 void ParserBase::fatalParserError(string const& _description)
 {
-	m_errorReporter.fatalParserError(SourceLocation(position(), endPosition(), source()), _description);
+	m_errorReporter.fatalParserError(SourceLocation{position(), endPosition(), source()}, _description);
 }

--- a/liblangutil/SourceLocation.h
+++ b/liblangutil/SourceLocation.h
@@ -38,10 +38,6 @@ namespace langutil
  */
 struct SourceLocation
 {
-	SourceLocation(): start(-1), end(-1), source{nullptr} { }
-	SourceLocation(int _start, int _end, std::shared_ptr<CharStream> _source):
-		start(_start), end(_end), source{std::move(_source)} { }
-
 	bool operator==(SourceLocation const& _other) const
 	{
 		return source.get() == _other.source.get() && start == _other.start && end == _other.end;
@@ -53,8 +49,8 @@ struct SourceLocation
 
 	bool isEmpty() const { return start == -1 && end == -1; }
 
-	int start;
-	int end;
+	int start = -1;
+	int end = -1;
 	std::shared_ptr<CharStream> source;
 };
 

--- a/liblangutil/SourceReferenceExtractor.h
+++ b/liblangutil/SourceReferenceExtractor.h
@@ -31,28 +31,29 @@ namespace langutil
 
 struct LineColumn
 {
-	int line;
-	int column;
+	int line = {-1};
+	int column = {-1};
 
+	LineColumn() = default;
 	LineColumn(std::tuple<int, int> const& _t): line{std::get<0>(_t)}, column{std::get<1>(_t)} {}
-	LineColumn(int _line, int _column): line{_line}, column{_column} {}
-	LineColumn(): line{-1}, column{-1} {}
 };
 
 struct SourceReference
 {
-	std::string message;    ///< A message that relates to this source reference (such as a warning or an error message).
-	std::string sourceName; ///< Underlying source name (for example the filename).
-	LineColumn position;    ///< Actual (error) position this source reference is surrounding.
-	bool multiline;         ///< Indicates whether the actual SourceReference is truncated to one line.
-	std::string text;       ///< Extracted source code text (potentially truncated if multiline or too long).
-	int startColumn;        ///< Highlighting range-start of text field.
-	int endColumn;          ///< Highlighting range-end of text field.
+	std::string message;      ///< A message that relates to this source reference (such as a warning or an error message).
+	std::string sourceName;   ///< Underlying source name (for example the filename).
+	LineColumn position;      ///< Actual (error) position this source reference is surrounding.
+	bool multiline = {false}; ///< Indicates whether the actual SourceReference is truncated to one line.
+	std::string text;         ///< Extracted source code text (potentially truncated if multiline or too long).
+	int startColumn = {-1};   ///< Highlighting range-start of text field.
+	int endColumn = {-1};     ///< Highlighting range-end of text field.
 
 	/// Constructs a SourceReference containing a message only.
 	static SourceReference MessageOnly(std::string _msg)
 	{
-		return SourceReference{std::move(_msg), "", LineColumn{-1, -1}, false, "", -1, -1};
+		SourceReference sref;
+		sref.message = std::move(_msg);
+		return sref;
 	}
 };
 

--- a/liblll/CodeFragment.h
+++ b/liblll/CodeFragment.h
@@ -41,7 +41,7 @@ class CodeFragment
 public:
 	using ReadCallback = std::function<std::string(std::string const&)>;
 
-	CodeFragment() {}
+	CodeFragment() = default;
 	CodeFragment(sp::utree const& _t, CompilerState& _s, ReadCallback const& _readFile, bool _allowASM = false);
 
 	static CodeFragment compile(std::string const& _src, CompilerState& _s, ReadCallback const& _readFile);

--- a/libsolidity/analysis/ControlFlowGraph.h
+++ b/libsolidity/analysis/ControlFlowGraph.h
@@ -103,7 +103,8 @@ struct CFGNode
 /** Describes the control flow of a function. */
 struct FunctionFlow
 {
-	virtual ~FunctionFlow() {}
+	virtual ~FunctionFlow() = default;
+
 	/// Entry node. Control flow of the function starts here.
 	/// This node is empty and does not have any entries.
 	CFGNode* entry = nullptr;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -46,7 +46,7 @@ using TypePointer = std::shared_ptr<Type const>;
 
 struct ASTAnnotation
 {
-	virtual ~ASTAnnotation() {}
+	virtual ~ASTAnnotation() = default;
 };
 
 struct DocTag
@@ -57,7 +57,7 @@ struct DocTag
 
 struct DocumentedAnnotation
 {
-	virtual ~DocumentedAnnotation() {}
+	virtual ~DocumentedAnnotation() = default;
 	/// Mapping docstring tag name -> content.
 	std::multimap<std::string, DocTag> docTags;
 };

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -601,7 +601,6 @@ private:
 class BoolType: public Type
 {
 public:
-	BoolType() {}
 	Category category() const override { return Category::Bool; }
 	std::string richIdentifier() const override { return "t_bool"; }
 	TypeResult unaryOperatorResult(Token _operator) const override;

--- a/libsolidity/codegen/LValue.h
+++ b/libsolidity/codegen/LValue.h
@@ -49,7 +49,7 @@ protected:
 		m_context(_compilerContext), m_dataType(_dataType) {}
 
 public:
-	virtual ~LValue() {}
+	virtual ~LValue() = default;
 	/// @returns the number of stack slots occupied by the lvalue reference
 	virtual unsigned sizeOnStack() const { return 1; }
 	/// Copies the value of the current lvalue to the top of the stack and, if @a _remove is true,

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -46,7 +46,7 @@ class Parser::ASTNodeFactory
 {
 public:
 	explicit ASTNodeFactory(Parser const& _parser):
-		m_parser(_parser), m_location(_parser.position(), -1, _parser.source()) {}
+		m_parser(_parser), m_location{_parser.position(), -1, _parser.source()} {}
 	ASTNodeFactory(Parser const& _parser, ASTPointer<ASTNode> const& _childNode):
 		m_parser(_parser), m_location(_childNode->location()) {}
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -48,7 +48,7 @@ public:
 	explicit ASTNodeFactory(Parser const& _parser):
 		m_parser(_parser), m_location{_parser.position(), -1, _parser.source()} {}
 	ASTNodeFactory(Parser const& _parser, ASTPointer<ASTNode> const& _childNode):
-		m_parser(_parser), m_location(_childNode->location()) {}
+		m_parser(_parser), m_location{_childNode->location()} {}
 
 	void markEndPosition() { m_location.end = m_parser.endPosition(); }
 	void setLocation(SourceLocation const& _location) { m_location = _location; }

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -47,7 +47,10 @@ private:
 
 	struct VarDeclParserOptions
 	{
+		// This is actually not needed, but due to a defect in the C++ standard, we have to.
+		// https://stackoverflow.com/questions/17430377
 		VarDeclParserOptions() {}
+
 		bool allowVar = false;
 		bool isStateVariable = false;
 		bool allowIndexed = false;
@@ -85,7 +88,7 @@ private:
 	ASTPointer<EnumDefinition> parseEnumDefinition();
 	ASTPointer<EnumValue> parseEnumValue();
 	ASTPointer<VariableDeclaration> parseVariableDeclaration(
-		VarDeclParserOptions const& _options = VarDeclParserOptions(),
+		VarDeclParserOptions const& _options = {},
 		ASTPointer<TypeName> const& _lookAheadArrayType = ASTPointer<TypeName>()
 	);
 	ASTPointer<ModifierDefinition> parseModifierDefinition();
@@ -99,7 +102,7 @@ private:
 	ASTPointer<FunctionTypeName> parseFunctionType();
 	ASTPointer<Mapping> parseMapping();
 	ASTPointer<ParameterList> parseParameterList(
-		VarDeclParserOptions const& _options,
+		VarDeclParserOptions const& _options = {},
 		bool _allowEmpty = true
 	);
 	ASTPointer<Block> parseBlock(ASTPointer<ASTString> const& _docString = {});

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -54,7 +54,7 @@ struct Dialect: boost::noncopyable
 	virtual BuiltinFunction const* builtin(YulString /*_name*/) const { return nullptr; }
 
 	Dialect(AsmFlavour _flavour): flavour(_flavour) {}
-	virtual ~Dialect() {}
+	virtual ~Dialect() = default;
 
 	static std::shared_ptr<Dialect> yul()
 	{

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -37,7 +37,7 @@ struct AsmAnalysisInfo;
  */
 struct ObjectNode
 {
-	virtual ~ObjectNode() {}
+	virtual ~ObjectNode() = default;
 	virtual std::string toString(bool _yul) const = 0;
 
 	YulString name;

--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -42,10 +42,9 @@ public:
 		size_t id;
 		std::uint64_t hash;
 	};
-	YulStringRepository():
-		m_strings{std::make_shared<std::string>()},
-		m_hashToID{std::make_pair(emptyHash(), 0)}
-	{}
+
+	YulStringRepository() = default;
+
 	static YulStringRepository& instance()
 	{
 		static YulStringRepository inst;
@@ -80,9 +79,10 @@ public:
 		return hash;
 	}
 	static constexpr std::uint64_t emptyHash() { return 14695981039346656037u; }
+
 private:
-	std::vector<std::shared_ptr<std::string>> m_strings;
-	std::unordered_multimap<std::uint64_t, size_t> m_hashToID;
+	std::vector<std::shared_ptr<std::string>> m_strings = {std::make_shared<std::string>()};
+	std::unordered_multimap<std::uint64_t, size_t> m_hashToID = {{emptyHash(), 0}};
 };
 
 /// Wrapper around handles into the YulString repository.

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -55,7 +55,7 @@ public:
 	using LabelID = size_t;
 	using SubID = size_t;
 
-	virtual ~AbstractAssembly() {}
+	virtual ~AbstractAssembly() = default;
 
 	/// Set a new source location valid starting from the next instruction.
 	virtual void setSourceLocation(langutil::SourceLocation const& _location) = 0;

--- a/libyul/backends/evm/EVMAssembly.h
+++ b/libyul/backends/evm/EVMAssembly.h
@@ -38,7 +38,7 @@ class EVMAssembly: public AbstractAssembly
 {
 public:
 	explicit EVMAssembly(bool _evm15 = false): m_evm15(_evm15) { }
-	virtual ~EVMAssembly() {}
+	virtual ~EVMAssembly() = default;
 
 	/// Set a new source location valid starting from the next instruction.
 	void setSourceLocation(langutil::SourceLocation const& _location) override;

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -38,7 +38,7 @@ using namespace dev::solidity;
 
 
 EVMDialect::EVMDialect(AsmFlavour _flavour, bool _objectAccess):
-	Dialect(_flavour), m_objectAccess(_objectAccess)
+	Dialect{_flavour}, m_objectAccess(_objectAccess)
 {
 	// The EVM instructions will be moved to builtins at some point.
 	if (!m_objectAccess)

--- a/libyul/optimiser/RedundantAssignEliminator.h
+++ b/libyul/optimiser/RedundantAssignEliminator.h
@@ -115,7 +115,7 @@ public:
 	static void run(Block& _ast);
 
 private:
-	RedundantAssignEliminator() {}
+	RedundantAssignEliminator() = default;
 
 	class State
 	{

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -41,8 +41,6 @@ enum class DocumentationType: uint8_t;
 class CommandLineInterface
 {
 public:
-	CommandLineInterface() {}
-
 	/// Parse command line arguments and return false if we should not continue
 	bool parseArguments(int _argc, char** _argv);
 	/// Parse the files and create source code objects

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -36,7 +36,7 @@ class TestCase
 public:
 	using TestCaseCreator = std::unique_ptr<TestCase>(*)(std::string const&);
 
-	virtual ~TestCase() {}
+	virtual ~TestCase() = default;
 
 	/// Runs the test case.
 	/// Outputs error messages to @arg _stream. Each line of output is prefixed with @arg _linePrefix.

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -56,11 +56,11 @@ BOOST_AUTO_TEST_CASE(all_assembly_items)
 {
 	Assembly _assembly;
 	auto root_asm = make_shared<CharStream>("", "root.asm");
-	_assembly.setSourceLocation(SourceLocation(1, 3, root_asm));
+	_assembly.setSourceLocation({1, 3, root_asm});
 
 	Assembly _subAsm;
 	auto sub_asm = make_shared<CharStream>("", "sub.asm");
-	_subAsm.setSourceLocation(SourceLocation(6, 8, sub_asm));
+	_subAsm.setSourceLocation({6, 8, sub_asm});
 	_subAsm.append(Instruction::INVALID);
 	shared_ptr<Assembly> _subAsmPtr = make_shared<Assembly>(_subAsm);
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -53,7 +53,7 @@ namespace
 		// add dummy locations to each item so that we can check that they are not deleted
 		AssemblyItems input = _input;
 		for (AssemblyItem& item: input)
-			item.setLocation(SourceLocation(1, 3, nullptr));
+			item.setLocation({1, 3, nullptr});
 		return input;
 	}
 

--- a/test/liblangutil/SourceLocation.cpp
+++ b/test/liblangutil/SourceLocation.cpp
@@ -37,12 +37,12 @@ BOOST_AUTO_TEST_CASE(test_fail)
 	auto const sourceA = std::make_shared<CharStream>("", "sourceA");
 	auto const sourceB = std::make_shared<CharStream>("", "sourceB");
 
-	BOOST_CHECK(SourceLocation() == SourceLocation());
-	BOOST_CHECK(SourceLocation(0, 3, sourceA) != SourceLocation(0, 3, sourceB));
-	BOOST_CHECK(SourceLocation(0, 3, source) == SourceLocation(0, 3, source));
-	BOOST_CHECK(SourceLocation(3, 7, source).contains(SourceLocation(4, 6, source)));
-	BOOST_CHECK(!SourceLocation(3, 7, sourceA).contains(SourceLocation(4, 6, sourceB)));
-	BOOST_CHECK(SourceLocation(3, 7, sourceA) < SourceLocation(4, 6, sourceB));
+	BOOST_CHECK(SourceLocation{} == SourceLocation{});
+	BOOST_CHECK((SourceLocation{0, 3, sourceA} != SourceLocation{0, 3, sourceB}));
+	BOOST_CHECK((SourceLocation{0, 3, source} == SourceLocation{0, 3, source}));
+	BOOST_CHECK((SourceLocation{3, 7, source}.contains(SourceLocation{4, 6, source})));
+	BOOST_CHECK((!SourceLocation{3, 7, sourceA}.contains(SourceLocation{4, 6, sourceB})));
+	BOOST_CHECK((SourceLocation{3, 7, sourceA} < SourceLocation{4, 6, sourceB}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -165,19 +165,19 @@ BOOST_AUTO_TEST_CASE(location_test)
 	auto codegenCharStream = make_shared<CharStream>("", "--CODEGEN--");
 
 	vector<SourceLocation> locations =
-		vector<SourceLocation>(4, SourceLocation(2, 82, sourceCode)) +
-		vector<SourceLocation>(1, SourceLocation(8, 17, codegenCharStream)) +
-		vector<SourceLocation>(3, SourceLocation(5, 7, codegenCharStream)) +
-		vector<SourceLocation>(1, SourceLocation(30, 31, codegenCharStream)) +
-		vector<SourceLocation>(1, SourceLocation(27, 28, codegenCharStream)) +
-		vector<SourceLocation>(1, SourceLocation(20, 32, codegenCharStream)) +
-		vector<SourceLocation>(1, SourceLocation(5, 7, codegenCharStream)) +
-		vector<SourceLocation>(hasShifts ? 19 : 20, SourceLocation(2, 82, sourceCode)) +
-		vector<SourceLocation>(24, SourceLocation(20, 79, sourceCode)) +
-		vector<SourceLocation>(1, SourceLocation(49, 58, sourceCode)) +
-		vector<SourceLocation>(1, SourceLocation(72, 74, sourceCode)) +
-		vector<SourceLocation>(2, SourceLocation(65, 74, sourceCode)) +
-		vector<SourceLocation>(2, SourceLocation(20, 79, sourceCode));
+		vector<SourceLocation>(4, SourceLocation{2, 82, sourceCode}) +
+		vector<SourceLocation>(1, SourceLocation{8, 17, codegenCharStream}) +
+		vector<SourceLocation>(3, SourceLocation{5, 7, codegenCharStream}) +
+		vector<SourceLocation>(1, SourceLocation{30, 31, codegenCharStream}) +
+		vector<SourceLocation>(1, SourceLocation{27, 28, codegenCharStream}) +
+		vector<SourceLocation>(1, SourceLocation{20, 32, codegenCharStream}) +
+		vector<SourceLocation>(1, SourceLocation{5, 7, codegenCharStream}) +
+		vector<SourceLocation>(hasShifts ? 19 : 20, SourceLocation{2, 82, sourceCode}) +
+		vector<SourceLocation>(24, SourceLocation{20, 79, sourceCode}) +
+		vector<SourceLocation>(1, SourceLocation{49, 58, sourceCode}) +
+		vector<SourceLocation>(1, SourceLocation{72, 74, sourceCode}) +
+		vector<SourceLocation>(2, SourceLocation{65, 74, sourceCode}) +
+		vector<SourceLocation>(2, SourceLocation{20, 79, sourceCode});
 	checkAssemblyLocations(items, locations);
 }
 

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -44,7 +44,6 @@ namespace test
 class GasMeterTestFramework: public SolidityExecutionFramework
 {
 public:
-	GasMeterTestFramework() { }
 	void compile(string const& _sourceCode)
 	{
 		m_compiler.reset(false);

--- a/test/libsolidity/SolidityABIJSON.cpp
+++ b/test/libsolidity/SolidityABIJSON.cpp
@@ -38,8 +38,6 @@ namespace test
 class JSONInterfaceChecker
 {
 public:
-	JSONInterfaceChecker(): m_compilerStack() {}
-
 	void checkInterface(std::string const& _code, std::string const& _contractName, std::string const& _expectedInterfaceString)
 	{
 		m_compilerStack.reset(false);

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -39,8 +39,6 @@ namespace test
 class DocumentationChecker
 {
 public:
-	DocumentationChecker(): m_compilerStack() {}
-
 	void checkNatspec(
 		std::string const& _code,
 		std::string const& _contractName,

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -45,8 +45,6 @@ namespace test
 class OptimizerTestFramework: public SolidityExecutionFramework
 {
 public:
-	OptimizerTestFramework() { }
-
 	bytes const& compileAndRunWithOptimizer(
 		std::string const& _sourceCode,
 		u256 const& _value = 0,


### PR DESCRIPTION
Interesting references in the CppCoreGuidelines

* [C.45 Don’t define a default constructor that only initializes data members; use in-class member initializers instead](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c45-dont-define-a-default-constructor-that-only-initializes-data-members-use-in-class-member-initializers-instead)
* [C.48: Prefer in-class initializers to member initializers in constructors for constant initializers](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-in-class-initializers-to-member-initializers-in-constructors-for-constant-initializers)
