### PR TITLE
[soltest] Add support for arrays in function signatures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ Bugfixes:
 
 
 Build System:
-
+ * Soltest: Add support for arrays in function signatures.
 
 
 ### 0.5.5 (2019-03-05)

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -252,6 +252,15 @@ string TestFileParser::parseIdentifierOrTuple()
 	{
 		identOrTuple = m_scanner.currentLiteral();
 		expect(Token::Identifier);
+		while (accept(Token::LBrack))
+		{
+			identOrTuple += formatToken(Token::LBrack);
+			expect(Token::LBrack);
+			if (accept(Token::Number))
+				identOrTuple += parseDecimalNumber();
+			identOrTuple += formatToken(Token::RBrack);
+			expect(Token::RBrack);
+		}
 		return identOrTuple;
 	}
 	expect(Token::LParen);
@@ -401,6 +410,12 @@ void TestFileParser::Scanner::scanNextToken()
 			break;
 		case ')':
 			token = selectToken(Token::RParen);
+			break;
+		case '[':
+			token = selectToken(Token::LBrack);
+			break;
+		case ']':
+			token = selectToken(Token::RBrack);
 			break;
 		default:
 			if (langutil::isIdentifierStart(current()))

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -460,6 +460,20 @@ BOOST_AUTO_TEST_CASE(call_multiple_arguments_mixed_format)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(call_signature_array)
+{
+	char const* source = R"(
+		// f(uint256[]) ->
+		// f(uint256[3]) ->
+		// f(uint256[3][][], uint8[9]) ->
+	)";
+	auto const calls = parse(source);
+	BOOST_REQUIRE_EQUAL(calls.size(), 3);
+	testFunctionCall(calls.at(0), Mode::SingleLine, "f(uint256[])", false);
+	testFunctionCall(calls.at(1), Mode::SingleLine, "f(uint256[3])", false);
+	testFunctionCall(calls.at(2), Mode::SingleLine, "f(uint256[3][][],uint8[9])", false);
+}
+
 BOOST_AUTO_TEST_CASE(call_signature_valid)
 {
 	char const* source = R"(


### PR DESCRIPTION
This PR adds support for arrays in function signatures:
```
contract c {
    uint[4][] a;
    uint[10][] b;
    uint[][] c;
    function test(uint[2][] calldata d) external returns (uint) {
        a = d;
	b = a;
	c = b;
	return c[1][1] | c[1][2] | c[1][3] | c[1][4];
    }
}
// ----
// test(uint256[2][]): 32, 3, 7, 8, 9, 10, 11, 12 -> 10
```