### PR TITLE
resolve spelling issues in the docs folder

### DIFF
--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -171,7 +171,7 @@ Command Line and JSON Interfaces
   the first 36 hex characters of the keccak256 hash of the fully qualified
   library name, surrounded by ``$...$``. Previously,
   just the fully qualified library name was used.
-  This recudes the chances of collisions, especially when long paths are used.
+  This reduces the chances of collisions, especially when long paths are used.
   Binary files now also contain a list of mappings from these placeholders
   to the fully qualified names.
 

--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -597,7 +597,7 @@ Strict encoding mode is the mode that leads to exactly the same encoding as defi
 This means offsets have to be as small as possible while still not creating overlaps in the data areas and thus no gaps are
 allowed.
 
-Usually, ABI decoders are written in a straigthforward way just following offset pointers, but some decoders
+Usually, ABI decoders are written in a straightforward way just following offset pointers, but some decoders
 might enforce strict mode. The Solidity ABI decoder currently does not enforce strict mode, but the encoder
 always creates data in strict mode.
 

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -43,7 +43,7 @@
     {
         "name": "DelegateCallReturnValue",
         "summary": "The low-level .delegatecall() does not return the execution outcome, but converts the value returned by the functioned called to a boolean instead.",
-        "description": "The return value of the low-level .delegatecall() function is taken from a position in memory, where the call data or the return data resides. This value is interpreted as a boolean and put onto the stack. This means if the called function returns at least 32 zero bytes, .delegatecall() returns false even if the call was successuful.",
+        "description": "The return value of the low-level .delegatecall() function is taken from a position in memory, where the call data or the return data resides. This value is interpreted as a boolean and put onto the stack. This means if the called function returns at least 32 zero bytes, .delegatecall() returns false even if the call was successful.",
         "introduced": "0.3.0",
         "fixed": "0.4.15",
         "severity": "low"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -112,7 +112,7 @@ For example, you could run the following command in your ``build`` folder:
    cmake -DCMAKE_BUILD_TYPE=Debug ..
    make
 
-This will create symbols such that when you debug a test using the ``--debug`` flag, you will have acecess to functions and varialbes in which you can break or print with.
+This will create symbols such that when you debug a test using the ``--debug`` flag, you will have access to functions and variables in which you can break or print with.
 
 
 The script ``./scripts/tests.sh`` also runs commandline tests and compilation tests

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -171,7 +171,7 @@ As an exception, identifiers defined in the "init" part of the for-loop
 (the first block) are visible in all other parts of the for-loop
 (but not outside of the loop).
 Identifiers declared in the other parts of the for loop respect the regular
-syntatical scoping rules.
+syntactical scoping rules.
 The parameters and return parameters of functions are visible in the
 function body and their names cannot overlap.
 


### PR DESCRIPTION
### Description

Made some minor spelling changes in the docs/* folder that had been bugging me for a while. specifically in:
docs/050-breaking-changes.rst 
docs/abi-spec.rst
docs/bugs.json
docs/contributing.rst
docs/yul.rst

### Checklist

- [ ] Code compiles correctly (  N/A did not touch any of the code just docs.)
- [ ] All tests are passing (  N/A did not touch any of the code just docs.)
- [ ] New tests have been created which fail without the change (if possible)   N/A did not touch any of the code just docs.
- [X ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)   N/A did not touch any of the code just docs.
- [ X] Used meaningful commit messages
