### PR TITLE
Add type(C).name to the documentation

### DIFF
--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -385,6 +385,7 @@ Global Variables
 - ``<address>.balance`` (``uint256``): balance of the :ref:`address` in Wei
 - ``<address payable>.send(uint256 amount) returns (bool)``: send given amount of Wei to :ref:`address`, returns ``false`` on failure
 - ``<address payable>.transfer(uint256 amount)``: send given amount of Wei to :ref:`address`, throws on failure
+- ``type(C).name`` (``string``): the name of the contract
 - ``type(C).creationCode`` (``bytes memory``): creation bytecode of the given contract, see :ref:`Type Information<meta-type>`.
 - ``type(C).runtimeCode`` (``bytes memory``): runtime bytecode of the given contract, see :ref:`Type Information<meta-type>`.
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -269,6 +269,9 @@ type ``X``. Currently, there is limited support for this feature, but
 it might be expanded in the future. The following properties are
 available for a contract type ``C``:
 
+``type(C).name``:
+    The name of the contract.
+
 ``type(C).creationCode``:
     Memory byte array that contains the creation bytecode of the contract.
     This can be used in inline assembly to build custom creation routines,


### PR DESCRIPTION
Fixes #6097.