### PR TITLE
Make sure "value" error hint is only displayed in the right context

### DIFF
--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(address_staticcall_value)
 				}
 			}
 		)";
-		CHECK_ERROR(sourceCode, TypeError, "Member \"value\" not found or not visible after argument-dependent lookup");
+		CHECK_ERROR(sourceCode, TypeError, "Member \"value\" is only available for payable functions.");
 	}
 }
 

--- a/test/libsolidity/syntaxTests/functionTypes/call_value_on_non_constructor.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/call_value_on_non_constructor.sol
@@ -1,0 +1,7 @@
+contract C {
+  // Tests that we don't get a wrong error about constructors
+  function f() public view returns (C) { return this; }
+  function g() public { this.f.value(); }
+}
+// ----
+// TypeError: (155-167): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/functionTypes/call_value_on_non_payable_function_type.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/call_value_on_non_payable_function_type.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (94-101): Member "value" not found or not visible after argument-dependent lookup in function (uint256) external returns (uint256) - did you forget the "payable" modifier?
+// TypeError: (94-101): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/297_library_functions_do_not_have_value.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/297_library_functions_do_not_have_value.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// TypeError: (87-96): Member "value" not found or not visible after argument-dependent lookup in function () - did you forget the "payable" modifier?
+// TypeError: (87-96): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/362_calling_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/362_calling_nonpayable.sol
@@ -3,4 +3,4 @@ contract test {
     function f() public { (new receiver()).nopay.value(10)(); }
 }
 // ----
-// TypeError: (91-119): Member "value" not found or not visible after argument-dependent lookup in function () external - did you forget the "payable" modifier?
+// TypeError: (91-119): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/363_non_payable_constructor.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/363_non_payable_constructor.sol
@@ -8,4 +8,4 @@ contract D {
     }
 }
 // ----
-// TypeError: (106-119): Member "value" not found or not visible after argument-dependent lookup in function () returns (contract C) - did you forget the "payable" modifier?
+// TypeError: (106-119): Constructor for contract C must be payable for member "value" to be available.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/502_builtin_keccak256_reject_value.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/502_builtin_keccak256_reject_value.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (47-62): Member "value" not found or not visible after argument-dependent lookup in function (bytes memory) pure returns (bytes32) - did you forget the "payable" modifier?
+// TypeError: (47-62): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/503_builtin_sha256_reject_value.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/503_builtin_sha256_reject_value.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (47-59): Member "value" not found or not visible after argument-dependent lookup in function (bytes memory) pure returns (bytes32) - did you forget the "payable" modifier?
+// TypeError: (47-59): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/504_builtin_ripemd160_reject_value.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/504_builtin_ripemd160_reject_value.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (47-62): Member "value" not found or not visible after argument-dependent lookup in function (bytes memory) pure returns (bytes20) - did you forget the "payable" modifier?
+// TypeError: (47-62): Member "value" is only available for payable functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/505_builtin_ecrecover_reject_value.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/505_builtin_ecrecover_reject_value.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (47-62): Member "value" not found or not visible after argument-dependent lookup in function (bytes32,uint8,bytes32,bytes32) pure returns (address) - did you forget the "payable" modifier?
+// TypeError: (47-62): Member "value" is only available for payable functions.


### PR DESCRIPTION
Before, the hint would be shown for any "value" member, even a user-specified one.