### PR TITLE
Add missing Changelog entries for Yul switch changes.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Compiler Features:
 
 Bugfixes:
  * Yul: Check that arguments to ``dataoffset`` and ``datasize`` are literals at parse time and properly take this into account in the optimizer.
+ * Yul: Parse number literals for detecting duplicate switch cases.
+ * Yul: Require switch cases to have the same type.
 
 
 Build System:


### PR DESCRIPTION
Adds changelog entries that were omitted in #5793.