### PR TITLE
[SMTChecker] Clear state knowledge after external function calls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Language Features:
 Compiler Features:
  * Control Flow Graph: Warn about unreachable code.
  * SMTChecker: Support basic typecasts without truncation.
+ * SMTChecker: Support external function calls and erase all knowledge regarding storage variables and references.
 
 
 Bugfixes:

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -147,8 +147,11 @@ private:
 
 	void initializeLocalVariables(FunctionDefinition const& _function);
 	void initializeFunctionCallParameters(FunctionDefinition const& _function, std::vector<smt::Expression> const& _callArgs);
+	void resetVariable(VariableDeclaration const& _variable);
 	void resetStateVariables();
+	void resetStorageReferences();
 	void resetVariables(std::vector<VariableDeclaration const*> _variables);
+	void resetVariables(std::function<bool(VariableDeclaration const&)> const& _filter);
 	/// Given two different branches and the touched variables,
 	/// merge the touched variables into after-branch ite variables
 	/// using the branch condition as guard.

--- a/test/libsolidity/smtCheckerTests/functions/function_call_does_not_clear_local_vars.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_call_does_not_clear_local_vars.sol
@@ -9,5 +9,4 @@ contract C {
     }
 }
 // ----
-// Warning: (99-107): Assertion checker does not yet implement this type of function call.
 // Warning: (141-144): Assertion checker does not support recursive function calls.

--- a/test/libsolidity/smtCheckerTests/functions/functions_external_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_external_1.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract D
+{
+	function g(uint x) public;
+}
+
+contract C
+{
+	uint x;
+	function f(uint y, D d) public {
+		require(x == y);
+		assert(x == y);
+		d.g(y);
+		// Storage knowledge is cleared after an external call.
+		assert(x == y);
+	}
+}
+// ----
+// Warning: (119-122): Assertion checker does not yet support the type of this variable.
+// Warning: (240-254): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/functions/functions_external_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_external_2.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract D
+{
+	function g(uint x) public;
+}
+
+contract C
+{
+	mapping (uint => uint) map;
+	function f(uint y, D d) public {
+		require(map[0] == map[1]);
+		assert(map[0] == map[1]);
+		d.g(y);
+		// Storage knowledge is cleared after an external call.
+		assert(map[0] == map[1]);
+	}
+}
+// ----
+// Warning: (139-142): Assertion checker does not yet support the type of this variable.
+// Warning: (280-304): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/functions/functions_external_3.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_external_3.sol
@@ -1,0 +1,22 @@
+pragma experimental SMTChecker;
+
+contract D
+{
+	function g(uint x) public;
+}
+
+contract C
+{
+	mapping (uint => uint) storageMap;
+	function f(uint y, D d) public {
+		mapping (uint => uint) storage map = storageMap;
+		require(map[0] == map[1]);
+		assert(map[0] == map[1]);
+		d.g(y);
+		// Storage knowledge is cleared after an external call.
+		assert(map[0] == map[1]);
+	}
+}
+// ----
+// Warning: (146-149): Assertion checker does not yet support the type of this variable.
+// Warning: (338-362): Assertion violation happens here


### PR DESCRIPTION
Fixes #5190 