### PR TITLE
Update install_deps.sh

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -352,7 +352,7 @@ case $(uname -s) in
 # CentOS needs some more testing. This is the general idea of packages
 # needed, but some tweaking/improvements can definitely happen
 #------------------------------------------------------------------------------
-            CentOS)
+            CentOS*)
                 read -p "This script will heavily modify your system in order to allow for compilation of Solidity. Are you sure? [Y/N]" -n 1 -r
                 if [[ $REPLY =~ ^[Yy]$ ]]; then
                     # Make Sure we have the EPEL repos


### PR DESCRIPTION
In install_deps.sh, line 59 (sed -n -e 's/^NAME="?([^"])"?$/\1/p' /etc/os-release) will get CentOS Linux instead of CentOS, so it cant match CentOS.
I suggest that in line 355， can modified " CentOS)" to " CentOS*)"

Closes #5692.

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
