### PR TITLE
[Yul] introduce break/continue keywords.

### DIFF
--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -94,6 +94,12 @@ public:
 		(*this)(_for.body);
 		(*this)(_for.post);
 	}
+	void operator()(yul::Break const&)
+	{
+	}
+	void operator()(yul::Continue const&)
+	{
+	}
 	void operator()(yul::Block const& _block)
 	{
 		for (auto const& s: _block.statements)

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -34,6 +34,7 @@
 #include <boost/optional.hpp>
 
 #include <functional>
+#include <list>
 #include <memory>
 
 namespace langutil
@@ -93,6 +94,8 @@ public:
 	bool operator()(If const& _if);
 	bool operator()(Switch const& _switch);
 	bool operator()(ForLoop const& _forLoop);
+	bool operator()(Break const&);
+	bool operator()(Continue const&);
 	bool operator()(Block const& _block);
 
 private:
@@ -124,6 +127,7 @@ private:
 	langutil::EVMVersion m_evmVersion;
 	std::shared_ptr<Dialect> m_dialect;
 	boost::optional<langutil::Error::Type> m_errorTypeForLoose;
+	ForLoop const* m_currentForLoop = nullptr;
 };
 
 }

--- a/libyul/AsmData.h
+++ b/libyul/AsmData.h
@@ -78,6 +78,10 @@ struct Case { langutil::SourceLocation location; std::unique_ptr<Literal> value;
 /// Switch statement
 struct Switch { langutil::SourceLocation location; std::unique_ptr<Expression> expression; std::vector<Case> cases; };
 struct ForLoop { langutil::SourceLocation location; Block pre; std::unique_ptr<Expression> condition; Block post; Block body; };
+/// Break statement (valid within for loop)
+struct Break { langutil::SourceLocation location; };
+/// Continue statement (valid within for loop)
+struct Continue { langutil::SourceLocation location; };
 
 struct LocationExtractor: boost::static_visitor<langutil::SourceLocation>
 {

--- a/libyul/AsmDataForward.h
+++ b/libyul/AsmDataForward.h
@@ -41,12 +41,14 @@ struct If;
 struct Switch;
 struct Case;
 struct ForLoop;
+struct Break;
+struct Continue;
 struct ExpressionStatement;
 struct Block;
 
 struct TypedName;
 
 using Expression = boost::variant<FunctionalInstruction, FunctionCall, Identifier, Literal>;
-using Statement = boost::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Block>;
+using Statement = boost::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Block>;
 
 }

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -39,7 +39,7 @@ class Parser: public langutil::ParserBase
 {
 public:
 	explicit Parser(langutil::ErrorReporter& _errorReporter, std::shared_ptr<Dialect> _dialect):
-		ParserBase(_errorReporter), m_dialect(std::move(_dialect)) {}
+		ParserBase(_errorReporter), m_dialect(std::move(_dialect)), m_insideForLoopBody{false} {}
 
 	/// Parses an inline assembly block starting with `{` and ending with `}`.
 	/// @param _reuseScanner if true, do check for end of input after the `}`.
@@ -87,6 +87,7 @@ protected:
 
 private:
 	std::shared_ptr<Dialect> m_dialect;
+	bool m_insideForLoopBody;
 };
 
 }

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -224,6 +224,16 @@ string AsmPrinter::operator()(ForLoop const& _forLoop) const
 	return out;
 }
 
+string AsmPrinter::operator()(Break const&) const
+{
+	return "break";
+}
+
+string AsmPrinter::operator()(Continue const&) const
+{
+	return "continue";
+}
+
 string AsmPrinter::operator()(Block const& _block) const
 {
 	if (_block.statements.empty())

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -50,6 +50,8 @@ public:
 	std::string operator()(If const& _if) const;
 	std::string operator()(Switch const& _switch) const;
 	std::string operator()(ForLoop const& _forLoop) const;
+	std::string operator()(Break const& _break) const;
+	std::string operator()(Continue const& _continue) const;
 	std::string operator()(Block const& _block) const;
 
 private:

--- a/libyul/AsmScopeFiller.h
+++ b/libyul/AsmScopeFiller.h
@@ -63,6 +63,8 @@ public:
 	bool operator()(If const& _if);
 	bool operator()(Switch const& _switch);
 	bool operator()(ForLoop const& _forLoop);
+	bool operator()(Break const&) { return true; }
+	bool operator()(Continue const&) { return true; }
 	bool operator()(Block const& _block);
 
 private:

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -30,6 +30,8 @@
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
 
+#include <stack>
+
 namespace langutil
 {
 class ErrorReporter;
@@ -57,6 +59,20 @@ struct CodeTransformContext
 	std::map<Scope::Function const*, AbstractAssembly::LabelID> functionEntryIDs;
 	std::map<Scope::Variable const*, int> variableStackHeights;
 	std::map<Scope::Variable const*, unsigned> variableReferences;
+
+	struct JumpInfo
+	{
+		AbstractAssembly::LabelID label;  ///< Jump's LabelID to jump to.
+		int targetStackHeight;            ///< Stack height after the jump.
+	};
+
+	struct ForLoopLabels
+	{
+		JumpInfo post; ///< Jump info for jumping to post branch.
+		JumpInfo done; ///< Jump info for jumping to done branch.
+	};
+
+	std::stack<ForLoopLabels> forLoopStack;
 };
 
 /**
@@ -166,6 +182,8 @@ public:
 	void operator()(Switch const& _switch);
 	void operator()(FunctionDefinition const&);
 	void operator()(ForLoop const&);
+	void operator()(Break const&);
+	void operator()(Continue const&);
 	void operator()(Block const& _block);
 
 private:

--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -138,6 +138,15 @@ Statement ASTCopier::operator()(ForLoop const& _forLoop)
 		translate(_forLoop.body)
 	};
 }
+Statement ASTCopier::operator()(Break const& _break)
+{
+	return Break{ _break };
+}
+
+Statement ASTCopier::operator()(Continue const& _continue)
+{
+	return Continue{ _continue };
+}
 
 Statement ASTCopier::operator ()(Block const& _block)
 {

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -58,6 +58,8 @@ public:
 	virtual Statement operator()(Switch const& _switch) = 0;
 	virtual Statement operator()(FunctionDefinition const&) = 0;
 	virtual Statement operator()(ForLoop const&) = 0;
+	virtual Statement operator()(Break const&) = 0;
+	virtual Statement operator()(Continue const&) = 0;
 	virtual Statement operator()(Block const& _block) = 0;
 };
 
@@ -83,6 +85,8 @@ public:
 	Statement operator()(Switch const& _switch) override;
 	Statement operator()(FunctionDefinition const&) override;
 	Statement operator()(ForLoop const&) override;
+	Statement operator()(Break const&) override;
+	Statement operator()(Continue const&) override;
 	Statement operator()(Block const& _block) override;
 
 	virtual Expression translate(Expression const& _expression);

--- a/libyul/optimiser/ASTWalker.cpp
+++ b/libyul/optimiser/ASTWalker.cpp
@@ -161,6 +161,14 @@ void ASTModifier::operator()(ForLoop& _for)
 	(*this)(_for.body);
 }
 
+void ASTModifier::operator()(Break&)
+{
+}
+
+void ASTModifier::operator()(Continue&)
+{
+}
+
 void ASTModifier::operator()(Block& _block)
 {
 	walkVector(_block.statements);

--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -56,6 +56,8 @@ public:
 	virtual void operator()(Switch const& _switch);
 	virtual void operator()(FunctionDefinition const&);
 	virtual void operator()(ForLoop const&);
+	virtual void operator()(Break const&) {}
+	virtual void operator()(Continue const&) {}
 	virtual void operator()(Block const& _block);
 
 	virtual void visit(Statement const& _st);
@@ -91,6 +93,8 @@ public:
 	virtual void operator()(Switch& _switch);
 	virtual void operator()(FunctionDefinition&);
 	virtual void operator()(ForLoop&);
+	virtual void operator()(Break&);
+	virtual void operator()(Continue&);
 	virtual void operator()(Block& _block);
 
 	virtual void visit(Statement& _st);

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -130,6 +130,16 @@ void DataFlowAnalyzer::operator()(ForLoop& _for)
 	popScope();
 }
 
+void DataFlowAnalyzer::operator()(Break&)
+{
+	yulAssert(false, "Not implemented yet.");
+}
+
+void DataFlowAnalyzer::operator()(Continue&)
+{
+	yulAssert(false, "Not implemented yet.");
+}
+
 void DataFlowAnalyzer::operator()(Block& _block)
 {
 	size_t numScopes = m_variableScopes.size();

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -53,6 +53,8 @@ public:
 	void operator()(Switch& _switch) override;
 	void operator()(FunctionDefinition&) override;
 	void operator()(ForLoop&) override;
+	void operator()(Break& _continue) override;
+	void operator()(Continue& _continue) override;
 	void operator()(Block& _block) override;
 
 protected:

--- a/libyul/optimiser/RedundantAssignEliminator.cpp
+++ b/libyul/optimiser/RedundantAssignEliminator.cpp
@@ -149,6 +149,16 @@ void RedundantAssignEliminator::operator()(ForLoop const& _forLoop)
 	join(zeroRuns);
 }
 
+void RedundantAssignEliminator::operator()(Break const&)
+{
+	yulAssert(false, "Not implemented yet.");
+}
+
+void RedundantAssignEliminator::operator()(Continue const&)
+{
+	yulAssert(false, "Not implemented yet.");
+}
+
 void RedundantAssignEliminator::operator()(Block const& _block)
 {
 	// This will set all variables that are declared in this

--- a/libyul/optimiser/RedundantAssignEliminator.h
+++ b/libyul/optimiser/RedundantAssignEliminator.h
@@ -112,6 +112,8 @@ public:
 	void operator()(Switch const& _switch) override;
 	void operator()(FunctionDefinition const&) override;
 	void operator()(ForLoop const&) override;
+	void operator()(Break const&) override;
+	void operator()(Continue const&) override;
 	void operator()(Block const& _block) override;
 
 	static void run(Dialect const& _dialect, Block& _ast);

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -55,6 +55,8 @@ public:
 	bool statementEqual(Switch const& _lhs, Switch const& _rhs);
 	bool switchCaseEqual(Case const& _lhs, Case const& _rhs);
 	bool statementEqual(ForLoop const& _lhs, ForLoop const& _rhs);
+	bool statementEqual(Break const&, Break const&) { return true; }
+	bool statementEqual(Continue const&, Continue const&) { return true; }
 	bool statementEqual(Block const& _lhs, Block const& _rhs);
 private:
 	bool statementEqual(Instruction const& _lhs, Instruction const& _rhs);

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -295,6 +295,74 @@ BOOST_AUTO_TEST_CASE(if_statement)
 	BOOST_CHECK(successParse("{ function f() -> x:bool {} if f() { let b:bool := f() } }"));
 }
 
+BOOST_AUTO_TEST_CASE(for_statement)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	BOOST_CHECK(successParse("{ for {let i := 0} iszero(eq(i, 10)) {i := add(i, 1)} {} }", dialect));
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_break)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	BOOST_CHECK(successParse("{ for {let i := 0} iszero(eq(i, 10)) {i := add(i, 1)} {break} }", dialect));
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_break_init)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	CHECK_ERROR_DIALECT(
+		"{ for {let i := 0 break} iszero(eq(i, 10)) {i := add(i, 1)} {} }",
+		SyntaxError,
+		"Keyword break outside for-loop body is not allowed.",
+		dialect);
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_break_post)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	CHECK_ERROR_DIALECT(
+		"{ for {let i := 0} iszero(eq(i, 10)) {i := add(i, 1) break} {} }",
+		SyntaxError,
+		"Keyword break outside for-loop body is not allowed.",
+		dialect);
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_nested_break)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	CHECK_ERROR_DIALECT(
+		"{ for {let i := 0} iszero(eq(i, 10)) {} { function f() { break } } }",
+		SyntaxError,
+		"Keyword break outside for-loop body is not allowed.",
+		dialect);
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_continue)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	BOOST_CHECK(successParse("{ for {let i := 0} iszero(eq(i, 10)) {i := add(i, 1)} {continue} }", dialect));
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_continue_fail_init)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	CHECK_ERROR_DIALECT(
+		"{ for {let i := 0 continue} iszero(eq(i, 10)) {i := add(i, 1)} {} }",
+		SyntaxError,
+		"Keyword continue outside for-loop body is not allowed.",
+		dialect);
+}
+
+BOOST_AUTO_TEST_CASE(for_statement_continue_fail_post)
+{
+	auto dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion::constantinople());
+	CHECK_ERROR_DIALECT(
+		"{ for {let i := 0} iszero(eq(i, 10)) {i := add(i, 1) continue} {} }",
+		SyntaxError,
+		"Keyword continue outside for-loop body is not allowed.",
+		dialect);
+}
+
 BOOST_AUTO_TEST_CASE(if_statement_invalid)
 {
 	CHECK_ERROR("{ if let x:u256 {} }", ParserError, "Literal or identifier expected.");

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -105,10 +105,25 @@ void Interpreter::operator()(ForLoop const& _forLoop)
 		visit(statement);
 	while (evaluate(*_forLoop.condition) != 0)
 	{
+		m_state.loopState = LoopState::Default;
 		(*this)(_forLoop.body);
+		if (m_state.loopState == LoopState::Break)
+			break;
+
 		(*this)(_forLoop.post);
 	}
+	m_state.loopState = LoopState::Default;
 	closeScope();
+}
+
+void Interpreter::operator()(Break const&)
+{
+	m_state.loopState = LoopState::Break;
+}
+
+void Interpreter::operator()(Continue const&)
+{
+	m_state.loopState = LoopState::Continue;
 }
 
 void Interpreter::operator()(Block const& _block)
@@ -122,7 +137,14 @@ void Interpreter::operator()(Block const& _block)
 			m_functions[funDef.name] = &funDef;
 			m_scopes.back().insert(funDef.name);
 		}
-	ASTWalker::operator()(_block);
+
+	for (auto const& statement: _block.statements)
+	{
+		visit(statement);
+		if (m_state.loopState != LoopState::Default)
+			break;
+	}
+
 	closeScope();
 }
 

--- a/test/tools/yulInterpreter/Interpreter.h
+++ b/test/tools/yulInterpreter/Interpreter.h
@@ -39,6 +39,13 @@ class InterpreterTerminated: dev::Exception
 {
 };
 
+enum class LoopState
+{
+	Default,
+	Continue,
+	Break,
+};
+
 struct InterpreterState
 {
 	dev::bytes calldata;
@@ -65,6 +72,7 @@ struct InterpreterState
 	std::vector<std::string> trace;
 	/// This is actually an input parameter that more or less limits the runtime.
 	size_t maxTraceSize = 0;
+	LoopState loopState = LoopState::Default;
 };
 
 /**
@@ -90,6 +98,8 @@ public:
 	void operator()(Switch const& _switch) override;
 	void operator()(FunctionDefinition const&) override;
 	void operator()(ForLoop const&) override;
+	void operator()(Break const&) override;
+	void operator()(Continue const&) override;
 	void operator()(Block const& _block) override;
 
 	std::vector<std::string> const& trace() const { return m_state.trace; }


### PR DESCRIPTION
This PR implements `break` and `continue` keywords in Yul. (refs #4576)

### Checklist
- [x] code generation for EVM backend (currently just yulAssert()'ting)
- [x] interpreter
- [x] syntax tests for each keyword

