### PR TITLE
Use specific boost include in DocStringParser

### DIFF
--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -20,7 +20,7 @@
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Exceptions.h>
 
-#include <boost/range/algorithm.hpp>
+#include <boost/range/algorithm/find_first_of.hpp>
 #include <boost/range/irange.hpp>
 
 using namespace std;


### PR DESCRIPTION
Part of #5913.

This is needed for C++17 support (at least on certain Boost and OS combinations)

I have boost 1.66 and `range/algorithm.h` includes `range/algoritm/random_shuffle.h` which relies on https://en.cppreference.com/w/cpp/algorithm/random_shuffle - a removed `std` feature in C++17.

Boost changelog claims even 1.66 is C++17 compat though.