### PR TITLE
Fix SSA for multi-assignments.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ### 0.5.8 (unreleased)
 
+Important Bugfixes:
+ * Yul Optimizer: Fix SSA transform for multi-assignments.
+
+
 Language Features:
  * Code Generation: Implement copying recursive structs from storage to memory.
 

--- a/libyul/optimiser/SSATransform.h
+++ b/libyul/optimiser/SSATransform.h
@@ -87,6 +87,8 @@ private:
 	{ }
 
 	NameDispenser& m_nameDispenser;
+	/// This is a set of all variables that are assigned to anywhere in the code.
+	/// Variables that are only declared but never re-assigned are not touched.
 	std::set<YulString> const& m_variablesToReplace;
 	std::map<YulString, YulString> m_currentVariableValues;
 };

--- a/test/libyul/yulOptimizerTests/fullSuite/ssaReverse.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/ssaReverse.yul
@@ -36,13 +36,13 @@
 // ----
 // {
 //     let a, b := abi_decode_t_bytes_calldata_ptr(mload(0), mload(1))
-//     a, b := abi_decode_t_bytes_calldata_ptr(a, b)
-//     a, b := abi_decode_t_bytes_calldata_ptr(a, b)
-//     a, b := abi_decode_t_bytes_calldata_ptr(a, b)
-//     a, b := abi_decode_t_bytes_calldata_ptr(a, b)
-//     a, b := abi_decode_t_bytes_calldata_ptr(a, b)
-//     a, b := abi_decode_t_bytes_calldata_ptr(a, b)
-//     mstore(a, b)
+//     let a_1, b_1 := abi_decode_t_bytes_calldata_ptr(a, b)
+//     let a_2, b_2 := abi_decode_t_bytes_calldata_ptr(a_1, b_1)
+//     let a_3, b_3 := abi_decode_t_bytes_calldata_ptr(a_2, b_2)
+//     let a_4, b_4 := abi_decode_t_bytes_calldata_ptr(a_3, b_3)
+//     let a_5, b_5 := abi_decode_t_bytes_calldata_ptr(a_4, b_4)
+//     let a_6, b_6 := abi_decode_t_bytes_calldata_ptr(a_5, b_5)
+//     mstore(a_6, b_6)
 //     function abi_decode_t_bytes_calldata_ptr(offset, end) -> arrayPos, length
 //     {
 //         if iszero(slt(add(offset, 0x1f), end))

--- a/test/libyul/yulOptimizerTests/ssaTransform/multi_assign.yul
+++ b/test/libyul/yulOptimizerTests/ssaTransform/multi_assign.yul
@@ -1,0 +1,29 @@
+{
+  let a := mload(0)
+  let b := mload(1)
+  a, b := f()
+  sstore(a, b)
+  a := mload(5)
+  b := mload(a)
+  function f() -> x, y {}
+}
+// ====
+// step: ssaTransform
+// ----
+// {
+//     let a_1 := mload(0)
+//     let a := a_1
+//     let b_2 := mload(1)
+//     let b := b_2
+//     let a_3, b_4 := f()
+//     a := a_3
+//     b := b_4
+//     sstore(a_3, b_4)
+//     let a_5 := mload(5)
+//     a := a_5
+//     let b_6 := mload(a_5)
+//     b := b_6
+//     function f() -> x, y
+//     {
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/ssaTransform/multi_decl.yul
+++ b/test/libyul/yulOptimizerTests/ssaTransform/multi_decl.yul
@@ -1,0 +1,25 @@
+{
+  let x, y := f(1, 2)
+  x := mload(y)
+  y := mload(x)
+  let a, b := f(x, y)
+  sstore(a, b)
+  function f(t, v) -> x, y {}
+}
+// ====
+// step: ssaTransform
+// ----
+// {
+//     let x_2, y_3 := f(1, 2)
+//     let x := x_2
+//     let y := y_3
+//     let x_4 := mload(y_3)
+//     x := x_4
+//     let y_5 := mload(x_4)
+//     y := y_5
+//     let a, b := f(x_4, y_5)
+//     sstore(a, b)
+//     function f(t, v) -> x_1, y_2
+//     {
+//     }
+// }


### PR DESCRIPTION
This fixes a bug in the SSA transform. Previously, the SSA transform ignored multi-assignments. This resulted in the outdated values of variables being used for references after the assignment.