### PR TITLE
Disallow internal function types as parameters for public/external library function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 
 Bugfixes:
  * Code Generator: Defensively pad memory for ``type(Contract).name`` to multiples of 32.
+ * Type System: Detect and disallow internal function pointers as parameters for public/external library functions, even when they are nested/wrapped in structs, arrays or other types.
  * Yul Optimizer: Properly determine whether a variable can be eliminated during stack compression pass.
 
 

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -213,7 +213,7 @@ void ReferencesResolver::endVisit(FunctionTypeName const& _typeName)
 		for (auto const& t: _typeName.parameterTypes() + _typeName.returnParameterTypes())
 		{
 			solAssert(t->annotation().type, "Type not set for parameter.");
-			if (!t->annotation().type->interfaceType(false))
+			if (!t->annotation().type->interfaceType(false).get())
 			{
 				fatalTypeError(t->location(), "Internal type cannot be used for external function type.");
 				return;

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -355,8 +355,16 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		{
 			if (!type(var)->canLiveOutsideStorage() && _function.isPublic())
 				m_errorReporter.typeError(var.location(), "Type is required to live outside storage.");
-			if (_function.isPublic() && !(type(var)->interfaceType(isLibraryFunction).get()))
-				m_errorReporter.fatalTypeError(var.location(), "Internal or recursive type is not allowed for public or external functions.");
+			if (_function.isPublic())
+			{
+				auto iType = type(var)->interfaceType(isLibraryFunction);
+
+				if (!iType.get())
+				{
+					solAssert(!iType.message().empty(), "Expected detailed error message!");
+					m_errorReporter.fatalTypeError(var.location(), iType.message());
+				}
+			}
 		}
 		if (
 			_function.isPublic() &&

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -355,7 +355,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		{
 			if (!type(var)->canLiveOutsideStorage() && _function.isPublic())
 				m_errorReporter.typeError(var.location(), "Type is required to live outside storage.");
-			if (_function.isPublic() && !(type(var)->interfaceType(isLibraryFunction)))
+			if (_function.isPublic() && !(type(var)->interfaceType(isLibraryFunction).get()))
 				m_errorReporter.fatalTypeError(var.location(), "Internal or recursive type is not allowed for public or external functions.");
 		}
 		if (
@@ -576,7 +576,7 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 			numIndexed++;
 		if (!type(*var)->canLiveOutsideStorage())
 			m_errorReporter.typeError(var->location(), "Type is required to live outside storage.");
-		if (!type(*var)->interfaceType(false))
+		if (!type(*var)->interfaceType(false).get())
 			m_errorReporter.typeError(var->location(), "Internal or recursive type is not allowed as event parameter type.");
 		if (
 			!_eventDef.sourceUnit().annotation().experimentalFeatures.count(ExperimentalFeature::ABIEncoderV2) &&
@@ -599,7 +599,7 @@ void TypeChecker::endVisit(FunctionTypeName const& _funType)
 {
 	FunctionType const& fun = dynamic_cast<FunctionType const&>(*_funType.annotation().type);
 	if (fun.kind() == FunctionType::Kind::External)
-		solAssert(fun.interfaceType(false), "External function type uses internal types.");
+		solAssert(fun.interfaceType(false).get(), "External function type uses internal types.");
 }
 
 bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1878,21 +1878,21 @@ TypeResult ArrayType::interfaceType(bool _inLibrary) const
 		return *m_interfaceType;
 
 	TypeResult result{TypePointer{}};
-	TypeResult baseExt = m_baseType->interfaceType(_inLibrary);
+	TypeResult baseInterfaceType = m_baseType->interfaceType(_inLibrary);
 
-	if (!baseExt.get())
+	if (!baseInterfaceType.get())
 	{
-		solAssert(!baseExt.message().empty(), "Expected detailed error message!");
-		result = baseExt;
+		solAssert(!baseInterfaceType.message().empty(), "Expected detailed error message!");
+		result = baseInterfaceType;
 	}
 	else if (_inLibrary && location() == DataLocation::Storage)
 		result = shared_from_this();
 	else if (m_arrayKind != ArrayKind::Ordinary)
 		result = this->copyForLocation(DataLocation::Memory, true);
 	else if (isDynamicallySized())
-		result = TypePointer{make_shared<ArrayType>(DataLocation::Memory, baseExt)};
+		result = TypePointer{make_shared<ArrayType>(DataLocation::Memory, baseInterfaceType)};
 	else
-		result = TypePointer{make_shared<ArrayType>(DataLocation::Memory, baseExt, m_length)};
+		result = TypePointer{make_shared<ArrayType>(DataLocation::Memory, baseInterfaceType, m_length)};
 
 	if (_inLibrary)
 		m_interfaceType_library = result;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1869,7 +1869,7 @@ TypePointer ArrayType::decodingType() const
 		return shared_from_this();
 }
 
-TypePointer ArrayType::interfaceType(bool _inLibrary) const
+TypeResult ArrayType::interfaceType(bool _inLibrary) const
 {
 	if (_inLibrary && m_interfaceType_library.is_initialized())
 		return *m_interfaceType_library;
@@ -2135,7 +2135,7 @@ MemberList::MemberMap StructType::nativeMembers(ContractDefinition const*) const
 	return members;
 }
 
-TypePointer StructType::interfaceType(bool _inLibrary) const
+TypeResult StructType::interfaceType(bool _inLibrary) const
 {
 	if (_inLibrary && m_interfaceType_library.is_initialized())
 		return *m_interfaceType_library;
@@ -2168,7 +2168,7 @@ TypePointer StructType::interfaceType(bool _inLibrary) const
 				allOkay = false;
 				break;
 			}
-			if (!var->annotation().type->interfaceType(false))
+			if (!var->annotation().type->interfaceType(false).get())
 			{
 				allOkay = false;
 				break;
@@ -2204,8 +2204,8 @@ string StructType::signatureInExternalFunction(bool _structsByName) const
 		{
 			solAssert(_t, "Parameter should have external type.");
 			auto t = _t->interfaceType(_structsByName);
-			solAssert(t, "");
-			return t->signatureInExternalFunction(_structsByName);
+			solAssert(t.get(), "");
+			return t.get()->signatureInExternalFunction(_structsByName);
 		});
 		return "(" + boost::algorithm::join(memberTypeStrings, ",") + ")";
 	}
@@ -2574,7 +2574,7 @@ FunctionType::FunctionType(FunctionTypeName const& _typeName):
 		solAssert(t->annotation().type, "Type not set for parameter.");
 		if (m_kind == Kind::External)
 			solAssert(
-				t->annotation().type->interfaceType(false),
+				t->annotation().type->interfaceType(false).get(),
 				"Internal type used as parameter for external function."
 			);
 		m_parameterTypes.push_back(t->annotation().type);
@@ -2584,7 +2584,7 @@ FunctionType::FunctionType(FunctionTypeName const& _typeName):
 		solAssert(t->annotation().type, "Type not set for return parameter.");
 		if (m_kind == Kind::External)
 			solAssert(
-				t->annotation().type->interfaceType(false),
+				t->annotation().type->interfaceType(false).get(),
 				"Internal type used as return parameter for external function."
 			);
 		m_returnParameterTypes.push_back(t->annotation().type);
@@ -2885,14 +2885,14 @@ FunctionTypePointer FunctionType::interfaceFunctionType() const
 
 	for (auto type: m_parameterTypes)
 	{
-		if (auto ext = type->interfaceType(isLibraryFunction))
+		if (auto ext = type->interfaceType(isLibraryFunction).get())
 			paramTypes.push_back(ext);
 		else
 			return FunctionTypePointer();
 	}
 	for (auto type: m_returnParameterTypes)
 	{
-		if (auto ext = type->interfaceType(isLibraryFunction))
+		if (auto ext = type->interfaceType(isLibraryFunction).get())
 			retParamTypes.push_back(ext);
 		else
 			return FunctionTypePointer();
@@ -2978,7 +2978,7 @@ TypePointer FunctionType::encodingType() const
 		return TypePointer();
 }
 
-TypePointer FunctionType::interfaceType(bool /*_inLibrary*/) const
+TypeResult FunctionType::interfaceType(bool /*_inLibrary*/) const
 {
 	if (m_kind == Kind::External)
 		return shared_from_this();

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -863,15 +863,9 @@ public:
 	TypePointers memoryMemberTypes() const;
 	/// @returns the set of all members that are removed in the memory version (typically mappings).
 	std::set<std::string> membersMissingInMemory() const;
-
-	/// @returns true if the same struct is used recursively in one of its members. Only
-	/// analyses the "memory" representation, i.e. mappings are ignored in all structs.
-	bool recursive() const;
-
 private:
 	StructDefinition const& m_struct;
-	/// Cache for the recursive() function.
-	mutable boost::optional<bool> m_recursive;
+	// Caches for interfaceType(bool)
 	mutable boost::optional<TypeResult> m_interfaceType;
 	mutable boost::optional<TypeResult> m_interfaceType_library;
 };
@@ -1223,10 +1217,7 @@ public:
 	{
 		return std::make_shared<IntegerType>(256);
 	}
-	TypeResult interfaceType(bool _inLibrary) const override
-	{
-		return _inLibrary ? shared_from_this() : TypePointer();
-	}
+	TypeResult interfaceType(bool _inLibrary) const override;
 	bool dataStoredIn(DataLocation _location) const override { return _location == DataLocation::Storage; }
 	/// Cannot be stored in memory, but just in case.
 	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -304,7 +304,7 @@ public:
 	/// If there is no such type, returns an empty shared pointer.
 	/// @param _inLibrary if set, returns types as used in a library, e.g. struct and contract types
 	/// are returned without modification.
-	virtual TypePointer interfaceType(bool /*_inLibrary*/) const { return TypePointer(); }
+	virtual TypeResult interfaceType(bool /*_inLibrary*/) const { return TypePointer(); }
 
 private:
 	/// @returns a member list containing all members added to this type by `using for` directives.
@@ -355,7 +355,7 @@ public:
 	u256 literalValue(Literal const* _literal) const override;
 
 	TypePointer encodingType() const override { return shared_from_this(); }
-	TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypeResult interfaceType(bool) const override { return shared_from_this(); }
 
 	StateMutability stateMutability(void) const { return m_stateMutability; }
 
@@ -395,7 +395,7 @@ public:
 	std::string toString(bool _short) const override;
 
 	TypePointer encodingType() const override { return shared_from_this(); }
-	TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypeResult interfaceType(bool) const override { return shared_from_this(); }
 
 	unsigned numBits() const { return m_bits; }
 	bool isSigned() const { return m_modifier == Modifier::Signed; }
@@ -437,7 +437,7 @@ public:
 	std::string toString(bool _short) const override;
 
 	TypePointer encodingType() const override { return shared_from_this(); }
-	TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypeResult interfaceType(bool) const override { return shared_from_this(); }
 
 	/// Number of bits used for this type in total.
 	unsigned numBits() const { return m_totalBits; }
@@ -583,7 +583,7 @@ public:
 	std::string toString(bool) const override { return "bytes" + dev::toString(m_bytes); }
 	MemberList::MemberMap nativeMembers(ContractDefinition const*) const override;
 	TypePointer encodingType() const override { return shared_from_this(); }
-	TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypeResult interfaceType(bool) const override { return shared_from_this(); }
 
 	unsigned numBytes() const { return m_bytes; }
 
@@ -609,7 +609,7 @@ public:
 	std::string toString(bool) const override { return "bool"; }
 	u256 literalValue(Literal const* _literal) const override;
 	TypePointer encodingType() const override { return shared_from_this(); }
-	TypePointer interfaceType(bool) const override { return shared_from_this(); }
+	TypeResult interfaceType(bool) const override { return shared_from_this(); }
 };
 
 /**
@@ -716,7 +716,7 @@ public:
 	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 	TypePointer encodingType() const override;
 	TypePointer decodingType() const override;
-	TypePointer interfaceType(bool _inLibrary) const override;
+	TypeResult interfaceType(bool _inLibrary) const override;
 
 	/// @returns true if this is valid to be stored in calldata
 	bool validForCalldata() const;
@@ -749,8 +749,8 @@ private:
 	TypePointer m_baseType;
 	bool m_hasDynamicLength = true;
 	u256 m_length;
-	mutable boost::optional<TypePointer> m_interfaceType;
-	mutable boost::optional<TypePointer> m_interfaceType_library;
+	mutable boost::optional<TypeResult> m_interfaceType;
+	mutable boost::optional<TypeResult> m_interfaceType_library;
 };
 
 /**
@@ -788,7 +788,7 @@ public:
 			return TypePointer{};
 		return std::make_shared<AddressType>(isPayable() ? StateMutability::Payable : StateMutability::NonPayable);
 	}
-	TypePointer interfaceType(bool _inLibrary) const override
+	TypeResult interfaceType(bool _inLibrary) const override
 	{
 		if (isSuper())
 			return TypePointer{};
@@ -842,7 +842,7 @@ public:
 	{
 		return location() == DataLocation::Storage ? std::make_shared<IntegerType>(256) : shared_from_this();
 	}
-	TypePointer interfaceType(bool _inLibrary) const override;
+	TypeResult interfaceType(bool _inLibrary) const override;
 
 	TypePointer copyForLocation(DataLocation _location, bool _isPointer) const override;
 
@@ -872,8 +872,8 @@ private:
 	StructDefinition const& m_struct;
 	/// Cache for the recursive() function.
 	mutable boost::optional<bool> m_recursive;
-	mutable boost::optional<TypePointer> m_interfaceType;
-	mutable boost::optional<TypePointer> m_interfaceType_library;
+	mutable boost::optional<TypeResult> m_interfaceType;
+	mutable boost::optional<TypeResult> m_interfaceType_library;
 };
 
 /**
@@ -902,7 +902,7 @@ public:
 	{
 		return std::make_shared<IntegerType>(8 * int(storageBytes()));
 	}
-	TypePointer interfaceType(bool _inLibrary) const override
+	TypeResult interfaceType(bool _inLibrary) const override
 	{
 		return _inLibrary ? shared_from_this() : encodingType();
 	}
@@ -1098,7 +1098,7 @@ public:
 	bool hasSimpleZeroValueInMemory() const override { return false; }
 	MemberList::MemberMap nativeMembers(ContractDefinition const* _currentScope) const override;
 	TypePointer encodingType() const override;
-	TypePointer interfaceType(bool _inLibrary) const override;
+	TypeResult interfaceType(bool _inLibrary) const override;
 
 	/// @returns TypePointer of a new FunctionType object. All input/return parameters are an
 	/// appropriate external types (i.e. the interfaceType()s) of input/return parameters of
@@ -1223,7 +1223,7 @@ public:
 	{
 		return std::make_shared<IntegerType>(256);
 	}
-	TypePointer interfaceType(bool _inLibrary) const override
+	TypeResult interfaceType(bool _inLibrary) const override
 	{
 		return _inLibrary ? shared_from_this() : TypePointer();
 	}

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -844,6 +844,16 @@ public:
 	}
 	TypeResult interfaceType(bool _inLibrary) const override;
 
+	bool recursive() const
+	{
+		if (m_recursive.is_initialized())
+			return m_recursive.get();
+
+		interfaceType(false);
+
+		return m_recursive.get();
+	}
+
 	TypePointer copyForLocation(DataLocation _location, bool _isPointer) const override;
 
 	std::string canonicalName() const override;
@@ -868,6 +878,7 @@ private:
 	// Caches for interfaceType(bool)
 	mutable boost::optional<TypeResult> m_interfaceType;
 	mutable boost::optional<TypeResult> m_interfaceType_library;
+	mutable boost::optional<bool> m_recursive;
 };
 
 /**

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -107,9 +107,9 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 		for (auto const& p: it->parameters())
 		{
 			auto type = p->annotation().type->interfaceType(false);
-			solAssert(type, "");
+			solAssert(type.get(), "");
 			Json::Value input;
-			auto param = formatType(p->name(), *type, false);
+			auto param = formatType(p->name(), *type.get(), false);
 			param["indexed"] = p->isIndexed();
 			params.append(param);
 		}
@@ -173,8 +173,8 @@ Json::Value ABI::formatType(string const& _name, Type const& _type, bool _forLib
 		{
 			solAssert(member.type, "");
 			auto t = member.type->interfaceType(_forLibrary);
-			solAssert(t, "");
-			ret["components"].append(formatType(member.name, *t, _forLibrary));
+			solAssert(t.get(), "");
+			ret["components"].append(formatType(member.name, *t.get(), _forLibrary));
 		}
 	}
 	else

--- a/test/libsolidity/syntaxTests/functionTypes/internal_function_array_memory_as_external_parameter_in_library_external.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/internal_function_array_memory_as_external_parameter_in_library_external.sol
@@ -1,0 +1,6 @@
+library L {
+    // Used to cause internal error
+    function f(function(uint) internal returns (uint)[] memory x) public { }
+}
+// ----
+// TypeError: (63-112): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionTypes/internal_function_array_storage_as_external_parameter_in_library_external.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/internal_function_array_storage_as_external_parameter_in_library_external.sol
@@ -1,0 +1,6 @@
+library L {
+    // Used to cause internal error
+    function g(function(uint) internal returns (uint)[] storage x) public { }
+}
+// ----
+// TypeError: (63-113): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionTypes/internal_function_as_external_parameter.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/internal_function_as_external_parameter.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (124-164): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (124-164): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionTypes/internal_function_as_external_parameter_in_library_external.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/internal_function_as_external_parameter_in_library_external.sol
@@ -3,4 +3,4 @@ library L {
     }
 }
 // ----
-// TypeError: (27-67): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (27-67): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionTypes/internal_function_returned_from_public_function.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/internal_function_returned_from_public_function.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (129-169): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (129-169): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionTypes/internal_function_struct_as_external_parameter_in_library_external.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/internal_function_struct_as_external_parameter_in_library_external.sol
@@ -1,0 +1,9 @@
+library L {
+    struct S
+    {
+        function(uint) internal returns (uint)[] x;
+    }
+    function f(S storage s) public { }
+}
+// ----
+// TypeError: (104-115): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/041_functions_with_stucts_of_non_external_types_in_interface.sol
@@ -6,4 +6,4 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (103-111): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (103-111): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/042_functions_with_stucts_of_non_external_types_in_interface_2.sol
@@ -6,4 +6,4 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (105-113): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (105-113): Only libraries are allowed to use the mapping type in public or external functions.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/043_functions_with_stucts_of_non_external_types_in_interface_nested.sol
@@ -7,4 +7,4 @@ contract C {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (132-140): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (132-140): Only libraries are allowed to use the mapping type in public or external functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_as_contract_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_as_contract_function_parameter.sol
@@ -1,0 +1,10 @@
+contract Test {
+    struct MyStructName {
+        address addr;
+        MyStructName[] x;
+    }
+
+    function f(MyStructName memory s) public {}
+}
+// ----
+// TypeError: (112-133): Recursive type not allowed for public or external contract functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_as_library_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_as_library_function_parameter.sol
@@ -1,0 +1,9 @@
+library Test {
+    struct MyStructName {
+        address addr;
+        MyStructName[] x;
+    }
+
+    function f(MyStructName storage s) public {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_as_memory_library_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_as_memory_library_function_parameter.sol
@@ -1,0 +1,14 @@
+pragma experimental ABIEncoderV2;
+
+library Test {
+    struct MyStructName {
+        address addr;
+        MyStructName[] x;
+    }
+
+    function f(MyStructName memory _x) public {
+    }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError: (146-168): Recursive structs can only be passed as storage pointers to libraries, not as memory objects to contract functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_forward_reference.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_forward_reference.sol
@@ -8,4 +8,4 @@ contract Data {
 }
 // ----
 // Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.
-// TypeError: (63-78): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (63-78): Recursive type not allowed for public or external contract functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_with_internal_function_as_library_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_with_internal_function_as_library_function_parameter.sol
@@ -1,0 +1,11 @@
+library Test {
+    struct MyStructName {
+        address addr;
+        MyStructName[] x;
+        function() internal y;
+    }
+
+    function f(MyStructName storage s) public {}
+}
+// ----
+// TypeError: (142-164): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (91-99): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (91-99): Recursive type not allowed for public or external contract functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs2.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (94-102): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (94-102): Recursive type not allowed for public or external contract functions.

--- a/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/return_recursive_structs3.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (119-129): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (119-129): Recursive type not allowed for public or external contract functions.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_array_data_location_function_param_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_array_data_location_function_param_external.sol
@@ -3,4 +3,4 @@ contract c {
 }
 // ----
 // TypeError: (29-61): Type is required to live outside storage.
-// TypeError: (29-61): Internal or recursive type is not allowed for public or external functions.
+// TypeError: (29-61): Only libraries are allowed to use the mapping type in public or external functions.


### PR DESCRIPTION
I am not very sure about my changes here, but the tests all work, so.. yeah.

Fixes #6215 and fixes #6151