### PR TITLE
Fix external tests

### DIFF
--- a/test/externalTests.sh
+++ b/test/externalTests.sh
@@ -65,7 +65,7 @@ function test_truffle
       fi
       cd ext
       echo "Current commit hash: `git rev-parse HEAD`"
-      npm install
+      npm ci
       # Replace solc package by v0.5.0
       for d in node_modules node_modules/truffle/node_modules
       do


### PR DESCRIPTION
The external tests broke with https://github.com/ethereum/solidity/pull/6104 because of an issue in Truffle's dependency management in Node. 

This PR adds applies a workaround: https://github.com/trufflesuite/ganache/issues/1110.