### PR TITLE
snap: update libicu to bionic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ parts:
     source-type: git
     plugin: cmake
     build-packages: [build-essential, libboost-all-dev, libz3-dev]
-    stage-packages: [libicu55]
+    stage-packages: [libicu60]
     prepare: |
       if git describe --exact-match --tags 2> /dev/null
       then


### PR DESCRIPTION
Required to build the snap in bionic, as explained in #5889.

### Description

Update the version of the libicu package to the one present in Ubuntu bionic.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
