### PR TITLE
Ensuring UTF-8 encoding for MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0.0)
-
 set(ETH_CMAKE_DIR   "${CMAKE_CURRENT_LIST_DIR}/cmake"   CACHE PATH "The the path to the cmake directory")
 list(APPEND CMAKE_MODULE_PATH ${ETH_CMAKE_DIR})
 

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -124,7 +124,7 @@ elseif (DEFINED MSVC)
 	add_compile_options(/wd4800)					# disable forcing value to bool 'true' or 'false' (performance warning) (4800)
 	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
 	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
-
+	add_compile_options(/utf-8)					# enable utf-8 encoding (solves warning 4819)
 	# disable empty object file warning
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
 	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -97,7 +97,7 @@ void OptimiserSuite::run(
 		ExpressionJoiner::run(ast);
 		ExpressionJoiner::run(ast);
 		ExpressionInliner(_dialect, ast).run();
-		UnusedPruner::runUntilStabilised(_dialect, ast);
+		UnusedPruner::runUntilStabilised(_dialect, ast, reservedIdentifiers);
 
 		ExpressionSplitter{_dialect, dispenser}(ast);
 		SSATransform::run(ast, dispenser);
@@ -124,11 +124,11 @@ void OptimiserSuite::run(
 	}
 	ExpressionJoiner::run(ast);
 	Rematerialiser::run(_dialect, ast);
-	UnusedPruner::runUntilStabilised(_dialect, ast);
+	UnusedPruner::runUntilStabilised(_dialect, ast, reservedIdentifiers);
 	ExpressionJoiner::run(ast);
-	UnusedPruner::runUntilStabilised(_dialect, ast);
+	UnusedPruner::runUntilStabilised(_dialect, ast, reservedIdentifiers);
 	ExpressionJoiner::run(ast);
-	UnusedPruner::runUntilStabilised(_dialect, ast);
+	UnusedPruner::runUntilStabilised(_dialect, ast, reservedIdentifiers);
 
 	SSAReverser::run(ast);
 	CommonSubexpressionEliminator{_dialect}(ast);
@@ -136,7 +136,7 @@ void OptimiserSuite::run(
 
 	ExpressionJoiner::run(ast);
 	Rematerialiser::run(_dialect, ast);
-	UnusedPruner::runUntilStabilised(_dialect, ast);
+	UnusedPruner::runUntilStabilised(_dialect, ast, reservedIdentifiers);
 
 	_ast = std::move(ast);
 }

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -53,7 +53,7 @@ packagename=solc
 
 static_build_distribution=cosmic
 
-DISTRIBUTIONS="bionic cosmic"
+DISTRIBUTIONS="bionic cosmic disco"
 
 if [ branch != develop ]
 then

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -53,7 +53,14 @@ packagename=solc
 
 static_build_distribution=cosmic
 
-for distribution in bionic cosmic STATIC
+DISTRIBUTIONS="bionic cosmic"
+
+if [ branch != develop ]
+then
+    DISTRIBUTIONS="$DISTRIBUTIONS STATIC"
+fi
+
+for distribution in $DISTRIBUTIONS
 do
 cd /tmp/
 rm -rf $distribution
@@ -96,7 +103,7 @@ commitdate=$(git show --format=%ci HEAD | head -n 1 | cut - -b1-10 | sed -e 's/-
 echo "$commithash" > commit_hash.txt
 if [ $branch = develop ]
 then
-    debversion="$version-develop-$commitdate-$commithash"
+    debversion="$version~develop-$commitdate-$commithash"
 else
     debversion="$version"
     echo -n > prerelease.txt # proper release


### PR DESCRIPTION
Support for different locales in WIN compilation by setting /utf-8 flag in MSVC.

Build may otherwise fail with errors such as:
`solidity\test\libdevcore\utf8.cpp : warning C4819: The file contains a character that cannot be represented in the current code page (1255). Save the file in Unicode format to prevent data loss`