### PR TITLE
[Yul] Value Constraint Based Simplifier.

### DIFF
--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -91,6 +91,24 @@ inline u256 s2u(s256 _u)
 		return u256(c_end + _u);
 }
 
+/// @returns the highest bit set in @a. If _v is zero, returns -1.
+inline int highestBitSet(u256 const& _v)
+{
+	if (_v == 0)
+		return -1;
+	else
+		return boost::multiprecision::msb(_v);
+}
+
+/// @returns the lowest bit set in @a. If _v is zero, returns 256
+inline int lowestBitSet(u256 const& _v)
+{
+	if (_v == 0)
+		return 256;
+	else
+		return boost::multiprecision::lsb(_v);
+}
+
 inline std::ostream& operator<<(std::ostream& os, bytes const& _bytes)
 {
 	std::ostringstream ss;

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -108,6 +108,8 @@ add_library(yul
 	optimiser/SyntacticalEquality.h
 	optimiser/UnusedPruner.cpp
 	optimiser/UnusedPruner.h
+	optimiser/ValueConstraintBasedSimplifier.cpp
+	optimiser/ValueConstraintBasedSimplifier.h
 	optimiser/VarDeclInitializer.cpp
 	optimiser/VarDeclInitializer.h
 	optimiser/VarNameCleaner.cpp

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -213,6 +213,8 @@ void DataFlowAnalyzer::clearValues(set<YulString> _variables)
 			m_referencedBy[ref].erase(name);
 		m_references[name].clear();
 	}
+
+	valuesCleared(_variables);
 }
 
 bool DataFlowAnalyzer::inScope(YulString _variableName) const

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -57,7 +57,7 @@ public:
 
 protected:
 	/// Registers the assignment.
-	void handleAssignment(std::set<YulString> const& _names, Expression* _value);
+	virtual void handleAssignment(std::set<YulString> const& _names, Expression* _value);
 
 	/// Creates a new inner scope.
 	void pushScope(bool _functionScope);
@@ -68,6 +68,10 @@ protected:
 	/// Clears information about the values assigned to the given variables,
 	/// for example at points where control flow is merged.
 	void clearValues(std::set<YulString> _names);
+
+	/// Called whenever the variables given have been cleared, just before
+	/// some of them are assigned new values.
+	virtual void valuesCleared(std::set<YulString> const& /*_names*/) {}
 
 	/// Returns true iff the variable is in scope.
 	bool inScope(YulString _variableName) const;

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -34,6 +34,7 @@
 #include <libyul/optimiser/Rematerialiser.h>
 #include <libyul/optimiser/UnusedPruner.h>
 #include <libyul/optimiser/ExpressionSimplifier.h>
+#include <libyul/optimiser/ValueConstraintBasedSimplifier.h>
 #include <libyul/optimiser/CommonSubexpressionEliminator.h>
 #include <libyul/optimiser/SSAReverser.h>
 #include <libyul/optimiser/SSATransform.h>
@@ -99,6 +100,7 @@ void OptimiserSuite::run(
 			RedundantAssignEliminator::run(*_dialect, ast);
 			RedundantAssignEliminator::run(*_dialect, ast);
 
+			ValueConstraintBasedSimplifier::run(*_dialect, ast);
 			ExpressionSimplifier::run(*_dialect, ast);
 			CommonSubexpressionEliminator{*_dialect}(ast);
 		}
@@ -156,6 +158,9 @@ void OptimiserSuite::run(
 			RedundantAssignEliminator::run(*_dialect, ast);
 			RedundantAssignEliminator::run(*_dialect, ast);
 			ExpressionSimplifier::run(*_dialect, ast);
+			ValueConstraintBasedSimplifier::run(*_dialect, ast);
+			ExpressionSimplifier::run(*_dialect, ast);
+			ValueConstraintBasedSimplifier::run(*_dialect, ast);
 			StructuralSimplifier{*_dialect}(ast);
 			BlockFlattener{}(ast);
 			CommonSubexpressionEliminator{*_dialect}(ast);

--- a/libyul/optimiser/ValueConstraintBasedSimplifier.cpp
+++ b/libyul/optimiser/ValueConstraintBasedSimplifier.cpp
@@ -1,0 +1,384 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that uses the simplification rules to simplify expressions.
+ */
+
+#include <libyul/optimiser/ValueConstraintBasedSimplifier.h>
+
+#include <libyul/optimiser/Semantics.h>
+
+#include <libyul/AsmData.h>
+#include <libyul/Utilities.h>
+#include <libyul/Exceptions.h>
+
+#include <libdevcore/CommonData.h>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+using namespace dev::solidity;
+
+namespace
+{
+class ConstraintDeduction: public boost::static_visitor<ValueConstraint>
+{
+public:
+	explicit ConstraintDeduction(map<YulString, ValueConstraint> const& _variableConstraints):
+		m_variableConstraints{_variableConstraints}
+	{}
+
+	ValueConstraint visit(Expression const& _expr)
+	{
+		return boost::apply_visitor(*this, _expr);
+	}
+
+	ValueConstraint operator()(Literal const& _literal)
+	{
+		return ValueConstraint::constant(valueOfLiteral(_literal));
+	}
+
+	ValueConstraint operator()(Identifier const& _identifier)
+	{
+		auto it = m_variableConstraints.find(_identifier.name);
+		if (it != m_variableConstraints.end())
+			return it->second;
+		else
+			return ValueConstraint{};
+	}
+
+	ValueConstraint operator()(FunctionCall const&)
+	{
+		return {};
+	}
+
+	ValueConstraint operator()(FunctionalInstruction const& _instr)
+	{
+		vector<Expression> const& args = _instr.arguments;
+		switch (_instr.instruction)
+		{
+		case dev::solidity::Instruction::ADD:
+			return visit(args.at(0)) + visit(args.at(1));
+		// TODO MUL
+		case dev::solidity::Instruction::SUB:
+			return visit(args.at(0)) - visit(args.at(1));
+		// TODO DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP, SIGNEXTEND
+		case dev::solidity::Instruction::LT:
+			return visit(args.at(0)) < visit(args.at(1));
+		case dev::solidity::Instruction::GT:
+			return visit(args.at(1)) < visit(args.at(0));
+		// TODO SLT, SGT
+		case dev::solidity::Instruction::EQ:
+			return visit(args.at(1)) == visit(args.at(0));
+		case dev::solidity::Instruction::ISZERO:
+			return visit(args.at(0)) == ValueConstraint::constant(0);
+		case dev::solidity::Instruction::AND:
+			return visit(args.at(0)) & visit(args.at(1));
+		case dev::solidity::Instruction::OR:
+			return visit(args.at(0)) | visit(args.at(1));
+		// TODO XOR
+		case dev::solidity::Instruction::NOT:
+			return ~visit(args.at(0));
+		case dev::solidity::Instruction::BYTE:
+			// TODO Could be more specific.
+			return ValueConstraint::bitRange(7, 0);
+		case dev::solidity::Instruction::SHL:
+			return visit(args.at(1)) << visit(args.at(0));
+		case dev::solidity::Instruction::SHR:
+			return visit(args.at(1)) >> visit(args.at(0));
+		// TODO SAR
+		case dev::solidity::Instruction::ADDRESS:
+		case dev::solidity::Instruction::ORIGIN:
+		case dev::solidity::Instruction::CALLER:
+		case dev::solidity::Instruction::COINBASE:
+		case dev::solidity::Instruction::CREATE:
+		case dev::solidity::Instruction::CREATE2:
+			return ValueConstraint::bitRange(160, 0);
+
+		case dev::solidity::Instruction::CALL:
+		case dev::solidity::Instruction::CALLCODE:
+		case dev::solidity::Instruction::DELEGATECALL:
+		case dev::solidity::Instruction::STATICCALL:
+			return ValueConstraint::boolean();
+
+		case dev::solidity::Instruction::KECCAK256:
+		case dev::solidity::Instruction::EXTCODEHASH:
+		case dev::solidity::Instruction::BLOCKHASH:
+		case dev::solidity::Instruction::MLOAD:
+		case dev::solidity::Instruction::SLOAD:
+
+		// These could be restricted in a real-world setting:
+		case dev::solidity::Instruction::BALANCE:
+		case dev::solidity::Instruction::CALLVALUE:
+		case dev::solidity::Instruction::CALLDATASIZE:
+		case dev::solidity::Instruction::GASPRICE:
+		case dev::solidity::Instruction::EXTCODESIZE:
+		case dev::solidity::Instruction::RETURNDATASIZE:
+		case dev::solidity::Instruction::TIMESTAMP:
+		case dev::solidity::Instruction::NUMBER:
+		case dev::solidity::Instruction::DIFFICULTY:
+		case dev::solidity::Instruction::GASLIMIT:
+		case dev::solidity::Instruction::PC:
+		case dev::solidity::Instruction::MSIZE:
+		case dev::solidity::Instruction::GAS:
+		default:
+			return {};
+		}
+	}
+
+private:
+
+	map<YulString, ValueConstraint> const& m_variableConstraints;
+};
+}
+
+ValueConstraint ValueConstraint::constant(u256 const& _value)
+{
+	return ValueConstraint{_value, _value, _value, _value};
+}
+
+ValueConstraint ValueConstraint::boolean()
+{
+	return ValueConstraint{0, 1, 0, 1};
+}
+
+ValueConstraint ValueConstraint::bitRange(size_t _highest, size_t _lowest)
+{
+	yulAssert(_highest >= _lowest, "");
+	return valueFromBits(
+		0,
+		(u256(-1) >> (255 - _highest)) & ~(u256(-1) >> (256 - _lowest))
+	);
+}
+
+ValueConstraint ValueConstraint::valueFromBits(u256 _minBits, u256 _maxBits)
+{
+	int highestBit = highestBitSet(_maxBits);
+	return ValueConstraint{
+		0,
+		u256(-1) >> (255 - highestBit),
+		move(_minBits),
+		move(_maxBits)
+	};
+}
+
+ValueConstraint ValueConstraint::bitsFromValue(u256 _minValue, u256 _maxValue)
+{
+	int highestBit = highestBitSet(_maxValue);
+	return ValueConstraint{
+		move(_minValue),
+		move(_maxValue),
+		0,
+		u256(-1) >> (255 - highestBit)
+	};
+}
+
+ValueConstraint ValueConstraint::operator&(ValueConstraint const& _other)
+{
+	return valueFromBits(
+		minBits & _other.minBits,
+		maxBits & _other.maxBits
+	);
+}
+
+ValueConstraint ValueConstraint::operator|(ValueConstraint const& _other)
+{
+	return valueFromBits(
+		minBits | _other.minBits,
+		maxBits | _other.maxBits
+	);
+}
+
+ValueConstraint ValueConstraint::operator~()
+{
+	return valueFromBits(~maxBits, ~minBits);
+}
+
+ValueConstraint ValueConstraint::operator+(ValueConstraint const& _other)
+{
+	if (bigint(maxValue) + bigint(_other.maxValue) > u256(-1))
+		return ValueConstraint{}; // overflow
+	else
+		return bitsFromValue(
+			minValue + _other.minValue,
+			maxValue + _other.maxValue
+		);
+}
+
+ValueConstraint ValueConstraint::operator-(ValueConstraint const& _other)
+{
+	if (minValue < _other.maxValue)
+		return ValueConstraint{}; // underflow
+	else
+		return bitsFromValue(
+			maxValue - _other.minValue,
+			minValue - _other.maxValue
+		);
+}
+
+ValueConstraint ValueConstraint::operator<(ValueConstraint const& _other)
+{
+	if (maxValue < _other.minValue)
+		return constant(1);
+	else if (minValue >= _other.maxValue)
+		return constant(0);
+	else
+		return boolean();
+}
+
+ValueConstraint ValueConstraint::operator==(ValueConstraint const& _other)
+{
+	if (minValue == maxValue && minValue == _other.minValue && _other.minValue == _other.maxValue)
+		return constant(1);
+	else if (minBits == maxBits && minBits == _other.maxBits && _other.minBits == _other.maxBits)
+		return constant(1);
+	else if (maxValue < _other.minValue || minValue > _other.maxValue)
+		return constant(0);
+	else if ((maxBits == 0 && _other.minBits == 1) || (minBits == 1 && _other.maxBits == 0))
+		return constant(0);
+	else
+		return boolean();
+}
+
+ValueConstraint ValueConstraint::operator<<(ValueConstraint const& _other)
+{
+	if (boost::optional<u256> c = _other.isConstant())
+	{
+		if (*c >= 256)
+			return constant(0);
+		unsigned amount = unsigned(*c);
+		return ValueConstraint{
+			dev::bigintShiftLeftWorkaround(minValue, amount),
+			dev::bigintShiftLeftWorkaround(maxValue, amount),
+			dev::bigintShiftLeftWorkaround(minBits, amount),
+			dev::bigintShiftLeftWorkaround(maxBits, amount)
+		};
+	}
+	else
+	{
+		size_t lowestBit = lowestBitSet(maxBits);
+		if (lowestBit + bigint(_other.minValue) > 255)
+			return constant(0);
+		else
+			/// TODO could be more accurate, also taking "lastBit set" and _other.maxValue into account.
+			return bitRange(255, lowestBit + size_t(_other.minValue));
+	}
+}
+
+ValueConstraint ValueConstraint::operator>>(ValueConstraint const& _other)
+{
+	if (boost::optional<u256> c = _other.isConstant())
+	{
+		if (*c >= 256)
+			return constant(0);
+		unsigned amount = unsigned(*c);
+		return ValueConstraint{
+			minValue >> amount,
+			maxValue >> amount,
+			minBits >> amount,
+			maxBits >> amount
+		};
+	}
+	else
+	{
+		int highestBit = highestBitSet(maxBits);
+		if (highestBit - bigint(_other.minValue) < 0)
+			return constant(0);
+		else
+			/// TODO could be more accurate, also taking "lastBit set" and _other.maxValue into account.
+			return bitRange(size_t(highestBit - _other.minValue), 0);
+	}
+}
+
+boost::optional<u256> ValueConstraint::isConstant() const
+{
+	if (minValue == maxValue)
+		return minValue;
+	else
+		return {};
+}
+
+void ValueConstraintBasedSimplifier::visit(Expression& _expression)
+{
+	ASTModifier::visit(_expression);
+
+	// TODO this runs constraint deduction multiple times on the same sub-expression.
+
+	// Replace movable expressions that are equal to constants by constants.
+	if (_expression.type() != typeid(Literal) && MovableChecker(m_dialect, _expression).movable())
+	{
+		ValueConstraint c = ConstraintDeduction{m_variableConstraints}.visit(_expression);
+		if (boost::optional<u256> value = c.isConstant())
+			_expression = Literal{
+				locationOf(_expression),
+				LiteralKind::Number,
+				YulString{formatNumber(*value)},
+				{}
+			};
+	}
+
+
+	// TODO We need more complicated rules that also do things like
+	// and(x, 0xff) -> x if x is known to be less than 256
+	// These rules might be just rules from the ruleList,
+	// where the `feasible` function gets access to the value constraints.
+	// It might also be a new RuleList that re-uses the existing classes.
+	// We could add another template to SimplificationRule to modify the
+	// parameter of the feasibility function, or we capture somehow.
+
+	// Another next step is to add new information in control-flow branches.
+	// If such a branch is terminating, also the 'else' branch can
+	// get new information.
+
+	// Finally, the ValueConstrainst should be extended such that the upper
+	// and lower bounds can be other variables.
+}
+
+void ValueConstraintBasedSimplifier::run(Dialect const& _dialect, Block& _ast)
+{
+	ValueConstraintBasedSimplifier{_dialect}(_ast);
+}
+
+void ValueConstraintBasedSimplifier::handleAssignment(set<YulString> const& _names, Expression* _value)
+{
+	// Determine the constraint before the assignment is performed, because
+	// that will change the values of variables.
+
+	ValueConstraint constraint = ValueConstraint::constant(0);
+	if (_value)
+		constraint = ConstraintDeduction{m_variableConstraints}.visit(*_value);
+
+	// This calls valuesCleared internally, which might clear more values
+	// than just _names.
+	DataFlowAnalyzer::handleAssignment(_names, _value);
+
+	if (_value)
+	{
+		if (_names.size() == 1)
+			m_variableConstraints[*_names.begin()] = constraint;
+	}
+	else
+		for (auto const& name: _names)
+			m_variableConstraints[name] = constraint;
+}
+
+void ValueConstraintBasedSimplifier::valuesCleared(set<YulString> const& _names)
+{
+	for (auto const& name: _names)
+		m_variableConstraints.erase(name);
+}
+

--- a/libyul/optimiser/ValueConstraintBasedSimplifier.h
+++ b/libyul/optimiser/ValueConstraintBasedSimplifier.h
@@ -1,0 +1,106 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that uses the simplification rules to simplify expressions.
+ */
+
+#pragma once
+
+#include <libyul/AsmDataForward.h>
+
+#include <libyul/optimiser/DataFlowAnalyzer.h>
+
+#include <libdevcore/Common.h>
+
+namespace yul
+{
+struct Dialect;
+
+struct ValueConstraint
+{
+	static ValueConstraint constant(dev::u256 const& _value);
+	static ValueConstraint boolean();
+	/// @returns a constraint that does not restrict the bits between
+	/// (inclusive) _highest and _lowest bit but forces all other
+	/// bits to zero.
+	static ValueConstraint bitRange(size_t _highest, size_t _lowest);
+
+	/// Fill the minValue and maxValue fields from the minBits and maxBits fields.
+	static ValueConstraint valueFromBits(dev::u256 _minBits, dev::u256 _maxBits);
+	/// Fill the minBits and maxBits fields from the minValue and maxValue fields.
+	static ValueConstraint bitsFromValue(dev::u256 _minValue, dev::u256 _maxValue);
+
+	ValueConstraint operator&(ValueConstraint const& _other);
+	ValueConstraint operator|(ValueConstraint const& _other);
+	ValueConstraint operator~();
+	ValueConstraint operator+(ValueConstraint const& _other);
+	ValueConstraint operator-(ValueConstraint const& _other);
+	ValueConstraint operator<(ValueConstraint const& _other);
+	ValueConstraint operator==(ValueConstraint const& _other);
+	ValueConstraint operator<<(ValueConstraint const& _other);
+	ValueConstraint operator>>(ValueConstraint const& _other);
+
+	boost::optional<dev::u256> isConstant() const;
+
+	dev::u256 minValue = 0;
+	dev::u256 maxValue = dev::u256(-1);
+	dev::u256 minBits = 0; ///< For each 1-bit here, the value's bit is also 1
+	dev::u256 maxBits = dev::u256(-1); ///< For each 0-bit here, the value's bit is also 0
+};
+
+/**
+ * Performs simplifications that take value and bit constraints
+ * of variables and expressions into account.
+ *
+ * Example:
+ *
+ * let x := and(callvalue(), 0xff)
+ * if lt(x, 0x100) { ... }
+ *
+ * is reduced to
+ *
+ * let x := and(callvalue(), 0xff)
+ * if 1 { ... }
+ *
+ * because ``x`` is known to be at most 0xff.
+ *
+ * Most effective if run on code in SSA form.
+ *
+ * Prerequisite: Disambiguator.
+ */
+class ValueConstraintBasedSimplifier: public DataFlowAnalyzer
+{
+public:
+	using ASTModifier::operator();
+
+	void visit(Expression& _expression) override;
+
+	static void run(Dialect const& _dialect, Block& _ast);
+
+protected:
+	void handleAssignment(std::set<YulString> const& _names, Expression* _value) override;
+
+	void valuesCleared(std::set<YulString> const& _names) override;
+
+private:
+	explicit ValueConstraintBasedSimplifier(Dialect const& _dialect): DataFlowAnalyzer(_dialect) {}
+
+	std::map<YulString, ValueConstraint> m_variableConstraints;
+	ValueConstraint m_currentConstraint;
+};
+
+}

--- a/libyul/optimiser/ValueConstraintBasedSimplifier.h
+++ b/libyul/optimiser/ValueConstraintBasedSimplifier.h
@@ -96,7 +96,6 @@ protected:
 
 	void valuesCleared(std::set<YulString> const& _names) override;
 
-private:
 	explicit ValueConstraintBasedSimplifier(Dialect const& _dialect): DataFlowAnalyzer(_dialect) {}
 
 	std::map<YulString, ValueConstraint> m_variableConstraints;

--- a/test/libyul/VerboseValueConstraintsSimplifier.cpp
+++ b/test/libyul/VerboseValueConstraintsSimplifier.cpp
@@ -1,0 +1,60 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Debugging / testing component that adds reporting to the value constraint based
+ * optimiser stage.
+ */
+
+#include <test/libyul/VerboseValueConstraintsSimplifier.h>
+
+#include <libdevcore/CommonData.h>
+#include <libdevcore/StringUtils.h>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+using namespace yul::test;
+
+
+void VerboseValueConstraintsSimplifier::run(Dialect const& _dialect, Block& _ast, string& _report)
+{
+	VerboseValueConstraintsSimplifier{_dialect, _report}(_ast);
+}
+
+void VerboseValueConstraintsSimplifier::handleAssignment(set<YulString> const& _names, Expression* _value)
+{
+	ValueConstraintBasedSimplifier::handleAssignment(_names, _value);
+
+	for (YulString var: _names)
+	{
+		auto it = m_variableConstraints.find(var);
+		if (it == m_variableConstraints.end())
+			continue;
+		m_report +=
+			var.str() +
+			":\n";
+		ValueConstraint const& constr = it->second;
+		if (boost::optional<u256> value = constr.isConstant())
+			m_report += "       = " + formatNumberReadable(*value) + "\n";
+		else
+			m_report +=
+				("    min: " + formatNumberReadable(it->second.minValue) + "\n") +
+				("    max: " + formatNumberReadable(it->second.maxValue) + "\n") +
+				("   minB: " + formatNumberReadable(it->second.minBits) + "\n") +
+				("   maxB: " + formatNumberReadable(it->second.maxBits) + "\n");
+	}
+}

--- a/test/libyul/VerboseValueConstraintsSimplifier.h
+++ b/test/libyul/VerboseValueConstraintsSimplifier.h
@@ -1,0 +1,52 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Debugging / testing component that adds reporting to the value constraint based
+ * optimiser stage.
+ */
+
+#pragma once
+
+#include <libyul/optimiser/ValueConstraintBasedSimplifier.h>
+
+namespace yul
+{
+namespace test
+{
+
+/**
+ * Debugging / testing component that adds reporting to the value constraint based
+ * optimiser stage.
+ */
+class VerboseValueConstraintsSimplifier: public ValueConstraintBasedSimplifier
+{
+public:
+	static void run(Dialect const& _dialect, Block& _ast, std::string& _report);
+
+protected:
+	VerboseValueConstraintsSimplifier(Dialect const& _dialect, std::string& _report):
+		ValueConstraintBasedSimplifier(_dialect),
+		m_report(_report)
+	{}
+	void handleAssignment(std::set<YulString> const& _names, Expression* _value) override;
+
+private:
+	std::string& m_report;
+};
+
+}
+}

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -35,6 +35,7 @@
 #include <libyul/optimiser/MainFunction.h>
 #include <libyul/optimiser/Rematerialiser.h>
 #include <libyul/optimiser/ExpressionSimplifier.h>
+#include <libyul/optimiser/ValueConstraintBasedSimplifier.h>
 #include <libyul/optimiser/UnusedPruner.h>
 #include <libyul/optimiser/ExpressionJoiner.h>
 #include <libyul/optimiser/SSAReverser.h>
@@ -181,6 +182,11 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 	{
 		disambiguate();
 		ExpressionSimplifier::run(*m_dialect, *m_ast);
+	}
+	else if (m_optimizerStep == "valueConstraintBasedSimplifier")
+	{
+		disambiguate();
+		ValueConstraintBasedSimplifier::run(*m_dialect, *m_ast);
 	}
 	else if (m_optimizerStep == "fullSimplify")
 	{

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -17,6 +17,8 @@
 
 #include <test/libyul/YulOptimizerTest.h>
 
+#include <test/libyul/VerboseValueConstraintsSimplifier.h>
+
 #include <test/Options.h>
 
 #include <libyul/optimiser/BlockFlattener.h>
@@ -103,6 +105,8 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 	if (!parse(_stream, _linePrefix, _formatted))
 		return false;
 
+	string additionalInfo;
+
 	if (m_optimizerStep == "disambiguator")
 		disambiguate();
 	else if (m_optimizerStep == "blockFlattener")
@@ -186,7 +190,9 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 	else if (m_optimizerStep == "valueConstraintBasedSimplifier")
 	{
 		disambiguate();
-		ValueConstraintBasedSimplifier::run(*m_dialect, *m_ast);
+
+		// subclass of ValueConstraintBasedSimplifier that adds reporting
+		VerboseValueConstraintsSimplifier::run(*m_dialect, *m_ast, additionalInfo);
 	}
 	else if (m_optimizerStep == "fullSimplify")
 	{
@@ -265,7 +271,7 @@ bool YulOptimizerTest::run(ostream& _stream, string const& _linePrefix, bool con
 		return false;
 	}
 
-	m_obtainedResult = m_optimizerStep + "\n" + AsmPrinter{m_yul}(*m_ast) + "\n";
+	m_obtainedResult = m_optimizerStep + "\n" + additionalInfo + AsmPrinter{m_yul}(*m_ast) + "\n";
 
 	if (m_expectation != m_obtainedResult)
 	{

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/arithmetics.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/arithmetics.yul
@@ -1,0 +1,48 @@
+{
+    let a := and(calldataload(0), 0xffff)
+    let b := and(calldataload(1), 0xffff)
+    let c := add(a, b)
+    let d := add(a, calldataload(7))
+    let e := sub(add(a, 0x1000000), b)
+    let f := sub(add(a, 7), 1)
+}
+// ----
+// valueConstraintBasedSimplifier
+// a:
+//     min: 0
+//     max: 65535
+//    minB: 0
+//    maxB: 65535
+// b:
+//     min: 0
+//     max: 65535
+//    minB: 0
+//    maxB: 65535
+// c:
+//     min: 0
+//     max: 131070
+//    minB: 0
+//    maxB: 131071
+// d:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// e:
+//     min: 16711681
+//     max: 0x0100ffff
+//    minB: 0
+//    maxB: 0x02 * 2**24 - 1
+// f:
+//     min: 6
+//     max: 65541
+//    minB: 0
+//    maxB: 131071
+// {
+//     let a := and(calldataload(0), 0xffff)
+//     let b := and(calldataload(1), 0xffff)
+//     let c := add(a, b)
+//     let d := add(a, calldataload(7))
+//     let e := sub(add(a, 0x1000000), b)
+//     let f := sub(add(a, 7), 1)
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/bits.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/bits.yul
@@ -12,8 +12,8 @@
 // a:
 //        = 65535
 // b:
-//     min: 0
-//     max: 0x10 * 2**32 - 1
+//     min: 0x0fFFF00000
+//     max: 0x0fFFF000ff
 //    minB: 0x0fFFF00000
 //    maxB: 0x0fFFF000ff
 // c:
@@ -26,8 +26,8 @@
 //    minB: 0
 //    maxB: 255
 // f:
-//     min: 0
-//     max: 2**256 - 1
+//     min: 0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFfff0000Fff00
+//     max: 0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFfff0000Fffff
 //    minB: 0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFfff0000Fff00
 //    maxB: 0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFfff0000Fffff
 // g:

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/bits.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/bits.yul
@@ -1,0 +1,46 @@
+{
+    let a := 0xffff
+    let b := or(shl(20, a), and(calldataload(0), 0xff))
+    let c := shl(add(300, lt(a, b)), calldataload(0))
+    let d := shr(add(300, lt(a, b)), calldataload(0))
+    let e := and(b, 0xff)
+    let f := not(b)
+    let g := byte(calldataload(0), 2)
+}
+// ----
+// valueConstraintBasedSimplifier
+// a:
+//        = 65535
+// b:
+//     min: 0
+//     max: 0x10 * 2**32 - 1
+//    minB: 0x0fFFF00000
+//    maxB: 0x0fFFF000ff
+// c:
+//        = 0
+// d:
+//        = 0
+// e:
+//     min: 0
+//     max: 255
+//    minB: 0
+//    maxB: 255
+// f:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFfff0000Fff00
+//    maxB: 0xFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFffffFFFFfff0000Fffff
+// g:
+//     min: 0
+//     max: 255
+//    minB: 0
+//    maxB: 255
+// {
+//     let a := 0xffff
+//     let b := or(0x0ffff00000, and(calldataload(0), 0xff))
+//     let c := 0
+//     let d := 0
+//     let e := and(b, 0xff)
+//     let f := not(b)
+//     let g := byte(calldataload(0), 2)
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/chainaccess.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/chainaccess.yul
@@ -1,0 +1,205 @@
+{
+    // restricted to 160 bits
+    let a := address()
+    let b := origin()
+    let c := caller()
+    let d := coinbase()
+    let e := create(0, 0, 0)
+    let f := create2(0, 0, 0, 0)
+    // restricted to bool
+    let gb := call(0, 0, 0, 0, 0, 0, 0)
+    let hb := callcode(0, 0, 0, 0, 0, 0, 0)
+    let ib := delegatecall(0, 0, 0, 0, 0, 0)
+    let jb := staticcall(0, 0, 0, 0, 0, 0)
+    // No restriction starting from here
+    let k_ := keccak256(0, 0)
+    let l_ := extcodehash(0)
+    let m_ := blockhash(0)
+    let n_ := mload(0)
+    let o_ := sload(0)
+    let p_ := balance(0)
+    let q_ := callvalue()
+    let r_ := calldatasize()
+    let s_ := gasprice()
+    let t_ := extcodesize(0)
+    let u_ := returndatasize()
+    let v_ := timestamp()
+    let w_ := number()
+    let x_ := difficulty()
+    let y_ := gaslimit()
+    let z_ := pc()
+    let z1_ := msize()
+    let z2_ := gas()
+}
+// ----
+// valueConstraintBasedSimplifier
+// a:
+//     min: 0
+//     max: 2**160 - 1
+//    minB: 0
+//    maxB: 2**160 - 1
+// b:
+//     min: 0
+//     max: 2**160 - 1
+//    minB: 0
+//    maxB: 2**160 - 1
+// c:
+//     min: 0
+//     max: 2**160 - 1
+//    minB: 0
+//    maxB: 2**160 - 1
+// d:
+//     min: 0
+//     max: 2**160 - 1
+//    minB: 0
+//    maxB: 2**160 - 1
+// e:
+//     min: 0
+//     max: 2**160 - 1
+//    minB: 0
+//    maxB: 2**160 - 1
+// f:
+//     min: 0
+//     max: 2**160 - 1
+//    minB: 0
+//    maxB: 2**160 - 1
+// gb:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// hb:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// ib:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// jb:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// k_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// l_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// m_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// n_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// o_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// p_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// q_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// r_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// s_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// t_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// u_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// v_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// w_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// x_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// y_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// z_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// z1_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// z2_:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// {
+//     let a := address()
+//     let b := origin()
+//     let c := caller()
+//     let d := coinbase()
+//     let e := create(0, 0, 0)
+//     let f := create2(0, 0, 0, 0)
+//     let gb := call(0, 0, 0, 0, 0, 0, 0)
+//     let hb := callcode(0, 0, 0, 0, 0, 0, 0)
+//     let ib := delegatecall(0, 0, 0, 0, 0, 0)
+//     let jb := staticcall(0, 0, 0, 0, 0, 0)
+//     let k_ := keccak256(0, 0)
+//     let l_ := extcodehash(0)
+//     let m_ := blockhash(0)
+//     let n_ := mload(0)
+//     let o_ := sload(0)
+//     let p_ := balance(0)
+//     let q_ := callvalue()
+//     let r_ := calldatasize()
+//     let s_ := gasprice()
+//     let t_ := extcodesize(0)
+//     let u_ := returndatasize()
+//     let v_ := timestamp()
+//     let w_ := number()
+//     let x_ := difficulty()
+//     let y_ := gaslimit()
+//     let z_ := pc()
+//     let z1_ := msize()
+//     let z2_ := gas()
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/comparison.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/comparison.yul
@@ -31,8 +31,8 @@
 // d:
 //     min: 256
 //     max: 271
-//    minB: 0
-//    maxB: 511
+//    minB: 256
+//    maxB: 271
 // e:
 //     min: 0
 //     max: 1

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/comparison.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/comparison.yul
@@ -1,0 +1,74 @@
+{
+    let a := and(calldataload(0), 0xf)
+    let b := and(calldataload(1), 0xf)
+    let c := add(b, 2) // overlaps with a
+    let d := add(b, 0x100) // does not overlap with a
+    let e := lt(a, c)
+    let f := lt(a, d)
+    let g := lt(c, a)
+    let h := lt(d, a)
+    let r := lt(a, a) // currently unknown, might change later.
+    let x := gt(d, a)
+    let y := gt(c, a)
+}
+// ----
+// valueConstraintBasedSimplifier
+// a:
+//     min: 0
+//     max: 15
+//    minB: 0
+//    maxB: 15
+// b:
+//     min: 0
+//     max: 15
+//    minB: 0
+//    maxB: 15
+// c:
+//     min: 2
+//     max: 17
+//    minB: 0
+//    maxB: 31
+// d:
+//     min: 256
+//     max: 271
+//    minB: 0
+//    maxB: 511
+// e:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// f:
+//        = 1
+// g:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// h:
+//        = 0
+// r:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// x:
+//        = 1
+// y:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// {
+//     let a := and(calldataload(0), 0xf)
+//     let b := and(calldataload(1), 0xf)
+//     let c := add(b, 2)
+//     let d := add(b, 0x100)
+//     let e := lt(a, c)
+//     let f := 1
+//     let g := lt(c, a)
+//     let h := 0
+//     let r := lt(a, a)
+//     let x := 1
+//     let y := gt(c, a)
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/equal.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/equal.yul
@@ -1,0 +1,25 @@
+{
+    let x := 7
+    let a := eq(x, x)
+    let b := eq(x, and(calldataload(0), 1)) // not equal
+    let c := eq(calldataload(0), calldataload(1))
+}
+// ----
+// valueConstraintBasedSimplifier
+// x:
+//        = 7
+// a:
+//        = 1
+// b:
+//        = 0
+// c:
+//     min: 0
+//     max: 1
+//    minB: 0
+//    maxB: 1
+// {
+//     let x := 7
+//     let a := 1
+//     let b := 0
+//     let c := eq(calldataload(0), calldataload(1))
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt.yul
@@ -1,0 +1,38 @@
+{
+    let x := 2
+    if lt(x, 9) { sstore(0, 1) }
+    if lt(x, 2) { sstore(0, 1) }
+    if gt(x, 0) { sstore(0, 1) }
+    if lt(9, x) { sstore(0, 1) }
+    if lt(2, x) { sstore(0, 1) }
+    if gt(0, x) { sstore(0, 1) }
+}
+// ----
+// valueConstraintBasedSimplifier
+// {
+//     let x := 2
+//     if 1
+//     {
+//         sstore(0, 1)
+//     }
+//     if 0
+//     {
+//         sstore(0, 1)
+//     }
+//     if 1
+//     {
+//         sstore(0, 1)
+//     }
+//     if 0
+//     {
+//         sstore(0, 1)
+//     }
+//     if 0
+//     {
+//         sstore(0, 1)
+//     }
+//     if 0
+//     {
+//         sstore(0, 1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt.yul
@@ -9,6 +9,8 @@
 }
 // ----
 // valueConstraintBasedSimplifier
+// x:
+//        = 2
 // {
 //     let x := 2
 //     if 1

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt_bits_combined.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt_bits_combined.yul
@@ -1,0 +1,18 @@
+{
+    let x := and(callvalue(), 0xff)
+    if lt(x, 0x100) { sstore(0, 1) }
+    if lt(x, 0xff) { sstore(0, 1) }
+}
+// ----
+// valueConstraintBasedSimplifier
+// {
+//     let x := and(callvalue(), 0xff)
+//     if 1
+//     {
+//         sstore(0, 1)
+//     }
+//     if lt(x, 0xff)
+//     {
+//         sstore(0, 1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt_bits_combined.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/lt_bits_combined.yul
@@ -5,6 +5,11 @@
 }
 // ----
 // valueConstraintBasedSimplifier
+// x:
+//     min: 0
+//     max: 255
+//    minB: 0
+//    maxB: 255
 // {
 //     let x := and(callvalue(), 0xff)
 //     if 1

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/multi_assign.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/multi_assign.yul
@@ -1,0 +1,54 @@
+{
+    function f() -> x, y {}
+    let a, b := f()
+    let d := a
+    let e := b
+    a := 1
+    b := 3
+    a, b := f()
+    let s := a
+    let t := b
+}
+// ----
+// valueConstraintBasedSimplifier
+// x:
+//        = 0
+// y:
+//        = 0
+// d:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// e:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// a:
+//        = 1
+// b:
+//        = 3
+// s:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// t:
+//     min: 0
+//     max: 2**256 - 1
+//    minB: 0
+//    maxB: 2**256 - 1
+// {
+//     function f() -> x, y
+//     {
+//     }
+//     let a, b := f()
+//     let d := a
+//     let e := b
+//     a := 1
+//     b := 3
+//     a, b := f()
+//     let s := a
+//     let t := b
+// }

--- a/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/smoke.yul
+++ b/test/libyul/yulOptimizerTests/valueConstraintBasedSimplifier/smoke.yul
@@ -1,0 +1,6 @@
+{
+}
+// ----
+// valueConstraintBasedSimplifier
+// {
+// }

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(isoltest
 	../libsolidity/ASTJSONTest.cpp
 	../libsolidity/SMTCheckerJSONTest.cpp
 	../libyul/ObjectCompilerTest.cpp
+	../libyul/VerboseValueConstraintsSimplifier.cpp
 	../libyul/YulOptimizerTest.cpp
 	../libyul/YulInterpreterTest.cpp
 )

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -43,6 +43,7 @@
 #include <libyul/optimiser/MainFunction.h>
 #include <libyul/optimiser/Rematerialiser.h>
 #include <libyul/optimiser/ExpressionSimplifier.h>
+#include <libyul/optimiser/ValueConstraintBasedSimplifier.h>
 #include <libyul/optimiser/UnusedPruner.h>
 #include <libyul/optimiser/ExpressionJoiner.h>
 #include <libyul/optimiser/RedundantAssignEliminator.h>
@@ -129,10 +130,10 @@ public:
 				disambiguated = true;
 			}
 			cout << "(q)quit/(f)flatten/(c)se/initialize var(d)ecls/(x)plit/(j)oin/(g)rouper/(h)oister/" << endl;
-			cout << "  (e)xpr inline/(i)nline/(s)implify/varname c(l)eaner/(u)nusedprune/ss(a) transform/" << endl;
-			cout << "  (r)edundant assign elim./re(m)aterializer/f(o)r-loop-pre-rewriter/" << endl;
-			cout << "  s(t)ructural simplifier/equi(v)alent function combiner/ssa re(V)erser/? " << endl;
-			cout << "  stack com(p)ressor? " << endl;
+			cout << "  (e)xpr inline/(i)nline/(s)implify/(C)onstraint simplify/varname c(l)eaner/" << endl;
+			cout << "  (u)nusedprune/ss(a) transform/(r)edundant assign elim./re(m)aterializer/" << endl;
+			cout << "  f(o)r-loop-pre-rewriter/s(t)ructural simplifier/equi(v)alent function combiner/" << endl;
+			cout << "  ssa re(V)erser/stack com(p)ressor? " << endl;
 			cout.flush();
 			int option = readStandardInputChar();
 			cout << ' ' << char(option) << endl;
@@ -175,6 +176,9 @@ public:
 				break;
 			case 's':
 				ExpressionSimplifier::run(*m_dialect, *m_ast);
+				break;
+			case 'C':
+				ValueConstraintBasedSimplifier::run(*m_dialect, *m_ast);
 				break;
 			case 't':
 				(StructuralSimplifier{*m_dialect})(*m_ast);


### PR DESCRIPTION
Implements part of #6252 

This implements value range tracking on variables but is horribly complicated. It solves a problem the old optimizer was not able to solve, for example:

```
let size := and(calldatasize(), 0xff)
if lt(size, 0x100) { ... }
```

is reduced to 

```
let size := and(calldatasize(), 0xff)
if 1 { ... }
```


Still, it can only handle static bounds and injecting information in branches is also not yet implemented. Perhaps we need a completely new strategy for the following example, that would then also make this complicated solution obsolete?

This can not yet be reduced:
```
let size := and(calldatasize(), 0xff)
for { let i := 0 } lt(i, size) { i := add(i, 1) }
{
  if gt(i, 0x500) { revert(0, 0) }
}
```