### PR TITLE
[WIP] Basic recovering parser.

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -959,7 +959,21 @@ ASTPointer<Block> Parser::parseBlock(ASTPointer<ASTString> const& _docString)
 	expectToken(Token::LBrace);
 	vector<ASTPointer<Statement>> statements;
 	while (m_scanner->currentToken() != Token::RBrace)
-		statements.push_back(parseStatement());
+	{
+		try
+		{
+			statements.push_back(parseStatement());
+		}
+		catch (FatalError const&)
+		{
+			if (m_errorReporter.errors().empty())
+				throw; // Something is weird here, rather throw again.
+			while (m_scanner->currentToken() != Token::RBrace && m_scanner->currentToken() != Token::Semicolon)
+				m_scanner->next();
+			if (m_scanner->currentToken() == Token::Semicolon)
+				m_scanner->next();
+		}
+	}
 	nodeFactory.markEndPosition();
 	expectToken(Token::RBrace);
 	return nodeFactory.createNode<Block>(_docString, statements);


### PR DESCRIPTION
@rocky this is my small recovering parser attempt. I stopped once I realized that I put the code in the wrong place. It is looking for `;` even in statements that are not terminated by a `;`. It is probably better to put it inside `parseStatement` (next function below).