### PR TITLE
[SMTChecker] Refactor VariableUsage

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -18,7 +18,6 @@
 #include <libsolidity/formal/SMTChecker.h>
 
 #include <libsolidity/formal/SMTPortfolio.h>
-#include <libsolidity/formal/VariableUsage.h>
 #include <libsolidity/formal/SymbolicTypes.h>
 
 #include <libdevcore/StringUtils.h>
@@ -51,7 +50,6 @@ SMTChecker::SMTChecker(ErrorReporter& _errorReporter, map<h256, string> const& _
 
 void SMTChecker::analyze(SourceUnit const& _source, shared_ptr<Scanner> const& _scanner)
 {
-	m_variableUsage = make_shared<VariableUsage>(_source);
 	m_scanner = _scanner;
 	if (_source.annotation().experimentalFeatures.count(ExperimentalFeature::SMTChecker))
 		_source.accept(*this);
@@ -202,17 +200,17 @@ bool SMTChecker::visit(IfStatement const& _node)
 		checkBooleanNotConstant(_node.condition(), "Condition is always $VALUE.");
 
 	auto indicesEndTrue = visitBranch(&_node.trueStatement(), expr(_node.condition()));
-	vector<VariableDeclaration const*> touchedVariables = m_variableUsage->touchedVariables(_node.trueStatement());
+	auto touchedVars = touchedVariables(_node.trueStatement());
 	decltype(indicesEndTrue) indicesEndFalse;
 	if (_node.falseStatement())
 	{
 		indicesEndFalse = visitBranch(_node.falseStatement(), !expr(_node.condition()));
-		touchedVariables += m_variableUsage->touchedVariables(*_node.falseStatement());
+		touchedVars += touchedVariables(*_node.falseStatement());
 	}
 	else
 		indicesEndFalse = copyVariableIndices();
 
-	mergeVariables(touchedVariables, expr(_node.condition()), indicesEndTrue, indicesEndFalse);
+	mergeVariables(touchedVars, expr(_node.condition()), indicesEndTrue, indicesEndFalse);
 
 	return false;
 }
@@ -229,8 +227,8 @@ bool SMTChecker::visit(IfStatement const& _node)
 bool SMTChecker::visit(WhileStatement const& _node)
 {
 	auto indicesBeforeLoop = copyVariableIndices();
-	auto touchedVariables = m_variableUsage->touchedVariables(_node);
-	resetVariables(touchedVariables);
+	auto touchedVars = touchedVariables(_node);
+	resetVariables(touchedVars);
 	decltype(indicesBeforeLoop) indicesAfterLoop;
 	if (_node.isDoWhile())
 	{
@@ -257,7 +255,7 @@ bool SMTChecker::visit(WhileStatement const& _node)
 	if (!_node.isDoWhile())
 		_node.condition().accept(*this);
 
-	mergeVariables(touchedVariables, expr(_node.condition()), indicesAfterLoop, copyVariableIndices());
+	mergeVariables(touchedVars, expr(_node.condition()), indicesAfterLoop, copyVariableIndices());
 
 	m_loopExecutionHappened = true;
 	return false;
@@ -272,17 +270,13 @@ bool SMTChecker::visit(ForStatement const& _node)
 	auto indicesBeforeLoop = copyVariableIndices();
 
 	// Do not reset the init expression part.
-	auto touchedVariables =
-		m_variableUsage->touchedVariables(_node.body());
+	auto touchedVars = touchedVariables(_node.body());
 	if (_node.condition())
-		touchedVariables += m_variableUsage->touchedVariables(*_node.condition());
+		touchedVars += touchedVariables(*_node.condition());
 	if (_node.loopExpression())
-		touchedVariables += m_variableUsage->touchedVariables(*_node.loopExpression());
-	// Remove duplicates
-	std::sort(touchedVariables.begin(), touchedVariables.end());
-	touchedVariables.erase(std::unique(touchedVariables.begin(), touchedVariables.end()), touchedVariables.end());
+		touchedVars += touchedVariables(*_node.loopExpression());
 
-	resetVariables(touchedVariables);
+	resetVariables(touchedVars);
 
 	if (_node.condition())
 	{
@@ -307,7 +301,7 @@ bool SMTChecker::visit(ForStatement const& _node)
 		_node.condition()->accept(*this);
 
 	auto forCondition = _node.condition() ? expr(*_node.condition()) : smt::Expression(true);
-	mergeVariables(touchedVariables, forCondition, indicesAfterLoop, copyVariableIndices());
+	mergeVariables(touchedVars, forCondition, indicesAfterLoop, copyVariableIndices());
 
 	m_loopExecutionHappened = true;
 	return false;
@@ -1153,17 +1147,17 @@ void SMTChecker::booleanOperation(BinaryOperation const& _op)
 	{
 		// @TODO check that both of them are not constant
 		_op.leftExpression().accept(*this);
-		auto touchedVariables = m_variableUsage->touchedVariables(_op.leftExpression());
+		auto touchedVars = touchedVariables(_op.leftExpression());
 		if (_op.getOperator() == Token::And)
 		{
 			auto indicesAfterSecond = visitBranch(&_op.rightExpression(), expr(_op.leftExpression()));
-			mergeVariables(touchedVariables, !expr(_op.leftExpression()), copyVariableIndices(), indicesAfterSecond);
+			mergeVariables(touchedVars, !expr(_op.leftExpression()), copyVariableIndices(), indicesAfterSecond);
 			defineExpr(_op, expr(_op.leftExpression()) && expr(_op.rightExpression()));
 		}
 		else
 		{
 			auto indicesAfterSecond = visitBranch(&_op.rightExpression(), !expr(_op.leftExpression()));
-			mergeVariables(touchedVariables, expr(_op.leftExpression()), copyVariableIndices(), indicesAfterSecond);
+			mergeVariables(touchedVars, expr(_op.leftExpression()), copyVariableIndices(), indicesAfterSecond);
 			defineExpr(_op, expr(_op.leftExpression()) || expr(_op.rightExpression()));
 		}
 	}
@@ -1498,7 +1492,7 @@ void SMTChecker::resetStorageReferences()
 	resetVariables([&](VariableDeclaration const& _variable) { return _variable.hasReferenceOrMappingType(); });
 }
 
-void SMTChecker::resetVariables(vector<VariableDeclaration const*> _variables)
+void SMTChecker::resetVariables(set<VariableDeclaration const*> const& _variables)
 {
 	for (auto const* decl: _variables)
 		resetVariable(*decl);
@@ -1518,12 +1512,6 @@ TypePointer SMTChecker::typeWithoutPointer(TypePointer const& _type)
 	if (auto refType = dynamic_cast<ReferenceType const*>(_type.get()))
 		return ReferenceType::copyForLocationIfReference(refType->location(), _type);
 	return _type;
-}
-
-void SMTChecker::mergeVariables(vector<VariableDeclaration const*> const& _variables, smt::Expression const& _condition, VariableIndices const& _indicesEndTrue, VariableIndices const& _indicesEndFalse)
-{
-	set<VariableDeclaration const*> uniqueVars(_variables.begin(), _variables.end());
-	mergeVariables(uniqueVars, _condition, _indicesEndTrue, _indicesEndFalse);
 }
 
 void SMTChecker::mergeVariables(set<VariableDeclaration const*> const& _variables, smt::Expression const& _condition, VariableIndices const& _indicesEndTrue, VariableIndices const& _indicesEndFalse)
@@ -1754,4 +1742,10 @@ FunctionDefinition const* SMTChecker::inlinedFunctionCallToDefinition(FunctionCa
 		return funDef;
 
 	return nullptr;
+}
+
+set<VariableDeclaration const*> SMTChecker::touchedVariables(ASTNode const& _node)
+{
+	solAssert(!m_functionPath.empty(), "");
+	return m_variableUsage.touchedVariables(_node, m_functionPath);
 }

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -20,6 +20,7 @@
 
 #include <libsolidity/formal/SolverInterface.h>
 #include <libsolidity/formal/SymbolicVariables.h>
+#include <libsolidity/formal/VariableUsage.h>
 
 #include <libsolidity/ast/ASTVisitor.h>
 #include <libsolidity/interface/ReadFile.h>
@@ -40,8 +41,6 @@ namespace dev
 {
 namespace solidity
 {
-
-class VariableUsage;
 
 class SMTChecker: private ASTConstVisitor
 {
@@ -200,7 +199,7 @@ private:
 	void resetVariable(VariableDeclaration const& _variable);
 	void resetStateVariables();
 	void resetStorageReferences();
-	void resetVariables(std::vector<VariableDeclaration const*> _variables);
+	void resetVariables(std::set<VariableDeclaration const*> const& _variables);
 	void resetVariables(std::function<bool(VariableDeclaration const&)> const& _filter);
 	/// @returns the type without storage pointer information if it has it.
 	TypePointer typeWithoutPointer(TypePointer const& _type);
@@ -208,7 +207,6 @@ private:
 	/// Given two different branches and the touched variables,
 	/// merge the touched variables into after-branch ite variables
 	/// using the branch condition as guard.
-	void mergeVariables(std::vector<VariableDeclaration const*> const& _variables, smt::Expression const& _condition, VariableIndices const& _indicesEndTrue, VariableIndices const& _indicesEndFalse);
 	void mergeVariables(std::set<VariableDeclaration const*> const& _variables, smt::Expression const& _condition, VariableIndices const& _indicesEndTrue, VariableIndices const& _indicesEndFalse);
 	/// Tries to create an uninitialized variable and returns true on success.
 	/// This fails if the type is not supported.
@@ -271,8 +269,11 @@ private:
 	/// Resets the variable indices.
 	void resetVariableIndices(VariableIndices const& _indices);
 
+	/// @returns variables that are touched in _node's subtree.
+	std::set<VariableDeclaration const*> touchedVariables(ASTNode const& _node);
+
 	std::shared_ptr<smt::SolverInterface> m_interface;
-	std::shared_ptr<VariableUsage> m_variableUsage;
+	VariableUsage m_variableUsage;
 	bool m_loopExecutionHappened = false;
 	bool m_arrayAssignmentHappened = false;
 	// True if the "No SMT solver available" warning was already created.

--- a/libsolidity/formal/VariableUsage.h
+++ b/libsolidity/formal/VariableUsage.h
@@ -17,33 +17,35 @@
 
 #pragma once
 
-#include <map>
-#include <set>
+#include <libsolidity/ast/ASTVisitor.h>
+
 #include <vector>
+#include <set>
 
 namespace dev
 {
 namespace solidity
 {
 
-class ASTNode;
-class VariableDeclaration;
-
 /**
- * This class collects information about which local variables of value type
- * are modified in which parts of the AST.
+ * This class computes information about which variables are modified in a certain subtree.
  */
-class VariableUsage
+class VariableUsage: private ASTConstVisitor
 {
 public:
-	explicit VariableUsage(ASTNode const& _node);
-
-	std::vector<VariableDeclaration const*> touchedVariables(ASTNode const& _node) const;
+	/// @param _outerCallstack the current callstack in the callers context.
+	std::set<VariableDeclaration const*> touchedVariables(ASTNode const& _node, std::vector<FunctionDefinition const*> const& _outerCallstack);
 
 private:
-	// Variable touched by a specific AST node.
-	std::map<ASTNode const*, VariableDeclaration const*> m_touchedVariable;
-	std::map<ASTNode const*, std::vector<ASTNode const*>> m_children;
+	void endVisit(Identifier const& _node) override;
+	void endVisit(FunctionCall const& _node) override;
+	bool visit(FunctionDefinition const& _node) override;
+	void endVisit(FunctionDefinition const& _node) override;
+	void endVisit(ModifierInvocation const& _node) override;
+	void endVisit(PlaceholderStatement const& _node) override;
+
+	std::set<VariableDeclaration const*> m_touchedVariables;
+	std::vector<FunctionDefinition const*> m_functionPath;
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/functions/function_inline_chain.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_inline_chain.sol
@@ -1,0 +1,41 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint x;
+	uint y;
+	uint z;
+
+	function f() public {
+		if (x == 1)
+			x = 2;
+		else
+			x = 1;
+		g();
+		assert(y == 1);
+	}
+
+	function g() public {
+		y = 1;
+		h();
+		assert(z == 1);
+	}
+
+	function h() public {
+		z = 1;
+		x = 1;
+		f();
+		// This fails for the following calls to the contract:
+		// h()
+		// g() h()
+		// It does not fail for f() g() h() because in that case
+		// h() will not inline f() since it already is in the callstack.
+		assert(x == 1);
+	}
+}
+// ----
+// Warning: (271-274): Assertion checker does not support recursive function calls.
+// Warning: (140-143): Assertion checker does not support recursive function calls.
+// Warning: (483-497): Assertion violation happens here
+// Warning: (201-204): Assertion checker does not support recursive function calls.
+// Warning: (483-497): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_assignment_outside_branch.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_assignment_outside_branch.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+    uint x;
+    address owner;
+
+	modifier onlyOwner {
+        if (msg.sender == owner) _;
+    }
+
+    function f() public onlyOwner {
+    }
+
+    function g(uint y) public {
+        y = 1;
+        if (y > x) f();
+    }
+}

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+
+contract C {
+    address owner;
+    modifier onlyOwner {
+        if (msg.sender == owner) _;
+    }
+    function g() public onlyOwner {
+    }
+    function f(uint x) public {
+        if (x > 0) g();
+    }
+}

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch_assignment.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch_assignment.sol
@@ -1,0 +1,23 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x;
+	address owner;
+
+	modifier onlyOwner {
+		if (msg.sender == owner) _;
+	}
+
+	function f() public onlyOwner {
+		x = 0;
+	}
+	function g(uint y) public {
+		x = 1;
+		if (y > 0)
+			f();
+		// Fails for {y = >0, msg.sender == owner, x = 0}.
+		assert(x > 0);
+	}
+}
+// ----
+// Warning: (287-300): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch_assignment_branch.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch_assignment_branch.sol
@@ -1,0 +1,27 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x;
+	address owner;
+
+	modifier onlyOwner {
+		if (msg.sender == owner) {
+			require(x > 0);
+			_;
+		}
+	}
+
+	function f() public onlyOwner {
+		// Condition is always true due to `require(x > 0)` in the modifier.
+		if (x > 0)
+			x -= 1;
+	}
+	function g(uint y) public {
+		x = 2;
+		if (y > 0)
+			f();
+		assert(x > 0);
+	}
+}
+// ----
+// Warning: (266-271): Condition is always true.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch_assignment_multi_branches.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_inside_branch_assignment_multi_branches.sol
@@ -1,0 +1,35 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x;
+	address owner;
+
+	modifier onlyOwner {
+		if (msg.sender == owner) {
+			require(x > 0);
+			_;
+		}
+	}
+
+	function f() public onlyOwner {
+		x -= 1;
+		h();
+	}
+	function h() public onlyOwner {
+		require(x < 10000);
+		x += 2;
+	}
+	function g(uint y) public {
+		require(y > 0 && y < 10000);
+		require(msg.sender == owner);
+		x = y;
+		if (y > 1) {
+			f();
+			assert(x == y + 1);
+		}
+		// Fails for {y = 0, x = 0}.
+		assert(x == 0);
+	}
+}
+// ----
+// Warning: (461-475): Assertion violation happens here


### PR DESCRIPTION
Fixes #5903 

The previous `VariableUsage` class pre-processed the AST in its constructor to keep only paths to nodes that touched variables. When adding support to modifier inlining, it got too complicated to keep the state and know what's happening when a `PlaceholderStatement` is visited.
This PR refactors `VariableUsage` as a simple visitor that inlines function calls and modifiers following the same rules as the SMTChecker. It is of course slower than the previous `VariableUsage`, but less complicated to deal with (in my opinion).

The added tests were leading to ICEs due to the latest PR on `VariableUsage` that added function call inlining. This PR also fixes that. The tests were simplified versions of `rubixi.sol` from #5903.

Maybe a future refactor can be done where the class `SMTChecker` derives from `VariableUsage` and we can use shared visitor functions.