### PR TITLE
Removes assert on magic ABI functions in code generation

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1401,6 +1401,10 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			m_context << Instruction::DUP1 << u256(32) << Instruction::ADD;
 			utils().storeStringData(contract.name());
 		}
+		else if (member == "encode" || member == "decode")
+		{
+			// no-op
+		}
 		else
 			solAssert(false, "Unknown magic member.");
 		break;

--- a/test/libsolidity/semanticTests/specialFunctions/abi_encode_decode_member_access.sol
+++ b/test/libsolidity/semanticTests/specialFunctions/abi_encode_decode_member_access.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        abi.encode;
+        abi.decode;
+    }
+}
+// ----
+// f() ->


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6509.

With this PR, we do not assert a non-member access of `abi.encode` and `abi.decode` anymore. Member access is allowed instead, but no bytecode is generated for them:
```
contract C {
    function f() public pure {
        abi.encode;
        abi.decode;
    }
}
```