### PR TITLE
Disallow calldata structs.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,8 @@ Compiler Features:
 
 Bugfixes:
  * Emscripten: Split simplification rule initialization up further to work around issues with soljson.js in some browsers.
- * TypeChecker: Return type error if fixed point encoding is attempted instead of throwing ``UnimplementedFeatureError``.
+ * Type Checker: Disallow calldata structs until implemented.
+ * Type Checker: Return type error if fixed point encoding is attempted instead of throwing ``UnimplementedFeatureError``.
  * Yul: Check that arguments to ``dataoffset`` and ``datasize`` are literals at parse time and properly take this into account in the optimizer.
  * Yul: Parse number literals for detecting duplicate switch cases.
  * Yul: Require switch cases to have the same type.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -359,6 +359,16 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 	};
 	for (ASTPointer<VariableDeclaration> const& var: _function.parameters())
 	{
+		TypePointer baseType = type(*var);
+		while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
+			baseType = arrayType->baseType();
+
+		if (
+			!m_scope->isInterface() &&
+			baseType->category() == Type::Category::Struct &&
+			baseType->dataStoredIn(DataLocation::CallData)
+		)
+			m_errorReporter.typeError(var->location(), "Calldata structs are not yet supported.");
 		checkArgumentAndReturnParameter(*var);
 		var->accept(*this);
 	}

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(enum_external_type)
 		}
 }
 
-BOOST_AUTO_TEST_CASE(external_structs)
+BOOST_AUTO_TEST_CASE(external_struct_signatures)
 {
 	char const* text = R"(
 		pragma experimental ABIEncoderV2;
@@ -213,7 +213,10 @@ BOOST_AUTO_TEST_CASE(external_structs)
 			function i(Nested[] calldata) external {}
 		}
 	)";
-	SourceUnit const* sourceUnit = parseAndAnalyse(text);
+	// Ignore analysis errors. This test only checks that correct signatures
+	// are generated for external structs, but they are not yet supported
+	// in code generation and therefore cause an error in the TypeChecker.
+	SourceUnit const* sourceUnit = parseAnalyseAndReturnError(text, false, true, true).first;
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 		{
@@ -226,7 +229,7 @@ BOOST_AUTO_TEST_CASE(external_structs)
 		}
 }
 
-BOOST_AUTO_TEST_CASE(external_structs_in_libraries)
+BOOST_AUTO_TEST_CASE(external_struct_signatures_in_libraries)
 {
 	char const* text = R"(
 		pragma experimental ABIEncoderV2;
@@ -241,7 +244,10 @@ BOOST_AUTO_TEST_CASE(external_structs_in_libraries)
 			function i(Nested[] calldata) external {}
 		}
 	)";
-	SourceUnit const* sourceUnit = parseAndAnalyse(text);
+	// Ignore analysis errors. This test only checks that correct signatures
+	// are generated for external structs, but calldata structs are not yet supported
+	// in code generation and therefore cause an error in the TypeChecker.
+	SourceUnit const* sourceUnit = parseAnalyseAndReturnError(text, false, true, true).first;
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 		{

--- a/test/libsolidity/syntaxTests/inheritance/override/calldata_memory_struct.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/calldata_memory_struct.sol
@@ -15,3 +15,7 @@ contract B is A {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (102-112): Calldata structs are not yet supported.
+// TypeError: (146-156): Calldata structs are not yet supported.
+// TypeError: (198-208): Calldata structs are not yet supported.
+// TypeError: (250-260): Calldata structs are not yet supported.

--- a/test/libsolidity/syntaxTests/structs/array_calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/array_calldata.sol
@@ -1,0 +1,10 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    struct S { int a; }
+    function f(S[] calldata) external { }
+    function f(S[][] calldata) external { }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (89-101): Calldata structs are not yet supported.
+// TypeError: (131-145): Calldata structs are not yet supported.

--- a/test/libsolidity/syntaxTests/structs/calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/calldata.sol
@@ -1,0 +1,8 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    struct S { int a; }
+    function f(S calldata) external { }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (89-99): Calldata structs are not yet supported.


### PR DESCRIPTION
Fixes #5479.

I guess we have a separate issue for actually specifying and implementing calldata structs?

~~I also added ``isInterface``, since we had ``isLibrary`` already.~~(merged separately)

~~EDIT: non-extracted contracts still need to be adjusted.~~(done)