### PR TITLE
CircleCI run performance improvements

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,21 @@
+## CircleCI integration
+
+### Docker images
+
+The docker images are build locally on the developer machine:
+
+```!sh
+cd .circleci/docker/
+
+docker build -t ethereum/solc-buildpack-deps:ubuntu1904 -f Dockerfile.ubuntu1904 .
+docker push solidity/solc-buildpack-deps:ubuntu1904
+
+docker build -t ethereum/solc-buildpack-deps:archlinux -f Dockerfile.archlinux .
+docker push solidity/solc-buildpack-deps:archlinux
+```
+
+which you can find on Dockerhub after the push at:
+
+    https://hub.docker.com/r/ethereum/solidity-buildpack-deps
+
+where the image tag reflects the target OS to build Solidity and run its test on.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,72 @@
+# vim:ts=2:sw=2:et
+# --------------------------------------------------------------------------
+#   Prefixes used in order to keep CircleCI workflow overview more readable:
+#     - b: build
+#     - t: test
+#     - ubu: ubuntu
+#     - ems: Emscripten
+version: 2
+
 defaults:
-  # The default for tags is to not run, so we have to explicitly match a filter.
-  - build_on_tags: &build_on_tags
-      filters:
-        tags:
-          only: /.*/
+
+  # --------------------------------------------------------------------------
+  # Build Templates
+
   - setup_prerelease_commit_hash: &setup_prerelease_commit_hash
       name: Store commit hash and prerelease
       command: |
         if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" ]; then echo -n > prerelease.txt; else date -u +"nightly.%Y.%-m.%-d" > prerelease.txt; fi
         echo -n "$CIRCLE_SHA1" > commit_hash.txt
+
   - run_build: &run_build
       name: Build
       command: |
+        set -ex
+        if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" ]; then echo -n > prerelease.txt; else date -u +"nightly.%Y.%-m.%-d" > prerelease.txt; fi
+        echo -n "$CIRCLE_SHA1" > commit_hash.txt
         mkdir -p build
         cd build
         [ -n "$COVERAGE" -a "$CIRCLE_BRANCH" != release -a -z "$CIRCLE_TAG" ] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
-        cmake .. -DCMAKE_BUILD_TYPE=Release $CMAKE_OPTIONS
+        cmake .. -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} $CMAKE_OPTIONS -G "Unix Makefiles"
         make -j4
+
   - run_build_ossfuzz: &run_build_ossfuzz
       name: Build_ossfuzz
       command: |
         mkdir -p build
         cd build
-        /src/LPM/external.protobuf/bin/protoc --proto_path=../test/tools/ossfuzz yulProto.proto --cpp_out=../test/tools/ossfuzz
-        cmake .. -DCMAKE_BUILD_TYPE=Release $CMAKE_OPTIONS
+        protoc --proto_path=../test/tools/ossfuzz yulProto.proto --cpp_out=../test/tools/ossfuzz
+        cmake .. -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release} $CMAKE_OPTIONS
         make ossfuzz ossfuzz_proto -j4
-  - run_tests: &run_tests
-      name: Tests
-      command: scripts/tests.sh --junit_report test_results
-  - run_regressions: &run_regressions
-      name: Regression tests
-      command: |
-        export ASAN_OPTIONS="check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2"
-        scripts/regressions.py -o test_results
+
   - run_proofs: &run_proofs
       name: Correctness proofs for optimization rules
       command: scripts/run_proofs.sh
-  - solc_artifact: &solc_artifact
+
+  # --------------------------------------------------------------------------
+  # Artifacts Templates
+
+  # the whole build directory
+  - artifacts_build_dir: &artifacts_build_dir
+      root: build
+      paths:
+        - "*"
+
+  # compiled solc executable target
+  - artifacts_solc: &artifacts_solc
       path: build/solc/solc
       destination: solc
-  - all_artifacts: &all_artifacts
+
+  # compiled executable targets
+  - artifacts_executables: &artifacts_executables
       root: build
       paths:
         - solc/solc
         - test/soltest
         - test/tools/solfuzzer
-  - ossfuzz_artifacts: &ossfuzz_artifacts
+
+  # compiled OSSFUZZ targets
+  - artifacts_executables_ossfuzz: &artifacts_executables_ossfuzz
       root: build
       paths:
         - test/tools/ossfuzz/const_opt_ossfuzz
@@ -57,9 +78,280 @@ defaults:
         - test/tools/ossfuzz/yul_proto_diff_ossfuzz
         - test/tools/ossfuzz/yul_proto_ossfuzz
 
-version: 2
+  # test result output directory
+  - artifacts_test_results: &artifacts_test_results
+      path: test_results/
+      destination: test_results/
+
+  # --------------------------------------------------------------------------
+  # Tests Templates
+
+  # store_test_results helper
+  - store_test_results: &store_test_results
+      path: test_results/
+
+  - run_soltest: &run_soltest
+      name: soltest
+      command: ./.circleci/soltest.sh
+
+  - run_cmdline_tests: &run_cmdline_tests
+      name: command line tests
+      command: ./test/cmdlineTests.sh
+
+  - test_steps: &test_steps
+      - checkout
+      - attach_workspace:
+          at: build
+      - run: *run_soltest
+      - store_test_results: *store_test_results
+      - store_artifacts: *artifacts_test_results
+
+  - test_ubuntu1904: &test_ubuntu1904
+      docker:
+        - image: ethereum/solidity-buildpack-deps:ubuntu1904
+      steps: *test_steps
+
+  - test_asan: &test_asan
+      <<: *test_ubuntu1904
+      steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          <<: *run_soltest
+          no_output_timeout: 30m
+      - store_test_results: *store_test_results
+      - store_artifacts: *artifacts_test_results
+
+  # --------------------------------------------------------------------------
+  # Workflow Templates
+
+  - workflow_trigger_on_tags: &workflow_trigger_on_tags
+      filters:
+        tags:
+          only: /.*/
+
+  - workflow_ubuntu1904: &workflow_ubuntu1904
+      <<: *workflow_trigger_on_tags
+      requires:
+        - b_ubu
+
+  - workflow_ubuntu1904_codecov: &workflow_ubuntu1904_codecov
+      <<: *workflow_trigger_on_tags
+      requires:
+        - b_ubu_codecov
+
+  - workflow_osx: &workflow_osx
+      <<: *workflow_trigger_on_tags
+      requires:
+        - b_osx
+
+  - workflow_ubuntu1904_asan: &workflow_ubuntu1904_asan
+      <<: *workflow_trigger_on_tags
+      requires:
+        - b_ubu_asan
+
+  - workflow_emscripten: &workflow_emscripten
+      <<: *workflow_trigger_on_tags
+      requires:
+        - b_ems
+
+  - workflow_ubuntu1904_ossfuzz: &workflow_ubuntu1904_ossfuzz
+      <<: *workflow_trigger_on_tags
+      requires:
+        - b_ubu_ossfuzz
+
+# -----------------------------------------------------------------------------------------------
 jobs:
-  build_emscripten:
+
+  chk_spelling:
+    docker:
+      - image: circleci/python:3.6
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          name: Install dependencies
+          command: |
+            pip install --user codespell
+      - run:
+          name: Check spelling
+          command: ~/.local/bin/codespell -S "*.enc,.git" -I ./scripts/codespell_whitelist.txt
+
+  chk_coding_style:
+    docker:
+      - image: buildpack-deps:disco
+    steps:
+      - checkout
+      - run:
+          name: Check for C++ coding style
+          command: ./scripts/check_style.sh
+
+  chk_buglist:
+    docker:
+      - image: circleci/node
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - run:
+          name: JS deps
+          command: |
+            npm install download
+            npm install JSONPath
+            npm install mktemp
+      - run:
+          name: Test buglist
+          command: ./test/buglistTests.js
+
+  chk_proofs:
+    docker:
+      - image: buildpack-deps:disco
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - run:
+          name: Z3 python deps
+          command: |
+            apt-get -qq update
+            apt-get -qy install python-pip
+            pip install --user z3-solver
+      - run: *run_proofs
+
+  b_ubu: &build_ubuntu1904
+    docker:
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904
+    steps:
+      - checkout
+      - run: *run_build
+      - store_artifacts: *artifacts_solc
+      - persist_to_workspace: *artifacts_executables
+
+  b_ubu_codecov:
+    <<: *build_ubuntu1904
+    environment:
+      COVERAGE: ON
+      CMAKE_BUILD_TYPE: Debug
+    steps:
+      - checkout
+      - run: *run_build
+      - persist_to_workspace: *artifacts_build_dir
+
+  t_ubu_codecov:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: constantinople
+      OPTIMIZE: 1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          name: "soltest: Syntax Tests"
+          command: build/test/soltest -t 'syntaxTest*' -- --no-ipc --testpath test
+      - run:
+          name: "Code Coverage: Syntax Tests"
+          command: codecov --flags syntax --gcov-root build
+      - run: *run_soltest
+      - run:
+          name: "Coverage: All"
+          command: codecov --flags all --gcov-root build
+      - store_artifacts: *artifacts_test_results
+
+  # Builds in C++17 mode and uses debug build in order to speed up.
+  # Do *NOT* store any artifacts or workspace as we don't run tests on this build.
+  b_ubu_cxx17:
+    <<: *build_ubuntu1904
+    environment:
+      CMAKE_BUILD_TYPE: Debug
+      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/cxx17.cmake -DUSE_CVC4=OFF
+    steps:
+      - checkout
+      - run: *run_build
+
+  b_ubu_ossfuzz:
+    <<: *build_ubuntu1904
+    environment:
+      TERM: xterm
+      CC: /usr/bin/clang-8
+      CXX: /usr/bin/clang++-8
+      CMAKE_OPTIONS: -DOSSFUZZ=1 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/libfuzzer.cmake
+    steps:
+      - checkout
+      - run: *setup_prerelease_commit_hash
+      - run: *run_build_ossfuzz
+      - persist_to_workspace: *artifacts_executables_ossfuzz
+
+  t_ubu_ossfuzz: &t_ubu_ossfuzz
+    <<: *test_ubuntu1904
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          name: Regression tests
+          command: |
+            mkdir -p test_results
+            export ASAN_OPTIONS="check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2"
+            scripts/regressions.py -o test_results
+      - store_test_results: *store_test_results
+      - store_artifacts: *artifacts_test_results
+
+  b_archlinux:
+    docker:
+      - image: ethereum/solidity-buildpack-deps:archlinux
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - run: *run_build
+      - store_artifacts: *artifacts_solc
+      - persist_to_workspace: *artifacts_executables
+
+  b_osx:
+    macos:
+      xcode: "10.0.0"
+    environment:
+      TERM: xterm
+      CMAKE_BUILD_TYPE: Debug
+      CMAKE_OPTIONS: -DLLL=ON
+    steps:
+      - checkout
+      - run:
+          name: Install build dependencies
+          command: |
+            brew unlink python
+            brew install z3
+            brew install boost
+            brew install cmake
+            brew install wget
+            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
+      - run: *run_build
+      - store_artifacts: *artifacts_solc
+      - persist_to_workspace: *artifacts_executables
+
+  t_osx_cli:
+    macos:
+      xcode: "10.0.0"
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          name: Install dependencies
+          command: |
+            brew unlink python
+            brew install z3
+      - run: *run_cmdline_tests
+      - store_artifacts: *artifacts_test_results
+
+  b_ems:
     docker:
       - image: trzeci/emscripten:sdk-tag-1.38.22-64bit
     environment:
@@ -94,7 +386,123 @@ jobs:
             - soljson.js
             - version.txt
 
-  test_emscripten_solcjs:
+  # x64 ASAN build, for testing for memory related bugs
+  b_ubu_asan: &b_ubu_asan
+    <<: *build_ubuntu1904
+    environment:
+      CMAKE_OPTIONS: -DSANITIZE=address
+      CMAKE_BUILD_TYPE: Release
+    steps:
+      - checkout
+      - run: *run_build
+      - store_artifacts: *artifacts_solc
+      - persist_to_workspace: *artifacts_executables
+
+  b_docs:
+    docker:
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904
+    steps:
+      - checkout
+      - run: *setup_prerelease_commit_hash
+      - run:
+          name: Build documentation
+          command: ./scripts/docs.sh
+      - store_artifacts:
+          path: docs/_build/html/
+          destination: docs-html
+
+  t_ubu_cli: &t_ubu_cli
+    docker:
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run: *run_cmdline_tests
+      - store_test_results: *store_test_results
+      - store_artifacts: *artifacts_test_results
+
+  t_ubu_asan_cli:
+    <<: *t_ubu_cli
+    environment:
+      TERM: xterm
+      ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          <<: *run_cmdline_tests
+          no_output_timeout: 30m
+      - store_test_results: *store_test_results
+      - store_artifacts: *artifacts_test_results
+
+  t_ubu_asan_constantinople:
+    <<: *test_asan
+    environment:
+      EVM: constantinople
+      OPTIMIZE: 0
+      SOLTEST_IPC: 0
+      ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
+
+  t_ubu_homestead:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: homestead
+      OPTIMIZE: 0
+
+  t_ubu_homestead_opt:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: homestead
+      OPTIMIZE: 1
+
+  t_ubu_byzantium:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: byzantium
+      OPTIMIZE: 0
+
+  t_ubu_byzantium_opt:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: byzantium
+      OPTIMIZE: 1
+
+  t_ubu_constantinople:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: constantinople
+      OPTIMIZE: 0
+
+  t_ubu_constantinople_opt:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: constantinople
+      OPTIMIZE: 1
+
+  t_ubu_constantinople_opt_abiv2:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: constantinople
+      OPTIMIZE: 1
+      ABI_ENCODER_V2: 1
+
+  t_ubu_petersburg:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: petersburg
+      OPTIMIZE: 0
+
+  t_ubu_petersburg_opt:
+    <<: *test_ubuntu1904
+    environment:
+      EVM: petersburg
+      OPTIMIZE: 1
+
+  t_ems_solcjs:
     docker:
       - image: circleci/node:10
     environment:
@@ -104,16 +512,13 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Install external tests deps
+          name: Test solcjs
           command: |
             node --version
             npm --version
-      - run:
-          name: Test solcjs
-          command: |
             test/solcjsTests.sh /tmp/workspace/soljson.js $(cat /tmp/workspace/version.txt)
 
-  test_emscripten_external_gnosis:
+  t_ems_external_gnosis:
     docker:
       - image: circleci/node:10
     environment:
@@ -127,7 +532,7 @@ jobs:
           command: |
             test/externalTests/gnosis.sh /tmp/workspace/soljson.js || test/externalTests/gnosis.sh /tmp/workspace/soljson.js
 
-  test_emscripten_external_zeppelin:
+  t_ems_external_zeppelin:
     docker:
       - image: circleci/node:10
     environment:
@@ -141,7 +546,7 @@ jobs:
           command: |
             test/externalTests/zeppelin.sh /tmp/workspace/soljson.js || test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
 
-  test_emscripten_external_colony:
+  t_ems_external_colony:
     docker:
       - image: circleci/node:10
     environment:
@@ -159,386 +564,51 @@ jobs:
           command: |
             test/externalTests/colony.sh /tmp/workspace/soljson.js || test/externalTests/colony.sh /tmp/workspace/soljson.js
 
-  build_x86_linux:
-    docker:
-      - image: buildpack-deps:bionic
-    environment:
-      TERM: xterm
-      COVERAGE: "ON"
-    steps:
-      - checkout
-      - run:
-          name: Install build dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libcvc4-dev libjsoncpp-dev=1.7.4-\*
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build
-      - store_artifacts: *solc_artifact
-      - persist_to_workspace:
-          root: build
-          paths:
-            - "*"
-
-  build_x86_linux_cxx17:
-    docker:
-      - image: buildpack-deps:disco
-    environment:
-      TERM: xterm
-      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/cxx17.cmake
-    steps:
-      - checkout
-      - run:
-          name: Install build dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libcvc4-dev libjsoncpp-dev=1.7.4-\*
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build
-
-  build_x86_archlinux:
-    docker:
-      - image: archlinux/base
-    environment:
-      TERM: xterm
-    steps:
-      - run:
-          name: Install build dependencies
-          command: |
-            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake z3 cvc4 git openssh tar
-      - checkout
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build
-      - store_artifacts: *solc_artifact
-      - persist_to_workspace:
-          root: build
-          paths:
-            - solc/solc
-            - test/soltest
-            - test/tools/solfuzzer
-
-  build_x86_clang7_asan:
-    docker:
-      - image: buildpack-deps:cosmic
-    environment:
-      TERM: xterm
-      CC: /usr/bin/clang-7
-      CXX: /usr/bin/clang++-7
-      CMAKE_OPTIONS: -DSANITIZE=address -DCMAKE_BUILD_TYPE=Debug
-    steps:
-      - checkout
-      - run:
-          name: Install build dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install clang-7 cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libcvc4-dev libjsoncpp-dev=1.7.4-\*
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build
-      - store_artifacts: *solc_artifact
-      - persist_to_workspace:
-          root: build
-          paths:
-            - solc/solc
-            - test/soltest
-            - test/tools/solfuzzer
-
-  build_x86_mac:
-    macos:
-      xcode: "10.0.0"
-    environment:
-      TERM: xterm
-      CMAKE_OPTIONS: -DLLL=ON
-    steps:
-      - checkout
-      - run:
-          name: Install build dependencies
-          command: |
-            brew unlink python
-            brew install z3
-            brew install boost
-            brew install cmake
-            brew install wget
-            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build
-      - store_artifacts: *solc_artifact
-      - persist_to_workspace: *all_artifacts
-
-  test_check_spelling:
-    docker:
-      - image: circleci/python:3.6
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - attach_workspace:
-          at: build
-      - run:
-          name: Install dependencies
-          command: |
-            pip install --user codespell
-      - run:
-          name: Check spelling
-          command: ~/.local/bin/codespell -S "*.enc,.git" -I ./scripts/codespell_whitelist.txt
-
-  test_check_style:
-    docker:
-      - image: buildpack-deps:bionic
-    steps:
-      - checkout
-      - run:
-          name: Check for trailing whitespace
-          command: ./scripts/check_style.sh
-
-  test_buglist:
-    docker:
-      - image: circleci/node
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - run:
-          name: JS deps
-          command: |
-            npm install download
-            npm install JSONPath
-            npm install mktemp
-      - run:
-          name: Test buglist
-          command: ./test/buglistTests.js
-
-  proofs:
-    docker:
-      - image: buildpack-deps:bionic
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - run:
-          name: Z3 python deps
-          command: |
-            apt-get -qq update
-            apt-get -qy install python-pip
-            pip install --user z3-solver
-      - run: *run_proofs
-
-  test_x86_linux:
-    docker:
-      - image: buildpack-deps:bionic
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - attach_workspace:
-          at: build
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install libcvc4-dev libleveldb1v5 python-pip
-            pip install codecov
-      - run: mkdir -p test_results
-      - run:
-          name: Test type checker
-          command: build/test/soltest -t 'syntaxTest*' -- --no-ipc --testpath test
-      - run:
-          name: Coverage of type checker
-          command: codecov --flags syntax --gcov-root build
-      - run: *run_tests
-      - run:
-          name: Coverage of all
-          command: codecov --flags all --gcov-root build
-      - store_test_results:
-          path: test_results/
-      - store_artifacts:
-          path: test_results/
-          destination: test_results/
-
-  test_x86_clang7_asan:
-    docker:
-      - image: buildpack-deps:cosmic
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - attach_workspace:
-          at: build
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install llvm-7-dev libcvc4-dev libleveldb1v5 python-pip
-            # This is needed to resolve the symbols. Since we're using clang7 in the build, we must use the appropriate symbolizer.
-            update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-7 1
-      - run: mkdir -p test_results
-      - run:
-          name: Run soltest with ASAN
-          command: |
-            ulimit -a
-            # Increase stack size because ASan makes stack frames bigger and that breaks our assumptions (in tests).
-            ulimit -s 16384
-            export ASAN_OPTIONS="check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2"
-            build/test/soltest --logger=JUNIT,test_suite,test_results/result.xml -- --no-ipc --testpath test
-      - run:
-          name: Run commandline tests with ASAN
-          command: |
-            ulimit -a
-            # Increase stack size because ASan makes stack frames bigger and that breaks our assumptions (in tests).
-            ulimit -s 16384
-            export ASAN_OPTIONS="check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2"
-            test/cmdlineTests.sh
-      - store_test_results:
-          path: test_results/
-      - store_artifacts:
-          path: test_results/
-          destination: test_results/
-
-  test_x86_archlinux:
-    docker:
-      - image: archlinux/base
-    environment:
-      TERM: xterm
-    steps:
-      - run:
-          name: Install dependencies
-          command: |
-            pacman --noconfirm -Syu --noprogressbar --needed boost z3 cvc4 git openssh tar
-      - checkout
-      - attach_workspace:
-          at: build
-      - run: mkdir -p test_results
-      - run: build/test/soltest --logger=JUNIT,test_suite,test_results/result.xml -- --no-ipc --testpath test
-      - store_test_results:
-          path: test_results/
-      - store_artifacts:
-          path: test_results/
-          destination: test_results/
-
-  test_x86_mac:
-    macos:
-      xcode: "10.0.0"
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - attach_workspace:
-          at: build
-      - run:
-          name: Install dependencies
-          command: |
-            brew unlink python
-            brew install z3
-      - run: mkdir -p test_results
-      - run: *run_tests
-      - store_test_results:
-          path: test_results/
-      - store_artifacts:
-          path: test_results/
-          destination: test_results/
-
-  docs:
-    docker:
-      - image: buildpack-deps:bionic
-    environment:
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - checkout
-      - run:
-          name: Install build dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install python-sphinx python-pip
-      - run: *setup_prerelease_commit_hash
-      - run:
-          name: Build documentation
-          command: ./scripts/docs.sh
-      - store_artifacts:
-          path: docs/_build/html/
-          destination: docs-html
-
-  build_x86_linux_ossfuzz:
-    docker:
-      - image: buildpack-deps:disco
-    environment:
-      TERM: xterm
-      CC: /usr/bin/clang-8
-      CXX: /usr/bin/clang++-8
-      CMAKE_OPTIONS: -DOSSFUZZ=1 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/libfuzzer.cmake
-    steps:
-      - checkout
-      - run:
-          name: Install build dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install wget clang-8 cmake libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev libboost-program-options-dev libcvc4-dev libbz2-dev ninja-build zlib1g-dev libjsoncpp-dev=1.7.4-\*
-            ./scripts/install_lpm.sh
-            ./scripts/install_libfuzzer.sh
-            # Install evmone and dependencies (intx and ethash)
-            ./scripts/install_evmone.sh
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build_ossfuzz
-      - persist_to_workspace: *ossfuzz_artifacts
-
-  test_x86_ossfuzz_regression:
-    docker:
-      - image: buildpack-deps:disco
-    environment:
-      TERM: xterm
-    steps:
-      - checkout
-      - attach_workspace:
-          at: build
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get -qq update
-            apt-get -qy install libcvc4-dev llvm-8-dev
-            ./scripts/download_ossfuzz_corpus.sh
-            update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-8 1
-      - run: mkdir -p test_results
-      - run: *run_regressions
-      - store_artifacts:
-          path: test_results/
-          destination: test_results/
-
 workflows:
   version: 2
-  build_all:
-    jobs:
-      - test_check_spelling: *build_on_tags
-      - test_check_style: *build_on_tags
-      - test_buglist: *build_on_tags
-      - proofs: *build_on_tags
-      - build_emscripten: *build_on_tags
-      - test_emscripten_solcjs:
-          <<: *build_on_tags
-          requires:
-            - build_emscripten
-      - build_x86_linux: *build_on_tags
-      - build_x86_linux_cxx17: *build_on_tags
-      - build_x86_clang7_asan: *build_on_tags
-      - build_x86_mac: *build_on_tags
-      - test_x86_linux:
-          <<: *build_on_tags
-          requires:
-            - build_x86_linux
-      - test_x86_clang7_asan:
-          <<: *build_on_tags
-          requires:
-            - build_x86_clang7_asan
-      - test_x86_mac:
-          <<: *build_on_tags
-          requires:
-            - build_x86_mac
-      - docs: *build_on_tags
-      - build_x86_archlinux: *build_on_tags
-      - test_x86_archlinux:
-          <<: *build_on_tags
-          requires:
-            - build_x86_archlinux
-      - build_x86_linux_ossfuzz: *build_on_tags
 
-  test_nightly:
+  main:
+    jobs:
+      # basic checks
+      - chk_spelling: *workflow_trigger_on_tags
+      - chk_coding_style: *workflow_trigger_on_tags
+      - chk_buglist: *workflow_trigger_on_tags
+      - chk_proofs: *workflow_trigger_on_tags
+
+      # build-only
+      - b_docs: *workflow_trigger_on_tags
+      - b_archlinux: *workflow_trigger_on_tags
+      - b_ubu_cxx17: *workflow_trigger_on_tags
+      - b_ubu_ossfuzz: *workflow_trigger_on_tags
+
+      # OS/X build and tests
+      - b_osx: *workflow_trigger_on_tags
+      - t_osx_cli: *workflow_osx
+
+      # Ubuntu 18.10 build and tests
+      - b_ubu: *workflow_trigger_on_tags
+      - t_ubu_cli: *workflow_ubuntu1904
+      - t_ubu_homestead: *workflow_ubuntu1904
+      - t_ubu_homestead_opt: *workflow_ubuntu1904
+      - t_ubu_byzantium: *workflow_ubuntu1904
+      - t_ubu_byzantium_opt: *workflow_ubuntu1904
+      - t_ubu_constantinople: *workflow_ubuntu1904
+      - t_ubu_constantinople_opt: *workflow_ubuntu1904
+      - t_ubu_constantinople_opt_abiv2: *workflow_ubuntu1904
+      - t_ubu_petersburg: *workflow_ubuntu1904
+      - t_ubu_petersburg_opt: *workflow_ubuntu1904
+
+      # ASan build and tests
+      - b_ubu_asan: *workflow_trigger_on_tags
+      - t_ubu_asan_constantinople: *workflow_ubuntu1904_asan
+      - t_ubu_asan_cli: *workflow_ubuntu1904_asan
+
+      # Emscripten build and selected tests
+      - b_ems: *workflow_trigger_on_tags
+      - t_ems_solcjs: *workflow_emscripten
+
+  nightly:
+
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -546,23 +616,19 @@ workflows:
             branches:
               only:
                 - develop
+
     jobs:
-      - build_emscripten: *build_on_tags
-      - test_emscripten_external_zeppelin:
-          <<: *build_on_tags
-          requires:
-            - build_emscripten
-      - test_emscripten_external_gnosis:
-          <<: *build_on_tags
-          requires:
-            - build_emscripten
-      - test_emscripten_external_colony:
-          <<: *build_on_tags
-          requires:
-            - build_emscripten
-      - build_x86_linux_ossfuzz: *build_on_tags
-      - test_x86_ossfuzz_regression:
-          <<: *build_on_tags
-          requires:
-            - build_x86_linux_ossfuzz
+      # Emscripten builds and external tests
+      - b_ems: *workflow_trigger_on_tags
+      - t_ems_external_zeppelin: *workflow_emscripten
+      - t_ems_external_gnosis: *workflow_emscripten
+      - t_ems_external_colony: *workflow_emscripten
+
+      # OSSFUZZ builds and (regression) tests
+      - b_ubu_ossfuzz: *workflow_trigger_on_tags
+      - t_ubu_ossfuzz: *workflow_ubuntu1904_ossfuzz
+
+      # Code Coverage enabled build and tests
+      - b_ubu_codecov: *workflow_trigger_on_tags
+      - t_ubu_codecov: *workflow_ubuntu1904_codecov
 

--- a/.circleci/docker/Dockerfile.archlinux
+++ b/.circleci/docker/Dockerfile.archlinux
@@ -1,13 +1,9 @@
-#!/usr/bin/env bash
-
+# vim:syntax=dockerfile
 #------------------------------------------------------------------------------
-# Bash script to run external Solidity tests.
+# Dockerfile for building and testing Solidity Compiler on CI
+# Target: Arch Linux
+# URL: https://hub.docker.com/r/ethereum/solidity-buildpack-deps
 #
-# Argument: Path to soljson.js to test.
-#
-# Requires npm, networking access and git to download the tests.
-#
-# ------------------------------------------------------------------------------
 # This file is part of solidity.
 #
 # solidity is free software: you can redistribute it and/or modify
@@ -23,27 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with solidity.  If not, see <http://www.gnu.org/licenses/>
 #
-# (c) 2016 solidity contributors.
+# (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
+FROM archlinux/base
 
-set -e
+RUN pacman --noconfirm -Syu --noprogressbar --needed \
+		base-devel boost cmake z3 cvc4 git openssh tar
 
-if [ ! -f "$1" ]
-then
-  echo "Usage: $0 <path to soljson.js>"
-  exit 1
-fi
-
-SOLJSON="$1"
-REPO_ROOT="$(dirname "$0")"
-
-source scripts/common.sh
-source test/externalTests/common.sh
-
-printTask "Running external tests..."
-
-$REPO_ROOT/externalTests/zeppelin.sh "$SOLJSON"
-$REPO_ROOT/externalTests/gnosis.sh "$SOLJSON"
-
-# Disabled temporarily as it needs to be updated to latest Truffle first.
-#test_truffle Gnosis https://github.com/axic/pm-contracts.git solidity-050

--- a/.circleci/docker/Dockerfile.ubuntu1904
+++ b/.circleci/docker/Dockerfile.ubuntu1904
@@ -1,0 +1,124 @@
+# vim:syntax=dockerfile
+#------------------------------------------------------------------------------
+# Dockerfile for building and testing Solidity Compiler on CI
+# Target: Ubuntu 19.04 (Disco Dingo)
+# URL: https://hub.docker.com/r/ethereum/solidity-buildpack-deps
+#
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2019 solidity contributors.
+#------------------------------------------------------------------------------
+FROM buildpack-deps:disco
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -qqy --no-install-recommends \
+		build-essential \
+		software-properties-common \
+		cmake ninja-build clang++-8 \
+		libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev \
+		libboost-program-options-dev \
+		libjsoncpp-dev \
+		llvm-8-dev libcvc4-dev libleveldb1d \
+		; \
+	apt-get install -qy python-pip python-sphinx; \
+	update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-8 1; \
+	pip install codecov; \
+	rm -rf /var/lib/apt/lists/*
+
+# Aleth for end-to-end tests
+ARG ALETH_VERSION="1.6.0"
+ARG ALETH_HASH="7f7004e1563299bc57882e32b32e4a195747dfb6"
+ARG ALETH_URL="https://github.com/ethereum/aleth/releases/download/v${ALETH_VERSION}/aleth-${ALETH_VERSION}-linux-x86_64.tar.gz"
+RUN set -ex; \
+	wget -q -O /tmp/aleth.tar.gz "${ALETH_URL}"; \
+	test "$(shasum /tmp/aleth.tar.gz)" = "$ALETH_HASH  /tmp/aleth.tar.gz"; \
+	tar -xf /tmp/aleth.tar.gz -C /usr
+
+# Z3
+RUN set -ex; \
+	git clone --depth=1 --branch="Z3-4.8.5" https://github.com/Z3Prover/z3.git /usr/src/z3; \
+	mkdir /usr/src/z3/build; \
+	cd /usr/src/z3/build; \
+	cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_INSTALL_PREFIX="/usr" -G "Ninja" ..; \
+	ninja; \
+	ninja install/strip; \
+	rm -rf /usr/src/z3
+
+# OSSFUZZ: LPM package (do not remove build dirs as solidity compiles/links against that dir)
+RUN set -ex; \
+	mkdir /src; \
+	cd /src; \
+	git clone https://github.com/google/libprotobuf-mutator.git; \
+	cd libprotobuf-mutator; \
+	git checkout d1fe8a7d8ae18f3d454f055eba5213c291986f21; \
+	mkdir ../LPM; \
+	cd ../LPM; \
+	cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release; \
+	ninja; \
+	cp -vpr external.protobuf/bin/* /usr/bin/; \
+	cp -vpr external.protobuf/include/* /usr/include/; \
+	cp -vpr external.protobuf/lib/* /usr/lib/; \
+	ninja install/strip
+
+# OSSFUZZ: libfuzzer
+RUN set -ex; \
+    cd /var/tmp; \
+    svn co https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer libfuzzer; \
+    mkdir -p build-libfuzzer; \
+    cd build-libfuzzer; \
+    clang++-8 -O1 -stdlib=libstdc++ -std=c++11 -O2 -fPIC -c ../libfuzzer/*.cpp -I../libfuzzer; \
+    ar r /usr/lib/libFuzzingEngine.a *.o; \
+	rm -rf /var/lib/libfuzzer
+
+# ETHASH
+RUN set -ex; \
+	cd /usr/src; \
+	git clone --branch="v0.4.4" https://github.com/chfast/ethash.git; \
+	cd ethash; \
+	mkdir build; \
+	cd build; \
+	cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DETHASH_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
+	ninja; \
+	ninja install/strip; \
+	rm -rf /usr/src/ethash
+
+# INTX
+RUN set -ex; \
+	cd /usr/src; \
+	git clone --branch="v0.2.0" https://github.com/chfast/intx.git; \
+	cd intx; \
+	mkdir build; \
+	cd build; \
+	cmake .. -G Ninja -DBUILD_SHARED_LIBS=OFF -DINTX_TESTING=OFF -DINTX_BENCHMARKING=OFF -DCMAKE_INSTALL_PREFIX="/usr"; \
+	ninja; \
+	ninja install/strip; \
+	rm -rf /usr/src/intx;
+
+# EVMONE
+RUN set -ex; \
+	cd /usr/src; \
+	git clone --branch="v0.1.0" --recurse-submodules https://github.com/chfast/evmone.git; \
+	cd evmone; \
+	mkdir build; \
+	cd build; \
+	cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="/usr" ..; \
+	ninja; \
+	ninja install/strip; \
+	rm -rf /usr/src/evmone
+

--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -1,0 +1,63 @@
+#! /bin/bash
+#------------------------------------------------------------------------------
+# Bash script to execute the Solidity tests by CircleCI.
+#
+# The documentation for solidity is hosted at:
+#
+#     https://solidity.readthedocs.org
+#
+# ------------------------------------------------------------------------------
+# Configuration Environment Variables:
+#
+#     EVM=version_string      Specifies EVM version to compile for (such as homestead, etc)
+#     OPTIMIZE=1              Enables backend optimizer
+#     ABI_ENCODER_V2=1        Enables ABI encoder version 2
+#
+# ------------------------------------------------------------------------------
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2019 solidity contributors.
+# ------------------------------------------------------------------------------
+set -e
+
+OPTIMIZE=${OPTIMIZE:-"0"}
+EVM=${EVM:-"invalid"}
+WORKDIR=${CIRCLE_WORKING_DIRECTORY:-.}
+SOLTEST_IPC=${SOLTEST_IPC:-1}
+REPODIR="$(realpath $(dirname $0)/..)"
+ALETH_PATH="/usr/bin/aleth"
+
+source "${REPODIR}/scripts/common.sh"
+# Test result output directory (CircleCI is reading test results from here)
+mkdir -p test_results
+
+ALETH_PID=$(run_aleth)
+
+function cleanup() {
+	safe_kill $ALETH_PID $ALETH_PATH
+}
+trap cleanup INT TERM
+
+# in case we run with ASAN enabled, we must increase stck size.
+ulimit -s 16384
+
+BOOST_TEST_ARGS="--color_output=no --show_progress=yes --logger=JUNIT,error,test_results/$EVM.xml"
+SOLTEST_ARGS="--evm-version=$EVM --ipcpath "${WORKDIR}/geth.ipc" $flags"
+test "${SOLTEST_IPC}" = "1" || SOLTEST_ARGS="$SOLTEST_ARGS --no-ipc"
+test "${OPTIMIZE}" = "1" && SOLTEST_ARGS="${SOLTEST_ARGS} --optimize"
+test "${ABI_ENCODER_V2}" = "1" && SOLTEST_ARGS="${SOLTEST_ARGS} --abiencoderv2 --optimize-yul"
+
+${REPODIR}/build/test/soltest ${BOOST_TEST_ARGS} -- ${SOLTEST_ARGS}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -130,7 +130,7 @@ The CI runs additional tests (including ``solc-js`` and testing third party Soli
 
     Some versions of ``aleth`` can not be used for testing. We suggest using
     the same version that the Solidity continuous integration tests use.
-    Currently the CI uses version ``1.5.0-alpha.7`` of ``aleth``.
+    Currently the CI uses version ``1.6.0`` of ``aleth``.
 
 Writing and running syntax tests
 --------------------------------

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,96 @@
+# ------------------------------------------------------------------------------
+# vim:ts=4:et
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2019 solidity contributors.
+# ------------------------------------------------------------------------------
+
+if [ "$CIRCLECI" ]
+then
+    export TERM="${TERM:-xterm}"
+    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
+    function printError() { echo "$(tput setaf 1)$1$(tput setaf 7)"; }
+    function printLog() { echo "$(tput setaf 3)$1$(tput setaf 7)"; }
+else
+    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
+    function printError() { echo "$(tput setaf 1)$1$(tput sgr0)"; }
+    function printLog() { echo "$(tput setaf 3)$1$(tput sgr0)"; }
+fi
+
+safe_kill()
+{
+    local PID=${1}
+    local NAME=${2:-${1}}
+    local n=1
+
+    # only proceed if $PID does exist
+    kill -0 $PID 2>/dev/null || return
+
+    echo "Sending SIGTERM to ${NAME} (${PID}) ..."
+    kill $PID
+
+    # wait until process terminated gracefully
+    while kill -0 $PID 2>/dev/null && [[ $n -le 4 ]]; do
+        echo "Waiting ($n) ..."
+        sleep 1
+        n=$[n + 1]
+    done
+
+    # process still alive? then hard-kill
+    if kill -0 $PID 2>/dev/null; then
+        echo "Sending SIGKILL to ${NAME} (${PID}) ..."
+        kill -9 $PID
+    fi
+}
+
+# Ensures aleth executable and exposes the following information:
+#
+#  - env var ALETH_PATH: to point to the aleth executable.
+#  - directory /tmp/test if needed. No cleanup is done on this directory
+function download_aleth()
+{
+    if which aleth &>/dev/null; then
+        ALETH_PATH=`which aleth`
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        ALETH_PATH="$(realpath $(dirname "$0")/..)/aleth"
+    elif [ "$CIRCLECI" ] || [ -z $CI ]; then
+        ALETH_PATH="aleth"
+    else
+        ALETH_PATH="/tmp/test/bin/aleth"
+        mkdir -p /tmp/test
+        # Any time the hash is updated here, the "Running the compiler tests" section in contributing.rst should also be updated.
+        local ALETH_HASH="7f7004e1563299bc57882e32b32e4a195747dfb6"
+        local ALETH_VERSION="1.6.0"
+        wget -q -O /tmp/test/aleth.tar.gz https://github.com/ethereum/aleth/releases/download/v${ALETH_VERSION}/aleth-${ALETH_VERSION}-linux-x86_64.tar.gz
+        test "$(shasum /tmp/test/aleth.tar.gz)" = "$ALETH_HASH  /tmp/test/aleth.tar.gz"
+        tar -xf /tmp/test/aleth.tar.gz -C /tmp/test
+        sync
+        chmod +x $ALETH_PATH
+        sync # Otherwise we might get a "text file busy" error
+    fi
+}
+
+# Executes aleth in the background and echos its PID.
+function run_aleth()
+{
+    $ALETH_PATH --db memorydb --test -d "${WORKDIR}" &> /dev/null &
+    echo $!
+
+    # Wait until the IPC endpoint is available.
+    while [ ! -S "${WORKDIR}/geth.ipc" ] ; do sleep 1; done
+    sleep 2
+}
+

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -28,7 +28,9 @@
 
 set -e
 
-REPO_ROOT="$(dirname "$0")"/..
+REPO_ROOT="$(dirname "$0")/.."
+
+source "${REPO_ROOT}/scripts/common.sh"
 
 WORKDIR=`mktemp -d`
 # Will be printed in case of a test failure
@@ -40,37 +42,7 @@ CMDLINE_PID=
 if [[ "$OSTYPE" == "darwin"* ]]
 then
     SMT_FLAGS="--no-smt"
-    if [ "$CIRCLECI" ]
-    then
-        IPC_ENABLED=false
-        IPC_FLAGS="--no-ipc"
-    fi
 fi
-
-safe_kill() {
-    local PID=${1}
-    local NAME=${2:-${1}}
-    local n=1
-
-    # only proceed if $PID does exist
-    kill -0 $PID 2>/dev/null || return
-
-    echo "Sending SIGTERM to ${NAME} (${PID}) ..."
-    kill $PID
-
-    # wait until process terminated gracefully
-    while kill -0 $PID 2>/dev/null && [[ $n -le 4 ]]; do
-        echo "Waiting ($n) ..."
-        sleep 1
-        n=$[n + 1]
-    done
-
-    # process still alive? then hard-kill
-    if kill -0 $PID 2>/dev/null; then
-        echo "Sending SIGKILL to ${NAME} (${PID}) ..."
-        kill -9 $PID
-    fi
-}
 
 cleanup() {
     # ensure failing commands don't cause termination during cleanup (especially within safe_kill)
@@ -103,15 +75,6 @@ else
     log_directory=""
 fi
 
-if [ "$CIRCLECI" ]
-then
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput setaf 7)"; }
-else
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput sgr0)"; }
-fi
-
 printTask "Running commandline tests..."
 # Only run in parallel if this is run on CI infrastructure
 if [[ -n "$CI" ]]
@@ -125,41 +88,6 @@ else
         exit 1
     fi
 fi
-
-function download_aleth()
-{
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        ALETH_PATH="$REPO_ROOT/aleth"
-    elif [ -z $CI ]; then
-        ALETH_PATH="aleth"
-    else
-        mkdir -p /tmp/test
-        # Any time the hash is updated here, the "Running the compiler tests" section in contributing.rst should also be updated.
-        ALETH_HASH="7f7004e1563299bc57882e32b32e4a195747dfb6"
-        ALETH_VERSION=1.6.0
-        wget -q -O /tmp/test/aleth.tar.gz https://github.com/ethereum/aleth/releases/download/v${ALETH_VERSION}/aleth-${ALETH_VERSION}-linux-x86_64.tar.gz
-        test "$(shasum /tmp/test/aleth.tar.gz)" = "$ALETH_HASH  /tmp/test/aleth.tar.gz"
-        tar -xf /tmp/test/aleth.tar.gz -C /tmp/test
-        ALETH_PATH="/tmp/test/bin/aleth"
-        sync
-        chmod +x $ALETH_PATH
-        sync # Otherwise we might get a "text file busy" error
-    fi
-
-}
-
-# $1: data directory
-# echos the PID
-function run_aleth()
-{
-    # Use this to have aleth log output
-    #$REPO_ROOT/scripts/aleth_with_log.sh $ALETH_PATH $ALETH_TMP_OUT --log-verbosity 3 --db memorydb --test -d "${WORKDIR}" &> /dev/null &
-    $ALETH_PATH --db memorydb --test -d "${WORKDIR}" &> /dev/null &
-    echo $!
-    # Wait until the IPC endpoint is available.
-    while [ ! -S "${WORKDIR}/geth.ipc" ] ; do sleep 1; done
-    sleep 2
-}
 
 function check_aleth() {
     printTask "Running IPC tests with $ALETH_PATH..."
@@ -176,17 +104,11 @@ then
     ALETH_PID=$(run_aleth)
 fi
 
-progress="--show-progress"
-if [ "$CIRCLECI" ]
-then
-    progress=""
-fi
-
 EVM_VERSIONS="homestead byzantium"
 
-if [ "$CIRCLECI" ] || [ -z "$CI" ]
+if [ -z "$CI" ]
 then
-EVM_VERSIONS+=" constantinople petersburg"
+    EVM_VERSIONS+=" constantinople petersburg"
 fi
 
 # And then run the Solidity unit-tests in the matrix combination of optimizer / no optimizer
@@ -212,16 +134,16 @@ do
         log=""
         if [ -n "$log_directory" ]
         then
-        if [ -n "$optimize" ]
-        then
-            log=--logger=JUNIT,error,$log_directory/opt_$vm.xml $testargs
-        else
-            log=--logger=JUNIT,error,$log_directory/noopt_$vm.xml $testargs_no_opt
-        fi
+			if [ -n "$optimize" ]
+			then
+				log=--logger=JUNIT,error,$log_directory/opt_$vm.xml $testargs
+			else
+				log=--logger=JUNIT,error,$log_directory/noopt_$vm.xml $testargs_no_opt
+			fi
         fi
 
         set +e
-        "$REPO_ROOT"/build/test/soltest $progress $log -- --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $IPC_FLAGS $force_abiv2_flag --ipcpath "${WORKDIR}/geth.ipc"
+        "$REPO_ROOT"/build/test/soltest --show-progress $log -- --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $IPC_FLAGS $force_abiv2_flag --ipcpath "${WORKDIR}/geth.ipc"
 
         if test "0" -ne "$?"; then
             if [ -n "$log_directory" ]

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -31,6 +31,7 @@ set -e
 ## GLOBAL VARIABLES
 
 REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
+source "${REPO_ROOT}/scripts/common.sh"
 SOLC="$REPO_ROOT/build/solc/solc"
 INTERACTIVE=true
 if ! tty -s || [ "$CI" ]
@@ -40,17 +41,13 @@ fi
 
 FULLARGS="--optimize --ignore-missing --combined-json abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
 
-## FUNCTIONS
-
-if [ "$CIRCLECI" ]
-then
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput setaf 7)"; }
-else
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput sgr0)"; }
+# extend stack size in case we run via ASAN
+if [[ -n "${CIRCLECI}" ]] || [[ -n "$CI" ]]; then
+    ulimit -s 16384
+    ulimit -a
 fi
 
+## FUNCTIONS
 
 function compileFull()
 {

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -18,6 +18,7 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+source scripts/common.sh
 source test/externalTests/common.sh
 
 verify_input "$1"

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -20,16 +20,7 @@
 #------------------------------------------------------------------------------
 set -e
 
-if [ "$CIRCLECI" ]
-then
-    function printTask() { echo ""; echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
-    function printError() { echo ""; echo "$(tput setaf 1)$1$(tput setaf 7)"; }
-    function printLog() { echo "$(tput setaf 3)$1$(tput setaf 7)"; }
-else
-    function printTask() { echo ""; echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
-    function printError() { echo ""; echo "$(tput setaf 1)$1$(tput sgr0)"; }
-    function printLog() { echo "$(tput setaf 3)$1$(tput sgr0)"; }
-fi
+# Requires "${REPO_ROOT}/scripts/common.sh" to be included before.
 
 function verify_input
 {

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -18,6 +18,7 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+source scripts/common.sh
 source test/externalTests/common.sh
 
 verify_input "$1"

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -18,6 +18,7 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+source scripts/common.sh
 source test/externalTests/common.sh
 
 verify_input "$1"


### PR DESCRIPTION
The motivation behind this PR is to speed up CircleCI runs to not wait for too long when pushing to your code for review.

### Changes
* move always-same-tasks into a designated docker image; Dockerfiles reside in `/.circleci/docker/`
* designated soltest script for circleci in `/.circleci/soltest.sh` for running soltest (with aleth) exclusively
* soltest runs are now done via CircleCI jobs, one job per EVM version with custom flags, such as optimizer on / off.
* Ubuntu version in use now is: **19.04**
* codecov run in nightly jobs only
