### PR TITLE
Properly assign reference to context.

### DIFF
--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -44,7 +44,6 @@ public:
 		m_runtimeCompiler(_runtimeCompiler),
 		m_context(_context)
 	{
-		m_context = CompilerContext(_context.evmVersion(), _runtimeCompiler ? &_runtimeCompiler->m_context : nullptr);
 	}
 
 	void compileContract(


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6141

`m_context` is stored as a reference - and rightfully so. I don't know why the context was re-created in the constructor in the first place...