### PR TITLE
Inplace and non-padded encoding for ABIEncoderV2.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Language Features:
 
 
 Compiler Features:
+ * Implement packed encoding for ABIEncoderV2.
  * C API (``libsolc`` / raw ``soljson.js``): Introduce ``solidity_free`` method which releases all internal buffers to save memory.
  * Commandline interface: Adds new option ``--new-reporter`` for improved diagnostics formatting
    along with ``--color`` and ``--no-color`` for colorized output to be forced (or explicitly disabled).

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -48,9 +48,9 @@ using namespace dev::solidity;
 namespace
 {
 
-bool typeSupportedByOldABIEncoder(Type const& _type)
+bool typeSupportedByOldABIEncoder(Type const& _type, bool _isLibraryCall)
 {
-	if (_type.dataStoredIn(DataLocation::Storage))
+	if (_isLibraryCall && _type.dataStoredIn(DataLocation::Storage))
 		return true;
 	if (_type.category() == Type::Category::Struct)
 		return false;
@@ -58,7 +58,7 @@ bool typeSupportedByOldABIEncoder(Type const& _type)
 	{
 		auto const& arrayType = dynamic_cast<ArrayType const&>(_type);
 		auto base = arrayType.baseType();
-		if (!typeSupportedByOldABIEncoder(*base) || (base->category() == Type::Category::Array && base->isDynamicallySized()))
+		if (!typeSupportedByOldABIEncoder(*base, _isLibraryCall) || (base->category() == Type::Category::Array && base->isDynamicallySized()))
 			return false;
 	}
 	return true;
@@ -355,7 +355,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		if (
 			_function.isPublic() &&
 			!_function.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2) &&
-			!typeSupportedByOldABIEncoder(*type(var))
+			!typeSupportedByOldABIEncoder(*type(var), isLibraryFunction)
 		)
 			m_errorReporter.typeError(
 				var.location(),
@@ -475,7 +475,7 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 		{
 			vector<string> unsupportedTypes;
 			for (auto const& param: getter.parameterTypes() + getter.returnParameterTypes())
-				if (!typeSupportedByOldABIEncoder(*param))
+				if (!typeSupportedByOldABIEncoder(*param, false /* isLibrary */))
 					unsupportedTypes.emplace_back(param->toString());
 			if (!unsupportedTypes.empty())
 				m_errorReporter.typeError(_variable.location(),
@@ -585,7 +585,7 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 			m_errorReporter.typeError(var->location(), "Internal or recursive type is not allowed as event parameter type.");
 		if (
 			!_eventDef.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2) &&
-			!typeSupportedByOldABIEncoder(*type(*var))
+			!typeSupportedByOldABIEncoder(*type(*var), false /* isLibrary */)
 		)
 			m_errorReporter.typeError(
 				var->location(),
@@ -1548,6 +1548,15 @@ void TypeChecker::typeCheckABIEncodeFunctions(
 				);
 				continue;
 			}
+		}
+
+		if (isPacked && !typeSupportedByOldABIEncoder(*argType, false /* isLibrary */))
+		{
+			m_errorReporter.typeError(
+				arguments[i]->location(),
+				"Type not supported in packed mode."
+			);
+			continue;
 		}
 
 		if (!argType->fullEncodingType(false, abiEncoderV2, !_functionType->padArguments()))

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -578,17 +578,7 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 	for (ASTPointer<VariableDeclaration> const& var: _eventDef.parameters())
 	{
 		if (var->isIndexed())
-		{
 			numIndexed++;
-			if (
-				_eventDef.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2) &&
-				dynamic_cast<ReferenceType const*>(type(*var).get())
-			)
-				m_errorReporter.typeError(
-					var->location(),
-					"Indexed reference types cannot yet be used with ABIEncoderV2."
-				);
-		}
 		if (!type(*var)->canLiveOutsideStorage())
 			m_errorReporter.typeError(var->location(), "Type is required to live outside storage.");
 		if (!type(*var)->interfaceType(false))

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -415,7 +415,7 @@ MemberList const& Type::members(ContractDefinition const* _currentScope) const
 	return *m_members[_currentScope];
 }
 
-TypePointer Type::fullEncodingType(bool _inLibraryCall, bool _encoderV2, bool _packed) const
+TypePointer Type::fullEncodingType(bool _inLibraryCall, bool _encoderV2, bool) const
 {
 	TypePointer encodingType = mobileType();
 	if (encodingType)
@@ -423,7 +423,7 @@ TypePointer Type::fullEncodingType(bool _inLibraryCall, bool _encoderV2, bool _p
 	if (encodingType)
 		encodingType = encodingType->encodingType();
 	// Structs are fine in the following circumstances:
-	// - ABIv2 without packed encoding or,
+	// - ABIv2 or,
 	// - storage struct for a library
 	if (_inLibraryCall && encodingType->dataStoredIn(DataLocation::Storage))
 		return encodingType;
@@ -431,7 +431,7 @@ TypePointer Type::fullEncodingType(bool _inLibraryCall, bool _encoderV2, bool _p
 	while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
 		baseType = arrayType->baseType();
 	if (dynamic_cast<StructType const*>(baseType.get()))
-		if (!_encoderV2 || _packed)
+		if (!_encoderV2)
 			return TypePointer();
 	return encodingType;
 }

--- a/libsolidity/codegen/ABIFunctions.h
+++ b/libsolidity/codegen/ABIFunctions.h
@@ -60,15 +60,25 @@ public:
 	/// The values represent stack slots. If a type occupies more or less than one
 	/// stack slot, it takes exactly that number of values.
 	/// Returns a pointer to the end of the area written in memory.
-	/// Does not allocate memory (does not change the memory head pointer), but writes
+	/// Does not allocate memory (does not change the free memory pointer), but writes
 	/// to memory starting at $headStart and an unrestricted amount after that.
-	/// Assigns the end of encoded memory either to $value0 or (if that is not present)
-	/// to $headStart.
 	std::string tupleEncoder(
 		TypePointers const& _givenTypes,
 		TypePointers const& _targetTypes,
 		bool _encodeAsLibraryTypes = false
 	);
+
+	/// @returns name of an assembly function to encode values of @a _givenTypes
+	/// with packed encoding into memory, converting the types to @a _targetTypes on the fly.
+	/// Parameters are: <memPos> <value_n> ... <value_1>, i.e.
+	/// the layout on the stack is <value_1> ... <value_n> <memPos> with
+	/// the top of the stack on the right.
+	/// The values represent stack slots. If a type occupies more or less than one
+	/// stack slot, it takes exactly that number of values.
+	/// Returns a pointer to the end of the area written in memory.
+	/// Does not allocate memory (does not change the free memory pointer), but writes
+	/// to memory starting at memPos and an unrestricted amount after that.
+	std::string tupleEncoderPacked(TypePointers const& _givenTypes, TypePointers const& _targetTypes);
 
 	/// @returns name of an assembly function to ABI-decode values of @a _types
 	/// into memory. If @a _fromMemory is true, decodes from memory instead of

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -348,11 +348,15 @@ void CompilerUtils::encodeToMemory(
 
 	if (_givenTypes.empty())
 		return;
-	else if (_padToWordBoundaries && !_copyDynamicDataInPlace && encoderV2)
+	if (encoderV2)
 	{
 		// Use the new Yul-based encoding function
+		solAssert(
+			_padToWordBoundaries != _copyDynamicDataInPlace,
+			"Non-padded and in-place encoding can only be combined."
+		);
 		auto stackHeightBefore = m_context.stackHeight();
-		abiEncodeV2(_givenTypes, targetTypes, _encodeAsLibraryTypes);
+		abiEncodeV2(_givenTypes, targetTypes, _encodeAsLibraryTypes, _padToWordBoundaries);
 		solAssert(stackHeightBefore - m_context.stackHeight() == sizeOnStack(_givenTypes), "");
 		return;
 	}
@@ -466,15 +470,22 @@ void CompilerUtils::encodeToMemory(
 void CompilerUtils::abiEncodeV2(
 	TypePointers const& _givenTypes,
 	TypePointers const& _targetTypes,
-	bool _encodeAsLibraryTypes
+	bool _encodeAsLibraryTypes,
+	bool _padToWordBoundaries
 )
 {
+	if (!_padToWordBoundaries)
+		solAssert(!_encodeAsLibraryTypes, "Library calls cannot be packed.");
+
 	// stack: <$value0> <$value1> ... <$value(n-1)> <$headStart>
 
 	auto ret = m_context.pushNewTag();
 	moveIntoStack(sizeOnStack(_givenTypes) + 1);
 
-	string encoderName = m_context.abiFunctions().tupleEncoder(_givenTypes, _targetTypes, _encodeAsLibraryTypes);
+	string encoderName =
+		_padToWordBoundaries ?
+		m_context.abiFunctions().tupleEncoder(_givenTypes, _targetTypes, _encodeAsLibraryTypes) :
+		m_context.abiFunctions().tupleEncoderPacked(_givenTypes, _targetTypes);
 	m_context.appendJumpTo(m_context.namedTag(encoderName));
 	m_context.adjustStackOffset(-int(sizeOnStack(_givenTypes)) - 1);
 	m_context << ret.tag();

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -159,7 +159,8 @@ public:
 	void abiEncodeV2(
 		TypePointers const& _givenTypes,
 		TypePointers const& _targetTypes,
-		bool _encodeAsLibraryTypes = false
+		bool _encodeAsLibraryTypes = false,
+		bool _padToWordBoundaries = true
 	);
 
 	/// Decodes data from ABI encoding into internal encoding. If @a _fromMemory is set to true,

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -731,6 +731,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			}
 			arguments.front()->accept(*this);
 			utils().fetchFreeMemoryPointer();
+			solAssert(function.parameterTypes().front()->isValueType(), "");
 			utils().packedEncode(
 				{arguments.front()->annotation().type},
 				{function.parameterTypes().front()}
@@ -744,28 +745,32 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			_functionCall.expression().accept(*this);
 			auto const& event = dynamic_cast<EventDefinition const&>(function.declaration());
 			unsigned numIndexed = 0;
+			TypePointers paramTypes = function.parameterTypes();
 			// All indexed arguments go to the stack
 			for (unsigned arg = arguments.size(); arg > 0; --arg)
 				if (event.parameters()[arg - 1]->isIndexed())
 				{
 					++numIndexed;
 					arguments[arg - 1]->accept(*this);
-					if (auto const& arrayType = dynamic_pointer_cast<ArrayType const>(function.parameterTypes()[arg - 1]))
+					if (auto const& referenceType = dynamic_pointer_cast<ReferenceType const>(paramTypes[arg - 1]))
 					{
 						utils().fetchFreeMemoryPointer();
 						utils().packedEncode(
 							{arguments[arg - 1]->annotation().type},
-							{arrayType}
+							{referenceType}
 						);
 						utils().toSizeAfterFreeMemoryPointer();
 						m_context << Instruction::KECCAK256;
 					}
 					else
+					{
+						solAssert(paramTypes[arg - 1]->isValueType(), "");
 						utils().convertType(
 							*arguments[arg - 1]->annotation().type,
-							*function.parameterTypes()[arg - 1],
+							*paramTypes[arg - 1],
 							true
 						);
+					}
 				}
 			if (!event.isAnonymous())
 			{
@@ -782,7 +787,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				{
 					arguments[arg]->accept(*this);
 					nonIndexedArgTypes.push_back(arguments[arg]->annotation().type);
-					nonIndexedParamTypes.push_back(function.parameterTypes()[arg]);
+					nonIndexedParamTypes.push_back(paramTypes[arg]);
 				}
 			utils().fetchFreeMemoryPointer();
 			utils().abiEncode(nonIndexedArgTypes, nonIndexedParamTypes);

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -13715,25 +13715,22 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_structs)
 				s.d[0] = -7;
 				s.d[1] = -8;
 			}
-			function testStorage() public returns (bytes memory) {
+			function testStorage() public {
 				emit E(s);
-				return abi.encodePacked(uint8(0x33), s, uint8(0x44));
 			}
-			function testMemory() public returns (bytes memory) {
+			function testMemory() public {
 				S memory m = s;
 				emit E(m);
-				return abi.encodePacked(uint8(0x33), m, uint8(0x44));
 			}
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
 	bytes structEnc = encodeArgs(int(0x12), u256(-7), int(2), int(3), u256(-7), u256(-8));
-	string encoding = "\x33" + asString(structEnc) + "\x44";
-	ABI_CHECK(callContractFunction("testStorage()"), encodeArgs(0x20, encoding.size(), encoding));
+	ABI_CHECK(callContractFunction("testStorage()"), encodeArgs());
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("E((uint8,int16,uint8[2],int16[]))")));
 	BOOST_CHECK_EQUAL(m_logs[0].topics[1], dev::keccak256(asString(structEnc)));
-	ABI_CHECK(callContractFunction("testMemory()"), encodeArgs(0x20, encoding.size(), encoding));
+	ABI_CHECK(callContractFunction("testMemory()"), encodeArgs());
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("E((uint8,int16,uint8[2],int16[]))")));
 	BOOST_CHECK_EQUAL(m_logs[0].topics[1], dev::keccak256(asString(structEnc)));
@@ -13749,7 +13746,7 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_nestedArray)
 				int16 b;
 			}
 			event E(S[2][][3] indexed);
-			function testNestedArrays() public returns (bytes memory) {
+			function testNestedArrays() public {
 				S[2][][3] memory x;
 				x[1] = new S[2][](2);
 				x[1][0][0].a = 1;
@@ -13757,14 +13754,12 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_nestedArray)
 				x[1][0][1].a = 3;
 				x[1][1][1].b = 4;
 				emit E(x);
-				return abi.encodePacked(uint8(0x33), x, uint8(0x44));
 			}
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
 	bytes structEnc = encodeArgs(1, 2, 3, 0, 0, 0, 0, 4);
-	string encoding = "\x33" + asString(structEnc) + "\x44";
-	ABI_CHECK(callContractFunction("testNestedArrays()"), encodeArgs(0x20, encoding.size(), encoding));
+	ABI_CHECK(callContractFunction("testNestedArrays()"), encodeArgs());
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("E((uint8,int16)[2][][3])")));
 	BOOST_CHECK_EQUAL(m_logs[0].topics[1], dev::keccak256(asString(structEnc)));
@@ -13782,27 +13777,22 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_arrayOfStrings)
 				x[0] = "abc";
 				x[1] = "0123456789012345678901234567890123456789";
 			}
-			function testStorage() public returns (bytes memory) {
+			function testStorage() public {
 				emit E(x);
-				return abi.encodePacked(uint8(0x33), x, uint8(0x44));
 			}
-			function testMemory() public returns (bytes memory) {
+			function testMemory() public {
 				string[] memory y = x;
 				emit E(y);
-				return abi.encodePacked(uint8(0x33), y, uint8(0x44));
 			}
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
 	bytes arrayEncoding = encodeArgs("abc", "0123456789012345678901234567890123456789");
-	// This pads to multiple of 32 bytes
-	string encoding = "\x33" + asString(arrayEncoding) + "\x44";
-	BOOST_CHECK_EQUAL(encoding.size(), 2 + 32 * 3);
-	ABI_CHECK(callContractFunction("testStorage()"), encodeArgs(0x20, encoding.size(), encoding));
+	ABI_CHECK(callContractFunction("testStorage()"), encodeArgs());
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("E(string[])")));
 	BOOST_CHECK_EQUAL(m_logs[0].topics[1], dev::keccak256(asString(arrayEncoding)));
-	ABI_CHECK(callContractFunction("testMemory()"), encodeArgs(0x20, encoding.size(), encoding));
+	ABI_CHECK(callContractFunction("testMemory()"), encodeArgs());
 	BOOST_REQUIRE_EQUAL(m_logs[0].topics.size(), 2);
 	BOOST_CHECK_EQUAL(m_logs[0].topics[0], dev::keccak256(string("E(string[])")));
 	BOOST_CHECK_EQUAL(m_logs[0].topics[1], dev::keccak256(asString(arrayEncoding)));

--- a/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_array_indexed_v2.sol
@@ -4,4 +4,3 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (59-73): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array_indexed_v2.sol
@@ -4,4 +4,3 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (59-75): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_indexed_v2.sol
@@ -5,4 +5,3 @@ contract c {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (85-94): Indexed reference types cannot yet be used with ABIEncoderV2.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_structs_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_structs_v2.sol
@@ -12,5 +12,3 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (191-192): This type cannot be encoded.
-// TypeError: (194-195): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_structs_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_structs_v2.sol
@@ -12,3 +12,5 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (191-192): Type not supported in packed mode.
+// TypeError: (194-195): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs.sol
@@ -13,5 +13,5 @@ contract C {
 // ----
 // TypeError: (131-132): This type cannot be encoded.
 // TypeError: (134-135): This type cannot be encoded.
-// TypeError: (200-201): This type cannot be encoded.
-// TypeError: (203-204): This type cannot be encoded.
+// TypeError: (200-201): Type not supported in packed mode.
+// TypeError: (203-204): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs_abiv2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs_abiv2.sol
@@ -5,6 +5,10 @@ contract C {
     S s;
     struct T { uint y; }
     T t;
+    function e() public view {
+        S memory st;
+        abi.encodePacked(st);
+    }
     function f() public view {
         abi.encode(s, t);
     }
@@ -14,3 +18,6 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (193-195): Type not supported in packed mode.
+// TypeError: (323-324): Type not supported in packed mode.
+// TypeError: (326-327): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs_abiv2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs_abiv2.sol
@@ -14,5 +14,3 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (235-236): This type cannot be encoded.
-// TypeError: (238-239): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/encodePacked_array_of_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/encodePacked_array_of_structs.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (116-117): This type cannot be encoded.
+// TypeError: (116-117): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/encodePacked_dynamic_string_array_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/encodePacked_dynamic_string_array_v2.sol
@@ -1,0 +1,13 @@
+contract C {
+    string[] s;
+    function f() public pure {
+        string[] memory m;
+        abi.encodePacked(m);
+    }
+    function g() public pure {
+        abi.encodePacked(s);
+    }
+}
+// ----
+// TypeError: (112-113): Type not supported in packed mode.
+// TypeError: (178-179): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_structs.sol
@@ -9,5 +9,5 @@ contract C {
     }
 }
 // ----
-// TypeError: (156-157): This type cannot be encoded.
-// TypeError: (159-160): This type cannot be encoded.
+// TypeError: (156-157): Type not supported in packed mode.
+// TypeError: (159-160): Type not supported in packed mode.


### PR DESCRIPTION
Fixes #4821 
Fixes https://github.com/ethereum/solidity/issues/5695

Replaces https://github.com/ethereum/solidity/pull/5812