### PR TITLE
Allow env var REPO_ROOT to limit check_style.sh

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -3,7 +3,7 @@
 . scripts/report_errors.sh
 
 (
-REPO_ROOT="$(dirname "$0")"/..
+REPO_ROOT=${REPO_ROOT:-"$(dirname "$0")"/..}
 cd $REPO_ROOT
 
 WHITESPACE=$(git grep -n -I -E "^.*[[:space:]]+$" | grep -v "test/libsolidity/ASTJSON\|test/compilationTests/zeppelin/LICENSE")


### PR DESCRIPTION
When I run this on my checked out repository, I am picking up artifacts in build directories,
and other temporary files outside of the repository. Allowing REPO_ROOT to optionally be specified
help here.

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
