### PR TITLE
Update aleth version to 1.5.2.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -90,7 +90,7 @@ The option ``--no-smt`` disables the tests that require ``libz3`` and
 ``--no-ipc`` disables those that require ``aleth``.
 
 If you want to run the ipc tests (that test the semantics of the generated code),
-you need to install `aleth <https://github.com/ethereum/aleth/releases/download/v1.5.0-alpha.7/aleth-1.5.0-alpha.7-linux-x86_64.tar.gz>`_ and run it in testing mode: ``aleth --db memorydb --test -d /tmp/testeth``.
+you need to install `aleth <https://github.com/ethereum/aleth/releases/download/v1.5.2/aleth-1.5.2-linux-x86_64.tar.gz>`_ and run it in testing mode: ``aleth --db memorydb --test -d /tmp/testeth``.
 
 To run the actual tests, use: ``./scripts/soltest.sh --ipcpath /tmp/testeth/geth.ipc``.
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -132,8 +132,8 @@ function download_aleth()
     else
         mkdir -p /tmp/test
         # Any time the hash is updated here, the "Running compiler tests" section should also be updated.
-        ALETH_HASH="8ce2f00539d2fd8b5f093d854c6999424f7494ff"
-        ALETH_VERSION=1.5.0-alpha.7
+        ALETH_HASH="a6a9884bf3e5d8b3e01b55d4f6e9fe6dce5b5db7"
+        ALETH_VERSION=1.5.2
         wget -q -O /tmp/test/aleth.tar.gz https://github.com/ethereum/aleth/releases/download/v${ALETH_VERSION}/aleth-${ALETH_VERSION}-linux-x86_64.tar.gz
         test "$(shasum /tmp/test/aleth.tar.gz)" = "$ALETH_HASH  /tmp/test/aleth.tar.gz"
         tar -xf /tmp/test/aleth.tar.gz -C /tmp/test


### PR DESCRIPTION
Maybe this will work towards #5803.

Should we use alpha releases or stick to stable releases (there's 1.6.0-alpha1)? (@chfast suggested to use stable)