### PR TITLE
Remove Z3 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,13 +58,11 @@ matrix:
           before_install:
               - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
               - sudo add-apt-repository -y ppa:mhier/libboost-latest
-              - sudo add-apt-repository -y ppa:hvr/z3
               - sudo apt-get update -qq
           install:
               - sudo apt-get install -qq g++-8 gcc-8
               - sudo apt-get install -qq libboost1.67-dev
               - sudo apt-get install -qq libleveldb1
-              - sudo apt-get install -qq libz3-dev
               - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
               - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 90
 
@@ -78,13 +76,11 @@ matrix:
           before_install:
               - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
               - sudo add-apt-repository -y ppa:mhier/libboost-latest
-              - sudo add-apt-repository -y ppa:hvr/z3
               - sudo apt-get update -qq
           install:
               - sudo apt-get install -qq g++-8 gcc-8
               - sudo apt-get install -qq libboost1.67-dev
               - sudo apt-get install -qq libleveldb1
-              - sudo apt-get install -qq libz3-dev
               - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
               - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 90
 


### PR DESCRIPTION
Travis doesn't run tests, Trusty won't compile Solidity with old Z3 and Trusty doesn't have CVC4