### PR TITLE
DOCS: Remove comments FAQ item

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -71,12 +71,6 @@ arguments for you.
 See `ping.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_ping.sol>`_ and
 `pong.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_pong.sol>`_.
 
-Are comments included with deployed contracts and do they increase deployment gas?
-==================================================================================
-
-No, everything that is not needed for execution is removed during compilation.
-This includes, among others, comments, variable names and type names.
-
 What happens if you send ether along with a function call to a contract?
 ========================================================================
 


### PR DESCRIPTION
### Description

Remove FAQ item about comments not included with deployed contracts, it's covered already now. Part of https://github.com/ethereum/solidity/issues/1219

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
