### PR TITLE
Pass docker password in Travis via stdin

### DIFF
--- a/scripts/docker_deploy.sh
+++ b/scripts/docker_deploy.sh
@@ -10,7 +10,7 @@ tag_and_push()
     docker push "$image:$2"
 }
 
-docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 version=$($(dirname "$0")/get_version.sh)
 if [ "$TRAVIS_BRANCH" = "develop" ]
 then


### PR DESCRIPTION
Travis warns about the password for the docker registry being passed via the CLI. This PR aims to pass it via stdin, as described here: https://docs.travis-ci.com/user/docker/#pushing-a-docker-image-to-a-registry