### PR TITLE
Remove type check that is covered by assertions.

### DIFF
--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -569,7 +569,7 @@ string ABIFunctions::abiEncodingFunction(
 		)");
 		templ("functionName", functionName);
 
-		if (_from.dataStoredIn(DataLocation::Storage) && to.isValueType())
+		if (_from.dataStoredIn(DataLocation::Storage))
 		{
 			// special case: convert storage reference type to value type - this is only
 			// possible for library calls where we just forward the storage reference


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/pull/5839#discussion_r254583550

This is fine because there is an assertion further up that verifies it is a value type and even inside the if body, there is an assertion that it is exactly uint256.