### PR TITLE
Allow simplification patterns to signal failure

### DIFF
--- a/libevmasm/ExpressionClasses.cpp
+++ b/libevmasm/ExpressionClasses.cpp
@@ -196,13 +196,15 @@ ExpressionClasses::Id ExpressionClasses::tryToSimplify(Expression const& _expr)
 	if (auto match = rules.findFirstMatch(_expr, *this))
 	{
 		// Debug info
-		//cout << "Simplifying " << *_expr.item << "(";
-		//for (Id arg: _expr.arguments)
-		//	cout << fullDAGToString(arg) << ", ";
-		//cout << ")" << endl;
-		//cout << "with rule " << match->first.toString() << endl;
-		//ExpressionTemplate t(match->second());
-		//cout << "to " << match->second().toString() << endl;
+		if (false)
+		{
+			cout << "Simplifying " << *_expr.item << "(";
+			for (Id arg: _expr.arguments)
+				cout << fullDAGToString(arg) << ", ";
+			cout << ")" << endl;
+			cout << "with rule " << match->pattern.toString() << endl;
+			cout << "to " << match->action().toString() << endl;
+		}
 
 		return rebuildExpression(ExpressionTemplate(match->action(), _expr.item->location()));
 	}

--- a/libevmasm/ExpressionClasses.cpp
+++ b/libevmasm/ExpressionClasses.cpp
@@ -203,6 +203,7 @@ ExpressionClasses::Id ExpressionClasses::tryToSimplify(Expression const& _expr)
 		//cout << "with rule " << match->first.toString() << endl;
 		//ExpressionTemplate t(match->second());
 		//cout << "to " << match->second().toString() << endl;
+
 		return rebuildExpression(ExpressionTemplate(match->action(), _expr.item->location()));
 	}
 

--- a/libevmasm/SimplificationRule.h
+++ b/libevmasm/SimplificationRule.h
@@ -36,9 +36,22 @@ namespace solidity
 template <class Pattern>
 struct SimplificationRule
 {
+	SimplificationRule(
+		Pattern _pattern,
+		std::function<Pattern()> _action,
+		bool _removesNonConstants,
+		std::function<bool()> _feasible = {}
+	):
+		pattern(std::move(_pattern)),
+		action(std::move(_action)),
+		removesNonConstants(_removesNonConstants),
+		feasible(std::move(_feasible))
+	{}
+
 	Pattern pattern;
 	std::function<Pattern()> action;
 	bool removesNonConstants;
+	std::function<bool()> feasible;
 };
 
 }

--- a/libevmasm/SimplificationRules.cpp
+++ b/libevmasm/SimplificationRules.cpp
@@ -51,7 +51,9 @@ SimplificationRule<Pattern> const* Rules::findFirstMatch(
 	for (auto const& rule: m_rules[uint8_t(_expr.item->instruction())])
 	{
 		if (rule.pattern.matches(_expr, _classes))
-			return &rule;
+			if (!rule.feasible || rule.feasible())
+				return &rule;
+
 		resetMatchGroups();
 	}
 	return nullptr;

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -51,7 +51,8 @@ SimplificationRule<Pattern> const* SimplificationRules::findFirstMatch(
 	{
 		rules.resetMatchGroups();
 		if (rule.pattern.matches(_expr, _dialect, _ssaValues))
-			return &rule;
+			if (!rule.feasible || rule.feasible())
+				return &rule;
 	}
 	return nullptr;
 }


### PR DESCRIPTION
split out uncontroversial parts of #6160
