### PR TITLE
clarify antecedents in deprecation notices

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -103,11 +103,11 @@ Block and Transaction Properties
     values will be zero.
 
 .. note::
-    The function ``blockhash`` was previously known as ``block.blockhash``. It was deprecated in
+    The function ``blockhash`` was previously known as ``block.blockhash``, which was deprecated in
     version 0.4.22 and removed in version 0.5.0.
 
 .. note::
-    The function ``gasleft`` was previously known as ``msg.gas``. It was deprecated in
+    The function ``gasleft`` was previously known as ``msg.gas``, which was deprecated in
     version 0.4.21 and removed in version 0.5.0.
 
 .. index:: abi, encoding, packed


### PR DESCRIPTION
This is a change to the documentation [here](https://solidity.readthedocs.io/en/latest/units-and-global-variables.html) which clarifies which variables have been deprecated.  The current version seems to imply that the new functions `blockhash` and `gasleft` have been deprecated.