### PR TITLE
[SMTChecker] Support tuples

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * SMTChecker: Support tuples and functions with multiple return values.
 
 
 Bugfixes:

--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -376,17 +376,37 @@ void SMTChecker::endVisit(Assignment const& _assignment)
 
 void SMTChecker::endVisit(TupleExpression const& _tuple)
 {
-	if (
-		_tuple.isInlineArray() ||
-		_tuple.components().size() != 1 ||
-		!isSupportedType(_tuple.components()[0]->annotation().type->category())
-	)
+	if (_tuple.isInlineArray())
 		m_errorReporter.warning(
 			_tuple.location(),
-			"Assertion checker does not yet implement tuples and inline arrays."
+			"Assertion checker does not yet implement inline arrays."
 		);
+	else if (_tuple.annotation().type->category() == Type::Category::Tuple)
+	{
+		defineExpr(_tuple, expr(_tuple));
+		vector<shared_ptr<SymbolicVariable>> components;
+		for (auto const& component: _tuple.components())
+		{
+			if (auto varDecl = identifierToVariable(*component))
+				components.push_back(m_variables[varDecl]);
+			else
+			{
+				knownExpr(*component);
+				components.push_back(m_expressions[component.get()]);
+			}
+		}
+		solAssert(components.size() == _tuple.components().size(), "");
+		auto const& symbTuple = dynamic_pointer_cast<SymbolicTupleVariable>(m_expressions[&_tuple]);
+		solAssert(symbTuple, "");
+		symbTuple->addComponents(move(components));
+	}
 	else
-		defineExpr(_tuple, expr(*_tuple.components()[0]));
+	{
+		auto const& components = _tuple.components();
+		solAssert(components.size() == 1, "");
+		if (isSupportedType(components.front()->annotation().type->category()))
+			defineExpr(_tuple, expr(*components.front()));
+	}
 }
 
 void SMTChecker::addOverflowTarget(

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -141,7 +141,7 @@ private:
 	/// Will also be used for assignments of tuple components.
 	void assignment(
 		Expression const& _left,
-		smt::Expression const& _right,
+		std::vector<smt::Expression> const& _right,
 		TypePointer const& _type,
 		langutil::SourceLocation const& _location
 	);

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -99,7 +99,8 @@ bool dev::solidity::isSupportedType(Type::Category _category)
 	return isNumber(_category) ||
 		isBool(_category) ||
 		isMapping(_category) ||
-		isArray(_category);
+		isArray(_category) ||
+		isTuple(_category);
 }
 
 bool dev::solidity::isSupportedTypeDeclaration(Type::Category _category)
@@ -151,6 +152,8 @@ pair<bool, shared_ptr<SymbolicVariable>> dev::solidity::newSymbolicVariable(
 		var = make_shared<SymbolicMappingVariable>(type, _uniqueName, _solver);
 	else if (isArray(_type.category()))
 		var = make_shared<SymbolicArrayVariable>(type, _uniqueName, _solver);
+	else if (isTuple(_type.category()))
+		var = make_shared<SymbolicTupleVariable>(type, _uniqueName, _solver);
 	else
 		solAssert(false, "");
 	return make_pair(abstract, var);
@@ -224,6 +227,11 @@ bool dev::solidity::isMapping(Type::Category _category)
 bool dev::solidity::isArray(Type::Category _category)
 {
 	return _category == Type::Category::Array;
+}
+
+bool dev::solidity::isTuple(Type::Category _category)
+{
+	return _category == Type::Category::Tuple;
 }
 
 smt::Expression dev::solidity::minValue(IntegerType const& _type)

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -51,6 +51,7 @@ bool isBool(Type::Category _category);
 bool isFunction(Type::Category _category);
 bool isMapping(Type::Category _category);
 bool isArray(Type::Category _category);
+bool isTuple(Type::Category _category);
 
 /// Returns a new symbolic variable, according to _type.
 /// Also returns whether the type is abstract or not,

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -173,3 +173,26 @@ SymbolicEnumVariable::SymbolicEnumVariable(
 {
 	solAssert(isEnum(m_type->category()), "");
 }
+
+SymbolicTupleVariable::SymbolicTupleVariable(
+	TypePointer _type,
+	string _uniqueName,
+	smt::SolverInterface& _interface
+):
+	SymbolicVariable(move(_type), move(_uniqueName), _interface)
+{
+	solAssert(isTuple(m_type->category()), "");
+}
+
+void SymbolicTupleVariable::addComponents(vector<shared_ptr<SymbolicVariable>> _components)
+{
+	solAssert(m_components.empty(), "");
+	auto const& tupleType = dynamic_cast<TupleType const*>(m_type);
+	solAssert(_components.size() == tupleType->components().size(), "");
+	m_components = move(_components);
+}
+
+shared_ptr<SymbolicVariable> const& SymbolicTupleVariable::at(unsigned _pos)
+{
+	return m_components.at(_pos);
+}

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -191,8 +191,3 @@ void SymbolicTupleVariable::addComponents(vector<shared_ptr<SymbolicVariable>> _
 	solAssert(_components.size() == tupleType->components().size(), "");
 	m_components = move(_components);
 }
-
-shared_ptr<SymbolicVariable> const& SymbolicTupleVariable::at(unsigned _pos)
-{
-	return m_components.at(_pos);
-}

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -187,5 +187,24 @@ public:
 	);
 };
 
+/**
+ * Specialization of SymbolicVariable for Tuple
+ */
+class SymbolicTupleVariable: public SymbolicVariable
+{
+public:
+	SymbolicTupleVariable(
+		TypePointer _type,
+		std::string _uniqueName,
+		smt::SolverInterface& _interface
+	);
+
+	std::shared_ptr<SymbolicVariable> const& at(unsigned _pos);
+	void addComponents(std::vector<std::shared_ptr<SymbolicVariable>> _components);
+
+private:
+	std::vector<std::shared_ptr<SymbolicVariable>> m_components;
+};
+
 }
 }

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -199,7 +199,11 @@ public:
 		smt::SolverInterface& _interface
 	);
 
-	std::shared_ptr<SymbolicVariable> const& at(unsigned _pos);
+	std::vector<std::shared_ptr<SymbolicVariable>> const& components()
+	{
+		return m_components;
+	}
+
 	void addComponents(std::vector<std::shared_ptr<SymbolicVariable>> _components);
 
 private:

--- a/test/libsolidity/smtCheckerTests/functions/functions_identity_as_tuple.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_identity_as_tuple.sol
@@ -12,4 +12,3 @@ contract C
 }
 
 // ----
-// Warning: (153-156): Assertion checker does not yet implement tuples and inline arrays.

--- a/test/libsolidity/smtCheckerTests/functions/functions_identity_as_tuple_fail.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_identity_as_tuple_fail.sol
@@ -12,5 +12,4 @@ contract C
 }
 
 // ----
-// Warning: (153-156): Assertion checker does not yet implement tuples and inline arrays.
 // Warning: (163-176): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_call.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_call.sol
@@ -19,5 +19,4 @@ contract C
 // EVMVersion: >spuriousDragon
 // ----
 // Warning: (224-240): Unused local variable.
-// Warning: (209-256): Assertion checker does not yet support such variable declarations.
 // Warning: (260-275): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_delegatecall.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_delegatecall.sol
@@ -19,5 +19,4 @@ contract C
 // EVMVersion: >spuriousDragon
 // ----
 // Warning: (224-240): Unused local variable.
-// Warning: (209-264): Assertion checker does not yet support such variable declarations.
 // Warning: (268-283): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_staticcall.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_staticcall.sol
@@ -19,5 +19,4 @@ contract C
 // EVMVersion: >spuriousDragon
 // ----
 // Warning: (224-240): Unused local variable.
-// Warning: (209-262): Assertion checker does not yet support such variable declarations.
 // Warning: (266-281): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_transfer.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer.sol
@@ -12,5 +12,4 @@ contract C
 }
 // ----
 // Warning: (131-146): Insufficient funds happens here
-// Warning: (131-146): Assertion checker does not yet implement this type.
 // Warning: (195-219): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_transfer_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer_2.sol
@@ -15,7 +15,5 @@ contract C
 }
 // ----
 // Warning: (217-232): Insufficient funds happens here
-// Warning: (217-232): Assertion checker does not yet implement this type.
 // Warning: (236-251): Insufficient funds happens here
-// Warning: (236-251): Assertion checker does not yet implement this type.
 // Warning: (295-324): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_transfer_insufficient.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer_insufficient.sol
@@ -12,7 +12,5 @@ contract C
 }
 // ----
 // Warning: (134-149): Insufficient funds happens here
-// Warning: (134-149): Assertion checker does not yet implement this type.
 // Warning: (153-169): Insufficient funds happens here
-// Warning: (153-169): Assertion checker does not yet implement this type.
 // Warning: (213-237): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/array_literal_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_1.sol
@@ -8,5 +8,5 @@ contract C
 }
 // ----
 // Warning: (76-96): Unused local variable.
-// Warning: (99-114): Assertion checker does not yet implement tuples and inline arrays.
+// Warning: (99-114): Assertion checker does not yet implement inline arrays.
 // Warning: (99-114): Internal error: Expression undefined for SMT solver.

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function g() public pure {
+		uint x;
+		uint y;
+		(x, y) = (2, 4);
+		assert(x == 2);
+		assert(y == 4);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment.sol
@@ -6,7 +6,9 @@ contract C
 		uint x;
 		uint y;
 		(x, y) = (2, 4);
-		assert(x == 2);
-		assert(y == 4);
+		assert(x == 1);
+		assert(0 == 1);
 	}
 }
+// ----
+// Warning: (115-129): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment_array.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment_array.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint[] a;
+	function g(uint x, uint y) public {
+		require(x != y);
+		(a[x], a[y]) = (2, 4);
+		assert(a[x] == 2);
+		assert(a[y] == 4);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment_array_empty.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment_array_empty.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint[] a;
+	function g(uint x, uint y) public {
+		require(x != y);
+		(, a[y]) = (2, 4);
+		assert(a[x] == 2);
+		assert(a[y] == 4);
+	}
+}
+// ----
+// Warning: (136-153): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment_compound.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment_compound.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		uint a = 1;
+		uint b = 3;
+		a += ((((b))));
+		assert(a == 3);
+	}
+}
+// ----
+// Warning: (122-136): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment_empty.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment_empty.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function g() public pure {
+		uint x;
+		uint y;
+		(x, ) = (2, 4);
+		assert(x == 2);
+		assert(y == 4);
+	}
+}
+// ----
+// Warning: (132-146): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_declarations.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_declarations.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function g() public pure {
+		(uint x, uint y) = (2, 4);
+		assert(x == 2);
+		assert(y == 4);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/tuple_declarations_empty.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_declarations_empty.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function g() public pure {
+		(uint x, ) = (2, 4);
+		assert(x == 2);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/tuple_declarations_function.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_declarations_function.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() internal pure returns (uint, bool, uint) {
+		uint x = 3;
+		bool b = true;
+		uint y = 999;
+		return (x, b, y);
+	}
+	function g() public pure {
+		(uint x, bool b, uint y) = f();
+		assert(x == 3);
+		assert(b);
+		assert(y == 999);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/tuple_declarations_function_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_declarations_function_2.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) internal pure returns (uint, bool, uint) {
+		bool b = true;
+		uint y = 999;
+		return (x * 2, b, y);
+	}
+	function g() public pure {
+		(uint x, bool b, uint y) = f(7);
+		assert(x == 14);
+		assert(b);
+		assert(y == 999);
+	}
+}
+// ----
+// Warning: (152-157): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_declarations_function_empty.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_declarations_function_empty.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() internal pure returns (uint, bool, uint) {
+		uint x = 3;
+		bool b = true;
+		uint y = 999;
+		return (x, b, y);
+	}
+	function g() public pure {
+		(, bool b,) = f();
+		assert(!b);
+	}
+}
+// ----
+// Warning: (224-234): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_function.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_function.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() internal pure returns (uint, uint) {
+		return (2, 3);
+	}
+	function g() public pure {
+		uint x;
+		uint y;
+		(x,y) = f();
+		assert(x == 1);
+		assert(y == 4);
+	}
+}
+// ----
+// Warning: (182-196): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_function_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_function_2.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() internal pure returns (uint, uint) {
+		return (2, 3);
+	}
+	function g() public pure {
+		uint x;
+		uint y;
+		(x,) = f();
+		assert(x == 2);
+		assert(y == 4);
+	}
+}
+// ----
+// Warning: (199-213): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/tuple_function_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_function_3.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() internal pure returns (uint, bool, uint) {
+		return (2, false, 3);
+	}
+	function g() public pure {
+		uint x;
+		uint y;
+		bool b;
+		(,b,) = f();
+		assert(x == 2);
+		assert(y == 4);
+		assert(!b);
+	}
+}
+// ----
+// Warning: (205-219): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTestsJSON/multi.json
+++ b/test/libsolidity/smtCheckerTestsJSON/multi.json
@@ -3,9 +3,9 @@
 	{
 		"smtlib2responses":
 		{
-			"0x47a038dd9021ecb218726ea6bf1f75c215a50b1981bae4341e89c9f2b7ac5db7": "sat\n((|EVALEXPR_0| 1))\n",
-			"0xf057b272f2ceb99a2f714cb132960babdeedfb84ff8ffb96106a58bc0c2060cb": "sat\n((|EVALEXPR_0| 0))\n",
-			"0xf49b9d0eb7b6d2f2ac9e1604288e52ee1a08cda57058e26d7843ed109ca6d7c9": "unsat\n"
+			"0x092d52dc5c2b54c1909592f7b3c8efedfd87afc0223ce421a24a1cc7905006b4": "sat\n((|EVALEXPR_0| 1))\n",
+			"0x8faacfc008b6f2278b5927ff22d76832956dfb46b3c21a64fab96583c241b88f": "unsat\n",
+			"0xa66d08de30c873ca7d0e7e9e426f278640e0ee463a1aed2e4e80baee916b6869": "sat\n((|EVALEXPR_0| 0))\n"
 		}
 	}
 }

--- a/test/libsolidity/smtCheckerTestsJSON/simple.json
+++ b/test/libsolidity/smtCheckerTestsJSON/simple.json
@@ -3,7 +3,7 @@
 	{
 		"smtlib2responses":
 		{
-			"0xf057b272f2ceb99a2f714cb132960babdeedfb84ff8ffb96106a58bc0c2060cb": "sat\n((|EVALEXPR_0| 0))\n"
+			"0xa66d08de30c873ca7d0e7e9e426f278640e0ee463a1aed2e4e80baee916b6869": "sat\n((|EVALEXPR_0| 0))\n"
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4141 #5380

This includes support to functions with multiple return values.

Needs to be rebased after release.