### PR TITLE
Use v0.5.0 tag of solc-js repository for external tests.

### DIFF
--- a/test/externalTests.sh
+++ b/test/externalTests.sh
@@ -55,13 +55,13 @@ function test_truffle
       cd "$DIR"
       echo "Current commit hash: `git rev-parse HEAD`"
       npm install
-      # Replace solc package by master
+      # Replace solc package by v0.5.0
       for d in node_modules node_modules/truffle/node_modules
       do
       (
         cd $d
         rm -rf solc
-        git clone --depth 1 https://github.com/ethereum/solc-js.git solc
+        git clone --depth 1 -b v0.5.0 https://github.com/ethereum/solc-js.git solc
         cp "$SOLJSON" solc/
       )
       done

--- a/test/solcjsTests.sh
+++ b/test/solcjsTests.sh
@@ -39,8 +39,8 @@ VERSION="$2"
 
 DIR=$(mktemp -d)
 (
-    echo "Preparing solc-js..."
-    git clone --depth 1 https://github.com/ethereum/solc-js "$DIR"
+    echo "Preparing solc-js (0.5.0)..."
+    git clone --depth 1 --branch v0.5.0 https://github.com/ethereum/solc-js "$DIR"
     cd "$DIR"
     # disable "prepublish" script which downloads the latest version
     # (we will replace it anyway and it is often incorrectly cached


### PR DESCRIPTION
Follow-up of https://github.com/ethereum/solidity/pull/5831