### PR TITLE
[WIP] Allow local variables of calldata reference type.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Language Features:
  * Allow calldata arrays with dynamically encoded base types with ABIEncoderV2.
+ * Allow local variables of calldata reference type.
  * Allow dynamically encoded calldata structs with ABIEncoderV2.
 
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -872,9 +872,9 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 
 		if (auto ref = dynamic_cast<ReferenceType const*>(type(varDecl).get()))
 		{
-			if (ref->dataStoredIn(DataLocation::Storage))
+			if (ref->dataStoredIn(DataLocation::Storage) || ref->dataStoredIn(DataLocation::CallData))
 			{
-				string errorText{"Uninitialized storage pointer."};
+				string errorText = "Uninitialized " + dataLocationToString(ref->location()) + " pointer.";
 				solAssert(varDecl.referenceLocation() != VariableDeclaration::Location::Unspecified, "Expected a specified location at this point");
 				solAssert(m_scope, "");
 				m_errorReporter.declarationError(varDecl.location(), errorText);

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -541,8 +541,7 @@ set<VariableDeclaration::Location> VariableDeclaration::allowedDataLocations() c
 		if (typeName()->annotation().type->category() == Type::Category::Mapping)
 			return set<Location>{ Location::Storage };
 		else
-			//  TODO: add Location::Calldata once implemented for local variables.
-			return set<Location>{ Location::Memory, Location::Storage };
+			return set<Location>{ Location::Memory, Location::Storage, Location::CallData };
 	}
 	else
 		// Struct members etc.

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -65,6 +65,20 @@ inline rational makeRational(bigint const& _numerator, bigint const& _denominato
 }
 
 enum class DataLocation { Storage, CallData, Memory };
+inline std::string dataLocationToString(DataLocation _location)
+{
+	switch(_location)
+	{
+		case DataLocation::Storage:
+			return "storage";
+		case DataLocation::CallData:
+			return "calldata";
+		case DataLocation::Memory:
+			return "memory";
+		default:
+			solAssert(false, "Invalid data location.");
+	}
+}
 
 
 /**

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1133,7 +1133,7 @@ void CompilerUtils::pushZeroValue(Type const& _type)
 		}
 	}
 	auto const* referenceType = dynamic_cast<ReferenceType const*>(&_type);
-	if (!referenceType || referenceType->location() == DataLocation::Storage)
+	if (!referenceType || referenceType->location() == DataLocation::Storage || referenceType->location() == DataLocation::CallData)
 	{
 		for (size_t i = 0; i < _type.sizeOnStack(); ++i)
 			m_context << u256(0);

--- a/test/libsolidity/semanticTests/arrays/calldata/local.sol
+++ b/test/libsolidity/semanticTests/arrays/calldata/local.sol
@@ -1,0 +1,25 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function f(uint[] calldata s) external pure returns (uint256 a, uint256 b, uint256 c) {
+        uint256 memPtr_before = 0;
+        assembly {
+            memPtr_before := mload(0x40)
+        }
+
+        uint[] calldata l = s;
+
+        a = l.length;
+        b = l[0];
+        c = l[1];
+
+        uint256 memPtr_after = 0;
+        assembly {
+            memPtr_after := mload(0x40)
+        }
+
+        assert(memPtr_before == memPtr_after);
+    }
+}
+// ----
+// f(uint256[]): 32, 2, 23, 42 -> 2, 23, 42

--- a/test/libsolidity/semanticTests/arrays/calldata/local_V1.sol
+++ b/test/libsolidity/semanticTests/arrays/calldata/local_V1.sol
@@ -1,0 +1,23 @@
+contract C {
+    function f(uint[] calldata s) external pure returns (uint256 a, uint256 b, uint256 c) {
+        uint256 memPtr_before = 0;
+        assembly {
+            memPtr_before := mload(0x40)
+        }
+
+        uint[] calldata l = s;
+
+        a = l.length;
+        b = l[0];
+        c = l[1];
+
+        uint256 memPtr_after = 0;
+        assembly {
+            memPtr_after := mload(0x40)
+        }
+
+        assert(memPtr_before == memPtr_after);
+    }
+}
+// ----
+// f(uint256[]): 32, 2, 23, 42 -> 2, 23, 42

--- a/test/libsolidity/semanticTests/arrays/calldata/local_multi.sol
+++ b/test/libsolidity/semanticTests/arrays/calldata/local_multi.sol
@@ -1,0 +1,26 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function f(uint[] calldata s1, uint[] calldata s2, bool which) external pure returns (uint256 a, uint256 b, uint256 c) {
+        uint256 memPtr_before = 0;
+        assembly {
+            memPtr_before := mload(0x40)
+        }
+
+        uint[] calldata l = which ? s1 : s2;
+
+        a = l.length;
+        b = l[0];
+        c = l[1];
+
+        uint256 memPtr_after = 0;
+        assembly {
+            memPtr_after := mload(0x40)
+        }
+
+        assert(memPtr_before == memPtr_after);
+    }
+}
+// ----
+// f(uint256[],uint256[],bool): 96, 192, 1, 2, 23, 42, 2, 27, 99 -> 2, 23, 42
+// f(uint256[],uint256[],bool): 96, 192, 0, 2, 23, 42, 2, 27, 99 -> 2, 27, 99

--- a/test/libsolidity/semanticTests/arrays/calldata/local_multi_V1.sol
+++ b/test/libsolidity/semanticTests/arrays/calldata/local_multi_V1.sol
@@ -1,0 +1,24 @@
+contract C {
+    function f(uint[] calldata s1, uint[] calldata s2, bool which) external pure returns (uint256 a, uint256 b, uint256 c) {
+        uint256 memPtr_before = 0;
+        assembly {
+            memPtr_before := mload(0x40)
+        }
+
+        uint[] calldata l = which ? s1 : s2;
+
+        a = l.length;
+        b = l[0];
+        c = l[1];
+
+        uint256 memPtr_after = 0;
+        assembly {
+            memPtr_after := mload(0x40)
+        }
+
+        assert(memPtr_before == memPtr_after);
+    }
+}
+// ----
+// f(uint256[],uint256[],bool): 96, 192, 1, 2, 23, 42, 2, 27, 99 -> 2, 23, 42
+// f(uint256[],uint256[],bool): 96, 192, 0, 2, 23, 42, 2, 27, 99 -> 2, 27, 99

--- a/test/libsolidity/syntaxTests/array/calldata_local.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_local.sol
@@ -1,0 +1,6 @@
+contract Test {
+    function f(uint[] calldata a, uint[] calldata b, bool c) pure external returns (uint, uint, uint) {
+        uint[] calldata l = c ? a : b;
+        return (l.length, l[0], l[1]);
+    }
+}

--- a/test/libsolidity/syntaxTests/array/uninitialized_calldata_var.sol
+++ b/test/libsolidity/syntaxTests/array/uninitialized_calldata_var.sol
@@ -1,0 +1,9 @@
+contract C {
+	function f() public {
+		uint[] calldata x;
+		uint[10] calldata y;
+	}
+}
+// ----
+// DeclarationError: (38-55): Uninitialized calldata pointer.
+// DeclarationError: (59-78): Uninitialized calldata pointer.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/471_unspecified_storage_fail.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/471_unspecified_storage_fail.sol
@@ -9,5 +9,5 @@ contract C {
     }
 }
 // ----
-// TypeError: (104-107): Data location must be "storage" or "memory" for variable, but none was given.
-// TypeError: (123-131): Data location must be "storage" or "memory" for variable, but none was given.
+// TypeError: (104-107): Data location must be "storage", "memory" or "calldata" for variable, but none was given.
+// TypeError: (123-131): Data location must be "storage", "memory" or "calldata" for variable, but none was given.


### PR DESCRIPTION
I don't see a reason not to allow this for ABIEncoderV1 - is there?

TODO: needs more tests (especially arrays of arrays, converting to memory, and passing down to external function calls, which should copy to memory; also assigning to such a variable, etc.).