### PR TITLE
Fix throw in error output

### DIFF
--- a/test/RPCSession.cpp
+++ b/test/RPCSession.cpp
@@ -351,7 +351,7 @@ Json::Value RPCSession::rpcCall(string const& _methodName, vector<string> const&
 	}
 
 	if (!result.isMember("result") || result["result"].isNull())
-		BOOST_FAIL("Missing result for JSON-RPC call: " + result.asString());
+		BOOST_FAIL("Missing result for JSON-RPC call: " + result.toStyledString());
 
 	return result["result"];
 }


### PR DESCRIPTION
Fix throw in error output

As it turns out `asString()` does not output the json value as string but expects a json value of type string.
The correct method to use was `toStyledString()`

Problem visible for example here:

https://circleci.com/gh/ethereum/solidity/101734
