### PR TITLE
[DOCS] Add BSD build instructions

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -154,23 +154,35 @@ Gentoo Linux also provides a solidity package that can be installed using ``emer
 Building from Source
 ====================
 
-Prerequisites - Linux
----------------------
+Prerequisites - All Operating Systems
+-------------------------------------
 
-You need to install the following dependencies for Linux builds of Solidity:
+The following are dependencies for all builds of Solidity:
 
 +-----------------------------------+-------------------------------------------------------+
 | Software                          | Notes                                                 |
 +===================================+=======================================================+
-| `Git for Linux`_                  | Command-line tool for retrieving source from Github.  |
+| `CMake`_                          | Cross-platform build file generator.                  |
++-----------------------------------+-------------------------------------------------------+
+| `Boost`_  (version 1.65+)         | C++ libraries.                                        |
++-----------------------------------+-------------------------------------------------------+
+| `Git`_                            | Command-line tool for retrieving source code.         |
++-----------------------------------+-------------------------------------------------------+
+| `z3`_ (version 5.6+, Optional)    | For use with SMT checker.                             |
++-----------------------------------+-------------------------------------------------------+
+| `cvc4`_ (Optional)                | For use with SMT checker.                             |
 +-----------------------------------+-------------------------------------------------------+
 
-.. _Git for Linux: https://git-scm.com/download/linux
+.. _cvc4: http://cvc4.cs.stanford.edu/web/
+.. _Git: https://git-scm.com/download
+.. _Boost: https://www.boost.org
+.. _CMake: https://cmake.org/download/
+.. _z3: https://github.com/Z3Prover/z3
 
 Prerequisites - macOS
 ---------------------
 
-For macOS, ensure that you have the latest version of
+For macOS builds, ensure that you have the latest version of
 `Xcode installed <https://developer.apple.com/xcode/download/>`_.
 This contains the `Clang C++ compiler <https://en.wikipedia.org/wiki/Clang>`_, the
 `Xcode IDE <https://en.wikipedia.org/wiki/Xcode>`_ and other Apple development
@@ -183,12 +195,11 @@ command-line builds:
 
     sudo xcodebuild -license accept
 
-Our OS X builds require you to `install the Homebrew <http://brew.sh>`_
+Our OS X build script uses `the Homebrew <http://brew.sh>`_
 package manager for installing external dependencies.
 Here's how to `uninstall Homebrew
 <https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md#how-do-i-uninstall-homebrew>`_,
 if you ever want to start again from scratch.
-
 
 Prerequisites - Windows
 -----------------------
@@ -198,21 +209,17 @@ You need to install the following dependencies for Windows builds of Solidity:
 +-----------------------------------+-------------------------------------------------------+
 | Software                          | Notes                                                 |
 +===================================+=======================================================+
-| `Git for Windows`_                | Command-line tool for retrieving source from Github.  |
-+-----------------------------------+-------------------------------------------------------+
-| `CMake`_                          | Cross-platform build file generator.                  |
-+-----------------------------------+-------------------------------------------------------+
 | `Visual Studio 2017 Build Tools`_ | C++ compiler                                          |
 +-----------------------------------+-------------------------------------------------------+
 | `Visual Studio 2017`_  (Optional) | C++ compiler and dev environment.                     |
 +-----------------------------------+-------------------------------------------------------+
 
-If you've already had one IDE and only need compiler and libraries,
+If you already have one IDE and only need the compiler and libraries,
 you could install Visual Studio 2017 Build Tools.
 
 Visual Studio 2017 provides both IDE and necessary compiler and libraries.
 So if you have not got an IDE and prefer to develop solidity, Visual Studio 2017
-may be an choice for you to get everything setup easily.
+may be a choice for you to get everything setup easily.
 
 Here is the list of components that should be installed
 in Visual Studio 2017 Build Tools or Visual Studio 2017:
@@ -223,10 +230,24 @@ in Visual Studio 2017 Build Tools or Visual Studio 2017:
 * Windows 8.1 SDK
 * C++/CLI support
 
-.. _Git for Windows: https://git-scm.com/download/win
-.. _CMake: https://cmake.org/download/
 .. _Visual Studio 2017: https://www.visualstudio.com/vs/
 .. _Visual Studio 2017 Build Tools: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017
+
+Dependencies Helper Script
+--------------------------
+
+We have a helper script which you can use to install all required external dependencies
+on macOS, Windows and on numerous Linux distros.
+
+.. code-block:: bash
+
+    ./scripts/install_deps.sh
+
+Or, on Windows:
+
+.. code-block:: bat
+
+    scripts\install_deps.bat
 
 Clone the Repository
 --------------------
@@ -245,23 +266,6 @@ you should fork Solidity and add your personal fork as a second remote:
 
     git remote add personal git@github.com:[username]/solidity.git
 
-External Dependencies
----------------------
-
-We have a helper script which installs all required external dependencies
-on macOS, Windows and on numerous Linux distros.
-
-.. code-block:: bash
-
-    ./scripts/install_deps.sh
-
-Or, on Windows:
-
-.. code-block:: bat
-
-    scripts\install_deps.bat
-
-
 Command-Line Build
 ------------------
 
@@ -278,7 +282,11 @@ Building Solidity is quite similar on Linux, macOS and other Unices:
     cd build
     cmake .. && make
 
-or even easier:
+.. warning::
+
+    BSD builds should work, but are untested by the Solidity team.
+
+or even easier on Linux and macOS, you can run:
 
 .. code-block:: bash
 


### PR DESCRIPTION
### Description

Closes https://github.com/ethereum/solidity/issues/5728 by adding BSD build instructions as mentioned by @flipchan I haven't been able to successfully test these running in an emulator on my Mac, but the original poster said they work. So either we test them elsewhere or add a disclaimer saying that they are untested?

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
