### PR TITLE
Disallow index access on contracts and libraries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Bugfixes:
  * Inline Assembly: Proper error message for missing variables.
  * Optimizer: Fix internal error related to unused tag removal across assemblies. This never generated any invalid code.
  * SMTChecker: Fixed crash when used with fixed-sized arrays.
+ * TypeChecker: Fix internal error and disallow index access on contracts and libraries.
  * Yul: Properly detect name clashes with functions before their declaration.
  * Yul: Take builtin functions into account in the compilability checker.
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2208,6 +2208,8 @@ bool TypeChecker::visit(IndexAccess const& _access)
 	case Type::Category::TypeType:
 	{
 		TypeType const& typeType = dynamic_cast<TypeType const&>(*baseType);
+		if (dynamic_cast<ContractType const*>(typeType.actualType().get()))
+			m_errorReporter.typeError(_access.location(), "Index access for contracts or libraries is not possible.");
 		if (!index)
 			resultType = make_shared<TypeType>(make_shared<ArrayType>(DataLocation::Memory, typeType.actualType()));
 		else

--- a/test/libsolidity/syntaxTests/array/contract_array.sol
+++ b/test/libsolidity/syntaxTests/array/contract_array.sol
@@ -1,0 +1,11 @@
+contract C {
+    C[] y = new C[](3);
+    C[3] x;
+    function f() public {
+        C[3] memory z;
+        y.push(this);
+        x[0] = this;
+        z[0] = this;
+    }
+}
+

--- a/test/libsolidity/syntaxTests/array/invalid/contract_index_access.sol
+++ b/test/libsolidity/syntaxTests/array/invalid/contract_index_access.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() view public {
+        C[0];
+    }
+}
+// ----
+// TypeError: (52-56): Index access for contracts or libraries is not possible.

--- a/test/libsolidity/syntaxTests/array/invalid/library_index_access.sol
+++ b/test/libsolidity/syntaxTests/array/invalid/library_index_access.sol
@@ -1,0 +1,7 @@
+library C {
+    function f() view public {
+        C[0];
+    }
+}
+// ----
+// TypeError: (51-55): Index access for contracts or libraries is not possible.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/5722.