### PR TITLE
Add extra token for assembly assignment

### DIFF
--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -596,7 +596,12 @@ void Scanner::scanToken()
 				token = Token::Period;
 			break;
 		case ':':
-			token = selectToken(Token::Colon);
+			// : :=
+			advance();
+			if (m_char == '=')
+				token = selectToken(Token::AssemblyAssign);
+			else
+				token = Token::Colon;
 			break;
 		case ';':
 			token = selectToken(Token::Semicolon);

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -140,6 +140,8 @@ namespace langutil
 	T(Dec, "--", 0)                                                    \
 	K(Delete, "delete", 0)                                             \
 	\
+	/* Inline Assembly Operators */                                    \
+	T(AssemblyAssign, ":=", 2)                                         \
 	/* Keywords */                                                     \
 	K(Anonymous, "anonymous", 0)                                       \
 	K(As, "as", 0)                                                     \

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -138,63 +138,66 @@ Statement Parser::parseStatement()
 		return ExpressionStatement{locationOf(expr), expr};
 	}
 	case Token::Comma:
+	case Token::AssemblyAssign:
 	{
-		// if a comma follows, a multiple assignment is assumed
+		std::vector<Identifier> variableNames;
 
-		if (elementary.type() != typeid(Identifier))
-			fatalParserError("Label name / variable name must precede \",\" (multiple assignment).");
-		Identifier const& identifier = boost::get<Identifier>(elementary);
-
-		Assignment assignment = createWithLocation<Assignment>(identifier.location);
-		assignment.variableNames.emplace_back(identifier);
-
-		do
+		while (true)
 		{
-			expectToken(Token::Comma);
-			elementary = parseElementaryOperation();
 			if (elementary.type() != typeid(Identifier))
-				fatalParserError("Variable name expected in multiple assignment.");
-			assignment.variableNames.emplace_back(boost::get<Identifier>(elementary));
-		}
-		while (currentToken() == Token::Comma);
+			{
+				auto const token = currentToken() == Token::Comma ? "," : ":=";
 
-		expectToken(Token::Colon);
-		expectToken(Token::Assign);
+				fatalParserError(
+					std::string("Variable name must precede \"") +
+					token +
+					"\"" +
+					(currentToken() == Token::Comma ? " in multiple assignment." : " in assignment.")
+				);
+			}
+
+			auto const& identifier = boost::get<Identifier>(elementary);
+
+			if (m_dialect->builtin(identifier.name))
+				fatalParserError("Cannot assign to builtin function \"" + identifier.name.str() + "\".");
+
+			variableNames.emplace_back(identifier);
+
+			if (currentToken() != Token::Comma)
+				break;
+
+			expectToken(Token::Comma);
+
+			elementary = parseElementaryOperation();
+		}
+
+		Assignment assignment =
+			createWithLocation<Assignment>(boost::get<Identifier>(elementary).location);
+		assignment.variableNames = std::move(variableNames);
+
+		expectToken(Token::AssemblyAssign);
 
 		assignment.value.reset(new Expression(parseExpression()));
 		assignment.location.end = locationOf(*assignment.value).end;
+
 		return Statement{std::move(assignment)};
 	}
 	case Token::Colon:
 	{
 		if (elementary.type() != typeid(Identifier))
-			fatalParserError("Label name / variable name must precede \":\".");
+			fatalParserError("Label name must precede \":\".");
+
 		Identifier const& identifier = boost::get<Identifier>(elementary);
+
 		advance();
-		// identifier:=: should be parsed as identifier: =: (i.e. a label),
-		// while identifier:= (being followed by a non-colon) as identifier := (assignment).
-		if (currentToken() == Token::Assign && peekNextToken() != Token::Colon)
-		{
-			Assignment assignment = createWithLocation<Assignment>(identifier.location);
-			if (m_dialect->builtin(identifier.name))
-				fatalParserError("Cannot assign to builtin function \"" + identifier.name.str() + "\".");
-			else if (m_dialect->flavour != AsmFlavour::Yul && instructions().count(identifier.name.str()))
-				fatalParserError("Cannot use instruction names for identifier names.");
-			advance();
-			assignment.variableNames.emplace_back(identifier);
-			assignment.value.reset(new Expression(parseExpression()));
-			assignment.location.end = locationOf(*assignment.value).end;
-			return Statement{std::move(assignment)};
-		}
-		else
-		{
-			// label
-			if (m_dialect->flavour != AsmFlavour::Loose)
-				fatalParserError("Labels are not supported.");
-			Label label = createWithLocation<Label>(identifier.location);
-			label.name = identifier.name;
-			return label;
-		}
+
+		// label
+		if (m_dialect->flavour != AsmFlavour::Loose)
+			fatalParserError("Labels are not supported.");
+
+		Label label = createWithLocation<Label>(identifier.location);
+		label.name = identifier.name;
+		return label;
 	}
 	default:
 		if (m_dialect->flavour != AsmFlavour::Loose)
@@ -439,10 +442,9 @@ VariableDeclaration Parser::parseVariableDeclaration()
 		else
 			break;
 	}
-	if (currentToken() == Token::Colon)
+	if (currentToken() == Token::AssemblyAssign)
 	{
-		expectToken(Token::Colon);
-		expectToken(Token::Assign);
+		expectToken(Token::AssemblyAssign);
 		varDecl.value = make_unique<Expression>(parseExpression());
 		varDecl.location.end = locationOf(*varDecl.value).end;
 	}

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -490,8 +490,8 @@ BOOST_AUTO_TEST_CASE(recursion_depth)
 
 BOOST_AUTO_TEST_CASE(multiple_assignment)
 {
-	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} 123, x := f() }", ParserError, "Label name / variable name must precede \",\" (multiple assignment).");
-	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} x, 123 := f() }", ParserError, "Variable name expected in multiple assignment.");
+	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} 123, x := f() }", ParserError, "Variable name must precede \",\" in multiple assignment.");
+	CHECK_PARSE_ERROR("{ let x function f() -> a, b {} x, 123 := f() }", ParserError, "Variable name must precede \":=\" in assignment.");
 
 	/// NOTE: Travis hiccups if not having a variable
 	char const* text = R"(
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE(inline_assembly_shadowed_instruction_assignment)
 
 BOOST_AUTO_TEST_CASE(inline_assembly_shadowed_instruction_functional_assignment)
 {
-	CHECK_ASSEMBLE_ERROR("{ gas := 2 }", ParserError, "Label name / variable name must precede \":\"");
+	CHECK_ASSEMBLE_ERROR("{ gas := 2 }", ParserError, "Variable name must precede \":=\"");
 }
 
 BOOST_AUTO_TEST_CASE(revert)

--- a/test/libsolidity/SolidityScanner.cpp
+++ b/test/libsolidity/SolidityScanner.cpp
@@ -59,6 +59,32 @@ BOOST_AUTO_TEST_CASE(smoke_test)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
+BOOST_AUTO_TEST_CASE(assembly_assign)
+{
+	Scanner scanner(CharStream("let a := 1", ""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Let);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::AssemblyAssign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "1");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+}
+
+BOOST_AUTO_TEST_CASE(assembly_multiple_assign)
+{
+	Scanner scanner(CharStream("let a, b, c := 1", ""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Let);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Comma);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Comma);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::AssemblyAssign);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Number);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "1");
+	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
+}
+
 BOOST_AUTO_TEST_CASE(string_escapes)
 {
 	Scanner scanner(CharStream("  { \"a\\x61\"", ""));

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/assign_to_instruction.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/assign_to_instruction.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      let mod := 2
+    }
+  }
+}
+// ----
+// ParserError: (67-70): Cannot use instruction names for identifier names.
+// ParserError: (71-73): Expected ';' but got ':='

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/missing_variable_in_assign.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/missing_variable_in_assign.sol
@@ -7,5 +7,5 @@ contract C {
   }
 }
 // ----
-// ParserError: (87-88): Literal, identifier or instruction expected.
-// ParserError: (87-88): Expected primary expression.
+// ParserError: (87-89): Literal, identifier or instruction expected.
+// ParserError: (87-89): Expected primary expression.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/multiple_assign_to_instruction.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/multiple_assign_to_instruction.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public pure {
+    assembly {
+      function g() -> a,b, c {}
+      let a, sub, mov := g()
+    }
+  }
+}
+// ----
+// ParserError: (102-105): Cannot use instruction names for identifier names.
+// ParserError: (105-106): Expected ';' but got ','

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/no_identifier_assignment.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/no_identifier_assignment.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      return := 1
+    }
+  }
+}
+// ----
+// ParserError: (70-72): Variable name must precede ":=" in assignment.
+// ParserError: (70-72): Expected primary expression.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/no_identifier_label.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/no_identifier_label.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      return : 1
+    }
+  }
+}
+// ----
+// ParserError: (70-71): Label name must precede ":".
+// ParserError: (70-71): Expected primary expression.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/whitespace_in_assignment.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/whitespace_in_assignment.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      let x : = mload(0)
+    }
+  }
+}
+// ----
+// ParserError: (69-70): Literal, identifier or instruction expected.
+// ParserError: (69-70): Expected primary expression.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/whitespace_in_multiple_assignment.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/whitespace_in_multiple_assignment.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public pure {
+    assembly {
+      function g() -> a,b, c {}
+      let x, y ,z : = g()
+    }
+  }
+}
+// ----
+// ParserError: (107-108): Literal, identifier or instruction expected.
+// ParserError: (107-108): Expected primary expression.

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(tokens_as_identifers)
 
 BOOST_AUTO_TEST_CASE(lacking_types)
 {
-	CHECK_ERROR("{ let x := 1:u256 }", ParserError, "Expected identifier but got '='");
+	CHECK_ERROR("{ let x := 1:u256 }", ParserError, "Expected ':' but got ':='");
 	CHECK_ERROR("{ let x:u256 := 1 }", ParserError, "Expected ':' but got '}'");
 	CHECK_ERROR("{ function f(a) {} }", ParserError, "Expected ':' but got ')'");
 	CHECK_ERROR("{ function f(a:u256) -> b {} }", ParserError, "Expected ':' but got '{'");
@@ -271,8 +271,8 @@ BOOST_AUTO_TEST_CASE(recursion_depth)
 
 BOOST_AUTO_TEST_CASE(multiple_assignment)
 {
-	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} 123:u256, x := f() }", ParserError, "Label name / variable name must precede \",\" (multiple assignment).");
-	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} x, 123:u256 := f() }", ParserError, "Variable name expected in multiple assignment.");
+	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} 123:u256, x := f() }", ParserError, "Variable name must precede \",\" in multiple assignment.");
+	CHECK_ERROR("{ let x:u256 function f() -> a:u256, b:u256 {} x, 123:u256 := f() }", ParserError, "Variable name must precede \":=\" in assignment.");
 
 	/// NOTE: Travis hiccups if not having a variable
 	char const* text = R"(
@@ -333,6 +333,7 @@ BOOST_AUTO_TEST_CASE(builtins_parser)
 	CHECK_ERROR_DIALECT("{ let builtin := 6 }", ParserError, "Cannot use builtin function name \"builtin\" as identifier name.", dialect);
 	CHECK_ERROR_DIALECT("{ function builtin() {} }", ParserError, "Cannot use builtin function name \"builtin\" as identifier name.", dialect);
 	CHECK_ERROR_DIALECT("{ builtin := 6 }", ParserError, "Cannot assign to builtin function \"builtin\".", dialect);
+	CHECK_ERROR_DIALECT("{ function g() -> a,b  {} builtin, builtin2 := g() }", ParserError, "Cannot assign to builtin function \"builtin\".", dialect);
 }
 
 BOOST_AUTO_TEST_CASE(builtins_analysis)


### PR DESCRIPTION
Adding an extra token for := prevents whitespace between : = being valid

Fixes #4185