### PR TITLE
Allow calldata arrays with dynamically encoded base type.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.6.0 (unreleased)
 
 Language Features:
+ * Allow calldata arrays with dynamically encoded base types with ABIEncoderV2.
 
 
 Compiler Features:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -372,16 +372,6 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 	for (ASTPointer<VariableDeclaration> const& var: _function.parameters())
 	{
 		TypePointer baseType = type(*var);
-		if (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
-		{
-			baseType = arrayType->baseType();
-			if (
-				!m_scope->isInterface() &&
-				baseType->dataStoredIn(DataLocation::CallData) &&
-				baseType->isDynamicallyEncoded()
-			)
-				m_errorReporter.typeError(var->location(), "Calldata arrays with dynamically encoded base types are not yet supported.");
-		}
 		while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
 			baseType = arrayType->baseType();
 

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -1354,13 +1354,10 @@ string ABIFunctions::abiDecodingFunctionArray(ArrayType const& _type, bool _from
 
 string ABIFunctions::abiDecodingFunctionCalldataArray(ArrayType const& _type)
 {
-	// This does not work with arrays of complex types - the array access
-	// is not yet implemented in Solidity.
 	solAssert(_type.dataStoredIn(DataLocation::CallData), "");
 	if (!_type.isDynamicallySized())
 		solAssert(_type.length() < u256("0xffffffffffffffff"), "");
-	if (_type.baseType()->isDynamicallyEncoded())
-		solUnimplemented("Calldata arrays with non-value base types are not yet supported by Solidity.");
+	solAssert(_type.baseType()->calldataEncodedSize() > 0, "");
 	solAssert(_type.baseType()->calldataEncodedSize() < u256("0xffffffffffffffff"), "");
 
 	string functionName =
@@ -1376,7 +1373,7 @@ string ABIFunctions::abiDecodingFunctionCalldataArray(ArrayType const& _type)
 					length := calldataload(offset)
 					if gt(length, 0xffffffffffffffff) { revert(0, 0) }
 					arrayPos := add(offset, 0x20)
-					if gt(add(arrayPos, mul(<length>, <baseEncodedSize>)), end) { revert(0, 0) }
+					if gt(add(arrayPos, mul(length, <baseEncodedSize>)), end) { revert(0, 0) }
 				}
 			)";
 		else
@@ -1391,7 +1388,8 @@ string ABIFunctions::abiDecodingFunctionCalldataArray(ArrayType const& _type)
 		w("functionName", functionName);
 		w("readableTypeName", _type.toString(true));
 		w("baseEncodedSize", toCompactHexWithPrefix(_type.isByteArray() ? 1 : _type.baseType()->calldataEncodedSize()));
-		w("length", _type.isDynamicallyEncoded() ? "length" : toCompactHexWithPrefix(_type.length()));
+		if (!_type.isDynamicallySized())
+			w("length", toCompactHexWithPrefix(_type.length()));
 		return w.render();
 	});
 }

--- a/libsolidity/codegen/ArrayUtils.h
+++ b/libsolidity/codegen/ArrayUtils.h
@@ -97,11 +97,13 @@ public:
 	/// on the stack at position @a _stackDepthLength and the storage reference at @a _stackDepthRef.
 	/// If @a _arrayType is a byte array, takes tight coding into account.
 	void storeLength(ArrayType const& _arrayType, unsigned _stackDepthLength = 0, unsigned _stackDepthRef = 1) const;
-	/// Performs bounds checking and returns a reference on the stack.
+	/// Checks whether the index is out of range and returns the absolute offset of the element reference[index]
+	/// (i.e. reference + index * size_of_base_type).
+	/// If @a _keepReference is true, the base reference to the beginning of the array is kept on the stack.
 	/// Stack pre: reference [length] index
-	/// Stack post (storage): storage_slot byte_offset
-	/// Stack post: memory/calldata_offset
-	void accessIndex(ArrayType const& _arrayType, bool _doBoundsCheck = true) const;
+	/// Stack post (storage): [reference] storage_slot byte_offset
+	/// Stack post: [reference] memory/calldata_offset
+	void accessIndex(ArrayType const& _arrayType, bool _doBoundsCheck = true, bool _keepReference = false) const;
 
 private:
 	/// Adds the given number of bytes to a storage byte offset counter and also increments

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -202,6 +202,31 @@ public:
 		return m_blockNumber;
 	}
 
+	template<typename Range>
+	bytes encodeArray(bool _dynamicallySized, bool _dynamicallyEncoded, Range const& _elements)
+	{
+		bytes result;
+		if (_dynamicallySized)
+			result += encode(u256(_elements.size()));
+		if (_dynamicallyEncoded)
+		{
+			u256 offset = u256(_elements.size()) * 32;
+			std::vector<bytes> subEncodings;
+			for (auto const& element: _elements)
+			{
+				result += encode(offset);
+				subEncodings.emplace_back(encode(element));
+				offset += subEncodings.back().size();
+			}
+			for (auto const& subEncoding: subEncodings)
+				result += subEncoding;
+		}
+		else
+			for (auto const& element: _elements)
+				result += encode(element);
+		return result;
+	}
+
 private:
 	template <class CppFunction, class... Args>
 	auto callCppAndEncodeResult(CppFunction const& _cppFunction, Args const&... _arguments)

--- a/test/libsolidity/syntaxTests/array/calldata_multi_dynamic.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_multi_dynamic.sol
@@ -4,4 +4,3 @@ contract Test {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (65-82): Calldata arrays with dynamically encoded base types are not yet supported.

--- a/test/libsolidity/syntaxTests/array/calldata_multi_dynamic_V1.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_multi_dynamic_V1.sol
@@ -1,0 +1,7 @@
+contract Test {
+    function f(uint[][] calldata) external { }
+    function g(uint[][1] calldata) external { }
+}
+// ----
+// TypeError: (31-48): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.
+// TypeError: (78-96): This type is only supported in the new experimental ABI encoder. Use "pragma experimental ABIEncoderV2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/structs/array_calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/array_calldata.sol
@@ -6,4 +6,3 @@ contract Test {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (131-145): Calldata arrays with dynamically encoded base types are not yet supported.


### PR DESCRIPTION
Fixes #3293 

Probably more tests missing (dynamic structs as base type? might be excluded in typechecker).
