### PR TITLE
Modify language assertion in AssemblyStack::optimize

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Bugfixes:
  * Type Checker: Dissallow mappings with data locations other than 'storage'
  * Type Checker: Fix internal error when a struct array index does not fit into a uint256.
  * Type system: Properly report packed encoded size for arrays and structs (mostly unused until now).
+ * Commandline interface: Allow yul optimizer only for strict assembly.
 
 
 Language Features:

--- a/libsolidity/interface/AssemblyStack.cpp
+++ b/libsolidity/interface/AssemblyStack.cpp
@@ -84,7 +84,8 @@ bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string 
 
 void AssemblyStack::optimize()
 {
-	solAssert(m_language != Language::Assembly, "Optimization requested for loose assembly.");
+	if (m_language != Language::StrictAssembly)
+		solUnimplemented("Optimizer for both loose assembly and Yul is not yet implemented");
 	solAssert(m_analysisSuccessful, "Analysis was not successful.");
 	m_analysisSuccessful = false;
 	optimize(*m_parserResult);

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -861,13 +861,11 @@ bool CommandLineInterface::processInput()
 				return false;
 			}
 		}
-		if (optimize && inputLanguage == Input::Assembly)
+		if (optimize && inputLanguage != Input::StrictAssembly)
 		{
 			serr() <<
-				"Optimizer cannot be used for loose assembly. Use --" <<
+				"Optimizer can only be used for strict assembly. Use --" <<
 				g_strStrictAssembly <<
-				" or --" <<
-				g_strYul <<
 				"." <<
 				endl;
 			return false;

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -332,13 +332,12 @@ printTask "Testing assemble, yul, strict-assembly and optimize..."
     # Test options above in conjunction with --optimize.
     # Using both, --assemble and --optimize should fail.
     ! echo '{}' | "$SOLC" - --assemble --optimize &>/dev/null
+    ! echo '{}' | "$SOLC" - --yul --optimize &>/dev/null
 
     # Test yul and strict assembly output
     # Non-empty code results in non-empty binary representation with optimizations turned off,
     # while it results in empty binary representation with optimizations turned on.
     test_solc_assembly_output "{ let x:u256 := 0:u256 }" "{ let x:u256 := 0:u256 }" "--yul"
-    test_solc_assembly_output "{ let x:u256 := 0:u256 }" "{ }" "--yul --optimize"
-
     test_solc_assembly_output "{ let x := 0 }" "{ let x := 0 }" "--strict-assembly"
     test_solc_assembly_output "{ let x := 0 }" "{ }" "--strict-assembly --optimize"
 )


### PR DESCRIPTION
### Description

Currently, `AssemblyStack::optimize()` is targeted at `StrictAssembly` only. It was found that one YUL input was somehow successfully parsed, and only at the time of optimization it was found that the following assertion inside `libyul/AsmAnalysis.cpp` would fail

```
        solAssert(m_dialect->flavour != AsmFlavour::Yul, "");
```

The fix in this PR ensures that such failures are caught much earlier inside the call to `AssemblyStack::optimize()`

In addition to modifying the assertion, cmdline test `--yul --optimize` is disabled. This is because the patch rightly fails this test.