### PR TITLE
Move ConstantOptimiser constructor to header

### DIFF
--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -134,11 +134,6 @@ bigint LiteralMethod::gasNeeded() const
 	);
 }
 
-CodeCopyMethod::CodeCopyMethod(Params const& _params, u256 const& _value):
-	ConstantOptimisationMethod(_params, _value)
-{
-}
-
 bigint CodeCopyMethod::gasNeeded() const
 {
 	return combineGas(

--- a/libevmasm/ConstantOptimiser.h
+++ b/libevmasm/ConstantOptimiser.h
@@ -119,7 +119,8 @@ public:
 class CodeCopyMethod: public ConstantOptimisationMethod
 {
 public:
-	explicit CodeCopyMethod(Params const& _params, u256 const& _value);
+	explicit CodeCopyMethod(Params const& _params, u256 const& _value):
+		ConstantOptimisationMethod(_params, _value) {}
 	bigint gasNeeded() const override;
 	AssemblyItems execute(Assembly& _assembly) const override;
 


### PR DESCRIPTION
Purely cosmetic. The rest of the constructors are in the header.