### PR TITLE
Change FIXMEs into TODOs where appropriate

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3027,8 +3027,8 @@ u256 FunctionType::externalIdentifier() const
 
 bool FunctionType::isPure() const
 {
-	// FIXME: replace this with m_stateMutability == StateMutability::Pure once
-	//        the callgraph analyzer is in place
+	// TODO: replace this with m_stateMutability == StateMutability::Pure once
+	//       the callgraph analyzer is in place
 	return
 		m_kind == Kind::KECCAK256 ||
 		m_kind == Kind::ECRecover ||

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -473,7 +473,7 @@ eth::LinkerObject const& CompilerStack::runtimeObject(string const& _contractNam
 	return contract(_contractName).runtimeObject;
 }
 
-/// FIXME: cache this string
+/// TODO: cache this string
 string CompilerStack::assemblyString(string const& _contractName, StringMap _sourceCodes) const
 {
 	if (m_stackState != CompilationSuccessful)
@@ -486,7 +486,7 @@ string CompilerStack::assemblyString(string const& _contractName, StringMap _sou
 		return string();
 }
 
-/// FIXME: cache the JSON
+/// TODO: cache the JSON
 Json::Value CompilerStack::assemblyJSON(string const& _contractName, StringMap _sourceCodes) const
 {
 	if (m_stackState != CompilationSuccessful)

--- a/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
+++ b/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
@@ -50,7 +50,7 @@ void InlinableExpressionFunctionFinder::operator()(FunctionDefinition const& _fu
 			Assignment const& assignment = boost::get<Assignment>(bodyStatement);
 			if (assignment.variableNames.size() == 1 && assignment.variableNames.front().name == retVariable)
 			{
-				// FIXME: use code size metric here
+				// TODO: use code size metric here
 
 				// We cannot overwrite previous settings, because this function definition
 				// would not be valid here if we were searching inside a functionally inlinable


### PR DESCRIPTION
This improves the report on lgtm.com and makes it easier to search for TODOs. There's about ~50 of them and 2 FIXMEs which are really FIXMEs :)