### PR TITLE
[soltest] Test filter for isoltest

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,8 @@ Bugfixes:
  * Yul: Properly register functions and disallow shadowing between function variables and variables in the outside scope.
 
 
+Build System:
+ * Soltest: Add commandline option `--test` / `-t` to isoltest which takes a string that allows filtering unit tests.
 
 
 ### 0.5.7 (2019-03-26)

--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -59,7 +59,7 @@ IsolTestOptions::IsolTestOptions(std::string* _editor):
 		("editor", po::value<std::string>(_editor)->default_value(editorPath()), "Path to editor for opening test files.")
 		("help", po::bool_switch(&showHelp), "Show this help screen.")
 		("no-color", po::bool_switch(&noColor), "Don't use colors.")
-		("test,t", po::value<std::string>(&test)->default_value("*/*"), "Filters which test units to include.");
+		("test,t", po::value<std::string>(&testFilter)->default_value("*/*"), "Filters which test units to include.");
 }
 
 bool IsolTestOptions::parse(int _argc, char const* const* _argv)
@@ -77,11 +77,12 @@ bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 
 void IsolTestOptions::validate() const
 {
-	std::regex filterExpression{"(((\\*+|\\w+|\\w+\\*+)\\/)+(\\*|\\w+\\**))"};
+	static std::string filterString{"[a-zA-Z1-9_/*]*"};
+	static std::regex filterExpression{filterString};
 	assertThrow(
-		regex_match(test, filterExpression),
+		regex_match(testFilter, filterExpression),
 		ConfigException,
-		"Invalid test unit filter: " + test
+		"Invalid test unit filter - can only contain '" + filterString + ": " + testFilter
 	);
 }
 

--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -19,9 +19,14 @@
 */
 
 #include <test/tools/IsolTestOptions.h>
+
+#include <libdevcore/Assertions.h>
+
 #include <boost/filesystem.hpp>
-#include <string>
+
 #include <iostream>
+#include <regex>
+#include <string>
 
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
@@ -32,7 +37,7 @@ namespace test
 {
 
 auto const description = R"(isoltest, tool for interactively managing test contracts.
-Usage: isoltest [Options] --ipcpath ipcpath
+Usage: isoltest [Options]
 Interactively validates test contracts.
 
 Allowed options)";
@@ -51,10 +56,10 @@ IsolTestOptions::IsolTestOptions(std::string* _editor):
 	CommonOptions(description)
 {
 	options.add_options()
+		("editor", po::value<std::string>(_editor)->default_value(editorPath()), "Path to editor for opening test files.")
 		("help", po::bool_switch(&showHelp), "Show this help screen.")
-		("no-color", po::bool_switch(&noColor), "don't use colors")
-		("editor", po::value<std::string>(_editor)->default_value(editorPath()), "editor for opening test files");
-
+		("no-color", po::bool_switch(&noColor), "Don't use colors.")
+		("test,t", po::value<std::string>(&test)->default_value("*/*"), "Filters which test units to include.");
 }
 
 bool IsolTestOptions::parse(int _argc, char const* const* _argv)
@@ -68,6 +73,16 @@ bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 	}
 
 	return res;
+}
+
+void IsolTestOptions::validate() const
+{
+	std::regex filterExpression{"(((\\*+|\\w+|\\w+\\*+)\\/)+(\\*|\\w+\\**))"};
+	assertThrow(
+		regex_match(test, filterExpression),
+		ConfigException,
+		"Invalid test unit filter: " + test
+	);
 }
 
 }

--- a/test/tools/IsolTestOptions.h
+++ b/test/tools/IsolTestOptions.h
@@ -30,11 +30,13 @@ namespace test
 
 struct IsolTestOptions: CommonOptions
 {
-	bool noColor = false;
 	bool showHelp = false;
+	bool noColor = false;
+	std::string test = std::string{};
 
 	IsolTestOptions(std::string* _editor);
 	bool parse(int _argc, char const* const* _argv) override;
+	void validate() const override;
 };
 }
 }

--- a/test/tools/IsolTestOptions.h
+++ b/test/tools/IsolTestOptions.h
@@ -32,7 +32,7 @@ struct IsolTestOptions: CommonOptions
 {
 	bool showHelp = false;
 	bool noColor = false;
-	std::string test = std::string{};
+	std::string testFilter = std::string{};
 
 	IsolTestOptions(std::string* _editor);
 	bool parse(int _argc, char const* const* _argv) override;

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -98,7 +98,7 @@ public:
 	):
 		m_testCaseCreator(_testCaseCreator),
 		m_options(_options),
-		m_filter(TestFilter{_options.test}),
+		m_filter(TestFilter{_options.testFilter}),
 		m_path(_path),
 		m_name(_name)
 	{}


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/6255.

This PR adds the option `--test`or in short `-t` to `isoltest`. It can be used to filter the tests to be executed like this:
```
isoltest --test */* (default, needs to be quoted)
isoltest -t yulOptimizerTests/*
isoltest -t smt*/*
isoltest -t syntaxTests/array/*
isoltest -t syntaxTests/array/array_pop_arg
isoltest -t syntaxTests/array/array_*
isoltest -t */array*
```
if `--test` is not defined it defaults to `*/*` and all tests are executed. 

Invalid filter values are e.g.:
```
isoltest -t syntaxTests/
isoltest -t syntaxTests//
```