### PR TITLE
correct documentation around contract type conversion

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -305,8 +305,7 @@ Contract Types
 
 Every :ref:`contract<contracts>` defines its own type.
 You can implicitly convert contracts to contracts they inherit from.
-Contracts can be explicitly converted to and from all other contract types
-and the ``address`` type.
+Contracts can be explicitly converted to and from the ``address`` type.
 
 Explicit conversion to and from the ``address payable`` type
 is only possible if the contract type has a payable fallback function.


### PR DESCRIPTION
### Description

Small doc fix to cover the changes to explicit contract conversion added in 0.5.0 ("Explicit conversions between unrelated contract types are now disallowed.") [link](https://solidity.readthedocs.io/en/v0.5.4/050-breaking-changes.html#explicitness-requirements).
