### PR TITLE
snap: build the latest z3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,10 +26,24 @@ parts:
     source: .
     source-type: git
     plugin: cmake
-    build-packages: [build-essential, libboost-all-dev, libz3-dev]
+    build-packages: [build-essential, libboost-all-dev]
     stage-packages: [libicu60]
-    prepare: |
+    override-build: |
       if git describe --exact-match --tags 2> /dev/null
       then
         echo -n > ../src/prerelease.txt
       fi
+      snapcraftctl build
+    after: [z3]
+  z3:
+    source: https://github.com/Z3Prover/z3.git
+    source-tag: z3-4.8.4
+    plugin: make
+    build-packages: [python]
+    stage-packages: [libstdc++6]
+    makefile: build/Makefile
+    override-build: |
+      python scripts/mk_make.py
+      cd build
+      make -j -l $(grep -c "^processor" /proc/cpuinfo)
+      make install DESTDIR=$SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
Fixes #5985

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

solc now requires a z3 version that is not available in the Ubuntu archive.
This change to the snap metadata builds the latest z3 from source.

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
