### PR TITLE
yulInterpreter: Add timeout based on the number of interpreted statem…

### DIFF
--- a/test/libyul/YulInterpreterTest.cpp
+++ b/test/libyul/YulInterpreterTest.cpp
@@ -130,12 +130,14 @@ string YulInterpreterTest::interpret()
 {
 	InterpreterState state;
 	state.maxTraceSize = 10000;
+	state.maxSteps = 10000;
+	state.maxMemSize = 0x20000000;
 	Interpreter interpreter(state);
 	try
 	{
 		interpreter(*m_ast);
 	}
-	catch (InterpreterTerminated const&)
+	catch (InterpreterTerminatedGeneric const&)
 	{
 	}
 

--- a/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
@@ -76,9 +76,26 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	ostringstream os1;
 	ostringstream os2;
-	yulFuzzerUtil::interpret(os1, stack.parserResult()->code);
+	try
+	{
+		yulFuzzerUtil::interpret(os1, stack.parserResult()->code);
+	}
+	catch (yul::test::StepLimitReached const&)
+	{
+		return 0;
+	}
+	catch (yul::test::InterpreterTerminatedGeneric const&)
+	{
+	}
+
 	stack.optimize();
-	yulFuzzerUtil::interpret(os2, stack.parserResult()->code);
+	try
+	{
+		yulFuzzerUtil::interpret(os2, stack.parserResult()->code);
+	}
+	catch (yul::test::InterpreterTerminatedGeneric const&)
+	{
+	}
 
 	bool isTraceEq = (os1.str() == os2.str());
 	yulAssert(isTraceEq, "Interpreted traces for optimized and unoptimized code differ.");

--- a/test/tools/ossfuzz/yulFuzzerCommon.cpp
+++ b/test/tools/ossfuzz/yulFuzzerCommon.cpp
@@ -24,16 +24,9 @@ void yulFuzzerUtil::interpret(ostream& _os, shared_ptr<yul::Block> _ast)
 {
 	InterpreterState state;
 	state.maxTraceSize = 75;
-	state.maxSteps = 10000;
+	state.maxSteps = 100;
 	Interpreter interpreter(state);
-	try
-	{
-		interpreter(*_ast);
-	}
-	catch (InterpreterTerminated const&)
-	{
-	}
-
+	interpreter(*_ast);
 	_os << "Trace:" << endl;
 	for (auto const& line: interpreter.trace())
 		_os << "  " << line << endl;

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -72,9 +72,26 @@ DEFINE_PROTO_FUZZER(Function const& _input)
 
 	ostringstream os1;
 	ostringstream os2;
-	yulFuzzerUtil::interpret(os1, stack.parserResult()->code);
+	try
+	{
+		yulFuzzerUtil::interpret(os1, stack.parserResult()->code);
+	}
+	catch (yul::test::StepLimitReached const&)
+	{
+		return;
+	}
+	catch (yul::test::InterpreterTerminatedGeneric const&)
+	{
+	}
+
 	stack.optimize();
-	yulFuzzerUtil::interpret(os2, stack.parserResult()->code);
+	try
+	{
+		yulFuzzerUtil::interpret(os2, stack.parserResult()->code);
+	}
+	catch (yul::test::InterpreterTerminatedGeneric const&)
+	{
+	}
 
 	bool isTraceEq = (os1.str() == os2.str());
 	yulAssert(isTraceEq, "Interpreted traces for optimized and unoptimized code differ.");

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -106,7 +106,7 @@ u256 EVMInstructionInterpreter::eval(
 	switch (_instruction)
 	{
 	case Instruction::STOP:
-		throw InterpreterTerminated();
+		throw ExplicitlyTerminated();
 	// --------------- arithmetic ---------------
 	case Instruction::ADD:
 		return arg[0] + arg[1];
@@ -342,18 +342,18 @@ u256 EVMInstructionInterpreter::eval(
 		if (logMemoryRead(arg[0], arg[1]))
 			data = bytesConstRef(m_state.memory.data() + size_t(arg[0]), size_t(arg[1])).toBytes();
 		logTrace(_instruction, arg, data);
-		throw InterpreterTerminated();
+		throw ExplicitlyTerminated();
 	}
 	case Instruction::REVERT:
 		logMemoryRead(arg[0], arg[1]);
 		logTrace(_instruction, arg);
-		throw InterpreterTerminated();
+		throw ExplicitlyTerminated();
 	case Instruction::INVALID:
 		logTrace(_instruction);
-		throw InterpreterTerminated();
+		throw ExplicitlyTerminated();
 	case Instruction::SELFDESTRUCT:
 		logTrace(_instruction, arg);
-		throw InterpreterTerminated();
+		throw ExplicitlyTerminated();
 	case Instruction::POP:
 		break;
 	// --------------- invalid in strict assembly ---------------
@@ -492,6 +492,6 @@ void EVMInstructionInterpreter::logTrace(std::string const& _pseudoInstruction, 
 	if (m_state.maxTraceSize > 0 && m_state.trace.size() >= m_state.maxTraceSize)
 	{
 		m_state.trace.emplace_back("Trace size limit reached.");
-		throw InterpreterTerminated();
+		throw TraceLimitReached();
 	}
 }

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -132,7 +132,7 @@ void Interpreter::operator()(Block const& _block)
 	if (m_state.maxSteps > 0 && m_state.numSteps >= m_state.maxSteps)
 	{
 		m_state.trace.emplace_back("Interpreter execution step limit reached.");
-		throw InterpreterTerminated();
+		throw StepLimitReached();
 	}
 	openScope();
 	// Register functions.

--- a/test/tools/yulInterpreter/Interpreter.h
+++ b/test/tools/yulInterpreter/Interpreter.h
@@ -35,7 +35,19 @@ namespace yul
 namespace test
 {
 
-class InterpreterTerminated: dev::Exception
+class InterpreterTerminatedGeneric: public dev::Exception
+{
+};
+
+class ExplicitlyTerminated: public InterpreterTerminatedGeneric
+{
+};
+
+class StepLimitReached: public InterpreterTerminatedGeneric
+{
+};
+
+class TraceLimitReached: public InterpreterTerminatedGeneric
 {
 };
 

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -96,7 +96,7 @@ void interpret(string const& _source)
 	{
 		interpreter(*ast);
 	}
-	catch (InterpreterTerminated const&)
+	catch (InterpreterTerminatedGeneric const&)
 	{
 	}
 


### PR DESCRIPTION
This PR ensures that we don't flag a bug in the following scenario.

Unoptimized trace times out because of exceeding the step limit

Optimized trace does is valid because the code that exceeded the step limit is redundant and hence optimized out.

Example

```
{
let a,b := foo(calldataload(0),calldataload(32),calldataload(64),calldataload(96),calldataload(128),calldataload(160),calldataload(192),calldataload(224))
sstore(0, a)
sstore(32, b)
function foo(x_0, x_1, x_2, x_3, x_4, x_5, x_6, x_7) -> x_8, x_9
{
for { let i_0 := 0 } lt(i_0, 0x100) { i_0 := add(i_0, 0x20) } {
for { let i_1 := 0 } lt(i_1, 0x100) { i_1 := add(i_1, 0x20) } {
for { let i_2 := 0 } lt(i_2, 0x100) { i_2 := add(i_2, 0x20) } {
for { let i_3 := 0 } lt(i_3, 0x100) { i_3 := add(i_3, 0x20) } {
if sdiv(div(not(1),18446744073709551615),add(1,18446744073709551615)) {}
}
}
}
}
}
}

$ ./fuzzer
Unoptimized trace:
  Interpreter execution step limit reached.

Optimized trace
  SSTORE(0, 0)
  SSTORE(32, 0)
```

In this code, the nested for loops do not have any side effect and are removed by the optimizer. However, the traces of unoptimized code and optimized code differ, resulting in this program being flagged as buggy input. This is clearly a false positive.