### PR TITLE
[soltest] Improve interactive update routine

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -74,6 +74,7 @@ bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool _format
 
 		test.setFailure(!m_transactionSuccessful);
 		test.setRawBytes(std::move(output));
+		test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName()));
 	}
 
 	if (!success)

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -80,12 +80,19 @@ bool SemanticTest::run(ostream& _stream, string const& _linePrefix, bool _format
 	{
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
 		for (auto const& test: m_tests)
-			_stream << test.format(_linePrefix, false, _formatted) << endl;
+		{
+			ErrorReporter errorReporter;
+			_stream << test.format(errorReporter, _linePrefix, false, _formatted) << endl;
+			_stream << errorReporter.format(_linePrefix, _formatted);
+		}
 		_stream << endl;
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << endl;
 		for (auto const& test: m_tests)
-			_stream << test.format(_linePrefix, true, _formatted) << endl;
-
+		{
+			ErrorReporter errorReporter;
+			_stream << test.format(errorReporter, _linePrefix, true, _formatted) << endl;
+			_stream << errorReporter.format(_linePrefix, _formatted);
+		}
 		AnsiColorized(_stream, _formatted, {BOLD, RED}) << _linePrefix << endl << _linePrefix
 			<< "Attention: Updates on the test will apply the detected format displayed." << endl;
 		return false;

--- a/test/libsolidity/semanticTests/smoke_test.sol
+++ b/test/libsolidity/semanticTests/smoke_test.sol
@@ -1,31 +1,35 @@
 contract C {
-    function f() public returns (uint) {
+    function f() payable public returns (uint) {
         return 2;
     }
-    function g(uint x, uint y) public returns (uint) {
+    function g() public returns (uint, uint) {
+        return (2, 3);
+    }
+    function h(uint x, uint y) public returns (uint) {
         return x - y;
-    }
-    function h() public payable returns (uint) {
-        return f();
-    }
-    function i(bytes32 b) public returns (bytes32) {
-        return b;
     }
     function j(bool b) public returns (bool) {
         return !b;
     }
-    function k(bytes32 b) public returns (bytes32) {
-        return b;
+    function k(bytes32 b) public returns (bytes32, bytes32) {
+        return (b, b);
     }
-    function s() public returns (uint256) {
+    function l() public returns (uint256) {
         return msg.data.length;
+    }
+    function m(bytes memory b) public returns (bytes memory) {
+        return b;
     }
 }
 // ----
+// _() -> FAILURE
 // f() -> 2
-// g(uint256,uint256): 1, -2 -> 3
-// h(), 1 ether -> 2
-// i() -> FAILURE
+// f(), 1 ether -> 2
+// g() -> 2, 3
+// h(uint256,uint256): 1, -2 -> 3
 // j(bool): true -> false
-// k(bytes32): 0x31 -> 0x31
-// s(): hex"4200ef" -> 7
+// k(bytes32): 0x10 -> 0x10, 0x10
+// l(): hex"4200ef" -> 7
+// m(bytes): 32, 32, 0x20 -> 32, 32, 0x20
+// m(bytes): 32, 3, hex"AB33BB" -> 32, 3, left(0xAB33BB)
+// m(bytes): 32, 3, hex"AB33FF" -> 32, 3, hex"ab33ff0000000000000000000000000000000000000000000000000000000000"

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -105,13 +105,13 @@ struct ABIType
 {
 	enum Type
 	{
+		None,
+		Failure,
+		Boolean,
 		UnsignedDec,
 		SignedDec,
-		Boolean,
 		Hex,
-		HexString,
-		Failure,
-		None
+		HexString
 	};
 	enum Align
 	{

--- a/test/libsolidity/util/TestFunctionCall.h
+++ b/test/libsolidity/util/TestFunctionCall.h
@@ -19,6 +19,7 @@
 
 #include <libsolidity/ast/Types.h>
 #include <liblangutil/Exceptions.h>
+#include <libdevcore/AnsiColorized.h>
 #include <libdevcore/CommonData.h>
 
 #include <iosfwd>
@@ -33,6 +34,99 @@ namespace solidity
 {
 namespace test
 {
+
+/**
+ * Representation of a notice, warning or error that can occur while
+ * formatting and therefore updating an interactive function call test.
+ */
+struct FormatError
+{
+	enum Type
+	{
+		Notice,
+		Warning,
+		Error
+	};
+
+	explicit FormatError(Type _type, std::string _message):
+		type(_type),
+		message(std::move(_message))
+	{}
+
+	Type type;
+	std::string message;
+};
+using FormatErrors = std::vector<FormatError>;
+
+/**
+ * Utility class that collects notices, warnings and errors and is able
+ * to format them for ANSI colorized output during the interactive update
+ * process in isoltest.
+ * It's purpose is to help users of isoltest to automatically
+ * update test files but always keep track of what is happening.
+ */
+class ErrorReporter
+{
+public:
+	explicit ErrorReporter() {}
+
+	/// Adds a new FormatError of type Notice with the given message.
+	void notice(std::string _notice)
+	{
+		m_errors.push_back(FormatError{FormatError::Notice, std::move(_notice)});
+	}
+
+	/// Adds a new FormatError of type Warning with the given message.
+	void warning(std::string _warning)
+	{
+		m_errors.push_back(FormatError{FormatError::Warning, std::move(_warning)});
+	}
+
+	/// Adds a new FormatError of type Error with the given message.
+	void error(std::string _error)
+	{
+		m_errors.push_back(FormatError{FormatError::Error, std::move(_error)});
+	}
+
+	/// Prints all errors depending on their type using ANSI colorized output.
+	/// It will be used to print notices, warnings and errors during the
+	/// interactive update process.
+	std::string format(std::string const& _linePrefix, bool _formatted)
+	{
+		std::stringstream os;
+		for (auto const& error: m_errors)
+		{
+			switch (error.type)
+			{
+			case FormatError::Notice:
+				AnsiColorized(
+					os,
+					_formatted,
+					{formatting::WHITE}
+				) << _linePrefix << "Notice: " << error.message << std::endl;
+				break;
+			case FormatError::Warning:
+				AnsiColorized(
+					os,
+					_formatted,
+					{formatting::YELLOW}
+				) << _linePrefix << "Warning: " << error.message << std::endl;
+				break;
+			case FormatError::Error:
+				AnsiColorized(
+					os,
+					_formatted,
+					{formatting::RED}
+				) << _linePrefix << "Error: " << error.message << std::endl;
+				break;
+			}
+		}
+		return os.str();
+	}
+
+private:
+	FormatErrors m_errors;
+};
 
 /**
  * Represents a function call and the result it returned. It stores the call
@@ -51,7 +145,25 @@ public:
 	/// the actual result is used.
 	/// If _highlight is false, it's formatted without colorized highlighting. If it's true, AnsiColorized is
 	/// used to apply a colorized highlighting.
-	std::string format(std::string const& _linePrefix = "", bool const _renderResult = false, bool const _highlight = false) const;
+	/// Reports warnings and errors to the error reporter.
+	std::string format(
+		ErrorReporter& _errorReporter,
+		std::string const& _linePrefix = "",
+		bool const _renderResult = false,
+		bool const _highlight = false
+	) const;
+
+	/// Overloaded version that passes an error reporter which is never used outside
+	/// of this function.
+	std::string format(
+		std::string const& _linePrefix = "",
+		bool const _renderResult = false,
+		bool const _highlight = false
+	) const
+	{
+		ErrorReporter reporter;
+		return format(reporter, _linePrefix, _renderResult, _highlight);
+	}
 
 	/// Resets current results in case the function was called and the result
 	/// stored already (e.g. if test case was updated via isoltest).
@@ -65,7 +177,12 @@ private:
 	/// Tries to format the given `bytes`, applying the detected ABI types that have be set for each parameter.
 	/// Throws if there's a mismatch in the size of `bytes` and the desired formats that are specified
 	/// in the ABI type.
-	std::string formatBytesParameters(bytes const& _bytes, ParameterList const& _params) const;
+	/// Reports warnings and errors to the error reporter.
+	std::string formatBytesParameters(
+		ErrorReporter& _errorReporter,
+		bytes const& _bytes,
+		ParameterList const& _params
+	) const;
 
 	/// Formats the given parameters using their raw string representation.
 	std::string formatRawParameters(ParameterList const& _params, std::string const& _linePrefix = "") const;

--- a/test/libsolidity/util/TestFunctionCallTests.cpp
+++ b/test/libsolidity/util/TestFunctionCallTests.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(format_hex_singleline)
 	test.setRawBytes(actualBytes);
 	test.setFailure(false);
 
-	BOOST_REQUIRE_EQUAL(test.format("", true), "// f(bytes32): 0x31 -> 0x3200000000000000000000000000000000000000000000000000000000000000");
+	BOOST_REQUIRE_EQUAL(test.format("", true), "// f(bytes32): 0x31 -> 0x32");
 }
 
 BOOST_AUTO_TEST_CASE(format_hex_string_singleline)
@@ -235,40 +235,6 @@ BOOST_AUTO_TEST_CASE(format_failure_singleline)
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(uint8): 1 -> FAILURE");
-}
-
-BOOST_AUTO_TEST_CASE(format_parameter_encoding_too_short)
-{
-	bytes expectedBytes = toBigEndian(u256{1}) + toBigEndian(u256{1});
-	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 20};
-	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}};
-	FunctionCallArgs arguments{vector<Parameter>{param, param}, string{}};
-	FunctionCall call{"f(uint8, uint8)", 0, arguments, expectations};
-	TestFunctionCall test{call};
-
-	bytes resultBytes = toBigEndian(u256{1}) + toBigEndian(u256{2});
-	test.setRawBytes(resultBytes);
-	test.setFailure(false);
-
-	BOOST_REQUIRE_THROW(test.format("", true), runtime_error);
-}
-
-BOOST_AUTO_TEST_CASE(format_byte_range_too_short)
-{
-	bytes expectedBytes = toBigEndian(u256{1});
-	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
-	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}};
-	FunctionCallArgs arguments{vector<Parameter>{param, param}, string{}};
-	FunctionCall call{"f(uint8, uint8)", 0, arguments, expectations};
-	TestFunctionCall test{call};
-
-	bytes resultBytes{0};
-	test.setRawBytes(resultBytes);
-	test.setFailure(false);
-
-	BOOST_REQUIRE_THROW(test.format("", true), runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Description

This PR removes the need to always match the size of expected and obtained results of semantic test function calls. The following test throws because they outputs don't match:
```
contract C {
    function f() public returns(uint d) {
        return true ? 5 : 10;
    }
}
// ====
// EVMVersion: >byzantium
// ----
// f() -> 
```
Exception:

`Encoding does not match byte range: the call returned 32 bytes, but 0 bytes were expected.`

### Solution

Since we can make use of the end-to-end execution framework, it's possible to get type information for the returned bytes from the contract ABI. These type are then used to format the output and make updating the test possible.

With these changes it will be possible to still auto-update the test without throwing an exception. A warning will be reported instead such the user can react accordingly:
```
Contract:
  contract C {
      function f() public returns(uint d) {
          return true ? 5 : 10;
      }
  }
  // ====
  // EVMVersion: >byzantium

  Expected result:
  // f() -> 

  Obtained result:
  // f() -> 5
  Warning: Encoding does not match byte range. The call returned 32 bytes, but 0 bytes were expected.
  
  Attention: Updates on the test will apply the detected format displayed.

```
### Output

![isoltest](https://user-images.githubusercontent.com/20012009/56049268-5f0a0a00-5d49-11e9-95c0-17d9497b5f99.png)
