### PR TITLE
Simplify constant switch first

### DIFF
--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -180,6 +180,9 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 			return {};
 		},
 		[&](Switch& _switchStmt) -> OptionalStatements {
+			if (boost::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
+				return replaceConstArgSwitch(_switchStmt, constExprVal.get());
+
 			removeEmptyDefaultFromSwitch(_switchStmt);
 			removeEmptyCasesFromSwitch(_switchStmt);
 
@@ -187,8 +190,6 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 				return reduceNoCaseSwitch(_switchStmt);
 			else if (_switchStmt.cases.size() == 1)
 				return reduceSingleCaseSwitch(_switchStmt);
-			else if (boost::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
-				return replaceConstArgSwitch(_switchStmt, constExprVal.get());
 
 			return {};
 		},

--- a/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_all.yul
+++ b/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_all.yul
@@ -5,7 +5,7 @@
 	case 1 { }
 	default { }
 
-	switch 4
+	switch mload(4)
 	case 0 { }
 	case 1 { }
 	default { }
@@ -15,5 +15,5 @@
 // {
 //     let y := 200
 //     pop(add(y, 4))
-//     pop(4)
+//     pop(mload(4))
 // }

--- a/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_case.yul
+++ b/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_case.yul
@@ -1,15 +1,19 @@
 {
 	let y := 200
-	switch y
+	switch calldataload(0)
 	case 0 { }
 	case 1 { y := 9 }
+	case 2 { y := 10 }
 }
 // ----
 // structuralSimplifier
 // {
 //     let y := 200
-//     if eq(1, y)
-//     {
+//     switch calldataload(0)
+//     case 1 {
 //         y := 9
+//     }
+//     case 2 {
+//         y := 10
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_cases.yul
+++ b/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_cases.yul
@@ -1,6 +1,6 @@
 {
 	let y := 200
-	switch y
+	switch calldataload(0)
 	case 0 { }
 	case 1 { y := 9 }
 	default { }
@@ -9,7 +9,7 @@
 // structuralSimplifier
 // {
 //     let y := 200
-//     if eq(1, y)
+//     if eq(1, calldataload(0))
 //     {
 //         y := 9
 //     }

--- a/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_default_case.yul
+++ b/test/libyul/yulOptimizerTests/structuralSimplifier/switch_remove_empty_default_case.yul
@@ -1,15 +1,19 @@
 {
 	let y := 200
-	switch y
+	switch calldataload(0)
 	case 1 { y := 9 }
+	case 2 { y := 10 }
 	default { }
 }
 // ----
 // structuralSimplifier
 // {
 //     let y := 200
-//     if eq(1, y)
-//     {
+//     switch calldataload(0)
+//     case 1 {
 //         y := 9
+//     }
+//     case 2 {
+//         y := 10
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/structuralSimplifier/switch_to_if.yul
+++ b/test/libyul/yulOptimizerTests/structuralSimplifier/switch_to_if.yul
@@ -1,10 +1,10 @@
 {
-	switch 1 case 2 { mstore(0, 0) }
+	switch calldataload(0) case 2 { mstore(0, 0) }
 }
 // ----
 // structuralSimplifier
 // {
-//     if eq(2, 1)
+//     if eq(2, calldataload(0))
 //     {
 //         mstore(0, 0)
 //     }


### PR DESCRIPTION
Simplify switch with constant expression first because it allows the biggest simplification.

Depends on #6207 