### PR TITLE
[SMTChecker] Fix ICE in touched vars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Bugfixes:
  * SMTChecker: Fix internal error when visiting state variable inherited from base class.
  * SMTChecker: Fix internal error in fixed point operations.
  * SMTChecker: Fix internal error in assignment to unsupported type.
+ * SMTChecker: Fix internal error in branching when inlining function calls that modify local variables.
 
 
 

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -400,6 +400,21 @@ SourceUnit const& Scopable::sourceUnit() const
 	return dynamic_cast<SourceUnit const&>(*s);
 }
 
+CallableDeclaration const* Scopable::functionOrModifierDefinition() const
+{
+	ASTNode const* s = scope();
+	solAssert(s, "");
+	while (dynamic_cast<Scopable const*>(s))
+	{
+		if (auto funDef = dynamic_cast<FunctionDefinition const*>(s))
+			return funDef;
+		if (auto modDef = dynamic_cast<ModifierDefinition const*>(s))
+			return modDef;
+		s = dynamic_cast<Scopable const*>(s)->scope();
+	}
+	return nullptr;
+}
+
 string Scopable::sourceUnitName() const
 {
 	return sourceUnit().annotation().path;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -161,6 +161,9 @@ public:
 	/// @returns the source unit this scopable is present in.
 	SourceUnit const& sourceUnit() const;
 
+	/// @returns the function or modifier definition this scopable is present in or nullptr.
+	CallableDeclaration const* functionOrModifierDefinition() const;
+
 	/// @returns the source name this scopable is present in.
 	/// Can be combined with annotation().canonicalName (if present) to form a globally unique name.
 	std::string sourceUnitName() const;

--- a/libsolidity/ast/ASTForward.h
+++ b/libsolidity/ast/ASTForward.h
@@ -38,6 +38,7 @@ class SourceUnit;
 class PragmaDirective;
 class ImportDirective;
 class Declaration;
+class CallableDeclaration;
 class ContractDefinition;
 class InheritanceSpecifier;
 class UsingForDirective;

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -173,6 +173,8 @@ private:
 		std::string const& _description
 	);
 
+	using CallStackEntry = std::pair<CallableDeclaration const*, ASTNode const*>;
+
 	struct OverflowTarget
 	{
 		enum class Type { Underflow, Overflow, All } type;
@@ -180,9 +182,9 @@ private:
 		smt::Expression value;
 		smt::Expression path;
 		langutil::SourceLocation const& location;
-		std::vector<ASTNode const*> callStack;
+		std::vector<CallStackEntry> callStack;
 
-		OverflowTarget(Type _type, TypePointer _intType, smt::Expression _value, smt::Expression _path, langutil::SourceLocation const& _location, std::vector<ASTNode const*> _callStack):
+		OverflowTarget(Type _type, TypePointer _intType, smt::Expression _value, smt::Expression _path, langutil::SourceLocation const& _location, std::vector<CallStackEntry> _callStack):
 			type(_type),
 			intType(_intType),
 			value(_value),
@@ -266,9 +268,9 @@ private:
 	/// Returns the current callstack. Used for models.
 	langutil::SecondarySourceLocation currentCallStack();
 	/// Copies and pops the last called node.
-	ASTNode const* popCallStack();
-	/// Adds @param _node to the callstack.
-	void pushCallStack(ASTNode const* _node);
+	CallStackEntry popCallStack();
+	/// Adds (_definition, _node) to the callstack.
+	void pushCallStack(CallStackEntry _entry);
 	/// Conjoin the current path conditions with the given parameter and add to the solver
 	void addPathConjoinedExpression(smt::Expression const& _e);
 	/// Add to the solver: the given expression implied by the current path conditions
@@ -315,10 +317,8 @@ private:
 	langutil::ErrorList m_smtErrors;
 	std::shared_ptr<langutil::Scanner> m_scanner;
 
-	/// Stores the current path of function calls.
-	std::vector<FunctionDefinition const*> m_functionPath;
-	/// Stores the current call/invocation path.
-	std::vector<ASTNode const*> m_callStack;
+	/// Stores the current function/modifier call/invocation path.
+	std::vector<CallStackEntry> m_callStack;
 	/// Returns true if the current function was not visited by
 	/// a function call.
 	bool isRootFunction();

--- a/libsolidity/formal/VariableUsage.cpp
+++ b/libsolidity/formal/VariableUsage.cpp
@@ -31,26 +31,30 @@ void VariableUsage::endVisit(Identifier const& _identifier)
 	solAssert(declaration, "");
 	if (VariableDeclaration const* varDecl = dynamic_cast<VariableDeclaration const*>(declaration))
 		if (_identifier.annotation().lValueRequested)
-			m_touchedVariables.insert(varDecl);
+		{
+			solAssert(m_lastCall, "");
+			if (!varDecl->isLocalVariable() || varDecl->functionOrModifierDefinition() == m_lastCall)
+				m_touchedVariables.insert(varDecl);
+		}
 }
 
 void VariableUsage::endVisit(FunctionCall const& _funCall)
 {
 	if (auto const& funDef = SMTChecker::inlinedFunctionCallToDefinition(_funCall))
-		if (find(m_functionPath.begin(), m_functionPath.end(), funDef) == m_functionPath.end())
+		if (find(m_callStack.begin(), m_callStack.end(), funDef) == m_callStack.end())
 			funDef->accept(*this);
 }
 
 bool VariableUsage::visit(FunctionDefinition const& _function)
 {
-	m_functionPath.push_back(&_function);
+	m_callStack.push_back(&_function);
 	return true;
 }
 
 void VariableUsage::endVisit(FunctionDefinition const&)
 {
-	solAssert(!m_functionPath.empty(), "");
-	m_functionPath.pop_back();
+	solAssert(!m_callStack.empty(), "");
+	m_callStack.pop_back();
 }
 
 void VariableUsage::endVisit(ModifierInvocation const& _modifierInv)
@@ -62,18 +66,21 @@ void VariableUsage::endVisit(ModifierInvocation const& _modifierInv)
 
 void VariableUsage::endVisit(PlaceholderStatement const&)
 {
-	solAssert(!m_functionPath.empty(), "");
-	FunctionDefinition const* function = m_functionPath.back();
-	solAssert(function, "");
-	if (function->isImplemented())
-		function->body().accept(*this);
+	solAssert(!m_callStack.empty(), "");
+	FunctionDefinition const* funDef = nullptr;
+	for (auto it = m_callStack.rbegin(); it != m_callStack.rend() && !funDef; ++it)
+		funDef = dynamic_cast<FunctionDefinition const*>(*it);
+	solAssert(funDef, "");
+	if (funDef->isImplemented())
+		funDef->body().accept(*this);
 }
 
-set<VariableDeclaration const*> VariableUsage::touchedVariables(ASTNode const& _node, vector<FunctionDefinition const*> const& _outerCallstack)
+set<VariableDeclaration const*> VariableUsage::touchedVariables(ASTNode const& _node, vector<CallableDeclaration const*> const& _outerCallstack)
 {
 	m_touchedVariables.clear();
-	m_functionPath.clear();
-	m_functionPath += _outerCallstack;
+	m_callStack.clear();
+	m_callStack += _outerCallstack;
+	m_lastCall = m_callStack.back();
 	_node.accept(*this);
 	return m_touchedVariables;
 }

--- a/libsolidity/formal/VariableUsage.h
+++ b/libsolidity/formal/VariableUsage.h
@@ -34,7 +34,7 @@ class VariableUsage: private ASTConstVisitor
 {
 public:
 	/// @param _outerCallstack the current callstack in the callers context.
-	std::set<VariableDeclaration const*> touchedVariables(ASTNode const& _node, std::vector<FunctionDefinition const*> const& _outerCallstack);
+	std::set<VariableDeclaration const*> touchedVariables(ASTNode const& _node, std::vector<CallableDeclaration const*> const& _outerCallstack);
 
 private:
 	void endVisit(Identifier const& _node) override;
@@ -45,7 +45,8 @@ private:
 	void endVisit(PlaceholderStatement const& _node) override;
 
 	std::set<VariableDeclaration const*> m_touchedVariables;
-	std::vector<FunctionDefinition const*> m_functionPath;
+	std::vector<CallableDeclaration const*> m_callStack;
+	CallableDeclaration const* m_lastCall = nullptr;
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
+++ b/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
@@ -1,0 +1,96 @@
+pragma experimental SMTChecker;
+
+contract ContractWithFunctionCalled {
+    function funcCalled() external  {
+        uint256 i = 0;
+    }
+}
+
+contract ContractWithFunctionCalledSuper is ContractWithFunctionCalled {
+    function callWithSuper() public {
+        uint256 i = 0;
+    }
+}
+
+contract ContractWithFunctionNotCalled {
+
+    function funcNotCalled3() public {
+
+    }
+
+    function funcNotCalled2() public {
+
+    }
+
+    function funcNotCalled() public {
+
+    }
+
+    function my_func() internal returns(bool){
+        return true;
+    }
+
+}
+
+contract ContractWithFunctionNotCalled2 is ContractWithFunctionCalledSuper {
+    function funcNotCalled() public {
+        uint256 i = 0;
+        address three = address(new ContractWithFunctionNotCalled());
+        three.call(abi.encode(bytes4(keccak256("helloTwo()"))));
+        super.callWithSuper();
+        ContractWithFunctionCalled c = new ContractWithFunctionCalled();
+        c.funcCalled();
+    }
+}
+
+contract InternalCall {
+
+    function() returns(uint) ptr;
+
+    function set_test1() external{
+        ptr = test1;
+    }
+
+    function set_test2() external{
+        ptr = test2;
+    }
+
+    function test1() public returns(uint){
+        return 1;
+    }
+
+    function test2() public returns(uint){
+        return 2;
+    }
+
+    function test3() public returns(uint){
+        return 3;
+    }
+
+    function exec() external returns(uint){
+        return ptr();
+    }
+
+}
+// ----
+// Warning: (760-815): Return value of low-level calls not used.
+// Warning: (117-126): Unused local variable.
+// Warning: (260-269): Unused local variable.
+// Warning: (667-676): Unused local variable.
+// Warning: (75-137): Function state mutability can be restricted to pure
+// Warning: (218-280): Function state mutability can be restricted to pure
+// Warning: (470-539): Function state mutability can be restricted to pure
+// Warning: (1144-1206): Function state mutability can be restricted to pure
+// Warning: (1212-1274): Function state mutability can be restricted to pure
+// Warning: (1280-1342): Function state mutability can be restricted to pure
+// Warning: (714-749): Internal error: Expression undefined for SMT solver.
+// Warning: (799-811): Assertion checker does not yet support the type of this literal (literal_string "helloTwo()").
+// Warning: (782-813): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (771-814): Assertion checker does not yet implement this type of function call.
+// Warning: (825-830): Assertion checker does not yet support the type of this variable.
+// Warning: (887-919): Internal error: Expression undefined for SMT solver.
+// Warning: (690-750): Underflow (resulting value less than 0) happens here
+// Warning: (690-750): Overflow (resulting value larger than 2**160 - 1) happens here
+// Warning: (1057-1068): Assertion checker does not yet implement type function () returns (uint256)
+// Warning: (1120-1131): Assertion checker does not yet implement type function () returns (uint256)
+// Warning: (1403-1408): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch.sol
@@ -1,0 +1,20 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		if (true) {
+			address a = g();
+			assert(a == address(0));
+		}
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+}
+// ----
+// Warning: (208-218): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (123-133): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (208-218): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_2.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_2.sol
@@ -1,0 +1,27 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		if (true) {
+			address a = g();
+			assert(a == address(0));
+		}
+		else
+		{
+			address b = g();
+			assert(b == address(0));
+		}
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+}
+// ----
+// Warning: (271-281): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (123-133): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (271-281): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (186-196): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (271-281): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_3.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_3.sol
@@ -1,0 +1,27 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		if (true) {
+			address a = g();
+			assert(a == address(0));
+		}
+		if (true) {
+			address a = g();
+			assert(a == address(0));
+		}
+
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+}
+// ----
+// Warning: (275-285): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (123-133): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (275-285): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (189-199): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (275-285): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_4.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_4.sol
@@ -1,0 +1,31 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		if (true) {
+			address a = g();
+			assert(a == address(0));
+		}
+		if (true) {
+			address a = h();
+			assert(a == address(0));
+		}
+
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+	function h() public pure returns (address) {
+		address a;
+		return a;
+	}
+
+}
+// ----
+// Warning: (275-285): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (123-133): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (189-199): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (275-285): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_else_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_else_branch.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		if (true) {
+		} else {
+			address a = g();
+			assert(a == address(0));
+		}
+	}
+	function g() public pure returns (address) {
+		address x;
+		x = address(0);
+		return x;
+	}
+}
+// ----
+// Warning: (219-229): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (134-144): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (219-229): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_modifier_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_modifier_branch.sol
@@ -1,0 +1,24 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	modifier m(address a) {
+		if (true) {
+			a = g();
+			_;
+			assert(a == address(0));
+		}
+	}
+
+	function f(address a) m(a) public pure {
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+}
+// ----
+// Warning: (249-259): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (118-128): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (249-259): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_placeholder_inside_modifier_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_placeholder_inside_modifier_branch.sol
@@ -1,0 +1,25 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	modifier m {
+		if (true)
+			_;
+	}
+
+	function f(address a) m public pure {
+		if (true) {
+			a = g();
+			assert(a == address(0));
+		}
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+}
+// ----
+// Warning: (247-257): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (162-172): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (247-257): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/functions/functions_external_4.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_external_4.sol
@@ -1,0 +1,20 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint _x) public pure returns (uint) {
+		return _x;
+	}
+}
+
+contract D
+{
+	C c;
+	function g(uint _y) public view {
+		uint z = c.f(_y);
+		assert(z == _y);
+	}
+}
+// ----
+// Warning: (180-187): Internal error: Expression undefined for SMT solver.
+// Warning: (191-206): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_inline_function_inside_branch.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_inline_function_inside_branch.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	address owner;
+	modifier m {
+		if (true)
+			owner = g();
+		_;
+	}
+	function f() m public {
+	}
+	function g() public pure returns (address) {
+		address a;
+		a = address(0);
+		return a;
+	}
+}
+// ----
+// Warning: (205-215): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (205-215): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_multi_functions.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_multi_functions.sol
@@ -22,5 +22,4 @@ contract C
 	}
 }
 // ----
-// Warning: (86-93): Condition is always true.
 // Warning: (311-324): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_parameters.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_parameters.sol
@@ -15,4 +15,3 @@ contract C
 	}
 }
 // ----
-// Warning: (127-132): Condition is always true.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_return.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_return.sol
@@ -18,4 +18,3 @@ contract C
 	}
 }
 // ----
-// Warning: (138-144): Condition is always false.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_two_invocations.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_two_invocations.sol
@@ -17,5 +17,3 @@ contract C
 	}
 }
 // ----
-// Warning: (137-142): Condition is always true.
-// Warning: (155-164): Condition is always true.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6563 https://github.com/ethereum/solidity/issues/6009
Depends on https://github.com/ethereum/solidity/pull/6675
```
function f() {
    if (true)
        g();
}
function g() {
    uint x;
    x = 2;
}
```
The issue here was that `x` was considered as touched by `f`, which tried to merge the SSA versions of `x` after `if (true)`. Because this merging is already resolved inside `g` the assertion inside `mergeVariables` failed.
The fix is to only add a certain variable as touched by the queried node if the variable is declared in the same function (even if it actually is in the subtree like in the example above), since the SMTChecker keeps all the local variables of a certain function alive while visiting that function.