### PR TITLE
[DOCS] Add rounding warning

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -72,7 +72,6 @@ all function arguments have to be copied to memory.
 
 When calling functions of other contracts, you can specify the amount of Wei or gas sent with the call with the special options ``.value()`` and ``.gas()``, respectively. Any Wei you send to the contract is added to the total balance of the contract:
 
-
 ::
 
     pragma solidity >=0.4.0 <0.7.0;

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -149,6 +149,9 @@ Sending and Receiving Ether
   into the sending contract or other state changes you might not have thought of.
   So it allows for great flexibility for honest users but also for malicious actors.
 
+- Use the most precise units to represent the wei amount as possible, as you lose
+  any that is rounded due to a lack of precision.
+
 - If you want to send Ether using ``address.transfer``, there are certain details to be aware of:
 
   1. If the recipient is a contract, it causes its fallback function to be executed which can, in turn, call back the sending contract.


### PR DESCRIPTION
### Description

Final PR as part of https://github.com/ethereum/solidity/issues/4913 this adds a warning about rounding when sending wei and eth. There may be other locations to add this warning later.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
