### PR TITLE
Return TypeError is fixed point encoding is attempted.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * TypeChecker: Return type error if fixed point encoding is attempted instead of throwing ``UnimplementedFeatureError``.
  * Yul: Check that arguments to ``dataoffset`` and ``datasize`` are literals at parse time and properly take this into account in the optimizer.
  * Yul: Parse number literals for detecting duplicate switch cases.
  * Yul: Require switch cases to have the same type.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1482,7 +1482,16 @@ void TypeChecker::typeCheckABIEncodeFunctions(
 
 		if (argType->category() == Type::Category::RationalNumber)
 		{
-			if (!argType->mobileType())
+			auto const& rationalType = dynamic_cast<RationalNumberType const&>(*argType);
+			if (rationalType.isFractional())
+			{
+				m_errorReporter.typeError(
+					arguments[i]->location(),
+					"Fixed point numbers cannot yet be encoded."
+				);
+				continue;
+			}
+			else if (!argType->mobileType())
 			{
 				m_errorReporter.typeError(
 					arguments[i]->location(),

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1487,7 +1487,7 @@ void TypeChecker::typeCheckABIEncodeFunctions(
 			{
 				m_errorReporter.typeError(
 					arguments[i]->location(),
-					"Fixed point numbers cannot yet be encoded."
+					"Fractional numbers cannot yet be encoded."
 				);
 				continue;
 			}

--- a/test/libsolidity/syntaxTests/types/encoding_fractional.sol
+++ b/test/libsolidity/syntaxTests/types/encoding_fractional.sol
@@ -1,0 +1,7 @@
+contract C {
+   function f1() public pure returns (bytes memory) {
+       return abi.encode(0.1, 1);
+   }
+}
+// ----
+// TypeError: (92-95): Fractional numbers cannot yet be encoded.

--- a/test/libsolidity/syntaxTests/types/encoding_fractional_abiencoderv2.sol
+++ b/test/libsolidity/syntaxTests/types/encoding_fractional_abiencoderv2.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+contract C {
+   function f1() public pure returns (bytes memory) {
+       return abi.encode(0.1, 1);
+   }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (126-129): Fractional numbers cannot yet be encoded.

--- a/test/libsolidity/syntaxTests/types/encoding_packed_fractional.sol
+++ b/test/libsolidity/syntaxTests/types/encoding_packed_fractional.sol
@@ -1,0 +1,8 @@
+contract C {
+   function f1() public pure returns (bytes memory) {
+       return abi.encodePacked(0.1, 1);
+   }
+}
+// ----
+// TypeError: (98-101): Fractional numbers cannot yet be encoded.
+// TypeError: (103-104): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.

--- a/test/libsolidity/syntaxTests/types/encoding_packed_fractional_abiencoderv2.sol
+++ b/test/libsolidity/syntaxTests/types/encoding_packed_fractional_abiencoderv2.sol
@@ -1,0 +1,10 @@
+pragma experimental ABIEncoderV2;
+contract C {
+   function f1() public pure returns (bytes memory) {
+       return abi.encodePacked(0.1, 1);
+   }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (132-135): Fractional numbers cannot yet be encoded.
+// TypeError: (137-138): Cannot perform packed encoding for a literal. Please convert it to an explicit type first.


### PR DESCRIPTION
Fixes #4715.

This PR returns a `TypeError` if fixed point encoding is attempted (with or without `ABIEncoderV2`), by checking if the argument type is rational and fractional.
Another option would be to make `Type::fullEncodingType` virtual and return `nullptr` in the `RationalNumberType` implementation.