### PR TITLE
[SMTChecker] Merge SSA state vars properly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * SMTChecker: SSA control-flow did not take into account state variables that were modified inside inlined functions that were called inside branches.
 
 
 

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -55,6 +55,10 @@ public:
 	/// the constructor.
 	std::vector<std::string> unhandledQueries() { return m_interface->unhandledQueries(); }
 
+	/// @return the FunctionDefinition of a called function if possible and should inline,
+	/// otherwise nullptr.
+	static FunctionDefinition const* inlinedFunctionCallToDefinition(FunctionCall const& _funCall);
+
 private:
 	// TODO: Check that we do not have concurrent reads and writes to a variable,
 	// because the order of expression evaluation is undefined

--- a/test/libsolidity/smtCheckerTests/functions/function_inside_branch_modify_state_var.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_inside_branch_modify_state_var.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint x;
+	function f() internal {
+		require(x < 10000);
+		x = x + 1;
+	}
+	function g(bool b) public {
+		x = 0;
+		if (b)
+			f();
+		// Should fail for `b == true`.
+		assert(x == 0);
+	}
+}
+// ----
+// Warning: (209-223): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/functions/function_inside_branch_modify_state_var_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_inside_branch_modify_state_var_2.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint x;
+	function f() internal {
+		require(x < 10000);
+		x = x + 1;
+	}
+	function g(bool b) public {
+		x = 0;
+		if (b)
+			f();
+		else
+			f();
+		assert(x == 1);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/functions/function_inside_branch_modify_state_var_3.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_inside_branch_modify_state_var_3.sol
@@ -1,0 +1,28 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint x;
+	function f() internal {
+		require(x < 10000);
+		x = x + 1;
+	}
+	function g(bool b) public {
+		x = 0;
+		if (b)
+			f();
+		// Should fail for `b == true`.
+		assert(x == 0);
+	}
+	function h(bool b) public {
+		x = 0;
+		if (!b)
+			f();
+		// Should fail for `b == false`.
+		assert(x == 0);
+	}
+
+}
+// ----
+// Warning: (209-223): Assertion violation happens here
+// Warning: (321-335): Assertion violation happens here


### PR DESCRIPTION
When a function that modifies a state variable is called/inlined inside a branch, the assignment was not taken into account and therefore the SSA vars were not merged properly.