### PR TITLE
[Yul] Output an error of a switch case which contains string literals…

### DIFF
--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -390,6 +390,12 @@ BOOST_AUTO_TEST_CASE(switch_duplicate_case_different_literal)
 	BOOST_CHECK(successParse("{ switch 1:u256 case \"1\":u256 {} case \"2\":u256 {} }"));
 }
 
+BOOST_AUTO_TEST_CASE(switch_case_string_literal_too_long)
+{
+	BOOST_CHECK(successParse("{let x:u256 switch x case \"01234567890123456789012345678901\":u256 {}}"));
+	CHECK_ERROR("{let x:u256 switch x case \"012345678901234567890123456789012\":u256 {}}", TypeError, "String literal too long (33 > 32)");
+}
+
 BOOST_AUTO_TEST_CASE(function_shadowing_outside_vars)
 {
 	CHECK_ERROR("{ let x:u256 function f() -> x:u256 {} }", DeclarationError, "already taken in this scope");


### PR DESCRIPTION
### Description

Fix #6510 

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
