### PR TITLE
Discard fuzz input containing non ASCII character(s).

### DIFF
--- a/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
@@ -50,6 +50,11 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	string input(reinterpret_cast<char const*>(_data), _size);
 
+	if (std::any_of(input.begin(), input.end(), [](char c) {
+		return ((static_cast<unsigned char>(c) > 127) || !(std::isprint(c) || (c == '\n') || (c == '\t')));
+	}))
+		return 0;
+
 	AssemblyStack stack(EVMVersion::petersburg(), AssemblyStack::Language::StrictAssembly);
 	try
 	{


### PR DESCRIPTION
### Description

(fixes #6288 )
