### PR TITLE
Update to boost 1.68 for emscripten builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Save Boost build
           key: *boost-cache-key
           paths:
-            - boost_1_67_0
+            - boost_1_68_0
       - store_artifacts:
           path: build/libsolc/soljson.js
           destination: soljson.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,7 @@ git:
 cache:
     ccache: true
     directories:
-        - boost_1_67_0
+        - boost_1_68_0
         - $HOME/.local
 
 install:

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -58,7 +58,7 @@ fi
 
 # Boost
 echo -en 'travis_fold:start:compiling_boost\\r'
-cd "$WORKSPACE"/boost_1_67_0
+cd "$WORKSPACE"/boost_1_68_0
 # if b2 exists, it is a fresh checkout, otherwise it comes from the cache
 # and is already compiled
 test -e b2 && (
@@ -84,12 +84,12 @@ cmake \
   -DBoost_FOUND=1 \
   -DBoost_USE_STATIC_LIBS=1 \
   -DBoost_USE_STATIC_RUNTIME=1 \
-  -DBoost_INCLUDE_DIR="$WORKSPACE"/boost_1_67_0/ \
-  -DBoost_FILESYSTEM_LIBRARY_RELEASE="$WORKSPACE"/boost_1_67_0/libboost_filesystem.a \
-  -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE="$WORKSPACE"/boost_1_67_0/libboost_program_options.a \
-  -DBoost_REGEX_LIBRARY_RELEASE="$WORKSPACE"/boost_1_67_0/libboost_regex.a \
-  -DBoost_SYSTEM_LIBRARY_RELEASE="$WORKSPACE"/boost_1_67_0/libboost_system.a \
-  -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE="$WORKSPACE"/boost_1_67_0/libboost_unit_test_framework.a \
+  -DBoost_INCLUDE_DIR="$WORKSPACE"/boost_1_68_0/ \
+  -DBoost_FILESYSTEM_LIBRARY_RELEASE="$WORKSPACE"/boost_1_68_0/libboost_filesystem.a \
+  -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE="$WORKSPACE"/boost_1_68_0/libboost_program_options.a \
+  -DBoost_REGEX_LIBRARY_RELEASE="$WORKSPACE"/boost_1_68_0/libboost_regex.a \
+  -DBoost_SYSTEM_LIBRARY_RELEASE="$WORKSPACE"/boost_1_68_0/libboost_system.a \
+  -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE="$WORKSPACE"/boost_1_68_0/libboost_unit_test_framework.a \
   -DTESTS=0 \
   ..
 make -j 4

--- a/scripts/travis-emscripten/install_deps.sh
+++ b/scripts/travis-emscripten/install_deps.sh
@@ -30,15 +30,15 @@
 set -ev
 
 echo -en 'travis_fold:start:installing_dependencies\\r'
-test -e boost_1_67_0 -a -e boost_1_67_0/boost || (
-rm -rf boost_1_67_0
+test -e boost_1_68_0 -a -e boost_1_68_0/boost || (
+rm -rf boost_1_68_0
 rm -f boost.tar.xz
-wget -q 'https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz/download'\
+wget -q 'https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.tar.gz/download'\
  -O boost.tar.xz
-test "$(shasum boost.tar.xz)" = "77e73c9fd7bf85b14067767b9e8fdc39b49ee0f2  boost.tar.xz"
+test "$(shasum boost.tar.xz)" = "a78cf6ebb111a48385dd0c135e145a6819a8c856  boost.tar.xz"
 tar -xzf boost.tar.xz
 rm boost.tar.xz
-cd boost_1_67_0
+cd boost_1_68_0
 ./bootstrap.sh
 wget -q 'https://raw.githubusercontent.com/tee3/boost-build-emscripten/master/emscripten.jam'
 test "$(shasum emscripten.jam)" = "a7e13fc2c1e53b0e079ef440622f879aa6da3049  emscripten.jam"


### PR DESCRIPTION
Since it came up in #5475, this PR is meant to check whether an update to boost 1.68 will work out of the box or not (it may require an emscripten update).
