### PR TITLE
[Yul] Require equal types for switch cases and detect duplicates by number value.

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -130,9 +130,10 @@ Restrictions on the Grammar
 ---------------------------
 
 Switches must have at least one case (including the default case).
-If all possible values of the expression is covered, the default case should
-not be allowed (i.e. a switch with a ``bool`` expression and having both a
-true and false case should not allow a default case).
+If all possible values of the expression are covered, a default case should
+not be allowed (i.e. a switch with a ``bool`` expression that has both a
+true and a false case should not allow a default case). All case values need to
+have the same type.
 
 Every expression evaluates to zero or more values. Identifiers and Literals
 evaluate to exactly

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(yul
 	Object.h
 	ObjectParser.cpp
 	ObjectParser.h
+	Utilities.cpp
+	Utilities.h
 	YulString.h
 	backends/evm/AbstractAssembly.h
 	backends/evm/EVMAssembly.cpp
@@ -68,6 +70,8 @@ add_library(yul
 	optimiser/NameCollector.h
 	optimiser/NameDispenser.cpp
 	optimiser/NameDispenser.h
+	optimiser/OptimizerUtilities.cpp
+	optimiser/OptimizerUtilities.h
 	optimiser/RedundantAssignEliminator.cpp
 	optimiser/RedundantAssignEliminator.h
 	optimiser/Rematerialiser.cpp
@@ -90,8 +94,6 @@ add_library(yul
 	optimiser/SyntacticalEquality.h
 	optimiser/UnusedPruner.cpp
 	optimiser/UnusedPruner.h
-	optimiser/Utilities.cpp
-	optimiser/Utilities.h
 	optimiser/VarDeclInitializer.cpp
 	optimiser/VarDeclInitializer.h
 )

--- a/libyul/Utilities.h
+++ b/libyul/Utilities.h
@@ -26,9 +26,34 @@
 namespace yul
 {
 
-/// Removes statements that are just empty blocks (non-recursive).
-void removeEmptyBlocks(Block& _block);
-
 dev::u256 valueOfNumberLiteral(Literal const& _literal);
+
+/**
+ * Linear order on Yul AST nodes.
+ *
+ * Defines a linear order on Yul AST nodes to be used in maps and sets.
+ * Note: the order is total and deterministic, but independent of the semantics, e.g.
+ * it is not guaranteed that the false Literal is "less" than the true Literal.
+ */
+template<typename T>
+struct Less
+{
+	bool operator()(T const& _lhs, T const& _rhs) const;
+};
+
+template<typename T>
+struct Less<T*>
+{
+	bool operator()(T const* _lhs, T const* _rhs) const
+	{
+		if (_lhs && _rhs)
+			return Less<T>{}(*_lhs, *_rhs);
+		else
+			return _lhs < _rhs;
+	}
+};
+
+template<> bool Less<Literal>::operator()(Literal const& _lhs, Literal const& _rhs) const;
+extern template struct Less<Literal>;
 
 }

--- a/libyul/optimiser/ExpressionJoiner.cpp
+++ b/libyul/optimiser/ExpressionJoiner.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/ExpressionJoiner.h>
 
 #include <libyul/optimiser/NameCollector.h>
-#include <libyul/optimiser/Utilities.h>
+#include <libyul/optimiser/OptimizerUtilities.h>
 #include <libyul/Exceptions.h>
 #include <libyul/AsmData.h>
 

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -23,7 +23,7 @@
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/NameCollector.h>
-#include <libyul/optimiser/Utilities.h>
+#include <libyul/optimiser/OptimizerUtilities.h>
 #include <libyul/optimiser/Metrics.h>
 #include <libyul/optimiser/SSAValueTracker.h>
 #include <libyul/Exceptions.h>

--- a/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
+++ b/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
@@ -20,7 +20,7 @@
 
 #include <libyul/optimiser/InlinableExpressionFunctionFinder.h>
 
-#include <libyul/optimiser/Utilities.h>
+#include <libyul/optimiser/OptimizerUtilities.h>
 #include <libyul/AsmData.h>
 
 using namespace std;

--- a/libyul/optimiser/OptimizerUtilities.h
+++ b/libyul/optimiser/OptimizerUtilities.h
@@ -1,0 +1,32 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Small useful snippets for the optimiser.
+ */
+
+#pragma once
+
+#include <libdevcore/Common.h>
+#include <libyul/AsmDataForward.h>
+
+namespace yul
+{
+
+/// Removes statements that are just empty blocks (non-recursive).
+void removeEmptyBlocks(Block& _block);
+
+}

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -20,11 +20,11 @@
 
 #include <libyul/optimiser/SimplificationRules.h>
 
-#include <libyul/optimiser/Utilities.h>
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/SyntacticalEquality.h>
 #include <libyul/AsmData.h>
+#include <libyul/Utilities.h>
 
 #include <libevmasm/RuleList.h>
 

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -16,8 +16,8 @@
 */
 #include <libyul/optimiser/StructuralSimplifier.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/optimiser/Utilities.h>
 #include <libyul/AsmData.h>
+#include <libyul/Utilities.h>
 #include <libdevcore/CommonData.h>
 #include <libdevcore/Visitor.h>
 

--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -22,7 +22,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/optimiser/Utilities.h>
+#include <libyul/optimiser/OptimizerUtilities.h>
 #include <libyul/Exceptions.h>
 #include <libyul/AsmData.h>
 

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(switch_no_cases)
 
 BOOST_AUTO_TEST_CASE(switch_duplicate_case)
 {
-	CHECK_PARSE_ERROR("{ switch 42 case 1 {} case 1 {} default {} }", DeclarationError, "Duplicate case defined");
+	CHECK_PARSE_ERROR("{ switch 42 case 1 {} case 1 {} default {} }", DeclarationError, "Duplicate case defined.");
 }
 
 BOOST_AUTO_TEST_CASE(switch_invalid_expression)

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -304,6 +304,19 @@ BOOST_AUTO_TEST_CASE(if_statement_invalid)
 	BOOST_CHECK(successParse("{ if 42:u256 { } }"));
 }
 
+BOOST_AUTO_TEST_CASE(switch_case_types)
+{
+	CHECK_ERROR("{ switch 0:u256 case 0:u256 {} case 1:u32 {} }", TypeError, "Switch cases have non-matching types.");
+	// The following should be an error in the future, but this is not yet detected.
+	BOOST_CHECK(successParse("{ switch 0:u256 case 0:u32 {} case 1:u32 {} }"));
+}
+
+BOOST_AUTO_TEST_CASE(switch_duplicate_case)
+{
+	CHECK_ERROR("{ switch 0:u256 case 0:u256 {} case 0x0:u256 {} }", DeclarationError, "Duplicate case defined.");
+	BOOST_CHECK(successParse("{ switch 0:u256 case 42:u256 {} case 0x42:u256 {} }"));
+}
+
 BOOST_AUTO_TEST_CASE(builtins_parser)
 {
 	struct SimpleDialect: public Dialect


### PR DESCRIPTION
Fixes #5792.
References #2324.

Came up during #5776 and will allow to more reasonably sort switch cases for the syntactic equality comparison there.

EDIT: I'm not sure whether it was a deliberate design decision **not** to require matching types in switch cases so far.
EDIT: Also this is two things at once - let me know if I should split.