### PR TITLE
Extract semantic tests Pt. 1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 
 Compiler Features:
  * Control Flow Graph: Warn about unreachable code.
+ * Tests: Add infrastructure to ``isoltest`` for running semantic tests.
 
 
 Bugfixes:

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -49,8 +49,13 @@ string getIPCSocketPath()
 
 }
 
-ExecutionFramework::ExecutionFramework() :
-	m_rpc(RPCSession::instance(getIPCSocketPath())),
+ExecutionFramework::ExecutionFramework():
+	ExecutionFramework(getIPCSocketPath())
+{
+}
+
+ExecutionFramework::ExecutionFramework(string const& _ipcPath):
+	m_rpc(RPCSession::instance(_ipcPath)),
 	m_evmVersion(dev::test::Options::get().evmVersion()),
 	m_optimize(dev::test::Options::get().optimize),
 	m_showMessages(dev::test::Options::get().showMessages),

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -53,6 +53,7 @@ class ExecutionFramework
 
 public:
 	ExecutionFramework();
+	ExecutionFramework(std::string const& _ipcPath);
 	virtual ~ExecutionFramework() = default;
 
 	virtual bytes const& compileAndRunWithoutCheck(

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -20,6 +20,7 @@
 #include <test/TestCase.h>
 #include <test/libsolidity/ASTJSONTest.h>
 #include <test/libsolidity/SyntaxTest.h>
+#include <test/libsolidity/SemanticTest.h>
 #include <test/libsolidity/SMTCheckerJSONTest.h>
 #include <test/libyul/YulOptimizerTest.h>
 #include <test/libyul/ObjectCompilerTest.h>
@@ -52,6 +53,7 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"Yul Optimizer",       "libyul",      "yulOptimizerTests",   false, false, &yul::test::YulOptimizerTest::create},
 	{"Yul Object Compiler", "libyul",      "objectCompiler",      false, false, &yul::test::ObjectCompilerTest::create},
 	{"Syntax",              "libsolidity", "syntaxTests",         false, false, &SyntaxTest::create},
+	{"Semantic",            "libsolidity", "semanticTests",       false, true,  &SemanticTest::create},
 	{"JSON AST",            "libsolidity", "ASTJSON",             false, false, &ASTJSONTest::create},
 	{"SMT Checker",         "libsolidity", "smtCheckerTests",     true,  false, &SyntaxTest::create},
 	{"SMT Checker JSON",    "libsolidity", "smtCheckerTestsJSON", true,  false, &SMTCheckerTest::create}

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -34,7 +34,13 @@ namespace test
 class TestCase
 {
 public:
-	using TestCaseCreator = std::unique_ptr<TestCase>(*)(std::string const&);
+	struct Config
+	{
+		std::string filename;
+		std::string ipcPath;
+	};
+
+	using TestCaseCreator = std::unique_ptr<TestCase>(*)(Config const&);
 
 	virtual ~TestCase() = default;
 

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -59,8 +59,6 @@ public:
 	/// Each line of output is prefixed with @arg _linePrefix.
 	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const = 0;
 
-	virtual bool allowsUpdate() const { return true; }
-
 	static bool isTestFilename(boost::filesystem::path const& _filename);
 
 protected:

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -53,6 +53,8 @@ public:
 	/// Each line of output is prefixed with @arg _linePrefix.
 	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const = 0;
 
+	virtual bool allowsUpdate() const { return true; }
+
 	static bool isTestFilename(boost::filesystem::path const& _filename);
 
 protected:

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -138,6 +138,8 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 		if (ts.ipc && options.disableIPC)
 			continue;
 
+		// TODO: remove this or the equivalent call in isoltest.cpp
+		SemanticTest::ipcPath = dev::test::Options::get().ipcPath;
 		solAssert(registerTests(
 			master,
 			options.testPath / ts.path,

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -138,8 +138,8 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 		if (ts.ipc && options.disableIPC)
 			continue;
 
-		// TODO: remove this or the equivalent call in isoltest.cpp
 		SemanticTest::ipcPath = dev::test::Options::get().ipcPath;
+
 		solAssert(registerTests(
 			master,
 			options.testPath / ts.path,

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -74,11 +74,13 @@ int registerTests(
 	boost::unit_test::test_suite& _suite,
 	boost::filesystem::path const& _basepath,
 	boost::filesystem::path const& _path,
+	std::string const& _ipcPath,
 	TestCase::TestCaseCreator _testCaseCreator
 )
 {
 	int numTestsAdded = 0;
 	fs::path fullpath = _basepath / _path;
+	TestCase::Config config{fullpath.string(), _ipcPath};
 	if (fs::is_directory(fullpath))
 	{
 		test_suite* sub_suite = BOOST_TEST_SUITE(_path.filename().string());
@@ -87,7 +89,7 @@ int registerTests(
 			fs::directory_iterator()
 		))
 			if (fs::is_directory(entry.path()) || TestCase::isTestFilename(entry.path().filename()))
-				numTestsAdded += registerTests(*sub_suite, _basepath, _path / entry.path().filename(), _testCaseCreator);
+				numTestsAdded += registerTests(*sub_suite, _basepath, _path / entry.path().filename(), _ipcPath, _testCaseCreator);
 		_suite.add(sub_suite);
 	}
 	else
@@ -96,13 +98,13 @@ int registerTests(
 
 		filenames.emplace_back(new string(_path.string()));
 		_suite.add(make_test_case(
-			[fullpath, _testCaseCreator]
+			[config, _testCaseCreator]
 			{
 				BOOST_REQUIRE_NO_THROW({
 					try
 					{
 						stringstream errorStream;
-						if (!_testCaseCreator(fullpath.string())->run(errorStream))
+						if (!_testCaseCreator(config)->run(errorStream))
 							BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
 					}
 					catch (boost::exception const& _e)
@@ -138,12 +140,11 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 		if (ts.ipc && options.disableIPC)
 			continue;
 
-		SemanticTest::ipcPath = dev::test::Options::get().ipcPath;
-
 		solAssert(registerTests(
 			master,
 			options.testPath / ts.path,
 			ts.subpath,
+			options.ipcPath,
 			ts.testCaseCreator
 		) > 0, std::string("no ") + ts.title + " tests found");
 	}

--- a/test/libsolidity/ASTJSONTest.h
+++ b/test/libsolidity/ASTJSONTest.h
@@ -35,8 +35,8 @@ namespace test
 class ASTJSONTest: public TestCase
 {
 public:
-	static std::unique_ptr<TestCase> create(std::string const& _filename)
-	{ return std::unique_ptr<TestCase>(new ASTJSONTest(_filename)); }
+	static std::unique_ptr<TestCase> create(Config const& _config)
+	{ return std::unique_ptr<TestCase>(new ASTJSONTest(_config.filename)); }
 	ASTJSONTest(std::string const& _filename);
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;

--- a/test/libsolidity/ExpectationParser.cpp
+++ b/test/libsolidity/ExpectationParser.cpp
@@ -1,0 +1,232 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/libsolidity/ExpectationParser.h>
+
+#include <test/Options.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/throw_exception.hpp>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+using namespace dev;
+using namespace langutil;
+using namespace solidity;
+using namespace dev::solidity::test;
+using namespace std;
+
+namespace
+{
+	void expect(std::string::iterator& _it, std::string::iterator _end, std::string::value_type _c)
+	{
+		if (_it == _end || *_it != _c)
+			throw std::runtime_error(std::string("Invalid test expectation. Expected: \"") + _c + "\".");
+		++_it;
+	}
+
+	template<typename IteratorType>
+	void skipWhitespace(IteratorType& _it, IteratorType _end)
+	{
+		while (_it != _end && isspace(*_it))
+			++_it;
+	}
+
+	template<typename IteratorType>
+	void skipSlashes(IteratorType& _it, IteratorType _end)
+	{
+		while (_it != _end && *_it == '/')
+			++_it;
+	}
+}
+
+string ExpectationParser::bytesToString(bytes const& _bytes)
+{
+	std::string result;
+	auto it = _bytes.begin();
+
+	bytes byteRange(it, _bytes.end());
+	stringstream resultStream;
+	// TODO: Convert from compact big endian if padded
+	resultStream << fromBigEndian<u256>(byteRange);
+
+	result += resultStream.str();
+	return result;
+}
+
+bytes ExpectationParser::stringToBytes(std::string _string)
+{
+	bytes result;
+	auto it = _string.begin();
+	while (it != _string.end())
+	{
+		if (isdigit(*it) || (*it == '-' && (it + 1) != _string.end() && isdigit(*(it + 1))))
+		{
+			auto valueBegin = it;
+			while (it != _string.end() && !isspace(*it) && *it != ',')
+				++it;
+
+			bytes newBytes;
+			u256 numberValue(std::string(valueBegin, it));
+			// TODO: Convert to compact big endian if padded
+			if (numberValue == u256(0))
+				newBytes = bytes{0};
+			else
+				newBytes = toBigEndian(numberValue);
+			result += newBytes;
+		}
+		else
+			BOOST_THROW_EXCEPTION(std::runtime_error("Test expectations contain invalidly formatted data."));
+
+		skipWhitespace(it, _string.end());
+		if (it != _string.end())
+			expect(it, _string.end(), ',');
+		skipWhitespace(it, _string.end());
+	}
+	return result;
+}
+
+vector<ExpectationParser::FunctionCall> ExpectationParser::parseFunctionCalls()
+{
+	vector<ExpectationParser::FunctionCall> calls;
+	while (advanceLine())
+	{
+		if (endOfLine())
+			continue;
+		ExpectationParser::FunctionCall call;
+		call.signature = parseFunctionCallSignature();
+		call.costs = parseFunctionCallCosts();
+		call.arguments = parseFunctionCallArgument();
+
+		if (!advanceLine())
+			throw runtime_error("Invalid test expectation. No result specified.");
+
+		call.result = parseFunctionCallResult();
+		calls.emplace_back(std::move(call));
+	}
+	return calls;
+}
+
+string ExpectationParser::parseFunctionCallSignature()
+{
+	auto signatureBegin = m_char;
+	while (!endOfLine() && *m_char != ')')
+		++m_char;
+	expect(m_char, m_line.end(), ')');
+
+	return string{signatureBegin, m_char};
+}
+
+ExpectationParser::FunctionCallArgs ExpectationParser::parseFunctionCallArgument()
+{
+	skipWhitespace(m_char, m_line.end());
+
+	FunctionCallArgs arguments;
+	if (!endOfLine())
+	{
+		if (*m_char != '#')
+		{
+			expect(m_char, m_line.end(), ':');
+			skipWhitespace(m_char, m_line.end());
+
+			auto argumentBegin = m_char;
+			// TODO: allow # in quotes
+			while (!endOfLine() && *m_char != '#')
+				++m_char;
+			arguments.raw = string(argumentBegin, m_char);
+			arguments.input = stringToBytes(arguments.raw);
+		}
+
+		if (!endOfLine())
+		{
+			expect(m_char, m_line.end(), '#');
+			skipWhitespace(m_char, m_line.end());
+			arguments.comment = string(m_char, m_line.end());
+		}
+	}
+	return arguments;
+}
+
+ExpectationParser::FunctionCallResult ExpectationParser::parseFunctionCallResult()
+{
+	FunctionCallResult result;
+	if (!endOfLine() && *m_char == '-')
+	{
+		expect(m_char, m_line.end(), '-');
+		expect(m_char, m_line.end(), '>');
+
+		skipWhitespace(m_char, m_line.end());
+
+		auto expectedResultBegin = m_char;
+		// TODO: allow # in quotes
+		while (!endOfLine() && *m_char != '#')
+			++m_char;
+
+		result.raw = string(expectedResultBegin, m_char);
+		result.output = stringToBytes(result.raw);
+		result.status = true;
+
+		if (!endOfLine())
+		{
+			expect(m_char, m_line.end(), '#');
+			skipWhitespace(m_char, m_line.end());
+			result.comment = string(m_char, m_line.end());
+		}
+	}
+	else
+	{
+		for (char c: string("REVERT"))
+			expect(m_char, m_line.end(), c);
+		result.status = false;
+	}
+	return result;
+}
+
+u256 ExpectationParser::parseFunctionCallCosts()
+{
+	u256 cost;
+	if (!endOfLine() && *m_char == '[')
+	{
+		++m_char;
+		auto etherBegin = m_char;
+		while (m_char != m_line.end() && *m_char != ']')
+			++m_char;
+		string etherString(etherBegin, m_char);
+		cost = u256(etherString);
+		expect(m_char, m_line.end(), ']');
+	}
+	return cost;
+}
+
+bool ExpectationParser::advanceLine()
+{
+	auto& line = getline(m_stream, m_line);
+
+	m_char = m_line.begin();
+	skipSlashes(m_char, m_line.end());
+	skipWhitespace(m_char, m_line.end());
+
+	if (!line)
+		return false;
+	return true;
+}
+
+bool ExpectationParser::endOfLine()
+{
+	return m_char == m_line.end();
+}

--- a/test/libsolidity/ExpectationParser.h
+++ b/test/libsolidity/ExpectationParser.h
@@ -33,16 +33,19 @@ namespace test
 class ExpectationParser
 {
 public:
-	struct FunctionCallResult {
+	struct FunctionCallExpectations
+	{
 		std::string raw;
-		bytes output;
+		bytes rawBytes;
 		bool status = true;
+		std::string output;
 		std::string comment;
 	};
 
-	struct FunctionCallArgs {
+	struct FunctionCallArgs
+	{
 		std::string raw;
-		bytes input;
+		bytes rawBytes;
 		std::string comment;
 	};
 
@@ -50,8 +53,8 @@ public:
 	{
 		std::string signature;
 		FunctionCallArgs arguments;
-		FunctionCallResult result;
-		u256 costs;
+		FunctionCallExpectations expectations;
+		u256 value;
 	};
 
 	static std::string bytesToString(bytes const& _bytes);
@@ -87,8 +90,8 @@ private:
 
 	std::string parseFunctionCallSignature();
 	FunctionCallArgs parseFunctionCallArgument();
-	FunctionCallResult parseFunctionCallResult();
-	u256 parseFunctionCallCosts();
+	FunctionCallExpectations parseFunctionCallExpectations();
+	u256 parseFunctionCallValue();
 
 	void skipWhitespaces();
 	void expectCharacter(char const _char);

--- a/test/libsolidity/ExpectationParser.h
+++ b/test/libsolidity/ExpectationParser.h
@@ -1,0 +1,81 @@
+/*
+	This file is part of solidity.
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libdevcore/CommonData.h>
+#include <libsolidity/ast/Types.h>
+
+#include <iosfwd>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+class ExpectationParser
+{
+public:
+	struct FunctionCallResult {
+		std::string raw;
+		bytes output;
+		bool status = true;
+		std::string comment;
+	};
+
+	struct FunctionCallArgs {
+		std::string raw;
+		bytes input;
+		std::string comment;
+	};
+
+	struct FunctionCall
+	{
+		std::string signature;
+		FunctionCallArgs arguments;
+		FunctionCallResult result;
+		u256 costs;
+	};
+
+	static std::string bytesToString(bytes const& _bytes);
+	static bytes stringToBytes(std::string _string);
+
+	ExpectationParser(std::istream& _stream): m_stream(_stream) {}
+
+	std::vector<FunctionCall> parseFunctionCalls();
+
+private:
+	std::string parseFunctionCallSignature();
+	FunctionCallArgs parseFunctionCallArgument();
+	FunctionCallResult parseFunctionCallResult();
+	u256 parseFunctionCallCosts();
+
+	bool advanceLine();
+	bool endOfLine();
+
+	std::istream& m_stream;
+	std::string m_line;
+	std::string::iterator m_char;
+
+};
+
+}
+}
+}

--- a/test/libsolidity/ExpectationParser.h
+++ b/test/libsolidity/ExpectationParser.h
@@ -57,23 +57,44 @@ public:
 	static std::string bytesToString(bytes const& _bytes);
 	static bytes stringToBytes(std::string _string);
 
-	ExpectationParser(std::istream& _stream): m_stream(_stream) {}
+	ExpectationParser(std::istream& _stream): m_scanner(_stream) {}
 
 	std::vector<FunctionCall> parseFunctionCalls();
 
 private:
+	class Scanner {
+	public:
+		Scanner(std::istream& _stream): m_stream(_stream) {}
+
+		char current() const { return *m_char; }
+		bool eol() const { return m_char == m_line.end(); }
+		std::string::iterator& position() { return m_char; }
+		std::string::iterator endPosition() { return m_line.end(); }
+
+		void advance() { ++m_char; }
+		bool advanceLine()
+		{
+			auto& line = getline(m_stream, m_line);
+			m_char = m_line.begin();
+			return line ? true : false;
+		}
+
+	private:
+		std::string m_line;
+		std::string::iterator m_char;
+		std::istream& m_stream;
+	};
+
 	std::string parseFunctionCallSignature();
 	FunctionCallArgs parseFunctionCallArgument();
 	FunctionCallResult parseFunctionCallResult();
 	u256 parseFunctionCallCosts();
 
+	void skipWhitespaces();
+	void expectCharacter(char const _char);
 	bool advanceLine();
-	bool endOfLine();
 
-	std::istream& m_stream;
-	std::string m_line;
-	std::string::iterator m_char;
-
+	Scanner m_scanner;
 };
 
 }

--- a/test/libsolidity/ExpectationParser.h
+++ b/test/libsolidity/ExpectationParser.h
@@ -33,10 +33,20 @@ namespace test
 class ExpectationParser
 {
 public:
+	struct ByteFormat
+	{
+		enum Type {
+			UnsignedDec,
+			SignedDec
+		};
+		Type type;
+	};
+
 	struct FunctionCallExpectations
 	{
 		std::string raw;
 		bytes rawBytes;
+		ByteFormat format;
 		bool status = true;
 		std::string output;
 		std::string comment;
@@ -46,6 +56,7 @@ public:
 	{
 		std::string raw;
 		bytes rawBytes;
+		ByteFormat format;
 		std::string comment;
 	};
 
@@ -57,8 +68,8 @@ public:
 		u256 value;
 	};
 
-	static std::string bytesToString(bytes const& _bytes);
-	static bytes stringToBytes(std::string _string);
+	static std::string bytesToString(bytes const& _bytes, ByteFormat const& _format);
+	static std::pair<bytes, ByteFormat> stringToBytes(std::string _string);
 
 	ExpectationParser(std::istream& _stream): m_scanner(_stream) {}
 

--- a/test/libsolidity/SMTCheckerJSONTest.h
+++ b/test/libsolidity/SMTCheckerJSONTest.h
@@ -33,9 +33,9 @@ namespace test
 class SMTCheckerTest: public SyntaxTest
 {
 public:
-	static std::unique_ptr<TestCase> create(std::string const& _filename)
+	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
-		return std::unique_ptr<TestCase>(new SMTCheckerTest(_filename));
+		return std::unique_ptr<TestCase>(new SMTCheckerTest(_config.filename));
 	}
 	SMTCheckerTest(std::string const& _filename);
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -80,15 +80,18 @@ bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool const _
 	return true;
 }
 
-void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool const _formatted) const
+void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool const) const
 {
-	if (_formatted)
-		_stream << _linePrefix;
+	stringstream stream(m_source);
+	string line;
+	while (getline(stream, line))
+		_stream << _linePrefix << line << endl;
 }
 
-void SemanticTest::printUpdatedExpectations(ostream& _stream, string const& _linePrefix) const
+void SemanticTest::printUpdatedExpectations(ostream& _stream, string const&) const
 {
-	_stream << _linePrefix;
+	solAssert(_stream, "");
+	solUnimplemented("Printing update expectations not implemented.");
 }
 
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -35,8 +35,8 @@ using namespace boost;
 using namespace boost::algorithm;
 using namespace boost::unit_test;
 
-SemanticTest::SemanticTest(string const& _filename):
-	SolidityExecutionFramework(ipcPath)
+SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath):
+	SolidityExecutionFramework(_ipcPath)
 {
 	ifstream file(_filename);
 	if (!file)
@@ -158,5 +158,3 @@ void SemanticTest::printFunctionCallTest(
 		_stream << " # " << _test.call.expectations.comment;
 	_stream << endl;
 }
-
-string SemanticTest::ipcPath;

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -107,10 +107,13 @@ void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool
 		_stream << _linePrefix << line << endl;
 }
 
-void SemanticTest::printUpdatedExpectations(ostream& _stream, string const&) const
+void SemanticTest::printUpdatedExpectations(ostream& _stream, string const& _linePrefix) const
 {
-	solAssert(_stream, "");
-	solUnimplemented("Printing update expectations not implemented.");
+	for (auto const& test: m_tests)
+	{
+		printFunctionCall(_stream, test.call, _linePrefix);
+		printFunctionCallTest(_stream, test, false, _linePrefix);
+	}
 }
 
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -69,7 +69,7 @@ bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool const _
 
 		string resultOutput;
 		if (m_transactionSuccessful)
-			resultOutput = "-> " + ExpectationParser::bytesToString(output);
+			resultOutput = "-> " + ExpectationParser::bytesToString(output, test.call.expectations.format);
 		else
 			resultOutput = "REVERT";
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -53,28 +53,47 @@ bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool const _
 		BOOST_THROW_EXCEPTION(runtime_error("Failed to deploy contract."));
 
 	bool success = true;
-	m_results.clear();
+	for (auto& test: m_tests)
+		test.reset();
 
-	for (auto const& test: m_calls)
+	for (auto& test: m_tests)
 	{
 		bytes output = callContractFunctionWithValueNoEncoding(
-			test.signature,
-			test.costs,
-			test.arguments.input
+			test.call.signature,
+			test.call.value,
+			test.call.arguments.rawBytes
 		);
-		if ((m_transactionSuccessful != test.result.status) || (output != test.result.output))
+
+		if ((m_transactionSuccessful != test.call.expectations.status) || (output != test.call.expectations.rawBytes))
 			success = false;
 
-		m_results.emplace_back(m_transactionSuccessful, std::move(output));
+		string resultOutput;
+		if (m_transactionSuccessful)
+			resultOutput = "-> " + ExpectationParser::bytesToString(output);
+		else
+			resultOutput = "REVERT";
+
+		test.status = m_transactionSuccessful;
+		test.rawBytes = std::move(output);
+		test.output = std::move(resultOutput);
 	}
 
 	if (!success)
 	{
 		string nextIndentLevel = _linePrefix + "  ";
 		FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
-		printCalls(false, _stream, nextIndentLevel, _formatted);
+		for (auto const& test: m_tests)
+		{
+			printFunctionCall(_stream, test.call, _linePrefix);
+			printFunctionCallTest(_stream, test, true, _linePrefix, _formatted);
+		}
+
 		FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << endl;
-		printCalls(true, _stream, nextIndentLevel, _formatted);
+		for (auto const& test: m_tests)
+		{
+			printFunctionCall(_stream, test.call, _linePrefix);
+			printFunctionCallTest(_stream, test, false, _linePrefix, _formatted);
+		}
 		return false;
 	}
 	return true;
@@ -98,7 +117,8 @@ void SemanticTest::printUpdatedExpectations(ostream& _stream, string const&) con
 void SemanticTest::parseExpectations(istream& _stream)
 {
 	ExpectationParser parser{_stream};
-	m_calls = parser.parseFunctionCalls();
+	for (auto const& call: parser.parseFunctionCalls())
+		m_tests.emplace_back(FunctionCallTest{std::move(call), false, bytes{}, string{}});
 }
 
 bool SemanticTest::deploy(string const& _contractName, u256 const& _value, bytes const& _arguments)
@@ -107,55 +127,36 @@ bool SemanticTest::deploy(string const& _contractName, u256 const& _value, bytes
 	return !output.empty() && m_transactionSuccessful;
 }
 
-void SemanticTest::printCalls(
-	bool _actualResults,
+void SemanticTest::printFunctionCall(ostream& _stream, FunctionCall const& _call, string const& _linePrefix) const
+{
+	_stream << _linePrefix << _call.signature;
+	if (_call.value > u256(0))
+		_stream << "[" << _call.value << "]";
+	if (!_call.arguments.raw.empty())
+		_stream << ": " << boost::algorithm::trim_copy(_call.arguments.raw);
+	if (!_call.arguments.comment.empty())
+		_stream << " # " << _call.arguments.comment;
+	_stream << endl;
+}
+
+void SemanticTest::printFunctionCallTest(
 	ostream& _stream,
+	FunctionCallTest const& _test,
+	bool _expected,
 	string const& _linePrefix,
 	bool const _formatted
 ) const
 {
-	solAssert(m_calls.size() == m_results.size(), "");
-	for (size_t i = 0; i < m_calls.size(); i++)
-	{
-		auto const& call = m_calls[i];
-		_stream << _linePrefix << call.signature;
-		if (call.costs > u256(0))
-			_stream << "[" << call.costs << "]";
-		if (!call.arguments.raw.empty())
-			_stream << ": " << boost::algorithm::trim_copy(call.arguments.raw);
-		if (!call.arguments.comment.empty())
-			_stream << " # " << call.arguments.comment;
-		_stream << endl;
-
-		string result;
-		auto expectedBytes = ExpectationParser::stringToBytes(call.result.raw);
-		if (_actualResults)
-		{
-			if (m_results[i].first)
-				result = "-> " + ExpectationParser::bytesToString(m_results[i].second);
-			else
-				result = "REVERT";
-		}
-		else
-		{
-			if (call.result.status)
-				result = "-> " + call.result.raw;
-			else
-				result = "REVERT";
-		}
-
-		bool expectationsMatch = (m_results[i].first == call.result.status) && (m_results[i].second == expectedBytes);
-
-		_stream << _linePrefix;
-		if (_formatted && !expectationsMatch)
-			_stream << formatting::RED_BACKGROUND;
-		_stream << boost::algorithm::trim_copy(result);
-		if (_formatted && !expectationsMatch)
-			_stream << formatting::RESET;
-		if (!call.result.comment.empty())
-			_stream << " # " << call.result.comment;
-		_stream << endl;
-	}
+	_stream << _linePrefix;
+	if (_formatted && !_test.matchesExpectation())
+		_stream << formatting::RED_BACKGROUND;
+	string output = _expected ? _test.call.expectations.output : _test.output;
+	_stream << boost::algorithm::trim_copy(output);
+	if (_formatted && !_test.matchesExpectation())
+		_stream << formatting::RESET;
+	if (!_test.call.expectations.comment.empty())
+		_stream << " # " << _test.call.expectations.comment;
+	_stream << endl;
 }
 
 string SemanticTest::ipcPath;

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -1,0 +1,194 @@
+/*
+	This file is part of solidity.
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/libsolidity/SemanticTest.h>
+#include <test/Options.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/throw_exception.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+using namespace dev;
+using namespace solidity;
+using namespace dev::solidity::test;
+using namespace dev::solidity::test::formatting;
+using namespace std;
+namespace fs = boost::filesystem;
+using namespace boost;
+using namespace boost::algorithm;
+using namespace boost::unit_test;
+
+SemanticTest::SemanticTest(string const& _filename):
+	SolidityExecutionFramework(ipcPath)
+{
+	ifstream file(_filename);
+	if (!file)
+		BOOST_THROW_EXCEPTION(runtime_error("Cannot open test contract: \"" + _filename + "\"."));
+	file.exceptions(ios::badbit);
+
+	m_source = parseSource(file);
+	parseExpectations(file);
+}
+
+bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+{
+	FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
+
+	if (!deploy("", 0, bytes()))
+		BOOST_THROW_EXCEPTION(runtime_error("Failed to deploy contract."));
+
+	bool success = true;
+	m_results.clear();
+
+	for (auto const& test: m_calls)
+	{
+		bytes output = callContractFunctionWithValueNoEncoding(
+			test.signature,
+			test.etherValue,
+			test.argumentBytes
+		);
+
+		if ((m_transactionSuccessful != test.expectedStatus) || (output != test.expectedBytes))
+			success = false;
+
+		m_results.emplace_back(m_transactionSuccessful, std::move(output));
+	}
+
+	if (!success)
+	{
+		string nextIndentLevel = _linePrefix + "  ";
+		FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
+		printCalls(false, _stream, nextIndentLevel, _formatted);
+		FormattedScope(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << endl;
+		printCalls(true, _stream, nextIndentLevel, _formatted);
+		return false;
+	}
+
+	return true;
+}
+
+void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool const _formatted) const
+{
+	if (_formatted)
+		_stream << _linePrefix;
+}
+
+void SemanticTest::printUpdatedExpectations(ostream& _stream, string const& _linePrefix) const
+{
+	_stream << _linePrefix;
+}
+
+
+void SemanticTest::parseExpectations(istream& _stream)
+{
+	string line;
+	bool isPreamble = true;
+	while (getline(_stream, line))
+	{
+		auto it = line.begin();
+
+		skipSlashes(it, line.end());
+		skipWhitespace(it, line.end());
+
+		if (it == line.end())
+			continue;
+
+
+		if (isPreamble)
+		{
+
+		}
+
+		FunctionCall call;
+
+		auto signatureBegin = it;
+		while (it != line.end() && *it != ')')
+			++it;
+		expect(it, line.end(), ')');
+
+		call.signature = string(signatureBegin, it);
+
+		m_calls.emplace_back(std::move(call));
+	}
+}
+
+bool SemanticTest::deploy(string const& _contractName, u256 const& _value, bytes const& _arguments)
+{
+	auto output = compileAndRunWithoutCheck(m_source, _value, _contractName, _arguments, m_libraryAddresses);
+	return !output.empty() && m_transactionSuccessful;
+}
+
+void SemanticTest::printCalls(
+	bool _actualResults,
+	ostream& _stream,
+	string const& _linePrefix,
+	bool const _formatted
+) const
+{
+	solAssert(m_calls.size() == m_results.size(), "");
+	for (size_t i = 0; i < m_calls.size(); i++)
+	{
+		auto const& call = m_calls[i];
+		_stream << _linePrefix << call.signature;
+		if (call.etherValue > u256(0))
+			_stream << "[" << call.etherValue << "]";
+		if (!call.arguments.empty())
+			_stream << ": " << boost::algorithm::trim_copy(call.arguments);
+		if (!call.argumentComment.empty())
+			_stream << " # " << call.argumentComment;
+		_stream << endl;
+
+		if(_actualResults && _formatted)
+			_stream << endl;
+
+//		string result;
+//		std::vector<ByteRangeFormat> formatList;
+//		auto expectedBytes = stringToBytes(call.expectedResult, &formatList);
+//		if (_actualResults)
+//		{
+//			if (m_results[i].first)
+//				result = "-> " + bytesToString(m_results[i].second, formatList);
+//			else
+//				result = "REVERT";
+//		}
+//		else
+//		{
+//			if (call.expectedStatus)
+//				result = "-> " + call.expectedResult;
+//			else
+//				result = "REVERT";
+//		}
+
+//		bool expectationsMatch = (m_results[i].first == call.expectedStatus) && (m_results[i].second == expectedBytes);
+
+//		_stream << _linePrefix;
+//		if (_formatted && !expectationsMatch)
+//			_stream << formatting::RED_BACKGROUND;
+//		_stream << boost::algorithm::trim_copy(result);
+//		if (_formatted && !expectationsMatch)
+//			_stream << formatting::RESET;
+//		if (!call.resultComment.empty())
+//			_stream << " # " << call.resultComment;
+//		_stream << endl;
+	}
+}
+
+
+string SemanticTest::ipcPath;

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -42,8 +42,8 @@ public:
 
 	virtual bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 
-	virtual void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool const _formatted = false) const override;
-	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
+	virtual void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
+	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix = "") const override;
 
 	virtual bool allowsUpdate() const override { return false; }
 

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -57,8 +57,8 @@ private:
 		std::string output;
 		bool matchesExpectation() const
 		{
-			auto expectedBytes = ExpectationParser::stringToBytes(call.expectations.raw);
-			return status == call.expectations.status && rawBytes == expectedBytes;
+			auto expectedByteFormat = ExpectationParser::stringToBytes(call.expectations.raw);
+			return status == call.expectations.status && rawBytes == expectedByteFormat.first;
 		}
 		void reset()
 		{

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -1,0 +1,78 @@
+/*
+	This file is part of solidity.
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <test/libsolidity/FormattedScope.h>
+#include <test/libsolidity/SolidityExecutionFramework.h>
+#include <test/libsolidity/AnalysisFramework.h>
+#include <test/TestCase.h>
+#include <liblangutil/Exceptions.h>
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace dev
+{
+namespace solidity
+{
+namespace test
+{
+
+class SemanticTest: public SolidityExecutionFramework, public TestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(std::string const& _filename)
+	{ return std::unique_ptr<TestCase>(new SemanticTest(_filename)); }
+	SemanticTest(std::string const& _filename);
+
+	virtual bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+
+	virtual void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool const _formatted = false) const override;
+	virtual void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
+
+	virtual bool allowsUpdate() const override { return false; }
+
+	static std::string ipcPath;
+
+private:
+	struct FunctionCall
+	{
+		std::string signature;
+		std::string arguments;
+		bytes argumentBytes;
+		std::string argumentComment;
+		u256 etherValue;
+		bool expectedStatus = true;
+		std::string expectedResult;
+		bytes expectedBytes;
+//		std::vector<ByteRangeFormat> expectedFormat;
+		std::string resultComment;
+	};
+
+	void parseExpectations(std::istream& _stream);
+	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments);
+	void printCalls(bool _actualResults, std::ostream& _stream, std::string const& _linePrefix, bool const _formatted) const;
+
+	std::string m_source;
+	std::vector<FunctionCall> m_calls;
+	std::map<std::string, dev::test::Address> m_libraryAddresses;
+	std::vector<std::pair<bool, bytes>> m_results;
+};
+
+}
+}
+}

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -47,7 +47,6 @@ public:
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 	void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix = "") const override;
-	bool allowsUpdate() const override { return false; }
 
 private:
 	struct FunctionCallTest

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -39,16 +39,15 @@ using Expectation = ExpectationParser::FunctionCallExpectations;
 class SemanticTest: public SolidityExecutionFramework, public TestCase
 {
 public:
-	static std::unique_ptr<TestCase> create(std::string const& _filename)
-	{ return std::unique_ptr<TestCase>(new SemanticTest(_filename)); }
-	SemanticTest(std::string const& _filename);
+	static std::unique_ptr<TestCase> create(Config const& _options)
+	{ return std::unique_ptr<TestCase>(new SemanticTest(_options.filename, _options.ipcPath)); }
+
+	explicit SemanticTest(std::string const& _filename, std::string const& _ipcPath);
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 	void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix = "") const override;
 	bool allowsUpdate() const override { return false; }
-
-	static std::string ipcPath;
 
 private:
 	struct FunctionCallTest

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <test/libsolidity/ExpectationParser.h>
 #include <test/libsolidity/FormattedScope.h>
 #include <test/libsolidity/SolidityExecutionFramework.h>
 #include <test/libsolidity/AnalysisFramework.h>
@@ -49,26 +50,12 @@ public:
 	static std::string ipcPath;
 
 private:
-	struct FunctionCall
-	{
-		std::string signature;
-		std::string arguments;
-		bytes argumentBytes;
-		std::string argumentComment;
-		u256 etherValue;
-		bool expectedStatus = true;
-		std::string expectedResult;
-		bytes expectedBytes;
-//		std::vector<ByteRangeFormat> expectedFormat;
-		std::string resultComment;
-	};
-
 	void parseExpectations(std::istream& _stream);
 	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments);
 	void printCalls(bool _actualResults, std::ostream& _stream, std::string const& _linePrefix, bool const _formatted) const;
 
 	std::string m_source;
-	std::vector<FunctionCall> m_calls;
+	std::vector<ExpectationParser::FunctionCall> m_calls;
 	std::map<std::string, dev::test::Address> m_libraryAddresses;
 	std::vector<std::pair<bool, bytes>> m_results;
 };

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -67,7 +67,6 @@ BOOST_AUTO_TEST_CASE(transaction_status)
 	BOOST_CHECK(!m_transactionSuccessful);
 }
 
-
 BOOST_AUTO_TEST_CASE(smoke_test)
 {
 	char const* sourceCode = R"(
@@ -77,15 +76,6 @@ BOOST_AUTO_TEST_CASE(smoke_test)
 	)";
 	compileAndRun(sourceCode);
 	testContractAgainstCppOnRange("f(uint256)", [](u256 const& a) -> u256 { return a * 7; }, 0, 100);
-}
-
-BOOST_AUTO_TEST_CASE(empty_contract)
-{
-	char const* sourceCode = R"(
-		contract test { }
-	)";
-	compileAndRun(sourceCode);
-	BOOST_CHECK(callContractFunction("i_am_not_there()", bytes()).empty());
 }
 
 BOOST_AUTO_TEST_CASE(exp_operator)
@@ -99,28 +89,6 @@ BOOST_AUTO_TEST_CASE(exp_operator)
 	testContractAgainstCppOnRange("f(uint256)", [](u256 const& a) -> u256 { return u256(1 << a.convert_to<int>()); }, 0, 16);
 }
 
-BOOST_AUTO_TEST_CASE(exp_operator_const)
-{
-	char const* sourceCode = R"(
-		contract test {
-			function f() public returns(uint d) { return 2 ** 3; }
-		}
-	)";
-	compileAndRun(sourceCode);
-	ABI_CHECK(callContractFunction("f()", bytes()), toBigEndian(u256(8)));
-}
-
-BOOST_AUTO_TEST_CASE(exp_operator_const_signed)
-{
-	char const* sourceCode = R"(
-		contract test {
-			function f() public returns(int d) { return (-2) ** 3; }
-		}
-	)";
-	compileAndRun(sourceCode);
-	ABI_CHECK(callContractFunction("f()", bytes()), toBigEndian(u256(-8)));
-}
-
 BOOST_AUTO_TEST_CASE(exp_zero)
 {
 	char const* sourceCode = R"(
@@ -131,18 +99,6 @@ BOOST_AUTO_TEST_CASE(exp_zero)
 	compileAndRun(sourceCode);
 	testContractAgainstCppOnRange("f(uint256)", [](u256 const&) -> u256 { return u256(1); }, 0, 16);
 }
-
-BOOST_AUTO_TEST_CASE(exp_zero_literal)
-{
-	char const* sourceCode = R"(
-		contract test {
-			function f() public returns(uint d) { return 0 ** 0; }
-		}
-	)";
-	compileAndRun(sourceCode);
-	ABI_CHECK(callContractFunction("f()", bytes()), toBigEndian(u256(1)));
-}
-
 
 BOOST_AUTO_TEST_CASE(conditional_expression_true_literal)
 {

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -28,7 +28,12 @@ using namespace dev::test;
 using namespace dev::solidity;
 using namespace dev::solidity::test;
 
-SolidityExecutionFramework::SolidityExecutionFramework() :
+SolidityExecutionFramework::SolidityExecutionFramework():
 	ExecutionFramework()
+{
+}
+
+SolidityExecutionFramework::SolidityExecutionFramework(std::string const& _ipcPath):
+	ExecutionFramework(_ipcPath)
 {
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -43,6 +43,7 @@ class SolidityExecutionFramework: public dev::test::ExecutionFramework
 
 public:
 	SolidityExecutionFramework();
+	SolidityExecutionFramework(std::string const& _ipcPath);
 
 	virtual bytes const& compileAndRunWithoutCheck(
 		std::string const& _sourceCode,

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -53,8 +53,8 @@ struct SyntaxTestError
 class SyntaxTest: AnalysisFramework, public TestCase
 {
 public:
-	static std::unique_ptr<TestCase> create(std::string const& _filename)
-	{ return std::unique_ptr<TestCase>(new SyntaxTest(_filename)); }
+	static std::unique_ptr<TestCase> create(Config const& _config)
+	{ return std::unique_ptr<TestCase>(new SyntaxTest(_config.filename)); }
 	SyntaxTest(std::string const& _filename);
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;

--- a/test/libsolidity/semanticTests/empty_contract.sol
+++ b/test/libsolidity/semanticTests/empty_contract.sol
@@ -1,0 +1,4 @@
+contract test { }
+// ----
+// i_am_not_there()
+// REVERT

--- a/test/libsolidity/semanticTests/empty_contract.sol
+++ b/test/libsolidity/semanticTests/empty_contract.sol
@@ -1,4 +1,4 @@
 contract test { }
 // ----
-// i_am_not_there()
+// i_am_not_there() # This fails.
 // REVERT

--- a/test/libsolidity/semanticTests/exp_operator.sol
+++ b/test/libsolidity/semanticTests/exp_operator.sol
@@ -1,5 +1,9 @@
 contract test {
     function f(uint a) public returns(uint d) { return 2 ** a; }
+    function g(uint a, uint b) public returns(uint c) { return a ** b; }
 }
-// f(uint256): 1
+// ----
+// f(uint256): 1 
 // -> 2
+// g(uint256, uint256): 1, 1
+// REVERT # Argument encoding is not properly implemented, yet.

--- a/test/libsolidity/semanticTests/exp_operator.sol
+++ b/test/libsolidity/semanticTests/exp_operator.sol
@@ -1,0 +1,5 @@
+contract test {
+    function f(uint a) public returns(uint d) { return 2 ** a; }
+}
+// f(uint256): 1
+// -> 2

--- a/test/libsolidity/semanticTests/exp_operator.sol
+++ b/test/libsolidity/semanticTests/exp_operator.sol
@@ -3,7 +3,7 @@ contract test {
     function g(uint a, uint b) public returns(uint c) { return a ** b; }
 }
 // ----
-// f(uint256): 1 
+// f(uint256): 1
 // -> 2
 // g(uint256, uint256): 1, 1
 // REVERT # Argument encoding is not properly implemented, yet.

--- a/test/libsolidity/semanticTests/exp_operator_const.sol
+++ b/test/libsolidity/semanticTests/exp_operator_const.sol
@@ -1,0 +1,6 @@
+contract test {
+    function f() public returns(uint d) { return 2 ** 3; }
+}
+// ----
+// f()
+// -> 8

--- a/test/libsolidity/semanticTests/exp_operator_const_signed.sol
+++ b/test/libsolidity/semanticTests/exp_operator_const_signed.sol
@@ -1,0 +1,6 @@
+contract test {
+    function f() public returns(int d) { return (-2) ** 3; }
+}
+// ----
+// f()
+// -> -8

--- a/test/libsolidity/semanticTests/exp_zero_literal.sol
+++ b/test/libsolidity/semanticTests/exp_zero_literal.sol
@@ -1,0 +1,6 @@
+contract test {
+    function f() public returns(uint d) { return 0 ** 0; }
+}
+// ----
+// f()
+// -> 1

--- a/test/libyul/ObjectCompilerTest.h
+++ b/test/libyul/ObjectCompilerTest.h
@@ -40,9 +40,9 @@ namespace test
 class ObjectCompilerTest: public dev::solidity::test::TestCase
 {
 public:
-	static std::unique_ptr<TestCase> create(std::string const& _filename)
+	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
-		return std::unique_ptr<TestCase>(new ObjectCompilerTest(_filename));
+		return std::unique_ptr<TestCase>(new ObjectCompilerTest(_config.filename));
 	}
 
 	explicit ObjectCompilerTest(std::string const& _filename);

--- a/test/libyul/YulOptimizerTest.h
+++ b/test/libyul/YulOptimizerTest.h
@@ -41,9 +41,9 @@ namespace test
 class YulOptimizerTest: public dev::solidity::test::TestCase
 {
 public:
-	static std::unique_ptr<TestCase> create(std::string const& _filename)
+	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
-		return std::unique_ptr<TestCase>(new YulOptimizerTest(_filename));
+		return std::unique_ptr<TestCase>(new YulOptimizerTest(_config.filename));
 	}
 
 	explicit YulOptimizerTest(std::string const& _filename);

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(isoltest
 	../Common.cpp
 	../TestCase.cpp
 	../libsolidity/SyntaxTest.cpp
+        ../libsolidity/SemanticTest.cpp
 	../libsolidity/AnalysisFramework.cpp
 	../libsolidity/SolidityExecutionFramework.cpp
 	../ExecutionFramework.cpp

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(isoltest
 	../Options.cpp
 	../Common.cpp
 	../TestCase.cpp
+        ../libsolidity/ExpectationParser.cpp
 	../libsolidity/SyntaxTest.cpp
         ../libsolidity/SemanticTest.cpp
 	../libsolidity/AnalysisFramework.cpp

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -380,7 +380,6 @@ Allowed options)",
 				fs::exists(ipcPath),
 				"Invalid ipc path specified."
 			);
-			// TODO: remove this or the equivalent call in boostTest.cpp
 			SemanticTest::ipcPath = ipcPath;
 		}
 

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -161,10 +161,7 @@ TestTool::Request TestTool::handleResponse(bool const _exception)
 	if (_exception)
 		cout << "(e)dit/(s)kip/(q)uit? ";
 	else
-		if (m_test->allowsUpdate())
-			cout << "(e)dit/(u)pdate expectations/(s)kip/(q)uit? ";
-		else
-			cout << "(e)dit/(s)kip/(q)uit? ";
+		cout << "(e)dit/(u)pdate expectations/(s)kip/(q)uit? ";
 	cout.flush();
 
 	while (true)

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -380,6 +380,7 @@ Allowed options)",
 				fs::exists(ipcPath),
 				"Invalid ipc path specified."
 			);
+			// TODO: remove this or the equivalent call in boostTest.cpp
 			SemanticTest::ipcPath = ipcPath;
 		}
 


### PR DESCRIPTION
### Description
Part of https://github.com/ethereum/solidity/issues/4223.
Based on https://github.com/ethereum/solidity/pull/4245.

This PR adds support for running semantic (end-to-end) tests via ``isoltest``. It enables:
- calling functions with *one* argument value and *one* return value
- Argument / return type encodings: ``uint``, ``int`` (unpadded) 
- Test cases like:
```
contract test {
    function f(uint a) public returns(uint d) { return a ** 0; }
}
// ----
// f(uint256): 1 # A comment
// -> 1
```
A test that fails, creates an output of this form:
```
semanticTests/empty_contract.sol: FAIL
  Contract:
    contract test { }

  Expected result:
    i_am_not_there() # This fails.
    -> 1
  Obtained result:
    i_am_not_there() # This fails.
    REVERT
``` 

Not supported:
- Argument / return type encodings: ``string``, ``bool``
- Multiple arguments, return values:
```
// ----
// f(uint256, uint256): 1, 1
// -> bool
```

### Todo
- [ ] Extend documentation (also inline)

### Follow-up PRs
- [ ] Let tests fail that don't specify expectations (Exception vs. fail?)
- [ ] If ``no-ipc`` is specified, at least compile tests
