### PR TITLE
Disallow calldata arrays with dynamically encoded base types in TypeChecker.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -366,6 +366,16 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 	for (ASTPointer<VariableDeclaration> const& var: _function.parameters())
 	{
 		TypePointer baseType = type(*var);
+		if (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
+		{
+			baseType = arrayType->baseType();
+			if (
+				!m_scope->isInterface() &&
+				baseType->dataStoredIn(DataLocation::CallData) &&
+				baseType->isDynamicallyEncoded()
+			)
+				m_errorReporter.typeError(var->location(), "Calldata arrays with dynamically encoded base types are not yet supported.");
+		}
 		while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
 			baseType = arrayType->baseType();
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -8013,6 +8013,22 @@ BOOST_AUTO_TEST_CASE(struct_named_constructor)
 	ABI_CHECK(callContractFunction("s()"), encodeArgs(u256(1), true));
 }
 
+BOOST_AUTO_TEST_CASE(calldata_array)
+{
+	char const* sourceCode = R"(
+	    pragma experimental ABIEncoderV2;
+		contract C {
+			function f(uint[2] calldata s) external pure returns (uint256 a, uint256 b) {
+			    a = s[0];
+			    b = s[1];
+			}
+		}
+	)";
+	compileAndRun(sourceCode, 0, "C");
+
+	ABI_CHECK(callContractFunction("f(uint256[2])", encodeArgs(u256(42), u256(23))), encodeArgs(u256(42), u256(23)));
+}
+
 BOOST_AUTO_TEST_CASE(calldata_struct)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/syntaxTests/array/calldata.sol
+++ b/test/libsolidity/syntaxTests/array/calldata.sol
@@ -1,0 +1,6 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    function f(uint[3] calldata) external { }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/array/calldata_dynamic.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_dynamic.sol
@@ -1,0 +1,6 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    function f(uint[] calldata) external { }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/array/calldata_multi.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_multi.sol
@@ -1,0 +1,6 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    function f(uint[3][4] calldata) external { }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/array/calldata_multi_dynamic.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_multi_dynamic.sol
@@ -1,0 +1,7 @@
+pragma experimental ABIEncoderV2;
+contract Test {
+    function f(uint[][] calldata) external { }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (65-82): Calldata arrays with dynamically encoded base types are not yet supported.

--- a/test/libsolidity/syntaxTests/structs/array_calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/array_calldata.sol
@@ -6,3 +6,4 @@ contract Test {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (131-145): Calldata arrays with dynamically encoded base types are not yet supported.


### PR DESCRIPTION
In case that we don't manage to implement this for the release, we should at least merge this, since otherwise this will lead to Unimplemented-assertions in code generation.