### PR TITLE
[soltest] Allow struct array in function signatures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
 
 Build System:
  * Soltest: Add support for arrays in function signatures.
+ * Soltest: Add support for struct arrays in function signatures.
 
 
 ### 0.5.5 (2019-03-05)

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -318,10 +318,8 @@ string TestFileParser::parseIdentifierOrTuple()
 {
 	string identOrTuple;
 
-	if (accept(Token::Identifier))
+	auto parseArrayDimensions = [&]()
 	{
-		identOrTuple = m_scanner.currentLiteral();
-		expect(Token::Identifier);
 		while (accept(Token::LBrack))
 		{
 			identOrTuple += formatToken(Token::LBrack);
@@ -331,6 +329,13 @@ string TestFileParser::parseIdentifierOrTuple()
 			identOrTuple += formatToken(Token::RBrack);
 			expect(Token::RBrack);
 		}
+	};
+
+	if (accept(Token::Identifier))
+	{
+		identOrTuple = m_scanner.currentLiteral();
+		expect(Token::Identifier);
+		parseArrayDimensions();
 		return identOrTuple;
 	}
 	expect(Token::LParen);
@@ -345,6 +350,8 @@ string TestFileParser::parseIdentifierOrTuple()
 	}
 	expect(Token::RParen);
 	identOrTuple += formatToken(Token::RParen);
+
+	parseArrayDimensions();
 	return identOrTuple;
 }
 

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -474,6 +474,23 @@ BOOST_AUTO_TEST_CASE(call_signature_array)
 	testFunctionCall(calls.at(2), Mode::SingleLine, "f(uint256[3][][],uint8[9])", false);
 }
 
+BOOST_AUTO_TEST_CASE(call_signature_struct_array)
+{
+	char const* source = R"(
+		// f((uint256)[]) ->
+		// f((uint256)[3]) ->
+		// f((uint256, uint8)[3]) ->
+		// f((uint256)[3][][], (uint8, bool)[9]) ->
+	)";
+	auto const calls = parse(source);
+	BOOST_REQUIRE_EQUAL(calls.size(), 4);
+	testFunctionCall(calls.at(0), Mode::SingleLine, "f((uint256)[])", false);
+	testFunctionCall(calls.at(1), Mode::SingleLine, "f((uint256)[3])", false);
+	testFunctionCall(calls.at(2), Mode::SingleLine, "f((uint256,uint8)[3])", false);
+	testFunctionCall(calls.at(3), Mode::SingleLine, "f((uint256)[3][][],(uint8,bool)[9])", false);
+
+}
+
 BOOST_AUTO_TEST_CASE(call_signature_valid)
 {
 	char const* source = R"(


### PR DESCRIPTION
Functions that can take struct arrays as parameters need to have that supported in soltest:
```
// f((uint256)[]) ->
// f((uint256)[3]) ->
// f((uint256, uint8)[3]) ->
// f((uint256)[3][][], (uint8, bool)[9]) ->
```