### PR TITLE
[DOCS] Add Solidity IDE to resources page

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -27,11 +27,14 @@ Solidity Integrations
     * `Remix <https://remix.ethereum.org/>`_
         Browser-based IDE with integrated compiler and Solidity runtime environment without server-side components.
 
-    * `Solium <https://github.com/duaraghav8/Solium/>`_
-        Linter to identify and fix style and security issues in Solidity.
-
     * `Solhint <https://github.com/protofire/solhint>`_
         Solidity linter that provides security, style guide and best practice rules for smart contract validation.
+
+    * `Solidity IDE <https://github.com/System-Glitch/Solidity-IDE>`_
+        Browser-based IDE with integrated compiler, Ganache and local file system support.
+
+    * `Solium <https://github.com/duaraghav8/Solium/>`_
+        Linter to identify and fix style and security issues in Solidity.
 
     * `Superblocks Lab <https://lab.superblocks.com/>`_
         Browser-based IDE. Built-in browser-based VM and Metamask integration (one click deployment to Testnet/Mainnet).


### PR DESCRIPTION
### Description

Add [Solidity IDE](https://github.com/System-Glitch/Solidity-IDE) to the "Resources" documentation page. (`docs/resources.rst`)

### Checklist
- [x] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
