### PR TITLE
[SMTChecker] Add callstack to model report

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 Compiler Features:
  * Inline Assembly: Issue error when using ``callvalue()`` inside nonpayable function (in the same way that ``msg.value`` already does).
+ * SMTChecker: Show callstack together with model if applicable.
  * Yul Optimizer: Enable stack allocation optimization by default if yul optimizer is active (disable in yulDetails).
 
 

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <libdevcore/Exceptions.h>
 #include <libdevcore/Assertions.h>
+#include <libdevcore/CommonData.h>
 #include <liblangutil/SourceLocation.h>
 
 namespace langutil
@@ -106,6 +107,11 @@ public:
 	SecondarySourceLocation& append(std::string const& _errMsg, SourceLocation const& _sourceLocation)
 	{
 		infos.emplace_back(_errMsg, _sourceLocation);
+		return *this;
+	}
+	SecondarySourceLocation& append(SecondarySourceLocation&& _other)
+	{
+		infos += std::move(_other.infos);
 		return *this;
 	}
 

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -229,6 +229,8 @@ private:
 	void popPathCondition();
 	/// Returns the conjunction of all path conditions or True if empty
 	smt::Expression currentPathConditions();
+	/// Returns the current callstack. Used for models.
+	langutil::SecondarySourceLocation currentCallStack();
 	/// Conjoin the current path conditions with the given parameter and add to the solver
 	void addPathConjoinedExpression(smt::Expression const& _e);
 	/// Add to the solver: the given expression implied by the current path conditions
@@ -269,6 +271,8 @@ private:
 
 	/// Stores the current path of function calls.
 	std::vector<FunctionDefinition const*> m_functionPath;
+	/// Stores the current call/invocation path.
+	std::vector<ASTNode const*> m_callStack;
 	/// Returns true if the current function was not visited by
 	/// a function call.
 	bool isRootFunction();


### PR DESCRIPTION
Split #6244 

For the following code, part of the report will be
```
pragma experimental SMTChecker;

contract C
{
	function f(uint x) public pure returns (uint) {
		assert(x > 0);
		return x + 1;
	}
	function g(uint x) public pure returns (uint) {
		return f(x);
	}
	function h(uint x) public pure {
		uint y = g(x);
	}
}
```

```
a.sol:6:3: Warning: Assertion violation happens here
		assert(x > 0);
		^-----------^
  for:
   = 0
  x = 0
  y = 0

Callstack: 
a.sol:13:12: 
		uint y = g(x);
		         ^--^
a.sol:10:10: 
		return f(x);
		       ^--^
```

Did not add tests because this is a secondary location.