### PR TITLE
yul Interpreter: Move memory size limit to interpreter state.

### DIFF
--- a/test/tools/ossfuzz/yulFuzzerCommon.cpp
+++ b/test/tools/ossfuzz/yulFuzzerCommon.cpp
@@ -23,7 +23,7 @@ using namespace yul::test::yul_fuzzer;
 void yulFuzzerUtil::interpret(ostream& _os, shared_ptr<yul::Block> _ast)
 {
 	InterpreterState state;
-	state.maxTraceSize = 10000;
+	state.maxTraceSize = 75;
 	Interpreter interpreter(state);
 	try
 	{

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -455,17 +455,13 @@ bool EVMInstructionInterpreter::logMemoryWrite(u256 const& _offset, u256 const& 
 
 bool EVMInstructionInterpreter::logMemory(bool _write, u256 const& _offset, u256 const& _size, bytes const& _data)
 {
-	/// Memory size limit. Anything beyond this will still work, but it has
-	/// deterministic yet not necessarily consistent behaviour.
-	size_t constexpr maxMemSize = 0x20000000;
-
 	logTrace(_write ? "MSTORE_AT_SIZE" : "MLOAD_FROM_SIZE", {_offset, _size}, _data);
 
 	if (((_offset + _size) >= _offset) && ((_offset + _size + 0x1f) >= (_offset + _size)))
 	{
 		u256 newSize = (_offset + _size + 0x1f) & ~u256(0x1f);
 		m_state.msize = max(m_state.msize, newSize);
-		if (newSize < maxMemSize)
+		if (newSize < m_state.maxMemSize)
 		{
 			if (m_state.memory.size() < newSize)
 				m_state.memory.resize(size_t(newSize));

--- a/test/tools/yulInterpreter/Interpreter.h
+++ b/test/tools/yulInterpreter/Interpreter.h
@@ -72,6 +72,9 @@ struct InterpreterState
 	std::vector<std::string> trace;
 	/// This is actually an input parameter that more or less limits the runtime.
 	size_t maxTraceSize = 0;
+	/// Memory size limit. Anything beyond this will still work, but it has
+	/// deterministic yet not necessarily consistent behaviour.
+	size_t maxMemSize = 0x200;
 	LoopState loopState = LoopState::Default;
 };
 

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -86,6 +86,7 @@ void interpret(string const& _source)
 
 	InterpreterState state;
 	state.maxTraceSize = 10000;
+	state.maxMemSize = 0x20000000;
 	Interpreter interpreter(state);
 	try
 	{


### PR DESCRIPTION
### Description

(closes #6227 )