### PR TITLE
Fix fuzzer_common to keep assembly intact

### DIFF
--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -101,7 +101,7 @@ void FuzzerUtil::testConstantOptimizer(string const& _input, bool _quiet)
 					isCreation,
 					runs,
 					EVMVersion{},
-					assembly,
+					tmp,
 					const_cast<AssemblyItems &>(tmp.items())
 			);
 		}


### PR DESCRIPTION
Fixed #5874.

Found by @bshastry.

The main assembly is modified in case `codeCopyMethod` where a `newData` is appended. This avoids that too.