### PR TITLE
[DOCS] use correct global remapping syntax in documentation

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -65,7 +65,7 @@ explanatory purposes.
       settings:
       {
         // Required for Solidity: Sorted list of remappings
-        remappings: [ ":g/dir" ],
+        remappings: [ ":g=/dir" ],
         // Optional: Optimizer settings. The fields "enabled" and "runs" are deprecated
         // and are only given for backwards-compatibility.
         optimizer: {

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -187,7 +187,7 @@ Input Description
       "settings":
       {
         // Optional: Sorted list of remappings
-        "remappings": [ ":g/dir" ],
+        "remappings": [ ":g=/dir" ],
         // Optional: Optimizer settings
         "optimizer": {
           // disabled by default


### PR DESCRIPTION
### Description
The documentation for Solidity versions >= 0.5 has an invalid syntax for remappings in the compiler JSON input. It appears that as of 0.5, the correct syntax for a global remapping is `:g=/some/dir` instead of `:g/some/dir`. The documentation has not been updated to reflect this, and this PR addresses that.