### PR TITLE
Add CI to build ossfuzz fuzzer binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ defaults:
         [ -n "$COVERAGE" -a "$CIRCLE_BRANCH" != release -a -z "$CIRCLE_TAG" ] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
         cmake .. -DCMAKE_BUILD_TYPE=Release $CMAKE_OPTIONS
         make -j4
+  - run_build_ossfuzz: &run_build_ossfuzz
+      name: Build_ossfuzz
+      command: |
+        mkdir -p build
+        cd build
+        /src/LPM/external.protobuf/bin/protoc --proto_path=../test/tools/ossfuzz yulProto.proto --cpp_out=../test/tools/ossfuzz
+        cmake .. -DCMAKE_BUILD_TYPE=Release $CMAKE_OPTIONS
+        make ossfuzz ossfuzz_proto -j4
   - run_tests: &run_tests
       name: Tests
       command: scripts/tests.sh --junit_report test_results
@@ -390,6 +398,27 @@ jobs:
           path: docs/_build/html/
           destination: docs-html
 
+  build_x86_linux_ossfuzz:
+    docker:
+      - image: buildpack-deps:cosmic
+    environment:
+      TERM: xterm
+      CC: /usr/bin/clang-7
+      CXX: /usr/bin/clang++-7
+      CMAKE_OPTIONS: -DOSSFUZZ=1 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/libfuzzer.cmake
+    steps:
+      - checkout
+      - run:
+          name: Install build dependencies
+          command: |
+            apt-get -qq update
+            apt-get -qy install clang-7 cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libcvc4-dev libbz2-dev ninja-build zlib1g-dev
+            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
+            ./scripts/install_lpm.sh
+            ./scripts/install_libfuzzer.sh
+      - run: *setup_prerelease_commit_hash
+      - run: *run_build_ossfuzz
+
 workflows:
   version: 2
   build_all:
@@ -434,6 +463,8 @@ workflows:
           <<: *build_on_tags
           requires:
             - build_x86_archlinux
+      - build_x86_linux_ossfuzz: *build_on_tags
+
   test_nightly:
     triggers:
       - schedule:

--- a/cmake/toolchains/libfuzzer.cmake
+++ b/cmake/toolchains/libfuzzer.cmake
@@ -1,0 +1,2 @@
+# Require libfuzzer specific flags
+set(CMAKE_CXX_FLAGS "-O1 -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libstdc++")

--- a/scripts/install_libfuzzer.sh
+++ b/scripts/install_libfuzzer.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+TEMPDIR=$(mktemp -d)
+(
+    cd $TEMPDIR
+    svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer libfuzzer
+    mkdir -p build-libfuzzer
+    cd build-libfuzzer
+    CXXFLAGS="-O1 -stdlib=libstdc++"
+    $CXX $CXXFLAGS -std=c++11 -O2 -fPIC -c ../libfuzzer/*.cpp -I../libfuzzer
+    ar r /usr/lib/libFuzzingEngine.a *.o
+)
+rm -rf $TEMPDIR

--- a/scripts/install_lpm.sh
+++ b/scripts/install_lpm.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+
+TEMPDIR="src"
+cd /
+mkdir -p $TEMPDIR
+(
+    cd $TEMPDIR
+    git clone --depth 1 https://github.com/google/libprotobuf-mutator.git
+    mkdir -p LPM
+    cd LPM
+    cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release && ninja install
+)


### PR DESCRIPTION
(closes #5829 )

Notes
  - only verifies ossfuzz build
  - does not replicate ossfuzz environment. Deviations are
     - link against libstdc++ instead of libc++
     - don't compile libFuzzingEngine.a with ASan instead of with
  - this may or may not be relevant but retaining it for posterity/future use