### PR TITLE
Fix crash for too large struct array indicies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Bugfixes:
  * Code generator: Defensively pad allocation of creationCode and runtimeCode to multiples of 32 bytes.
  * Parser: Disallow empty import statements.
  * Type Checker: Dissallow mappings with data locations other than 'storage'
+ * Type Checker: Fix internal error when a struct array index does not fit into a uint256.
  * Type system: Properly report packed encoded size for arrays and structs (mostly unused until now).
 
 

--- a/test/libsolidity/syntaxTests/indexing/struct_array_noninteger_index.sol
+++ b/test/libsolidity/syntaxTests/indexing/struct_array_noninteger_index.sol
@@ -1,0 +1,10 @@
+contract test {
+ struct s { uint a; uint b;}
+    function f() pure public returns (byte) {
+        s[75555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555];
+        s[7];
+    }
+}
+
+// ----
+// TypeError: (101-241): Type int_const 7555...(132 digits omitted)...5555 is not implicitly convertible to expected type uint256.


### PR DESCRIPTION
Fixes #5056