### PR TITLE
yul proto: Add support for generating string and hex literals.

### DIFF
--- a/test/tools/ossfuzz/protoToYul.h
+++ b/test/tools/ossfuzz/protoToYul.h
@@ -31,6 +31,8 @@ class Function;
 
 std::string functionToString(Function const& input);
 std::string protoToYul(uint8_t const* data, size_t size);
+std::string createHex(std::string const& _hexBytes);
+std::string createAlphaNum(std::string const& _strBytes);
 std::ostream& operator<<(std::ostream& _os, BinaryOp const& _x);
 std::ostream& operator<<(std::ostream& _os, Block const& _x);
 std::ostream& operator<<(std::ostream& _os, Literal const& _x);

--- a/test/tools/ossfuzz/yulProto.proto
+++ b/test/tools/ossfuzz/yulProto.proto
@@ -48,6 +48,8 @@ message VarRef {
 message Literal {
   oneof literal_oneof {
     uint64 intval = 1;
+    string hexval = 2;
+    string strval = 3;
   }
 }
 


### PR DESCRIPTION
### Description

(closes #6307 )

This PR adds support for generating string and hex literals in fuzzing input for the proto-based differential fuzzer.