### PR TITLE
[soltest] Add support for boolean literals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Bugfixes:
 
 Build System:
  * Soltest: Add support for left-aligned, padded hex literals.
+ * Soltest: Add support for right-aligned, padded boolean literals.
 
 ### 0.5.4 (2019-02-12)
 

--- a/test/libsolidity/semanticTests/smoke_test.sol
+++ b/test/libsolidity/semanticTests/smoke_test.sol
@@ -11,6 +11,9 @@ contract C {
     function x(bytes32 b) public returns (bytes32) {
         return b;
     }
+    function t(bool b) public returns (bool) {
+        return !b;
+    }
 }
 // ----
 // f() -> 1
@@ -19,3 +22,4 @@ contract C {
 // j() -> FAILURE
 // i() # Does not exist. # -> FAILURE # Reverts. #
 // x(bytes32): 0x31 -> 0x31
+// t(bool): true -> false

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -60,6 +60,7 @@ namespace test
 	T(Identifier, "identifier", 0) \
 	/* type keywords */            \
 	K(Ether, "ether", 0)           \
+	K(Boolean, "boolean", 0)       \
 	/* special keywords */         \
 	K(Failure, "FAILURE", 0)       \
 
@@ -103,6 +104,7 @@ struct ABIType
 	{
 		UnsignedDec,
 		SignedDec,
+		Boolean,
 		Hex,
 		Failure,
 		None
@@ -355,6 +357,9 @@ private:
 	/// and / or parentheses like `((uint, uint), (uint, (uint, uint)), uint)`.
 	std::string parseIdentifierOrTuple();
 
+	/// Parses a boolean literal.
+	std::string parseBoolean();
+
 	/// Parses a comment that is defined like this:
 	/// # A nice comment. #
 	std::string parseComment();
@@ -364,6 +369,10 @@ private:
 
 	/// Parses the current hex number literal.
 	std::string parseHexNumber();
+
+	/// Coverts "true" to `true`, "false" to `false` and throws
+	/// otherwise.
+	bool convertBoolean(std::string const& _literal);
 
 	/// Tries to convert \param _literal to right-aligned, padded `u256`
 	/// representation of the decimal number literal.

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -293,6 +293,23 @@ BOOST_AUTO_TEST_CASE(call_arguments)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(call_arguments_bool)
+{
+	char const* source = R"(
+		// f(bool): true -> false
+	)";
+	auto const calls = parse(source);
+	BOOST_REQUIRE_EQUAL(calls.size(), 1);
+	testFunctionCall(
+		calls.at(0),
+		Mode::SingleLine,
+		"f(bool)",
+		false,
+		fmt::encodeArgs(true),
+		fmt::encodeArgs(false)
+	);
+}
+
 BOOST_AUTO_TEST_CASE(call_arguments_tuple)
 {
 	char const* source = R"(

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -126,13 +126,6 @@ string TestFunctionCall::formatBytesParameters(bytes const& _bytes, ParameterLis
 		bytes byteRange{it, offsetIter};
 		switch (param.abiType.type)
 		{
-		case ABIType::SignedDec:
-			soltestAssert(param.abiType.align == ABIType::AlignRight, "Signed decimals must be right-aligned.");
-			if (*byteRange.begin() & 0x80)
-				resultStream << u2s(fromBigEndian<u256>(byteRange));
-			else
-				resultStream << fromBigEndian<u256>(byteRange);
-			break;
 		case ABIType::UnsignedDec:
 			// Check if the detected type was wrong and if this could
 			// be signed. If an unsigned was detected in the expectations,
@@ -144,6 +137,23 @@ string TestFunctionCall::formatBytesParameters(bytes const& _bytes, ParameterLis
 			else
 				resultStream << fromBigEndian<u256>(byteRange);
 			break;
+		case ABIType::SignedDec:
+			soltestAssert(param.abiType.align == ABIType::AlignRight, "Signed decimals must be right-aligned.");
+			if (*byteRange.begin() & 0x80)
+				resultStream << u2s(fromBigEndian<u256>(byteRange));
+			else
+				resultStream << fromBigEndian<u256>(byteRange);
+			break;
+		case ABIType::Boolean:
+		{
+			soltestAssert(param.abiType.align == ABIType::AlignRight, "Booleans must be right-aligned.");
+			u256 result = fromBigEndian<u256>(byteRange);
+			if (result == 0)
+				resultStream << "false";
+			else
+				resultStream << "true";
+			break;
+		}
 		case ABIType::Hex:
 			soltestAssert(param.abiType.align == ABIType::AlignLeft, "Hex numbers must be left-aligned.");
 			byteRange.erase(

--- a/test/libsolidity/util/TestFunctionCallTests.cpp
+++ b/test/libsolidity/util/TestFunctionCallTests.cpp
@@ -103,6 +103,45 @@ BOOST_AUTO_TEST_CASE(format_hex_right_align)
 	BOOST_REQUIRE_THROW(test.format(), runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(format_bool_true_singleline)
+{
+	bytes expectedBytes = toBigEndian(u256{true});
+	ABIType abiType{ABIType::Boolean, ABIType::AlignRight, 32};
+	Parameter param{expectedBytes, "true", abiType, FormatInfo{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
+	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	TestFunctionCall test{call};
+
+	BOOST_REQUIRE_EQUAL(test.format(), "// f(bool): true -> true");
+}
+
+BOOST_AUTO_TEST_CASE(format_bool_false_singleline)
+{
+	bytes expectedBytes = toBigEndian(u256{false});
+	ABIType abiType{ABIType::Boolean, ABIType::AlignRight, 32};
+	Parameter param{expectedBytes, "false", abiType, FormatInfo{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
+	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	TestFunctionCall test{call};
+
+	BOOST_REQUIRE_EQUAL(test.format(), "// f(bool): false -> false");
+}
+
+BOOST_AUTO_TEST_CASE(format_bool_left_align_singleline)
+{
+	bytes expectedBytes = toBigEndian(u256{true});
+	ABIType abiType{ABIType::Boolean, ABIType::AlignLeft, 32};
+	Parameter param{expectedBytes, "true", abiType, FormatInfo{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
+	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	TestFunctionCall test{call};
+
+	BOOST_REQUIRE_THROW(test.format(), runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(format_empty_byte_range)
 {
 	bytes expectedBytes;


### PR DESCRIPTION
Part of #4223.

This PR aims to add support for boolean literals in (i)soltest. Boolean literals result in a right-aligned, padded 32-byte representation:

```
contract C {
    function g(bool x) public returns (bool) {
        return !x;
    }
}
// ----
// g(bool): true -> false
```