### PR TITLE
ossfuzz: switch to bionic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ jobs:
 
   build_x86_linux_ossfuzz:
     docker:
-      - image: buildpack-deps:cosmic
+      - image: buildpack-deps:bionic
     environment:
       TERM: xterm
       CC: /usr/bin/clang-7
@@ -439,7 +439,7 @@ jobs:
 
   test_x86_ossfuzz_regression:
     docker:
-      - image: buildpack-deps:cosmic
+      - image: buildpack-deps:bionic
     environment:
       TERM: xterm
     steps:


### PR DESCRIPTION
(closes #6667 )

Unknown bug in boost 1.67 (multiprecision library) miscomputes large exponent mod 2^256 in this function

https://github.com/ethereum/solidity/blob/35677019a3216938b76acd6f3ab53899814f8790/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp#L39-L51

This PR simply downgrades CI distro to bionic that uses an older boost version (1.65) that does not contain this unknown bug.