### PR TITLE
Move metadata settings into its own object.

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -84,6 +84,10 @@ explanatory purposes.
             yulDetails: {}
           }
         },
+        metadata: {
+          // Reflects the setting used in the input json, defaults to false
+          useLiteralContent: true
+        }
         // Required for Solidity: File and name of the contract or library this
         // metadata is created for.
         compilationTarget: {
@@ -92,9 +96,7 @@ explanatory purposes.
         // Required for Solidity: Addresses for libraries used
         libraries: {
           "MyLib": "0x123123..."
-        },
-        // Reflects the setting used in the input json, defaults to false
-        "useLiteralContent": false
+        }
       },
       // Required: Generated information about the contract.
       output:

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1067,7 +1067,8 @@ string CompilerStack::createMetadata(Contract const& _contract) const
 		meta["settings"]["optimizer"]["details"] = std::move(details);
 	}
 
-	meta["settings"]["useLiteralContent"] = m_metadataLiteralSources;
+	if (m_metadataLiteralSources)
+		meta["settings"]["metadata"]["useLiteralContent"] = true;
 	meta["settings"]["evmVersion"] = m_evmVersion.name();
 	meta["settings"]["compilationTarget"][_contract.contract->sourceUnitName()] =
 		_contract.contract->annotation().canonicalName;

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -186,22 +186,29 @@ BOOST_AUTO_TEST_CASE(metadata_useLiteralContent)
 		}
 	)";
 
-	auto check = [](char const* _src, bool _check)
+	auto check = [](char const* _src, bool _literal)
 	{
 		CompilerStack compilerStack;
 		compilerStack.setSources({{"", std::string(_src)}});
 		compilerStack.setEVMVersion(dev::test::Options::get().evmVersion());
 		compilerStack.setOptimiserSettings(dev::test::Options::get().optimize);
-		compilerStack.useMetadataLiteralSources(_check);
+		compilerStack.useMetadataLiteralSources(_literal);
 		BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 		string metadata_str = compilerStack.metadata("test");
 		Json::Value metadata;
 		jsonParse(metadata_str, metadata);
-		BOOST_CHECK(metadata.isMember("settings"));
-		BOOST_CHECK(metadata["settings"].isMember("useLiteralContent"));
-		BOOST_CHECK(_check == metadata["settings"]["useLiteralContent"].asBool());
 		BOOST_CHECK(dev::test::isValidMetadata(metadata_str));
-
+		BOOST_CHECK(metadata.isMember("settings"));
+		if (_literal)
+		{
+			BOOST_CHECK(metadata["settings"].isMember("metadata"));
+			BOOST_CHECK(metadata["settings"]["metadata"].isMember("useLiteralContent"));
+			BOOST_CHECK(metadata["settings"]["metadata"]["useLiteralContent"].asBool());
+		}
+		else
+		{
+			BOOST_CHECK(!metadata["settings"].isMember("metadata"));
+		}
 	};
 
 	check(sourceCode, true);


### PR DESCRIPTION
@marenz please check - I think it should be one level deeper actually.

Follow-up of https://github.com/ethereum/solidity/pull/6534/