### PR TITLE
[WIP] [RFC] [isoltest] Yul AST Structural Equality tests

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(yul
 	Object.h
 	ObjectParser.cpp
 	ObjectParser.h
+	StructualEquality.cpp
+	StructualEquality.h
 	Utilities.cpp
 	Utilities.h
 	YulString.h

--- a/libyul/StructualEquality.cpp
+++ b/libyul/StructualEquality.cpp
@@ -1,0 +1,155 @@
+#include <libyul/StructualEquality.h>
+#include <libyul/AsmPrinter.h>
+
+#include <algorithm>
+#include <tuple>
+
+using namespace std;
+using namespace yul;
+
+void StructualEquality::compare(Statement const& a, Statement const& b)
+{
+	tryCompare<
+		Assignment, Block, Break, Continue, ExpressionStatement, ForLoop,
+		FunctionDefinition, If, Instruction, Label, StackAssignment,
+		Switch, VariableDeclaration
+	>(a, b);
+}
+
+void StructualEquality::compare(Expression const* a, Expression const* b)
+{
+	if (a && b)
+		compare(*a, *b);
+	else if (a || b)
+		return;// TODO: report invariant
+}
+
+void StructualEquality::compare(Expression const& a, Expression const& b)
+{
+	tryCompareExpr<FunctionalInstruction, FunctionCall, Identifier, Literal>(a, b);
+}
+
+template <typename T>
+void StructualEquality::compare(vector<T> const& a, vector<T> const& b)
+{
+	for (size_t i = 0; i < min(a.size(), b.size()); i++)
+		compare(a[i], b[i]);
+
+	if (a.size() < b.size())
+		return; // TODO fail<T>(nullptr, &b[a.size()]);
+	else if (a.size() > b.size())
+		return;// TODO fail<T>(&a[b.size()], nullptr);
+}
+
+void StructualEquality::compare(Block const& a, Block const& b)
+{
+	compare(a.statements, b.statements);
+}
+
+void StructualEquality::compare(Instruction const& a, Instruction const& b)
+{
+	leaf(a, b, a.instruction == b.instruction);
+}
+
+void StructualEquality::compare(Literal const& a, Literal const& b)
+{
+	leaf(a, b, a.kind == b.kind && a.value == b.value && a.type == b.type);
+}
+
+bool StructualEquality::compare(Identifier const& a, Identifier const& b)
+{
+	return leaf(a, b, a.name == b.name);
+}
+
+void StructualEquality::compare(Label const& a, Label const& b)
+{
+	leaf(a, b, a.name == b.name);
+}
+
+void StructualEquality::compare(StackAssignment const& a, StackAssignment const& b)
+{
+	compare(a.variableName, b.variableName);
+}
+
+void StructualEquality::compare(Assignment const& a, Assignment const& b)
+{
+	compare(a.variableNames, b.variableNames);
+	compare(*a.value, *b.value);
+}
+
+void StructualEquality::compare(FunctionalInstruction const& a, FunctionalInstruction const& b)
+{
+	if (leaf(a, b, a.instruction == b.instruction))
+		compare(a.arguments, b.arguments);
+}
+
+void StructualEquality::compare(FunctionCall const& a, FunctionCall const& b)
+{
+	if (compare(a.functionName, b.functionName))
+		compare(a.arguments, b.arguments);
+}
+
+void StructualEquality::compare(ExpressionStatement const& a, ExpressionStatement const& b)
+{
+	compare(a.expression, b.expression);
+}
+
+void StructualEquality::compare(VariableDeclaration const& a, VariableDeclaration const& b)
+{
+	compare(a.variables, b.variables);
+	compare(a.value.get(), b.value.get());
+}
+
+bool StructualEquality::compare(TypedName const& a, TypedName const& b)
+{
+	return leaf(a, b, a.name == b.name && a.type == b.type);
+}
+
+void StructualEquality::compare(FunctionDefinition const& a, FunctionDefinition const& b)
+{
+	if (leaf(a, b, a.name == b.name))
+	{
+		compare(a.parameters, b.parameters);
+		compare(a.returnVariables, b.returnVariables);
+		compare(a.body, b.body);
+	}
+}
+
+void StructualEquality::compare(If const& a, If const& b)
+{
+	compare(*a.condition, *b.condition);
+	compare(a.body, b.body);
+}
+
+void StructualEquality::compare(Case const& a, Case const& b)
+{
+	if (leaf(a, b, (!a.value.get() && !b.value.get()) || (a.value.get() && b.value.get())))
+	{
+		if (a.value && b.value)
+			compare(*a.value, *b.value);
+		compare(a.body, b.body);
+	}
+}
+
+void StructualEquality::compare(Switch const& a, Switch const& b)
+{
+	compare(*a.expression, *b.expression);
+	compare(a.cases, b.cases);
+}
+
+void StructualEquality::compare(ForLoop const& a, ForLoop const& b)
+{
+	compare(a.pre, b.pre);
+	compare(*a.condition, *b.condition);
+	compare(a.post, b.post);
+	compare(a.body, b.body);
+}
+
+void StructualEquality::compare(Break const&, Break const&)
+{
+}
+
+void StructualEquality::compare(Continue const&, Continue const&)
+{
+}
+

--- a/libyul/StructualEquality.h
+++ b/libyul/StructualEquality.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <libyul/AsmData.h>
+#include <liblangutil/ErrorReporter.h>
+
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace yul
+{
+
+class StructualEquality
+{
+private:
+	langutil::ErrorReporter& m_errorReporter;
+
+public:
+	explicit StructualEquality(langutil::ErrorReporter _errorReporter): m_errorReporter{_errorReporter} {}
+
+	void compare(Statement const& actual, Statement const& expected);
+	void compare(Expression const& actual, Expression const& expected);
+	void compare(Expression const* actual, Expression const* expected);
+
+	template<typename T>
+	void compare(std::vector<T> const& a, std::vector<T> const& b);
+
+	void compare(Block const& a, Block const& b);
+	void compare(Instruction const& a, Instruction const& b);
+	void compare(Literal const& a, Literal const& b);
+	bool compare(Identifier const& a, Identifier const& b);
+	void compare(Label const& a, Label const& b);
+	void compare(StackAssignment const& a, StackAssignment const& b);
+	void compare(Assignment const& a, Assignment const& b);
+	void compare(FunctionalInstruction const& a, FunctionalInstruction const& b);
+	void compare(FunctionCall const& a, FunctionCall const& b);
+	void compare(ExpressionStatement const& a, ExpressionStatement const& b);
+	void compare(VariableDeclaration const& a, VariableDeclaration const& b);
+	bool compare(TypedName const& a, TypedName const& b);
+	void compare(FunctionDefinition const& a, FunctionDefinition const& b);
+	void compare(If const& a, If const& b);
+	void compare(Case const& a, Case const& b);
+	void compare(Switch const& a, Switch const& b);
+	void compare(ForLoop const& a, ForLoop const& b);
+	void compare(Break const&, Break const&);
+	void compare(Continue const&, Continue const&);
+
+private:
+	// a little convenience helper
+	template <typename T>
+	bool fail(T const* _actual, T const* _expected) {
+		m_errorReporter.declarationError(
+			locationOf(*_actual),
+			langutil::SecondarySourceLocation{}.append("Expected instead:", locationOf(*_expected)),
+			"Unexpected syntactical element."
+		);
+		return false;
+	}
+
+	template <typename T>
+	void tryCompare(Statement const& a, Statement const& b)
+	{
+		if (a.type() != typeid(T) || b.type() != typeid(T))
+			fail(&a, &b);
+		else
+			compare(boost::get<T>(a), boost::get<T>(b));
+	}
+
+	template <typename T, typename T2, typename... MoreT>
+	void tryCompare(Statement const& a, Statement const& b)
+	{
+		if (a.type() == typeid(T) && b.type() == typeid(T))
+			compare(boost::get<T>(a), boost::get<T>(b));
+		else
+			tryCompare<T2, MoreT...>(a, b);
+	}
+
+	template <typename T>
+	void tryCompareExpr(Expression const& a, Expression const& b)
+	{
+		if (a.type() == typeid(T) && b.type() == typeid(T))
+			compare(boost::get<T>(a), boost::get<T>(b));
+		else
+			fail(&a, &b);
+	}
+
+	template <typename T, typename T2, typename... MoreT>
+	void tryCompareExpr(Expression const& a, Expression const& b)
+	{
+		if (a.type() == typeid(T) && b.type() == typeid(T))
+			compare(boost::get<T>(a), boost::get<T>(b));
+		else
+			tryCompareExpr<T2, MoreT...>(a, b);
+	}
+
+	template <typename T>
+	bool leaf(T const& a, T const& b, bool result)
+	{
+		if (!result)
+			return fail(&a, &b);
+
+		return result;
+	}
+};
+
+} // namespace yul

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -49,7 +49,7 @@ bool SyntacticallyEqual::operator()(Statement const& _lhs, Statement const& _rhs
 bool SyntacticallyEqual::expressionEqual(FunctionalInstruction const& _lhs, FunctionalInstruction const& _rhs)
 {
 	return
-		_lhs.instruction == _rhs.instruction &&
+		check(_lhs, _rhs, _lhs.instruction == _rhs.instruction) &&
 		containerEqual(_lhs.arguments, _rhs.arguments, [this](Expression const& _lhsExpr, Expression const& _rhsExpr) -> bool {
 			return (*this)(_lhsExpr, _rhsExpr);
 		});
@@ -68,24 +68,29 @@ bool SyntacticallyEqual::expressionEqual(Identifier const& _lhs, Identifier cons
 {
 	auto lhsIt = m_identifiersLHS.find(_lhs.name);
 	auto rhsIt = m_identifiersRHS.find(_rhs.name);
-	return
+	return check(
+		_lhs, _rhs,
 		(lhsIt == m_identifiersLHS.end() && rhsIt == m_identifiersRHS.end() && _lhs.name == _rhs.name) ||
-		(lhsIt != m_identifiersLHS.end() && rhsIt != m_identifiersRHS.end() && lhsIt->second == rhsIt->second);
+		(lhsIt != m_identifiersLHS.end() && rhsIt != m_identifiersRHS.end() && lhsIt->second == rhsIt->second)
+	);
 }
+
 bool SyntacticallyEqual::expressionEqual(Literal const& _lhs, Literal const& _rhs)
 {
-	if (_lhs.kind != _rhs.kind || _lhs.type != _rhs.type)
+	if (!check(_lhs, _rhs, _lhs.kind == _rhs.kind && _lhs.type == _rhs.type))
 		return false;
+
 	if (_lhs.kind == LiteralKind::Number)
-		return valueOfNumberLiteral(_lhs) == valueOfNumberLiteral(_rhs);
+		return check(_lhs, _rhs, valueOfNumberLiteral(_lhs) == valueOfNumberLiteral(_rhs));
 	else
-		return _lhs.value == _rhs.value;
+		return check(_lhs, _rhs, _lhs.value == _rhs.value);
 }
 
 bool SyntacticallyEqual::statementEqual(ExpressionStatement const& _lhs, ExpressionStatement const& _rhs)
 {
 	return (*this)(_lhs.expression, _rhs.expression);
 }
+
 bool SyntacticallyEqual::statementEqual(Assignment const& _lhs, Assignment const& _rhs)
 {
 	return containerEqual(

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -23,12 +23,15 @@
 #include <libyul/AsmDataForward.h>
 #include <libyul/YulString.h>
 
+#include <boost/variant.hpp>
+
+#include <functional>
 #include <map>
 #include <type_traits>
+#include <utility>
 
 namespace yul
 {
-
 
 /**
  * Component that can compare ASTs for equality on a syntactic basis.
@@ -39,6 +42,23 @@ namespace yul
 class SyntacticallyEqual
 {
 public:
+	using FailReportArgs = boost::variant<
+		std::pair<Expression, Expression>,
+		std::pair<Statement, Statement>
+	>;
+	using FailReporter = std::function<void(FailReportArgs)>;
+
+	FailReporter m_report;
+
+	template <typename Node>
+	bool check(Node const& a, Node const& b, bool result)
+	{
+		if (!result)
+			m_report(std::make_pair(a, b));
+
+		return result;
+	}
+
 	bool operator()(Expression const& _lhs, Expression const& _rhs);
 	bool operator()(Statement const& _lhs, Statement const& _rhs);
 

--- a/test/libyul/YulOptimizerTest.h
+++ b/test/libyul/YulOptimizerTest.h
@@ -59,7 +59,9 @@ private:
 	void disambiguate();
 
 	static void printErrors(std::ostream& _stream, langutil::ErrorList const& _errors);
+	static void printErrorsHuman(std::ostream& _stream, langutil::ErrorList const& _errors);
 
+	std::string m_filename;
 	std::string m_source;
 	bool m_yul = false;
 	std::string m_optimizerStep;
@@ -68,6 +70,7 @@ private:
 	std::shared_ptr<Dialect> m_dialect;
 	std::shared_ptr<Block> m_ast;
 	std::shared_ptr<AsmAnalysisInfo> m_analysisInfo;
+	std::shared_ptr<Block> m_expectationAST;
 	std::string m_obtainedResult;
 };
 


### PR DESCRIPTION
### isoltest example output excerpt:
![image](https://user-images.githubusercontent.com/56763/54274274-f3851f00-4587-11e9-9bf2-6122a0a2b427.png)

This PR is work-in-progress but open for comments/suggestions (not all code considered complete yet).

### Motivation
* [x] better error reporting in isoltest for Yul output (not just dumping everything but providing proper locations based on syntax diffs)
* [x] ignore white spaces in expectation output, so creating expectations (manually) becomes a little easier.

### Checklist
* [ ] Add a CLI flag to isoltest to still provide the old dump-it-all output.
* [ ] Consider still dumping the whole expected (and/or actual) output but color-highlight the parts that differ (idea from @ekpyron)
* [ ] fix source name/position in secondary source location (expected AST)
* [ ] have merged my timestamp-commits once feeling happy. :-)