### PR TITLE
Reduce input file size for solc and constant optimizer fuzzers.

### DIFF
--- a/test/tools/ossfuzz/const_opt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/const_opt_ossfuzz.cpp
@@ -21,7 +21,10 @@ using namespace std;
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 {
-	string input(reinterpret_cast<char const*>(_data), _size);
-	FuzzerUtil::testConstantOptimizer(input, /*quiet=*/true);
+	if (_size <= 250)
+	{
+		string input(reinterpret_cast<char const*>(_data), _size);
+		FuzzerUtil::testConstantOptimizer(input, /*quiet=*/true);
+	}
 	return 0;
 }

--- a/test/tools/ossfuzz/solc_noopt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/solc_noopt_ossfuzz.cpp
@@ -21,7 +21,10 @@ using namespace std;
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 {
-	string input(reinterpret_cast<char const*>(_data), _size);
-	FuzzerUtil::testCompiler(input, /*optimize=*/false, /*quiet=*/true);
+	if (_size <= 600)
+	{
+		string input(reinterpret_cast<char const*>(_data), _size);
+		FuzzerUtil::testCompiler(input, /*optimize=*/false, /*quiet=*/true);
+	}
 	return 0;
 }

--- a/test/tools/ossfuzz/solc_opt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/solc_opt_ossfuzz.cpp
@@ -21,7 +21,10 @@ using namespace std;
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 {
-	string input(reinterpret_cast<char const*>(_data), _size);
-	FuzzerUtil::testCompiler(input, /*optimize=*/true, /*quiet=*/true);
+	if (_size <= 600)
+	{
+		string input(reinterpret_cast<char const *>(_data), _size);
+		FuzzerUtil::testCompiler(input, /*optimize=*/true, /*quiet=*/true);
+	}
 	return 0;
 }


### PR DESCRIPTION
### Description

This PR reduces the test input file size for the solc and constant optimizer fuzzers. This does not affect code coverage, rather it makes fuzz testing more efficient.