### PR TITLE
Pass large strings by value

### DIFF
--- a/liblll/CodeFragment.cpp
+++ b/liblll/CodeFragment.cpp
@@ -256,7 +256,7 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 			string contents = m_readFile(fileName);
 			if (contents.empty())
 				error<InvalidName>(std::string("File not found (or empty): ") + fileName);
-			m_asm.append(CodeFragment::compile(contents, _s, m_readFile).m_asm);
+			m_asm.append(CodeFragment::compile(std::move(contents), _s, m_readFile).m_asm);
 		}
 		else if (us == "SET")
 		{
@@ -745,11 +745,11 @@ void CodeFragment::constructOperation(sp::utree const& _t, CompilerState& _s)
 	}
 }
 
-CodeFragment CodeFragment::compile(string const& _src, CompilerState& _s, ReadCallback const& _readFile)
+CodeFragment CodeFragment::compile(string _src, CompilerState& _s, ReadCallback const& _readFile)
 {
 	CodeFragment ret;
 	sp::utree o;
-	parseTreeLLL(_src, o);
+	parseTreeLLL(std::move(_src), o);
 	if (!o.empty())
 		ret = CodeFragment(o, _s, _readFile);
 	_s.treesToKill.push_back(o);

--- a/liblll/CodeFragment.h
+++ b/liblll/CodeFragment.h
@@ -44,7 +44,7 @@ public:
 	CodeFragment() = default;
 	CodeFragment(sp::utree const& _t, CompilerState& _s, ReadCallback const& _readFile, bool _allowASM = false);
 
-	static CodeFragment compile(std::string const& _src, CompilerState& _s, ReadCallback const& _readFile);
+	static CodeFragment compile(std::string _src, CompilerState& _s, ReadCallback const& _readFile);
 
 	/// Consolidates data and compiles code.
 	eth::Assembly& assembly(CompilerState const& _cs) { finalise(_cs); return m_asm; }
@@ -69,4 +69,3 @@ static CodeFragment const NullCodeFragment;
 
 }
 }
-

--- a/liblll/Compiler.cpp
+++ b/liblll/Compiler.cpp
@@ -28,13 +28,13 @@ using namespace std;
 using namespace dev;
 using namespace dev::lll;
 
-bytes dev::lll::compileLLL(string const& _src, langutil::EVMVersion _evmVersion, bool _opt, std::vector<std::string>* _errors, ReadCallback const& _readFile)
+bytes dev::lll::compileLLL(string _src, langutil::EVMVersion _evmVersion, bool _opt, std::vector<std::string>* _errors, ReadCallback const& _readFile)
 {
 	try
 	{
 		CompilerState cs;
 		cs.populateStandard();
-		auto assembly = CodeFragment::compile(_src, cs, _readFile).assembly(cs);
+		auto assembly = CodeFragment::compile(std::move(_src), cs, _readFile).assembly(cs);
 		if (_opt)
 			assembly = assembly.optimise(true, _evmVersion, true, 200);
 		bytes ret = assembly.assemble().bytecode;
@@ -66,13 +66,13 @@ bytes dev::lll::compileLLL(string const& _src, langutil::EVMVersion _evmVersion,
 	return bytes();
 }
 
-std::string dev::lll::compileLLLToAsm(std::string const& _src, langutil::EVMVersion _evmVersion, bool _opt, std::vector<std::string>* _errors, ReadCallback const& _readFile)
+std::string dev::lll::compileLLLToAsm(std::string _src, langutil::EVMVersion _evmVersion, bool _opt, std::vector<std::string>* _errors, ReadCallback const& _readFile)
 {
 	try
 	{
 		CompilerState cs;
 		cs.populateStandard();
-		auto assembly = CodeFragment::compile(_src, cs, _readFile).assembly(cs);
+		auto assembly = CodeFragment::compile(std::move(_src), cs, _readFile).assembly(cs);
 		if (_opt)
 			assembly = assembly.optimise(true, _evmVersion, true, 200);
 		string ret = assembly.assemblyString();
@@ -104,13 +104,13 @@ std::string dev::lll::compileLLLToAsm(std::string const& _src, langutil::EVMVers
 	return string();
 }
 
-string dev::lll::parseLLL(string const& _src)
+string dev::lll::parseLLL(string _src)
 {
 	sp::utree o;
 
 	try
 	{
-		parseTreeLLL(_src, o);
+		parseTreeLLL(std::move(_src), o);
 	}
 	catch (...)
 	{

--- a/liblll/Compiler.h
+++ b/liblll/Compiler.h
@@ -35,9 +35,9 @@ namespace lll
 
 using ReadCallback = std::function<std::string(std::string const&)>;
 
-std::string parseLLL(std::string const& _src);
-std::string compileLLLToAsm(std::string const& _src, langutil::EVMVersion _evmVersion, bool _opt = true, std::vector<std::string>* _errors = nullptr, ReadCallback const& _readFile = ReadCallback());
-bytes compileLLL(std::string const& _src, langutil::EVMVersion _evmVersion, bool _opt = true, std::vector<std::string>* _errors = nullptr, ReadCallback const& _readFile = ReadCallback());
+std::string parseLLL(std::string _src);
+std::string compileLLLToAsm(std::string _src, langutil::EVMVersion _evmVersion, bool _opt = true, std::vector<std::string>* _errors = nullptr, ReadCallback const& _readFile = ReadCallback());
+bytes compileLLL(std::string _src, langutil::EVMVersion _evmVersion, bool _opt = true, std::vector<std::string>* _errors = nullptr, ReadCallback const& _readFile = ReadCallback());
 
 }
 }

--- a/libsolc/libsolc.cpp
+++ b/libsolc/libsolc.cpp
@@ -72,10 +72,10 @@ ReadCallback::Callback wrapReadCallback(CStyleReadFileCallback _readCallback = n
 	return readCallback;
 }
 
-string compile(string const& _input, CStyleReadFileCallback _readCallback = nullptr)
+string compile(string _input, CStyleReadFileCallback _readCallback = nullptr)
 {
 	StandardCompiler compiler(wrapReadCallback(_readCallback));
-	return compiler.compile(_input);
+	return compiler.compile(std::move(_input));
 }
 
 }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -181,14 +181,14 @@ void CompilerStack::reset(bool _keepSettings)
 	TypeProvider::reset();
 }
 
-void CompilerStack::setSources(StringMap const& _sources)
+void CompilerStack::setSources(StringMap _sources)
 {
 	if (m_stackState == SourcesSet)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Cannot change sources once set."));
 	if (m_stackState != Empty)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set sources before parsing."));
-	for (auto const& source: _sources)
-		m_sources[source.first].scanner = make_shared<Scanner>(CharStream(/*content*/source.second, /*name*/source.first));
+	for (auto source: _sources)
+		m_sources[source.first].scanner = make_shared<Scanner>(CharStream(/*content*/std::move(source.second), /*name*/source.first));
 	m_stackState = SourcesSet;
 }
 
@@ -571,7 +571,7 @@ string CompilerStack::assemblyString(string const& _contractName, StringMap _sou
 }
 
 /// TODO: cache the JSON
-Json::Value CompilerStack::assemblyJSON(string const& _contractName, StringMap _sourceCodes) const
+Json::Value CompilerStack::assemblyJSON(string const& _contractName, StringMap const& _sourceCodes) const
 {
 	if (m_stackState != CompilationSuccessful)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -150,7 +150,7 @@ public:
 	void useMetadataLiteralSources(bool _metadataLiteralSources);
 
 	/// Sets the sources. Must be set before parsing.
-	void setSources(StringMap const& _sources);
+	void setSources(StringMap _sources);
 
 	/// Adds a response to an SMTLib2 query (identified by the hash of the query input).
 	/// Must be set before parsing.
@@ -238,7 +238,7 @@ public:
 	/// @returns a JSON representation of the assembly.
 	/// @arg _sourceCodes is the map of input files to source code strings
 	/// Prerequisite: Successful compilation.
-	Json::Value assemblyJSON(std::string const& _contractName, StringMap _sourceCodes = StringMap()) const;
+	Json::Value assemblyJSON(std::string const& _contractName, StringMap const& _sourceCodes = StringMap()) const;
 
 	/// @returns a JSON representing the contract ABI.
 	/// Prerequisite: Successful call to parse or compile.

--- a/lllc/main.cpp
+++ b/lllc/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
 	}
 	else if (mode == Binary || mode == Hex)
 	{
-		auto bs = compileLLL(src, langutil::EVMVersion{}, optimise ? true : false, &errors, readFileAsString);
+		auto bs = compileLLL(std::move(src), langutil::EVMVersion{}, optimise ? true : false, &errors, readFileAsString);
 		if (mode == Hex)
 			cout << toHex(bs) << endl;
 		else if (mode == Binary)
@@ -141,11 +141,11 @@ int main(int argc, char** argv)
 	}
 	else if (mode == ParseTree)
 	{
-		cout << parseLLL(src) << endl;
+		cout << parseLLL(std::move(src)) << endl;
 	}
 	else if (mode == Assembly)
 	{
-		cout << compileLLLToAsm(src, langutil::EVMVersion{}, optimise ? true : false, &errors, readFileAsString) << endl;
+		cout << compileLLLToAsm(std::move(src), langutil::EVMVersion{}, optimise ? true : false, &errors, readFileAsString) << endl;
 	}
 
 	for (auto const& i: errors)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -834,7 +834,7 @@ bool CommandLineInterface::processInput()
 	{
 		string input = dev::readStandardInput();
 		StandardCompiler compiler(fileReader);
-		sout() << compiler.compile(input) << endl;
+		sout() << compiler.compile(std::move(input)) << endl;
 		return true;
 	}
 

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -83,10 +83,10 @@ Json::Value getContractResult(Json::Value const& _compilerResult, string const& 
 	return _compilerResult["contracts"][_file][_name];
 }
 
-Json::Value compile(string const& _input)
+Json::Value compile(string _input)
 {
 	StandardCompiler compiler;
-	string output = compiler.compile(_input);
+	string output = compiler.compile(std::move(_input));
 	Json::Value ret;
 	BOOST_REQUIRE(jsonParseStrict(output, ret));
 	return ret;


### PR DESCRIPTION
### Description

Modified method signatures taking in large `const string` or `const StringMap` references to take values instead. Places calling these methods have been updated to use move semantics where possible.

Addresses #6216 

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [N/A] New tests have been created which fail without the change (if possible)
- [N/A ] README / documentation was extended, if necessary
- [N/A] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
