### PR TITLE
Exclude metadata in compiler test

### DIFF
--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <test/libsolidity/AnalysisFramework.h>
-
+#include <test/Metadata.h>
 #include <test/Options.h>
 
 using namespace std;
@@ -31,7 +31,7 @@ namespace solidity
 namespace test
 {
 
-BOOST_FIXTURE_TEST_SUITE(Compiler, AnalysisFramework)
+BOOST_FIXTURE_TEST_SUITE(SolidityCompiler, AnalysisFramework)
 
 BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 {
@@ -45,12 +45,12 @@ BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 	m_compiler.setOptimiserSettings(dev::test::Options::get().optimize);
 	BOOST_REQUIRE(success(sourceCode));
 	BOOST_REQUIRE_MESSAGE(m_compiler.compile(), "Compiling contract failed");
-	bytes const& creationBytecode = m_compiler.object("C").bytecode;
-	bytes const& runtimeBytecode = m_compiler.runtimeObject("C").bytecode;
-	BOOST_CHECK(creationBytecode.size() >= 130);
-	BOOST_CHECK(creationBytecode.size() <= 160);
-	BOOST_CHECK(runtimeBytecode.size() >= 50);
-	BOOST_CHECK(runtimeBytecode.size() <= 70);
+	bytes const& creationBytecode = dev::test::bytecodeSansMetadata(m_compiler.object("C").bytecode);
+	bytes const& runtimeBytecode = dev::test::bytecodeSansMetadata(m_compiler.runtimeObject("C").bytecode);
+	BOOST_CHECK(creationBytecode.size() >= 90);
+	BOOST_CHECK(creationBytecode.size() <= 120);
+	BOOST_CHECK(runtimeBytecode.size() >= 10);
+	BOOST_CHECK(runtimeBytecode.size() <= 30);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In SolidityCompiler/does_not_include_creation_time_only_internal_functions.

Part of #4764.
