### PR TITLE
[soltest] Add support for left-aligned hex literals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,7 +22,7 @@ Bugfixes:
 
 
 Build System:
-
+ * Soltest: Add support for left-aligned, padded hex literals.
 
 ### 0.5.4 (2019-02-12)
 

--- a/test/libsolidity/semanticTests/smoke_test.sol
+++ b/test/libsolidity/semanticTests/smoke_test.sol
@@ -8,6 +8,9 @@ contract C {
     function h() public payable returns (uint) {
         return f();
     }
+    function x(bytes32 b) public returns (bytes32) {
+        return b;
+    }
 }
 // ----
 // f() -> 1
@@ -15,3 +18,4 @@ contract C {
 // h(), 1 ether -> 1
 // j() -> FAILURE
 // i() # Does not exist. # -> FAILURE # Reverts. #
+// x(bytes32): 0x31 -> 0x31

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -56,6 +56,7 @@ namespace test
 	/* Literals & identifier */    \
 	T(Comment, "#", 0)             \
 	T(Number, "number", 0)         \
+	T(HexNumber, "hex_number", 0)  \
 	T(Identifier, "identifier", 0) \
 	/* type keywords */            \
 	K(Ether, "ether", 0)           \
@@ -102,10 +103,10 @@ struct ABIType
 	{
 		UnsignedDec,
 		SignedDec,
+		Hex,
 		Failure,
 		None
 	};
-
 	enum Align
 	{
 		AlignLeft,
@@ -113,7 +114,7 @@ struct ABIType
 	};
 
 	Type type = ABIType::None;
-	Align align = Align::AlignRight;
+	Align align = ABIType::AlignRight;
 	size_t size = 0;
 };
 
@@ -290,7 +291,8 @@ private:
 
 		std::string scanComment();
 		std::string scanIdentifierOrKeyword();
-		std::string scanNumber();
+		std::string scanDecimalNumber();
+		std::string scanHexNumber();
 
 	private:
 		using TokenDesc = std::pair<Token, std::string>;
@@ -357,12 +359,20 @@ private:
 	/// # A nice comment. #
 	std::string parseComment();
 
-	/// Parses the current number literal.
-	std::string parseNumber();
+	/// Parses the current decimal number literal.
+	std::string parseDecimalNumber();
 
-	/// Tries to convert \param _literal to `uint256` and throws if
-	/// conversion fails.
+	/// Parses the current hex number literal.
+	std::string parseHexNumber();
+
+	/// Tries to convert \param _literal to right-aligned, padded `u256`
+	/// representation of the decimal number literal.
+	/// Throws if conversion fails.
 	u256 convertNumber(std::string const& _literal);
+
+	/// Tries to convert \param _literal to left-aligned, padded `bytes`
+	/// representation of the hex literal. Throws if conversion fails.
+	bytes convertHexNumber(std::string const& _literal);
 
 	/// A scanner instance
 	Scanner m_scanner;

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -305,6 +305,38 @@ BOOST_AUTO_TEST_CASE(call_arguments_tuple)
 	testFunctionCall(calls.at(1), Mode::SingleLine, "f((uint8),uint8)", false);
 }
 
+BOOST_AUTO_TEST_CASE(call_arguments_left_aligned)
+{
+	char const* source = R"(
+		// f(bytes32, bytes32): 0x6161, 0x420000EF -> 1
+		// g(bytes32, bytes32): 0x0616, 0x0042EF00 -> 1
+	)";
+	auto const calls = parse(source);
+	BOOST_REQUIRE_EQUAL(calls.size(), 2);
+	testFunctionCall(
+		calls.at(0),
+		Mode::SingleLine,
+		"f(bytes32,bytes32)",
+		false,
+		fmt::encodeArgs(
+			u256("0x6161000000000000000000000000000000000000000000000000000000000000"),
+			u256("0x420000EF00000000000000000000000000000000000000000000000000000000")
+		),
+		fmt::encodeArgs(1)
+	);
+	testFunctionCall(
+		calls.at(1),
+		Mode::SingleLine,
+		"g(bytes32,bytes32)",
+		false,
+		fmt::encodeArgs(
+			u256("0x0616000000000000000000000000000000000000000000000000000000000000"),
+			u256("0x0042EF0000000000000000000000000000000000000000000000000000000000")
+		),
+		fmt::encodeArgs(1)
+	);
+}
+
 BOOST_AUTO_TEST_CASE(call_arguments_tuple_of_tuples)
 {
 	char const* source = R"(
@@ -542,6 +574,14 @@ BOOST_AUTO_TEST_CASE(call_ether_type_invalid)
 {
 	char const* source = R"(
 		// f(uint256), 2 btc : 1 -> 1
+	)";
+	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
+BOOST_AUTO_TEST_CASE(call_hex_number_invalid)
+{
+	char const* source = R"(
+		// f(bytes32, bytes32): 0x616, 0x042 -> 1
 	)";
 	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
 }

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -144,6 +144,13 @@ string TestFunctionCall::formatBytesParameters(bytes const& _bytes, ParameterLis
 			else
 				resultStream << fromBigEndian<u256>(byteRange);
 			break;
+		case ABIType::Hex:
+			soltestAssert(param.abiType.align == ABIType::AlignLeft, "Hex numbers must be left-aligned.");
+			byteRange.erase(
+				std::remove(byteRange.begin(), byteRange.end(), 0), byteRange.end()
+			);
+			resultStream << toHex(byteRange, HexPrefix::Add);
+			break;
 		case ABIType::Failure:
 			break;
 		case ABIType::None:

--- a/test/libsolidity/util/TestFunctionCallTests.cpp
+++ b/test/libsolidity/util/TestFunctionCallTests.cpp
@@ -75,6 +75,34 @@ BOOST_AUTO_TEST_CASE(format_signed_singleline)
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(int8): -1 -> -1");
 }
 
+BOOST_AUTO_TEST_CASE(format_hex_singleline)
+{
+	bytes result = fromHex("0x31");
+	bytes expectedBytes = result + bytes(32 - result.size(), 0);
+	ABIType abiType{ABIType::Hex, ABIType::AlignLeft, 32};
+	Parameter param{expectedBytes, "0x31", abiType, FormatInfo{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
+	FunctionCall call{"f(bytes32)", 0, arguments, expectations};
+	TestFunctionCall test{call};
+
+	BOOST_REQUIRE_EQUAL(test.format(), "// f(bytes32): 0x31 -> 0x31");
+}
+
+BOOST_AUTO_TEST_CASE(format_hex_right_align)
+{
+	bytes result = fromHex("0x31");
+	bytes expectedBytes = result + bytes(32 - result.size(), 0);
+	ABIType abiType{ABIType::Hex, ABIType::AlignRight, 32};
+	Parameter param{expectedBytes, "0x31", abiType, FormatInfo{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
+	FunctionCall call{"f(bytes32)", 0, arguments, expectations};
+	TestFunctionCall test{call};
+
+	BOOST_REQUIRE_THROW(test.format(), runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(format_empty_byte_range)
 {
 	bytes expectedBytes;


### PR DESCRIPTION
Part of #4223.

- [x] Change base branch to `develop` after https://github.com/ethereum/solidity/pull/6060 got merged

This PR aims to add support for hex literals in (i)soltest. Hex literals result in a left-aligned, padded 32-byte representation:

```
contract C {
    function g(uint x, uint y) public returns (uint) {
        return x - y;
    }
    function x(bytes32 b) public returns (bytes32) {
        return b;
    }
}
// ----
// g(uint256,uint256): 1, -2 -> 3
// x(bytes32): 0x31 -> 0x31
```
Decimal number literals are still right-aligned, padded 32 bytes.

This PR also moves some code that is shared between the Solidity parser and the soltest parser.