### PR TITLE
SmtLib2Interface uses SMT solver callback provided to StandardCompiler

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
  * Code Generator: Use codecopy for string constants more aggressively.
  * Code Generator: Use binary search for dispatch function if more efficient. The size/speed tradeoff can be tuned using ``--optimize-runs``.
  * Compiler Interface: Disallow unknown keys in standard JSON input.
+ * SMTChecker: Support external JavaScript callback that runs an SMT solver.
  * SMTChecker: Support mathematical and cryptographic functions in an uninterpreted way.
  * Static Analyzer: Do not warn about unused variables or state mutability for functions with an empty body.
  * Type Checker: Add an additional reason to be displayed when type conversion fails.

--- a/libsolc/libsolc.cpp
+++ b/libsolc/libsolc.cpp
@@ -72,9 +72,9 @@ ReadCallback::Callback wrapReadCallback(CStyleReadFileCallback _readCallback = n
 	return readCallback;
 }
 
-string compile(string const& _input, CStyleReadFileCallback _readCallback = nullptr)
+string compile(string const& _input, CStyleReadFileCallback _readCallback = nullptr, CStyleReadFileCallback _smtSolver = nullptr)
 {
-	StandardCompiler compiler(wrapReadCallback(_readCallback));
+	StandardCompiler compiler(wrapReadCallback(_readCallback), wrapReadCallback(_smtSolver));
 	return compiler.compile(_input);
 }
 
@@ -93,9 +93,9 @@ extern char const* solidity_version() noexcept
 {
 	return VersionString.c_str();
 }
-extern char const* solidity_compile(char const* _input, CStyleReadFileCallback _readCallback) noexcept
+extern char const* solidity_compile(char const* _input, CStyleReadFileCallback _readCallback, CStyleReadFileCallback _smtSolver) noexcept
 {
-	s_outputBuffer = compile(_input, _readCallback);
+	s_outputBuffer = compile(_input, _readCallback, _smtSolver);
 	return s_outputBuffer.c_str();
 }
 }

--- a/libsolc/libsolc.h
+++ b/libsolc/libsolc.h
@@ -40,7 +40,7 @@ typedef void (*CStyleReadFileCallback)(char const* _path, char** o_contents, cha
 
 char const* solidity_license() SOLC_NOEXCEPT;
 char const* solidity_version() SOLC_NOEXCEPT;
-char const* solidity_compile(char const* _input, CStyleReadFileCallback _readCallback) SOLC_NOEXCEPT;
+char const* solidity_compile(char const* _input, CStyleReadFileCallback _readCallback, CStyleReadFileCallback _smtSolver) SOLC_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -34,8 +34,12 @@ using namespace dev;
 using namespace langutil;
 using namespace dev::solidity;
 
-SMTChecker::SMTChecker(ErrorReporter& _errorReporter, map<h256, string> const& _smtlib2Responses):
-	m_interface(make_shared<smt::SMTPortfolio>(_smtlib2Responses)),
+SMTChecker::SMTChecker(
+	ErrorReporter& _errorReporter,
+	map<h256, string> const& _smtlib2Responses,
+	ReadCallback::Callback const& _smtSolver
+):
+	m_interface(make_shared<smt::SMTPortfolio>(_smtlib2Responses, _smtSolver)),
 	m_errorReporter(_errorReporter)
 {
 #if defined (HAVE_Z3) || defined (HAVE_CVC4)

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -47,7 +47,11 @@ class VariableUsage;
 class SMTChecker: private ASTConstVisitor
 {
 public:
-	SMTChecker(langutil::ErrorReporter& _errorReporter, std::map<h256, std::string> const& _smtlib2Responses);
+	SMTChecker(
+		langutil::ErrorReporter& _errorReporter,
+		std::map<h256, std::string> const& _smtlib2Responses,
+		ReadCallback::Callback const& _smtSolver = ReadCallback::Callback()
+	);
 
 	void analyze(SourceUnit const& _sources, std::shared_ptr<langutil::Scanner> const& _scanner);
 

--- a/libsolidity/formal/SMTLib2Interface.cpp
+++ b/libsolidity/formal/SMTLib2Interface.cpp
@@ -39,8 +39,12 @@ using namespace dev;
 using namespace dev::solidity;
 using namespace dev::solidity::smt;
 
-SMTLib2Interface::SMTLib2Interface(map<h256, string> const& _queryResponses):
-	m_queryResponses(_queryResponses)
+SMTLib2Interface::SMTLib2Interface(
+	map<h256, string> const& _queryResponses,
+	ReadCallback::Callback const& _smtSolver
+):
+	m_queryResponses(_queryResponses),
+	m_smtSolverCallback(_smtSolver)
 {
 	reset();
 }
@@ -214,6 +218,13 @@ vector<string> SMTLib2Interface::parseValues(string::const_iterator _start, stri
 
 string SMTLib2Interface::querySolver(string const& _input)
 {
+	if (m_smtSolverCallback)
+	{
+		auto result = m_smtSolverCallback(_input);
+		if (result.success)
+			return result.responseOrErrorMessage;
+		return "error";
+	}
 	h256 inputHash = dev::keccak256(_input);
 	if (m_queryResponses.count(inputHash))
 		return m_queryResponses.at(inputHash);

--- a/libsolidity/formal/SMTLib2Interface.h
+++ b/libsolidity/formal/SMTLib2Interface.h
@@ -44,7 +44,10 @@ namespace smt
 class SMTLib2Interface: public SolverInterface, public boost::noncopyable
 {
 public:
-	explicit SMTLib2Interface(std::map<h256, std::string> const& _queryResponses);
+	explicit SMTLib2Interface(
+		std::map<h256, std::string> const& _queryResponses,
+		ReadCallback::Callback const& _smtSolver = ReadCallback::Callback()
+	);
 
 	void reset() override;
 
@@ -78,6 +81,9 @@ private:
 
 	std::map<h256, std::string> const& m_queryResponses;
 	std::vector<std::string> m_unhandledQueries;
+
+	/// Emscripten SMT solver callback
+	ReadCallback::Callback m_smtSolverCallback;
 };
 
 }

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -30,9 +30,15 @@ using namespace dev;
 using namespace dev::solidity;
 using namespace dev::solidity::smt;
 
-SMTPortfolio::SMTPortfolio(map<h256, string> const& _smtlib2Responses)
+SMTPortfolio::SMTPortfolio(
+	map<h256, string> const& _smtlib2Responses,
+	ReadCallback::Callback const& _smtSolver
+)
 {
-	m_solvers.emplace_back(make_shared<smt::SMTLib2Interface>(_smtlib2Responses));
+	m_solvers.emplace_back(make_shared<smt::SMTLib2Interface>(
+		_smtlib2Responses,
+		_smtSolver
+	));
 #ifdef HAVE_Z3
 	m_solvers.emplace_back(make_shared<smt::Z3Interface>());
 #endif

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -45,7 +45,10 @@ namespace smt
 class SMTPortfolio: public SolverInterface, public boost::noncopyable
 {
 public:
-	SMTPortfolio(std::map<h256, std::string> const& _smtlib2Responses);
+	SMTPortfolio(
+		std::map<h256, std::string> const& _smtlib2Responses,
+		ReadCallback::Callback const& _smtSolver = ReadCallback::Callback()
+	);
 
 	void reset() override;
 

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -300,7 +300,7 @@ bool CompilerStack::analyze()
 
 		if (noErrors)
 		{
-			SMTChecker smtChecker(m_errorReporter, m_smtlib2Responses);
+			SMTChecker smtChecker(m_errorReporter, m_smtlib2Responses, m_smtSolver);
 			for (Source const* source: m_sourceOrder)
 				smtChecker.analyze(*source->ast, source->scanner);
 			m_unhandledSMTLib2Queries += smtChecker.unhandledQueries();

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -98,8 +98,12 @@ public:
 	/// Creates a new compiler stack.
 	/// @param _readFile callback to used to read files for import statements. Must return
 	/// and must not emit exceptions.
-	explicit CompilerStack(ReadCallback::Callback const& _readFile = ReadCallback::Callback()):
+	explicit CompilerStack(
+		ReadCallback::Callback const& _readFile = ReadCallback::Callback(),
+		ReadCallback::Callback const& _smtSolver = ReadCallback::Callback()
+	):
 		m_readFile(_readFile),
+		m_smtSolver(_smtSolver),
 		m_errorList(),
 		m_errorReporter(m_errorList) {}
 
@@ -341,6 +345,7 @@ private:
 	) const;
 
 	ReadCallback::Callback m_readFile;
+	ReadCallback::Callback m_smtSolver;
 	bool m_optimize = false;
 	unsigned m_optimizeRuns = 200;
 	EVMVersion m_evmVersion;

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -40,8 +40,11 @@ public:
 	/// Creates a new StandardCompiler.
 	/// @param _readFile callback to used to read files for import statements. Must return
 	/// and must not emit exceptions.
-	explicit StandardCompiler(ReadCallback::Callback const& _readFile = ReadCallback::Callback())
-		: m_compilerStack(_readFile), m_readFile(_readFile)
+	explicit StandardCompiler(
+		ReadCallback::Callback const& _readFile = ReadCallback::Callback(),
+		ReadCallback::Callback const& _smtSolver = ReadCallback::Callback()
+	)
+		: m_compilerStack(_readFile, _smtSolver), m_readFile(_readFile), m_smtSolver(_smtSolver)
 	{
 	}
 
@@ -57,6 +60,7 @@ private:
 
 	CompilerStack m_compilerStack;
 	ReadCallback::Callback m_readFile;
+	ReadCallback::Callback m_smtSolver;
 };
 
 }

--- a/test/libsolidity/LibSolc.cpp
+++ b/test/libsolidity/LibSolc.cpp
@@ -42,7 +42,7 @@ namespace
 
 Json::Value compile(string const& _input)
 {
-	string output(solidity_compile(_input.c_str(), nullptr));
+	string output(solidity_compile(_input.c_str(), nullptr, nullptr));
 	Json::Value ret;
 	BOOST_REQUIRE(jsonParseStrict(output, ret));
 	return ret;

--- a/test/tools/fuzzer.cpp
+++ b/test/tools/fuzzer.cpp
@@ -89,7 +89,7 @@ void testConstantOptimizer(string const& input)
 
 void runCompiler(string input)
 {
-	string outputString(solidity_compile(input.c_str(), nullptr));
+	string outputString(solidity_compile(input.c_str(), nullptr, nullptr));
 	Json::Value output;
 	if (!jsonParseStrict(outputString, output))
 	{


### PR DESCRIPTION
This PR adds an extra callback to be used as an SMT solver by SmtLib2Interface in a single run. If the callback is not given, SmtLib2Interface falls back to the double run case with queries via JSON.