### PR TITLE
yulInterpreter: Fix u256 overflow in logMemory.

### DIFF
--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -460,10 +460,10 @@ bool EVMInstructionInterpreter::logMemory(bool _write, u256 const& _offset, u256
 	size_t constexpr maxMemSize = 0x20000000;
 
 	logTrace(_write ? "MSTORE_AT_SIZE" : "MLOAD_FROM_SIZE", {_offset, _size}, _data);
-	if (_offset + _size >= _offset)
+
+	if (((_offset + _size) >= _offset) && ((_offset + _size + 0x1f) >= (_offset + _size)))
 	{
-		u256 newSize = _offset + _size;
-		newSize = (newSize + 0x1f) & ~u256(0x1f);
+		u256 newSize = (_offset + _size + 0x1f) & ~u256(0x1f);
 		m_state.msize = max(m_state.msize, newSize);
 		if (newSize < maxMemSize)
 		{


### PR DESCRIPTION
(fixes #6135 )

### Description

An overflow in the computation of the size of the Interpreter's memory state used to cause a null dereference/out-of-bounds access.

This PR fixes that by more completely checking for overflows.

### Checklist
- [x] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
