### PR TITLE
Unifies behaviour for member access of ABI functions

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1401,7 +1401,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			m_context << Instruction::DUP1 << u256(32) << Instruction::ADD;
 			utils().storeStringData(contract.name());
 		}
-		else if (member == "encode" || member == "decode")
+		else if ((set<string>{"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "decode"}).count(member))
 		{
 			// no-op
 		}

--- a/test/libsolidity/semanticTests/specialFunctions/abi_functions_member_access.sol
+++ b/test/libsolidity/semanticTests/specialFunctions/abi_functions_member_access.sol
@@ -1,6 +1,9 @@
 contract C {
     function f() public pure {
         abi.encode;
+        abi.encodePacked;
+        abi.encodeWithSelector;
+        abi.encodeWithSignature;
         abi.decode;
     }
 }

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_functions_member_access.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_functions_member_access.sol
@@ -1,0 +1,15 @@
+contract C {
+    function f() public pure {
+        abi.encode;
+        abi.encodePacked;
+        abi.encodeWithSelector;
+        abi.encodeWithSignature;
+        abi.decode;
+    }
+}
+// ----
+// Warning: (52-62): Statement has no effect.
+// Warning: (72-88): Statement has no effect.
+// Warning: (98-120): Statement has no effect.
+// Warning: (130-153): Statement has no effect.
+// Warning: (163-173): Statement has no effect.


### PR DESCRIPTION
Follow-up on https://github.com/ethereum/solidity/pull/6603/.