### PR TITLE
Fixes compilation on Windows where STDERR_FILENO seems not to be present.

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -60,9 +60,14 @@
 #else // unix
 	#include <unistd.h>
 #endif
+
 #include <string>
 #include <iostream>
 #include <fstream>
+
+#if !defined(STDERR_FILENO)
+	#define STDERR_FILENO 2
+#endif
 
 using namespace std;
 using namespace langutil;


### PR DESCRIPTION
I'm not sure how this one did ninja through my local windows builds, but here's the fix.

I kept the check generic, even though it's highly unlikely non-windows systems won't have this PP var set. 