### PR TITLE
[libyul] use unique_ptr in AST over shared_ptr

### DIFF
--- a/libyul/AsmData.h
+++ b/libyul/AsmData.h
@@ -59,25 +59,25 @@ struct StackAssignment { langutil::SourceLocation location; Identifier variableN
 /// Multiple assignment ("x, y := f()"), where the left hand side variables each occupy
 /// a single stack slot and expects a single expression on the right hand returning
 /// the same amount of items as the number of variables.
-struct Assignment { langutil::SourceLocation location; std::vector<Identifier> variableNames; std::shared_ptr<Expression> value; };
+struct Assignment { langutil::SourceLocation location; std::vector<Identifier> variableNames; std::unique_ptr<Expression> value; };
 /// Functional instruction, e.g. "mul(mload(20:u256), add(2:u256, x))"
 struct FunctionalInstruction { langutil::SourceLocation location; dev::solidity::Instruction instruction; std::vector<Expression> arguments; };
 struct FunctionCall { langutil::SourceLocation location; Identifier functionName; std::vector<Expression> arguments; };
 /// Statement that contains only a single expression
 struct ExpressionStatement { langutil::SourceLocation location; Expression expression; };
 /// Block-scope variable declaration ("let x:u256 := mload(20:u256)"), non-hoisted
-struct VariableDeclaration { langutil::SourceLocation location; TypedNameList variables; std::shared_ptr<Expression> value; };
+struct VariableDeclaration { langutil::SourceLocation location; TypedNameList variables; std::unique_ptr<Expression> value; };
 /// Block that creates a scope (frees declared stack variables)
 struct Block { langutil::SourceLocation location; std::vector<Statement> statements; };
 /// Function definition ("function f(a, b) -> (d, e) { ... }")
 struct FunctionDefinition { langutil::SourceLocation location; YulString name; TypedNameList parameters; TypedNameList returnVariables; Block body; };
 /// Conditional execution without "else" part.
-struct If { langutil::SourceLocation location; std::shared_ptr<Expression> condition; Block body; };
+struct If { langutil::SourceLocation location; std::unique_ptr<Expression> condition; Block body; };
 /// Switch case or default case
-struct Case { langutil::SourceLocation location; std::shared_ptr<Literal> value; Block body; };
+struct Case { langutil::SourceLocation location; std::unique_ptr<Literal> value; Block body; };
 /// Switch statement
-struct Switch { langutil::SourceLocation location; std::shared_ptr<Expression> expression; std::vector<Case> cases; };
-struct ForLoop { langutil::SourceLocation location; Block pre; std::shared_ptr<Expression> condition; Block post; Block body; };
+struct Switch { langutil::SourceLocation location; std::unique_ptr<Expression> expression; std::vector<Case> cases; };
+struct ForLoop { langutil::SourceLocation location; Block pre; std::unique_ptr<Expression> condition; Block post; Block body; };
 
 struct LocationExtractor: boost::static_visitor<langutil::SourceLocation>
 {

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -93,10 +93,11 @@ protected:
 	std::vector<T> translateVector(std::vector<T> const& _values);
 
 	template <typename T>
-	std::shared_ptr<T> translate(std::shared_ptr<T> const& _v)
+	std::unique_ptr<T> translate(std::unique_ptr<T> const& _v)
 	{
-		return _v ? std::make_shared<T>(translate(*_v)) : nullptr;
+		return _v ? std::make_unique<T>(translate(*_v)) : nullptr;
 	}
+
 	Block translate(Block const& _block);
 	Case translate(Case const& _case);
 	Identifier translate(Identifier const& _identifier);

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -51,8 +51,10 @@ void DataFlowAnalyzer::operator()(VariableDeclaration& _varDecl)
 	for (auto const& var: _varDecl.variables)
 		names.emplace(var.name);
 	m_variableScopes.back().variables += names;
+
 	if (_varDecl.value)
 		visit(*_varDecl.value);
+
 	handleAssignment(names, _varDecl.value.get());
 }
 

--- a/libyul/optimiser/ExpressionSplitter.cpp
+++ b/libyul/optimiser/ExpressionSplitter.cpp
@@ -106,7 +106,7 @@ void ExpressionSplitter::outlineExpression(Expression& _expr)
 	m_statementsToPrefix.emplace_back(VariableDeclaration{
 		location,
 		{{TypedName{location, var, {}}}},
-		make_shared<Expression>(std::move(_expr))
+		make_unique<Expression>(std::move(_expr))
 	});
 	_expr = Identifier{location, var};
 }

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -181,9 +181,9 @@ vector<Statement> InlineModifier::performInline(Statement& _statement, FunctionC
 		variableReplacements[_existingVariable.name] = newName;
 		VariableDeclaration varDecl{_funCall.location, {{_funCall.location, newName, _existingVariable.type}}, {}};
 		if (_value)
-			varDecl.value = make_shared<Expression>(std::move(*_value));
+			varDecl.value = make_unique<Expression>(std::move(*_value));
 		else
-			varDecl.value = make_shared<Expression>(zero);
+			varDecl.value = make_unique<Expression>(zero);
 		newStatements.emplace_back(std::move(varDecl));
 	};
 
@@ -202,7 +202,7 @@ vector<Statement> InlineModifier::performInline(Statement& _statement, FunctionC
 				newStatements.emplace_back(Assignment{
 					_assignment.location,
 					{_assignment.variableNames[i]},
-					make_shared<Expression>(Identifier{
+					make_unique<Expression>(Identifier{
 						_assignment.location,
 						variableReplacements.at(function->returnVariables[i].name)
 					})
@@ -214,7 +214,7 @@ vector<Statement> InlineModifier::performInline(Statement& _statement, FunctionC
 				newStatements.emplace_back(VariableDeclaration{
 					_varDecl.location,
 					{std::move(_varDecl.variables[i])},
-					make_shared<Expression>(Identifier{
+					make_unique<Expression>(Identifier{
 						_varDecl.location,
 						variableReplacements.at(function->returnVariables[i].name)
 					})
@@ -232,10 +232,10 @@ Statement BodyCopier::operator()(VariableDeclaration const& _varDecl)
 	return ASTCopier::operator()(_varDecl);
 }
 
-Statement BodyCopier::operator()(FunctionDefinition const& _funDef)
+Statement BodyCopier::operator()(FunctionDefinition const&)
 {
 	assertThrow(false, OptimizerException, "Function hoisting has to be done before function inlining.");
-	return _funDef;
+	return {};
 }
 
 YulString BodyCopier::translateIdentifier(YulString _name)

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -51,7 +51,11 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 	GenericFallbackReturnsVisitor<OptionalStatements, If, Switch, ForLoop> const visitor(
 		[&](If& _ifStmt) -> OptionalStatements {
 			if (_ifStmt.body.statements.empty())
-				return {{makePopExpressionStatement(_ifStmt.location, std::move(*_ifStmt.condition))}};
+			{
+				OptionalStatements s = vector<Statement>{};
+				s->emplace_back(makePopExpressionStatement(_ifStmt.location, std::move(*_ifStmt.condition)));
+				return s;
+			}
 			if (expressionAlwaysTrue(*_ifStmt.condition))
 				return {std::move(_ifStmt.body.statements)};
 			else if (expressionAlwaysFalse(*_ifStmt.condition))
@@ -64,18 +68,24 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 				auto& switchCase = _switchStmt.cases.front();
 				auto loc = locationOf(*_switchStmt.expression);
 				if (switchCase.value)
-					return {{If{
+				{
+					OptionalStatements s = vector<Statement>{};
+					s->emplace_back(If{
 						std::move(_switchStmt.location),
-						make_shared<Expression>(FunctionalInstruction{
+						make_unique<Expression>(FunctionalInstruction{
 								std::move(loc),
 								solidity::Instruction::EQ,
 								{std::move(*switchCase.value), std::move(*_switchStmt.expression)}
-						}), std::move(switchCase.body)}}};
+						}), std::move(switchCase.body)});
+					return s;
+				}
 				else
-					return {{
-						makePopExpressionStatement(loc, std::move(*_switchStmt.expression)),
-						std::move(switchCase.body)
-					}};
+				{
+					OptionalStatements s = vector<Statement>{};
+					s->emplace_back(makePopExpressionStatement(loc, std::move(*_switchStmt.expression)));
+					s->emplace_back(std::move(switchCase.body));
+					return s;
+				}
 			}
 			else
 				return {};

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -100,7 +100,7 @@ bool SyntacticallyEqual::statementEqual(Assignment const& _lhs, Assignment const
 bool SyntacticallyEqual::statementEqual(VariableDeclaration const& _lhs, VariableDeclaration const& _rhs)
 {
 	// first visit expression, then variable declarations
-	if (!compareSharedPtr<Expression, &SyntacticallyEqual::operator()>(_lhs.value, _rhs.value))
+	if (!compareUniquePtr<Expression, &SyntacticallyEqual::operator()>(_lhs.value, _rhs.value))
 		return false;
 	return containerEqual(_lhs.variables, _rhs.variables, [this](TypedName const& _lhsVarName, TypedName const& _rhsVarName) -> bool {
 		return this->visitDeclaration(_lhsVarName, _rhsVarName);
@@ -123,7 +123,7 @@ bool SyntacticallyEqual::statementEqual(FunctionDefinition const& _lhs, Function
 bool SyntacticallyEqual::statementEqual(If const& _lhs, If const& _rhs)
 {
 	return
-		compareSharedPtr<Expression, &SyntacticallyEqual::operator()>(_lhs.condition, _rhs.condition) &&
+		compareUniquePtr<Expression, &SyntacticallyEqual::operator()>(_lhs.condition, _rhs.condition) &&
 		statementEqual(_lhs.body, _rhs.body);
 }
 
@@ -139,7 +139,7 @@ bool SyntacticallyEqual::statementEqual(Switch const& _lhs, Switch const& _rhs)
 	for (auto const& rhsCase: _rhs.cases)
 		rhsCases.insert(&rhsCase);
 	return
-		compareSharedPtr<Expression, &SyntacticallyEqual::operator()>(_lhs.expression, _rhs.expression) &&
+		compareUniquePtr<Expression, &SyntacticallyEqual::operator()>(_lhs.expression, _rhs.expression) &&
 		containerEqual(lhsCases, rhsCases, [this](Case const* _lhsCase, Case const* _rhsCase) -> bool {
 			return this->switchCaseEqual(*_lhsCase, *_rhsCase);
 		});
@@ -149,7 +149,7 @@ bool SyntacticallyEqual::statementEqual(Switch const& _lhs, Switch const& _rhs)
 bool SyntacticallyEqual::switchCaseEqual(Case const& _lhs, Case const& _rhs)
 {
 	return
-		compareSharedPtr<Literal, &SyntacticallyEqual::expressionEqual>(_lhs.value, _rhs.value) &&
+		compareUniquePtr<Literal, &SyntacticallyEqual::expressionEqual>(_lhs.value, _rhs.value) &&
 		statementEqual(_lhs.body, _rhs.body);
 }
 
@@ -157,7 +157,7 @@ bool SyntacticallyEqual::statementEqual(ForLoop const& _lhs, ForLoop const& _rhs
 {
 	return
 		statementEqual(_lhs.pre, _rhs.pre) &&
-		compareSharedPtr<Expression, &SyntacticallyEqual::operator()>(_lhs.condition, _rhs.condition) &&
+		compareUniquePtr<Expression, &SyntacticallyEqual::operator()>(_lhs.condition, _rhs.condition) &&
 		statementEqual(_lhs.body, _rhs.body) &&
 		statementEqual(_lhs.post, _rhs.post);
 }

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -76,7 +76,7 @@ private:
 	}
 
 	template<typename T, bool (SyntacticallyEqual::*CompareMember)(T const&, T const&)>
-	bool compareSharedPtr(std::shared_ptr<T> const& _lhs, std::shared_ptr<T> const& _rhs)
+	bool compareUniquePtr(std::unique_ptr<T> const& _lhs, std::unique_ptr<T> const& _rhs)
 	{
 		return (_lhs == _rhs) || (_lhs && _rhs && (this->*CompareMember)(*_lhs, *_rhs));
 	}

--- a/libyul/optimiser/VarDeclInitializer.cpp
+++ b/libyul/optimiser/VarDeclInitializer.cpp
@@ -39,7 +39,7 @@ void VarDeclInitializer::operator()(Block& _block)
 				return {};
 			else if (_varDecl.variables.size() == 1)
 			{
-				_varDecl.value = make_shared<Expression>(zero);
+				_varDecl.value = make_unique<Expression>(zero);
 				return {};
 			}
 			else
@@ -47,7 +47,7 @@ void VarDeclInitializer::operator()(Block& _block)
 				OptionalStatements ret{vector<Statement>{}};
 				langutil::SourceLocation loc{std::move(_varDecl.location)};
 				for (auto& var: _varDecl.variables)
-					ret->push_back(VariableDeclaration{loc, {std::move(var)}, make_shared<Expression>(zero)});
+					ret->push_back(VariableDeclaration{loc, {std::move(var)}, make_unique<Expression>(zero)});
 				return ret;
 			}
 		}


### PR DESCRIPTION
make use of unique_ptr instead of shared_ptr within the scope of libyul

Fixes #5653.
