### PR TITLE
ossfuzz: Enable optimization in Assembly stack assembler call.

### DIFF
--- a/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
@@ -35,7 +35,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	try
 	{
-		MachineAssemblyObject obj = stack.assemble(AssemblyStack::Machine::EVM);
+		MachineAssemblyObject obj = stack.assemble(AssemblyStack::Machine::EVM, /*optimize=*/true);
 		solAssert(obj.bytecode, "");
 	}
 	catch (StackTooDeepError const&)


### PR DESCRIPTION
### Description

#6118 changed AssemblyStack's `assemble()` API which broke the strict assembly "assembler" fuzzer. This PR updates the `assemble` call in the fuzzer test harness.

Note that the "optimize" parameter in the assemble call has been changed from "false" (previous default value) to "true".