### PR TITLE
[WIP][RFC] Possible fix for Overload resolution for .value()

### DIFF
--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -192,7 +192,8 @@ struct IdentifierAnnotation: ExpressionAnnotation
 struct MemberAccessAnnotation: ExpressionAnnotation
 {
 	/// Referenced declaration, set at latest during overload resolution stage.
-	Declaration const* referencedDeclaration = nullptr;
+	Declaration const* referencedDeclaration;
+	std::vector<Declaration const*> allReferencedDeclarations = {};
 };
 
 struct BinaryOperationAnnotation: ExpressionAnnotation


### PR DESCRIPTION
This is experimental code that attempts to solve issue #526

Basically, when faced with a non-unique overload situation, we remember all
possible declaration and just pick the first one. If at any point later we
encounter an error, we just retry with the next in the list.

This code is of course not merge ready, instead it wants to demonstrate the
concept and gather feedback.