### PR TITLE
[DOCS] Remove conversion FAQ Item

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -151,16 +151,6 @@ does not fit inside this range, it is truncated. These truncations can have
 `serious consequences <https://en.bitcoin.it/wiki/Value_overflow_incident>`_, so code like the one
 above is necessary to avoid certain attacks.
 
-
-Why can number literals not be converted to fixed-size bytes types?
-===================================================================
-
-Since version 0.5.0 only hexadecimal number literals can be converted to fixed-size bytes
-types and only if the number of hex digits matches the size of the type. See :ref:`types-conversion-literals`
-for a full explanation and examples.
-
-
-
 More Questions?
 ===============
 


### PR DESCRIPTION
The FAQ item directly points to the docs, so easy to remove. Do you think it's worth adding a "from 0.5.0" note though? Part of https://github.com/ethereum/solidity/issues/1219

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
