### PR TITLE
[Yul] Variables are free with regards to code size.

### DIFF
--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -91,7 +91,7 @@ public:
 	void tentativelyUpdateCodeSize(YulString _function, YulString _callSite);
 
 private:
-	void updateCodeSize(FunctionDefinition& fun);
+	void updateCodeSize(FunctionDefinition const& _fun);
 	void handleBlock(YulString _currentFunctionName, Block& _block);
 
 	/// The AST to be modified. The root block itself will not be modified, because

--- a/libyul/optimiser/Metrics.cpp
+++ b/libyul/optimiser/Metrics.cpp
@@ -25,6 +25,9 @@
 
 #include <libevmasm/Instruction.h>
 
+#include <libdevcore/Visitor.h>
+
+using namespace std;
 using namespace dev;
 using namespace yul;
 
@@ -45,7 +48,7 @@ size_t CodeSize::codeSize(Expression const& _expression)
 size_t CodeSize::codeSize(Block const& _block)
 {
 	CodeSize cs;
-	cs(_block);
+	cs.visit(_block);
 	return cs.m_size;
 }
 
@@ -53,14 +56,21 @@ void CodeSize::visit(Statement const& _statement)
 {
 	if (_statement.type() == typeid(FunctionDefinition))
 		return;
+	else if (!(
+		_statement.type() == typeid(Block) ||
+		_statement.type() == typeid(ExpressionStatement) ||
+		_statement.type() == typeid(Assignment) ||
+		_statement.type() == typeid(VariableDeclaration)
+	))
+		++m_size;
 
-	++m_size;
 	ASTWalker::visit(_statement);
 }
 
 void CodeSize::visit(Expression const& _expression)
 {
-	++m_size;
+	if (_expression.type() != typeid(Identifier))
+		++m_size;
 	ASTWalker::visit(_expression);
 }
 

--- a/libyul/optimiser/Metrics.h
+++ b/libyul/optimiser/Metrics.h
@@ -30,6 +30,13 @@ namespace yul
  * More specifically, the number of AST nodes.
  * Ignores function definitions while traversing the AST.
  * If you want to know the size of a function, you have to invoke this on its body.
+ *
+ * As an exception, the following AST elements have a cost of zero:
+ *  - expression statement (only the expression inside has a cost)
+ *  - block (only the statements inside have a cost)
+ *  - variable references
+ *  - variable declarations (only the right hand side has a cost)
+ *  - assignments (only the value has a cost)
  */
 class CodeSize: public ASTWalker
 {
@@ -39,6 +46,8 @@ public:
 	static size_t codeSize(Block const& _block);
 
 private:
+	CodeSize() {}
+
 	void visit(Statement const& _statement) override;
 	void visit(Expression const& _expression) override;
 

--- a/test/libyul/Metrics.cpp
+++ b/test/libyul/Metrics.cpp
@@ -1,0 +1,116 @@
+/*
+    This file is part of solidity.
+
+    solidity is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    solidity is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Unit tests for the code metrics.
+ */
+
+#include <test/Options.h>
+
+#include <test/libyul/Common.h>
+
+#include <libyul/optimiser/Metrics.h>
+#include <libyul/AsmData.h>
+
+
+using namespace std;
+using namespace langutil;
+
+namespace yul
+{
+namespace test
+{
+
+namespace
+{
+
+size_t codeSize(string const& _source)
+{
+	shared_ptr<Block> ast = parse(_source, false).first;
+	BOOST_REQUIRE(ast);
+	return CodeSize::codeSize(*ast);
+}
+
+}
+
+BOOST_AUTO_TEST_SUITE(YulCodeSize)
+
+BOOST_AUTO_TEST_CASE(empty_code)
+{
+	BOOST_CHECK_EQUAL(codeSize("{}"), 0);
+}
+
+BOOST_AUTO_TEST_CASE(nested_blocks)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ {} {} {{ }} }"), 0);
+}
+
+BOOST_AUTO_TEST_CASE(instruction)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ pop(calldatasize()) }"), 2);
+}
+
+BOOST_AUTO_TEST_CASE(variables_are_free)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ let x let y let a, b, c }"), 0);
+}
+
+BOOST_AUTO_TEST_CASE(constants_cost_one)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ let x := 3 }"), 1);
+}
+
+BOOST_AUTO_TEST_CASE(functions_are_skipped)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ function f(x) -> r { r := mload(x) } }"), 0);
+}
+
+BOOST_AUTO_TEST_CASE(function_with_arguments)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ function f(x) { sstore(x, 2) } f(2) }"), 2);
+}
+
+BOOST_AUTO_TEST_CASE(function_with_variables_as_arguments)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ function f(x) { sstore(x, 2) } let y f(y) }"), 1);
+}
+
+BOOST_AUTO_TEST_CASE(function_with_variables_and_constants_as_arguments)
+{
+	BOOST_CHECK_EQUAL(codeSize(
+		"{ function f(x, r) -> z { sstore(x, r) z := r } let y let t := f(y, 2) }"
+	), 2);
+}
+
+BOOST_AUTO_TEST_CASE(assignment)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ let a a := 3 }"), 1);
+}
+
+BOOST_AUTO_TEST_CASE(assignments_between_vars_are_free)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ let a let b := a a := b }"), 0);
+}
+
+BOOST_AUTO_TEST_CASE(assignment_complex)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ let a let x := mload(a) a := sload(x) }"), 2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+}

--- a/test/libyul/yulOptimizerTests/fullInliner/large_function_multi_use.yul
+++ b/test/libyul/yulOptimizerTests/fullInliner/large_function_multi_use.yul
@@ -21,22 +21,28 @@
 //     {
 //         let a_1 := mload(2)
 //         let a2 := 2
-//         let r := f(a_1)
-//         let f_a := a2
+//         let f_a := a_1
 //         let f_b := 0
 //         let f_x := mload(f_a)
 //         f_b := sload(f_x)
 //         let f_y := add(f_a, f_x)
 //         sstore(f_y, 10)
-//         let t := f_b
-//         let a3
-//         let f_a_3 := a3
+//         let r := f_b
+//         let f_a_3 := a2
 //         let f_b_4 := 0
 //         let f_x_5 := mload(f_a_3)
 //         f_b_4 := sload(f_x_5)
 //         let f_y_6 := add(f_a_3, f_x_5)
 //         sstore(f_y_6, 10)
-//         let s := f_b_4
+//         let t := f_b_4
+//         let a3
+//         let f_a_8 := a3
+//         let f_b_9 := 0
+//         let f_x_10 := mload(f_a_8)
+//         f_b_9 := sload(f_x_10)
+//         let f_y_11 := add(f_a_8, f_x_10)
+//         sstore(f_y_11, 10)
+//         let s := f_b_9
 //     }
 //     function f(a) -> b
 //     {

--- a/test/libyul/yulOptimizerTests/fullInliner/no_inline_into_big_function.yul
+++ b/test/libyul/yulOptimizerTests/fullInliner/no_inline_into_big_function.yul
@@ -39,6 +39,24 @@
 //         let f_a_35 := f_b_33
 //         let f_b_36 := 0
 //         f_b_36 := sload(mload(f_a_35))
-//         x_1 := f(f(f(f(f(f(f(f(f(f(f(f(f_b_36))))))))))))
+//         let f_a_38 := f_b_36
+//         let f_b_39 := 0
+//         f_b_39 := sload(mload(f_a_38))
+//         let f_a_41 := f_b_39
+//         let f_b_42 := 0
+//         f_b_42 := sload(mload(f_a_41))
+//         let f_a_44 := f_b_42
+//         let f_b_45 := 0
+//         f_b_45 := sload(mload(f_a_44))
+//         let f_a_47 := f_b_45
+//         let f_b_48 := 0
+//         f_b_48 := sload(mload(f_a_47))
+//         let f_a_50 := f_b_48
+//         let f_b_51 := 0
+//         f_b_51 := sload(mload(f_a_50))
+//         let f_a_53 := f_b_51
+//         let f_b_54 := 0
+//         f_b_54 := sload(mload(f_a_53))
+//         x_1 := f(f(f(f(f(f(f_b_54))))))
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/fullInliner/no_inline_into_big_global_context.yul
+++ b/test/libyul/yulOptimizerTests/fullInliner/no_inline_into_big_global_context.yul
@@ -32,7 +32,25 @@
 //         let f_a_35 := f_b_33
 //         let f_b_36 := 0
 //         f_b_36 := sload(mload(f_a_35))
-//         let x_1 := f(f(f(f(f(f(f(f(f(f(f(f(f_b_36))))))))))))
+//         let f_a_38 := f_b_36
+//         let f_b_39 := 0
+//         f_b_39 := sload(mload(f_a_38))
+//         let f_a_41 := f_b_39
+//         let f_b_42 := 0
+//         f_b_42 := sload(mload(f_a_41))
+//         let f_a_44 := f_b_42
+//         let f_b_45 := 0
+//         f_b_45 := sload(mload(f_a_44))
+//         let f_a_47 := f_b_45
+//         let f_b_48 := 0
+//         f_b_48 := sload(mload(f_a_47))
+//         let f_a_50 := f_b_48
+//         let f_b_51 := 0
+//         f_b_51 := sload(mload(f_a_50))
+//         let f_a_53 := f_b_51
+//         let f_b_54 := 0
+//         f_b_54 := sload(mload(f_a_53))
+//         let x_1 := f(f(f(f(f(f(f_b_54))))))
 //     }
 //     function f(a) -> b
 //     {

--- a/test/libyul/yulOptimizerTests/fullSuite/abi2.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/abi2.yul
@@ -1072,8 +1072,13 @@
 // ----
 // fullSuite
 // {
-//     let a, b := abi_decode_tuple_t_contract$_Module_$1038t_contract$_Module_$1038(mload(0), mload(1))
-//     sstore(0, a)
+//     let _2 := mload(1)
+//     let _1042 := mload(0)
+//     if slt(sub(_2, _1042), 64)
+//     {
+//         revert(0, 0)
+//     }
+//     sstore(0, and(calldataload(_1042), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
 //     let x0, x1, x2, x3, x4 := abi_decode_tuple_t_addresst_uint256t_bytes_calldata_ptrt_enum$_Operation_$1949(mload(7), mload(8))
 //     sstore(x1, x0)
 //     sstore(x3, x2)
@@ -1109,59 +1114,31 @@
 //         }
 //         value2_59 := add(_1092, 0x20)
 //         value3 := abi_decode_length_15_689
-//         value4 := cleanup_revert_t_enum$_Operation_$1949(calldataload(add(headStart_55, 96)))
-//     }
-//     function abi_decode_tuple_t_contract$_Module_$1038t_contract$_Module_$1038(headStart_154, dataEnd_155) -> value0_156, value1_157
-//     {
-//         if slt(sub(dataEnd_155, headStart_154), 64)
+//         let _1095 := calldataload(add(headStart_55, 96))
+//         if iszero(lt(_1095, 3))
 //         {
-//             revert(0, 0)
+//             revert(value4, value4)
 //         }
-//         let cleanup_as__1127 := 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
-//         value0_156 := and(calldataload(add(headStart_154, 0)), cleanup_as__1127)
-//         value1_157 := and(calldataload(add(headStart_154, 32)), cleanup_as__1127)
-//     }
-//     function abi_encode_t_address_to_t_address(value_164, pos)
-//     {
-//         mstore(pos, and(value_164, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
-//     }
-//     function abi_encode_t_bytes32_to_t_bytes32(value_171, pos_172)
-//     {
-//         mstore(pos_172, value_171)
-//     }
-//     function abi_encode_t_enum$_Operation_$1949_to_t_uint8(value_181, pos_182)
-//     {
-//         if iszero(lt(value_181, 3))
-//         {
-//             invalid()
-//         }
-//         mstore(pos_182, value_181)
-//     }
-//     function abi_encode_t_uint256_to_t_uint256(value_235, pos_236)
-//     {
-//         mstore(pos_236, value_235)
+//         value4 := _1095
 //     }
 //     function abi_encode_tuple_t_bytes32_t_address_t_uint256_t_bytes32_t_enum$_Operation_$1949_t_uint256_t_uint256_t_uint256_t_address_t_address_t_uint256__to_t_bytes32_t_address_t_uint256_t_bytes32_t_uint8_t_uint256_t_uint256_t_uint256_t_address_t_address_t_uint256_(headStart_252, value10_253, value9_254, value8_255, value7_256, value6_257, value5_258, value4_259, value3_260, value2_261, value1_262, value0_263) -> tail_264
 //     {
 //         tail_264 := add(headStart_252, 352)
-//         abi_encode_t_bytes32_to_t_bytes32(value0_263, headStart_252)
-//         abi_encode_t_address_to_t_address(value1_262, add(headStart_252, 32))
-//         abi_encode_t_uint256_to_t_uint256(value2_261, add(headStart_252, 64))
-//         abi_encode_t_bytes32_to_t_bytes32(value3_260, add(headStart_252, 96))
-//         abi_encode_t_enum$_Operation_$1949_to_t_uint8(value4_259, add(headStart_252, 128))
-//         abi_encode_t_uint256_to_t_uint256(value5_258, add(headStart_252, 160))
-//         abi_encode_t_uint256_to_t_uint256(value6_257, add(headStart_252, 192))
-//         abi_encode_t_uint256_to_t_uint256(value7_256, add(headStart_252, 224))
-//         abi_encode_t_address_to_t_address(value8_255, add(headStart_252, 256))
-//         abi_encode_t_address_to_t_address(value9_254, add(headStart_252, 288))
-//         abi_encode_t_uint256_to_t_uint256(value10_253, add(headStart_252, 320))
-//     }
-//     function cleanup_revert_t_enum$_Operation_$1949(value_369) -> cleaned_370
-//     {
-//         if iszero(lt(value_369, 3))
+//         mstore(headStart_252, value0_263)
+//         let _1307 := 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+//         mstore(add(headStart_252, 32), and(value1_262, _1307))
+//         mstore(add(headStart_252, 64), value2_261)
+//         mstore(add(headStart_252, 96), value3_260)
+//         if iszero(lt(value4_259, 3))
 //         {
-//             revert(0, 0)
+//             invalid()
 //         }
-//         cleaned_370 := value_369
+//         mstore(add(headStart_252, 128), value4_259)
+//         mstore(add(headStart_252, 160), value5_258)
+//         mstore(add(headStart_252, 192), value6_257)
+//         mstore(add(headStart_252, 224), value7_256)
+//         mstore(add(headStart_252, 256), and(value8_255, _1307))
+//         mstore(add(headStart_252, 288), and(value9_254, _1307))
+//         mstore(add(headStart_252, 320), value10_253)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
@@ -458,14 +458,14 @@
 // ----
 // fullSuite
 // {
-//     let _1 := 0x20
-//     let _485 := mload(0)
-//     let abi_encode_pos := _1
+//     let _2 := 0
+//     let _485 := mload(_2)
+//     let abi_encode_pos := 0x20
 //     let abi_encode_length_68 := mload(_485)
-//     mstore(_1, abi_encode_length_68)
+//     mstore(0x20, abi_encode_length_68)
 //     abi_encode_pos := 64
-//     let abi_encode_srcPtr := add(_485, _1)
-//     let abi_encode_i_69 := 0
+//     let abi_encode_srcPtr := add(_485, 0x20)
+//     let abi_encode_i_69 := _2
 //     for {
 //     }
 //     lt(abi_encode_i_69, abi_encode_length_68)
@@ -473,28 +473,32 @@
 //         abi_encode_i_69 := add(abi_encode_i_69, 1)
 //     }
 //     {
-//         let _874 := mload(abi_encode_srcPtr)
-//         let abi_encode_pos_71_978 := abi_encode_pos
-//         let abi_encode_srcPtr_73_980 := _874
-//         let abi_encode_i_74_981 := 0
-//         for {
-//         }
-//         lt(abi_encode_i_74_981, 0x3)
-//         {
-//             abi_encode_i_74_981 := add(abi_encode_i_74_981, 1)
-//         }
-//         {
-//             mstore(abi_encode_pos_71_978, and(mload(abi_encode_srcPtr_73_980), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
-//             abi_encode_srcPtr_73_980 := add(abi_encode_srcPtr_73_980, _1)
-//             abi_encode_pos_71_978 := add(abi_encode_pos_71_978, _1)
-//         }
-//         abi_encode_srcPtr := add(abi_encode_srcPtr, _1)
+//         abi_encode_t_array$_t_contract$_C_$55_$3_memory_to_t_array$_t_address_$3_memory_ptr(mload(abi_encode_srcPtr), abi_encode_pos)
+//         abi_encode_srcPtr := add(abi_encode_srcPtr, 0x20)
 //         abi_encode_pos := add(abi_encode_pos, 0x60)
 //     }
-//     let a, b, c, d := abi_decode_tuple_t_uint256t_uint256t_array$_t_uint256_$dyn_memory_ptrt_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(mload(_1), mload(0x40))
-//     sstore(a, b)
-//     sstore(c, d)
-//     sstore(0, abi_encode_pos)
+//     let _487 := mload(0x40)
+//     let _488 := mload(0x20)
+//     if slt(sub(_487, _488), 128)
+//     {
+//         revert(_2, _2)
+//     }
+//     let abi_decode_offset_64 := calldataload(add(_488, 64))
+//     let abi_decode__165 := 0xffffffffffffffff
+//     if gt(abi_decode_offset_64, abi_decode__165)
+//     {
+//         revert(_2, _2)
+//     }
+//     let abi_decode_value2_587 := abi_decode_t_array$_t_uint256_$dyn_memory_ptr(add(_488, abi_decode_offset_64), _487)
+//     let abi_decode_offset_65 := calldataload(add(_488, 96))
+//     if gt(abi_decode_offset_65, abi_decode__165)
+//     {
+//         revert(_2, _2)
+//     }
+//     let abi_decode_value3_588 := abi_decode_t_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(add(_488, abi_decode_offset_65), _487)
+//     sstore(calldataload(_488), calldataload(add(_488, 32)))
+//     sstore(abi_decode_value2_587, abi_decode_value3_588)
+//     sstore(_2, abi_encode_pos)
 //     function abi_decode_t_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(offset_3, end_4) -> array_5
 //     {
 //         if iszero(slt(add(offset_3, 0x1f), end_4))
@@ -502,17 +506,23 @@
 //             revert(0, 0)
 //         }
 //         let length_6 := calldataload(offset_3)
-//         let array_5_254 := allocateMemory(array_allocation_size_t_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(length_6))
-//         array_5 := array_5_254
-//         let dst_7 := array_5_254
-//         mstore(array_5_254, length_6)
-//         dst_7 := add(array_5_254, 0x20)
-//         let src_8 := add(offset_3, 0x20)
-//         if gt(add(add(offset_3, mul(length_6, 0x40)), 0x20), end_4)
+//         if gt(length_6, 0xffffffffffffffff)
 //         {
 //             revert(0, 0)
 //         }
-//         let i_9 := 0
+//         let array_allo__217 := 0x20
+//         let array_5_254 := allocateMemory(add(mul(length_6, array_allo__217), array_allo__217))
+//         array_5 := array_5_254
+//         let dst_7 := array_5_254
+//         mstore(array_5_254, length_6)
+//         dst_7 := add(array_5_254, array_allo__217)
+//         let src_8 := add(offset_3, array_allo__217)
+//         if gt(add(add(offset_3, mul(length_6, 0x40)), array_allo__217), end_4)
+//         {
+//             revert(0, 0)
+//         }
+//         let i_9_566 := 0
+//         let i_9 := i_9_566
 //         for {
 //         }
 //         lt(i_9, length_6)
@@ -520,87 +530,85 @@
 //             i_9 := add(i_9, 1)
 //         }
 //         {
-//             mstore(dst_7, abi_decode_t_array$_t_uint256_$2_memory(src_8, end_4))
-//             dst_7 := add(dst_7, 0x20)
+//             if iszero(slt(add(src_8, 0x1f), end_4))
+//             {
+//                 revert(i_9_566, i_9_566)
+//             }
+//             let abi_decode_array_13_263 := allocateMemory(array_allocation_size_t_array$_t_uint256_$2_memory(0x2))
+//             let abi_decode_dst_15 := abi_decode_array_13_263
+//             let abi_decode_src_16 := src_8
+//             if gt(add(src_8, 64), end_4)
+//             {
+//                 revert(i_9_566, i_9_566)
+//             }
+//             let abi_decode_i_17 := i_9_566
+//             for {
+//             }
+//             lt(abi_decode_i_17, 0x2)
+//             {
+//                 abi_decode_i_17 := add(abi_decode_i_17, 1)
+//             }
+//             {
+//                 mstore(abi_decode_dst_15, calldataload(abi_decode_src_16))
+//                 abi_decode_dst_15 := add(abi_decode_dst_15, array_allo__217)
+//                 abi_decode_src_16 := add(abi_decode_src_16, array_allo__217)
+//             }
+//             mstore(dst_7, abi_decode_array_13_263)
+//             dst_7 := add(dst_7, array_allo__217)
 //             src_8 := add(src_8, 0x40)
 //         }
 //     }
-//     function abi_decode_t_array$_t_uint256_$2_memory(offset_11, end_12) -> array_13
+//     function abi_decode_t_array$_t_uint256_$dyn_memory_ptr(offset_27, end_28) -> array_29
 //     {
-//         if iszero(slt(add(offset_11, 0x1f), end_12))
+//         if iszero(slt(add(offset_27, 0x1f), end_28))
 //         {
 //             revert(0, 0)
 //         }
-//         let array_13_263 := allocateMemory(64)
-//         array_13 := array_13_263
-//         let dst_15 := array_13_263
-//         let src_16 := offset_11
-//         if gt(add(offset_11, 64), end_12)
+//         let length_30 := calldataload(offset_27)
+//         if gt(length_30, 0xffffffffffffffff)
 //         {
 //             revert(0, 0)
 //         }
-//         let i_17 := 0
+//         let array_allo__234 := 0x20
+//         let array_allo__560 := mul(length_30, array_allo__234)
+//         let array_29_279 := allocateMemory(add(array_allo__560, array_allo__234))
+//         array_29 := array_29_279
+//         let dst_31 := array_29_279
+//         mstore(array_29_279, length_30)
+//         dst_31 := add(array_29_279, array_allo__234)
+//         let src_32 := add(offset_27, array_allo__234)
+//         if gt(add(add(offset_27, array_allo__560), array_allo__234), end_28)
+//         {
+//             revert(0, 0)
+//         }
+//         let i_33 := 0
 //         for {
 //         }
-//         lt(i_17, 0x2)
+//         lt(i_33, length_30)
 //         {
-//             i_17 := add(i_17, 1)
+//             i_33 := add(i_33, 1)
 //         }
 //         {
-//             mstore(dst_15, calldataload(src_16))
-//             dst_15 := add(dst_15, 0x20)
-//             src_16 := add(src_16, 0x20)
+//             mstore(dst_31, calldataload(src_32))
+//             dst_31 := add(dst_31, array_allo__234)
+//             src_32 := add(src_32, array_allo__234)
 //         }
 //     }
-//     function abi_decode_tuple_t_uint256t_uint256t_array$_t_uint256_$dyn_memory_ptrt_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(headStart_58, dataEnd_59) -> value0_60, value1_61, value2, value3
+//     function abi_encode_t_array$_t_contract$_C_$55_$3_memory_to_t_array$_t_address_$3_memory_ptr(value_70, pos_71)
 //     {
-//         if slt(sub(dataEnd_59, headStart_58), 128)
-//         {
-//             revert(value2, value2)
-//         }
-//         value0_60 := calldataload(add(headStart_58, value2))
-//         value1_61 := calldataload(add(headStart_58, 32))
-//         let offset_64 := calldataload(add(headStart_58, 64))
-//         let _165 := 0xffffffffffffffff
-//         if gt(offset_64, _165)
-//         {
-//             revert(value2, value2)
-//         }
-//         let _532 := add(headStart_58, offset_64)
-//         if iszero(slt(add(_532, 0x1f), dataEnd_59))
-//         {
-//             revert(value2, value2)
-//         }
-//         let abi_decode_length_30 := calldataload(_532)
-//         let abi_decode_array_29_279 := allocateMemory(array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr(abi_decode_length_30))
-//         let abi_decode_dst_31 := abi_decode_array_29_279
-//         mstore(abi_decode_array_29_279, abi_decode_length_30)
-//         let abi_decode__91 := 0x20
-//         abi_decode_dst_31 := add(abi_decode_array_29_279, abi_decode__91)
-//         let abi_decode_src_32 := add(_532, abi_decode__91)
-//         if gt(add(add(_532, mul(abi_decode_length_30, abi_decode__91)), abi_decode__91), dataEnd_59)
-//         {
-//             revert(value2, value2)
-//         }
-//         let abi_decode_i_33 := value2
+//         let srcPtr_73 := value_70
+//         let i_74 := 0
 //         for {
 //         }
-//         lt(abi_decode_i_33, abi_decode_length_30)
+//         lt(i_74, 0x3)
 //         {
-//             abi_decode_i_33 := add(abi_decode_i_33, 1)
+//             i_74 := add(i_74, 1)
 //         }
 //         {
-//             mstore(abi_decode_dst_31, calldataload(abi_decode_src_32))
-//             abi_decode_dst_31 := add(abi_decode_dst_31, abi_decode__91)
-//             abi_decode_src_32 := add(abi_decode_src_32, abi_decode__91)
+//             mstore(pos_71, and(mload(srcPtr_73), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+//             srcPtr_73 := add(srcPtr_73, 0x20)
+//             pos_71 := add(pos_71, 0x20)
 //         }
-//         value2 := abi_decode_array_29_279
-//         let offset_65 := calldataload(add(headStart_58, 96))
-//         if gt(offset_65, _165)
-//         {
-//             revert(0, 0)
-//         }
-//         value3 := abi_decode_t_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(add(headStart_58, offset_65), dataEnd_59)
 //     }
 //     function allocateMemory(size) -> memPtr
 //     {
@@ -613,20 +621,12 @@
 //         }
 //         mstore(64, newFreePtr)
 //     }
-//     function array_allocation_size_t_array$_t_array$_t_uint256_$2_memory_$dyn_memory_ptr(length_92) -> size_93
+//     function array_allocation_size_t_array$_t_uint256_$2_memory(length_94) -> size_95
 //     {
-//         if gt(length_92, 0xffffffffffffffff)
+//         if gt(length_94, 0xffffffffffffffff)
 //         {
 //             revert(0, 0)
 //         }
-//         size_93 := add(mul(length_92, 0x20), 0x20)
-//     }
-//     function array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr(length_98) -> size_99
-//     {
-//         if gt(length_98, 0xffffffffffffffff)
-//         {
-//             revert(0, 0)
-//         }
-//         size_99 := add(mul(length_98, 0x20), 0x20)
+//         size_95 := mul(length_94, 0x20)
 //     }
 // }


### PR DESCRIPTION
This will always inline functions that merely call other functions.

Fixes https://github.com/ethereum/solidity/issues/5762