### PR TITLE
DOCS: Remove FAQ item that covers array literals

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -45,31 +45,6 @@ Enums are not supported by the ABI, they are just supported by Solidity.
 You have to do the mapping yourself for now, we might provide some help
 later.
 
-Can state variables be initialized in-line?
-===========================================
-
-Yes, this is possible for all types (even for structs). However, for arrays it
-should be noted that you must declare them as static memory arrays.
-
-Examples::
-
-    pragma solidity >=0.4.0 <0.6.0;
-
-    contract C {
-        struct S {
-            uint a;
-            uint b;
-        }
-
-        S public x = S(1, 2);
-        string name = "Ada";
-        string[4] adaArr = ["This", "is", "an", "array"];
-    }
-
-    contract D {
-        C c = new C();
-    }
-
 How do structs work?
 ====================
 


### PR DESCRIPTION
### Description

Remove FAQ item covering initialising arrays, as this is now covered in _types.rst_ line 869.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
