### PR TITLE
[WIP] Parser Recovery (add "error" grammar rules)

### DIFF
--- a/docs/error-rules.txt
+++ b/docs/error-rules.txt
@@ -1,5 +1,6 @@
-// Error1 catches exceptions from below while Error2 doesn't.
+// Error catches exceptions from rules called below it.
 
-SourceUnit = '{' Error1 '}'
-ContractDefinition = '{' Error1 '}'
+SourceUnit = Error $
+Block = '{' Error '}'
+ContractDefinition = '{' Error '}'
 Statement = Error2 ';'

--- a/docs/error-rules.txt
+++ b/docs/error-rules.txt
@@ -1,4 +1,5 @@
 // Error1 catches exceptions from below while Error2 doesn't.
 
+SourceUnit = '{' Error1 '}'
 ContractDefinition = '{' Error1 '}'
 Statement = Error2 ';'

--- a/docs/error-rules.txt
+++ b/docs/error-rules.txt
@@ -1,0 +1,4 @@
+// Error1 catches exceptions from below while Error2 doesn't.
+
+ContractDefinition = '{' Error1 '}'
+Statement = Error2 ';'

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -456,3 +456,10 @@ Language Grammar
 
 .. literalinclude:: grammar.txt
    :language: none
+
+**********************
+Error Recovery Grammar
+**********************
+
+.. literalinclude:: error-rules.txt
+   :language: none

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -463,3 +463,14 @@ Error Recovery Grammar
 
 .. literalinclude:: error-rules.txt
    :language: none
+
+Literal strings in the grammar that are missing are inserted if they are not found. For example, in the rule:
+
+::
+
+   IfStatement = 'if' '(' Expression ')' Statement ( 'else' Statement )?
+
+
+If tokens '(', ')' are missing, they will be inserted by error recovery. The tokens 'if' and 'else' however will not be.
+The token 'if' cannot be unambiguously inferred as '(' can. At the beginning of a statement, the missing token might be 'while', or 'for'.
+Likewise 'else' is optional so that is not unambiguously inferrable.

--- a/liblangutil/CharStream.cpp
+++ b/liblangutil/CharStream.cpp
@@ -73,6 +73,12 @@ char CharStream::rollback(size_t _amount)
 	return get();
 }
 
+char CharStream::seek(size_t _location)
+{
+	m_position = _location;
+	return get();
+}
+
 string CharStream::lineAtPosition(int _position) const
 {
 	// if _position points to \n, it returns the line before the \n
@@ -106,5 +112,3 @@ tuple<int, int> CharStream::translatePositionToLineColumn(int _position) const
 	}
 	return tuple<int, int>(lineNumber, searchPosition - lineStart);
 }
-
-

--- a/liblangutil/CharStream.h
+++ b/liblangutil/CharStream.h
@@ -77,6 +77,7 @@ public:
 	char get(size_t _charsForward = 0) const { return m_source[m_position + _charsForward]; }
 	char advanceAndGet(size_t _chars = 1);
 	char rollback(size_t _amount);
+	char seek(size_t _location);
 
 	void reset() { m_position = 0; }
 

--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -59,7 +59,7 @@ void ErrorReporter::warning(
 	error(Error::Type::Warning, _location, _secondaryLocation, _description);
 }
 
-void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, string const& _description)
+void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, string const& _description, bool _throwError)
 {
 	if (checkForExcessiveErrors(_type))
 		return;
@@ -70,9 +70,13 @@ void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, st
 		errinfo_comment(_description);
 
 	m_errorList.push_back(err);
+	if (_throwError)
+	{
+		BOOST_THROW_EXCEPTION(ParserError());
+	}
 }
 
-void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, SecondarySourceLocation const& _secondaryLocation, string const& _description)
+void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, SecondarySourceLocation const& _secondaryLocation, string const& _description, bool _throwError)
 {
 	if (checkForExcessiveErrors(_type))
 		return;
@@ -84,6 +88,10 @@ void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, Se
 		errinfo_comment(_description);
 
 	m_errorList.push_back(err);
+	if (_throwError)
+	{
+		BOOST_THROW_EXCEPTION(ParserError());
+	}
 }
 
 bool ErrorReporter::checkForExcessiveErrors(Error::Type _type)
@@ -167,12 +175,13 @@ void ErrorReporter::fatalDeclarationError(SourceLocation const& _location, std::
 		_description);
 }
 
-void ErrorReporter::parserError(SourceLocation const& _location, string const& _description)
+void ErrorReporter::parserError(SourceLocation const& _location, string const& _description, bool _throwError)
 {
 	error(
 		Error::Type::ParserError,
 		_location,
-		_description
+		_description,
+		_throwError
 	);
 }
 

--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -72,7 +72,7 @@ void ErrorReporter::error(Error::Type _type, SourceLocation const& _location, st
 	m_errorList.push_back(err);
 	if (_throwError)
 	{
-		BOOST_THROW_EXCEPTION(ParserError());
+		BOOST_THROW_EXCEPTION(FatalError());
 	}
 }
 

--- a/liblangutil/ErrorReporter.h
+++ b/liblangutil/ErrorReporter.h
@@ -63,7 +63,8 @@ public:
 	void error(
 		Error::Type _type,
 		SourceLocation const& _location,
-		std::string const& _description
+		std::string const& _description,
+		bool _throwError = false
 	);
 
 	void declarationError(
@@ -76,7 +77,7 @@ public:
 
 	void fatalDeclarationError(SourceLocation const& _location, std::string const& _description);
 
-	void parserError(SourceLocation const& _location, std::string const& _description);
+	void parserError(SourceLocation const& _location, std::string const& _description, bool _throwError = false);
 
 	void fatalParserError(SourceLocation const& _location, std::string const& _description);
 
@@ -123,7 +124,8 @@ private:
 		Error::Type _type,
 		SourceLocation const& _location,
 		SecondarySourceLocation const& _secondaryLocation,
-		std::string const& _description = std::string());
+		std::string const& _description = std::string(),
+		bool _throwError = false);
 
 	void fatalError(
 		Error::Type _type,

--- a/liblangutil/ErrorReporter.h
+++ b/liblangutil/ErrorReporter.h
@@ -119,6 +119,9 @@ public:
 		return m_errorCount > 0;
 	}
 
+	// @returns true if error shouldn't be stored
+	bool checkForExcessiveErrors(Error::Type _type);
+
 private:
 	void error(
 		Error::Type _type,
@@ -138,9 +141,6 @@ private:
 		SourceLocation const& _location = SourceLocation(),
 		std::string const& _description = std::string());
 
-	// @returns true if error shouldn't be stored
-	bool checkForExcessiveErrors(Error::Type _type);
-
 	ErrorList& m_errorList;
 
 	unsigned m_errorCount = 0;
@@ -151,4 +151,3 @@ private:
 };
 
 }
-

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -39,6 +39,7 @@ using ErrorList = std::vector<std::shared_ptr<Error const>>;
 struct CompilerError: virtual dev::Exception {};
 struct InternalCompilerError: virtual dev::Exception {};
 struct FatalError: virtual dev::Exception {};
+struct ParserError: virtual dev::Exception {};
 struct UnimplementedFeatureError: virtual dev::Exception {};
 
 /// Assertion that throws an InternalCompilerError containing the given description if it is not met.

--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -24,6 +24,26 @@
 #include <liblangutil/Scanner.h>
 #include <liblangutil/ErrorReporter.h>
 
+// Should this be moved somewhere more global
+namespace fmt {
+
+template< class ...Args >
+std::string sprintf( char const * f, Args && ...args ) {
+	int size = snprintf( nullptr, 0, f, args... );
+	std::string res;
+	res.resize( size );
+	snprintf( & res[ 0 ], size + 1, f, args... );
+	// Some snprintf's pad nulls to the nearest word.
+	// Remove them.
+	while (res[size-1] == '\0' && size > 0) {
+		size--;
+	}
+	res.resize( size );
+	return res;
+}
+
+}
+
 using namespace std;
 using namespace langutil;
 
@@ -79,28 +99,54 @@ void ParserBase::expectToken(Token _value, bool _advance)
 	Token tok = m_scanner->currentToken();
 	if (tok != _value)
 	{
-		parserError(string("Expected ") + ParserBase::tokenName(_value) + string(" but got ") + ParserBase::tokenName(tok));
+		std::string const expectToken = ParserBase::tokenName(_value);
+		parserError(string("Expected ") + expectToken + string(" but got ") + tokenName(tok) + string(". Inserting ") + expectToken + " before here.");
+		// Do not advance so that recovery can sync or make use of the current token. This is especially useful if the expected token
+		// is the only one that is missing and is at the end of a construct.
+		// "{ ... ; }" is such an example.
+		//        ^
+		_advance = false;
 	}
 	if (_advance)
 		m_scanner->next();
 }
 
-void ParserBase::expectTokenOrConsumeUntil(Token _value, bool _advance)
+void ParserBase::expectTokenOrConsumeUntil(Token _value, char const *_lhs, bool _advance)
 {
 	Token tok = m_scanner->currentToken();
 	if (tok != _value)
 	{
 		Token token = m_scanner->currentToken();
-		SourceLocation errorLoc = SourceLocation{position(), endPosition(), source()};
+		int startPosition = position();
+		SourceLocation errorLoc = SourceLocation{startPosition, endPosition(), source()};
 		while (token != _value && token != Token::EOS)
 			token = m_scanner->next();
-		std::string tokenName = ParserBase::tokenName(_value);
-		std::string mess = string("Expected ") + tokenName + string(" but got ") + ParserBase::tokenName(tok) + string(". ");
+		std::string const expectToken = ParserBase::tokenName(_value);
+		std::string const mess = fmt::sprintf("In <%s>, %s is expected; got %s instead.", _lhs, expectToken.c_str(), ParserBase::tokenName(tok).c_str());
 		if (token == Token::EOS)
-			parserError(errorLoc, mess);
+		{
+			// rollback to where the token started, and raise exception to be caught at a higher level.
+			m_scanner->seek(startPosition);
+			m_inParserRecovery = true;
+			fatalParserError(errorLoc, mess);
+		}
 		else
-			parserError(errorLoc, mess + "Skipped to next " + tokenName + ".");
+		{
+			if (m_inParserRecovery)
+				parserWarning(fmt::sprintf("Recovered in <%s> at %s.", _lhs, expectToken.c_str()));
+			else
+				parserError(errorLoc, fmt::sprintf("%s Recovered at next %s.", mess.c_str(), expectToken.c_str()));
+			m_inParserRecovery = false;
+		}
 	}
+	else
+		if (m_inParserRecovery)
+		{
+			std::string expectToken = ParserBase::tokenName(_value);
+			parserWarning(fmt::sprintf("Recovered in <%s> at %s.", _lhs, expectToken.c_str()));
+			m_inParserRecovery = false;
+		}
+
 	if (_advance)
 		m_scanner->next();
 }
@@ -118,6 +164,11 @@ void ParserBase::decreaseRecursionDepth()
 	m_recursionDepth--;
 }
 
+void ParserBase::parserWarning(string const& _description)
+{
+	m_errorReporter.warning(SourceLocation{position(), endPosition(), source()}, _description);
+}
+
 void ParserBase::parserError(SourceLocation const& _location, string const& _description, bool _throw_error)
 {
 	m_errorReporter.parserError(_location, _description, _throw_error);
@@ -131,4 +182,9 @@ void ParserBase::parserError(string const& _description, bool _throw_error)
 void ParserBase::fatalParserError(string const& _description)
 {
 	m_errorReporter.fatalParserError(SourceLocation{position(), endPosition(), source()}, _description);
+}
+
+void ParserBase::fatalParserError(SourceLocation const& _location, string const& _description)
+{
+	m_errorReporter.fatalParserError(_location, _description);
 }

--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -79,7 +79,7 @@ void ParserBase::expectToken(Token _value, bool _advance)
 	Token tok = m_scanner->currentToken();
 	if (tok != _value)
 	{
-		fatalParserError(string("Expected ") + ParserBase::tokenName(_value) + string(" but got ") + ParserBase::tokenName(tok));
+		parserError(string("Expected ") + ParserBase::tokenName(_value) + string(" but got ") + ParserBase::tokenName(tok));
 	}
 	if (_advance)
 		m_scanner->next();
@@ -97,9 +97,9 @@ void ParserBase::expectTokenOrConsumeUntil(Token _value, bool _advance)
 		std::string tokenName = ParserBase::tokenName(_value);
 		std::string mess = string("Expected ") + tokenName + string(" but got ") + ParserBase::tokenName(tok) + string(". ");
 		if (token == Token::EOS)
-			parserError(errorLoc, mess + "Cannot find " + tokenName + " to synchronize to.");
+			parserError(errorLoc, mess);
 		else
-			parserError(errorLoc, mess + "Skipping to next " + tokenName + ".");
+			parserError(errorLoc, mess + "Skipped to next " + tokenName + ".");
 	}
 	if (_advance)
 		m_scanner->next();
@@ -118,14 +118,14 @@ void ParserBase::decreaseRecursionDepth()
 	m_recursionDepth--;
 }
 
-void ParserBase::parserError(SourceLocation const& _location, string const& _description)
+void ParserBase::parserError(SourceLocation const& _location, string const& _description, bool _throw_error)
 {
-	m_errorReporter.parserError(_location, _description);
+	m_errorReporter.parserError(_location, _description, _throw_error);
 }
 
-void ParserBase::parserError(string const& _description)
+void ParserBase::parserError(string const& _description, bool _throw_error)
 {
-	m_errorReporter.parserError(SourceLocation{position(), endPosition(), source()}, _description);
+	m_errorReporter.parserError(SourceLocation{position(), endPosition(), source()}, _description, _throw_error);
 }
 
 void ParserBase::fatalParserError(string const& _description)

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -82,8 +82,8 @@ protected:
 
 	/// Creates a @ref ParserError and annotates it with the current position and the
 	/// given @a _description.
-	void parserError(std::string const& _description);
-	void parserError(SourceLocation const& _location, std::string const& _description);
+	void parserError(std::string const& _description, bool _throwError = false);
+	void parserError(SourceLocation const& _location, std::string const& _description, bool _throw_error = false);
 
 	/// Creates a @ref ParserError and annotates it with the current position and the
 	/// given @a _description. Throws the FatalError.

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -62,10 +62,16 @@ protected:
 
 	///@{
 	///@name Helper functions
-	/// If current token value is not _value, throw exception otherwise advance token.
+	/// If current token value is not _value, throw exception otherwise advance token
+	//  if _advance is true.
 	void expectToken(Token _value, bool _advance = true);
+
+	/// Like expectToken but if there is an error we will delete tokens until
+	/// we get the expected token or EOS.
+	void expectTokenOrConsumeUntil(Token _value, bool _advance = true);
 	Token currentToken() const;
 	Token peekNextToken() const;
+	std::string tokenName(Token _token);
 	std::string currentLiteral() const;
 	Token advance();
 	///@}
@@ -77,10 +83,12 @@ protected:
 	/// Creates a @ref ParserError and annotates it with the current position and the
 	/// given @a _description.
 	void parserError(std::string const& _description);
+	void parserError(SourceLocation const& _location, std::string const& _description);
 
 	/// Creates a @ref ParserError and annotates it with the current position and the
 	/// given @a _description. Throws the FatalError.
 	void fatalParserError(std::string const& _description);
+	void fatalParserError(SourceLocation const& _location, std::string const& _description);
 
 	std::shared_ptr<Scanner> m_scanner;
 	/// The reference to the list of errors and warning to add errors/warnings during parsing

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -156,6 +156,13 @@ void Scanner::reset()
 	next();
 }
 
+void Scanner::seek(size_t _offset)
+{
+	m_char = m_source->seek(_offset);
+	scanToken();
+	next();
+}
+
 void Scanner::supportPeriodInIdentifier(bool _value)
 {
 	m_supportPeriodInIdentifier = _value;

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -110,6 +110,9 @@ public:
 	/// @returns the next token and advances input
 	Token next();
 
+	/// Set scanner to a specific offset. This is used in error recovery.
+	void seek(size_t _offset);
+
 	///@{
 	///@name Information about the current token
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -263,7 +263,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 {
 	RecursionGuard recursionGuard(*this);
 	ASTNodeFactory nodeFactory(*this);
-	ASTPointer<ASTString> name;
+	ASTPointer<ASTString> name =  make_shared<ASTString>("__ContractNameNotSet__");
 	ASTPointer<ASTString> docString;
 	vector<ASTPointer<InheritanceSpecifier>> baseContracts;
 	vector<ASTPointer<ASTNode>> subNodes;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -104,8 +104,8 @@ ASTPointer<SourceUnit> Parser::parse(shared_ptr<Scanner> const& _scanner)
 	}
 	catch (FatalError const&)
 	{
-		if (m_errorReporter.errors().empty())
-			throw; // Something is weird here, rather throw again.
+		if (!m_errorReporter.hasErrors() || m_errorReporter.checkForExcessiveErrors(Error::Type::ParserError))
+			throw; // Don't try to handle
 		return nullptr;
 	}
 }
@@ -314,8 +314,8 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 	}
 	catch (FatalError const&)
 	{
-		if (m_errorReporter.errors().empty())
-			throw; // Something is weird here, rather throw again.
+		if (!m_errorReporter.hasErrors() || m_errorReporter.checkForExcessiveErrors(Error::Type::ParserError))
+			throw; // Don't try to handle
 	}
 	expectTokenOrConsumeUntil(Token::RBrace);
 	return nodeFactory.createNode<ContractDefinition>(

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/contract_definition.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/contract_definition.sol
@@ -1,0 +1,24 @@
+pragma solidity >=0.0.0;
+
+contract {
+	mapping (address => uint) balances;
+}
+
+contract One {
+	mapping2 (address => uint) balances;
+}
+
+library Address {
+    function (address account internal view returns (bool) {
+        return account > 0;
+    }
+}
+
+// ----
+// ParserError: (12-13): Expected identifier but got '{'
+// ParserError: (12-13): Expected '}' but got '{'. Skipping to next '}'.
+// ParserError: (79-80): Expected identifier but got '('
+// ParserError: (79-80): Expected '}' but got '('. Skipping to next '}'.
+// ParserError: (158-166): Expected ',' but got 'internal'
+// ParserError: (158-166): Expected '}' but got 'internal'. Skipping to next '}'.
+// ParserError: (223-224): Expected pragma, import directive or contract/interface/library definition.

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/e2.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/e2.sol
@@ -1,0 +1,10 @@
+pragma solidity >=0.0.0;
+
+// Example to show why deleting the token at the
+// point of error is bad. Here, ")" is missing
+// and there is a ";" instead. That causes us to
+// not be able to syncronize to ';'. Advance again and
+// '}' is deleted and then we can't synchronize the contract.
+contract Error2 {
+	mapping (address => uint balances; // missing ) before "balances"
+}

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/e3.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/e3.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.0.0;
+
+contract Error3 {
+	constructor() public {
+	    balances[tx.origin] = ; // missing RHS.
+	}
+
+}

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/e4.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/e4.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.0.0;
+
+contract E4 {
+	constructor() public {
+	    balances[tx.origin] = 1 2; // missing operator
+	}
+
+}

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/e5.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/e5.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.0.0;
+
+contract E5 {
+	constructor() public {
+	    balances[tx.origin = 1  2; // missing ]
+	}
+
+}

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/e7.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/e7.sol
@@ -1,0 +1,8 @@
+pragma solidity >=0.0.0;
+
+contract E7 {
+	constructor() public {
+	    balances[tx.origin] = // missing RHS and semicolon.
+	}
+
+}

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/missing_stmt_semicolon.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/missing_stmt_semicolon.sol
@@ -1,0 +1,52 @@
+pragma solidity >=0.0.0;
+
+// This is a contract with a number of syntax errors involving missing
+// semicolons.
+
+// Tokens are deleted until the next subsequent semicolon.
+
+contract MetaCoin1 {
+	mapping (address => uint) balances;
+
+	event Transfer(address indexed _from, address indexed _to, uint256 _value);
+
+	constructor() public {
+		balances[tx.origin] = 10000;
+	}
+
+	function sendCoin(address receiver, uint amount) public returns(bool sufficient) {
+		uint i;
+		// "Return" missing its semicolon.
+		if (balances[msg.sender] < amount) return false
+
+		balances[msg.sender] -= amount;
+
+		// "Statement" missing its semicolon
+		balances[receiver] += amount
+		emit Transfer(msg.sender, receiver, amount);
+
+		//
+		while (amount < 10) {
+			// "Break" missing its semicolon
+			if (amount > 1) break
+			amount += 1;
+			// "Continue" missing its semicolon
+			continue
+			if (amount > 2) break;
+		}
+		return true;
+	}
+
+	function getBalanceInEth(address addr) public view returns(uint){
+		return ConvertLib.convert(getBalance(addr),2);
+	}
+
+	function getBalance(address addr) public view returns(uint) {
+		return balances[addr];
+	}
+}
+// ----
+// ParserError: (530-538): Expected ';' but got identifier. Skipping to next ';'.
+// ParserError: (635-639): Expected ';' but got 'emit'. Skipping to next ';'.
+// ParserError: (774-780): Expected ';' but got identifier. Skipping to next ';'.
+// ParserError: (841-843): Expected ';' but got 'if'. Skipping to next ';'.

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/semicolon_error_to_EOS.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/semicolon_error_to_EOS.sol
@@ -1,0 +1,18 @@
+pragma solidity >=0.0.0;
+
+// This is a contract with a missing semicolon for which there is
+// recovery semicolon to synchronize up to.
+
+// Tokens are deleted until the end of stream.
+
+contract ErrorStatementToEOS {
+  function five() returns(int) {
+    uint256 a;
+    a = 1
+    b = 2
+  }
+}
+// ----
+// ParserError: (255-256): Expected ';' but got identifier. Cannot find ';' to synchronize to.
+// ParserError: (267-267): Expected primary expression.
+// ParserError: (267-267): Expected '}' but got end of source. Cannot find '}' to synchronize to.

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/sync_to_semicolon.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/sync_to_semicolon.sol
@@ -7,7 +7,7 @@ pragma solidity >=0.0.0;
 // Tokens are deleted until the next subsequent semicolon.
 
 contract MetaCoin2 {
-	mapping (address => uint) balances;
+	mapping (address => uint balances;
 
 	event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
@@ -20,13 +20,13 @@ contract MetaCoin2 {
 		if (balances[msg.sender])
 		    return false;
 
-		balances[msg.sender] -= amount;
+		balances[msg.sender] -= // missing RHS
 
 		balances[receiver] += amount;
-		emit Transfer(msg.sender, receiver,);  // missing param or extra ,
+		emit Transfer(msg.sender;  // missing )
 
-		// missing ) in while
-		while (amount < 10) {
+		// missing < in while
+		while (amount 10) {
 			if (amount > 1) break;
 				amount += ;  //
 			continue;

--- a/test/libsolidity/syntaxTests/parsing/errorRecovery/sync_to_semicolon.sol
+++ b/test/libsolidity/syntaxTests/parsing/errorRecovery/sync_to_semicolon.sol
@@ -1,0 +1,50 @@
+pragma solidity >=0.0.0;
+
+// This is a contract with a number of syntax errors in
+// statements where deleting to semicolon seems to be
+// the right thing to do
+
+// Tokens are deleted until the next subsequent semicolon.
+
+contract MetaCoin2 {
+	mapping (address => uint) balances;
+
+	event Transfer(address indexed _from, address indexed _to, uint256 _value);
+
+	constructor() public {
+		balances[tx.origin] = 10000;
+	}
+
+	function sendCoin(address receiver, uint amount) public returns(bool sufficient) {
+		uint i;
+		if (balances[msg.sender])
+		    return false;
+
+		balances[msg.sender] -= amount;
+
+		balances[receiver] += amount;
+		emit Transfer(msg.sender, receiver,);  // missing param or extra ,
+
+		// missing ) in while
+		while (amount < 10) {
+			if (amount > 1) break;
+				amount += ;  //
+			continue;
+			if (amount > 2) break;
+		}
+		return true;
+	}
+
+	function getBalanceInEth(address addr) public view returns(uint){
+		return ConvertLib.convert(getBalance(addr),2);
+	}
+
+	function getBalance(address addr) public view returns(uint) {
+		return balances[addr];
+	}
+}
+// ----
+// ParserError: (530-538): Expected ';' but got identifier. Skipping to next ';'.
+// ParserError: (635-639): Expected ';' but got 'emit'. Skipping to next ';'.
+// ParserError: (774-780): Expected ';' but got identifier. Skipping to next ';'.
+// ParserError: (841-843): Expected ';' but got 'if'. Skipping to next ';'.


### PR DESCRIPTION
**Note:** this has been updated.

Add parser recovery rules:

```
SourceUnit = Error $
Block = '{' Error '}'
ContractDefinition = '{' Error '}'
Statement = Error';'
```
Note: this is documented in the [Error Recovery Grammar](https://github.com/rocky/solidity/blob/recoveringParser0/docs/miscellaneous.rst#error-recovery-grammar)  section of `miscellaneous.rst`.

TODO:

* Adjust existing tests which expect different error messages
* Add some unit tests for some lower-level functions
* Turn `catch` code into a macro which takes a parameter a
  grammar rule function and terminating symbols?
* Isolate into a new exception `PaserError` distinct from `FatalParserError`? (I tried this and it wasn't working)
* Feedback and probably a number of smaller tweaks. 

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
