### PR TITLE
[DOCS] fix typo in docs/contracts.rst

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -585,9 +585,8 @@ return variables and then using ``return;`` to leave the function.
 Returning Multiple Values
 -------------------------
 
-When a function has multiple return types, the statement ``return (v0, v1, ..., vn) can be used to return multiple values.
-vn)`` can return multiple values.  The number of components must be
-the same as the number of return types.
+When a function has multiple return types, the statement ``return (v0, v1, ..., vn)`` can be used to return multiple values.
+The number of components must be the same as the number of return types.
 
 .. index:: ! view function, function;view
 


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description
Simple typo in `docs/contracts.rst`. Sentence was [odd](https://solidity.readthedocs.io/en/v0.5.2/contracts.html#returning-multiple-values).
<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
