### PR TITLE
[SMTChecker] Shortcut RationalNumber expressions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * SMTChecker: Fix internal compiler error when contract contains too large rational number.
  * Type system: Detect if a contract's base uses types that require the experimental abi encoder while the contract still uses the old encoder
  * Yul Optimizer: Fix visitation order bug for the structural simplifier.
 

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -71,7 +71,9 @@ private:
 	void endVisit(VariableDeclarationStatement const& _node) override;
 	void endVisit(Assignment const& _node) override;
 	void endVisit(TupleExpression const& _node) override;
+	bool visit(UnaryOperation const& _node) override;
 	void endVisit(UnaryOperation const& _node) override;
+	bool visit(BinaryOperation const& _node) override;
 	void endVisit(BinaryOperation const& _node) override;
 	void endVisit(FunctionCall const& _node) override;
 	void endVisit(Identifier const& _node) override;
@@ -80,6 +82,9 @@ private:
 	bool visit(MemberAccess const& _node) override;
 	void endVisit(IndexAccess const& _node) override;
 
+	/// Do not visit subtree if node is a RationalNumber.
+	/// Symbolic _expr is the rational literal.
+	bool shortcutRationalNumber(Expression const& _expr);
 	void arithmeticOperation(BinaryOperation const& _op);
 	void compareOperation(BinaryOperation const& _op);
 	void booleanOperation(BinaryOperation const& _op);

--- a/libsolidity/formal/SolverInterface.h
+++ b/libsolidity/formal/SolverInterface.h
@@ -118,6 +118,7 @@ public:
 	explicit Expression(bool _v): Expression(_v ? "true" : "false", Kind::Bool) {}
 	Expression(size_t _number): Expression(std::to_string(_number), Kind::Int) {}
 	Expression(u256 const& _number): Expression(_number.str(), Kind::Int) {}
+	Expression(s256 const& _number): Expression(_number.str(), Kind::Int) {}
 	Expression(bigint const& _number): Expression(_number.str(), Kind::Int) {}
 
 	Expression(Expression const&) = default;

--- a/test/libsolidity/smtCheckerTests/simple/static_array.sol
+++ b/test/libsolidity/smtCheckerTests/simple/static_array.sol
@@ -7,4 +7,3 @@ contract C
 	int[3*1] x;
 }
 // ----
-// Warning: (153-156): Assertion checker does not yet implement this operator on non-integer types.

--- a/test/libsolidity/smtCheckerTests/types/rational_large_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/rational_large_1.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract c {
+	function f() public pure returns (uint) {
+		uint x = 8e130%9;
+		assert(x == 8);
+		assert(x != 8);
+	}
+}
+// ----
+// Warning: (128-142): Assertion violation happens here


### PR DESCRIPTION
Fixes #6095 

When visiting a `UnaryExpression` or `BinaryExpression`, if the type is `RationalNumber`, we can shortcut and add the constant literal as the symbolic expression and ignore the `endVisit` of those node types.