### PR TITLE
Implemented copying recursive structs from storage to memory.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.5.8 (unreleased)
 
 Language Features:
+ * Code Generation: Implement copying recursive structs from storage to memory.
 
 
 Compiler Features:

--- a/test/libsolidity/semanticTests/structs/conversion/recursive_storage_memory.sol
+++ b/test/libsolidity/semanticTests/structs/conversion/recursive_storage_memory.sol
@@ -1,0 +1,20 @@
+contract CopyTest {
+	struct Tree {
+		Tree[] children;
+	}
+	Tree storageTree;
+
+	constructor() public {
+		storageTree.children.length = 2;
+		storageTree.children[0].children.length = 23;
+		storageTree.children[1].children.length = 42;
+	}
+
+	function run() public returns (uint256, uint256, uint256) {
+		Tree memory memoryTree;
+		memoryTree = storageTree;
+		return (memoryTree.children.length, memoryTree.children[0].children.length, memoryTree.children[1].children.length);
+	}
+}
+// ----
+// run() -> 2, 23, 42

--- a/test/libsolidity/semanticTests/structs/conversion/recursive_storage_memory_complex.sol
+++ b/test/libsolidity/semanticTests/structs/conversion/recursive_storage_memory_complex.sol
@@ -1,0 +1,46 @@
+contract CopyTest {
+	struct Tree {
+		uint256 data;
+		Tree[] children;
+	}
+	Tree storageTree;
+
+	constructor() public {
+		storageTree.data = 0x42;
+		storageTree.children.length = 2;
+		storageTree.children[0].data = 0x4200;
+		storageTree.children[1].data = 0x4201;
+		storageTree.children[0].children.length = 3;
+		for (uint i = 0; i < 3; i++)
+		    storageTree.children[0].children[i].data = 0x420000 + i;
+		storageTree.children[1].children.length = 4;
+		for (uint i = 0; i < 4; i++)
+		    storageTree.children[1].children[i].data = 0x420100 + i;
+	}
+
+	function countData(Tree memory tree) internal returns (uint256 c) {
+	    c = 1;
+	    for (uint i = 0; i < tree.children.length; i++) {
+	        c += countData(tree.children[i]);
+	    }
+	}
+
+	function copyFromTree(Tree memory tree, uint256[] memory data, uint256 offset) internal returns (uint256) {
+	    data[offset++] = tree.data;
+	    for (uint i = 0; i < tree.children.length; i++) {
+	        offset = copyFromTree(tree.children[i], data, offset);
+	    }
+	    return offset;
+	}
+
+	function run() public returns (uint256[] memory) {
+		Tree memory memoryTree;
+		memoryTree = storageTree;
+		uint256 length = countData(memoryTree);
+		uint256[] memory result = new uint256[](length);
+		copyFromTree(memoryTree, result, 0);
+		return result;
+	}
+}
+// ----
+// run() -> 0x20, 10, 0x42, 0x4200, 0x420000, 0x420001, 0x420002, 0x4201, 0x420100, 0x420101, 0x420102, 0x420103


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6374.

Should we catch this (and the opposite case of copying from memory to storage) in the TypeChecker instead? It'd make it easier to test this :-).