### PR TITLE
Emacs and CMakeLists.txt administrivia

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 4
 [std/**.sol]
 indent_style = space
 indent_size = 4
+
+[*.{txt,cmake}]
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ prerelease.txt
 
 # Build directory
 build/
+build*/
 emscripten_build/
 docs/_build
 docs/utils/__pycache__
@@ -44,6 +45,9 @@ deps/cache
 [._]*.sw[a-p]
 [._]sw[a-p]
 
+# emacs stuff
+*~
+
 # IDE files
 .idea
 .vscode
@@ -53,3 +57,6 @@ CMakeLists.txt.user
 /.vs
 /.cproject
 /.project
+
+# place to put local temporary files
+tmp


### PR DESCRIPTION
Some small little developer-like changes
* `.editorconfig` - specify `CMakeLists.txt` indentation
* `.gitignore`
   - ignore emacs backups 
   - `tmp` - like `/tmp` but specific to this project
   - `build*` - allow multiple kinds of build directories

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
