### PR TITLE
[soltest] Extract ecrecover tests

### DIFF
--- a/test/libsolidity/semanticTests/ecrecover/ecrecover.sol
+++ b/test/libsolidity/semanticTests/ecrecover/ecrecover.sol
@@ -1,0 +1,12 @@
+contract test {
+    function a(bytes32 h, uint8 v, bytes32 r, bytes32 s) public returns (address addr) {
+        return ecrecover(h, v, r, s);
+    }
+}
+// ----
+// a(bytes32,uint8,bytes32,bytes32):
+// 0x18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c,
+// 28,
+// 0x73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75f,
+// 0xeeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549
+// -> 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b

--- a/test/libsolidity/semanticTests/ecrecover/ecrecover_abiV2.sol
+++ b/test/libsolidity/semanticTests/ecrecover/ecrecover_abiV2.sol
@@ -1,0 +1,13 @@
+pragma experimental ABIEncoderV2;
+contract test {
+    function a(bytes32 h, uint8 v, bytes32 r, bytes32 s) public returns (address addr) {
+        return ecrecover(h, v, r, s);
+    }
+}
+// ----
+// a(bytes32,uint8,bytes32,bytes32):
+// 0x18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c,
+// 28,
+// 0x73b1693892219d736caba55bdb67216e485557ea6b6af75f37096c9aa6a5a75f,
+// 0xeeb940b1d03b21e36b0e47e79769f095fe2ab855bd91e3a38756b7d75a9c4549
+// -> 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b

--- a/test/libsolidity/semanticTests/ecrecover/failing_ecrecover_invalid_input.sol
+++ b/test/libsolidity/semanticTests/ecrecover/failing_ecrecover_invalid_input.sol
@@ -1,0 +1,10 @@
+contract C {
+    // ecrecover should return zero for malformed input
+	// (v should be 27 or 28, not 1)
+	// Note that the precompile does not return zero but returns nothing.
+    function f() public returns (address) {
+        return ecrecover(bytes32(uint(-1)), 1, bytes32(uint(2)), bytes32(uint(3)));
+    }
+}
+// ----
+// f() -> 0

--- a/test/libsolidity/semanticTests/ecrecover/failing_ecrecover_invalid_input_asm.sol
+++ b/test/libsolidity/semanticTests/ecrecover/failing_ecrecover_invalid_input_asm.sol
@@ -1,0 +1,15 @@
+contract C {
+    function f() public returns (address) {
+        assembly {
+            mstore(mload(0x40), 0xca35b7d915458ef540ade6068dfe2f44e8fa733c)
+        }
+        return ecrecover(
+            0x77e5189111eb6557e8a637b27ef8fbb15bc61d61c2f00cc48878f3a296e5e0ca,
+            0, // invalid v value
+            0x6944c77849b18048f6abe0db8084b0d0d0689cdddb53d2671c36967b58691ad4,
+            0xef4f06ba4f78319baafd0424365777241af4dfd3da840471b4b4b087b7750d0d
+        );
+    }
+}
+// ----
+// f() -> 0

--- a/test/libsolidity/semanticTests/ecrecover/failing_ecrecover_invalid_input_proper.sol
+++ b/test/libsolidity/semanticTests/ecrecover/failing_ecrecover_invalid_input_proper.sol
@@ -1,0 +1,20 @@
+contract C {
+    function f() public returns (address) {
+        return recover(
+            0x77e5189111eb6557e8a637b27ef8fbb15bc61d61c2f00cc48878f3a296e5e0ca,
+            0, // invalid v value
+            0x6944c77849b18048f6abe0db8084b0d0d0689cdddb53d2671c36967b58691ad4,
+            0xef4f06ba4f78319baafd0424365777241af4dfd3da840471b4b4b087b7750d0d,
+            0x000000000000000000000000ca35b7d915458ef540ade6068dfe2f44e8fa733c,
+            0x000000000000000000000000ca35b7d915458ef540ade6068dfe2f44e8fa733c
+        );
+    }
+    function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s, uint blockExpired, bytes32 salt)
+        public returns (address)
+    {
+        require(hash == keccak256(abi.encodePacked(blockExpired, salt)));
+        return ecrecover(hash, v, r, s);
+    }
+}
+// ----
+// f() -> 0


### PR DESCRIPTION
After we get the alignment of hex number literals right with https://github.com/ethereum/solidity/pull/6183, we can finally start to extract some actual tests.

- [x] Change target to `develop` after https://github.com/ethereum/solidity/pull/6183 got merged