### PR TITLE
Fixes wrong source location when reporting pragma solidity version conflicts

### DIFF
--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -73,7 +73,7 @@ private:
 
 	///@{
 	///@name Parsing functions for the AST nodes
-	void parsePragmaVersion(std::vector<Token> const& tokens, std::vector<std::string> const& literals);
+	void parsePragmaVersion(langutil::SourceLocation const& _location, std::vector<Token> const& _tokens, std::vector<std::string> const& _literals);
 	ASTPointer<PragmaDirective> parsePragmaDirective();
 	ASTPointer<ImportDirective> parseImportDirective();
 	ContractDefinition::ContractKind parseContractKind();


### PR DESCRIPTION
Fixes #6329.

Which now looks like this:
![image](https://user-images.githubusercontent.com/56763/54677890-2db06c80-4b04-11e9-9988-5aa387f9787d.png)
