### PR TITLE
Add ossfuzz builder to nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,7 @@ workflows:
           <<: *build_on_tags
           requires:
             - build_emscripten
+      - build_x86_linux_ossfuzz: *build_on_tags
       - test_x86_ossfuzz_regression:
           <<: *build_on_tags
           requires:


### PR DESCRIPTION
It looks like the ossfuzz builder was missing in the nightly workflow that included the ossfuzz regression job. This PR adds the builder to the nightly job. Hopefully, with this change, the regression job should not complain.