### PR TITLE
Use error message returned by isImplicitlyConvertible

### DIFF
--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -198,6 +198,30 @@ void ErrorReporter::typeError(SourceLocation const& _location, SecondarySourceLo
 	);
 }
 
+void ErrorReporter::typeError(SourceLocation const& _location, std::initializer_list<std::string const> const& _descriptions)
+{
+	std::string errorStr;
+
+	auto const ItFirst = _descriptions.begin();
+	auto const ItEnd = _descriptions.end();
+
+	for (auto it = ItFirst; it != ItEnd; )
+	{
+		errorStr += *it;
+		it++;
+
+		if (it != _descriptions.end() && it->length())
+			errorStr += " ";
+	}
+
+	error(
+		Error::Type::TypeError,
+		_location,
+		errorStr
+	);
+
+}
+
 void ErrorReporter::typeError(SourceLocation const& _location, string const& _description)
 {
 	error(

--- a/liblangutil/ErrorReporter.h
+++ b/liblangutil/ErrorReporter.h
@@ -87,6 +87,11 @@ public:
 
 	void typeError(SourceLocation const& _location, std::string const& _description);
 
+	void typeError(
+		SourceLocation const& _location,
+		std::initializer_list<std::string const> const& _descriptions
+	);
+
 	void fatalTypeError(SourceLocation const& _location, std::string const& _description);
 
 	void docstringParsingError(std::string const& _description);


### PR DESCRIPTION
Early draft for https://github.com/ethereum/solidity/issues/4128
I haven't changed all calls of `isImplicitlyConvertible` yet and I still have to add  the actual error messages.

Early feedback is welcome.