### PR TITLE
Add additional information for Doc (Build from Source)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ CMakeLists.txt.user
 /.vs
 /.cproject
 /.project
+/cmake-build-debug

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -273,7 +273,7 @@ Command-Line Build
 
 **Be sure to install External Dependencies (see above) before build.**
 
-**If you want to perform a source build, please only use solidity.tar.gz in release page and not the zip provided by github directly.**
+**If you want to perform a source build, please only use solidity.tar.gz in `release page`_ and not the zip provided by github directly.**
 
 .. _release page: https://github.com/ethereum/solidity/releases
 

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -273,7 +273,7 @@ Command-Line Build
 
 **Be sure to install External Dependencies (see above) before build.**
 
-**If you want to perform a source build, please only use solidity.tar.gz in `release page`_ and not the zip provided by github directly.**
+If you want to perform a source build, please only use solidity.tar.gz in `release page`_ and not the zip provided by github directly.
 
 .. _release page: https://github.com/ethereum/solidity/releases
 

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -273,6 +273,10 @@ Command-Line Build
 
 **Be sure to install External Dependencies (see above) before build.**
 
+**If you want to perform a source build, please only use solidity.tar.gz in release page and not the zip provided by github directly.**
+
+.. _release page: https://github.com/ethereum/solidity/releases
+
 Solidity project uses CMake to configure the build.
 You might want to install ccache to speed up repeated builds.
 CMake will pick it up automatically.


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->
#### Add information about how to build from source

Directly using git repository or zip file provided by github to build can encounter this error on Ununtu 18.04: `Z3Interface.cpp:166:14: error: ‘mod’ is not a member of ‘z3’`

Guidance about cloning git repository is provided above so it is misleading and may make many people directly use the git repository to build.

Therefore, additional information is added in the front of section **Command-Line Build** to remind people to use the solidity.tar.gz file provided in release page. 