### PR TITLE
[SMTChecker] Add callstack model to overflow checks

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -389,7 +389,8 @@ void SMTChecker::addOverflowTarget(
 		std::move(_intType),
 		std::move(_value),
 		currentPathConditions(),
-		_location
+		_location,
+		m_callStack
 	);
 }
 
@@ -397,10 +398,12 @@ void SMTChecker::checkUnderOverflow()
 {
 	for (auto& target: m_overflowTargets)
 	{
+		swap(m_callStack, target.callStack);
 		if (target.type != OverflowTarget::Type::Overflow)
 			checkUnderflow(target);
 		if (target.type != OverflowTarget::Type::Underflow)
 			checkOverflow(target);
+		swap(m_callStack, target.callStack);
 	}
 }
 

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -154,13 +154,15 @@ private:
 		smt::Expression value;
 		smt::Expression path;
 		langutil::SourceLocation const& location;
+		std::vector<ASTNode const*> callStack;
 
-		OverflowTarget(Type _type, TypePointer _intType, smt::Expression _value, smt::Expression _path, langutil::SourceLocation const& _location):
+		OverflowTarget(Type _type, TypePointer _intType, smt::Expression _value, smt::Expression _path, langutil::SourceLocation const& _location, std::vector<ASTNode const*> _callStack):
 			type(_type),
 			intType(_intType),
 			value(_value),
 			path(_path),
-			location(_location)
+			location(_location),
+			callStack(move(_callStack))
 		{
 			solAssert(dynamic_cast<IntegerType const*>(intType.get()), "");
 		}


### PR DESCRIPTION
The other PR didn't add callstack model to overflow checks because these checks are delayed to the end of the function. That's why we need to copy the current callstack to the overflow targets.