### PR TITLE
ossfuzz: Reduce test input size to less than equal to 600 bytes.

### DIFF
--- a/test/tools/ossfuzz/const_opt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/const_opt_ossfuzz.cpp
@@ -22,6 +22,6 @@ using namespace std;
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 {
 	string input(reinterpret_cast<char const*>(_data), _size);
-	FuzzerUtil::testConstantOptimizer(input, true);
+	FuzzerUtil::testConstantOptimizer(input, /*quiet=*/true);
 	return 0;
 }

--- a/test/tools/ossfuzz/yulProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/yulProtoFuzzer.cpp
@@ -33,6 +33,8 @@ using namespace std;
 DEFINE_BINARY_PROTO_FUZZER(Function const& _input)
 {
 	string yul_source = functionToString(_input);
+	if (yul_source.size() > 600)
+		return;
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -39,6 +39,8 @@ using namespace yul::test;
 DEFINE_BINARY_PROTO_FUZZER(Function const& _input)
 {
 	string yul_source = functionToString(_input);
+	if (yul_source.size() > 600)
+		return;
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{


### PR DESCRIPTION
### Description

This PR does the following
  - Imposes a hard limit of 600 bytes for test inputs for the proto fuzzers
  - Adds a cosmetic fix for the constant optimizer fuzzer

The hard limit does not affect code coverage. It makes fuzzing more efficient since we are providing the fuzzer a minimal set of test inputs for mutation.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
