### PR TITLE
Allow additional EVMVersion comparators in isoltest

### DIFF
--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -116,19 +116,35 @@ bool EVMVersionRestrictedTestCase::validateSettings(langutil::EVMVersion _evmVer
 	if (versionString.empty())
 		return true;
 
-	char comparator = versionString.front();
-	versionString = versionString.substr(1);
+	string comparator;
+	size_t versionBegin = 0;
+	for (auto character: versionString)
+		if (!isalpha(character))
+		{
+			comparator += character;
+			versionBegin++;
+		}
+		else
+			break;
+
+	versionString = versionString.substr(versionBegin);
 	boost::optional<langutil::EVMVersion> version = langutil::EVMVersion::fromString(versionString);
 	if (!version)
 		throw runtime_error("Invalid EVM version: \"" + versionString + "\"");
 
-	switch (comparator)
-	{
-		case '>': return version < _evmVersion;
-		case '<': return _evmVersion < version;
-		case '=': return _evmVersion == version;
-		case '!': return !(_evmVersion == version);
-	}
-	throw runtime_error(string{"Invalid EVM comparator: \""} + comparator + "\"");
+	if (comparator == ">")
+		return _evmVersion > version;
+	else if (comparator == ">=")
+		return _evmVersion >= version;
+	else if (comparator == "<")
+		return _evmVersion < version;
+	else if (comparator == "<=")
+		return _evmVersion <= version;
+	else if (comparator == "=")
+		return _evmVersion == version;
+	else if (comparator == "!")
+		return !(_evmVersion == version);
+	else
+		throw runtime_error("Invalid EVM comparator: \"" + comparator + "\"");
 	return false; // not reached
 }

--- a/test/libsolidity/semanticTests/shifts.sol
+++ b/test/libsolidity/semanticTests/shifts.sol
@@ -4,6 +4,6 @@ contract C {
     }
 }
 // ====
-// EVMVersion: >byzantium
+// EVMVersion: >=constantinople
 // ----
 // f(uint256): 7 -> 28

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/remove_redundant_shift_masking.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/remove_redundant_shift_masking.yul
@@ -5,7 +5,7 @@
     let d := and(shr(247, calldataload(0)), 0xff)
 }
 // ====
-// EVMVersion: >byzantium
+// EVMVersion: >=constantinople
 // step: expressionSimplifier
 // ----
 // {

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/replace_too_large_shift.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/replace_too_large_shift.yul
@@ -5,7 +5,7 @@
     let d := shr(255, calldataload(3))
 }
 // ====
-// EVMVersion: >byzantium
+// EVMVersion: >=constantinople
 // step: expressionSimplifier
 // ----
 // {


### PR DESCRIPTION
This PR adds additional comparators for the EVM version in isoltest. These are the ones, that are now allowed:
```
// EVMVersion: >constantinople
// EVMVersion: >=constantinople
// EVMVersion: <constantinople
// EVMVersion: <=constantinople
// EVMVersion: =constantinople
// EVMVersion: !constantinople
```