### PR TITLE
[DOCS] Add mention of high s with ecrecover

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -163,6 +163,10 @@ Mathematical and Cryptographic Functions
 ``keccak256(bytes memory) returns (bytes32)``:
     compute the Keccak-256 hash of the input
 
+.. note::
+
+    There used to be an alias for ``keccak256`` called ``sha3``, which was removed in version 0.5.0.
+
 ``sha256(bytes memory) returns (bytes32)``:
     compute the SHA-256 hash of the input
 
@@ -182,12 +186,15 @@ Mathematical and Cryptographic Functions
 
     For further details, read `example usage <https://ethereum.stackexchange.com/q/1777/222>`_.
 
+.. warning::
+
+    If you use ``ecrecover``, be aware that a valid signature can be turned into a different valid signature without requiring
+    knowledge of the corresponding private key. This is usually not a problem unless you require signatures to be unique or
+    use them to identify items. OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.org/docs/cryptography_ecdsa>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
+
 .. note::
 
     When running ``sha256``, ``ripemd160`` or ``ecrecover`` on a *private blockchain*, you might encounter Out-of-Gas. This is because these functions are implemented as "precompiled contracts" and only really exist after they receive the first message (although their contract code is hardcoded). Messages to non-existing contracts are more expensive and thus the execution might run into an Out-of-Gas error. A workaround for this problem is to first send Wei (1 for example) to each of the contracts before you use them in your actual contracts. This is not an issue on the main or test net.
-
-.. note::
-    There used to be an alias for ``keccak256`` called ``sha3``, which was removed in version 0.5.0.
 
 .. index:: balance, send, transfer, call, callcode, delegatecall, staticcall
 


### PR DESCRIPTION
### Description

As discussed here - https://github.com/ethereum/solidity/issues/681#issuecomment-469259171 this PR adds mention of high `s` issues with `ecrecover`. Regarding the Zeppelin potential fix, I will watch that PR and create a new PR here when appropriate.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
