### PR TITLE
Support EVM Version rules for extracted tests.

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -75,6 +75,7 @@ CommonOptions::CommonOptions(std::string _caption):
 	)
 {
 	options.add_options()
+		("evm-version", po::value(&evmVersionString), "which evm version to use")
 		("testpath", po::value<fs::path>(&this->testPath)->default_value(dev::test::testPath()), "path to test files")
 		("ipcpath", po::value<fs::path>(&ipcPath)->default_value(IPCEnvOrDefaultPath()), "path to ipc socket")
 		("no-ipc", po::bool_switch(&disableIPC), "disable semantic tests")
@@ -119,6 +120,20 @@ bool CommonOptions::parse(int argc, char const* const* argv)
 	po::notify(arguments);
 
 	return true;
+}
+
+
+langutil::EVMVersion CommonOptions::evmVersion() const
+{
+	if (!evmVersionString.empty())
+	{
+		auto version = langutil::EVMVersion::fromString(evmVersionString);
+		if (!version)
+			throw std::runtime_error("Invalid EVM version: " + evmVersionString);
+		return *version;
+	}
+	else
+		return langutil::EVMVersion();
 }
 
 }

--- a/test/Common.h
+++ b/test/Common.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <libdevcore/Exceptions.h>
+#include <liblangutil/EVMVersion.h>
 
 #include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
@@ -39,6 +40,8 @@ struct CommonOptions: boost::noncopyable
 	bool disableIPC = false;
 	bool disableSMT = false;
 
+	langutil::EVMVersion evmVersion() const;
+
 	virtual bool parse(int argc, char const* const* argv);
 	// Throws a ConfigException on error
 	virtual void validate() const;
@@ -47,6 +50,9 @@ protected:
 	CommonOptions(std::string caption = "");
 
 	boost::program_options::options_description options;
+
+private:
+	std::string evmVersionString;
 };
 
 }

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -54,7 +54,7 @@ ExecutionFramework::ExecutionFramework():
 {
 }
 
-ExecutionFramework::ExecutionFramework(string const& _ipcPath, langutil::EVMVersion const _evmVersion):
+ExecutionFramework::ExecutionFramework(string const& _ipcPath, langutil::EVMVersion _evmVersion):
 	m_rpc(RPCSession::instance(_ipcPath)),
 	m_evmVersion(_evmVersion),
 	m_optimize(dev::test::Options::get().optimize),

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -50,13 +50,13 @@ string getIPCSocketPath()
 }
 
 ExecutionFramework::ExecutionFramework():
-	ExecutionFramework(getIPCSocketPath())
+	ExecutionFramework(getIPCSocketPath(), dev::test::Options::get().evmVersion())
 {
 }
 
-ExecutionFramework::ExecutionFramework(string const& _ipcPath):
+ExecutionFramework::ExecutionFramework(string const& _ipcPath, langutil::EVMVersion const _evmVersion):
 	m_rpc(RPCSession::instance(_ipcPath)),
-	m_evmVersion(dev::test::Options::get().evmVersion()),
+	m_evmVersion(_evmVersion),
 	m_optimize(dev::test::Options::get().optimize),
 	m_showMessages(dev::test::Options::get().showMessages),
 	m_sender(m_rpc.account(0))

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -53,7 +53,7 @@ class ExecutionFramework
 
 public:
 	ExecutionFramework();
-	explicit ExecutionFramework(std::string const& _ipcPath);
+	explicit ExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion const _evmVersion);
 	virtual ~ExecutionFramework() = default;
 
 	virtual bytes const& compileAndRunWithoutCheck(

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -53,7 +53,7 @@ class ExecutionFramework
 
 public:
 	ExecutionFramework();
-	explicit ExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion const _evmVersion);
+	explicit ExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion _evmVersion);
 	virtual ~ExecutionFramework() = default;
 
 	virtual bytes const& compileAndRunWithoutCheck(

--- a/test/Options.cpp
+++ b/test/Options.cpp
@@ -53,22 +53,7 @@ Options::Options()
 	options.add_options()
 		("optimize", po::bool_switch(&optimize), "enables optimization")
 		("abiencoderv2", po::bool_switch(&useABIEncoderV2), "enables abi encoder v2")
-		("evm-version", po::value(&evmVersionString), "which evm version to use")
 		("show-messages", po::bool_switch(&showMessages), "enables message output");
 
 	parse(suite.argc, suite.argv);
-}
-
-langutil::EVMVersion Options::evmVersion() const
-{
-	if (!evmVersionString.empty())
-	{
-		// We do this check as opposed to in the constructor because the BOOST_REQUIRE
-		// macros cannot yet be used in the constructor.
-		auto version = langutil::EVMVersion::fromString(evmVersionString);
-		BOOST_REQUIRE_MESSAGE(version, "Invalid EVM version: " + evmVersionString);
-		return *version;
-	}
-	else
-		return langutil::EVMVersion();
 }

--- a/test/Options.h
+++ b/test/Options.h
@@ -37,13 +37,9 @@ struct Options: CommonOptions
 	bool showMessages = false;
 	bool useABIEncoderV2 = false;
 
-	langutil::EVMVersion evmVersion() const;
-
 	static Options const& get();
 
 private:
-	std::string evmVersionString;
-
 	Options();
 };
 

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -17,6 +17,7 @@
 
 #include <test/TestCase.h>
 
+#include <boost/algorithm/cxx11/none_of.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -37,18 +38,15 @@ bool TestCase::isTestFilename(boost::filesystem::path const& _filename)
 
 bool TestCase::supportedForEVMVersion(langutil::EVMVersion _evmVersion) const
 {
-	for (auto const& rule: m_evmVersionRules)
-		if (!rule(_evmVersion))
-			return false;
-	return true;
+	return boost::algorithm::none_of(m_evmVersionRules, [&](auto const& rule) { return !rule(_evmVersion); });
 }
 
 string TestCase::parseSource(istream& _stream)
 {
 	string source;
 	string line;
-	string const delimiter("// ----");
-	string const evmVersion("// EVMVersion: ");
+	static string const delimiter("// ----");
+	static string const evmVersion("// EVMVersion: ");
 	bool isTop = true;
 	while (getline(_stream, line))
 		if (boost::algorithm::starts_with(line, delimiter))

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -35,16 +35,60 @@ bool TestCase::isTestFilename(boost::filesystem::path const& _filename)
 		   !boost::starts_with(_filename.string(), ".");
 }
 
+bool TestCase::supportedForEVMVersion(langutil::EVMVersion _evmVersion) const
+{
+	for (auto const& rule: m_evmVersionRules)
+		if (!rule(_evmVersion))
+			return false;
+	return true;
+}
+
 string TestCase::parseSource(istream& _stream)
 {
 	string source;
 	string line;
 	string const delimiter("// ----");
+	string const evmVersion("// EVMVersion: ");
+	bool isTop = true;
 	while (getline(_stream, line))
 		if (boost::algorithm::starts_with(line, delimiter))
 			break;
 		else
+		{
+			if (isTop && boost::algorithm::starts_with(line, evmVersion))
+			{
+				string versionString = line.substr(evmVersion.size() + 1);
+				auto version = langutil::EVMVersion::fromString(versionString);
+				if (!version)
+					throw runtime_error("Invalid EVM version: \"" + versionString + "\"");
+				switch (line.at(evmVersion.size()))
+				{
+					case '>':
+						m_evmVersionRules.emplace_back([version](langutil::EVMVersion _version) {
+							return version < _version;
+						});
+						break;
+					case '<':
+						m_evmVersionRules.emplace_back([version](langutil::EVMVersion _version) {
+							return _version < version;
+						});
+						break;
+					case '=':
+						m_evmVersionRules.emplace_back([version](langutil::EVMVersion _version) {
+							return _version == version;
+						});
+						break;
+					case '!':
+						m_evmVersionRules.emplace_back([version](langutil::EVMVersion _version) {
+							return !(_version == version);
+						});
+						break;
+				}
+			}
+			else
+				isTop = false;
 			source += line + "\n";
+		}
 	return source;
 }
 

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -17,11 +17,15 @@
 
 #pragma once
 
+#include <liblangutil/EVMVersion.h>
+
 #include <boost/filesystem.hpp>
 
+#include <functional>
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace dev
 {
@@ -46,6 +50,7 @@ public:
 	{
 		std::string filename;
 		std::string ipcPath;
+		langutil::EVMVersion evmVersion;
 	};
 
 	using TestCaseCreator = std::unique_ptr<TestCase>(*)(Config const&);
@@ -69,8 +74,11 @@ public:
 
 	static bool isTestFilename(boost::filesystem::path const& _filename);
 
+	/// Returns true, if the test case is supported for EVM version @arg _evmVersion, false otherwise.
+	bool supportedForEVMVersion(langutil::EVMVersion _evmVersion) const;
+
 protected:
-	static std::string parseSource(std::istream& _file);
+	std::string parseSource(std::istream& _file);
 	static void expect(std::string::iterator& _it, std::string::iterator _end, std::string::value_type _c);
 
 	template<typename IteratorType>
@@ -86,7 +94,8 @@ protected:
 		while (_it != _end && *_it == '/')
 			++_it;
 	}
-
+private:
+	std::vector<std::function<bool(langutil::EVMVersion)>> m_evmVersionRules;
 };
 
 }

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -80,7 +80,7 @@ int registerTests(
 {
 	int numTestsAdded = 0;
 	fs::path fullpath = _basepath / _path;
-	TestCase::Config config{fullpath.string(), _ipcPath};
+	TestCase::Config config{fullpath.string(), _ipcPath, dev::test::Options::get().evmVersion()};
 	if (fs::is_directory(fullpath))
 	{
 		test_suite* sub_suite = BOOST_TEST_SUITE(_path.filename().string());
@@ -104,8 +104,10 @@ int registerTests(
 					try
 					{
 						stringstream errorStream;
-						if (!_testCaseCreator(config)->run(errorStream))
-							BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
+						auto testCase = _testCaseCreator(config);
+						if (testCase->supportedForEVMVersion(dev::test::Options::get().evmVersion()))
+							if (!testCase->run(errorStream))
+								BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
 					}
 					catch (boost::exception const& _e)
 					{

--- a/test/libsolidity/SMTCheckerJSONTest.cpp
+++ b/test/libsolidity/SMTCheckerJSONTest.cpp
@@ -35,7 +35,7 @@ using namespace dev;
 using namespace std;
 using namespace boost::unit_test;
 
-SMTCheckerTest::SMTCheckerTest(string const& _filename, langutil::EVMVersion const _evmVersion)
+SMTCheckerTest::SMTCheckerTest(string const& _filename, langutil::EVMVersion _evmVersion)
 : SyntaxTest(_filename, _evmVersion)
 {
 	if (!boost::algorithm::ends_with(_filename, ".sol"))
@@ -49,7 +49,7 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename, langutil::EVMVersion con
 		BOOST_THROW_EXCEPTION(runtime_error("Invalid JSON file."));
 }
 
-bool SMTCheckerTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+bool SMTCheckerTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
 	StandardCompiler compiler;
 

--- a/test/libsolidity/SMTCheckerJSONTest.cpp
+++ b/test/libsolidity/SMTCheckerJSONTest.cpp
@@ -35,8 +35,8 @@ using namespace dev;
 using namespace std;
 using namespace boost::unit_test;
 
-SMTCheckerTest::SMTCheckerTest(string const& _filename)
-: SyntaxTest(_filename)
+SMTCheckerTest::SMTCheckerTest(string const& _filename, langutil::EVMVersion const _evmVersion)
+: SyntaxTest(_filename, _evmVersion)
 {
 	if (!boost::algorithm::ends_with(_filename, ".sol"))
 		BOOST_THROW_EXCEPTION(runtime_error("Invalid test contract file name: \"" + _filename + "\"."));

--- a/test/libsolidity/SMTCheckerJSONTest.h
+++ b/test/libsolidity/SMTCheckerJSONTest.h
@@ -35,11 +35,11 @@ class SMTCheckerTest: public SyntaxTest
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
-		return std::unique_ptr<TestCase>(new SMTCheckerTest(_config.filename, _config.evmVersion));
+		return std::make_unique<SMTCheckerTest>(_config.filename, _config.evmVersion);
 	}
 	SMTCheckerTest(std::string const& _filename, langutil::EVMVersion _evmVersion);
 
-	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
 
 private:
 	std::vector<std::string> hashesFromJson(Json::Value const& _jsonObj, std::string const& _auxInput, std::string const& _smtlib);

--- a/test/libsolidity/SMTCheckerJSONTest.h
+++ b/test/libsolidity/SMTCheckerJSONTest.h
@@ -35,9 +35,9 @@ class SMTCheckerTest: public SyntaxTest
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
-		return std::unique_ptr<TestCase>(new SMTCheckerTest(_config.filename));
+		return std::unique_ptr<TestCase>(new SMTCheckerTest(_config.filename, _config.evmVersion));
 	}
-	SMTCheckerTest(std::string const& _filename);
+	SMTCheckerTest(std::string const& _filename, langutil::EVMVersion _evmVersion);
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -36,8 +36,8 @@ using namespace boost::unit_test;
 namespace fs = boost::filesystem;
 
 
-SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath):
-	SolidityExecutionFramework(_ipcPath)
+SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath, langutil::EVMVersion const _evmVersion):
+	SolidityExecutionFramework(_ipcPath, _evmVersion)
 {
 	ifstream file(_filename);
 	soltestAssert(file, "Cannot open test contract: \"" + _filename + "\".");

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -36,7 +36,7 @@ using namespace boost::unit_test;
 namespace fs = boost::filesystem;
 
 
-SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath, langutil::EVMVersion const _evmVersion):
+SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath, langutil::EVMVersion _evmVersion):
 	SolidityExecutionFramework(_ipcPath, _evmVersion)
 {
 	ifstream file(_filename);
@@ -47,7 +47,7 @@ SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath, lang
 	parseExpectations(file);
 }
 
-bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
 	soltestAssert(deploy("", 0, bytes()), "Failed to deploy contract.");
 
@@ -87,7 +87,7 @@ bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool const _
 	return true;
 }
 
-void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool const) const
+void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool) const
 {
 	stringstream stream(m_source);
 	string line;

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -44,9 +44,9 @@ class SemanticTest: public SolidityExecutionFramework, public TestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _options)
-	{ return std::make_unique<SemanticTest>(_options.filename, _options.ipcPath); }
+	{ return std::make_unique<SemanticTest>(_options.filename, _options.ipcPath, _options.evmVersion); }
 
-	explicit SemanticTest(std::string const& _filename, std::string const& _ipcPath);
+	explicit SemanticTest(std::string const& _filename, std::string const& _ipcPath, langutil::EVMVersion const _evmVersion);
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 	void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -46,10 +46,10 @@ public:
 	static std::unique_ptr<TestCase> create(Config const& _options)
 	{ return std::make_unique<SemanticTest>(_options.filename, _options.ipcPath, _options.evmVersion); }
 
-	explicit SemanticTest(std::string const& _filename, std::string const& _ipcPath, langutil::EVMVersion const _evmVersion);
+	explicit SemanticTest(std::string const& _filename, std::string const& _ipcPath, langutil::EVMVersion _evmVersion);
 
-	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
-	void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
+	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
+	void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool _formatted = false) const override;
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix = "") const override;
 
 	/// Instantiates a test file parser that parses the additional comment section at the end of

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -33,7 +33,7 @@ SolidityExecutionFramework::SolidityExecutionFramework():
 {
 }
 
-SolidityExecutionFramework::SolidityExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion const _evmVersion):
+SolidityExecutionFramework::SolidityExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion _evmVersion):
 	ExecutionFramework(_ipcPath, _evmVersion)
 {
 }

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -33,7 +33,7 @@ SolidityExecutionFramework::SolidityExecutionFramework():
 {
 }
 
-SolidityExecutionFramework::SolidityExecutionFramework(std::string const& _ipcPath):
-	ExecutionFramework(_ipcPath)
+SolidityExecutionFramework::SolidityExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion const _evmVersion):
+	ExecutionFramework(_ipcPath, _evmVersion)
 {
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -43,7 +43,7 @@ class SolidityExecutionFramework: public dev::test::ExecutionFramework
 
 public:
 	SolidityExecutionFramework();
-	SolidityExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion const _evmVersion);
+	SolidityExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion _evmVersion);
 
 	virtual bytes const& compileAndRunWithoutCheck(
 		std::string const& _sourceCode,

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -43,7 +43,7 @@ class SolidityExecutionFramework: public dev::test::ExecutionFramework
 
 public:
 	SolidityExecutionFramework();
-	SolidityExecutionFramework(std::string const& _ipcPath);
+	SolidityExecutionFramework(std::string const& _ipcPath, langutil::EVMVersion const _evmVersion);
 
 	virtual bytes const& compileAndRunWithoutCheck(
 		std::string const& _sourceCode,

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -52,7 +52,7 @@ int parseUnsignedInteger(string::iterator& _it, string::iterator _end)
 
 }
 
-SyntaxTest::SyntaxTest(string const& _filename)
+SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion const _evmVersion): m_evmVersion(_evmVersion)
 {
 	ifstream file(_filename);
 	if (!file)
@@ -68,7 +68,7 @@ bool SyntaxTest::run(ostream& _stream, string const& _linePrefix, bool const _fo
 	string const versionPragma = "pragma solidity >=0.0;\n";
 	m_compiler.reset();
 	m_compiler.addSource("", versionPragma + m_source);
-	m_compiler.setEVMVersion(dev::test::Options::get().evmVersion());
+	m_compiler.setEVMVersion(m_evmVersion);
 
 	if (m_compiler.parse())
 		m_compiler.analyze();

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -52,7 +52,7 @@ int parseUnsignedInteger(string::iterator& _it, string::iterator _end)
 
 }
 
-SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion const _evmVersion): m_evmVersion(_evmVersion)
+SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion _evmVersion): m_evmVersion(_evmVersion)
 {
 	ifstream file(_filename);
 	if (!file)
@@ -63,7 +63,7 @@ SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion const _evmV
 	m_expectations = parseExpectations(file);
 }
 
-bool SyntaxTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+bool SyntaxTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
 	string const versionPragma = "pragma solidity >=0.0;\n";
 	m_compiler.reset();
@@ -95,7 +95,7 @@ bool SyntaxTest::run(ostream& _stream, string const& _linePrefix, bool const _fo
 	return printExpectationAndError(_stream, _linePrefix, _formatted);
 }
 
-bool SyntaxTest::printExpectationAndError(ostream& _stream, string const& _linePrefix, bool const _formatted)
+bool SyntaxTest::printExpectationAndError(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
 	if (m_expectations != m_errorList)
 	{
@@ -109,7 +109,7 @@ bool SyntaxTest::printExpectationAndError(ostream& _stream, string const& _lineP
 	return true;
 }
 
-void SyntaxTest::printSource(ostream& _stream, string const& _linePrefix, bool const _formatted) const
+void SyntaxTest::printSource(ostream& _stream, string const& _linePrefix, bool _formatted) const
 {
 	if (_formatted)
 	{
@@ -162,7 +162,7 @@ void SyntaxTest::printErrorList(
 	ostream& _stream,
 	vector<SyntaxTestError> const& _errorList,
 	string const& _linePrefix,
-	bool const _formatted
+	bool _formatted
 )
 {
 	if (_errorList.empty())

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -54,8 +54,8 @@ class SyntaxTest: AnalysisFramework, public TestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)
-	{ return std::unique_ptr<TestCase>(new SyntaxTest(_config.filename)); }
-	SyntaxTest(std::string const& _filename);
+	{ return std::unique_ptr<TestCase>(new SyntaxTest(_config.filename, _config.evmVersion)); }
+	SyntaxTest(std::string const& _filename, langutil::EVMVersion const _evmVersion);
 
 	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 
@@ -82,6 +82,7 @@ protected:
 	std::string m_source;
 	std::vector<SyntaxTestError> m_expectations;
 	std::vector<SyntaxTestError> m_errorList;
+	langutil::EVMVersion const m_evmVersion;
 };
 
 }

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -54,12 +54,12 @@ class SyntaxTest: AnalysisFramework, public TestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)
-	{ return std::unique_ptr<TestCase>(new SyntaxTest(_config.filename, _config.evmVersion)); }
-	SyntaxTest(std::string const& _filename, langutil::EVMVersion const _evmVersion);
+	{ return std::make_unique<SyntaxTest>(_config.filename, _config.evmVersion); }
+	SyntaxTest(std::string const& _filename, langutil::EVMVersion _evmVersion);
 
-	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+	bool run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
 
-	void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool const _formatted = false) const override;
+	void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool _formatted = false) const override;
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override
 	{
 		if (!m_errorList.empty())
@@ -72,10 +72,10 @@ protected:
 		std::ostream& _stream,
 		std::vector<SyntaxTestError> const& _errors,
 		std::string const& _linePrefix,
-		bool const _formatted = false
+		bool _formatted = false
 	);
 
-	virtual bool printExpectationAndError(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false);
+	virtual bool printExpectationAndError(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false);
 
 	static std::vector<SyntaxTestError> parseExpectations(std::istream& _stream);
 

--- a/test/tools/IsolTestOptions.h
+++ b/test/tools/IsolTestOptions.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <liblangutil/EVMVersion.h>
+
 #include <test/Common.h>
 
 namespace dev

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -50,7 +50,7 @@ struct TestStats
 	int successCount = 0;
 	int testCount = 0;
 	int skippedCount = 0;
-	operator bool() const { return successCount + skippedCount == testCount; }
+	operator bool() const noexcept { return successCount + skippedCount == testCount; }
 	TestStats& operator+=(TestStats const& _other) noexcept
 	{
 		successCount += _other.successCount;
@@ -88,8 +88,8 @@ public:
 		fs::path const& _basepath,
 		fs::path const& _path,
 		string const& _ipcPath,
-		bool const _formatted,
-		langutil::EVMVersion const _evmVersion
+		bool _formatted,
+		langutil::EVMVersion _evmVersion
 	);
 
 	static string editor;
@@ -101,7 +101,7 @@ private:
 		Quit
 	};
 
-	Request handleResponse(bool const _exception);
+	Request handleResponse(bool _exception);
 
 	TestCase::TestCaseCreator m_testCaseCreator;
 	string const m_name;
@@ -170,7 +170,7 @@ TestTool::Result TestTool::process()
 	}
 }
 
-TestTool::Request TestTool::handleResponse(bool const _exception)
+TestTool::Request TestTool::handleResponse(bool _exception)
 {
 	if (_exception)
 		cout << "(e)dit/(s)kip/(q)uit? ";
@@ -216,8 +216,8 @@ TestStats TestTool::processPath(
 	fs::path const& _basepath,
 	fs::path const& _path,
 	string const& _ipcPath,
-	bool const _formatted,
-	langutil::EVMVersion const _evmVersion
+	bool _formatted,
+	langutil::EVMVersion _evmVersion
 )
 {
 	std::queue<fs::path> paths;
@@ -318,7 +318,7 @@ boost::optional<TestStats> runTestSuite(
 	string const& _ipcPath,
 	TestCase::TestCaseCreator _testCaseCreator,
 	bool _formatted,
-	langutil::EVMVersion const _evmVersion
+	langutil::EVMVersion _evmVersion
 )
 {
 	fs::path testPath = _basePath / _subdirectory;
@@ -395,7 +395,7 @@ int main(int argc, char const *argv[])
 	{
 		cout << " (";
 		AnsiColorized(cout, !options.noColor, {BOLD, YELLOW}) << global_stats.skippedCount;
-		cout<< " tests skipped)";
+		cout << " tests skipped)";
 	}
 	cout << "." << endl;
 


### PR DESCRIPTION
This is not perfect, but we have to start somewhere.
In extracted tests this will allow the first lines to be comments of the form
```
// EVMVersion: >homestead
// EVMVersion: !byzantium
// EVMVersion: <petersburg
// EVMVersion: =contantinople
```

This will be matched against the current EVM version set for the tests one by one. The test will skipped, if any check fails.

Also adds an ``--evm-version`` argument to ``isoltest``.

Fixes #4262, although it won't support multiple expectations with differing EVM versions, which I suggest to postpone further until syntax and semantics tests are structurally merged.