### PR TITLE
[DOCS] Add call warning into main docs and remove FAQ item

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -54,18 +54,6 @@ Yes, you can use ``abi.encodePacked``::
         }
     }
 
-
-Why is the low-level function ``.call()`` less favorable than instantiating a contract with a variable (``ContractB b;``) and executing its functions (``b.doSomething();``)?
-=============================================================================================================================================================================
-
-If you use actual functions, the compiler will tell you if the types
-or your arguments do not match, if the function does not exist
-or is not visible and it will do the packing of the
-arguments for you.
-
-See `ping.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_ping.sol>`_ and
-`pong.sol <https://github.com/fivedogit/solidity-baby-steps/blob/master/contracts/45_pong.sol>`_.
-
 What happens if you send ether along with a function call to a contract?
 ========================================================================
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -200,7 +200,7 @@ Members of Address Types
 For more information, see the section on :ref:`address`.
 
 .. warning::
-    You should avoid using ``.call()`` when executing another contract function as it bypasses the compiler type checking,
+    You should avoid using ``.call()`` whenever possible when executing another contract function as it bypasses type checking,
     function existence check, and argument packing.
 
 .. warning::

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -200,6 +200,10 @@ Members of Address Types
 For more information, see the section on :ref:`address`.
 
 .. warning::
+    You should avoid using ``.call()`` when executing another contract function as it bypasses the compiler type checking,
+    function existence check, and argument packing.
+
+.. warning::
     There are some dangers in using ``send``: The transfer fails if the call stack depth is at 1024
     (this can always be forced by the caller) and it also fails if the recipient runs out of gas. So in order
     to make safe Ether transfers, always check the return value of ``send``, use ``transfer`` or even better:


### PR DESCRIPTION
As part of https://github.com/ethereum/solidity/issues/1219 attempting to move FAQ item to the most useful part of the documentation. Incidentally looks like Remix might have its own warnings about this, or does that come from the compiler?

https://ethereum.stackexchange.com/questions/25068/warning-the-use-of-low-level-call-should-be-avoided-whenever-possible

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
