### PR TITLE
Do not provide access to external assembly variables from within functions.

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -336,9 +336,11 @@ void CompilerContext::appendInlineAssembly(
 	identifierAccess.resolve = [&](
 		yul::Identifier const& _identifier,
 		yul::IdentifierContext,
-		bool
-	)
+		bool _insideFunction
+	) -> size_t
 	{
+		if (_insideFunction)
+			return size_t(-1);
 		auto it = std::find(_localVariables.begin(), _localVariables.end(), _identifier.name.str());
 		return it == _localVariables.end() ? size_t(-1) : 1;
 	};


### PR DESCRIPTION
This function is used within the compiler to inject yul snippets. The `_localVariables` provide access to the content of the stack as it is before the inline assembly snippet and thus this is not available from within yul functions.