### PR TITLE
[DOCS] Remove web3 return FAQ item

### DIFF
--- a/docs/frequently-asked-questions.rst
+++ b/docs/frequently-asked-questions.rst
@@ -4,18 +4,6 @@ Frequently Asked Questions
 
 This list was originally compiled by `fivedogit <mailto:fivedogit@gmail.com>`_.
 
-
-***************
-Basic Questions
-***************
-
-If I return an ``enum``, I only get integer values in web3.js. How to get the named values?
-===========================================================================================
-
-Enums are not supported by the ABI, they are just supported by Solidity.
-You have to do the mapping yourself for now, we might provide some help
-later.
-
 ******************
 Advanced Questions
 ******************


### PR DESCRIPTION
### Description

This PR removes the the FAQ item about returning values from web3.js as I think we discussed in the past that we'd generally remove items too specific to non-Solidity projects.

Part of https://github.com/ethereum/solidity/issues/1219

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
