### PR TITLE
Conversion: remove confusing int8 type

### DIFF
--- a/docs/types/conversion.rst
+++ b/docs/types/conversion.rst
@@ -26,11 +26,11 @@ doing, an explicit type conversion is sometimes possible. Note that this may
 give you some unexpected behaviour and allows you to bypass some security
 features of the compiler, so be sure to test that the
 result is what you want! Take the following example where you are converting
-a negative ``int8`` to a ``uint``:
+a negative ``int`` to a ``uint``:
 
 ::
 
-    int8 y = -3;
+    int  y = -3;
     uint x = uint(y);
 
 At the end of this code snippet, ``x`` will have the value ``0xfffff..fd`` (64 hex


### PR DESCRIPTION
The topic of converting a smaller type into a larger one is orthogonal to the one discussed in the example (namely, conversion between signed and unsigned integers).

Therefore, we change the `int8` to an `int` to make the example clearer.

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
