### PR TITLE
Change uid and gid for source tarball to 0:0.

### DIFF
--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -33,6 +33,6 @@ REPO_ROOT="$(dirname "$0")"/..
     mkdir -p "$SOLDIR/deps/downloads/" 2>/dev/null || true
     wget -O "$SOLDIR/deps/downloads/jsoncpp-1.8.4.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz
     mkdir -p "$REPO_ROOT/upload"
-    tar --owner user:1000 --group user:1000 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
+    tar --owner 0 --group 0 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
     rm -r "$TEMPDIR"
 )


### PR DESCRIPTION
I think this should have been done instead of #5703.

If a non-root user extracts the archive, ownership will be inherited from the extracting user anyways and if root extracts it, ownership should be root, not ``1000:1000``.