### PR TITLE
Fix Natspec parser error

### DIFF
--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -17,6 +17,7 @@
 
 #include <libsolidity/parsing/DocStringParser.h>
 
+#include <liblangutil/Common.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Exceptions.h>
 
@@ -39,12 +40,19 @@ string::const_iterator skipLineOrEOS(
 	return (_nlPos == _end) ? _end : ++_nlPos;
 }
 
-string::const_iterator firstSpaceOrTab(
+string::const_iterator firstNonIdentifier(
 	string::const_iterator _pos,
 	string::const_iterator _end
 )
 {
-	return boost::range::find_first_of(make_pair(_pos, _end), " \t");
+	auto currPos = _pos;
+	if (currPos == _pos && isIdentifierStart(*currPos))
+	{
+		currPos++;
+		while (currPos != _end && isIdentifierPart(*currPos))
+			currPos++;
+	}
+	return currPos;
 }
 
 string::const_iterator firstWhitespaceOrNewline(
@@ -135,7 +143,7 @@ DocStringParser::iter DocStringParser::parseDocTagParam(iter _pos, iter _end)
 		appendError("No param name given");
 		return _end;
 	}
-	auto nameEndPos = firstSpaceOrTab(nameStartPos, _end);
+	auto nameEndPos = firstNonIdentifier(nameStartPos, _end);
 	auto paramName = string(nameStartPos, nameEndPos);
 
 	auto descStartPos = skipWhitespace(nameEndPos, _end);

--- a/test/libsolidity/syntaxTests/natspec/docstring_parameter.sol
+++ b/test/libsolidity/syntaxTests/natspec/docstring_parameter.sol
@@ -1,0 +1,11 @@
+contract C {
+    /**
+     * @dev a function
+     * @param _from 5 from address
+     * @param _5to   : to address
+     * @param value: token transfer amount
+     * @param value? token transfer amount
+     */
+    function f(address _from, address _5to, uint256 value) internal {
+    }
+}

--- a/test/libsolidity/syntaxTests/natspec/invalid/docstring_parameter.sol
+++ b/test/libsolidity/syntaxTests/natspec/invalid/docstring_parameter.sol
@@ -1,0 +1,11 @@
+contract C {
+    /**
+     * @param 5value a value parameter
+     * @param _ a value parameter
+     */
+    function f(uint256 _5value, uint256 _value, uint256 value) internal {
+    }
+}
+// ----
+// DocstringParsingError: Documented parameter "" not found in the parameter list of the function.
+// DocstringParsingError: Documented parameter "_" not found in the parameter list of the function.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6124.

This PR fixes a `DocStringParserError` that was thrown if no whitespace was found between a parameter name and the colon that seperates it from the description.
```
contract C {
    /**
     * @param _value: a value description.
     */
    function f(uint256 _value) internal {
    }
}
```