### PR TITLE
Type System API refactor

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -47,6 +47,8 @@ set(sources
 	ast/ExperimentalFeatures.h
 	ast/Types.cpp
 	ast/Types.h
+	ast/TypeProvider.cpp
+	ast/TypeProvider.h
 	codegen/ABIFunctions.cpp
 	codegen/ABIFunctions.h
 	codegen/ArrayUtils.cpp

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -23,6 +23,7 @@
 #include <libsolidity/analysis/ConstantEvaluator.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <liblangutil/ErrorReporter.h>
 
 using namespace std;
@@ -56,7 +57,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 		setType(
 			_operation,
 			TokenTraits::isCompareOp(_operation.getOperator()) ?
-			make_shared<BoolType>() :
+			TypeProvider::boolType() :
 			commonType
 		);
 	}
@@ -64,7 +65,7 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 
 void ConstantEvaluator::endVisit(Literal const& _literal)
 {
-	setType(_literal, Type::forLiteral(_literal));
+	setType(_literal, TypeProvider::forLiteral(_literal));
 }
 
 void ConstantEvaluator::endVisit(Identifier const& _identifier)

--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -22,6 +22,7 @@
 #include <libsolidity/analysis/ContractLevelChecker.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/analysis/TypeChecker.h>
 #include <liblangutil/ErrorReporter.h>
 #include <boost/range/adaptor/reversed.hpp>
@@ -244,13 +245,13 @@ void ContractLevelChecker::checkAbstractFunctions(ContractDefinition const& _con
 	{
 		for (VariableDeclaration const* v: contract->stateVariables())
 			if (v->isPartOfExternalInterface())
-				registerFunction(*v, make_shared<FunctionType>(*v), true);
+				registerFunction(*v, TypeProvider::functionType(*v), true);
 
 		for (FunctionDefinition const* function: contract->definedFunctions())
 			if (!function->isConstructor())
 				registerFunction(
 					*function,
-					make_shared<FunctionType>(*function)->asCallableFunction(false),
+					TypeProvider::functionType(*function)->asCallableFunction(false),
 					function->isImplemented()
 				);
 	}
@@ -407,7 +408,7 @@ void ContractLevelChecker::checkExternalTypeClashes(ContractDefinition const& _c
 		for (FunctionDefinition const* f: contract->definedFunctions())
 			if (f->isPartOfExternalInterface())
 			{
-				auto functionType = make_shared<FunctionType>(*f);
+				auto functionType = TypeProvider::functionType(*f);
 				// under non error circumstances this should be true
 				if (functionType->interfaceFunctionType())
 					externalDeclarations[functionType->externalSignature()].emplace_back(
@@ -417,7 +418,7 @@ void ContractLevelChecker::checkExternalTypeClashes(ContractDefinition const& _c
 		for (VariableDeclaration const* v: contract->stateVariables())
 			if (v->isPartOfExternalInterface())
 			{
-				auto functionType = make_shared<FunctionType>(*v);
+				auto functionType = TypeProvider::functionType(*v);
 				// under non error circumstances this should be true
 				if (functionType->interfaceFunctionType())
 					externalDeclarations[functionType->externalSignature()].emplace_back(

--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -235,7 +235,7 @@ bool ControlFlowBuilder::visit(FunctionCall const& _functionCall)
 	solAssert(!!m_currentNode, "");
 	solAssert(!!_functionCall.expression().annotation().type, "");
 
-	if (auto functionType = dynamic_pointer_cast<FunctionType const>(_functionCall.expression().annotation().type))
+	if (auto functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type))
 		switch (functionType->kind())
 		{
 			case FunctionType::Kind::Revert:

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -24,6 +24,7 @@
 #include <libsolidity/analysis/GlobalContext.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/ast/Types.h>
 #include <memory>
 
@@ -34,42 +35,50 @@ namespace dev
 namespace solidity
 {
 
-GlobalContext::GlobalContext():
-m_magicVariables(vector<shared_ptr<MagicVariableDeclaration const>>{
-	make_shared<MagicVariableDeclaration>("abi", make_shared<MagicType>(MagicType::Kind::ABI)),
-	make_shared<MagicVariableDeclaration>("addmod", make_shared<FunctionType>(strings{"uint256", "uint256", "uint256"}, strings{"uint256"}, FunctionType::Kind::AddMod, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("assert", make_shared<FunctionType>(strings{"bool"}, strings{}, FunctionType::Kind::Assert, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("block", make_shared<MagicType>(MagicType::Kind::Block)),
-	make_shared<MagicVariableDeclaration>("blockhash", make_shared<FunctionType>(strings{"uint256"}, strings{"bytes32"}, FunctionType::Kind::BlockHash, false, StateMutability::View)),
-	make_shared<MagicVariableDeclaration>("ecrecover", make_shared<FunctionType>(strings{"bytes32", "uint8", "bytes32", "bytes32"}, strings{"address"}, FunctionType::Kind::ECRecover, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("gasleft", make_shared<FunctionType>(strings(), strings{"uint256"}, FunctionType::Kind::GasLeft, false, StateMutability::View)),
-	make_shared<MagicVariableDeclaration>("keccak256", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::KECCAK256, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("log0", make_shared<FunctionType>(strings{"bytes32"}, strings{}, FunctionType::Kind::Log0)),
-	make_shared<MagicVariableDeclaration>("log1", make_shared<FunctionType>(strings{"bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log1)),
-	make_shared<MagicVariableDeclaration>("log2", make_shared<FunctionType>(strings{"bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log2)),
-	make_shared<MagicVariableDeclaration>("log3", make_shared<FunctionType>(strings{"bytes32", "bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log3)),
-	make_shared<MagicVariableDeclaration>("log4", make_shared<FunctionType>(strings{"bytes32", "bytes32", "bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log4)),
-	make_shared<MagicVariableDeclaration>("msg", make_shared<MagicType>(MagicType::Kind::Message)),
-	make_shared<MagicVariableDeclaration>("mulmod", make_shared<FunctionType>(strings{"uint256", "uint256", "uint256"}, strings{"uint256"}, FunctionType::Kind::MulMod, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("now", make_shared<IntegerType>(256)),
-	make_shared<MagicVariableDeclaration>("require", make_shared<FunctionType>(strings{"bool"}, strings{}, FunctionType::Kind::Require, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("require", make_shared<FunctionType>(strings{"bool", "string memory"}, strings{}, FunctionType::Kind::Require, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("revert", make_shared<FunctionType>(strings(), strings(), FunctionType::Kind::Revert, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("revert", make_shared<FunctionType>(strings{"string memory"}, strings(), FunctionType::Kind::Revert, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("ripemd160", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bytes20"}, FunctionType::Kind::RIPEMD160, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("selfdestruct", make_shared<FunctionType>(strings{"address payable"}, strings{}, FunctionType::Kind::Selfdestruct)),
-	make_shared<MagicVariableDeclaration>("sha256", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SHA256, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("sha3", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::KECCAK256, false, StateMutability::Pure)),
-	make_shared<MagicVariableDeclaration>("suicide", make_shared<FunctionType>(strings{"address payable"}, strings{}, FunctionType::Kind::Selfdestruct)),
-	make_shared<MagicVariableDeclaration>("tx", make_shared<MagicType>(MagicType::Kind::Transaction)),
-	make_shared<MagicVariableDeclaration>("type", make_shared<FunctionType>(
-		strings{"address"} /* accepts any contract type, handled by the type checker */,
-		strings{} /* returns a MagicType, handled by the type checker */,
-		FunctionType::Kind::MetaType,
-		false,
-		StateMutability::Pure
-	)),
-})
+inline vector<shared_ptr<MagicVariableDeclaration const>> constructMagicVariables()
+{
+	static auto const magicVarDecl = [](string const& _name, Type const* _type) {
+		return make_shared<MagicVariableDeclaration>(_name, _type);
+	};
+
+	return {
+		magicVarDecl("abi", TypeProvider::magicType(MagicType::Kind::ABI)),
+		magicVarDecl("addmod", TypeProvider::functionType(strings{"uint256", "uint256", "uint256"}, strings{"uint256"}, FunctionType::Kind::AddMod, false, StateMutability::Pure)),
+		magicVarDecl("assert", TypeProvider::functionType(strings{"bool"}, strings{}, FunctionType::Kind::Assert, false, StateMutability::Pure)),
+		magicVarDecl("block", TypeProvider::magicType(MagicType::Kind::Block)),
+		magicVarDecl("blockhash", TypeProvider::functionType(strings{"uint256"}, strings{"bytes32"}, FunctionType::Kind::BlockHash, false, StateMutability::View)),
+		magicVarDecl("ecrecover", TypeProvider::functionType(strings{"bytes32", "uint8", "bytes32", "bytes32"}, strings{"address"}, FunctionType::Kind::ECRecover, false, StateMutability::Pure)),
+		magicVarDecl("gasleft", TypeProvider::functionType(strings(), strings{"uint256"}, FunctionType::Kind::GasLeft, false, StateMutability::View)),
+		magicVarDecl("keccak256", TypeProvider::functionType(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::KECCAK256, false, StateMutability::Pure)),
+		magicVarDecl("log0", TypeProvider::functionType(strings{"bytes32"}, strings{}, FunctionType::Kind::Log0)),
+		magicVarDecl("log1", TypeProvider::functionType(strings{"bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log1)),
+		magicVarDecl("log2", TypeProvider::functionType(strings{"bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log2)),
+		magicVarDecl("log3", TypeProvider::functionType(strings{"bytes32", "bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log3)),
+		magicVarDecl("log4", TypeProvider::functionType(strings{"bytes32", "bytes32", "bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log4)),
+		magicVarDecl("msg", TypeProvider::magicType(MagicType::Kind::Message)),
+		magicVarDecl("mulmod", TypeProvider::functionType(strings{"uint256", "uint256", "uint256"}, strings{"uint256"}, FunctionType::Kind::MulMod, false, StateMutability::Pure)),
+		magicVarDecl("now", TypeProvider::integerType(256)),
+		magicVarDecl("require", TypeProvider::functionType(strings{"bool"}, strings{}, FunctionType::Kind::Require, false, StateMutability::Pure)),
+		magicVarDecl("require", TypeProvider::functionType(strings{"bool", "string memory"}, strings{}, FunctionType::Kind::Require, false, StateMutability::Pure)),
+		magicVarDecl("revert", TypeProvider::functionType(strings(), strings(), FunctionType::Kind::Revert, false, StateMutability::Pure)),
+		magicVarDecl("revert", TypeProvider::functionType(strings{"string memory"}, strings(), FunctionType::Kind::Revert, false, StateMutability::Pure)),
+		magicVarDecl("ripemd160", TypeProvider::functionType(strings{"bytes memory"}, strings{"bytes20"}, FunctionType::Kind::RIPEMD160, false, StateMutability::Pure)),
+		magicVarDecl("selfdestruct", TypeProvider::functionType(strings{"address payable"}, strings{}, FunctionType::Kind::Selfdestruct)),
+		magicVarDecl("sha256", TypeProvider::functionType(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::SHA256, false, StateMutability::Pure)),
+		magicVarDecl("sha3", TypeProvider::functionType(strings{"bytes memory"}, strings{"bytes32"}, FunctionType::Kind::KECCAK256, false, StateMutability::Pure)),
+		magicVarDecl("suicide", TypeProvider::functionType(strings{"address payable"}, strings{}, FunctionType::Kind::Selfdestruct)),
+		magicVarDecl("tx", TypeProvider::magicType(MagicType::Kind::Transaction)),
+		magicVarDecl("type", TypeProvider::functionType(
+			strings{"address"} /* accepts any contract type, handled by the type checker */,
+			strings{} /* returns a MagicType, handled by the type checker */,
+			FunctionType::Kind::MetaType,
+			false,
+			StateMutability::Pure
+		)),
+	};
+}
+
+GlobalContext::GlobalContext(): m_magicVariables{constructMagicVariables()}
 {
 }
 
@@ -90,7 +99,7 @@ vector<Declaration const*> GlobalContext::declarations() const
 MagicVariableDeclaration const* GlobalContext::currentThis() const
 {
 	if (!m_thisPointer[m_currentContract])
-		m_thisPointer[m_currentContract] = make_shared<MagicVariableDeclaration>("this", make_shared<ContractType>(*m_currentContract));
+		m_thisPointer[m_currentContract] = make_shared<MagicVariableDeclaration>("this", TypeProvider::contractType(*m_currentContract));
 	return m_thisPointer[m_currentContract].get();
 
 }
@@ -98,7 +107,7 @@ MagicVariableDeclaration const* GlobalContext::currentThis() const
 MagicVariableDeclaration const* GlobalContext::currentSuper() const
 {
 	if (!m_superPointer[m_currentContract])
-		m_superPointer[m_currentContract] = make_shared<MagicVariableDeclaration>("super", make_shared<ContractType>(*m_currentContract, true));
+		m_superPointer[m_currentContract] = make_shared<MagicVariableDeclaration>("super", TypeProvider::contractType(*m_currentContract, true));
 	return m_superPointer[m_currentContract].get();
 }
 

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -57,7 +57,7 @@ inline vector<shared_ptr<MagicVariableDeclaration const>> constructMagicVariable
 		magicVarDecl("log4", TypeProvider::functionType(strings{"bytes32", "bytes32", "bytes32", "bytes32", "bytes32"}, strings{}, FunctionType::Kind::Log4)),
 		magicVarDecl("msg", TypeProvider::magicType(MagicType::Kind::Message)),
 		magicVarDecl("mulmod", TypeProvider::functionType(strings{"uint256", "uint256", "uint256"}, strings{"uint256"}, FunctionType::Kind::MulMod, false, StateMutability::Pure)),
-		magicVarDecl("now", TypeProvider::integerType(256)),
+		magicVarDecl("now", TypeProvider::uint256()),
 		magicVarDecl("require", TypeProvider::functionType(strings{"bool"}, strings{}, FunctionType::Kind::Require, false, StateMutability::Pure)),
 		magicVarDecl("require", TypeProvider::functionType(strings{"bool", "string memory"}, strings{}, FunctionType::Kind::Require, false, StateMutability::Pure)),
 		magicVarDecl("revert", TypeProvider::functionType(strings(), strings(), FunctionType::Kind::Revert, false, StateMutability::Pure)),

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -228,7 +228,7 @@ vector<Declaration const*> NameAndTypeResolver::cleanedDeclarations(
 			uniqueFunctions.end(),
 			[&](Declaration const* d)
 			{
-				shared_ptr<FunctionType const> newFunctionType { d->functionType(false) };
+				FunctionType const* newFunctionType = d->functionType(false);
 				if (!newFunctionType)
 					newFunctionType = d->functionType(true);
 				return newFunctionType && functionType->hasEqualParameterTypes(*newFunctionType);

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -182,7 +182,7 @@ void ReferencesResolver::endVisit(UserDefinedTypeName const& _typeName)
 	_typeName.annotation().referencedDeclaration = declaration;
 
 	if (StructDefinition const* structDef = dynamic_cast<StructDefinition const*>(declaration))
-		_typeName.annotation().type = TypeProvider::structType(*structDef);
+		_typeName.annotation().type = TypeProvider::structType(*structDef, DataLocation::Storage);
 	else if (EnumDefinition const* enumDef = dynamic_cast<EnumDefinition const*>(declaration))
 		_typeName.annotation().type = TypeProvider::enumType(*enumDef);
 	else if (ContractDefinition const* contract = dynamic_cast<ContractDefinition const*>(declaration))

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -24,6 +24,7 @@
 #include <libsolidity/analysis/NameAndTypeResolver.h>
 #include <libsolidity/analysis/ConstantEvaluator.h>
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
@@ -120,7 +121,7 @@ bool ReferencesResolver::visit(ElementaryTypeName const& _typeName)
 {
 	if (!_typeName.annotation().type)
 	{
-		_typeName.annotation().type = Type::fromElementaryTypeName(_typeName.typeName());
+		_typeName.annotation().type = TypeProvider::fromElementaryTypeName(_typeName.typeName());
 		if (_typeName.stateMutability().is_initialized())
 		{
 			// for non-address types this was already caught by the parser
@@ -128,8 +129,10 @@ bool ReferencesResolver::visit(ElementaryTypeName const& _typeName)
 			switch(*_typeName.stateMutability())
 			{
 				case StateMutability::Payable:
+					_typeName.annotation().type = TypeProvider::payableAddressType();
+					break;
 				case StateMutability::NonPayable:
-					_typeName.annotation().type = make_shared<AddressType>(*_typeName.stateMutability());
+					_typeName.annotation().type = TypeProvider::addressType();
 					break;
 				default:
 					m_errorReporter.typeError(
@@ -179,14 +182,14 @@ void ReferencesResolver::endVisit(UserDefinedTypeName const& _typeName)
 	_typeName.annotation().referencedDeclaration = declaration;
 
 	if (StructDefinition const* structDef = dynamic_cast<StructDefinition const*>(declaration))
-		_typeName.annotation().type = make_shared<StructType>(*structDef);
+		_typeName.annotation().type = TypeProvider::structType(*structDef);
 	else if (EnumDefinition const* enumDef = dynamic_cast<EnumDefinition const*>(declaration))
-		_typeName.annotation().type = make_shared<EnumType>(*enumDef);
+		_typeName.annotation().type = TypeProvider::enumType(*enumDef);
 	else if (ContractDefinition const* contract = dynamic_cast<ContractDefinition const*>(declaration))
-		_typeName.annotation().type = make_shared<ContractType>(*contract);
+		_typeName.annotation().type = TypeProvider::contractType(*contract);
 	else
 	{
-		_typeName.annotation().type = make_shared<TupleType>();
+		_typeName.annotation().type = TypeProvider::emptyTupleType();
 		typeError(_typeName.location(), "Name has to refer to a struct, enum or contract.");
 	}
 }
@@ -220,7 +223,7 @@ void ReferencesResolver::endVisit(FunctionTypeName const& _typeName)
 			}
 		}
 
-	_typeName.annotation().type = make_shared<FunctionType>(_typeName);
+	_typeName.annotation().type = TypeProvider::functionType(_typeName);
 }
 
 void ReferencesResolver::endVisit(Mapping const& _typeName)
@@ -231,7 +234,7 @@ void ReferencesResolver::endVisit(Mapping const& _typeName)
 	keyType = ReferenceType::copyForLocationIfReference(DataLocation::Memory, keyType);
 	// Convert value type to storage reference.
 	valueType = ReferenceType::copyForLocationIfReference(DataLocation::Storage, valueType);
-	_typeName.annotation().type = make_shared<MappingType>(keyType, valueType);
+	_typeName.annotation().type = TypeProvider::mappingType(keyType, valueType);
 }
 
 void ReferencesResolver::endVisit(ArrayTypeName const& _typeName)
@@ -249,7 +252,7 @@ void ReferencesResolver::endVisit(ArrayTypeName const& _typeName)
 		TypePointer& lengthTypeGeneric = length->annotation().type;
 		if (!lengthTypeGeneric)
 			lengthTypeGeneric = ConstantEvaluator(m_errorReporter).evaluate(*length);
-		RationalNumberType const* lengthType = dynamic_cast<RationalNumberType const*>(lengthTypeGeneric.get());
+		RationalNumberType const* lengthType = dynamic_cast<RationalNumberType const*>(lengthTypeGeneric);
 		if (!lengthType || !lengthType->mobileType())
 			fatalTypeError(length->location(), "Invalid array length, expected integer literal or constant expression.");
 		else if (lengthType->isZero())
@@ -259,10 +262,10 @@ void ReferencesResolver::endVisit(ArrayTypeName const& _typeName)
 		else if (lengthType->isNegative())
 			fatalTypeError(length->location(), "Array with negative length specified.");
 		else
-			_typeName.annotation().type = make_shared<ArrayType>(DataLocation::Storage, baseType, lengthType->literalValue(nullptr));
+			_typeName.annotation().type = TypeProvider::arrayType(DataLocation::Storage, baseType, lengthType->literalValue(nullptr));
 	}
 	else
-		_typeName.annotation().type = make_shared<ArrayType>(DataLocation::Storage, baseType);
+		_typeName.annotation().type = TypeProvider::arrayType(DataLocation::Storage, baseType);
 }
 
 bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
@@ -436,10 +439,10 @@ void ReferencesResolver::endVisit(VariableDeclaration const& _variable)
 		}
 
 	TypePointer type = _variable.typeName()->annotation().type;
-	if (auto ref = dynamic_cast<ReferenceType const*>(type.get()))
+	if (auto ref = dynamic_cast<ReferenceType const*>(type))
 	{
 		bool isPointer = !_variable.isStateVariable();
-		type = ref->copyForLocation(typeLoc, isPointer);
+		type = TypeProvider::withLocation(ref, typeLoc, isPointer);
 	}
 
 	_variable.annotation().type = type;

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -190,7 +190,7 @@ bool StaticAnalyzer::visit(ExpressionStatement const& _statement)
 
 bool StaticAnalyzer::visit(MemberAccess const& _memberAccess)
 {
-	if (MagicType const* type = dynamic_cast<MagicType const*>(_memberAccess.expression().annotation().type.get()))
+	if (MagicType const* type = dynamic_cast<MagicType const*>(_memberAccess.expression().annotation().type))
 	{
 		if (type->kind() == MagicType::Kind::Message && _memberAccess.memberName() == "gas")
 			m_errorReporter.typeError(
@@ -217,7 +217,7 @@ bool StaticAnalyzer::visit(MemberAccess const& _memberAccess)
 	}
 
 	if (_memberAccess.memberName() == "callcode")
-		if (auto const* type = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type.get()))
+		if (auto const* type = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type))
 			if (type->kind() == FunctionType::Kind::BareCallCode)
 				m_errorReporter.typeError(
 					_memberAccess.location(),
@@ -278,7 +278,7 @@ bool StaticAnalyzer::visit(BinaryOperation const& _operation)
 		_operation.rightExpression().annotation().isPure &&
 		(_operation.getOperator() == Token::Div || _operation.getOperator() == Token::Mod)
 	)
-		if (auto rhs = dynamic_pointer_cast<RationalNumberType const>(
+		if (auto rhs = dynamic_cast<RationalNumberType const*>(
 			ConstantEvaluator(m_errorReporter).evaluate(_operation.rightExpression())
 		))
 			if (rhs->isZero())
@@ -294,13 +294,13 @@ bool StaticAnalyzer::visit(FunctionCall const& _functionCall)
 {
 	if (_functionCall.annotation().kind == FunctionCallKind::FunctionCall)
 	{
-		auto functionType = dynamic_pointer_cast<FunctionType const>(_functionCall.expression().annotation().type);
+		auto functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type);
 		solAssert(functionType, "");
 		if (functionType->kind() == FunctionType::Kind::AddMod || functionType->kind() == FunctionType::Kind::MulMod)
 		{
 			solAssert(_functionCall.arguments().size() == 3, "");
 			if (_functionCall.arguments()[2]->annotation().isPure)
-				if (auto lastArg = dynamic_pointer_cast<RationalNumberType const>(
+				if (auto lastArg = dynamic_cast<RationalNumberType const*>(
 					ConstantEvaluator(m_errorReporter).evaluate(*(_functionCall.arguments())[2])
 				))
 					if (lastArg->isZero())

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1999,7 +1999,7 @@ void TypeChecker::endVisit(NewExpression const& _newExpression)
 			);
 		type = ReferenceType::copyForLocationIfReference(DataLocation::Memory, type);
 		_newExpression.annotation().type = TypeProvider::functionType(
-			TypePointers{TypeProvider::integerType(256)},
+			TypePointers{TypeProvider::uint256()},
 			TypePointers{type},
 			strings(1, ""),
 			strings(1, ""),
@@ -2195,7 +2195,7 @@ bool TypeChecker::visit(IndexAccess const& _access)
 		}
 		else
 		{
-			expectType(*index, *TypeProvider::integerType());
+			expectType(*index, *TypeProvider::uint256());
 			if (!m_errorReporter.hasErrors())
 				if (auto numberType = dynamic_cast<RationalNumberType const*>(type(*index)))
 				{
@@ -2229,7 +2229,7 @@ bool TypeChecker::visit(IndexAccess const& _access)
 		else
 		{
 			u256 length = 1;
-			if (expectType(*index, *TypeProvider::integerType()))
+			if (expectType(*index, *TypeProvider::uint256()))
 			{
 				if (auto indexValue = dynamic_cast<RationalNumberType const*>(type(*index)))
 					length = indexValue->literalValue(nullptr);
@@ -2254,7 +2254,7 @@ bool TypeChecker::visit(IndexAccess const& _access)
 			m_errorReporter.typeError(_access.location(), "Index expression cannot be omitted.");
 		else
 		{
-			if (!expectType(*index, *TypeProvider::integerType()))
+			if (!expectType(*index, *TypeProvider::uint256()))
 				m_errorReporter.fatalTypeError(_access.location(), "Index expression cannot be represented as an unsigned integer.");
 			if (auto integerType = dynamic_cast<RationalNumberType const*>(type(*index)))
 				if (bytesType.numBytes() <= integerType->literalValue(nullptr))

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -24,6 +24,7 @@
 
 #include <libsolidity/ast/ASTVisitor.h>
 #include <libsolidity/ast/AST_accept.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libdevcore/Keccak256.h>
 
 #include <boost/algorithm/string.hpp>
@@ -105,7 +106,7 @@ ImportAnnotation& ImportDirective::annotation() const
 TypePointer ImportDirective::type() const
 {
 	solAssert(!!annotation().sourceUnit, "");
-	return make_shared<ModuleType>(*annotation().sourceUnit);
+	return TypeProvider::moduleType(*annotation().sourceUnit);
 }
 
 map<FixedHash<4>, FunctionTypePointer> ContractDefinition::interfaceFunctions() const
@@ -188,10 +189,10 @@ vector<pair<FixedHash<4>, FunctionTypePointer>> const& ContractDefinition::inter
 			vector<FunctionTypePointer> functions;
 			for (FunctionDefinition const* f: contract->definedFunctions())
 				if (f->isPartOfExternalInterface())
-					functions.push_back(make_shared<FunctionType>(*f, false));
+					functions.push_back(TypeProvider::functionType(*f, false));
 			for (VariableDeclaration const* v: contract->stateVariables())
 				if (v->isPartOfExternalInterface())
-					functions.push_back(make_shared<FunctionType>(*v));
+					functions.push_back(TypeProvider::functionType(*v));
 			for (FunctionTypePointer const& fun: functions)
 			{
 				if (!fun->interfaceFunctionType())
@@ -246,7 +247,7 @@ vector<Declaration const*> const& ContractDefinition::inheritableMembers() const
 
 TypePointer ContractDefinition::type() const
 {
-	return make_shared<TypeType>(make_shared<ContractType>(*this));
+	return TypeProvider::typeType(TypeProvider::contractType(*this));
 }
 
 ContractDefinitionAnnotation& ContractDefinition::annotation() const
@@ -265,7 +266,7 @@ TypeNameAnnotation& TypeName::annotation() const
 
 TypePointer StructDefinition::type() const
 {
-	return make_shared<TypeType>(make_shared<StructType>(*this));
+	return TypeProvider::typeType(TypeProvider::structType(*this));
 }
 
 TypeDeclarationAnnotation& StructDefinition::annotation() const
@@ -279,12 +280,12 @@ TypePointer EnumValue::type() const
 {
 	auto parentDef = dynamic_cast<EnumDefinition const*>(scope());
 	solAssert(parentDef, "Enclosing Scope of EnumValue was not set");
-	return make_shared<EnumType>(*parentDef);
+	return TypeProvider::enumType(*parentDef);
 }
 
 TypePointer EnumDefinition::type() const
 {
-	return make_shared<TypeType>(make_shared<EnumType>(*this));
+	return TypeProvider::typeType(TypeProvider::enumType(*this));
 }
 
 TypeDeclarationAnnotation& EnumDefinition::annotation() const
@@ -312,7 +313,7 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 		case Declaration::Visibility::Private:
 		case Declaration::Visibility::Internal:
 		case Declaration::Visibility::Public:
-			return make_shared<FunctionType>(*this, _internal);
+			return TypeProvider::functionType(*this, _internal);
 		case Declaration::Visibility::External:
 			return {};
 		}
@@ -328,7 +329,7 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 			return {};
 		case Declaration::Visibility::Public:
 		case Declaration::Visibility::External:
-			return make_shared<FunctionType>(*this, _internal);
+			return TypeProvider::functionType(*this, _internal);
 		}
 	}
 
@@ -339,12 +340,12 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 TypePointer FunctionDefinition::type() const
 {
 	solAssert(visibility() != Declaration::Visibility::External, "");
-	return make_shared<FunctionType>(*this);
+	return TypeProvider::functionType(*this);
 }
 
 string FunctionDefinition::externalSignature() const
 {
-	return FunctionType(*this).externalSignature();
+	return TypeProvider::functionType(*this)->externalSignature();
 }
 
 FunctionDefinitionAnnotation& FunctionDefinition::annotation() const
@@ -356,7 +357,7 @@ FunctionDefinitionAnnotation& FunctionDefinition::annotation() const
 
 TypePointer ModifierDefinition::type() const
 {
-	return make_shared<ModifierType>(*this);
+	return TypeProvider::modifierType(*this);
 }
 
 ModifierDefinitionAnnotation& ModifierDefinition::annotation() const
@@ -368,15 +369,15 @@ ModifierDefinitionAnnotation& ModifierDefinition::annotation() const
 
 TypePointer EventDefinition::type() const
 {
-	return make_shared<FunctionType>(*this);
+	return TypeProvider::functionType(*this);
 }
 
 FunctionTypePointer EventDefinition::functionType(bool _internal) const
 {
 	if (_internal)
-		return make_shared<FunctionType>(*this);
+		return TypeProvider::functionType(*this);
 	else
-		return {};
+		return nullptr;
 }
 
 EventDefinitionAnnotation& EventDefinition::annotation() const
@@ -508,8 +509,8 @@ bool VariableDeclaration::hasReferenceOrMappingType() const
 {
 	solAssert(typeName(), "");
 	solAssert(typeName()->annotation().type, "Can only be called after reference resolution");
-	TypePointer const& type = typeName()->annotation().type;
-	return type->category() == Type::Category::Mapping || dynamic_cast<ReferenceType const*>(type.get());
+	Type const* type = typeName()->annotation().type;
+	return type->category() == Type::Category::Mapping || dynamic_cast<ReferenceType const*>(type);
 }
 
 set<VariableDeclaration::Location> VariableDeclaration::allowedDataLocations() const
@@ -557,21 +558,21 @@ TypePointer VariableDeclaration::type() const
 FunctionTypePointer VariableDeclaration::functionType(bool _internal) const
 {
 	if (_internal)
-		return {};
+		return nullptr;
 	switch (visibility())
 	{
 	case Declaration::Visibility::Default:
 		solAssert(false, "visibility() should not return Default");
 	case Declaration::Visibility::Private:
 	case Declaration::Visibility::Internal:
-		return {};
+		return nullptr;
 	case Declaration::Visibility::Public:
 	case Declaration::Visibility::External:
-		return make_shared<FunctionType>(*this);
+		return TypeProvider::functionType(*this);
 	}
 
 	// To make the compiler happy
-	return {};
+	return nullptr;
 }
 
 VariableDeclarationAnnotation& VariableDeclaration::annotation() const

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -266,7 +266,7 @@ TypeNameAnnotation& TypeName::annotation() const
 
 TypePointer StructDefinition::type() const
 {
-	return TypeProvider::typeType(TypeProvider::structType(*this));
+	return TypeProvider::typeType(TypeProvider::structType(*this, DataLocation::Storage));
 }
 
 TypeDeclarationAnnotation& StructDefinition::annotation() const

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -848,8 +848,9 @@ private:
 class MagicVariableDeclaration: public Declaration
 {
 public:
-	MagicVariableDeclaration(ASTString const& _name, std::shared_ptr<Type const> const& _type):
+	MagicVariableDeclaration(ASTString const& _name, Type const* _type):
 		Declaration(SourceLocation(), std::make_shared<ASTString>(_name)), m_type(_type) {}
+
 	void accept(ASTVisitor&) override
 	{
 		solAssert(false, "MagicVariableDeclaration used inside real AST.");
@@ -859,15 +860,15 @@ public:
 		solAssert(false, "MagicVariableDeclaration used inside real AST.");
 	}
 
-	FunctionTypePointer functionType(bool) const override
+	FunctionType const* functionType(bool) const override
 	{
 		solAssert(m_type->category() == Type::Category::Function, "");
-		return std::dynamic_pointer_cast<FunctionType const>(m_type);
+		return dynamic_cast<FunctionType const*>(m_type);
 	}
 	TypePointer type() const override { return m_type; }
 
 private:
-	std::shared_ptr<Type const> m_type;
+	Type const* m_type;
 };
 
 /// Types

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -45,7 +45,7 @@ namespace solidity
 {
 
 class Type;
-using TypePointer = std::shared_ptr<Type const>;
+using TypePointer = Type const*;
 
 struct ASTAnnotation
 {
@@ -122,7 +122,7 @@ struct ModifierDefinitionAnnotation: ASTAnnotation, DocumentedAnnotation
 struct VariableDeclarationAnnotation: ASTAnnotation
 {
 	/// Type of variable (type of identifier referencing this variable).
-	TypePointer type;
+	TypePointer type = nullptr;
 };
 
 struct StatementAnnotation: ASTAnnotation, DocumentedAnnotation
@@ -155,7 +155,7 @@ struct TypeNameAnnotation: ASTAnnotation
 {
 	/// Type declared by this type name, i.e. type of a variable where this type name is used.
 	/// Set during reference resolution stage.
-	TypePointer type;
+	TypePointer type = nullptr;
 };
 
 struct UserDefinedTypeNameAnnotation: TypeNameAnnotation
@@ -170,7 +170,7 @@ struct UserDefinedTypeNameAnnotation: TypeNameAnnotation
 struct ExpressionAnnotation: ASTAnnotation
 {
 	/// Inferred type of the expression.
-	TypePointer type;
+	TypePointer type = nullptr;
 	/// Whether the expression is a constant variable
 	bool isConstant = false;
 	/// Whether the expression is pure, i.e. compile-time constant.
@@ -203,7 +203,7 @@ struct BinaryOperationAnnotation: ExpressionAnnotation
 {
 	/// The common type that is used for the operation, not necessarily the result type (which
 	/// e.g. for comparisons is bool).
-	TypePointer commonType;
+	TypePointer commonType = nullptr;
 };
 
 enum class FunctionCallKind

--- a/libsolidity/ast/ASTEnums.h
+++ b/libsolidity/ast/ASTEnums.h
@@ -57,7 +57,7 @@ class Type;
 struct FuncCallArguments
 {
 	/// Types of arguments
-	std::vector<std::shared_ptr<Type const>> types;
+	std::vector<Type const*> types;
 	/// Names of the arguments if given, otherwise unset
 	std::vector<ASTPointer<ASTString>> names;
 

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -237,9 +237,9 @@ Type const* TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken const& 
 	case Token::Bool:
 		return boolType();
 	case Token::Bytes:
-		return bytesType();
+		return bytesStorageType();
 	case Token::String:
-		return stringType();
+		return stringStorageType();
 	default:
 		solAssert(
 			false,
@@ -293,7 +293,7 @@ TypePointer TypeProvider::fromElementaryTypeName(string const& _name)
 	}
 }
 
-ArrayType const* TypeProvider::bytesType()
+ArrayType const* TypeProvider::bytesStorageType()
 {
 	if (!m_bytesStorageType)
 		m_bytesStorageType = make_unique<ArrayType>(DataLocation::Storage, false);
@@ -307,7 +307,7 @@ ArrayType const* TypeProvider::bytesMemoryType()
 	return m_bytesMemoryType.get();
 }
 
-ArrayType const* TypeProvider::stringType()
+ArrayType const* TypeProvider::stringStorageType()
 {
 	if (!m_stringStorageType)
 		m_stringStorageType = make_unique<ArrayType>(DataLocation::Storage, true);
@@ -469,14 +469,14 @@ ArrayType const* TypeProvider::arrayType(DataLocation _location, bool _isString)
 	if (_isString)
 	{
 		if (_location == DataLocation::Storage)
-			return stringType();
+			return stringStorageType();
 		if (_location == DataLocation::Memory)
 			return stringMemoryType();
 	}
 	else
 	{
 		if (_location == DataLocation::Storage)
-			return bytesType();
+			return bytesStorageType();
 		if (_location == DataLocation::Memory)
 			return bytesMemoryType();
 	}

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -34,158 +34,152 @@ TupleType const TypeProvider::m_emptyTupleType{};
 AddressType const TypeProvider::m_payableAddressType{StateMutability::Payable};
 AddressType const TypeProvider::m_addressType{StateMutability::NonPayable};
 
-array<IntegerType, 32> const TypeProvider::m_intM{
-	IntegerType{8 * 1, IntegerType::Modifier::Signed},
-	IntegerType{8 * 2, IntegerType::Modifier::Signed},
-	IntegerType{8 * 3, IntegerType::Modifier::Signed},
-	IntegerType{8 * 4, IntegerType::Modifier::Signed},
-	IntegerType{8 * 5, IntegerType::Modifier::Signed},
-	IntegerType{8 * 6, IntegerType::Modifier::Signed},
-	IntegerType{8 * 7, IntegerType::Modifier::Signed},
-	IntegerType{8 * 8, IntegerType::Modifier::Signed},
-	IntegerType{8 * 9, IntegerType::Modifier::Signed},
-	IntegerType{8 * 10, IntegerType::Modifier::Signed},
-	IntegerType{8 * 11, IntegerType::Modifier::Signed},
-	IntegerType{8 * 12, IntegerType::Modifier::Signed},
-	IntegerType{8 * 13, IntegerType::Modifier::Signed},
-	IntegerType{8 * 14, IntegerType::Modifier::Signed},
-	IntegerType{8 * 15, IntegerType::Modifier::Signed},
-	IntegerType{8 * 16, IntegerType::Modifier::Signed},
-	IntegerType{8 * 17, IntegerType::Modifier::Signed},
-	IntegerType{8 * 18, IntegerType::Modifier::Signed},
-	IntegerType{8 * 19, IntegerType::Modifier::Signed},
-	IntegerType{8 * 20, IntegerType::Modifier::Signed},
-	IntegerType{8 * 21, IntegerType::Modifier::Signed},
-	IntegerType{8 * 22, IntegerType::Modifier::Signed},
-	IntegerType{8 * 23, IntegerType::Modifier::Signed},
-	IntegerType{8 * 24, IntegerType::Modifier::Signed},
-	IntegerType{8 * 25, IntegerType::Modifier::Signed},
-	IntegerType{8 * 26, IntegerType::Modifier::Signed},
-	IntegerType{8 * 27, IntegerType::Modifier::Signed},
-	IntegerType{8 * 28, IntegerType::Modifier::Signed},
-	IntegerType{8 * 29, IntegerType::Modifier::Signed},
-	IntegerType{8 * 30, IntegerType::Modifier::Signed},
-	IntegerType{8 * 31, IntegerType::Modifier::Signed},
-	IntegerType{8 * 32, IntegerType::Modifier::Signed}
-};
+array<unique_ptr<IntegerType>, 32> const TypeProvider::m_intM{{
+	{make_unique<IntegerType>(8 * 1, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 2, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 3, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 4, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 5, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 6, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 7, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 8, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 9, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 10, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 11, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 12, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 13, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 14, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 15, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 16, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 17, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 18, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 19, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 20, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 21, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 22, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 23, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 24, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 25, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 26, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 27, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 28, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 29, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 30, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 31, IntegerType::Modifier::Signed)},
+	{make_unique<IntegerType>(8 * 32, IntegerType::Modifier::Signed)}
+}};
 
-array<IntegerType, 32> const TypeProvider::m_uintM{
-	IntegerType{8 * 1, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 2, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 3, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 4, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 5, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 6, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 7, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 8, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 9, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 10, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 11, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 12, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 13, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 14, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 15, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 16, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 17, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 18, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 19, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 20, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 21, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 22, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 23, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 24, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 25, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 26, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 27, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 28, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 29, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 30, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 31, IntegerType::Modifier::Unsigned},
-	IntegerType{8 * 32, IntegerType::Modifier::Unsigned}
-};
+array<unique_ptr<IntegerType>, 32> const TypeProvider::m_uintM{{
+	{make_unique<IntegerType>(8 * 1, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 2, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 3, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 4, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 5, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 6, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 7, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 8, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 9, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 10, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 11, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 12, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 13, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 14, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 15, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 16, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 17, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 18, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 19, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 20, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 21, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 22, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 23, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 24, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 25, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 26, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 27, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 28, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 29, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 30, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 31, IntegerType::Modifier::Unsigned)},
+	{make_unique<IntegerType>(8 * 32, IntegerType::Modifier::Unsigned)}
+}};
 
-array<FixedBytesType, 32> const TypeProvider::m_bytesM{
-	FixedBytesType{1},
-	FixedBytesType{2},
-	FixedBytesType{3},
-	FixedBytesType{4},
-	FixedBytesType{5},
-	FixedBytesType{6},
-	FixedBytesType{7},
-	FixedBytesType{8},
-	FixedBytesType{9},
-	FixedBytesType{10},
-	FixedBytesType{11},
-	FixedBytesType{12},
-	FixedBytesType{13},
-	FixedBytesType{14},
-	FixedBytesType{15},
-	FixedBytesType{16},
-	FixedBytesType{17},
-	FixedBytesType{18},
-	FixedBytesType{19},
-	FixedBytesType{20},
-	FixedBytesType{21},
-	FixedBytesType{22},
-	FixedBytesType{23},
-	FixedBytesType{24},
-	FixedBytesType{25},
-	FixedBytesType{26},
-	FixedBytesType{27},
-	FixedBytesType{28},
-	FixedBytesType{29},
-	FixedBytesType{30},
-	FixedBytesType{31},
-	FixedBytesType{32}
-};
+array<unique_ptr<FixedBytesType>, 32> const TypeProvider::m_bytesM{{
+	{make_unique<FixedBytesType>(1)},
+	{make_unique<FixedBytesType>(2)},
+	{make_unique<FixedBytesType>(3)},
+	{make_unique<FixedBytesType>(4)},
+	{make_unique<FixedBytesType>(5)},
+	{make_unique<FixedBytesType>(6)},
+	{make_unique<FixedBytesType>(7)},
+	{make_unique<FixedBytesType>(8)},
+	{make_unique<FixedBytesType>(9)},
+	{make_unique<FixedBytesType>(10)},
+	{make_unique<FixedBytesType>(11)},
+	{make_unique<FixedBytesType>(12)},
+	{make_unique<FixedBytesType>(13)},
+	{make_unique<FixedBytesType>(14)},
+	{make_unique<FixedBytesType>(15)},
+	{make_unique<FixedBytesType>(16)},
+	{make_unique<FixedBytesType>(17)},
+	{make_unique<FixedBytesType>(18)},
+	{make_unique<FixedBytesType>(19)},
+	{make_unique<FixedBytesType>(20)},
+	{make_unique<FixedBytesType>(21)},
+	{make_unique<FixedBytesType>(22)},
+	{make_unique<FixedBytesType>(23)},
+	{make_unique<FixedBytesType>(24)},
+	{make_unique<FixedBytesType>(25)},
+	{make_unique<FixedBytesType>(26)},
+	{make_unique<FixedBytesType>(27)},
+	{make_unique<FixedBytesType>(28)},
+	{make_unique<FixedBytesType>(29)},
+	{make_unique<FixedBytesType>(30)},
+	{make_unique<FixedBytesType>(31)},
+	{make_unique<FixedBytesType>(32)}
+}};
 
-array<MagicType, 4> const TypeProvider::m_magicTypes{
-	MagicType{MagicType::Kind::Block},
-	MagicType{MagicType::Kind::Message},
-	MagicType{MagicType::Kind::Transaction},
-	MagicType{MagicType::Kind::ABI}
+array<unique_ptr<MagicType>, 4> const TypeProvider::m_magicTypes{{
+	{make_unique<MagicType>(MagicType::Kind::Block)},
+	{make_unique<MagicType>(MagicType::Kind::Message)},
+	{make_unique<MagicType>(MagicType::Kind::Transaction)},
+	{make_unique<MagicType>(MagicType::Kind::ABI)}
 	// MetaType is stored separately
-};
+}};
 
 inline void clearCache(Type const& type)
 {
 	type.clearCache();
 }
 
-template <typename... Args>
-inline void clearCache(Type const& type, Args&... moreTypes)
+template <typename T>
+inline void clearCache(unique_ptr<T> const& type)
 {
-	clearCache(type);
-	clearCache(moreTypes...);
+	type->clearCache();
 }
 
 template <typename Container>
-inline void clearAllCaches(Container& container)
+inline void clearCaches(Container& container)
 {
-	for_each(begin(container), end(container), [](Type const& t) { t.clearCache(); });
-}
-
-template <typename Container, typename... Args>
-inline void clearAllCaches(Container& types, Args&... more)
-{
-	clearAllCaches(types);
-	clearAllCaches(more...);
+	for (auto const& e: container)
+		clearCache(e);
 }
 
 void TypeProvider::reset()
 {
-	clearCache(
-		m_boolType,
-		m_inaccessibleDynamicType,
-		m_bytesStorageType,
-		m_bytesMemoryType,
-		m_stringStorageType,
-		m_stringMemoryType,
-		m_emptyTupleType,
-		m_payableAddressType,
-		m_addressType
-	);
-	clearAllCaches(instance().m_intM, instance().m_uintM, instance().m_bytesM, instance().m_magicTypes);
+	clearCache(m_boolType);
+	clearCache(m_inaccessibleDynamicType);
+	clearCache(m_bytesStorageType);
+	clearCache(m_bytesMemoryType);
+	clearCache(m_stringStorageType);
+	clearCache(m_stringMemoryType);
+	clearCache(m_emptyTupleType);
+	clearCache(m_payableAddressType);
+	clearCache(m_addressType);
+	clearCaches(instance().m_intM);
+	clearCaches(instance().m_uintM);
+	clearCaches(instance().m_bytesM);
+	clearCaches(instance().m_magicTypes);
 
 	instance().m_generalTypes.clear();
 	instance().m_stringLiteralTypes.clear();
@@ -498,7 +492,7 @@ ModifierType const* TypeProvider::modifierType(ModifierDefinition const& _def)
 MagicType const* TypeProvider::magicType(MagicType::Kind _kind)
 {
 	solAssert(_kind != MagicType::Kind::MetaType, "MetaType is handled separately");
-	return &m_magicTypes.at(static_cast<size_t>(_kind));
+	return m_magicTypes.at(static_cast<size_t>(_kind)).get();
 }
 
 MagicType const* TypeProvider::metaType(Type const* _type)

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -17,25 +17,12 @@
 
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/ast/TypeProvider.h>
-#include <libdevcore/make_array.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 
 using namespace std;
 using namespace dev;
 using namespace solidity;
-
-template <size_t... N>
-constexpr array<IntegerType, sizeof...(N)> createIntegerTypes(IntegerType::Modifier _modifier, index_sequence<N...>)
-{
-	return make_array<IntegerType>(IntegerType((static_cast<unsigned>(N) + 1) * 8, _modifier)...);
-}
-
-template <size_t... N>
-constexpr array<FixedBytesType, sizeof...(N)> createFixedBytesTypes(index_sequence<N...>)
-{
-	return make_array<FixedBytesType>(FixedBytesType(static_cast<unsigned>(N) + 1)...);
-}
 
 BoolType const TypeProvider::m_boolType{};
 InaccessibleDynamicType const TypeProvider::m_inaccessibleDynamicType{};
@@ -46,9 +33,112 @@ ArrayType const TypeProvider::m_stringMemoryType{DataLocation::Memory, true};
 TupleType const TypeProvider::m_emptyTupleType{};
 AddressType const TypeProvider::m_payableAddressType{StateMutability::Payable};
 AddressType const TypeProvider::m_addressType{StateMutability::NonPayable};
-array<IntegerType, 32> const TypeProvider::m_intM{createIntegerTypes(IntegerType::Modifier::Signed, make_index_sequence<32>{})};
-array<IntegerType, 32> const TypeProvider::m_uintM{createIntegerTypes(IntegerType::Modifier::Unsigned, make_index_sequence<32>{})};
-array<FixedBytesType, 32> const TypeProvider::m_bytesM{createFixedBytesTypes(make_index_sequence<32>{})};
+
+array<IntegerType, 32> const TypeProvider::m_intM{
+	IntegerType{8 * 1, IntegerType::Modifier::Signed},
+	IntegerType{8 * 2, IntegerType::Modifier::Signed},
+	IntegerType{8 * 3, IntegerType::Modifier::Signed},
+	IntegerType{8 * 4, IntegerType::Modifier::Signed},
+	IntegerType{8 * 5, IntegerType::Modifier::Signed},
+	IntegerType{8 * 6, IntegerType::Modifier::Signed},
+	IntegerType{8 * 7, IntegerType::Modifier::Signed},
+	IntegerType{8 * 8, IntegerType::Modifier::Signed},
+	IntegerType{8 * 9, IntegerType::Modifier::Signed},
+	IntegerType{8 * 10, IntegerType::Modifier::Signed},
+	IntegerType{8 * 11, IntegerType::Modifier::Signed},
+	IntegerType{8 * 12, IntegerType::Modifier::Signed},
+	IntegerType{8 * 13, IntegerType::Modifier::Signed},
+	IntegerType{8 * 14, IntegerType::Modifier::Signed},
+	IntegerType{8 * 15, IntegerType::Modifier::Signed},
+	IntegerType{8 * 16, IntegerType::Modifier::Signed},
+	IntegerType{8 * 17, IntegerType::Modifier::Signed},
+	IntegerType{8 * 18, IntegerType::Modifier::Signed},
+	IntegerType{8 * 19, IntegerType::Modifier::Signed},
+	IntegerType{8 * 20, IntegerType::Modifier::Signed},
+	IntegerType{8 * 21, IntegerType::Modifier::Signed},
+	IntegerType{8 * 22, IntegerType::Modifier::Signed},
+	IntegerType{8 * 23, IntegerType::Modifier::Signed},
+	IntegerType{8 * 24, IntegerType::Modifier::Signed},
+	IntegerType{8 * 25, IntegerType::Modifier::Signed},
+	IntegerType{8 * 26, IntegerType::Modifier::Signed},
+	IntegerType{8 * 27, IntegerType::Modifier::Signed},
+	IntegerType{8 * 28, IntegerType::Modifier::Signed},
+	IntegerType{8 * 29, IntegerType::Modifier::Signed},
+	IntegerType{8 * 30, IntegerType::Modifier::Signed},
+	IntegerType{8 * 31, IntegerType::Modifier::Signed},
+	IntegerType{8 * 32, IntegerType::Modifier::Signed}
+};
+
+array<IntegerType, 32> const TypeProvider::m_uintM{
+	IntegerType{8 * 1, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 2, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 3, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 4, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 5, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 6, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 7, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 8, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 9, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 10, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 11, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 12, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 13, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 14, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 15, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 16, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 17, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 18, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 19, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 20, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 21, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 22, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 23, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 24, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 25, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 26, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 27, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 28, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 29, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 30, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 31, IntegerType::Modifier::Unsigned},
+	IntegerType{8 * 32, IntegerType::Modifier::Unsigned}
+};
+
+array<FixedBytesType, 32> const TypeProvider::m_bytesM{
+	FixedBytesType{1},
+	FixedBytesType{2},
+	FixedBytesType{3},
+	FixedBytesType{4},
+	FixedBytesType{5},
+	FixedBytesType{6},
+	FixedBytesType{7},
+	FixedBytesType{8},
+	FixedBytesType{9},
+	FixedBytesType{10},
+	FixedBytesType{11},
+	FixedBytesType{12},
+	FixedBytesType{13},
+	FixedBytesType{14},
+	FixedBytesType{15},
+	FixedBytesType{16},
+	FixedBytesType{17},
+	FixedBytesType{18},
+	FixedBytesType{19},
+	FixedBytesType{20},
+	FixedBytesType{21},
+	FixedBytesType{22},
+	FixedBytesType{23},
+	FixedBytesType{24},
+	FixedBytesType{25},
+	FixedBytesType{26},
+	FixedBytesType{27},
+	FixedBytesType{28},
+	FixedBytesType{29},
+	FixedBytesType{30},
+	FixedBytesType{31},
+	FixedBytesType{32}
+};
+
 array<MagicType, 4> const TypeProvider::m_magicTypes{
 	MagicType{MagicType::Kind::Block},
 	MagicType{MagicType::Kind::Message},

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -1,0 +1,423 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
+#include <libdevcore/make_array.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
+
+using namespace std;
+using namespace dev;
+using namespace solidity;
+
+template <size_t... N>
+constexpr array<IntegerType, sizeof...(N)> createIntegerTypes(IntegerType::Modifier _modifier, index_sequence<N...>)
+{
+	return make_array<IntegerType>(IntegerType((static_cast<unsigned>(N) + 1) * 8, _modifier)...);
+}
+
+template <size_t... N>
+constexpr array<FixedBytesType, sizeof...(N)> createFixedBytesTypes(index_sequence<N...>)
+{
+	return make_array<FixedBytesType>(FixedBytesType(static_cast<unsigned>(N) + 1)...);
+}
+
+BoolType const TypeProvider::m_boolType{};
+InaccessibleDynamicType const TypeProvider::m_inaccessibleDynamicType{};
+ArrayType const TypeProvider::m_bytesStorageType{DataLocation::Storage, false};
+ArrayType const TypeProvider::m_bytesMemoryType{DataLocation::Memory, false};
+ArrayType const TypeProvider::m_stringStorageType{DataLocation::Storage, true};
+ArrayType const TypeProvider::m_stringMemoryType{DataLocation::Memory, true};
+TupleType const TypeProvider::m_emptyTupleType{};
+AddressType const TypeProvider::m_payableAddressType{StateMutability::Payable};
+AddressType const TypeProvider::m_addressType{StateMutability::NonPayable};
+array<IntegerType, 32> const TypeProvider::m_intM{createIntegerTypes(IntegerType::Modifier::Signed, make_index_sequence<32>{})};
+array<IntegerType, 32> const TypeProvider::m_uintM{createIntegerTypes(IntegerType::Modifier::Unsigned, make_index_sequence<32>{})};
+array<FixedBytesType, 32> const TypeProvider::m_bytesM{createFixedBytesTypes(make_index_sequence<32>{})};
+array<MagicType, 4> const TypeProvider::m_magicTypes{
+	MagicType{MagicType::Kind::Block},
+	MagicType{MagicType::Kind::Message},
+	MagicType{MagicType::Kind::Transaction},
+	MagicType{MagicType::Kind::ABI}
+	// MetaType is stored separately
+};
+
+inline void clearCache(Type const& type)
+{
+	type.clearCache();
+}
+
+template <typename... Args>
+inline void clearCache(Type const& type, Args&... moreTypes)
+{
+	clearCache(type);
+	clearCache(moreTypes...);
+}
+
+template <typename Container>
+inline void clearAllCaches(Container& container)
+{
+	for_each(begin(container), end(container), [](Type const& t) { t.clearCache(); });
+}
+
+template <typename Container, typename... Args>
+inline void clearAllCaches(Container& types, Args&... more)
+{
+	clearAllCaches(types);
+	clearAllCaches(more...);
+}
+
+void TypeProvider::reset()
+{
+	clearCache(
+		m_boolType,
+		m_inaccessibleDynamicType,
+		m_bytesStorageType,
+		m_bytesMemoryType,
+		m_stringStorageType,
+		m_stringMemoryType,
+		m_emptyTupleType,
+		m_payableAddressType,
+		m_addressType
+	);
+	clearAllCaches(instance().m_intM, instance().m_uintM, instance().m_bytesM, instance().m_magicTypes);
+
+	instance().m_generalTypes.clear();
+	instance().m_stringLiteralTypes.clear();
+	instance().m_ufixedMxN.clear();
+	instance().m_fixedMxN.clear();
+}
+
+template <typename T, typename... Args>
+inline T const* TypeProvider::createAndGet(Args&& ... _args)
+{
+	instance().m_generalTypes.emplace_back(make_unique<T>(std::forward<Args>(_args)...));
+	return static_cast<T const*>(instance().m_generalTypes.back().get());
+}
+
+Type const* TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken const& _type)
+{
+	solAssert(
+		TokenTraits::isElementaryTypeName(_type.token()),
+		"Expected an elementary type name but got " + _type.toString()
+	);
+
+	unsigned const m = _type.firstNumber();
+	unsigned const n = _type.secondNumber();
+
+	switch (_type.token())
+	{
+	case Token::IntM:
+		return integerType(m, IntegerType::Modifier::Signed);
+	case Token::UIntM:
+		return integerType(m, IntegerType::Modifier::Unsigned);
+	case Token::Byte:
+		return byteType();
+	case Token::BytesM:
+		return fixedBytesType(m);
+	case Token::FixedMxN:
+		return fixedPointType(m, n, FixedPointType::Modifier::Signed);
+	case Token::UFixedMxN:
+		return fixedPointType(m, n, FixedPointType::Modifier::Unsigned);
+	case Token::Int:
+		return integerType(256, IntegerType::Modifier::Signed);
+	case Token::UInt:
+		return integerType(256, IntegerType::Modifier::Unsigned);
+	case Token::Fixed:
+		return fixedPointType(128, 18, FixedPointType::Modifier::Signed);
+	case Token::UFixed:
+		return fixedPointType(128, 18, FixedPointType::Modifier::Unsigned);
+	case Token::Address:
+		return addressType();
+	case Token::Bool:
+		return boolType();
+	case Token::Bytes:
+		return bytesType();
+	case Token::String:
+		return stringType();
+	default:
+		solAssert(
+			false,
+			"Unable to convert elementary typename " + _type.toString() + " to type."
+		);
+	}
+}
+
+TypePointer TypeProvider::fromElementaryTypeName(string const& _name)
+{
+	vector<string> nameParts;
+	boost::split(nameParts, _name, boost::is_any_of(" "));
+	solAssert(nameParts.size() == 1 || nameParts.size() == 2, "Cannot parse elementary type: " + _name);
+
+	Token token;
+	unsigned short firstNum, secondNum;
+	tie(token, firstNum, secondNum) = TokenTraits::fromIdentifierOrKeyword(nameParts[0]);
+
+	auto t = fromElementaryTypeName(ElementaryTypeNameToken(token, firstNum, secondNum));
+	if (auto* ref = dynamic_cast<ReferenceType const*>(t))
+	{
+		DataLocation location = DataLocation::Storage;
+		if (nameParts.size() == 2)
+		{
+			if (nameParts[1] == "storage")
+				location = DataLocation::Storage;
+			else if (nameParts[1] == "calldata")
+				location = DataLocation::CallData;
+			else if (nameParts[1] == "memory")
+				location = DataLocation::Memory;
+			else
+				solAssert(false, "Unknown data location: " + nameParts[1]);
+		}
+		return withLocation(ref, location, true);
+	}
+	else if (t->category() == Type::Category::Address)
+	{
+		if (nameParts.size() == 2)
+		{
+			if (nameParts[1] == "payable")
+				return payableAddressType();
+			else
+				solAssert(false, "Invalid state mutability for address type: " + nameParts[1]);
+		}
+		return addressType();
+	}
+	else
+	{
+		solAssert(nameParts.size() == 1, "Storage location suffix only allowed for reference types");
+		return t;
+	}
+}
+
+TypePointer TypeProvider::forLiteral(Literal const& _literal)
+{
+	switch (_literal.token())
+	{
+	case Token::TrueLiteral:
+	case Token::FalseLiteral:
+		return boolType();
+	case Token::Number:
+		return rationalNumberType(_literal);
+	case Token::StringLiteral:
+		return stringLiteralType(_literal.value());
+	default:
+		return nullptr;
+	}
+}
+
+RationalNumberType const* TypeProvider::rationalNumberType(Literal const& _literal)
+{
+	solAssert(_literal.token() == Token::Number, "");
+	std::tuple<bool, rational> validLiteral = RationalNumberType::isValidLiteral(_literal);
+	if (std::get<0>(validLiteral))
+	{
+		TypePointer compatibleBytesType = nullptr;
+		if (_literal.isHexNumber())
+		{
+			size_t const digitCount = _literal.valueWithoutUnderscores().length() - 2;
+			if (digitCount % 2 == 0 && (digitCount / 2) <= 32)
+				compatibleBytesType = fixedBytesType(digitCount / 2);
+		}
+
+		return rationalNumberType(std::get<1>(validLiteral), compatibleBytesType);
+	}
+	return nullptr;
+}
+
+StringLiteralType const* TypeProvider::stringLiteralType(string const& literal)
+{
+	auto i = instance().m_stringLiteralTypes.find(literal);
+	if (i != instance().m_stringLiteralTypes.end())
+		return i->second.get();
+	else
+		return instance().m_stringLiteralTypes.emplace(literal, make_unique<StringLiteralType>(literal)).first->second.get();
+}
+
+FixedPointType const* TypeProvider::fixedPointType(unsigned m, unsigned n, FixedPointType::Modifier _modifier)
+{
+	auto& map = _modifier == FixedPointType::Modifier::Unsigned ? instance().m_ufixedMxN : instance().m_fixedMxN;
+
+	auto i = map.find(make_pair(m, n));
+	if (i != map.end())
+		return i->second.get();
+
+	return map.emplace(
+		make_pair(m, n),
+		make_unique<FixedPointType>(m, n, _modifier)
+	).first->second.get();
+}
+
+TupleType const* TypeProvider::tupleType(vector<Type const*> members)
+{
+	if (members.empty())
+		return &m_emptyTupleType;
+
+	return createAndGet<TupleType>(move(members));
+}
+
+ReferenceType const* TypeProvider::withLocation(ReferenceType const* _type, DataLocation _location, bool _isPointer)
+{
+	if (_type->location() == _location && _type->isPointer() == _isPointer)
+		return _type;
+
+	instance().m_generalTypes.emplace_back(_type->copyForLocation(_location, _isPointer));
+	return static_cast<ReferenceType const*>(instance().m_generalTypes.back().get());
+}
+
+FunctionType const* TypeProvider::functionType(FunctionDefinition const& _function, bool _isInternal)
+{
+	return createAndGet<FunctionType>(_function, _isInternal);
+}
+
+FunctionType const* TypeProvider::functionType(VariableDeclaration const& _varDecl)
+{
+	return createAndGet<FunctionType>(_varDecl);
+}
+
+FunctionType const* TypeProvider::functionType(EventDefinition const& _def)
+{
+	return createAndGet<FunctionType>(_def);
+}
+
+FunctionType const* TypeProvider::functionType(FunctionTypeName const& _typeName)
+{
+	return createAndGet<FunctionType>(_typeName);
+}
+
+FunctionType const* TypeProvider::functionType(
+	strings const& _parameterTypes,
+	strings const& _returnParameterTypes,
+	FunctionType::Kind _kind,
+	bool _arbitraryParameters,
+	StateMutability _stateMutability
+)
+{
+	return createAndGet<FunctionType>(
+		_parameterTypes, _returnParameterTypes,
+		_kind, _arbitraryParameters, _stateMutability
+	);
+}
+
+FunctionType const* TypeProvider::functionType(
+	TypePointers const& _parameterTypes,
+	TypePointers const& _returnParameterTypes,
+	strings _parameterNames,
+	strings _returnParameterNames,
+	FunctionType::Kind _kind,
+	bool _arbitraryParameters,
+	StateMutability _stateMutability,
+	Declaration const* _declaration,
+	bool _gasSet,
+	bool _valueSet,
+	bool _bound
+)
+{
+	return createAndGet<FunctionType>(
+		_parameterTypes,
+		_returnParameterTypes,
+		_parameterNames,
+		_returnParameterNames,
+		_kind,
+		_arbitraryParameters,
+		_stateMutability,
+		_declaration,
+		_gasSet,
+		_valueSet,
+		_bound
+	);
+}
+
+RationalNumberType const* TypeProvider::rationalNumberType(rational const& _value, Type const* _compatibleBytesType)
+{
+	return createAndGet<RationalNumberType>(_value, _compatibleBytesType);
+}
+
+ArrayType const* TypeProvider::arrayType(DataLocation _location, bool _isString)
+{
+	if (_isString)
+	{
+		if (_location == DataLocation::Storage)
+			return stringType();
+		if (_location == DataLocation::Memory)
+			return stringMemoryType();
+	}
+	else
+	{
+		if (_location == DataLocation::Storage)
+			return bytesType();
+		if (_location == DataLocation::Memory)
+			return bytesMemoryType();
+	}
+	return createAndGet<ArrayType>(_location, _isString);
+}
+
+ArrayType const* TypeProvider::arrayType(DataLocation _location, Type const* _baseType)
+{
+	return createAndGet<ArrayType>(_location, _baseType);
+}
+
+ArrayType const* TypeProvider::arrayType(DataLocation _location, Type const* _baseType, u256 const& _length)
+{
+	return createAndGet<ArrayType>(_location, _baseType, _length);
+}
+
+ContractType const* TypeProvider::contractType(ContractDefinition const& _contractDef, bool _isSuper)
+{
+	return createAndGet<ContractType>(_contractDef, _isSuper);
+}
+
+EnumType const* TypeProvider::enumType(EnumDefinition const& _enumDef)
+{
+	return createAndGet<EnumType>(_enumDef);
+}
+
+ModuleType const* TypeProvider::moduleType(SourceUnit const& _source)
+{
+	return createAndGet<ModuleType>(_source);
+}
+
+TypeType const* TypeProvider::typeType(Type const* _actualType)
+{
+	return createAndGet<TypeType>(_actualType);
+}
+
+StructType const* TypeProvider::structType(StructDefinition const& _struct, DataLocation _location)
+{
+	return createAndGet<StructType>(_struct, _location);
+}
+
+ModifierType const* TypeProvider::modifierType(ModifierDefinition const& _def)
+{
+	return createAndGet<ModifierType>(_def);
+}
+
+MagicType const* TypeProvider::magicType(MagicType::Kind _kind)
+{
+	solAssert(_kind != MagicType::Kind::MetaType, "MetaType is handled separately");
+	return &m_magicTypes.at(static_cast<size_t>(_kind));
+}
+
+MagicType const* TypeProvider::metaType(Type const* _type)
+{
+	solAssert(_type && _type->category() == Type::Category::Contract, "Only contracts supported for now.");
+	return createAndGet<MagicType>(_type);
+}
+
+MappingType const* TypeProvider::mappingType(Type const* _keyType, Type const* _valueType)
+{
+	return createAndGet<MappingType>(_keyType, _valueType);
+}

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -173,7 +173,7 @@ public:
 
 	static TypeType const* typeType(Type const* _actualType);
 
-	static StructType const* structType(StructDefinition const& _struct, DataLocation _location = DataLocation::Storage);
+	static StructType const* structType(StructDefinition const& _struct, DataLocation _location);
 
 	static ModifierType const* modifierType(ModifierDefinition const& _modifierDef);
 

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -66,9 +66,9 @@ public:
 	static FixedBytesType const* byteType() { return fixedBytesType(1); }
 	static FixedBytesType const* fixedBytesType(unsigned m) { return m_bytesM.at(m - 1).get(); }
 
-	static ArrayType const* bytesType();
+	static ArrayType const* bytesStorageType();
 	static ArrayType const* bytesMemoryType();
-	static ArrayType const* stringType();
+	static ArrayType const* stringStorageType();
 	static ArrayType const* stringMemoryType();
 
 	/// Constructor for a byte array ("bytes") and string.

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -64,7 +64,7 @@ public:
 	static BoolType const* boolType() noexcept { return &m_boolType; }
 
 	static FixedBytesType const* byteType() { return fixedBytesType(1); }
-	static FixedBytesType const* fixedBytesType(unsigned m) { return &m_bytesM.at(m - 1); }
+	static FixedBytesType const* fixedBytesType(unsigned m) { return m_bytesM.at(m - 1).get(); }
 
 	static ArrayType const* bytesType() noexcept { return &m_bytesStorageType; }
 	static ArrayType const* bytesMemoryType() noexcept { return &m_bytesMemoryType; }
@@ -87,9 +87,9 @@ public:
 	{
 		solAssert((_bits % 8) == 0, "");
 		if (_modifier == IntegerType::Modifier::Unsigned)
-			return &m_uintM.at(_bits / 8 - 1);
+			return m_uintM.at(_bits / 8 - 1).get();
 		else
-			return &m_intM.at(_bits / 8 - 1);
+			return m_intM.at(_bits / 8 - 1).get();
 	}
 	static IntegerType const* uint(unsigned _bits) { return integerType(_bits, IntegerType::Modifier::Unsigned); }
 
@@ -206,10 +206,10 @@ private:
 	static TupleType const m_emptyTupleType;
 	static AddressType const m_payableAddressType;
 	static AddressType const m_addressType;
-	static std::array<IntegerType, 32> const m_intM;
-	static std::array<IntegerType, 32> const m_uintM;
-	static std::array<FixedBytesType, 32> const m_bytesM;
-	static std::array<MagicType, 4> const m_magicTypes;     ///< MagicType's except MetaType
+	static std::array<std::unique_ptr<IntegerType>, 32> const m_intM;
+	static std::array<std::unique_ptr<IntegerType>, 32> const m_uintM;
+	static std::array<std::unique_ptr<FixedBytesType>, 32> const m_bytesM;
+	static std::array<std::unique_ptr<MagicType>, 4> const m_magicTypes;     ///< MagicType's except MetaType
 
 	std::map<std::pair<unsigned, unsigned>, std::unique_ptr<FixedPointType>> m_ufixedMxN{};
 	std::map<std::pair<unsigned, unsigned>, std::unique_ptr<FixedPointType>> m_fixedMxN{};

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -83,7 +83,7 @@ public:
 	static AddressType const* payableAddressType() noexcept { return &m_payableAddressType; }
 	static AddressType const* addressType() noexcept { return &m_addressType; }
 
-	static IntegerType const* integerType(unsigned _bits = 256, IntegerType::Modifier _modifier = IntegerType::Modifier::Unsigned)
+	static IntegerType const* integerType(unsigned _bits, IntegerType::Modifier _modifier)
 	{
 		solAssert((_bits % 8) == 0, "");
 		if (_modifier == IntegerType::Modifier::Unsigned)
@@ -91,6 +91,9 @@ public:
 		else
 			return &m_intM.at(_bits / 8 - 1);
 	}
+	static IntegerType const* uint(unsigned _bits) { return integerType(_bits, IntegerType::Modifier::Unsigned); }
+
+	static IntegerType const* uint256() { return uint(256); }
 
 	static FixedPointType const* fixedPointType(unsigned m, unsigned n, FixedPointType::Modifier _modifier);
 

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -66,10 +66,10 @@ public:
 	static FixedBytesType const* byteType() { return fixedBytesType(1); }
 	static FixedBytesType const* fixedBytesType(unsigned m) { return m_bytesM.at(m - 1).get(); }
 
-	static ArrayType const* bytesType() noexcept { return &m_bytesStorageType; }
-	static ArrayType const* bytesMemoryType() noexcept { return &m_bytesMemoryType; }
-	static ArrayType const* stringType() noexcept { return &m_stringStorageType; }
-	static ArrayType const* stringMemoryType() noexcept { return &m_stringMemoryType; }
+	static ArrayType const* bytesType();
+	static ArrayType const* bytesMemoryType();
+	static ArrayType const* stringType();
+	static ArrayType const* stringMemoryType();
 
 	/// Constructor for a byte array ("bytes") and string.
 	static ArrayType const* arrayType(DataLocation _location, bool _isString = false);
@@ -199,10 +199,13 @@ private:
 
 	static BoolType const m_boolType;
 	static InaccessibleDynamicType const m_inaccessibleDynamicType;
-	static ArrayType const m_bytesStorageType;
-	static ArrayType const m_bytesMemoryType;
-	static ArrayType const m_stringStorageType;
-	static ArrayType const m_stringMemoryType;
+
+	/// These are lazy-initialized because they depend on `byte` being available.
+	static std::unique_ptr<ArrayType> m_bytesStorageType;
+	static std::unique_ptr<ArrayType> m_bytesMemoryType;
+	static std::unique_ptr<ArrayType> m_stringStorageType;
+	static std::unique_ptr<ArrayType> m_stringMemoryType;
+
 	static TupleType const m_emptyTupleType;
 	static AddressType const m_payableAddressType;
 	static AddressType const m_addressType;

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -1,0 +1,218 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolidity/ast/Types.h>
+
+#include <array>
+#include <map>
+#include <memory>
+#include <utility>
+
+namespace dev
+{
+namespace solidity
+{
+
+/**
+ * API for accessing the Solidity Type System.
+ *
+ * This is the Solidity Compiler's type provider. Use it to request for types. The caller does
+ * <b>not</b> own the types.
+ *
+ * It is not recommended to explicitly instantiate types unless you really know what and why
+ * you are doing it.
+ */
+class TypeProvider
+{
+public:
+	TypeProvider() = default;
+	TypeProvider(TypeProvider&&) = default;
+	TypeProvider(TypeProvider const&) = delete;
+	TypeProvider& operator=(TypeProvider&&) = default;
+	TypeProvider& operator=(TypeProvider const&) = delete;
+	~TypeProvider() = default;
+
+	/// Resets state of this TypeProvider to initial state, wiping all mutable types.
+	/// This invalidates all dangling pointers to types provided by this TypeProvider.
+	static void reset();
+
+	/// @name Factory functions
+	/// Factory functions that convert an AST @ref TypeName to a Type.
+	static Type const* fromElementaryTypeName(ElementaryTypeNameToken const& _type);
+
+	/// Converts a given elementary type name with optional data location
+	/// suffix " storage", " calldata" or " memory" to a type pointer. If suffix not given, defaults to " storage".
+	static TypePointer fromElementaryTypeName(std::string const& _name);
+
+	/// @returns boolean type.
+	static BoolType const* boolType() noexcept { return &m_boolType; }
+
+	static FixedBytesType const* byteType() { return fixedBytesType(1); }
+	static FixedBytesType const* fixedBytesType(unsigned m) { return &m_bytesM.at(m - 1); }
+
+	static ArrayType const* bytesType() noexcept { return &m_bytesStorageType; }
+	static ArrayType const* bytesMemoryType() noexcept { return &m_bytesMemoryType; }
+	static ArrayType const* stringType() noexcept { return &m_stringStorageType; }
+	static ArrayType const* stringMemoryType() noexcept { return &m_stringMemoryType; }
+
+	/// Constructor for a byte array ("bytes") and string.
+	static ArrayType const* arrayType(DataLocation _location, bool _isString = false);
+
+	/// Constructor for a dynamically sized array type ("type[]")
+	static ArrayType const* arrayType(DataLocation _location, Type const* _baseType);
+
+	/// Constructor for a fixed-size array type ("type[20]")
+	static ArrayType const* arrayType(DataLocation _location, Type const* _baseType, u256 const& _length);
+
+	static AddressType const* payableAddressType() noexcept { return &m_payableAddressType; }
+	static AddressType const* addressType() noexcept { return &m_addressType; }
+
+	static IntegerType const* integerType(unsigned _bits = 256, IntegerType::Modifier _modifier = IntegerType::Modifier::Unsigned)
+	{
+		solAssert((_bits % 8) == 0, "");
+		if (_modifier == IntegerType::Modifier::Unsigned)
+			return &m_uintM.at(_bits / 8 - 1);
+		else
+			return &m_intM.at(_bits / 8 - 1);
+	}
+
+	static FixedPointType const* fixedPointType(unsigned m, unsigned n, FixedPointType::Modifier _modifier);
+
+	static StringLiteralType const* stringLiteralType(std::string const& literal);
+
+	/// @param members the member types the tuple type must contain. This is passed by value on purspose.
+	/// @returns a tuple type with the given members.
+	static TupleType const* tupleType(std::vector<Type const*> members);
+
+	static TupleType const* emptyTupleType() noexcept { return &m_emptyTupleType; }
+
+	static ReferenceType const* withLocation(ReferenceType const* _type, DataLocation _location, bool _isPointer);
+
+	/// @returns a copy of @a _type having the same location as this (and is not a pointer type)
+	///          if _type is a reference type and an unmodified copy of _type otherwise.
+	///          This function is mostly useful to modify inner types appropriately.
+	static Type const* withLocationIfReference(DataLocation _location, Type const* _type)
+	{
+		if (auto refType = dynamic_cast<ReferenceType const*>(_type))
+			return withLocation(refType, _location, false);
+
+		return _type;
+	}
+
+	/// @returns the internally-facing or externally-facing type of a function.
+	static FunctionType const* functionType(FunctionDefinition const& _function, bool _isInternal = true);
+
+	/// @returns the accessor function type of a state variable.
+	static FunctionType const* functionType(VariableDeclaration const& _varDecl);
+
+	/// @returns the function type of an event.
+	static FunctionType const* functionType(EventDefinition const& _event);
+
+	/// @returns the type of a function type name.
+	static FunctionType const* functionType(FunctionTypeName const& _typeName);
+
+	/// @returns the function type to be used for a plain type (not derived from a declaration).
+	static FunctionType const* functionType(
+		strings const& _parameterTypes,
+		strings const& _returnParameterTypes,
+		FunctionType::Kind _kind = FunctionType::Kind::Internal,
+		bool _arbitraryParameters = false,
+		StateMutability _stateMutability = StateMutability::NonPayable
+	);
+
+	/// @returns a highly customized FunctionType, use with care.
+	static FunctionType const* functionType(
+		TypePointers const& _parameterTypes,
+		TypePointers const& _returnParameterTypes,
+		strings _parameterNames = strings{},
+		strings _returnParameterNames = strings{},
+		FunctionType::Kind _kind = FunctionType::Kind::Internal,
+		bool _arbitraryParameters = false,
+		StateMutability _stateMutability = StateMutability::NonPayable,
+		Declaration const* _declaration = nullptr,
+		bool _gasSet = false,
+		bool _valueSet = false,
+		bool _bound = false
+	);
+
+	/// Auto-detect the proper type for a literal. @returns an empty pointer if the literal does
+	/// not fit any type.
+	static TypePointer forLiteral(Literal const& _literal);
+	static RationalNumberType const* rationalNumberType(Literal const& _literal);
+
+	static RationalNumberType const* rationalNumberType(
+		rational const& _value,
+		Type const* _compatibleBytesType = nullptr
+	);
+
+	static ContractType const* contractType(ContractDefinition const& _contract, bool _isSuper = false);
+
+	static InaccessibleDynamicType const* inaccessibleDynamicType() noexcept { return &m_inaccessibleDynamicType; }
+
+	/// @returns the type of an enum instance for given definition, there is one distinct type per enum definition.
+	static EnumType const* enumType(EnumDefinition const& _enum);
+
+	/// @returns special type for imported modules. These mainly give access to their scope via members.
+	static ModuleType const* moduleType(SourceUnit const& _source);
+
+	static TypeType const* typeType(Type const* _actualType);
+
+	static StructType const* structType(StructDefinition const& _struct, DataLocation _location = DataLocation::Storage);
+
+	static ModifierType const* modifierType(ModifierDefinition const& _modifierDef);
+
+	static MagicType const* magicType(MagicType::Kind _kind);
+
+	static MagicType const* metaType(Type const* _type);
+
+	static MappingType const* mappingType(Type const* _keyType, Type const* _valueType);
+
+private:
+	/// Global TypeProvider instance.
+	static TypeProvider& instance()
+	{
+		static TypeProvider _provider;
+		return _provider;
+	}
+
+	template <typename T, typename... Args>
+	static inline T const* createAndGet(Args&& ... _args);
+
+	static BoolType const m_boolType;
+	static InaccessibleDynamicType const m_inaccessibleDynamicType;
+	static ArrayType const m_bytesStorageType;
+	static ArrayType const m_bytesMemoryType;
+	static ArrayType const m_stringStorageType;
+	static ArrayType const m_stringMemoryType;
+	static TupleType const m_emptyTupleType;
+	static AddressType const m_payableAddressType;
+	static AddressType const m_addressType;
+	static std::array<IntegerType, 32> const m_intM;
+	static std::array<IntegerType, 32> const m_uintM;
+	static std::array<FixedBytesType, 32> const m_bytesM;
+	static std::array<MagicType, 4> const m_magicTypes;     ///< MagicType's except MetaType
+
+	std::map<std::pair<unsigned, unsigned>, std::unique_ptr<FixedPointType>> m_ufixedMxN{};
+	std::map<std::pair<unsigned, unsigned>, std::unique_ptr<FixedPointType>> m_fixedMxN{};
+	std::map<std::string, std::unique_ptr<StringLiteralType>> m_stringLiteralTypes{};
+	std::vector<std::unique_ptr<Type>> m_generalTypes{};
+};
+
+} // namespace solidity
+} // namespace dev

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -23,6 +23,7 @@
 #include <libsolidity/ast/Types.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 
 #include <libdevcore/Algorithms.h>
 #include <libdevcore/CommonData.h>
@@ -141,12 +142,17 @@ BoolResult fitsIntegerType(bigint const& _value, IntegerType const& _type)
 /// if _signed is true.
 bool fitsIntoBits(bigint const& _value, unsigned _bits, bool _signed)
 {
-	return fitsIntegerType(_value, IntegerType(
+	return fitsIntegerType(_value, *TypeProvider::integerType(
 		_bits,
 		_signed ? IntegerType::Modifier::Signed : IntegerType::Modifier::Unsigned
 	));
 }
 
+}
+
+void Type::clearCache() const
+{
+	m_members.clear();
 }
 
 void StorageOffsets::computeOffsets(TypePointers const& _types)
@@ -156,7 +162,7 @@ void StorageOffsets::computeOffsets(TypePointers const& _types)
 	map<size_t, pair<u256, unsigned>> offsets;
 	for (size_t i = 0; i < _types.size(); ++i)
 	{
-		TypePointer const& type = _types[i];
+		Type const* type = _types[i];
 		if (!type->canBeStored())
 			continue;
 		if (byteOffset + type->storageBytes() > 32)
@@ -237,7 +243,7 @@ string identifierList(Range const&& _list)
 	return parenthesizeIdentifier(boost::algorithm::join(_list, ","));
 }
 
-string richIdentifier(TypePointer const& _type)
+string richIdentifier(Type const* _type)
 {
 	return _type ? _type->richIdentifier() : "";
 }
@@ -247,12 +253,12 @@ string identifierList(vector<TypePointer> const& _list)
 	return identifierList(_list | boost::adaptors::transformed(richIdentifier));
 }
 
-string identifierList(TypePointer const& _type)
+string identifierList(Type const* _type)
 {
 	return parenthesizeIdentifier(richIdentifier(_type));
 }
 
-string identifierList(TypePointer const& _type1, TypePointer const& _type2)
+string identifierList(Type const* _type1, Type const* _type2)
 {
 	TypePointers list;
 	list.push_back(_type1);
@@ -289,124 +295,16 @@ string Type::identifier() const
 	return ret;
 }
 
-TypePointer Type::fromElementaryTypeName(ElementaryTypeNameToken const& _type)
-{
-	solAssert(TokenTraits::isElementaryTypeName(_type.token()),
-		"Expected an elementary type name but got " + _type.toString()
-	);
-
-	Token token = _type.token();
-	unsigned m = _type.firstNumber();
-	unsigned n = _type.secondNumber();
-
-	switch (token)
-	{
-	case Token::IntM:
-		return make_shared<IntegerType>(m, IntegerType::Modifier::Signed);
-	case Token::UIntM:
-		return make_shared<IntegerType>(m, IntegerType::Modifier::Unsigned);
-	case Token::BytesM:
-		return make_shared<FixedBytesType>(m);
-	case Token::FixedMxN:
-		return make_shared<FixedPointType>(m, n, FixedPointType::Modifier::Signed);
-	case Token::UFixedMxN:
-		return make_shared<FixedPointType>(m, n, FixedPointType::Modifier::Unsigned);
-	case Token::Int:
-		return make_shared<IntegerType>(256, IntegerType::Modifier::Signed);
-	case Token::UInt:
-		return make_shared<IntegerType>(256, IntegerType::Modifier::Unsigned);
-	case Token::Fixed:
-		return make_shared<FixedPointType>(128, 18, FixedPointType::Modifier::Signed);
-	case Token::UFixed:
-		return make_shared<FixedPointType>(128, 18, FixedPointType::Modifier::Unsigned);
-	case Token::Byte:
-		return make_shared<FixedBytesType>(1);
-	case Token::Address:
-		return make_shared<AddressType>(StateMutability::NonPayable);
-	case Token::Bool:
-		return make_shared<BoolType>();
-	case Token::Bytes:
-		return make_shared<ArrayType>(DataLocation::Storage);
-	case Token::String:
-		return make_shared<ArrayType>(DataLocation::Storage, true);
-	//no types found
-	default:
-		solAssert(
-			false,
-			"Unable to convert elementary typename " + _type.toString() + " to type."
-		);
-	}
-}
-
-TypePointer Type::fromElementaryTypeName(string const& _name)
-{
-	vector<string> nameParts;
-	boost::split(nameParts, _name, boost::is_any_of(" "));
-	solAssert(nameParts.size() == 1 || nameParts.size() == 2, "Cannot parse elementary type: " + _name);
-	Token token;
-	unsigned short firstNum, secondNum;
-	tie(token, firstNum, secondNum) = TokenTraits::fromIdentifierOrKeyword(nameParts[0]);
-	auto t = fromElementaryTypeName(ElementaryTypeNameToken(token, firstNum, secondNum));
-	if (auto* ref = dynamic_cast<ReferenceType const*>(t.get()))
-	{
-		DataLocation location = DataLocation::Storage;
-		if (nameParts.size() == 2)
-		{
-			if (nameParts[1] == "storage")
-				location = DataLocation::Storage;
-			else if (nameParts[1] == "calldata")
-				location = DataLocation::CallData;
-			else if (nameParts[1] == "memory")
-				location = DataLocation::Memory;
-			else
-				solAssert(false, "Unknown data location: " + nameParts[1]);
-		}
-		return ref->copyForLocation(location, true);
-	}
-	else if (t->category() == Type::Category::Address)
-	{
-		if (nameParts.size() == 2)
-		{
-			if (nameParts[1] == "payable")
-				return make_shared<AddressType>(StateMutability::Payable);
-			else
-				solAssert(false, "Invalid state mutability for address type: " + nameParts[1]);
-		}
-		return make_shared<AddressType>(StateMutability::NonPayable);
-	}
-	else
-	{
-		solAssert(nameParts.size() == 1, "Storage location suffix only allowed for reference types");
-		return t;
-	}
-}
-
-TypePointer Type::forLiteral(Literal const& _literal)
-{
-	switch (_literal.token())
-	{
-	case Token::TrueLiteral:
-	case Token::FalseLiteral:
-		return make_shared<BoolType>();
-	case Token::Number:
-		return RationalNumberType::forLiteral(_literal);
-	case Token::StringLiteral:
-		return make_shared<StringLiteralType>(_literal);
-	default:
-		return TypePointer();
-	}
-}
-
-TypePointer Type::commonType(TypePointer const& _a, TypePointer const& _b)
+TypePointer Type::commonType(Type const* _a, Type const* _b)
 {
 	if (!_a || !_b)
-		return TypePointer();
+		return nullptr;
 	else if (_a->mobileType() && _b->isImplicitlyConvertibleTo(*_a->mobileType()))
 		return _a->mobileType();
 	else if (_b->mobileType() && _a->isImplicitlyConvertibleTo(*_b->mobileType()))
 		return _b->mobileType();
 	else
-		return TypePointer();
+		return nullptr;
 }
 
 MemberList const& Type::members(ContractDefinition const* _currentScope) const
@@ -434,18 +332,18 @@ TypePointer Type::fullEncodingType(bool _inLibraryCall, bool _encoderV2, bool) c
 	if (_inLibraryCall && encodingType->dataStoredIn(DataLocation::Storage))
 		return encodingType;
 	TypePointer baseType = encodingType;
-	while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType.get()))
+	while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType))
 		baseType = arrayType->baseType();
-	if (dynamic_cast<StructType const*>(baseType.get()))
+	if (dynamic_cast<StructType const*>(baseType))
 		if (!_encoderV2)
-			return TypePointer();
+			return nullptr;
 	return encodingType;
 }
 
 MemberList::MemberMap Type::boundFunctions(Type const& _type, ContractDefinition const& _scope)
 {
 	// Normalise data location of type.
-	TypePointer type = ReferenceType::copyForLocationIfReference(DataLocation::Storage, _type.shared_from_this());
+	TypePointer type = ReferenceType::copyForLocationIfReference(DataLocation::Storage, &_type);
 	set<Declaration const*> seenFunctions;
 	MemberList::MemberMap members;
 	for (ContractDefinition const* contract: _scope.annotation().linearizedBaseContracts)
@@ -528,16 +426,16 @@ u256 AddressType::literalValue(Literal const* _literal) const
 
 TypeResult AddressType::unaryOperatorResult(Token _operator) const
 {
-	return _operator == Token::Delete ? make_shared<TupleType>() : TypePointer();
+	return _operator == Token::Delete ? TypeProvider::emptyTupleType() : nullptr;
 }
 
 
-TypeResult AddressType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult AddressType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
 	if (!TokenTraits::isCompareOp(_operator))
 		return TypeResult::err("Arithmetic operations on addresses are not supported. Convert to integer first before using them.");
 
-	return Type::commonType(shared_from_this(), _other);
+	return Type::commonType(this, _other);
 }
 
 bool AddressType::operator==(Type const& _other) const
@@ -551,16 +449,16 @@ bool AddressType::operator==(Type const& _other) const
 MemberList::MemberMap AddressType::nativeMembers(ContractDefinition const*) const
 {
 	MemberList::MemberMap members = {
-		{"balance", make_shared<IntegerType>(256)},
-		{"call", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareCall, false, StateMutability::Payable)},
-		{"callcode", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareCallCode, false, StateMutability::Payable)},
-		{"delegatecall", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareDelegateCall, false)},
-		{"staticcall", make_shared<FunctionType>(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareStaticCall, false, StateMutability::View)}
+		{"balance", TypeProvider::integerType(256)},
+		{"call", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareCall, false, StateMutability::Payable)},
+		{"callcode", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareCallCode, false, StateMutability::Payable)},
+		{"delegatecall", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareDelegateCall, false, StateMutability::NonPayable)},
+		{"staticcall", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareStaticCall, false, StateMutability::View)}
 	};
 	if (m_stateMutability == StateMutability::Payable)
 	{
-		members.emplace_back(MemberList::Member{"send", make_shared<FunctionType>(strings{"uint"}, strings{"bool"}, FunctionType::Kind::Send)});
-		members.emplace_back(MemberList::Member{"transfer", make_shared<FunctionType>(strings{"uint"}, strings(), FunctionType::Kind::Transfer)});
+		members.emplace_back(MemberList::Member{"send", TypeProvider::functionType(strings{"uint"}, strings{"bool"}, FunctionType::Kind::Send, false, StateMutability::NonPayable)});
+		members.emplace_back(MemberList::Member{"transfer", TypeProvider::functionType(strings{"uint"}, strings(), FunctionType::Kind::Transfer, false, StateMutability::NonPayable)});
 	}
 	return members;
 }
@@ -632,11 +530,11 @@ TypeResult IntegerType::unaryOperatorResult(Token _operator) const
 {
 	// "delete" is ok for all integer types
 	if (_operator == Token::Delete)
-		return TypeResult{make_shared<TupleType>()};
+		return TypeResult{TypeProvider::emptyTupleType()};
 	// we allow -, ++ and --
 	else if (_operator == Token::Sub || _operator == Token::Inc ||
 		_operator == Token::Dec || _operator == Token::BitNot)
-		return TypeResult{shared_from_this()};
+		return TypeResult{this};
 	else
 		return TypeResult::err("");
 }
@@ -671,40 +569,40 @@ bigint IntegerType::maxValue() const
 		return (bigint(1) << m_bits) - 1;
 }
 
-TypeResult IntegerType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult IntegerType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
 	if (
 		_other->category() != Category::RationalNumber &&
 		_other->category() != Category::FixedPoint &&
 		_other->category() != category()
 	)
-		return TypePointer();
+		return nullptr;
 	if (TokenTraits::isShiftOp(_operator))
 	{
 		// Shifts are not symmetric with respect to the type
 		if (isValidShiftAndAmountType(_operator, *_other))
-			return shared_from_this();
+			return this;
 		else
-			return TypePointer();
+			return nullptr;
 	}
 
-	auto commonType = Type::commonType(shared_from_this(), _other); //might be an integer or fixed point
+	auto commonType = Type::commonType(this, _other); //might be an integer or fixed point
 	if (!commonType)
-		return TypePointer();
+		return nullptr;
 
 	// All integer types can be compared
 	if (TokenTraits::isCompareOp(_operator))
 		return commonType;
 	if (TokenTraits::isBooleanOp(_operator))
-		return TypePointer();
-	if (auto intType = dynamic_pointer_cast<IntegerType const>(commonType))
+		return nullptr;
+	if (auto intType = dynamic_cast<IntegerType const*>(commonType))
 	{
 		if (Token::Exp == _operator && intType->isSigned())
 			return TypeResult::err("Exponentiation is not allowed for signed integer types.");
 	}
-	else if (auto fixType = dynamic_pointer_cast<FixedPointType const>(commonType))
+	else if (dynamic_cast<FixedPointType const*>(commonType))
 		if (Token::Exp == _operator)
-			return TypePointer();
+			return nullptr;
 	return commonType;
 }
 
@@ -749,15 +647,15 @@ TypeResult FixedPointType::unaryOperatorResult(Token _operator) const
 	{
 	case Token::Delete:
 		// "delete" is ok for all fixed types
-		return TypeResult(make_shared<TupleType>());
+		return TypeResult{TypeProvider::emptyTupleType()};
 	case Token::Add:
 	case Token::Sub:
 	case Token::Inc:
 	case Token::Dec:
 		// for fixed, we allow +, -, ++ and --
-		return shared_from_this();
+		return this;
 	default:
-		return TypePointer();
+		return nullptr;
 	}
 }
 
@@ -792,24 +690,24 @@ bigint FixedPointType::minIntegerValue() const
 		return bigint(0);
 }
 
-TypeResult FixedPointType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult FixedPointType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
-	auto commonType = Type::commonType(shared_from_this(), _other);
+	auto commonType = Type::commonType(this, _other);
 
 	if (!commonType)
-		return TypePointer();
+		return nullptr;
 
 	// All fixed types can be compared
 	if (TokenTraits::isCompareOp(_operator))
 		return commonType;
 	if (TokenTraits::isBitOp(_operator) || TokenTraits::isBooleanOp(_operator) || _operator == Token::Exp)
-		return TypePointer();
+		return nullptr;
 	return commonType;
 }
 
-std::shared_ptr<IntegerType> FixedPointType::asIntegerType() const
+IntegerType const* FixedPointType::asIntegerType() const
 {
-	return make_shared<IntegerType>(numBits(), isSigned() ? IntegerType::Modifier::Signed : IntegerType::Modifier::Unsigned);
+	return TypeProvider::integerType(numBits(), isSigned() ? IntegerType::Modifier::Signed : IntegerType::Modifier::Unsigned);
 }
 
 tuple<bool, rational> RationalNumberType::parseRational(string const& _value)
@@ -853,25 +751,6 @@ tuple<bool, rational> RationalNumberType::parseRational(string const& _value)
 	{
 		return make_tuple(false, rational(0));
 	}
-}
-
-TypePointer RationalNumberType::forLiteral(Literal const& _literal)
-{
-	solAssert(_literal.token() == Token::Number, "");
-	tuple<bool, rational> validLiteral = isValidLiteral(_literal);
-	if (get<0>(validLiteral))
-	{
-		TypePointer compatibleBytesType;
-		if (_literal.isHexNumber())
-		{
-			size_t const digitCount = _literal.valueWithoutUnderscores().length() - 2;
-			if (digitCount % 2 == 0 && (digitCount / 2) <= 32)
-				compatibleBytesType = make_shared<FixedBytesType>(digitCount / 2);
-		}
-
-		return make_shared<RationalNumberType>(get<1>(validLiteral), compatibleBytesType);
-	}
-	return TypePointer();
 }
 
 tuple<bool, rational> RationalNumberType::isValidLiteral(Literal const& _literal)
@@ -1030,7 +909,7 @@ TypeResult RationalNumberType::unaryOperatorResult(Token _operator) const
 	{
 	case Token::BitNot:
 		if (isFractional())
-			return TypePointer();
+			return nullptr;
 		value = ~m_value.numerator();
 		break;
 	case Token::Add:
@@ -1040,24 +919,24 @@ TypeResult RationalNumberType::unaryOperatorResult(Token _operator) const
 		value = -(m_value);
 		break;
 	case Token::After:
-		return shared_from_this();
+		return this;
 	default:
-		return TypePointer();
+		return nullptr;
 	}
-	return TypeResult(make_shared<RationalNumberType>(value));
+	return TypeResult{TypeProvider::rationalNumberType(value)};
 }
 
-TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult RationalNumberType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
 	if (_other->category() == Category::Integer || _other->category() == Category::FixedPoint)
 	{
-		auto commonType = Type::commonType(shared_from_this(), _other);
+		auto commonType = Type::commonType(this, _other);
 		if (!commonType)
-			return TypePointer();
+			return nullptr;
 		return commonType->binaryOperatorResult(_operator, _other);
 	}
 	else if (_other->category() != category())
-		return TypePointer();
+		return nullptr;
 
 	RationalNumberType const& other = dynamic_cast<RationalNumberType const&>(*_other);
 	if (TokenTraits::isCompareOp(_operator))
@@ -1068,7 +947,7 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 		TypePointer thisMobile = mobileType();
 		TypePointer otherMobile = other.mobileType();
 		if (!thisMobile || !otherMobile)
-			return TypePointer();
+			return nullptr;
 		return thisMobile->binaryOperatorResult(_operator, otherMobile);
 	}
 	else
@@ -1080,17 +959,17 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 		//bit operations will only be enabled for integers and fixed types that resemble integers
 		case Token::BitOr:
 			if (fractional)
-				return TypePointer();
+				return nullptr;
 			value = m_value.numerator() | other.m_value.numerator();
 			break;
 		case Token::BitXor:
 			if (fractional)
-				return TypePointer();
+				return nullptr;
 			value = m_value.numerator() ^ other.m_value.numerator();
 			break;
 		case Token::BitAnd:
 			if (fractional)
-				return TypePointer();
+				return nullptr;
 			value = m_value.numerator() & other.m_value.numerator();
 			break;
 		case Token::Add:
@@ -1104,13 +983,13 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 			break;
 		case Token::Div:
 			if (other.m_value == rational(0))
-				return TypePointer();
+				return nullptr;
 			else
 				value = m_value / other.m_value;
 			break;
 		case Token::Mod:
 			if (other.m_value == rational(0))
-				return TypePointer();
+				return nullptr;
 			else if (fractional)
 			{
 				rational tempValue = m_value / other.m_value;
@@ -1122,7 +1001,7 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 		case Token::Exp:
 		{
 			if (other.isFractional())
-				return TypePointer();
+				return nullptr;
 			solAssert(other.m_value.denominator() == 1, "");
 			bigint const& exp = other.m_value.numerator();
 
@@ -1140,7 +1019,7 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 			else
 			{
 				if (abs(exp) > numeric_limits<uint32_t>::max())
-					return TypePointer(); // This will need too much memory to represent.
+					return nullptr; // This will need too much memory to represent.
 
 				uint32_t absExp = bigint(abs(exp)).convert_to<uint32_t>();
 
@@ -1170,18 +1049,18 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 		case Token::SHL:
 		{
 			if (fractional)
-				return TypePointer();
+				return nullptr;
 			else if (other.m_value < 0)
-				return TypePointer();
+				return nullptr;
 			else if (other.m_value > numeric_limits<uint32_t>::max())
-				return TypePointer();
+				return nullptr;
 			if (m_value.numerator() == 0)
 				value = 0;
 			else
 			{
 				uint32_t exponent = other.m_value.numerator().convert_to<uint32_t>();
 				if (!fitsPrecisionBase2(abs(m_value.numerator()), exponent))
-					return TypePointer();
+					return nullptr;
 				value = m_value.numerator() * boost::multiprecision::pow(bigint(2), exponent);
 			}
 			break;
@@ -1191,11 +1070,11 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 		case Token::SAR:
 		{
 			if (fractional)
-				return TypePointer();
+				return nullptr;
 			else if (other.m_value < 0)
-				return TypePointer();
+				return nullptr;
 			else if (other.m_value > numeric_limits<uint32_t>::max())
-				return TypePointer();
+				return nullptr;
 			if (m_value.numerator() == 0)
 				value = 0;
 			else
@@ -1221,14 +1100,14 @@ TypeResult RationalNumberType::binaryOperatorResult(Token _operator, TypePointer
 			break;
 		}
 		default:
-			return TypePointer();
+			return nullptr;
 		}
 
 		// verify that numerator and denominator fit into 4096 bit after every operation
 		if (value.numerator() != 0 && max(mostSignificantBit(abs(value.numerator())), mostSignificantBit(abs(value.denominator()))) > 4096)
 			return TypeResult::err("Precision of rational constants is limited to 4096 bits.");
 
-		return TypeResult(make_shared<RationalNumberType>(value));
+		return TypeResult{TypeProvider::rationalNumberType(value)};
 	}
 }
 
@@ -1310,7 +1189,7 @@ TypePointer RationalNumberType::mobileType() const
 		return fixedPointType();
 }
 
-shared_ptr<IntegerType const> RationalNumberType::integerType() const
+IntegerType const* RationalNumberType::integerType() const
 {
 	solAssert(!isFractional(), "integerType() called for fractional number.");
 	bigint value = m_value.numerator();
@@ -1318,15 +1197,15 @@ shared_ptr<IntegerType const> RationalNumberType::integerType() const
 	if (negative) // convert to positive number of same bit requirements
 		value = ((0 - value) - 1) << 1;
 	if (value > u256(-1))
-		return shared_ptr<IntegerType const>();
+		return nullptr;
 	else
-		return make_shared<IntegerType>(
+		return TypeProvider::integerType(
 			max(bytesRequired(value), 1u) * 8,
 			negative ? IntegerType::Modifier::Signed : IntegerType::Modifier::Unsigned
 		);
 }
 
-shared_ptr<FixedPointType const> RationalNumberType::fixedPointType() const
+FixedPointType const* RationalNumberType::fixedPointType() const
 {
 	bool negative = (m_value < 0);
 	unsigned fractionalDigits = 0;
@@ -1342,7 +1221,8 @@ shared_ptr<FixedPointType const> RationalNumberType::fixedPointType() const
 	}
 
 	if (value > maxValue)
-		return shared_ptr<FixedPointType const>();
+		return nullptr;
+
 	// This means we round towards zero for positive and negative values.
 	bigint v = value.numerator() / value.denominator();
 
@@ -1352,12 +1232,12 @@ shared_ptr<FixedPointType const> RationalNumberType::fixedPointType() const
 		v = (v - 1) << 1;
 
 	if (v > u256(-1))
-		return shared_ptr<FixedPointType const>();
+		return nullptr;
 
 	unsigned totalBits = max(bytesRequired(v), 1u) * 8;
 	solAssert(totalBits <= 256, "");
 
-	return make_shared<FixedPointType>(
+	return TypeProvider::fixedPointType(
 		totalBits, fractionalDigits,
 		negative ? FixedPointType::Modifier::Signed : FixedPointType::Modifier::Unsigned
 	);
@@ -1365,6 +1245,11 @@ shared_ptr<FixedPointType const> RationalNumberType::fixedPointType() const
 
 StringLiteralType::StringLiteralType(Literal const& _literal):
 	m_value(_literal.value())
+{
+}
+
+StringLiteralType::StringLiteralType(string const& _value):
+	m_value{_value}
 {
 }
 
@@ -1407,7 +1292,7 @@ std::string StringLiteralType::toString(bool) const
 
 TypePointer StringLiteralType::mobileType() const
 {
-	return make_shared<ArrayType>(DataLocation::Memory, true);
+	return TypeProvider::stringMemoryType();
 }
 
 bool StringLiteralType::isValidUTF8() const
@@ -1443,37 +1328,37 @@ TypeResult FixedBytesType::unaryOperatorResult(Token _operator) const
 {
 	// "delete" and "~" is okay for FixedBytesType
 	if (_operator == Token::Delete)
-		return TypeResult(make_shared<TupleType>());
+		return TypeResult{TypeProvider::emptyTupleType()};
 	else if (_operator == Token::BitNot)
-		return shared_from_this();
+		return this;
 
-	return TypePointer();
+	return nullptr;
 }
 
-TypeResult FixedBytesType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult FixedBytesType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
 	if (TokenTraits::isShiftOp(_operator))
 	{
 		if (isValidShiftAndAmountType(_operator, *_other))
-			return shared_from_this();
+			return this;
 		else
-			return TypePointer();
+			return nullptr;
 	}
 
-	auto commonType = dynamic_pointer_cast<FixedBytesType const>(Type::commonType(shared_from_this(), _other));
+	auto commonType = dynamic_cast<FixedBytesType const*>(Type::commonType(this, _other));
 	if (!commonType)
-		return TypePointer();
+		return nullptr;
 
 	// FixedBytes can be compared and have bitwise operators applied to them
 	if (TokenTraits::isCompareOp(_operator) || TokenTraits::isBitOp(_operator))
 		return TypeResult(commonType);
 
-	return TypePointer();
+	return nullptr;
 }
 
 MemberList::MemberMap FixedBytesType::nativeMembers(ContractDefinition const*) const
 {
-	return MemberList::MemberMap{MemberList::Member{"length", make_shared<IntegerType>(8)}};
+	return MemberList::MemberMap{MemberList::Member{"length", TypeProvider::integerType(8)}};
 }
 
 string FixedBytesType::richIdentifier() const
@@ -1503,18 +1388,32 @@ u256 BoolType::literalValue(Literal const* _literal) const
 TypeResult BoolType::unaryOperatorResult(Token _operator) const
 {
 	if (_operator == Token::Delete)
-		return TypeResult(make_shared<TupleType>());
-	return (_operator == Token::Not) ? shared_from_this() : TypePointer();
+		return TypeProvider::emptyTupleType(); // TODO: Lag of understanding.
+	else if (_operator == Token::Not)
+		return this;
+	else
+		return nullptr;
 }
 
-TypeResult BoolType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult BoolType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
 	if (category() != _other->category())
-		return TypePointer();
+		return nullptr;
 	if (_operator == Token::Equal || _operator == Token::NotEqual || _operator == Token::And || _operator == Token::Or)
 		return _other;
 	else
-		return TypePointer();
+		return nullptr;
+}
+
+Type const* ContractType::encodingType() const
+{
+	if (isSuper())
+		return nullptr;
+
+	if (isPayable())
+		return TypeProvider::payableAddressType();
+	else
+		return TypeProvider::addressType();
 }
 
 BoolResult ContractType::isImplicitlyConvertibleTo(Type const& _convertTo) const
@@ -1550,36 +1449,44 @@ bool ContractType::isPayable() const
 TypeResult ContractType::unaryOperatorResult(Token _operator) const
 {
 	if (isSuper())
-		return TypePointer{};
-	return _operator == Token::Delete ? make_shared<TupleType>() : TypePointer();
+		return nullptr;
+	else if (_operator == Token::Delete)
+		return TypeProvider::emptyTupleType(); // TODO: Lag of understanding.
+	else
+		return nullptr;
+}
+
+Type const* ReferenceType::withLocation(DataLocation _location, bool _isPointer) const
+{
+	return TypeProvider::withLocation(this, _location, _isPointer);
 }
 
 TypeResult ReferenceType::unaryOperatorResult(Token _operator) const
 {
 	if (_operator != Token::Delete)
-		return TypePointer();
+		return nullptr;
 	// delete can be used on everything except calldata references or storage pointers
 	// (storage references are ok)
 	switch (location())
 	{
 	case DataLocation::CallData:
-		return TypePointer();
+		return nullptr;
 	case DataLocation::Memory:
-		return TypeResult(make_shared<TupleType>());
+		return TypeProvider::emptyTupleType();
 	case DataLocation::Storage:
-		return m_isPointer ? TypePointer() : make_shared<TupleType>();
+		return m_isPointer ? nullptr : TypeProvider::emptyTupleType();
 	}
-	return TypePointer();
+	return nullptr;
 }
 
-TypePointer ReferenceType::copyForLocationIfReference(DataLocation _location, TypePointer const& _type)
+TypePointer ReferenceType::copyForLocationIfReference(DataLocation _location, Type const* _type)
 {
-	if (auto type = dynamic_cast<ReferenceType const*>(_type.get()))
-		return type->copyForLocation(_location, false);
+	if (auto type = dynamic_cast<ReferenceType const*>(_type))
+		return TypeProvider::withLocation(type, _location, false);
 	return _type;
 }
 
-TypePointer ReferenceType::copyForLocationIfReference(TypePointer const& _type) const
+TypePointer ReferenceType::copyForLocationIfReference(Type const* _type) const
 {
 	return copyForLocationIfReference(m_location, _type);
 }
@@ -1619,6 +1526,21 @@ string ReferenceType::identifierLocationSuffix() const
 	return id;
 }
 
+ArrayType::ArrayType(DataLocation _location, bool _isString):
+	ReferenceType(_location),
+	m_arrayKind(_isString ? ArrayKind::String : ArrayKind::Bytes),
+	m_baseType{TypeProvider::byteType()}
+{
+}
+
+void ArrayType::clearCache() const
+{
+	Type::clearCache();
+
+	m_interfaceType.reset();
+	m_interfaceType_library.reset();
+}
+
 BoolResult ArrayType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 {
 	if (_convertTo.category() != category())
@@ -1646,8 +1568,8 @@ BoolResult ArrayType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 		// require that the base type is the same, not only convertible.
 		// This disallows assignment of nested dynamic arrays from storage to memory for now.
 		if (
-			*copyForLocationIfReference(location(), baseType()) !=
-			*copyForLocationIfReference(location(), convertTo.baseType())
+			*TypeProvider::withLocationIfReference(location(), baseType()) !=
+			*TypeProvider::withLocationIfReference(location(), convertTo.baseType())
 		)
 			return false;
 		if (isDynamicallySized() != convertTo.isDynamicallySized())
@@ -1714,7 +1636,7 @@ bool ArrayType::operator==(Type const& _other) const
 
 bool ArrayType::validForCalldata() const
 {
-	if (auto arrayBaseType = dynamic_cast<ArrayType const*>(baseType().get()))
+	if (auto arrayBaseType = dynamic_cast<ArrayType const*>(baseType()))
 		if (!arrayBaseType->validForCalldata())
 			return false;
 	return unlimitedCalldataEncodedSize(true) <= numeric_limits<unsigned>::max();
@@ -1831,17 +1753,17 @@ MemberList::MemberMap ArrayType::nativeMembers(ContractDefinition const*) const
 	MemberList::MemberMap members;
 	if (!isString())
 	{
-		members.emplace_back("length", make_shared<IntegerType>(256));
+		members.emplace_back("length", TypeProvider::integerType(256));
 		if (isDynamicallySized() && location() == DataLocation::Storage)
 		{
-			members.emplace_back("push", make_shared<FunctionType>(
+			members.emplace_back("push", TypeProvider::functionType(
 				TypePointers{baseType()},
-				TypePointers{make_shared<IntegerType>(256)},
+				TypePointers{TypeProvider::integerType(256)},
 				strings{string()},
 				strings{string()},
 				isByteArray() ? FunctionType::Kind::ByteArrayPush : FunctionType::Kind::ArrayPush
 			));
-			members.emplace_back("pop", make_shared<FunctionType>(
+			members.emplace_back("pop", TypeProvider::functionType(
 				TypePointers{},
 				TypePointers{},
 				strings{},
@@ -1856,17 +1778,17 @@ MemberList::MemberMap ArrayType::nativeMembers(ContractDefinition const*) const
 TypePointer ArrayType::encodingType() const
 {
 	if (location() == DataLocation::Storage)
-		return make_shared<IntegerType>(256);
+		return TypeProvider::integerType(256);
 	else
-		return this->copyForLocation(DataLocation::Memory, true);
+		return TypeProvider::withLocation(this, DataLocation::Memory, true);
 }
 
 TypePointer ArrayType::decodingType() const
 {
 	if (location() == DataLocation::Storage)
-		return make_shared<IntegerType>(256);
+		return TypeProvider::integerType(256);
 	else
-		return shared_from_this();
+		return this;
 }
 
 TypeResult ArrayType::interfaceType(bool _inLibrary) const
@@ -1886,13 +1808,13 @@ TypeResult ArrayType::interfaceType(bool _inLibrary) const
 		result = baseInterfaceType;
 	}
 	else if (_inLibrary && location() == DataLocation::Storage)
-		result = shared_from_this();
+		result = this;
 	else if (m_arrayKind != ArrayKind::Ordinary)
-		result = this->copyForLocation(DataLocation::Memory, true);
+		result = TypeProvider::withLocation(this, DataLocation::Memory, true);
 	else if (isDynamicallySized())
-		result = TypePointer{make_shared<ArrayType>(DataLocation::Memory, baseInterfaceType)};
+		result = TypeProvider::arrayType(DataLocation::Memory, baseInterfaceType);
 	else
-		result = TypePointer{make_shared<ArrayType>(DataLocation::Memory, baseInterfaceType, m_length)};
+		result = TypeProvider::arrayType(DataLocation::Memory, baseInterfaceType, m_length);
 
 	if (_inLibrary)
 		m_interfaceType_library = result;
@@ -1911,9 +1833,9 @@ u256 ArrayType::memorySize() const
 	return u256(size);
 }
 
-TypePointer ArrayType::copyForLocation(DataLocation _location, bool _isPointer) const
+std::unique_ptr<ReferenceType> ArrayType::copyForLocation(DataLocation _location, bool _isPointer) const
 {
-	auto copy = make_shared<ArrayType>(_location);
+	auto copy = make_unique<ArrayType>(_location);
 	copy->m_isPointer = _isPointer;
 	copy->m_arrayKind = m_arrayKind;
 	copy->m_baseType = copy->copyForLocationIfReference(m_baseType);
@@ -1964,13 +1886,13 @@ MemberList::MemberMap ContractType::nativeMembers(ContractDefinition const* _con
 				if (!function->isVisibleInDerivedContracts() || !function->isImplemented())
 					continue;
 
-				auto functionType = make_shared<FunctionType>(*function, true);
+				auto functionType = TypeProvider::functionType(*function, true);
 				bool functionWithEqualArgumentsFound = false;
 				for (auto const& member: members)
 				{
 					if (member.name != function->name())
 						continue;
-					auto memberType = dynamic_cast<FunctionType const*>(member.type.get());
+					auto memberType = dynamic_cast<FunctionType const*>(member.type);
 					solAssert(!!memberType, "Override changes type.");
 					if (!memberType->hasEqualParameterTypes(*functionType))
 						continue;
@@ -1993,7 +1915,7 @@ MemberList::MemberMap ContractType::nativeMembers(ContractDefinition const* _con
 	return members;
 }
 
-shared_ptr<FunctionType const> const& ContractType::newExpressionType() const
+FunctionType const* ContractType::newExpressionType() const
 {
 	if (!m_constructorType)
 		m_constructorType = FunctionType::newExpressionType(m_contract);
@@ -2018,6 +1940,22 @@ vector<tuple<VariableDeclaration const*, u256, unsigned>> ContractType::stateVar
 		if (auto const* offset = offsets.offset(index))
 			variablesAndOffsets.emplace_back(variables[index], offset->first, offset->second);
 	return variablesAndOffsets;
+}
+
+void StructType::clearCache() const
+{
+	Type::clearCache();
+
+	m_interfaceType.reset();
+	m_interfaceType_library.reset();
+}
+
+Type const* StructType::encodingType() const
+{
+	if (location() != DataLocation::Storage)
+		return this;
+
+	return TypeProvider::integerType(256);
 }
 
 BoolResult StructType::isImplicitlyConvertibleTo(Type const& _convertTo) const
@@ -2165,10 +2103,10 @@ TypeResult StructType::interfaceType(bool _inLibrary) const
 				return;
 			}
 
-			Type const* memberType = variable->annotation().type.get();
+			Type const* memberType = variable->annotation().type;
 
 			while (dynamic_cast<ArrayType const*>(memberType))
-				memberType = dynamic_cast<ArrayType const*>(memberType)->baseType().get();
+				memberType = dynamic_cast<ArrayType const*>(memberType)->baseType();
 
 			if (StructType const* innerStruct = dynamic_cast<StructType const*>(memberType))
 				if (
@@ -2205,9 +2143,9 @@ TypeResult StructType::interfaceType(bool _inLibrary) const
 		if (!result.message().empty())
 			m_interfaceType_library = result;
 		else if (location() == DataLocation::Storage)
-			m_interfaceType_library = shared_from_this();
+			m_interfaceType_library = this;
 		else
-			m_interfaceType_library = copyForLocation(DataLocation::Memory, true);
+			m_interfaceType_library = TypeProvider::withLocation(this, DataLocation::Memory, true);
 
 		if (m_recursive.get())
 			m_interfaceType = TypeResult::err(recursiveErrMsg);
@@ -2220,14 +2158,14 @@ TypeResult StructType::interfaceType(bool _inLibrary) const
 	else if (!result.message().empty())
 		m_interfaceType = result;
 	else
-		m_interfaceType = copyForLocation(DataLocation::Memory, true);
+		m_interfaceType = TypeProvider::withLocation(this, DataLocation::Memory, true);
 
 	return *m_interfaceType;
 }
 
-TypePointer StructType::copyForLocation(DataLocation _location, bool _isPointer) const
+std::unique_ptr<ReferenceType> StructType::copyForLocation(DataLocation _location, bool _isPointer) const
 {
-	auto copy = make_shared<StructType>(m_struct, _location);
+	auto copy = make_unique<StructType>(m_struct, _location);
 	copy->m_isPointer = _isPointer;
 	return copy;
 }
@@ -2266,9 +2204,9 @@ FunctionTypePointer StructType::constructorType() const
 		paramNames.push_back(member.name);
 		paramTypes.push_back(copyForLocationIfReference(DataLocation::Memory, member.type));
 	}
-	return make_shared<FunctionType>(
+	return TypeProvider::functionType(
 		paramTypes,
-		TypePointers{copyForLocation(DataLocation::Memory, false)},
+		TypePointers{TypeProvider::withLocation(this, DataLocation::Memory, false)},
 		paramNames,
 		strings(1, ""),
 		FunctionType::Kind::Internal
@@ -2312,9 +2250,14 @@ set<string> StructType::membersMissingInMemory() const
 	return missing;
 }
 
+TypePointer EnumType::encodingType() const
+{
+	return TypeProvider::integerType(8 * static_cast<int>(storageBytes()));
+}
+
 TypeResult EnumType::unaryOperatorResult(Token _operator) const
 {
-	return _operator == Token::Delete ? make_shared<TupleType>() : TypePointer();
+	return _operator == Token::Delete ? TypeProvider::emptyTupleType() : nullptr;
 }
 
 string EnumType::richIdentifier() const
@@ -2437,16 +2380,16 @@ TypePointer TupleType::mobileType() const
 		{
 			auto mt = c->mobileType();
 			if (!mt)
-				return TypePointer();
+				return nullptr;
 			mobiles.push_back(mt);
 		}
 		else
-			mobiles.push_back(TypePointer());
+			mobiles.push_back(nullptr);
 	}
-	return make_shared<TupleType>(mobiles);
+	return TypeProvider::tupleType(move(mobiles));
 }
 
-TypePointer TupleType::closestTemporaryType(TypePointer const& _targetType) const
+TypePointer TupleType::closestTemporaryType(Type const* _targetType) const
 {
 	solAssert(!!_targetType, "");
 	TypePointers const& targetComponents = dynamic_cast<TupleType const&>(*_targetType).components();
@@ -2460,7 +2403,7 @@ TypePointer TupleType::closestTemporaryType(TypePointer const& _targetType) cons
 			solAssert(tempComponents[i], "");
 		}
 	}
-	return make_shared<TupleType>(tempComponents);
+	return TypeProvider::tupleType(move(tempComponents));
 }
 
 FunctionType::FunctionType(FunctionDefinition const& _function, bool _isInternal):
@@ -2502,36 +2445,36 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 
 	while (true)
 	{
-		if (auto mappingType = dynamic_cast<MappingType const*>(returnType.get()))
+		if (auto mappingType = dynamic_cast<MappingType const*>(returnType))
 		{
 			m_parameterTypes.push_back(mappingType->keyType());
 			m_parameterNames.emplace_back("");
 			returnType = mappingType->valueType();
 		}
-		else if (auto arrayType = dynamic_cast<ArrayType const*>(returnType.get()))
+		else if (auto arrayType = dynamic_cast<ArrayType const*>(returnType))
 		{
 			if (arrayType->isByteArray())
 				// Return byte arrays as whole.
 				break;
 			returnType = arrayType->baseType();
 			m_parameterNames.emplace_back("");
-			m_parameterTypes.push_back(make_shared<IntegerType>(256));
+			m_parameterTypes.push_back(TypeProvider::integerType(256));
 		}
 		else
 			break;
 	}
 
-	if (auto structType = dynamic_cast<StructType const*>(returnType.get()))
+	if (auto structType = dynamic_cast<StructType const*>(returnType))
 	{
 		for (auto const& member: structType->members(nullptr))
 		{
 			solAssert(member.type, "");
 			if (member.type->category() != Category::Mapping)
 			{
-				if (auto arrayType = dynamic_cast<ArrayType const*>(member.type.get()))
+				if (auto arrayType = dynamic_cast<ArrayType const*>(member.type))
 					if (!arrayType->isByteArray())
 						continue;
-				m_returnParameterTypes.push_back(ReferenceType::copyForLocationIfReference(
+				m_returnParameterTypes.push_back(TypeProvider::withLocationIfReference(
 					DataLocation::Memory,
 					member.type
 				));
@@ -2541,7 +2484,7 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 	}
 	else
 	{
-		m_returnParameterTypes.push_back(ReferenceType::copyForLocationIfReference(
+		m_returnParameterTypes.push_back(TypeProvider::withLocationIfReference(
 			DataLocation::Memory,
 			returnType
 		));
@@ -2638,9 +2581,9 @@ FunctionTypePointer FunctionType::newExpressionType(ContractDefinition const& _c
 			stateMutability = StateMutability::Payable;
 	}
 
-	return make_shared<FunctionType>(
+	return TypeProvider::functionType(
 		parameters,
-		TypePointers{make_shared<ContractType>(_contract)},
+		TypePointers{TypeProvider::contractType(_contract)},
 		parameterNames,
 		strings{""},
 		Kind::Creation,
@@ -2670,7 +2613,7 @@ TypePointers FunctionType::returnParameterTypesWithoutDynamicTypes() const
 	)
 		for (auto& param: returnParameterTypes)
 			if (param->isDynamicallySized() && !param->dataStoredIn(DataLocation::Storage))
-				param = make_shared<InaccessibleDynamicType>();
+				param = TypeProvider::inaccessibleDynamicType();
 
 	return returnParameterTypes;
 }
@@ -2753,7 +2696,7 @@ bool FunctionType::operator==(Type const& _other) const
 
 BoolResult FunctionType::isExplicitlyConvertibleTo(Type const& _convertTo) const
 {
-	if (m_kind == Kind::External && _convertTo == AddressType::address())
+	if (m_kind == Kind::External && _convertTo == *TypeProvider::addressType())
 		return true;
 	return _convertTo.category() == category();
 }
@@ -2786,18 +2729,18 @@ BoolResult FunctionType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 TypeResult FunctionType::unaryOperatorResult(Token _operator) const
 {
 	if (_operator == Token::Delete)
-		return TypeResult(make_shared<TupleType>());
-	return TypePointer();
+		return TypeResult(TypeProvider::emptyTupleType());
+	return nullptr;
 }
 
-TypeResult FunctionType::binaryOperatorResult(Token _operator, TypePointer const& _other) const
+TypeResult FunctionType::binaryOperatorResult(Token _operator, Type const* _other) const
 {
 	if (_other->category() != category() || !(_operator == Token::Equal || _operator == Token::NotEqual))
-		return TypePointer();
+		return nullptr;
 	FunctionType const& other = dynamic_cast<FunctionType const&>(*_other);
 	if (kind() == Kind::Internal && other.kind() == Kind::Internal && sizeOnStack() == 1 && other.sizeOnStack() == 1)
-		return commonType(shared_from_this(), _other);
-	return TypePointer();
+		return commonType(this, _other);
+	return nullptr;
 }
 
 string FunctionType::canonicalName() const
@@ -2927,7 +2870,7 @@ FunctionTypePointer FunctionType::interfaceFunctionType() const
 	if (variable && retParamTypes.empty())
 		return FunctionTypePointer();
 
-	return make_shared<FunctionType>(
+	return TypeProvider::functionType(
 		paramTypes,
 		retParamTypes,
 		m_parameterNames,
@@ -2952,13 +2895,13 @@ MemberList::MemberMap FunctionType::nativeMembers(ContractDefinition const*) con
 	{
 		MemberList::MemberMap members;
 		if (m_kind == Kind::External)
-			members.emplace_back("selector", make_shared<FixedBytesType>(4));
+			members.emplace_back("selector", TypeProvider::fixedBytesType(4));
 		if (m_kind != Kind::BareDelegateCall)
 		{
 			if (isPayable())
 				members.emplace_back(
 					"value",
-					make_shared<FunctionType>(
+					TypeProvider::functionType(
 						parseElementaryTypeVector({"uint"}),
 						TypePointers{copyAndSetGasOrValue(false, true)},
 						strings(1, ""),
@@ -2975,7 +2918,7 @@ MemberList::MemberMap FunctionType::nativeMembers(ContractDefinition const*) con
 		if (m_kind != Kind::Creation)
 			members.emplace_back(
 				"gas",
-				make_shared<FunctionType>(
+				TypeProvider::functionType(
 					parseElementaryTypeVector({"uint"}),
 					TypePointers{copyAndSetGasOrValue(true, false)},
 					strings(1, ""),
@@ -2999,22 +2942,22 @@ TypePointer FunctionType::encodingType() const
 {
 	// Only external functions can be encoded, internal functions cannot leave code boundaries.
 	if (m_kind == Kind::External)
-		return shared_from_this();
+		return this;
 	else
-		return TypePointer();
+		return nullptr;
 }
 
 TypeResult FunctionType::interfaceType(bool /*_inLibrary*/) const
 {
 	if (m_kind == Kind::External)
-		return shared_from_this();
+		return this;
 	else
 		return TypeResult::err("Internal type is not allowed for public or external functions.");
 }
 
 bool FunctionType::canTakeArguments(
 	FuncCallArguments const& _arguments,
-	TypePointer const& _selfType
+	Type const* _selfType
 ) const
 {
 	solAssert(!bound() || _selfType, "");
@@ -3032,7 +2975,7 @@ bool FunctionType::canTakeArguments(
 			_arguments.types.cbegin(),
 			_arguments.types.cend(),
 			paramTypes.cbegin(),
-			[](TypePointer const& argumentType, TypePointer const& parameterType)
+			[](Type const* argumentType, Type const* parameterType)
 			{
 				return argumentType->isImplicitlyConvertibleTo(*parameterType);
 			}
@@ -3069,7 +3012,7 @@ bool FunctionType::hasEqualParameterTypes(FunctionType const& _other) const
 		m_parameterTypes.cbegin(),
 		m_parameterTypes.cend(),
 		_other.m_parameterTypes.cbegin(),
-		[](TypePointer const& _a, TypePointer const& _b) -> bool { return *_a == *_b; }
+		[](Type const* _a, Type const* _b) -> bool { return *_a == *_b; }
 	);
 }
 
@@ -3081,7 +3024,7 @@ bool FunctionType::hasEqualReturnTypes(FunctionType const& _other) const
 		m_returnParameterTypes.cbegin(),
 		m_returnParameterTypes.cend(),
 		_other.m_returnParameterTypes.cbegin(),
-		[](TypePointer const& _a, TypePointer const& _b) -> bool { return *_a == *_b; }
+		[](Type const* _a, Type const* _b) -> bool { return *_a == *_b; }
 	);
 }
 
@@ -3183,13 +3126,13 @@ TypePointers FunctionType::parseElementaryTypeVector(strings const& _types)
 	TypePointers pointers;
 	pointers.reserve(_types.size());
 	for (string const& type: _types)
-		pointers.push_back(Type::fromElementaryTypeName(type));
+		pointers.push_back(TypeProvider::fromElementaryTypeName(type));
 	return pointers;
 }
 
 TypePointer FunctionType::copyAndSetGasOrValue(bool _setGas, bool _setValue) const
 {
-	return make_shared<FunctionType>(
+	return TypeProvider::functionType(
 		m_parameterTypes,
 		m_returnParameterTypes,
 		m_parameterNames,
@@ -3212,9 +3155,9 @@ FunctionTypePointer FunctionType::asCallableFunction(bool _inLibrary, bool _boun
 	TypePointers parameterTypes;
 	for (auto const& t: m_parameterTypes)
 	{
-		auto refType = dynamic_cast<ReferenceType const*>(t.get());
+		auto refType = dynamic_cast<ReferenceType const*>(t);
 		if (refType && refType->location() == DataLocation::CallData)
-			parameterTypes.push_back(refType->copyForLocation(DataLocation::Memory, true));
+			parameterTypes.push_back(TypeProvider::withLocation(refType, DataLocation::Memory, true));
 		else
 			parameterTypes.push_back(t);
 	}
@@ -3229,7 +3172,7 @@ FunctionTypePointer FunctionType::asCallableFunction(bool _inLibrary, bool _boun
 			kind = Kind::DelegateCall;
 	}
 
-	return make_shared<FunctionType>(
+	return TypeProvider::functionType(
 		parameterTypes,
 		m_returnParameterTypes,
 		m_parameterNames,
@@ -3244,7 +3187,7 @@ FunctionTypePointer FunctionType::asCallableFunction(bool _inLibrary, bool _boun
 	);
 }
 
-TypePointer const& FunctionType::selfType() const
+Type const* FunctionType::selfType() const
 {
 	solAssert(bound(), "Function is not bound.");
 	solAssert(m_parameterTypes.size() > 0, "Function has no self type.");
@@ -3278,6 +3221,11 @@ bool FunctionType::padArguments() const
 		return true;
 	}
 	return true;
+}
+
+Type const* MappingType::encodingType() const
+{
+	return TypeProvider::integerType(256, IntegerType::Modifier::Unsigned);
 }
 
 string MappingType::richIdentifier() const
@@ -3320,7 +3268,7 @@ TypeResult MappingType::interfaceType(bool _inLibrary) const
 	else
 		return TypeResult::err("Only libraries are allowed to use the mapping type in public or external functions.");
 
-	return shared_from_this();
+	return this;
 }
 
 string TypeType::richIdentifier() const
@@ -3343,7 +3291,7 @@ u256 TypeType::storageSize() const
 
 unsigned TypeType::sizeOnStack() const
 {
-	if (auto contractType = dynamic_cast<ContractType const*>(m_actualType.get()))
+	if (auto contractType = dynamic_cast<ContractType const*>(m_actualType))
 		if (contractType->contractDefinition().isLibrary())
 			return 1;
 	return 0;
@@ -3387,7 +3335,7 @@ MemberList::MemberMap TypeType::nativeMembers(ContractDefinition const* _current
 	else if (m_actualType->category() == Category::Enum)
 	{
 		EnumDefinition const& enumDef = dynamic_cast<EnumType const&>(*m_actualType).enumDefinition();
-		auto enumType = make_shared<EnumType>(enumDef);
+		auto enumType = TypeProvider::enumType(enumDef);
 		for (ASTPointer<EnumValue> const& enumValue: enumDef.members())
 			members.emplace_back(enumValue->name(), enumType);
 	}
@@ -3421,7 +3369,7 @@ bool ModifierType::operator==(Type const& _other) const
 
 	if (m_parameterTypes.size() != other.m_parameterTypes.size())
 		return false;
-	auto typeCompare = [](TypePointer const& _a, TypePointer const& _b) -> bool { return *_a == *_b; };
+	auto typeCompare = [](Type const* _a, Type const* _b) -> bool { return *_a == *_b; };
 
 	if (!equal(
 		m_parameterTypes.cbegin(),
@@ -3467,12 +3415,9 @@ string ModuleType::toString(bool) const
 	return string("module \"") + m_sourceUnit.annotation().path + string("\"");
 }
 
-shared_ptr<MagicType> MagicType::metaType(TypePointer _type)
+MagicType const* MagicType::metaType(TypePointer _type)
 {
-	solAssert(_type && _type->category() == Type::Category::Contract, "Only contracts supported for now.");
-	auto t = make_shared<MagicType>(Kind::MetaType);
-	t->m_typeArgument = std::move(_type);
-	return t;
+	return TypeProvider::metaType(_type);
 }
 
 string MagicType::richIdentifier() const
@@ -3508,65 +3453,65 @@ MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const*) const
 	{
 	case Kind::Block:
 		return MemberList::MemberMap({
-			{"coinbase", make_shared<AddressType>(StateMutability::Payable)},
-			{"timestamp", make_shared<IntegerType>(256)},
-			{"blockhash", make_shared<FunctionType>(strings{"uint"}, strings{"bytes32"}, FunctionType::Kind::BlockHash, false, StateMutability::View)},
-			{"difficulty", make_shared<IntegerType>(256)},
-			{"number", make_shared<IntegerType>(256)},
-			{"gaslimit", make_shared<IntegerType>(256)}
+			{"coinbase", TypeProvider::payableAddressType()},
+			{"timestamp", TypeProvider::integerType(256)},
+			{"blockhash", TypeProvider::functionType(strings{"uint"}, strings{"bytes32"}, FunctionType::Kind::BlockHash, false, StateMutability::View)},
+			{"difficulty", TypeProvider::integerType(256)},
+			{"number", TypeProvider::integerType(256)},
+			{"gaslimit", TypeProvider::integerType(256)}
 		});
 	case Kind::Message:
 		return MemberList::MemberMap({
-			{"sender", make_shared<AddressType>(StateMutability::Payable)},
-			{"gas", make_shared<IntegerType>(256)},
-			{"value", make_shared<IntegerType>(256)},
-			{"data", make_shared<ArrayType>(DataLocation::CallData)},
-			{"sig", make_shared<FixedBytesType>(4)}
+			{"sender", TypeProvider::payableAddressType()},
+			{"gas", TypeProvider::integerType(256)},
+			{"value", TypeProvider::integerType(256)},
+			{"data", TypeProvider::arrayType(DataLocation::CallData)},
+			{"sig", TypeProvider::fixedBytesType(4)}
 		});
 	case Kind::Transaction:
 		return MemberList::MemberMap({
-			{"origin", make_shared<AddressType>(StateMutability::Payable)},
-			{"gasprice", make_shared<IntegerType>(256)}
+			{"origin", TypeProvider::payableAddressType()},
+			{"gasprice", TypeProvider::integerType(256)}
 		});
 	case Kind::ABI:
 		return MemberList::MemberMap({
-			{"encode", make_shared<FunctionType>(
-				TypePointers(),
-				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+			{"encode", TypeProvider::functionType(
+				TypePointers{},
+				TypePointers{TypeProvider::arrayType(DataLocation::Memory)},
 				strings{},
 				strings{1, ""},
 				FunctionType::Kind::ABIEncode,
 				true,
 				StateMutability::Pure
 			)},
-			{"encodePacked", make_shared<FunctionType>(
-				TypePointers(),
-				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+			{"encodePacked", TypeProvider::functionType(
+				TypePointers{},
+				TypePointers{TypeProvider::arrayType(DataLocation::Memory)},
 				strings{},
 				strings{1, ""},
 				FunctionType::Kind::ABIEncodePacked,
 				true,
 				StateMutability::Pure
 			)},
-			{"encodeWithSelector", make_shared<FunctionType>(
-				TypePointers{make_shared<FixedBytesType>(4)},
-				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+			{"encodeWithSelector", TypeProvider::functionType(
+				TypePointers{TypeProvider::fixedBytesType(4)},
+				TypePointers{TypeProvider::arrayType(DataLocation::Memory)},
 				strings{1, ""},
 				strings{1, ""},
 				FunctionType::Kind::ABIEncodeWithSelector,
 				true,
 				StateMutability::Pure
 			)},
-			{"encodeWithSignature", make_shared<FunctionType>(
-				TypePointers{make_shared<ArrayType>(DataLocation::Memory, true)},
-				TypePointers{make_shared<ArrayType>(DataLocation::Memory)},
+			{"encodeWithSignature", TypeProvider::functionType(
+				TypePointers{TypeProvider::arrayType(DataLocation::Memory, true)},
+				TypePointers{TypeProvider::arrayType(DataLocation::Memory)},
 				strings{1, ""},
 				strings{1, ""},
 				FunctionType::Kind::ABIEncodeWithSignature,
 				true,
 				StateMutability::Pure
 			)},
-			{"decode", make_shared<FunctionType>(
+			{"decode", TypeProvider::functionType(
 				TypePointers(),
 				TypePointers(),
 				strings{},
@@ -3585,9 +3530,9 @@ MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const*) const
 		ContractDefinition const& contract = dynamic_cast<ContractType const&>(*m_typeArgument).contractDefinition();
 		if (contract.canBeDeployed())
 			return MemberList::MemberMap({
-				{"creationCode", make_shared<ArrayType>(DataLocation::Memory)},
-				{"runtimeCode", make_shared<ArrayType>(DataLocation::Memory)},
-				{"name", make_shared<ArrayType>(DataLocation::Memory, true)},
+				{"creationCode", TypeProvider::arrayType(DataLocation::Memory)},
+				{"runtimeCode", TypeProvider::arrayType(DataLocation::Memory)},
+				{"name", TypeProvider::stringMemoryType()},
 			});
 		else
 			return {};
@@ -3622,4 +3567,9 @@ TypePointer MagicType::typeArgument() const
 	solAssert(m_kind == Kind::MetaType, "");
 	solAssert(m_typeArgument, "");
 	return m_typeArgument;
+}
+
+TypePointer InaccessibleDynamicType::decodingType() const
+{
+	return TypeProvider::integerType(256, IntegerType::Modifier::Unsigned);
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -449,7 +449,7 @@ bool AddressType::operator==(Type const& _other) const
 MemberList::MemberMap AddressType::nativeMembers(ContractDefinition const*) const
 {
 	MemberList::MemberMap members = {
-		{"balance", TypeProvider::integerType(256)},
+		{"balance", TypeProvider::uint256()},
 		{"call", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareCall, false, StateMutability::Payable)},
 		{"callcode", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareCallCode, false, StateMutability::Payable)},
 		{"delegatecall", TypeProvider::functionType(strings{"bytes memory"}, strings{"bool", "bytes memory"}, FunctionType::Kind::BareDelegateCall, false, StateMutability::NonPayable)},
@@ -1358,7 +1358,7 @@ TypeResult FixedBytesType::binaryOperatorResult(Token _operator, Type const* _ot
 
 MemberList::MemberMap FixedBytesType::nativeMembers(ContractDefinition const*) const
 {
-	return MemberList::MemberMap{MemberList::Member{"length", TypeProvider::integerType(8)}};
+	return MemberList::MemberMap{MemberList::Member{"length", TypeProvider::uint(8)}};
 }
 
 string FixedBytesType::richIdentifier() const
@@ -1753,12 +1753,12 @@ MemberList::MemberMap ArrayType::nativeMembers(ContractDefinition const*) const
 	MemberList::MemberMap members;
 	if (!isString())
 	{
-		members.emplace_back("length", TypeProvider::integerType(256));
+		members.emplace_back("length", TypeProvider::uint256());
 		if (isDynamicallySized() && location() == DataLocation::Storage)
 		{
 			members.emplace_back("push", TypeProvider::functionType(
 				TypePointers{baseType()},
-				TypePointers{TypeProvider::integerType(256)},
+				TypePointers{TypeProvider::uint256()},
 				strings{string()},
 				strings{string()},
 				isByteArray() ? FunctionType::Kind::ByteArrayPush : FunctionType::Kind::ArrayPush
@@ -1778,7 +1778,7 @@ MemberList::MemberMap ArrayType::nativeMembers(ContractDefinition const*) const
 TypePointer ArrayType::encodingType() const
 {
 	if (location() == DataLocation::Storage)
-		return TypeProvider::integerType(256);
+		return TypeProvider::uint256();
 	else
 		return TypeProvider::withLocation(this, DataLocation::Memory, true);
 }
@@ -1786,7 +1786,7 @@ TypePointer ArrayType::encodingType() const
 TypePointer ArrayType::decodingType() const
 {
 	if (location() == DataLocation::Storage)
-		return TypeProvider::integerType(256);
+		return TypeProvider::uint256();
 	else
 		return this;
 }
@@ -1955,7 +1955,7 @@ Type const* StructType::encodingType() const
 	if (location() != DataLocation::Storage)
 		return this;
 
-	return TypeProvider::integerType(256);
+	return TypeProvider::uint256();
 }
 
 BoolResult StructType::isImplicitlyConvertibleTo(Type const& _convertTo) const
@@ -2252,7 +2252,7 @@ set<string> StructType::membersMissingInMemory() const
 
 TypePointer EnumType::encodingType() const
 {
-	return TypeProvider::integerType(8 * static_cast<int>(storageBytes()));
+	return TypeProvider::uint(8 * storageBytes());
 }
 
 TypeResult EnumType::unaryOperatorResult(Token _operator) const
@@ -2458,7 +2458,7 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 				break;
 			returnType = arrayType->baseType();
 			m_parameterNames.emplace_back("");
-			m_parameterTypes.push_back(TypeProvider::integerType(256));
+			m_parameterTypes.push_back(TypeProvider::uint256());
 		}
 		else
 			break;
@@ -3454,24 +3454,24 @@ MemberList::MemberMap MagicType::nativeMembers(ContractDefinition const*) const
 	case Kind::Block:
 		return MemberList::MemberMap({
 			{"coinbase", TypeProvider::payableAddressType()},
-			{"timestamp", TypeProvider::integerType(256)},
+			{"timestamp", TypeProvider::uint256()},
 			{"blockhash", TypeProvider::functionType(strings{"uint"}, strings{"bytes32"}, FunctionType::Kind::BlockHash, false, StateMutability::View)},
-			{"difficulty", TypeProvider::integerType(256)},
-			{"number", TypeProvider::integerType(256)},
-			{"gaslimit", TypeProvider::integerType(256)}
+			{"difficulty", TypeProvider::uint256()},
+			{"number", TypeProvider::uint256()},
+			{"gaslimit", TypeProvider::uint256()}
 		});
 	case Kind::Message:
 		return MemberList::MemberMap({
 			{"sender", TypeProvider::payableAddressType()},
-			{"gas", TypeProvider::integerType(256)},
-			{"value", TypeProvider::integerType(256)},
+			{"gas", TypeProvider::uint256()},
+			{"value", TypeProvider::uint256()},
 			{"data", TypeProvider::arrayType(DataLocation::CallData)},
 			{"sig", TypeProvider::fixedBytesType(4)}
 		});
 	case Kind::Transaction:
 		return MemberList::MemberMap({
 			{"origin", TypeProvider::payableAddressType()},
-			{"gasprice", TypeProvider::integerType(256)}
+			{"gasprice", TypeProvider::uint256()}
 		});
 	case Kind::ABI:
 		return MemberList::MemberMap({

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -32,7 +32,6 @@
 #include <libdevcore/Result.h>
 
 #include <boost/optional.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/rational.hpp>
 
 #include <map>
@@ -155,9 +154,9 @@ class Type
 public:
 	Type() = default;
 	Type(Type const&) = delete;
-	Type(Type&&) = default;
+	Type(Type&&) = delete;
 	Type& operator=(Type const&) = delete;
-	Type& operator=(Type&&) = default;
+	Type& operator=(Type&&) = delete;
 	virtual ~Type() = default;
 
 	enum class Category
@@ -382,12 +381,6 @@ public:
 
 	Category category() const override { return Category::Integer; }
 
-	IntegerType(IntegerType&&) = default;
-	IntegerType& operator=(IntegerType&&) = default;
-	IntegerType(IntegerType const&) = default;
-	IntegerType& operator=(IntegerType const&) = default;
-	~IntegerType() = default;
-
 	std::string richIdentifier() const override;
 	BoolResult isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
@@ -578,12 +571,6 @@ public:
 
 	Category category() const override { return Category::FixedBytes; }
 
-	FixedBytesType(FixedBytesType const&) = delete;
-	FixedBytesType& operator=(FixedBytesType const&) = delete;
-	FixedBytesType(FixedBytesType&&) = default;
-	FixedBytesType& operator=(FixedBytesType&&) = default;
-	~FixedBytesType() = default;
-
 	BoolResult isImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	std::string richIdentifier() const override;
@@ -613,8 +600,6 @@ private:
 class BoolType: public Type
 {
 public:
-	BoolType() = default;
-
 	Category category() const override { return Category::Bool; }
 	std::string richIdentifier() const override { return "t_bool"; }
 	TypeResult unaryOperatorResult(Token _operator) const override;
@@ -950,8 +935,6 @@ public:
 	explicit TupleType(std::vector<TypePointer> _types = {}): m_components(std::move(_types)) {}
 
 	Category category() const override { return Category::Tuple; }
-	TupleType(TupleType&&) = default;
-	TupleType& operator=(TupleType&) = default;
 
 	BoolResult isImplicitlyConvertibleTo(Type const& _other) const override;
 	std::string richIdentifier() const override;
@@ -1398,8 +1381,6 @@ private:
 class InaccessibleDynamicType: public Type
 {
 public:
-	InaccessibleDynamicType() = default;
-
 	Category category() const override { return Category::InaccessibleDynamic; }
 
 	std::string richIdentifier() const override { return "t_inaccessible"; }

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -311,7 +311,7 @@ string ABIFunctions::abiEncodingFunction(
 			case DataLocation::CallData:
 				if (
 					fromArray.isByteArray() ||
-					*fromArray.baseType() == IntegerType::uint256() ||
+					*fromArray.baseType() == *TypeProvider::integerType() ||
 					*fromArray.baseType() == FixedBytesType(32)
 				)
 					return abiEncodingFunctionCalldataArrayWithoutCleanup(fromArray, *toArray, _options);
@@ -369,7 +369,7 @@ string ABIFunctions::abiEncodingFunction(
 			// possible for library calls where we just forward the storage reference
 			solAssert(_options.encodeAsLibraryTypes, "");
 			solAssert(_options.padded && !_options.dynamicInplace, "Non-padded / inplace encoding for library call requested.");
-			solAssert(to == IntegerType::uint256(), "");
+			solAssert(to == *TypeProvider::integerType(), "");
 			templ("cleanupConvert", "value");
 		}
 		else
@@ -445,7 +445,7 @@ string ABIFunctions::abiEncodingFunctionCalldataArrayWithoutCleanup(
 	solAssert(fromArrayType.location() == DataLocation::CallData, "");
 	solAssert(
 		fromArrayType.isByteArray() ||
-		*fromArrayType.baseType() == IntegerType::uint256() ||
+		*fromArrayType.baseType() == *TypeProvider::integerType() ||
 		*fromArrayType.baseType() == FixedBytesType(32),
 	"");
 	solAssert(fromArrayType.calldataStride() == toArrayType.memoryStride(), "");
@@ -1077,7 +1077,7 @@ string ABIFunctions::abiDecodingFunction(Type const& _type, bool _fromMemory, bo
 	TypePointer decodingType = _type.decodingType();
 	solAssert(decodingType, "");
 
-	if (auto arrayType = dynamic_cast<ArrayType const*>(decodingType.get()))
+	if (auto arrayType = dynamic_cast<ArrayType const*>(decodingType))
 	{
 		if (arrayType->dataStoredIn(DataLocation::CallData))
 		{
@@ -1089,7 +1089,7 @@ string ABIFunctions::abiDecodingFunction(Type const& _type, bool _fromMemory, bo
 		else
 			return abiDecodingFunctionArray(*arrayType, _fromMemory);
 	}
-	else if (auto const* structType = dynamic_cast<StructType const*>(decodingType.get()))
+	else if (auto const* structType = dynamic_cast<StructType const*>(decodingType))
 	{
 		if (structType->dataStoredIn(DataLocation::CallData))
 		{
@@ -1099,7 +1099,7 @@ string ABIFunctions::abiDecodingFunction(Type const& _type, bool _fromMemory, bo
 		else
 			return abiDecodingFunctionStruct(*structType, _fromMemory);
 	}
-	else if (auto const* functionType = dynamic_cast<FunctionType const*>(decodingType.get()))
+	else if (auto const* functionType = dynamic_cast<FunctionType const*>(decodingType))
 		return abiDecodingFunctionFunctionType(*functionType, _fromMemory, _forUseOnStack);
 	else
 		return abiDecodingFunctionValueType(_type, _fromMemory);

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -311,7 +311,7 @@ string ABIFunctions::abiEncodingFunction(
 			case DataLocation::CallData:
 				if (
 					fromArray.isByteArray() ||
-					*fromArray.baseType() == *TypeProvider::integerType() ||
+					*fromArray.baseType() == *TypeProvider::uint256() ||
 					*fromArray.baseType() == FixedBytesType(32)
 				)
 					return abiEncodingFunctionCalldataArrayWithoutCleanup(fromArray, *toArray, _options);
@@ -369,7 +369,7 @@ string ABIFunctions::abiEncodingFunction(
 			// possible for library calls where we just forward the storage reference
 			solAssert(_options.encodeAsLibraryTypes, "");
 			solAssert(_options.padded && !_options.dynamicInplace, "Non-padded / inplace encoding for library call requested.");
-			solAssert(to == *TypeProvider::integerType(), "");
+			solAssert(to == *TypeProvider::uint256(), "");
 			templ("cleanupConvert", "value");
 		}
 		else
@@ -445,7 +445,7 @@ string ABIFunctions::abiEncodingFunctionCalldataArrayWithoutCleanup(
 	solAssert(fromArrayType.location() == DataLocation::CallData, "");
 	solAssert(
 		fromArrayType.isByteArray() ||
-		*fromArrayType.baseType() == *TypeProvider::integerType() ||
+		*fromArrayType.baseType() == *TypeProvider::uint256() ||
 		*fromArrayType.baseType() == FixedBytesType(32),
 	"");
 	solAssert(fromArrayType.calldataStride() == toArrayType.memoryStride(), "");

--- a/libsolidity/codegen/ABIFunctions.h
+++ b/libsolidity/codegen/ABIFunctions.h
@@ -41,7 +41,7 @@ class Type;
 class ArrayType;
 class StructType;
 class FunctionType;
-using TypePointer = std::shared_ptr<Type const>;
+using TypePointer = Type const*;
 using TypePointers = std::vector<TypePointer>;
 
 /**

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -45,7 +45,7 @@ void ArrayUtils::copyArrayToStorage(ArrayType const& _targetType, ArrayType cons
 	// stack layout: [source_ref] [source length] target_ref (top)
 	solAssert(_targetType.location() == DataLocation::Storage, "");
 
-	TypePointer uint256 = TypeProvider::integerType(256);
+	TypePointer uint256 = TypeProvider::uint256();
 	TypePointer targetBaseType = _targetType.isByteArray() ? uint256 : _targetType.baseType();
 	TypePointer sourceBaseType = _sourceType.isByteArray() ? uint256 : _sourceType.baseType();
 
@@ -585,7 +585,7 @@ void ArrayUtils::clearArray(ArrayType const& _typeIn) const
 				ArrayUtils(_context).convertLengthToSize(_type);
 				_context << Instruction::ADD << Instruction::SWAP1;
 				if (_type.baseType()->storageBytes() < 32)
-					ArrayUtils(_context).clearStorageLoop(TypeProvider::integerType(256));
+					ArrayUtils(_context).clearStorageLoop(TypeProvider::uint256());
 				else
 					ArrayUtils(_context).clearStorageLoop(_type.baseType());
 				_context << Instruction::POP;
@@ -626,7 +626,7 @@ void ArrayUtils::clearDynamicArray(ArrayType const& _type) const
 		<< Instruction::SWAP1;
 	// stack: data_pos_end data_pos
 	if (_type.storageStride() < 32)
-		clearStorageLoop(TypeProvider::integerType(256));
+		clearStorageLoop(TypeProvider::uint256());
 	else
 		clearStorageLoop(_type.baseType());
 	// cleanup
@@ -733,7 +733,7 @@ void ArrayUtils::resizeDynamicArray(ArrayType const& _typeIn) const
 				ArrayUtils(_context).convertLengthToSize(_type);
 				_context << Instruction::DUP2 << Instruction::ADD << Instruction::SWAP1;
 				// stack: ref new_length current_length first_word data_location_end data_location
-				ArrayUtils(_context).clearStorageLoop(TypeProvider::integerType(256));
+				ArrayUtils(_context).clearStorageLoop(TypeProvider::uint256());
 				_context << Instruction::POP;
 				// stack: ref new_length current_length first_word
 				solAssert(_context.stackHeight() - stackHeightStart == 4 - 2, "3");
@@ -772,7 +772,7 @@ void ArrayUtils::resizeDynamicArray(ArrayType const& _typeIn) const
 			_context << Instruction::SWAP2 << Instruction::ADD;
 			// stack: ref new_length delete_end delete_start
 			if (_type.storageStride() < 32)
-				ArrayUtils(_context).clearStorageLoop(TypeProvider::integerType(256));
+				ArrayUtils(_context).clearStorageLoop(TypeProvider::uint256());
 			else
 				ArrayUtils(_context).clearStorageLoop(_type.baseType());
 

--- a/libsolidity/codegen/ArrayUtils.h
+++ b/libsolidity/codegen/ArrayUtils.h
@@ -32,7 +32,7 @@ namespace solidity
 class CompilerContext;
 class Type;
 class ArrayType;
-using TypePointer = std::shared_ptr<Type const>;
+using TypePointer = Type const*;
 
 /**
  * Class that provides code generation for handling arrays.
@@ -81,7 +81,7 @@ public:
 	/// Appends a loop that clears a sequence of storage slots of the given type (excluding end).
 	/// Stack pre: end_ref start_ref
 	/// Stack post: end_ref
-	void clearStorageLoop(TypePointer const& _type) const;
+	void clearStorageLoop(TypePointer _type) const;
 	/// Converts length to size (number of storage slots or calldata/memory bytes).
 	/// if @a _pad then add padding to multiples of 32 bytes for calldata/memory.
 	/// Stack pre: length

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -23,6 +23,7 @@
 #include <libsolidity/codegen/CompilerUtils.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/codegen/ABIFunctions.h>
 #include <libsolidity/codegen/ArrayUtils.h>
 #include <libsolidity/codegen/LValue.h>
@@ -83,13 +84,13 @@ void CompilerUtils::toSizeAfterFreeMemoryPointer()
 
 void CompilerUtils::revertWithStringData(Type const& _argumentType)
 {
-	solAssert(_argumentType.isImplicitlyConvertibleTo(*Type::fromElementaryTypeName("string memory")), "");
+	solAssert(_argumentType.isImplicitlyConvertibleTo(*TypeProvider::fromElementaryTypeName("string memory")), "");
 	fetchFreeMemoryPointer();
 	m_context << (u256(FixedHash<4>::Arith(FixedHash<4>(dev::keccak256("Error(string)")))) << (256 - 32));
 	m_context << Instruction::DUP2 << Instruction::MSTORE;
 	m_context << u256(4) << Instruction::ADD;
 	// Stack: <string data> <mem pos of encoding start>
-	abiEncode({_argumentType.shared_from_this()}, {make_shared<ArrayType>(DataLocation::Memory, true)});
+	abiEncode({&_argumentType}, {TypeProvider::arrayType(DataLocation::Memory, true)});
 	toSizeAfterFreeMemoryPointer();
 	m_context << Instruction::REVERT;
 }
@@ -185,7 +186,7 @@ void CompilerUtils::loadFromMemoryDynamic(
 
 void CompilerUtils::storeInMemory(unsigned _offset)
 {
-	unsigned numBytes = prepareMemoryStore(IntegerType::uint256(), true);
+	unsigned numBytes = prepareMemoryStore(*TypeProvider::integerType(), true);
 	if (numBytes > 0)
 		m_context << u256(_offset) << Instruction::MSTORE;
 }
@@ -199,7 +200,7 @@ void CompilerUtils::storeInMemoryDynamic(Type const& _type, bool _padToWordBound
 			ref->location() == DataLocation::Memory,
 			"Only in-memory reference type can be stored."
 		);
-		storeInMemoryDynamic(IntegerType::uint256(), _padToWordBoundaries);
+		storeInMemoryDynamic(*TypeProvider::integerType(), _padToWordBoundaries);
 	}
 	else if (auto str = dynamic_cast<StringLiteralType const*>(&_type))
 	{
@@ -311,11 +312,11 @@ void CompilerUtils::abiDecode(TypePointers const& _typeParameters, bool _fromMem
 			else
 			{
 				// first load from calldata and potentially convert to memory if arrayType is memory
-				TypePointer calldataType = arrayType.copyForLocation(DataLocation::CallData, false);
+				TypePointer calldataType = TypeProvider::withLocation(&arrayType, DataLocation::CallData, false);
 				if (calldataType->isDynamicallySized())
 				{
 					// put on stack: data_pointer length
-					loadFromMemoryDynamic(IntegerType::uint256(), !_fromMemory);
+					loadFromMemoryDynamic(*TypeProvider::integerType(), !_fromMemory);
 					m_context << Instruction::SWAP1;
 					// stack: input_end base_offset next_pointer data_offset
 					m_context.appendInlineAssembly("{ if gt(data_offset, 0x100000000) { revert(0, 0) } }", {"data_offset"});
@@ -326,7 +327,7 @@ void CompilerUtils::abiDecode(TypePointers const& _typeParameters, bool _fromMem
 						{"input_end", "base_offset", "next_ptr", "array_head_ptr"}
 					);
 					// retrieve length
-					loadFromMemoryDynamic(IntegerType::uint256(), !_fromMemory, true);
+					loadFromMemoryDynamic(*TypeProvider::integerType(), !_fromMemory, true);
 					// stack: input_end base_offset next_pointer array_length data_pointer
 					m_context << Instruction::SWAP2;
 					// stack: input_end base_offset data_pointer array_length next_pointer
@@ -454,7 +455,7 @@ void CompilerUtils::encodeToMemory(
 				type = _givenTypes[i]; // delay conversion
 			else
 				convertType(*_givenTypes[i], *targetType, true);
-			if (auto arrayType = dynamic_cast<ArrayType const*>(type.get()))
+			if (auto arrayType = dynamic_cast<ArrayType const*>(type))
 				ArrayUtils(m_context).copyArrayToMemory(*arrayType, _padToWordBoundaries);
 			else
 				storeInMemoryDynamic(*type, _padToWordBoundaries);
@@ -482,7 +483,7 @@ void CompilerUtils::encodeToMemory(
 			{
 				auto const& strType = dynamic_cast<StringLiteralType const&>(*_givenTypes[i]);
 				m_context << u256(strType.value().size());
-				storeInMemoryDynamic(IntegerType::uint256(), true);
+				storeInMemoryDynamic(*TypeProvider::integerType(), true);
 				// stack: ... <end_of_mem'>
 				storeInMemoryDynamic(strType, _padToWordBoundaries);
 			}
@@ -497,7 +498,7 @@ void CompilerUtils::encodeToMemory(
 				m_context << dupInstruction(1 + arrayType.sizeOnStack());
 				ArrayUtils(m_context).retrieveLength(arrayType, 1);
 				// stack: ... <end_of_mem> <value...> <end_of_mem'> <length>
-				storeInMemoryDynamic(IntegerType::uint256(), true);
+				storeInMemoryDynamic(*TypeProvider::integerType(), true);
 				// stack: ... <end_of_mem> <value...> <end_of_mem''>
 				// copy the new memory pointer
 				m_context << swapInstruction(arrayType.sizeOnStack() + 1) << Instruction::POP;
@@ -868,7 +869,7 @@ void CompilerUtils::convertType(
 			allocateMemory(storageSize);
 			// stack: mempos
 			m_context << Instruction::DUP1 << u256(data.size());
-			storeInMemoryDynamic(IntegerType::uint256());
+			storeInMemoryDynamic(*TypeProvider::integerType());
 			// stack: mempos datapos
 			storeStringData(data);
 		}
@@ -917,7 +918,7 @@ void CompilerUtils::convertType(
 				if (targetType.isDynamicallySized())
 				{
 					m_context << Instruction::DUP2;
-					storeInMemoryDynamic(IntegerType::uint256());
+					storeInMemoryDynamic(*TypeProvider::integerType());
 				}
 				// stack: <mem start> <source ref> (variably sized) <length> <mem data pos>
 				if (targetType.baseType()->isValueType())
@@ -988,10 +989,9 @@ void CompilerUtils::convertType(
 			{
 			case DataLocation::Storage:
 			{
-				auto conversionImpl = [
-					typeOnStack = dynamic_pointer_cast<StructType const>(_typeOnStack.shared_from_this()),
-					targetType = dynamic_pointer_cast<StructType const>(targetType.shared_from_this())
-				](CompilerContext& _context) {
+				auto conversionImpl =
+					[typeOnStack = &typeOnStack, targetType = &targetType](CompilerContext& _context)
+				{
 					CompilerUtils utils(_context);
 					// stack: <source ref>
 					utils.allocateMemory(typeOnStack->memorySize());
@@ -1029,7 +1029,7 @@ void CompilerUtils::convertType(
 				m_context << Instruction::DUP1;
 				m_context << Instruction::CALLDATASIZE;
 				m_context << Instruction::SUB;
-				abiDecode({targetType.shared_from_this()}, false);
+				abiDecode({&targetType}, false);
 				break;
 			}
 			case DataLocation::Memory:
@@ -1162,7 +1162,7 @@ void CompilerUtils::pushZeroValue(Type const& _type)
 			return;
 		}
 
-	TypePointer type = _type.shared_from_this();
+	TypePointer type = &_type;
 	m_context.callLowLevelFunction(
 		"$pushZeroValue_" + referenceType->identifier(),
 		0,
@@ -1172,13 +1172,13 @@ void CompilerUtils::pushZeroValue(Type const& _type)
 			utils.allocateMemory(max(32u, type->calldataEncodedSize()));
 			_context << Instruction::DUP1;
 
-			if (auto structType = dynamic_cast<StructType const*>(type.get()))
+			if (auto structType = dynamic_cast<StructType const*>(type))
 				for (auto const& member: structType->members(nullptr))
 				{
 					utils.pushZeroValue(*member.type);
 					utils.storeInMemoryDynamic(*member.type);
 				}
-			else if (auto arrayType = dynamic_cast<ArrayType const*>(type.get()))
+			else if (auto arrayType = dynamic_cast<ArrayType const*>(type))
 			{
 				solAssert(!arrayType->isDynamicallySized(), "");
 				if (arrayType->length() > 0)
@@ -1275,10 +1275,10 @@ void CompilerUtils::popAndJump(unsigned _toHeight, eth::AssemblyItem const& _jum
 	m_context.adjustStackOffset(amount);
 }
 
-unsigned CompilerUtils::sizeOnStack(vector<shared_ptr<Type const>> const& _variableTypes)
+unsigned CompilerUtils::sizeOnStack(vector<Type const*> const& _variableTypes)
 {
 	unsigned size = 0;
-	for (shared_ptr<Type const> const& type: _variableTypes)
+	for (Type const* const& type: _variableTypes)
 		size += type->sizeOnStack();
 	return size;
 }
@@ -1321,7 +1321,7 @@ void CompilerUtils::storeStringData(bytesConstRef _data)
 		for (unsigned i = 0; i < _data.size(); i += 32)
 		{
 			m_context << h256::Arith(h256(_data.cropped(i), h256::AlignLeft));
-			storeInMemoryDynamic(IntegerType::uint256());
+			storeInMemoryDynamic(*TypeProvider::integerType());
 		}
 		m_context << Instruction::POP;
 	}

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -82,7 +82,7 @@ public:
 	/// @returns the number of bytes consumed in memory.
 	unsigned loadFromMemory(
 		unsigned _offset,
-		Type const& _type = *TypeProvider::integerType(),
+		Type const& _type = *TypeProvider::uint256(),
 		bool _fromCalldata = false,
 		bool _padToWords = false
 	);

--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <libsolidity/ast/ASTForward.h>
+#include <libsolidity/ast/TypeProvider.h>
+#include <libsolidity/codegen/CompilerContext.h>
 #include <libsolidity/codegen/CompilerContext.h>
 
 namespace dev {
@@ -80,7 +82,7 @@ public:
 	/// @returns the number of bytes consumed in memory.
 	unsigned loadFromMemory(
 		unsigned _offset,
-		Type const& _type = IntegerType::uint256(),
+		Type const& _type = *TypeProvider::integerType(),
 		bool _fromCalldata = false,
 		bool _padToWords = false
 	);
@@ -264,7 +266,7 @@ public:
 
 	template <class T>
 	static unsigned sizeOnStack(std::vector<T> const& _variables);
-	static unsigned sizeOnStack(std::vector<std::shared_ptr<Type const>> const& _variableTypes);
+	static unsigned sizeOnStack(std::vector<Type const*> const& _variableTypes);
 
 	/// Helper function to shift top value on the stack to the left.
 	/// Stack pre: <value> <shift_by_bits>

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/codegen/CompilerUtils.h>
 #include <libsolidity/codegen/ContractCompiler.h>
 #include <libsolidity/codegen/ExpressionCompiler.h>
@@ -871,7 +872,7 @@ bool ContractCompiler::visit(Return const& _return)
 
 		TypePointer expectedType;
 		if (expression->annotation().type->category() == Type::Category::Tuple || types.size() != 1)
-			expectedType = make_shared<TupleType>(types);
+			expectedType = TypeProvider::tupleType(move(types));
 		else
 			expectedType = types.front();
 		compileExpression(*expression, expectedType);
@@ -915,7 +916,7 @@ bool ContractCompiler::visit(VariableDeclarationStatement const& _variableDeclar
 		CompilerUtils utils(m_context);
 		compileExpression(*expression);
 		TypePointers valueTypes;
-		if (auto tupleType = dynamic_cast<TupleType const*>(expression->annotation().type.get()))
+		if (auto tupleType = dynamic_cast<TupleType const*>(expression->annotation().type))
 			valueTypes = tupleType->components();
 		else
 			valueTypes = TypePointers{expression->annotation().type};

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -23,6 +23,7 @@
 #include <libsolidity/codegen/ExpressionCompiler.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/codegen/CompilerContext.h>
 #include <libsolidity/codegen/CompilerUtils.h>
 #include <libsolidity/codegen/LValue.h>
@@ -102,7 +103,7 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 
 	for (size_t i = 0; i < paramTypes.size(); ++i)
 	{
-		if (auto mappingType = dynamic_cast<MappingType const*>(returnType.get()))
+		if (auto mappingType = dynamic_cast<MappingType const*>(returnType))
 		{
 			solAssert(CompilerUtils::freeMemoryPointer >= 0x40, "");
 
@@ -152,7 +153,7 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 			m_context << u256(0);
 			returnType = mappingType->valueType();
 		}
-		else if (auto arrayType = dynamic_cast<ArrayType const*>(returnType.get()))
+		else if (auto arrayType = dynamic_cast<ArrayType const*>(returnType))
 		{
 			// pop offset
 			m_context << Instruction::POP;
@@ -176,7 +177,7 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 	unsigned retSizeOnStack = 0;
 	auto returnTypes = accessorType.returnParameterTypes();
 	solAssert(returnTypes.size() >= 1, "");
-	if (StructType const* structType = dynamic_cast<StructType const*>(returnType.get()))
+	if (StructType const* structType = dynamic_cast<StructType const*>(returnType))
 	{
 		// remove offset
 		m_context << Instruction::POP;
@@ -186,7 +187,7 @@ void ExpressionCompiler::appendStateVariableAccessor(VariableDeclaration const& 
 		{
 			if (returnTypes[i]->category() == Type::Category::Mapping)
 				continue;
-			if (auto arrayType = dynamic_cast<ArrayType const*>(returnTypes[i].get()))
+			if (auto arrayType = dynamic_cast<ArrayType const*>(returnTypes[i]))
 				if (!arrayType->isByteArray())
 					continue;
 			pair<u256, unsigned> const& offsets = structType->storageOffsetsOfMember(names[i]);
@@ -496,7 +497,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		functionType = structType.constructorType();
 	}
 	else
-		functionType = dynamic_pointer_cast<FunctionType const>(_functionCall.expression().annotation().type);
+		functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type);
 
 	TypePointers parameterTypes = functionType->parameterTypes();
 	vector<ASTPointer<Expression const>> const& callArguments = _functionCall.arguments();
@@ -647,7 +648,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			_functionCall.expression().accept(*this);
 
 			arguments.front()->accept(*this);
-			utils().convertType(*arguments.front()->annotation().type, IntegerType::uint256(), true);
+			utils().convertType(*arguments.front()->annotation().type, *TypeProvider::integerType(), true);
 			// Note that function is not the original function, but the ".gas" function.
 			// Its values of gasSet and valueSet is equal to the original function's though.
 			unsigned stackDepth = (function.gasSet() ? 1 : 0) + (function.valueSet() ? 1 : 0);
@@ -731,9 +732,9 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			arguments.front()->accept(*this);
 			// Optimization: If type is bytes or string, then do not encode,
 			// but directly compute keccak256 on memory.
-			if (*argType == ArrayType::bytesMemory() || *argType == ArrayType::stringMemory())
+			if (*argType == *TypeProvider::bytesMemoryType() || *argType == *TypeProvider::stringMemoryType())
 			{
-				ArrayUtils(m_context).retrieveLength(ArrayType::bytesMemory());
+				ArrayUtils(m_context).retrieveLength(*TypeProvider::bytesMemoryType());
 				m_context << Instruction::SWAP1 << u256(0x20) << Instruction::ADD;
 			}
 			else
@@ -780,7 +781,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				{
 					++numIndexed;
 					arguments[arg - 1]->accept(*this);
-					if (auto const& referenceType = dynamic_pointer_cast<ReferenceType const>(paramTypes[arg - 1]))
+					if (auto const& referenceType = dynamic_cast<ReferenceType const*>(paramTypes[arg - 1]))
 					{
 						utils().fetchFreeMemoryPointer();
 						utils().packedEncode(
@@ -835,13 +836,13 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::MulMod:
 		{
 			arguments[2]->accept(*this);
-			utils().convertType(*arguments[2]->annotation().type, IntegerType::uint256());
+			utils().convertType(*arguments[2]->annotation().type, *TypeProvider::integerType());
 			m_context << Instruction::DUP1 << Instruction::ISZERO;
 			m_context.appendConditionalInvalid();
 			for (unsigned i = 1; i < 3; i ++)
 			{
 				arguments[2 - i]->accept(*this);
-				utils().convertType(*arguments[2 - i]->annotation().type, IntegerType::uint256());
+				utils().convertType(*arguments[2 - i]->annotation().type, *TypeProvider::integerType());
 			}
 			if (function.kind() == FunctionType::Kind::AddMod)
 				m_context << Instruction::ADDMOD;
@@ -872,10 +873,10 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			solAssert(function.parameterTypes().size() == 1, "");
 			solAssert(!!function.parameterTypes()[0], "");
 			TypePointer paramType = function.parameterTypes()[0];
-			shared_ptr<ArrayType> arrayType =
+			ArrayType const* arrayType =
 				function.kind() == FunctionType::Kind::ArrayPush ?
-				make_shared<ArrayType>(DataLocation::Storage, paramType) :
-				make_shared<ArrayType>(DataLocation::Storage);
+				TypeProvider::arrayType(DataLocation::Storage, paramType) :
+				TypeProvider::arrayType(DataLocation::Storage);
 
 			// stack: ArrayReference
 			arguments[0]->accept(*this);
@@ -927,7 +928,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 
 			// Fetch requested length.
 			arguments[0]->accept(*this);
-			utils().convertType(*arguments[0]->annotation().type, IntegerType::uint256());
+			utils().convertType(*arguments[0]->annotation().type, *TypeProvider::integerType());
 
 			// Stack: requested_length
 			utils().fetchFreeMemoryPointer();
@@ -1057,11 +1058,11 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				if (function.kind() == FunctionType::Kind::ABIEncodeWithSignature)
 				{
 					// hash the signature
-					if (auto const* stringType = dynamic_cast<StringLiteralType const*>(selectorType.get()))
+					if (auto const* stringType = dynamic_cast<StringLiteralType const*>(selectorType))
 					{
 						FixedHash<4> hash(dev::keccak256(stringType->value()));
 						m_context << (u256(FixedHash<4>::Arith(hash)) << (256 - 32));
-						dataOnStack = make_shared<FixedBytesType>(4);
+						dataOnStack = TypeProvider::fixedBytesType(4);
 					}
 					else
 					{
@@ -1072,7 +1073,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 						m_context << Instruction::KECCAK256;
 						// stack: <memory pointer> <hash>
 
-						dataOnStack = make_shared<FixedBytesType>(32);
+						dataOnStack = TypeProvider::fixedBytesType(32);
 					}
 				}
 				else
@@ -1103,7 +1104,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			arguments.front()->accept(*this);
 			TypePointer firstArgType = arguments.front()->annotation().type;
 			TypePointers targetTypes;
-			if (TupleType const* targetTupleType = dynamic_cast<TupleType const*>(_functionCall.annotation().type.get()))
+			if (TupleType const* targetTupleType = dynamic_cast<TupleType const*>(_functionCall.annotation().type))
 				targetTypes = targetTupleType->components();
 			else
 				targetTypes = TypePointers{_functionCall.annotation().type};
@@ -1114,7 +1115,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				utils().abiDecode(targetTypes, false);
 			else
 			{
-				utils().convertType(*firstArgType, ArrayType::bytesMemory());
+				utils().convertType(*firstArgType, *TypeProvider::bytesMemoryType());
 				m_context << Instruction::DUP1 << u256(32) << Instruction::ADD;
 				m_context << Instruction::SWAP1 << Instruction::MLOAD;
 				// stack now: <mem_pos> <length>
@@ -1145,7 +1146,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 	CompilerContext::LocationSetter locationSetter(m_context, _memberAccess);
 	// Check whether the member is a bound function.
 	ASTString const& member = _memberAccess.memberName();
-	if (auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type.get()))
+	if (auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type))
 		if (funType->bound())
 		{
 			_memberAccess.expression().accept(*this);
@@ -1174,14 +1175,14 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 
 	// Special processing for TypeType because we do not want to visit the library itself
 	// for internal functions, or enum/struct definitions.
-	if (TypeType const* type = dynamic_cast<TypeType const*>(_memberAccess.expression().annotation().type.get()))
+	if (TypeType const* type = dynamic_cast<TypeType const*>(_memberAccess.expression().annotation().type))
 	{
-		if (dynamic_cast<ContractType const*>(type->actualType().get()))
+		if (dynamic_cast<ContractType const*>(type->actualType()))
 		{
 			solAssert(_memberAccess.annotation().type, "_memberAccess has no type");
 			if (auto variable = dynamic_cast<VariableDeclaration const*>(_memberAccess.annotation().referencedDeclaration))
 				appendVariable(*variable, static_cast<Expression const&>(_memberAccess));
-			else if (auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type.get()))
+			else if (auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type))
 			{
 				switch (funType->kind())
 				{
@@ -1223,14 +1224,14 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					solAssert(false, "unsupported member function");
 				}
 			}
-			else if (dynamic_cast<TypeType const*>(_memberAccess.annotation().type.get()))
+			else if (dynamic_cast<TypeType const*>(_memberAccess.annotation().type))
 			{
 				// no-op
 			}
 			else
 				_memberAccess.expression().accept(*this);
 		}
-		else if (auto enumType = dynamic_cast<EnumType const*>(type->actualType().get()))
+		else if (auto enumType = dynamic_cast<EnumType const*>(type->actualType()))
 		{
 			_memberAccess.expression().accept(*this);
 			m_context << enumType->memberValue(_memberAccess.memberName());
@@ -1288,7 +1289,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 				identifier = FunctionType(*function).externalIdentifier();
 			else
 				solAssert(false, "Contract member is neither variable nor function.");
-			utils().convertType(type, type.isPayable() ? AddressType::addressPayable() : AddressType::address(), true);
+			utils().convertType(type, type.isPayable() ? *TypeProvider::payableAddressType() : *TypeProvider::addressType(), true);
 			m_context << identifier;
 		}
 		else
@@ -1306,7 +1307,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		{
 			utils().convertType(
 				*_memberAccess.expression().annotation().type,
-				AddressType::address(),
+				*TypeProvider::addressType(),
 				true
 			);
 			m_context << Instruction::BALANCE;
@@ -1323,7 +1324,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		else if ((set<string>{"call", "callcode", "delegatecall", "staticcall"}).count(member))
 			utils().convertType(
 				*_memberAccess.expression().annotation().type,
-				AddressType::address(),
+				*TypeProvider::addressType(),
 				true
 			);
 		else
@@ -1542,7 +1543,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 				TypePointers{keyType}
 			);
 			m_context << Instruction::SWAP1;
-			utils().storeInMemoryDynamic(IntegerType::uint256());
+			utils().storeInMemoryDynamic(*TypeProvider::integerType());
 			utils().toSizeAfterFreeMemoryPointer();
 		}
 		else
@@ -1551,7 +1552,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 			appendExpressionCopyToMemory(*keyType, *_indexAccess.indexExpression());
 			m_context << Instruction::SWAP1;
 			solAssert(CompilerUtils::freeMemoryPointer >= 0x40, "");
-			utils().storeInMemoryDynamic(IntegerType::uint256());
+			utils().storeInMemoryDynamic(*TypeProvider::integerType());
 			m_context << u256(0);
 		}
 		m_context << Instruction::KECCAK256;
@@ -1564,7 +1565,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.indexExpression(), "Index expression expected.");
 
 		_indexAccess.indexExpression()->accept(*this);
-		utils().convertType(*_indexAccess.indexExpression()->annotation().type, IntegerType::uint256(), true);
+		utils().convertType(*_indexAccess.indexExpression()->annotation().type, *TypeProvider::integerType(), true);
 		// stack layout: <base_ref> [<length>] <index>
 		switch (arrayType.location())
 		{
@@ -1631,7 +1632,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.indexExpression(), "Index expression expected.");
 
 		_indexAccess.indexExpression()->accept(*this);
-		utils().convertType(*_indexAccess.indexExpression()->annotation().type, IntegerType::uint256(), true);
+		utils().convertType(*_indexAccess.indexExpression()->annotation().type, *TypeProvider::integerType(), true);
 		// stack layout: <value> <index>
 		// check out-of-bounds access
 		m_context << u256(fixedBytesType.numBytes());
@@ -2211,7 +2212,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 			needToUpdateFreeMemoryPtr = true;
 		else
 			for (auto const& retType: returnTypes)
-				if (dynamic_cast<ReferenceType const*>(retType.get()))
+				if (dynamic_cast<ReferenceType const*>(retType))
 					needToUpdateFreeMemoryPtr = true;
 
 		// Stack: return_data_start

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -648,7 +648,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			_functionCall.expression().accept(*this);
 
 			arguments.front()->accept(*this);
-			utils().convertType(*arguments.front()->annotation().type, *TypeProvider::integerType(), true);
+			utils().convertType(*arguments.front()->annotation().type, *TypeProvider::uint256(), true);
 			// Note that function is not the original function, but the ".gas" function.
 			// Its values of gasSet and valueSet is equal to the original function's though.
 			unsigned stackDepth = (function.gasSet() ? 1 : 0) + (function.valueSet() ? 1 : 0);
@@ -836,13 +836,13 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::MulMod:
 		{
 			arguments[2]->accept(*this);
-			utils().convertType(*arguments[2]->annotation().type, *TypeProvider::integerType());
+			utils().convertType(*arguments[2]->annotation().type, *TypeProvider::uint256());
 			m_context << Instruction::DUP1 << Instruction::ISZERO;
 			m_context.appendConditionalInvalid();
 			for (unsigned i = 1; i < 3; i ++)
 			{
 				arguments[2 - i]->accept(*this);
-				utils().convertType(*arguments[2 - i]->annotation().type, *TypeProvider::integerType());
+				utils().convertType(*arguments[2 - i]->annotation().type, *TypeProvider::uint256());
 			}
 			if (function.kind() == FunctionType::Kind::AddMod)
 				m_context << Instruction::ADDMOD;
@@ -928,7 +928,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 
 			// Fetch requested length.
 			arguments[0]->accept(*this);
-			utils().convertType(*arguments[0]->annotation().type, *TypeProvider::integerType());
+			utils().convertType(*arguments[0]->annotation().type, *TypeProvider::uint256());
 
 			// Stack: requested_length
 			utils().fetchFreeMemoryPointer();
@@ -1543,7 +1543,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 				TypePointers{keyType}
 			);
 			m_context << Instruction::SWAP1;
-			utils().storeInMemoryDynamic(*TypeProvider::integerType());
+			utils().storeInMemoryDynamic(*TypeProvider::uint256());
 			utils().toSizeAfterFreeMemoryPointer();
 		}
 		else
@@ -1552,7 +1552,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 			appendExpressionCopyToMemory(*keyType, *_indexAccess.indexExpression());
 			m_context << Instruction::SWAP1;
 			solAssert(CompilerUtils::freeMemoryPointer >= 0x40, "");
-			utils().storeInMemoryDynamic(*TypeProvider::integerType());
+			utils().storeInMemoryDynamic(*TypeProvider::uint256());
 			m_context << u256(0);
 		}
 		m_context << Instruction::KECCAK256;
@@ -1565,7 +1565,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.indexExpression(), "Index expression expected.");
 
 		_indexAccess.indexExpression()->accept(*this);
-		utils().convertType(*_indexAccess.indexExpression()->annotation().type, *TypeProvider::integerType(), true);
+		utils().convertType(*_indexAccess.indexExpression()->annotation().type, *TypeProvider::uint256(), true);
 		// stack layout: <base_ref> [<length>] <index>
 		switch (arrayType.location())
 		{
@@ -1632,7 +1632,7 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.indexExpression(), "Index expression expected.");
 
 		_indexAccess.indexExpression()->accept(*this);
-		utils().convertType(*_indexAccess.indexExpression()->annotation().type, *TypeProvider::integerType(), true);
+		utils().convertType(*_indexAccess.indexExpression()->annotation().type, *TypeProvider::uint256(), true);
 		// stack layout: <value> <index>
 		// check out-of-bounds access
 		m_context << u256(fixedBytesType.numBytes());

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -35,7 +35,7 @@ using namespace langutil;
 
 
 StackVariable::StackVariable(CompilerContext& _compilerContext, VariableDeclaration const& _declaration):
-	LValue(_compilerContext, _declaration.annotation().type.get()),
+	LValue(_compilerContext, _declaration.annotation().type),
 	m_baseStackOffset(m_context.baseStackOffsetOfVariable(_declaration)),
 	m_size(m_dataType->sizeOnStack())
 {
@@ -475,7 +475,7 @@ void StorageByteArrayElement::setToZero(SourceLocation const&, bool _removeRefer
 }
 
 StorageArrayLength::StorageArrayLength(CompilerContext& _compilerContext, ArrayType const& _arrayType):
-	LValue(_compilerContext, _arrayType.memberType("length").get()),
+	LValue(_compilerContext, _arrayType.memberType("length")),
 	m_arrayType(_arrayType)
 {
 	solAssert(m_arrayType.isDynamicallySized(), "");

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -145,7 +145,7 @@ string YulUtilFunctions::leftAlignFunction(Type const& _type)
 			templ("body", "aligned := value");
 			break;
 		case Type::Category::Contract:
-			templ("body", "aligned := " + leftAlignFunction(AddressType::address()) + "(value)");
+			templ("body", "aligned := " + leftAlignFunction(*TypeProvider::addressType()) + "(value)");
 			break;
 		case Type::Category::Enum:
 		{

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -82,7 +82,7 @@ void IRGeneratorForStatements::endVisit(BinaryOperation const& _binOp)
 {
 	solUnimplementedAssert(_binOp.getOperator() == Token::Add, "");
 	solUnimplementedAssert(*_binOp.leftExpression().annotation().type == *_binOp.rightExpression().annotation().type, "");
-	if (IntegerType const* type = dynamic_cast<IntegerType const*>(_binOp.annotation().commonType.get()))
+	if (IntegerType const* type = dynamic_cast<IntegerType const*>(_binOp.annotation().commonType))
 	{
 		solUnimplementedAssert(!type->isSigned(), "");
 		m_code <<
@@ -103,7 +103,7 @@ void IRGeneratorForStatements::endVisit(BinaryOperation const& _binOp)
 bool IRGeneratorForStatements::visit(FunctionCall const& _functionCall)
 {
 	solUnimplementedAssert(_functionCall.annotation().kind == FunctionCallKind::FunctionCall, "");
-	FunctionTypePointer functionType = dynamic_pointer_cast<FunctionType const>(_functionCall.expression().annotation().type);
+	FunctionTypePointer functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type);
 
 	TypePointers parameterTypes = functionType->parameterTypes();
 	vector<ASTPointer<Expression const>> const& callArguments = _functionCall.arguments();

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -17,6 +17,7 @@
 
 #include <libsolidity/formal/SMTChecker.h>
 
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/formal/SMTPortfolio.h>
 #include <libsolidity/formal/SymbolicTypes.h>
 
@@ -447,7 +448,7 @@ void SMTChecker::checkUnderOverflow()
 void SMTChecker::checkUnderflow(OverflowTarget& _target)
 {
 	solAssert(_target.type != OverflowTarget::Type::Overflow, "");
-	auto intType = dynamic_cast<IntegerType const*>(_target.intType.get());
+	auto intType = dynamic_cast<IntegerType const*>(_target.intType);
 	checkCondition(
 		_target.path && _target.value < minValue(*intType),
 		_target.location,
@@ -460,7 +461,7 @@ void SMTChecker::checkUnderflow(OverflowTarget& _target)
 void SMTChecker::checkOverflow(OverflowTarget& _target)
 {
 	solAssert(_target.type != OverflowTarget::Type::Underflow, "");
-	auto intType = dynamic_cast<IntegerType const*>(_target.intType.get());
+	auto intType = dynamic_cast<IntegerType const*>(_target.intType);
 	checkCondition(
 		_target.path && _target.value > maxValue(*intType),
 		_target.location,
@@ -681,7 +682,7 @@ void SMTChecker::inlineFunctionCall(FunctionCall const& _funCall)
 	{
 		vector<smt::Expression> funArgs;
 		Expression const* calledExpr = &_funCall.expression();
-		auto const& funType = dynamic_cast<FunctionType const*>(calledExpr->annotation().type.get());
+		auto const& funType = dynamic_cast<FunctionType const*>(calledExpr->annotation().type);
 		solAssert(funType, "");
 		if (funType->bound())
 		{
@@ -803,8 +804,8 @@ void SMTChecker::endVisit(Literal const& _literal)
 	{
 		if (type.category() == Type::Category::StringLiteral)
 		{
-			auto stringType = make_shared<ArrayType>(DataLocation::Memory, true);
-			auto stringLit = dynamic_cast<StringLiteralType const*>(_literal.annotation().type.get());
+			auto stringType = TypeProvider::stringMemoryType();
+			auto stringLit = dynamic_cast<StringLiteralType const*>(_literal.annotation().type);
 			solAssert(stringLit, "");
 			auto result = newSymbolicVariable(*stringType, stringLit->richIdentifier(), *m_interface);
 			m_expressions.emplace(&_literal, result.second);
@@ -859,7 +860,7 @@ bool SMTChecker::visit(MemberAccess const& _memberAccess)
 	{
 		if (identifier && dynamic_cast<EnumDefinition const*>(identifier->annotation().referencedDeclaration))
 		{
-			auto enumType = dynamic_cast<EnumType const*>(accessType.get());
+			auto enumType = dynamic_cast<EnumType const*>(accessType);
 			solAssert(enumType, "");
 			defineExpr(_memberAccess, enumType->memberValue(_memberAccess.memberName()));
 		}
@@ -939,13 +940,13 @@ void SMTChecker::arrayIndexAssignment(Expression const& _expr, smt::Expression c
 						return true;
 					if (prefix->category() == Type::Category::Mapping)
 					{
-						auto mapPrefix = dynamic_cast<MappingType const*>(prefix.get());
+						auto mapPrefix = dynamic_cast<MappingType const*>(prefix);
 						solAssert(mapPrefix, "");
 						prefix = mapPrefix->valueType();
 					}
 					else
 					{
-						auto arrayPrefix = dynamic_cast<ArrayType const*>(prefix.get());
+						auto arrayPrefix = dynamic_cast<ArrayType const*>(prefix);
 						solAssert(arrayPrefix, "");
 						prefix = arrayPrefix->baseType();
 					}
@@ -1017,7 +1018,7 @@ bool SMTChecker::shortcutRationalNumber(Expression const& _expr)
 {
 	if (_expr.annotation().type->category() == Type::Category::RationalNumber)
 	{
-		auto rationalType = dynamic_cast<RationalNumberType const*>(_expr.annotation().type.get());
+		auto rationalType = dynamic_cast<RationalNumberType const*>(_expr.annotation().type);
 		solAssert(rationalType, "");
 		if (rationalType->isNegative())
 			defineExpr(_expr, smt::Expression(u2s(rationalType->literalValue(nullptr))));
@@ -1205,7 +1206,7 @@ void SMTChecker::assignment(VariableDeclaration const& _variable, smt::Expressio
 	if (type->category() == Type::Category::Integer)
 		addOverflowTarget(OverflowTarget::Type::All, type,	_value,	_location);
 	else if (type->category() == Type::Category::Address)
-		addOverflowTarget(OverflowTarget::Type::All, make_shared<IntegerType>(160), _value, _location);
+		addOverflowTarget(OverflowTarget::Type::All, TypeProvider::integerType(160), _value, _location);
 	else if (type->category() == Type::Category::Mapping)
 		arrayAssignment();
 	m_interface->addAssertion(newValue(_variable) == _value);
@@ -1522,7 +1523,7 @@ void SMTChecker::resetVariables(function<bool(VariableDeclaration const&)> const
 
 TypePointer SMTChecker::typeWithoutPointer(TypePointer const& _type)
 {
-	if (auto refType = dynamic_cast<ReferenceType const*>(_type.get()))
+	if (auto refType = dynamic_cast<ReferenceType const*>(_type))
 		return ReferenceType::copyForLocationIfReference(refType->location(), _type);
 	return _type;
 }

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -1206,7 +1206,7 @@ void SMTChecker::assignment(VariableDeclaration const& _variable, smt::Expressio
 	if (type->category() == Type::Category::Integer)
 		addOverflowTarget(OverflowTarget::Type::All, type,	_value,	_location);
 	else if (type->category() == Type::Category::Address)
-		addOverflowTarget(OverflowTarget::Type::All, TypeProvider::integerType(160), _value, _location);
+		addOverflowTarget(OverflowTarget::Type::All, TypeProvider::uint(160), _value, _location);
 	else if (type->category() == Type::Category::Mapping)
 		arrayAssignment();
 	m_interface->addAssertion(newValue(_variable) == _value);

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -178,7 +178,7 @@ private:
 			location(_location),
 			callStack(move(_callStack))
 		{
-			solAssert(dynamic_cast<IntegerType const*>(intType.get()), "");
+			solAssert(dynamic_cast<IntegerType const*>(intType), "");
 		}
 	};
 

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -17,6 +17,7 @@
 
 #include <libsolidity/formal/SymbolicTypes.h>
 
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/ast/Types.h>
 #include <memory>
 
@@ -115,11 +116,11 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 {
 	bool abstract = false;
 	shared_ptr<SymbolicVariable> var;
-	TypePointer type = _type.shared_from_this();
+	TypePointer type = &_type;
 	if (!isSupportedTypeDeclaration(_type))
 	{
 		abstract = true;
-		var = make_shared<SymbolicIntVariable>(make_shared<IntegerType>(256), _uniqueName, _solver);
+		var = make_shared<SymbolicIntVariable>(TypeProvider::integerType(256), _uniqueName, _solver);
 	}
 	else if (isBool(_type.category()))
 		var = make_shared<SymbolicBoolVariable>(type, _uniqueName, _solver);
@@ -129,7 +130,7 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 		var = make_shared<SymbolicIntVariable>(type, _uniqueName, _solver);
 	else if (isFixedBytes(_type.category()))
 	{
-		auto fixedBytesType = dynamic_cast<FixedBytesType const*>(type.get());
+		auto fixedBytesType = dynamic_cast<FixedBytesType const*>(type);
 		solAssert(fixedBytesType, "");
 		var = make_shared<SymbolicFixedBytesVariable>(fixedBytesType->numBytes(), _uniqueName, _solver);
 	}
@@ -142,7 +143,7 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 		auto rational = dynamic_cast<RationalNumberType const*>(&_type);
 		solAssert(rational, "");
 		if (rational->isFractional())
-			var = make_shared<SymbolicIntVariable>(make_shared<IntegerType>(256), _uniqueName, _solver);
+			var = make_shared<SymbolicIntVariable>(TypeProvider::integerType(256), _uniqueName, _solver);
 		else
 			var = make_shared<SymbolicIntVariable>(type, _uniqueName, _solver);
 	}
@@ -253,14 +254,14 @@ void dev::solidity::smt::setSymbolicUnknownValue(smt::Expression _expr, TypePoin
 	solAssert(_type, "");
 	if (isEnum(_type->category()))
 	{
-		auto enumType = dynamic_cast<EnumType const*>(_type.get());
+		auto enumType = dynamic_cast<EnumType const*>(_type);
 		solAssert(enumType, "");
 		_interface.addAssertion(_expr >= 0);
 		_interface.addAssertion(_expr < enumType->numberOfMembers());
 	}
 	else if (isInteger(_type->category()))
 	{
-		auto intType = dynamic_cast<IntegerType const*>(_type.get());
+		auto intType = dynamic_cast<IntegerType const*>(_type);
 		solAssert(intType, "");
 		_interface.addAssertion(_expr >= minValue(*intType));
 		_interface.addAssertion(_expr <= maxValue(*intType));

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -120,7 +120,7 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 	if (!isSupportedTypeDeclaration(_type))
 	{
 		abstract = true;
-		var = make_shared<SymbolicIntVariable>(TypeProvider::integerType(256), _uniqueName, _solver);
+		var = make_shared<SymbolicIntVariable>(TypeProvider::uint256(), _uniqueName, _solver);
 	}
 	else if (isBool(_type.category()))
 		var = make_shared<SymbolicBoolVariable>(type, _uniqueName, _solver);
@@ -143,7 +143,7 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 		auto rational = dynamic_cast<RationalNumberType const*>(&_type);
 		solAssert(rational, "");
 		if (rational->isFractional())
-			var = make_shared<SymbolicIntVariable>(TypeProvider::integerType(256), _uniqueName, _solver);
+			var = make_shared<SymbolicIntVariable>(TypeProvider::uint256(), _uniqueName, _solver);
 		else
 			var = make_shared<SymbolicIntVariable>(type, _uniqueName, _solver);
 	}

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -19,6 +19,7 @@
 
 #include <libsolidity/formal/SymbolicTypes.h>
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 
 using namespace std;
 using namespace dev;
@@ -102,7 +103,7 @@ SymbolicAddressVariable::SymbolicAddressVariable(
 	string _uniqueName,
 	smt::SolverInterface& _interface
 ):
-	SymbolicIntVariable(make_shared<IntegerType>(160), move(_uniqueName), _interface)
+	SymbolicIntVariable(TypeProvider::integerType(160), move(_uniqueName), _interface)
 {
 }
 
@@ -111,7 +112,7 @@ SymbolicFixedBytesVariable::SymbolicFixedBytesVariable(
 	string _uniqueName,
 	smt::SolverInterface& _interface
 ):
-	SymbolicIntVariable(make_shared<IntegerType>(_numBytes * 8), move(_uniqueName), _interface)
+	SymbolicIntVariable(TypeProvider::integerType(_numBytes * 8), move(_uniqueName), _interface)
 {
 }
 

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -103,7 +103,7 @@ SymbolicAddressVariable::SymbolicAddressVariable(
 	string _uniqueName,
 	smt::SolverInterface& _interface
 ):
-	SymbolicIntVariable(TypeProvider::integerType(160), move(_uniqueName), _interface)
+	SymbolicIntVariable(TypeProvider::uint(160), move(_uniqueName), _interface)
 {
 }
 
@@ -112,7 +112,7 @@ SymbolicFixedBytesVariable::SymbolicFixedBytesVariable(
 	string _uniqueName,
 	smt::SolverInterface& _interface
 ):
-	SymbolicIntVariable(TypeProvider::integerType(_numBytes * 8), move(_uniqueName), _interface)
+	SymbolicIntVariable(TypeProvider::uint(_numBytes * 8), move(_uniqueName), _interface)
 {
 }
 

--- a/libsolidity/interface/ABI.h
+++ b/libsolidity/interface/ABI.h
@@ -32,7 +32,7 @@ namespace solidity
 // Forward declarations
 class ContractDefinition;
 class Type;
-using TypePointer = std::shared_ptr<Type const>;
+using TypePointer = Type const*;
 
 class ABI
 {

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -98,11 +98,9 @@ public:
 	/// Creates a new compiler stack.
 	/// @param _readFile callback to used to read files for import statements. Must return
 	/// and must not emit exceptions.
-	explicit CompilerStack(ReadCallback::Callback const& _readFile = ReadCallback::Callback()):
-		m_readFile(_readFile),
-		m_generateIR(false),
-		m_errorList(),
-		m_errorReporter(m_errorList) {}
+	explicit CompilerStack(ReadCallback::Callback const& _readFile = ReadCallback::Callback());
+
+	~CompilerStack();
 
 	/// @returns the list of errors that occurred during parsing and type checking.
 	langutil::ErrorList const& errors() const { return m_errorReporter.errors(); }

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -47,21 +47,21 @@ AnalysisFramework::parseAnalyseAndReturnError(
 	bool _allowMultipleErrors
 )
 {
-	m_compiler.reset();
-	m_compiler.setSources({{"", _insertVersionPragma ? "pragma solidity >=0.0;\n" + _source : _source}});
-	m_compiler.setEVMVersion(dev::test::Options::get().evmVersion());
-	if (!m_compiler.parse())
+	compiler().reset();
+	compiler().setSources({{"", _insertVersionPragma ? "pragma solidity >=0.0;\n" + _source : _source}});
+	compiler().setEVMVersion(dev::test::Options::get().evmVersion());
+	if (!compiler().parse())
 	{
 		BOOST_FAIL("Parsing contract failed in analysis test suite:" + formatErrors());
 	}
 
-	m_compiler.analyze();
+	compiler().analyze();
 
-	ErrorList errors = filterErrors(m_compiler.errors(), _reportWarnings);
+	ErrorList errors = filterErrors(compiler().errors(), _reportWarnings);
 	if (errors.size() > 1 && !_allowMultipleErrors)
 		BOOST_FAIL("Multiple errors found: " + formatErrors());
 
-	return make_pair(&m_compiler.ast(""), std::move(errors));
+	return make_pair(&compiler().ast(""), std::move(errors));
 }
 
 ErrorList AnalysisFramework::filterErrors(ErrorList const& _errorList, bool _includeWarnings) const
@@ -118,7 +118,7 @@ ErrorList AnalysisFramework::expectError(std::string const& _source, bool _warni
 string AnalysisFramework::formatErrors() const
 {
 	string message;
-	for (auto const& error: m_compiler.errors())
+	for (auto const& error: compiler().errors())
 		message += formatError(*error);
 	return message;
 }

--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -35,8 +35,8 @@ namespace solidity
 
 class Type;
 class FunctionType;
-using TypePointer = std::shared_ptr<Type const>;
-using FunctionTypePointer = std::shared_ptr<FunctionType const>;
+using TypePointer = Type const*;
+using FunctionTypePointer = FunctionType const*;
 
 namespace test
 {

--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -71,7 +71,25 @@ protected:
 	langutil::ErrorList filterErrors(langutil::ErrorList const& _errorList, bool _includeWarnings) const;
 
 	std::vector<std::string> m_warningsToFilter = {"This is a pre-release compiler version"};
-	dev::solidity::CompilerStack m_compiler;
+
+	/// @returns reference to lazy-instanciated CompilerStack.
+	dev::solidity::CompilerStack& compiler()
+	{
+		if (!m_compiler)
+			m_compiler = std::make_unique<dev::solidity::CompilerStack>();
+		return *m_compiler;
+	}
+
+	/// @returns reference to lazy-instanciated CompilerStack.
+	dev::solidity::CompilerStack const& compiler() const
+	{
+		if (!m_compiler)
+			m_compiler = std::make_unique<dev::solidity::CompilerStack>();
+		return *m_compiler;
+	}
+
+private:
+	mutable std::unique_ptr<dev::solidity::CompilerStack> m_compiler;
 };
 
 // Asserts that the compilation down to typechecking

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -42,11 +42,11 @@ BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 			function f() internal { for (uint i = 0; i < 10; ++i) x += 3 + i; }
 		}
 	)";
-	m_compiler.setOptimiserSettings(dev::test::Options::get().optimize);
+	compiler().setOptimiserSettings(dev::test::Options::get().optimize);
 	BOOST_REQUIRE(success(sourceCode));
-	BOOST_REQUIRE_MESSAGE(m_compiler.compile(), "Compiling contract failed");
-	bytes const& creationBytecode = dev::test::bytecodeSansMetadata(m_compiler.object("C").bytecode);
-	bytes const& runtimeBytecode = dev::test::bytecodeSansMetadata(m_compiler.runtimeObject("C").bytecode);
+	BOOST_REQUIRE_MESSAGE(compiler().compile(), "Compiling contract failed");
+	bytes const& creationBytecode = dev::test::bytecodeSansMetadata(compiler().object("C").bytecode);
+	bytes const& runtimeBytecode = dev::test::bytecodeSansMetadata(compiler().runtimeObject("C").bytecode);
 	BOOST_CHECK(creationBytecode.size() >= 90);
 	BOOST_CHECK(creationBytecode.size() <= 120);
 	BOOST_CHECK(runtimeBytecode.size() >= 10);

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -28,6 +28,7 @@
 #include <libsolidity/codegen/CompilerContext.h>
 #include <libsolidity/codegen/ExpressionCompiler.h>
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/analysis/TypeChecker.h>
 #include <liblangutil/ErrorReporter.h>
 #include <test/Options.h>
@@ -597,7 +598,7 @@ BOOST_AUTO_TEST_CASE(blockhash)
 		}
 	)";
 
-	auto blockhashFun = make_shared<FunctionType>(strings{"uint256"}, strings{"bytes32"},
+	auto blockhashFun = TypeProvider::functionType(strings{"uint256"}, strings{"bytes32"},
 		FunctionType::Kind::BlockHash, false, StateMutability::View);
 
 	bytes code = compileFirstExpression(sourceCode, {}, {}, {make_shared<MagicVariableDeclaration>("blockhash", blockhashFun)});
@@ -618,7 +619,7 @@ BOOST_AUTO_TEST_CASE(gas_left)
 	)";
 	bytes code = compileFirstExpression(
 		sourceCode, {}, {},
-		{make_shared<MagicVariableDeclaration>("gasleft", make_shared<FunctionType>(strings(), strings{"uint256"}, FunctionType::Kind::GasLeft))}
+		{make_shared<MagicVariableDeclaration>("gasleft", TypeProvider::functionType(strings(), strings{"uint256"}, FunctionType::Kind::GasLeft))}
 	);
 
 	bytes expectation = bytes({uint8_t(Instruction::GAS)});

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(getter_is_memory_type)
 	)";
 	CHECK_SUCCESS_NO_WARNINGS(text);
 	// Check that the getters return a memory strings, not a storage strings.
-	ContractDefinition const& c = dynamic_cast<ContractDefinition const&>(*m_compiler.ast("").nodes().at(1));
+	ContractDefinition const& c = dynamic_cast<ContractDefinition const&>(*compiler().ast("").nodes().at(1));
 	BOOST_CHECK(c.interfaceFunctions().size() == 2);
 	for (auto const& f: c.interfaceFunctions())
 	{

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <libsolidity/ast/Types.h>
+#include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/ast/AST.h>
 #include <libdevcore/Keccak256.h>
 #include <boost/test/unit_test.hpp>
@@ -39,51 +40,51 @@ BOOST_AUTO_TEST_SUITE(SolidityTypes)
 
 BOOST_AUTO_TEST_CASE(int_types)
 {
-	BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::Int, 0, 0)) == *make_shared<IntegerType>(256, IntegerType::Modifier::Signed));
+	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::Int, 0, 0)) == *TypeProvider::integerType(256, IntegerType::Modifier::Signed));
 	for (unsigned i = 8; i <= 256; i += 8)
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::IntM, i, 0)) == *make_shared<IntegerType>(i, IntegerType::Modifier::Signed));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::IntM, i, 0)) == *TypeProvider::integerType(i, IntegerType::Modifier::Signed));
 }
 
 BOOST_AUTO_TEST_CASE(uint_types)
 {
-	BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::UInt, 0, 0)) == *make_shared<IntegerType>(256, IntegerType::Modifier::Unsigned));
+	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UInt, 0, 0)) == *TypeProvider::integerType(256, IntegerType::Modifier::Unsigned));
 	for (unsigned i = 8; i <= 256; i += 8)
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::UIntM, i, 0)) == *make_shared<IntegerType>(i, IntegerType::Modifier::Unsigned));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UIntM, i, 0)) == *TypeProvider::integerType(i, IntegerType::Modifier::Unsigned));
 }
 
 BOOST_AUTO_TEST_CASE(byte_types)
 {
-	BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::Byte, 0, 0)) == *make_shared<FixedBytesType>(1));
+	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::Byte, 0, 0)) == *TypeProvider::fixedBytesType(1));
 	for (unsigned i = 1; i <= 32; i++)
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::BytesM, i, 0)) == *make_shared<FixedBytesType>(i));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::BytesM, i, 0)) == *TypeProvider::fixedBytesType(i));
 }
 
 BOOST_AUTO_TEST_CASE(fixed_types)
 {
-	BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::Fixed, 0, 0)) == *make_shared<FixedPointType>(128, 18, FixedPointType::Modifier::Signed));
+	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::Fixed, 0, 0)) == *TypeProvider::fixedPointType(128, 18, FixedPointType::Modifier::Signed));
 	for (unsigned i = 8; i <= 256; i += 8)
 	{
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 0)) == *make_shared<FixedPointType>(i, 0, FixedPointType::Modifier::Signed));
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 2)) == *make_shared<FixedPointType>(i, 2, FixedPointType::Modifier::Signed));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 0)) == *TypeProvider::fixedPointType(i, 0, FixedPointType::Modifier::Signed));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 2)) == *TypeProvider::fixedPointType(i, 2, FixedPointType::Modifier::Signed));
 	}
 }
 
 BOOST_AUTO_TEST_CASE(ufixed_types)
 {
-	BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixed, 0, 0)) == *make_shared<FixedPointType>(128, 18, FixedPointType::Modifier::Unsigned));
+	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixed, 0, 0)) == *TypeProvider::fixedPointType(128, 18, FixedPointType::Modifier::Unsigned));
 	for (unsigned i = 8; i <= 256; i += 8)
 	{
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 0)) == *make_shared<FixedPointType>(i, 0, FixedPointType::Modifier::Unsigned));
-		BOOST_CHECK(*Type::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 2)) == *make_shared<FixedPointType>(i, 2, FixedPointType::Modifier::Unsigned));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 0)) == *TypeProvider::fixedPointType(i, 0, FixedPointType::Modifier::Unsigned));
+		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 2)) == *TypeProvider::fixedPointType(i, 2, FixedPointType::Modifier::Unsigned));
 	}
 }
 
 BOOST_AUTO_TEST_CASE(storage_layout_simple)
 {
 	MemberList members(MemberList::MemberMap({
-		{string("first"), Type::fromElementaryTypeName("uint128")},
-		{string("second"), Type::fromElementaryTypeName("uint120")},
-		{string("wraps"), Type::fromElementaryTypeName("uint16")}
+		{string("first"), TypeProvider::fromElementaryTypeName("uint128")},
+		{string("second"), TypeProvider::fromElementaryTypeName("uint120")},
+		{string("wraps"), TypeProvider::fromElementaryTypeName("uint16")}
 	}));
 	BOOST_REQUIRE_EQUAL(u256(2), members.storageSize());
 	BOOST_REQUIRE(members.memberStorageOffset("first") != nullptr);
@@ -97,15 +98,15 @@ BOOST_AUTO_TEST_CASE(storage_layout_simple)
 BOOST_AUTO_TEST_CASE(storage_layout_mapping)
 {
 	MemberList members(MemberList::MemberMap({
-		{string("first"), Type::fromElementaryTypeName("uint128")},
-		{string("second"), make_shared<MappingType>(
-			Type::fromElementaryTypeName("uint8"),
-			Type::fromElementaryTypeName("uint8")
+		{string("first"), TypeProvider::fromElementaryTypeName("uint128")},
+		{string("second"), TypeProvider::mappingType(
+			TypeProvider::fromElementaryTypeName("uint8"),
+			TypeProvider::fromElementaryTypeName("uint8")
 		)},
-		{string("third"), Type::fromElementaryTypeName("uint16")},
-		{string("final"), make_shared<MappingType>(
-			Type::fromElementaryTypeName("uint8"),
-			Type::fromElementaryTypeName("uint8")
+		{string("third"), TypeProvider::fromElementaryTypeName("uint16")},
+		{string("final"), TypeProvider::mappingType(
+			TypeProvider::fromElementaryTypeName("uint8"),
+			TypeProvider::fromElementaryTypeName("uint8")
 		)},
 	}));
 	BOOST_REQUIRE_EQUAL(u256(4), members.storageSize());
@@ -121,13 +122,13 @@ BOOST_AUTO_TEST_CASE(storage_layout_mapping)
 
 BOOST_AUTO_TEST_CASE(storage_layout_arrays)
 {
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(1), 32).storageSize() == 1);
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(1), 33).storageSize() == 2);
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(2), 31).storageSize() == 2);
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(7), 8).storageSize() == 2);
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(7), 9).storageSize() == 3);
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(31), 9).storageSize() == 9);
-	BOOST_CHECK(ArrayType(DataLocation::Storage, make_shared<FixedBytesType>(32), 9).storageSize() == 9);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(1), 32).storageSize() == 1);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(1), 33).storageSize() == 2);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(2), 31).storageSize() == 2);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(7), 8).storageSize() == 2);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(7), 9).storageSize() == 3);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(31), 9).storageSize() == 9);
+	BOOST_CHECK(ArrayType(DataLocation::Storage, TypeProvider::fixedBytesType(32), 9).storageSize() == 9);
 }
 
 BOOST_AUTO_TEST_CASE(type_identifier_escaping)
@@ -149,12 +150,12 @@ BOOST_AUTO_TEST_CASE(type_identifier_escaping)
 BOOST_AUTO_TEST_CASE(type_identifiers)
 {
 	ASTNode::resetID();
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("uint128")->identifier(), "t_uint128");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("int128")->identifier(), "t_int128");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("address")->identifier(), "t_address");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("uint8")->identifier(), "t_uint8");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("ufixed64x2")->identifier(), "t_ufixed64x2");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("fixed128x8")->identifier(), "t_fixed128x8");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("uint128")->identifier(), "t_uint128");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("int128")->identifier(), "t_int128");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("address")->identifier(), "t_address");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("uint8")->identifier(), "t_uint8");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("ufixed64x2")->identifier(), "t_ufixed64x2");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("fixed128x8")->identifier(), "t_fixed128x8");
 	BOOST_CHECK_EQUAL(RationalNumberType(rational(7, 1)).identifier(), "t_rational_7_by_1");
 	BOOST_CHECK_EQUAL(RationalNumberType(rational(200, 77)).identifier(), "t_rational_200_by_77");
 	BOOST_CHECK_EQUAL(RationalNumberType(rational(2 * 200, 2 * 77)).identifier(), "t_rational_200_by_77");
@@ -163,22 +164,22 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 		StringLiteralType(Literal(SourceLocation{}, Token::StringLiteral, make_shared<string>("abc - def"))).identifier(),
 		 "t_stringliteral_196a9142ee0d40e274a6482393c762b16dd8315713207365e1e13d8d85b74fc4"
 	);
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("byte")->identifier(), "t_bytes1");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes8")->identifier(), "t_bytes8");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes32")->identifier(), "t_bytes32");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bool")->identifier(), "t_bool");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes")->identifier(), "t_bytes_storage_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes memory")->identifier(), "t_bytes_memory_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes storage")->identifier(), "t_bytes_storage_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("bytes calldata")->identifier(), "t_bytes_calldata_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("string")->identifier(), "t_string_storage_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("string memory")->identifier(), "t_string_memory_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("string storage")->identifier(), "t_string_storage_ptr");
-	BOOST_CHECK_EQUAL(Type::fromElementaryTypeName("string calldata")->identifier(), "t_string_calldata_ptr");
-	ArrayType largeintArray(DataLocation::Memory, Type::fromElementaryTypeName("int128"), u256("2535301200456458802993406410752"));
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("byte")->identifier(), "t_bytes1");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bytes8")->identifier(), "t_bytes8");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bytes32")->identifier(), "t_bytes32");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bool")->identifier(), "t_bool");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bytes")->identifier(), "t_bytes_storage_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bytes memory")->identifier(), "t_bytes_memory_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bytes storage")->identifier(), "t_bytes_storage_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("bytes calldata")->identifier(), "t_bytes_calldata_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("string")->identifier(), "t_string_storage_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("string memory")->identifier(), "t_string_memory_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("string storage")->identifier(), "t_string_storage_ptr");
+	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("string calldata")->identifier(), "t_string_calldata_ptr");
+	ArrayType largeintArray(DataLocation::Memory, TypeProvider::fromElementaryTypeName("int128"), u256("2535301200456458802993406410752"));
 	BOOST_CHECK_EQUAL(largeintArray.identifier(), "t_array$_t_int128_$2535301200456458802993406410752_memory_ptr");
-	TypePointer stringArray = make_shared<ArrayType>(DataLocation::Storage, Type::fromElementaryTypeName("string"), u256("20"));
-	TypePointer multiArray = make_shared<ArrayType>(DataLocation::Storage, stringArray);
+	TypePointer stringArray = TypeProvider::arrayType(DataLocation::Storage, TypeProvider::fromElementaryTypeName("string"), u256("20"));
+	TypePointer multiArray = TypeProvider::arrayType(DataLocation::Storage, stringArray);
 	BOOST_CHECK_EQUAL(multiArray->identifier(), "t_array$_t_array$_t_string_storage_$20_storage_$dyn_storage_ptr");
 
 	ContractDefinition c(SourceLocation{}, make_shared<string>("MyContract$"), {}, {}, {}, ContractDefinition::ContractKind::Contract);
@@ -194,14 +195,14 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 	TupleType t({e.type(), s.type(), stringArray, nullptr});
 	BOOST_CHECK_EQUAL(t.identifier(), "t_tuple$_t_type$_t_enum$_Enum_$4_$_$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$_t_array$_t_string_storage_$20_storage_ptr_$__$");
 
-	TypePointer keccak256fun = make_shared<FunctionType>(strings{}, strings{}, FunctionType::Kind::KECCAK256);
+	TypePointer keccak256fun = TypeProvider::functionType(strings{}, strings{}, FunctionType::Kind::KECCAK256);
 	BOOST_CHECK_EQUAL(keccak256fun->identifier(), "t_function_keccak256_nonpayable$__$returns$__$");
 
 	FunctionType metaFun(TypePointers{keccak256fun}, TypePointers{s.type()}, strings{""}, strings{""});
 	BOOST_CHECK_EQUAL(metaFun.identifier(), "t_function_internal_nonpayable$_t_function_keccak256_nonpayable$__$returns$__$_$returns$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$");
 
-	TypePointer m = make_shared<MappingType>(Type::fromElementaryTypeName("bytes32"), s.type());
-	MappingType m2(Type::fromElementaryTypeName("uint64"), m);
+	TypePointer m = TypeProvider::mappingType(TypeProvider::fromElementaryTypeName("bytes32"), s.type());
+	MappingType m2(TypeProvider::fromElementaryTypeName("uint64"), m);
 	BOOST_CHECK_EQUAL(m2.identifier(), "t_mapping$_t_uint64_$_t_mapping$_t_bytes32_$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$_$");
 
 	// TypeType is tested with contract
@@ -230,9 +231,9 @@ BOOST_AUTO_TEST_CASE(encoded_sizes)
 	BOOST_CHECK_EQUAL(BoolType().calldataEncodedSize(true), 32);
 	BOOST_CHECK_EQUAL(BoolType().calldataEncodedSize(false), 1);
 
-	shared_ptr<ArrayType> uint24Array = make_shared<ArrayType>(
+	ArrayType const* uint24Array = TypeProvider::arrayType(
 		DataLocation::Memory,
-		make_shared<IntegerType>(24),
+		TypeProvider::integerType(24),
 		9
 	);
 	BOOST_CHECK_EQUAL(uint24Array->calldataEncodedSize(true), 9 * 32);

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(encoded_sizes)
 
 	ArrayType const* uint24Array = TypeProvider::arrayType(
 		DataLocation::Memory,
-		TypeProvider::integerType(24),
+		TypeProvider::uint(24),
 		9
 	);
 	BOOST_CHECK_EQUAL(uint24Array->calldataEncodedSize(true), 9 * 32);

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -66,14 +66,14 @@ SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion _evmVersion
 bool SyntaxTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
 	string const versionPragma = "pragma solidity >=0.0;\n";
-	m_compiler.reset();
-	m_compiler.setSources({{"", versionPragma + m_source}});
-	m_compiler.setEVMVersion(m_evmVersion);
+	compiler().reset();
+	compiler().setSources({{"", versionPragma + m_source}});
+	compiler().setEVMVersion(m_evmVersion);
 
-	if (m_compiler.parse())
-		m_compiler.analyze();
+	if (compiler().parse())
+		compiler().analyze();
 
-	for (auto const& currentError: filterErrors(m_compiler.errors(), true))
+	for (auto const& currentError: filterErrors(compiler().errors(), true))
 	{
 		int locationStart = -1, locationEnd = -1;
 		if (auto location = boost::get_error_info<errinfo_sourceLocation>(*currentError))


### PR DESCRIPTION
### The Problem
We could create Solidity source code that caused the solidity compiler to leak memory due to circular dependencies in the type system and no clear ownership.

### The Motivation
With the aim for zero memory leaks I propose to create an API that
* provides clear ownership
* unified way of requesting for types.
* potentially internal optimizations by reusing types or having no heap allocation at all.
* fixes #4517

Implicitly we found out that we can get rid of `shared_ptr<>` and its `shared_from_this()`, overall making the related code look more clear.

### Implementation
The API for requesting/providing types is called `TypeProvider` and lives in `libsolidity/ast/`. It was attempted to keep the changes to all the type accessing code at a minimum, i.e. there were places that I would have written differently (such as how to you access the type provider?), but those should be done in a follow-up PR.

### Notes
* Currently the type provider is accessed via singleton pattern, a follow-up PR should change that. (not included here to keep changes to a minimum!).
* `TypePointer`, `TypePointers`, `FunctionTypePointer` are defined in many places. should be unified (isolated PR)
* I personally don't think the type system should know about the AST / syntax, but currently it does need that information. I'd favor abstracting that part away to keep isolation clean (and avoid circular API layer dependencies) - opinions, @chriseth?
* The type system also implements evaluation via `unaryOperatorResult()` and `binaryOperatorResult()`. I am not quite sure it should be mixed up (if changing at all, then in another PR of course). Objections?
* running soltest/isoltest with `CXXFLAGS=-fsanitize=address -fno-omit-frame-pointer` (yields no errors but without it does(?)).

p.s.: this branch is yet to be squashed when considered ready.