### PR TITLE
ABIEncoderV2: Implement calldata structs without dynamically encoded members.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Bugfixes:
 
 
 Language Features:
+ * Allow calldata structs without dynamically encoded members with ABIEncoderV2.
 
 
 Compiler Features:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -371,10 +371,12 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 
 		if (
 			!m_scope->isInterface() &&
-			baseType->category() == Type::Category::Struct &&
 			baseType->dataStoredIn(DataLocation::CallData)
 		)
-			m_errorReporter.typeError(var->location(), "Calldata structs are not yet supported.");
+			if (auto const* structType = dynamic_cast<StructType const*>(baseType.get()))
+				if (structType->isDynamicallyEncoded())
+					m_errorReporter.typeError(var->location(), "Dynamically encoded calldata structs are not yet supported.");
+
 		checkArgumentAndReturnParameter(*var);
 		var->accept(*this);
 	}
@@ -2071,8 +2073,8 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				exprType->toString() + " (expected " + funType->selfType()->toString() + ")."
 			);
 
-	if (exprType->category() == Type::Category::Struct)
-		annotation.isLValue = true;
+	if (auto const* structType = dynamic_cast<StructType const*>(exprType.get()))
+		annotation.isLValue = !structType->dataStoredIn(DataLocation::CallData);
 	else if (exprType->category() == Type::Category::Array)
 	{
 		auto const& arrayType(dynamic_cast<ArrayType const&>(*exprType));

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2053,6 +2053,24 @@ unsigned StructType::calldataEncodedSize(bool) const
 	return size;
 }
 
+unsigned StructType::calldataOffsetOfMember(std::string const& _member) const
+{
+	unsigned offset = 0;
+	for (auto const& member: members(nullptr))
+	{
+		solAssert(member.type->canLiveOutsideStorage(), "");
+		if (member.name == _member)
+			return offset;
+		{
+			// Struct members are always padded.
+			unsigned memberSize = member.type->calldataEncodedSize(true);
+			solAssert(memberSize != 0, "");
+			offset += memberSize;
+		}
+	}
+	solAssert(false, "Struct member not found.");
+}
+
 bool StructType::isDynamicallyEncoded() const
 {
 	solAssert(!recursive(), "");

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -852,6 +852,7 @@ public:
 
 	std::pair<u256, unsigned> const& storageOffsetsOfMember(std::string const& _name) const;
 	u256 memoryOffsetOfMember(std::string const& _name) const;
+	unsigned calldataOffsetOfMember(std::string const& _name) const;
 
 	StructDefinition const& structDefinition() const { return m_struct; }
 

--- a/libsolidity/codegen/ABIFunctions.h
+++ b/libsolidity/codegen/ABIFunctions.h
@@ -222,6 +222,8 @@ private:
 	std::string abiDecodingFunctionCalldataArray(ArrayType const& _type);
 	/// Part of @a abiDecodingFunction for byte array types.
 	std::string abiDecodingFunctionByteArray(ArrayType const& _type, bool _fromMemory);
+	/// Part of @a abiDecodingFunction for calldata struct types.
+	std::string abiDecodingFunctionCalldataStruct(StructType const& _type);
 	/// Part of @a abiDecodingFunction for struct types.
 	std::string abiDecodingFunctionStruct(StructType const& _type, bool _fromMemory);
 	/// Part of @a abiDecodingFunction for array types.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1380,6 +1380,24 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			setLValue<MemoryItem>(_memberAccess, *_memberAccess.annotation().type);
 			break;
 		}
+		case DataLocation::CallData:
+		{
+			solUnimplementedAssert(!type.isDynamicallyEncoded(), "");
+			m_context << type.calldataOffsetOfMember(member) << Instruction::ADD;
+			// For non-value types the calldata offset is returned directly.
+			if (_memberAccess.annotation().type->isValueType())
+			{
+				solAssert(_memberAccess.annotation().type->calldataEncodedSize(false) > 0, "");
+				CompilerUtils(m_context).loadFromMemoryDynamic(*_memberAccess.annotation().type, true, true, false);
+			}
+			else
+				solAssert(
+					_memberAccess.annotation().type->category() == Type::Category::Array ||
+					_memberAccess.annotation().type->category() == Type::Category::Struct,
+					""
+				);
+			break;
+		}
 		default:
 			solAssert(false, "Illegal data location for struct.");
 		}

--- a/test/libsolidity/syntaxTests/inheritance/override/calldata_memory_struct.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/calldata_memory_struct.sol
@@ -15,7 +15,3 @@ contract B is A {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (102-112): Calldata structs are not yet supported.
-// TypeError: (146-156): Calldata structs are not yet supported.
-// TypeError: (198-208): Calldata structs are not yet supported.
-// TypeError: (250-260): Calldata structs are not yet supported.

--- a/test/libsolidity/syntaxTests/structs/array_calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/array_calldata.sol
@@ -6,5 +6,3 @@ contract Test {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (89-101): Calldata structs are not yet supported.
-// TypeError: (131-145): Calldata structs are not yet supported.

--- a/test/libsolidity/syntaxTests/structs/calldata_array_assign.sol
+++ b/test/libsolidity/syntaxTests/structs/calldata_array_assign.sol
@@ -1,7 +1,10 @@
 pragma experimental ABIEncoderV2;
 contract Test {
-    struct S { int a; }
-    function f(S calldata) external { }
+    struct S { int[3] a; }
+    function f(S calldata s, int[3] calldata a) external {
+        s.a = a;
+    }
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (144-147): Expression has to be an lvalue.

--- a/test/libsolidity/syntaxTests/structs/calldata_assign.sol
+++ b/test/libsolidity/syntaxTests/structs/calldata_assign.sol
@@ -1,7 +1,8 @@
 pragma experimental ABIEncoderV2;
 contract Test {
     struct S { int a; }
-    function f(S calldata) external { }
+    function f(S calldata s) external { s.a = 4; }
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (114-117): Expression has to be an lvalue.

--- a/test/libsolidity/syntaxTests/structs/calldata_struct_function_type.sol
+++ b/test/libsolidity/syntaxTests/structs/calldata_struct_function_type.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+contract C {
+    struct S { function (uint) external returns (uint) fn; }
+    function f(S calldata s) external returns (uint256 a) {
+        return s.fn(42);
+    }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/structs/memory_to_calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/memory_to_calldata.sol
@@ -1,0 +1,12 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    struct S { int a; }
+    function f(S calldata s) external { s = S(2); }
+    function g(S calldata s) external { S memory m; s = m; }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (114-115): Expression has to be an lvalue.
+// TypeError: (118-122): Type struct Test.S memory is not implicitly convertible to expected type struct Test.S calldata.
+// TypeError: (178-179): Expression has to be an lvalue.
+// TypeError: (182-183): Type struct Test.S memory is not implicitly convertible to expected type struct Test.S calldata.


### PR DESCRIPTION
Part of #1603.
