### PR TITLE
Error on library calling itself externally

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.5.9 (unreleased)
 
 Language Features:
+ * Static Analyzer: Disallow libraries calling themselves externally.
 
 
 Compiler Features:

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -309,6 +309,19 @@ bool StaticAnalyzer::visit(FunctionCall const& _functionCall)
 							"Arithmetic modulo zero."
 						);
 		}
+		if (
+			m_currentContract->isLibrary() &&
+			functionType->kind() == FunctionType::Kind::DelegateCall &&
+			functionType->declaration().scope() == m_currentContract
+		)
+			m_errorReporter.typeError(
+				_functionCall.location(),
+				SecondarySourceLocation().append(
+					"The function declaration is here:",
+					functionType->declaration().scope()->location()
+				),
+				"Libraries cannot call their own functions externally."
+			);
 	}
 	return true;
 }

--- a/test/libsolidity/syntaxTests/visibility/library_self_delegatecall.sol
+++ b/test/libsolidity/syntaxTests/visibility/library_self_delegatecall.sol
@@ -1,0 +1,13 @@
+library L1 {
+    using L1 for *;
+    function f() public pure returns (uint r) { return r.g(); }
+    function g(uint) public pure returns (uint) { return 2; }
+}
+
+library L2 {
+    using L1 for *;
+    function f() public pure returns (uint r) { return r.g(); }
+    function g(uint) public pure returns (uint) { return 2; }
+}
+// ----
+// TypeError: (88-93): Libraries cannot call their own functions externally.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6451.

This PR introduces an error to be thrown, when a library is calling itself externally:
```
library L {
    using L for *;
    function f() public pure returns (uint r) { return r.g(); }
    function g(uint) public pure returns (uint) { return 2; }
}
```