### PR TITLE
Add ABIEncoderV2 cleanup tests.

### DIFF
--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/address.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/address.sol
@@ -1,0 +1,31 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function g(address x) external pure returns (uint256 r) {
+        assembly { r := x }
+    }
+    function f(uint256 a) external view returns (uint256) {
+        address x;
+        assembly { x := a }
+        return this.g(x);
+    }
+}
+// ----
+// f(uint256): 0 -> 0
+// g(address): 0 -> 0 # test validation as well as sanity check #
+// f(uint256): 1 -> 1
+// g(address): 1 -> 1
+// f(uint256): 2 -> 2
+// g(address): 2 -> 2
+// f(uint256): 0xabcdef0123456789abcdef0123456789abcdefff -> 0xabcdef0123456789abcdef0123456789abcdefff
+// g(address): 0xabcdef0123456789abcdef0123456789abcdefff -> 0xabcdef0123456789abcdef0123456789abcdefff
+// f(uint256): 0xffffffffffffffffffffffffffffffffffffffff -> 0xffffffffffffffffffffffffffffffffffffffff
+// g(address): 0xffffffffffffffffffffffffffffffffffffffff -> 0xffffffffffffffffffffffffffffffffffffffff
+// f(uint256): 0x010000000000000000000000000000000000000000 -> 0
+// g(address): 0x010000000000000000000000000000000000000000 -> FAILURE
+// f(uint256): 0x01abcdef0123456789abcdef0123456789abcdefff -> 0xabcdef0123456789abcdef0123456789abcdefff
+// g(address): 0x01abcdef0123456789abcdef0123456789abcdefff -> FAILURE
+// f(uint256): 0x01ffffffffffffffffffffffffffffffffffffffff -> 0xffffffffffffffffffffffffffffffffffffffff
+// g(address): 0x01ffffffffffffffffffffffffffffffffffffffff -> FAILURE
+// f(uint256): -1 -> 0xffffffffffffffffffffffffffffffffffffffff
+// g(address): -1 -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/bool.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/bool.sol
@@ -1,0 +1,21 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function gggg(bool x) external pure returns (bool) {
+        return x;
+    }
+    function f(uint256 a) external view returns (bool) {
+        bool x = false;
+        assembly { x := a }
+        return this.gggg(x);
+    }
+}
+// ----
+// f(uint256): 0 -> false
+// gggg(bool): 0 -> false # test validation as well as sanity check #
+// f(uint256): 1 -> true
+// gggg(bool): 1 -> true
+// f(uint256): 2 -> true
+// gggg(bool): 2 -> FAILURE
+// f(uint256): 0x1000 -> true
+// gggg(bool): 0x1000 -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/bytesx.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/bytesx.sol
@@ -1,0 +1,115 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function gg1(bytes1 x) external pure returns (bytes32) {
+        return x;
+    }
+    function f1(bytes32 a) external view returns (bytes32) {
+        bytes1 x;
+        assembly { x := a }
+        return this.gg1(x);
+    }
+    function gg2(bytes2 x) external pure returns (bytes32) {
+        return x;
+    }
+    function f2(bytes32 a) external view returns (bytes32) {
+        bytes2 x;
+        assembly { x := a }
+        return this.gg2(x);
+    }
+    function gg4(bytes4 x) external pure returns (bytes32) {
+        return x;
+    }
+    function f4(bytes32 a) external view returns (bytes32) {
+        bytes4 x;
+        assembly { x := a }
+        return this.gg4(x);
+    }
+    function gg8(bytes8 x) external pure returns (bytes32) {
+        return x;
+    }
+    function f8(bytes32 a) external view returns (bytes32) {
+        bytes8 x;
+        assembly { x := a }
+        return this.gg8(x);
+    }
+    function g16(bytes16 x) external pure returns (bytes32) {
+        return x;
+    }
+    function f16(bytes32 a) external view returns (bytes32) {
+        bytes16 x;
+        assembly { x := a }
+        return this.g16(x);
+    }
+}
+// ----
+// f1(bytes32): left(0) -> left(0)
+// gg1(bytes1): left(0) -> left(0) # test validation as well as sanity check #
+// f1(bytes32): left(1) -> left(1)
+// gg1(bytes1): left(1) -> left(1)
+// f1(bytes32): left(0xFE) -> left(0xFE)
+// gg1(bytes1): left(0xFE) -> left(0xFE)
+// f1(bytes32): left(0xFF) -> left(0xFF)
+// gg1(bytes1): left(0xFF) -> left(0xFF)
+// f1(bytes32): left(0x0001) -> left(0x00)
+// gg1(bytes1): left(0x0001) -> FAILURE
+// f1(bytes32): left(0x0101) -> left(0x01)
+// gg1(bytes1): left(0x0101) -> FAILURE
+// f1(bytes32): -1 -> left(0xFF)
+// gg1(bytes1): -1 -> FAILURE
+// f2(bytes32): left(0) -> left(0)
+// gg2(bytes2): left(0) -> left(0)
+// f2(bytes32): left(1) -> left(1)
+// gg2(bytes2): left(1) -> left(1)
+// f2(bytes32): left(0xFFFE) -> left(0xFFFE)
+// gg2(bytes2): left(0xFFFE) -> left(0xFFFE)
+// f2(bytes32): left(0xFFFF) -> left(0xFFFF)
+// gg2(bytes2): left(0xFFFF) -> left(0xFFFF)
+// f2(bytes32): left(0x000001) -> left(0x00)
+// gg2(bytes2): left(0x000001) -> FAILURE
+// f2(bytes32): left(0x010001) -> left(0x01)
+// gg2(bytes2): left(0x010001) -> FAILURE
+// f2(bytes32): -1 -> left(0xFFFF)
+// gg2(bytes2): -1 -> FAILURE
+// f4(bytes32): left(0) -> left(0)
+// gg4(bytes4): left(0) -> left(0)
+// f4(bytes32): left(1) -> left(1)
+// gg4(bytes4): left(1) -> left(1)
+// f4(bytes32): left(0xFFFFFFFE) -> left(0xFFFFFFFE)
+// gg4(bytes4): left(0xFFFFFFFE) -> left(0xFFFFFFFE)
+// f4(bytes32): left(0xFFFFFFFF) -> left(0xFFFFFFFF)
+// gg4(bytes4): left(0xFFFFFFFF) -> left(0xFFFFFFFF)
+// f4(bytes32): left(0x0000000001) -> left(0x00)
+// gg4(bytes4): left(0x0000000001) -> FAILURE
+// f4(bytes32): left(0x0100000001) -> left(0x01)
+// gg4(bytes4): left(0x0100000001) -> FAILURE
+// f4(bytes32): -1 -> left(0xFFFFFFFF)
+// gg4(bytes4): -1 -> FAILURE
+// f8(bytes32): left(0) -> left(0)
+// gg8(bytes8): left(0) -> left(0)
+// f8(bytes32): left(1) -> left(1)
+// gg8(bytes8): left(1) -> left(1)
+// f8(bytes32): left(0xFFFFFFFFFFFFFFFE) -> left(0xFFFFFFFFFFFFFFFE)
+// gg8(bytes8): left(0xFFFFFFFFFFFFFFFE) -> left(0xFFFFFFFFFFFFFFFE)
+// f8(bytes32): left(0xFFFFFFFFFFFFFFFF) -> left(0xFFFFFFFFFFFFFFFF)
+// gg8(bytes8): left(0xFFFFFFFFFFFFFFFF) -> left(0xFFFFFFFFFFFFFFFF)
+// f8(bytes32): left(0x000000000000000001) -> left(0x00)
+// gg8(bytes8): left(0x000000000000000001) -> FAILURE
+// f8(bytes32): left(0x010000000000000001) -> left(0x01)
+// gg8(bytes8): left(0x010000000000000001) -> FAILURE
+// f8(bytes32): -1 -> left(0xFFFFFFFFFFFFFFFF)
+// gg8(bytes8): -1 -> FAILURE
+// f16(bytes32): left(0) -> left(0)
+// g16(bytes16): left(0) -> left(0)
+// f16(bytes32): left(1) -> left(1)
+// g16(bytes16): left(1) -> left(1)
+// f16(bytes32): left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE) -> left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE)
+// g16(bytes16): left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE) -> left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE)
+// f16(bytes32): left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) -> left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+// g16(bytes16): left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) -> left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+// f16(bytes32): left(0x0000000000000000000000000000000001) -> left(0x00)
+// g16(bytes16): left(0x0000000000000000000000000000000001) -> FAILURE
+// f16(bytes32): left(0x0100000000000000000000000000000001) -> left(0x01)
+// g16(bytes16): left(0x0100000000000000000000000000000001) -> FAILURE
+// f16(bytes32): -1 -> left(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+// g16(bytes16): -1 -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/dynamic_array.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/dynamic_array.sol
@@ -1,0 +1,22 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function ggg(uint8[] calldata s) external pure returns (bytes memory) {
+        s[0]; // only this will validate.
+        return msg.data;
+    }
+    function f(uint256[] calldata a) external returns (bytes memory) {
+        uint8[] memory m = new uint8[](a.length);
+        assembly {
+            calldatacopy(add(m, 0x20), 0x44, mul(calldataload(4), 0x20))
+        }
+        return this.ggg(m);
+    }
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// f(uint256[]): 0x20, 2, 1, 1 -> 0x20, 0x84, hex"304a4c23", 0x20, 2, 1, 1, hex"00000000000000000000000000000000000000000000000000000000"
+// ggg(uint8[]): 0x20, 2, 1, 1 -> 0x20, 0x84, hex"304a4c23", 0x20, 2, 1, 1, hex"00000000000000000000000000000000000000000000000000000000"
+// f(uint256[]): 0x20, 2, 0x0101, 0x0101 -> 0x20, 0x84, hex"304a4c23", 0x20, 2, 1, 1, hex"00000000000000000000000000000000000000000000000000000000"
+// ggg(uint8[]): 0x20, 2, 0x0101, 0x0101 -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/function.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/function.sol
@@ -1,0 +1,28 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    struct S { function() external f; }
+    function ggg(function() external x) external pure returns (uint256 r) {
+        assembly { r := calldataload(4) }
+    }
+    function h(S calldata x) external pure returns (uint256 r) {
+        x.f; // validation only happens here
+        assembly { r := calldataload(4) }
+    }
+    function dummy() external {}
+    function ffff(uint256 a) external view returns (uint256, uint256) {
+        S memory s = S(this.dummy);
+        assembly { mstore(s, a) }
+        return (this.ggg(s.f), this.h(s));
+    }
+}
+// ----
+// ffff(uint256): 0 -> 0, 0
+// ggg(function): 0 -> 0
+// ffff(uint256): "01234567890123456789abcd" -> "01234567890123456789abcd", "01234567890123456789abcd"
+// ggg(function): "01234567890123456789abcd" -> "01234567890123456789abcd"
+// h((function)): "01234567890123456789abcd" -> "01234567890123456789abcd"
+// h((function)): 0 -> 0
+// ffff(uint256): "01234567890123456789abcdX" -> "01234567890123456789abcd", "01234567890123456789abcd"
+// ggg(function): "01234567890123456789abcdX" -> FAILURE
+// h((function)): "01234567890123456789abcdX" -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/intx.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/intx.sol
@@ -1,0 +1,155 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function ggg8(int8 x) external pure returns (int256) {
+        return x;
+    }
+    function gg16(int16 x) external pure returns (int256) {
+        return x;
+    }
+    function gg32(int32 x) external pure returns (int256) {
+        return x;
+    }
+    function gg64(int64 x) external pure returns (int256) {
+        return x;
+    }
+    function g128(int128 x) external pure returns (int256) {
+        return x;
+    }
+    function f8(int256 a) external view returns (int256) {
+        int8 x = 0;
+        assembly { x := a }
+        return this.ggg8(x);
+    }
+    function f16(int256 a) external view returns (int256) {
+        int16 x = 0;
+        assembly { x := a }
+        return this.gg16(x);
+    }
+    function f32(int256 a) external view returns (int256) {
+        int32 x = 0;
+        assembly { x := a }
+        return this.gg32(x);
+    }
+    function f64(int256 a) external view returns (int256) {
+        int64 x = 0;
+        assembly { x := a }
+        return this.gg64(x);
+    }
+    function f128(int256 a) external view returns (int256) {
+        int128 x = 0;
+        assembly { x := a }
+        return this.g128(x);
+    }
+}
+// ----
+// f8(int256): 0 -> 0
+// ggg8(int8): 0 -> 0 # test validation as well as sanity check #
+// f8(int256): 1 -> 1
+// ggg8(int8): 1 -> 1
+// f8(int256): -1 -> -1
+// ggg8(int8): -1 -> -1
+// f8(int256): 0x7F -> 0x7F
+// ggg8(int8): 0x7F -> 0x7F
+// f8(int256): 0x80 -> -128
+// ggg8(int8): 0x80 -> FAILURE
+// f8(int256): 0xFE -> -2
+// ggg8(int8): 0xFE -> FAILURE
+// f8(int256): 0xFF -> -1
+// ggg8(int8): 0xFF -> FAILURE
+// f8(int256): 0x0100 -> 0x00
+// ggg8(int8): 0x0100 -> FAILURE
+// f8(int256): 0x0101 -> 0x01
+// ggg8(int8): 0x0101 -> FAILURE
+// f8(int256): 0x01FF -> -1
+// ggg8(int8): 0x01FF -> FAILURE
+// f8(int256): 0x01FE -> -2
+// ggg8(int8): 0x01FE -> FAILURE
+// f16(int256): 0 -> 0
+// gg16(int16): 0 -> 0
+// f16(int256): 1 -> 1
+// gg16(int16): 1 -> 1
+// f16(int256): -1 -> -1
+// gg16(int16): -1 -> -1
+// f16(int256): 0x7FFF -> 0x7FFF
+// gg16(int16): 0x7FFF -> 0x7FFF
+// f16(int256): 0x8000 -> -32768
+// gg16(int16): 0x8000 -> FAILURE
+// f16(int256): 0xFFFE -> -2
+// gg16(int16): 0xFFFE -> FAILURE
+// f16(int256): 0xFFFF -> -1
+// gg16(int16): 0xFFFF -> FAILURE
+// f16(int256): 0x010000 -> 0x00
+// gg16(int16): 0x010000 -> FAILURE
+// f16(int256): 0x010001 -> 0x01
+// gg16(int16): 0x010001 -> FAILURE
+// f16(int256): 0x01FFFF -> -1
+// gg16(int16): 0x01FFFF -> FAILURE
+// f16(int256): 0x01FFFE -> -2
+// gg16(int16): 0x01FFFE -> FAILURE
+// f32(int256): 0 -> 0
+// gg32(int32): 0 -> 0
+// f32(int256): 1 -> 1
+// gg32(int32): 1 -> 1
+// f32(int256): -1 -> -1
+// gg32(int32): -1 -> -1
+// f32(int256): 0x7FFFFFFF -> 0x7FFFFFFF
+// gg32(int32): 0x7FFFFFFF -> 0x7FFFFFFF
+// f32(int256): 0x80000000 -> -2147483648
+// gg32(int32): 0x80000000 -> FAILURE
+// f32(int256): 0xFFFFFFFE -> -2
+// gg32(int32): 0xFFFFFFFE -> FAILURE
+// f32(int256): 0xFFFFFFFF -> -1
+// gg32(int32): 0xFFFFFFFF -> FAILURE
+// f32(int256): 0x0100000000 -> 0x00
+// gg32(int32): 0x0100000000 -> FAILURE
+// f32(int256): 0x0100000001 -> 0x01
+// gg32(int32): 0x0100000001 -> FAILURE
+// f32(int256): 0x01FFFFFFFF -> -1
+// gg32(int32): 0x01FFFFFFFF -> FAILURE
+// f32(int256): 0x01FFFFFFFE -> -2
+// gg32(int32): 0x01FFFFFFFE -> FAILURE
+// f64(int256): 0 -> 0
+// gg64(int64): 0 -> 0
+// f64(int256): 1 -> 1
+// gg64(int64): 1 -> 1
+// f64(int256): -1 -> -1
+// gg64(int64): -1 -> -1
+// f64(int256): 0x7FFFFFFFFFFFFFFF -> 0x7FFFFFFFFFFFFFFF
+// gg64(int64): 0x7FFFFFFFFFFFFFFF -> 0x7FFFFFFFFFFFFFFF
+// f64(int256): 0x8000000000000000 -> -9223372036854775808
+// gg64(int64): 0x8000000000000000 -> FAILURE
+// f64(int256): 0xFFFFFFFFFFFFFFFE -> -2
+// gg64(int64): 0xFFFFFFFFFFFFFFFE -> FAILURE
+// f64(int256): 0xFFFFFFFFFFFFFFFF -> -1
+// gg64(int64): 0xFFFFFFFFFFFFFFFF -> FAILURE
+// f64(int256): 0x010000000000000000 -> 0x00
+// gg64(int64): 0x010000000000000000 -> FAILURE
+// f64(int256): 0x010000000000000001 -> 0x01
+// gg64(int64): 0x010000000000000001 -> FAILURE
+// f64(int256): 0x01FFFFFFFFFFFFFFFF -> -1
+// gg64(int64): 0x01FFFFFFFFFFFFFFFF -> FAILURE
+// f64(int256): 0x01FFFFFFFFFFFFFFFE -> -2
+// gg64(int64): 0x01FFFFFFFFFFFFFFFE -> FAILURE
+// f128(int256): 0 -> 0
+// g128(int128): 0 -> 0
+// f128(int256): 1 -> 1
+// g128(int128): 1 -> 1
+// f128(int256): -1 -> -1
+// g128(int128): -1 -> -1
+// f128(int256): 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+// g128(int128): 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+// f128(int256): 0x80000000000000000000000000000000 -> -170141183460469231731687303715884105728
+// g128(int128): 0x80000000000000000000000000000000 -> FAILURE
+// f128(int256): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE -> -2
+// g128(int128): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE -> FAILURE
+// f128(int256): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> -1
+// g128(int128): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> FAILURE
+// f128(int256): 0x0100000000000000000000000000000000 -> 0x00
+// g128(int128): 0x0100000000000000000000000000000000 -> FAILURE
+// f128(int256): 0x0100000000000000000000000000000001 -> 0x01
+// g128(int128): 0x0100000000000000000000000000000001 -> FAILURE
+// f128(int256): 0x01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> -1
+// g128(int128): 0x01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> FAILURE
+// f128(int256): 0x01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE -> -2
+// g128(int128): 0x01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/simple_struct.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/simple_struct.sol
@@ -1,0 +1,24 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    struct S { uint8 a; bytes1 b; }
+    function gg(S calldata s) external pure returns (bytes memory) {
+        s.a; s.b; // only this will validate.
+        return msg.data;
+    }
+    function f(uint256 a, bytes32 b) public returns (bytes memory) {
+        S memory s = S(2,0x02);
+        assembly {
+            mstore(s, a)
+            mstore(add(s, 0x20), b)
+        }
+        return this.gg(s);
+    }
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// f(uint256,bytes32): 1, left(0x01) -> 0x20, 0x44, hex"b63240b0", 1, left(0x01), hex"00000000000000000000000000000000000000000000000000000000"
+// gg((uint8,bytes1)): 1, left(0x01) -> 0x20, 0x44, hex"b63240b0", 1, left(0x01), hex"00000000000000000000000000000000000000000000000000000000"
+// f(uint256,bytes32): 0x0101, left(0x0101) -> 0x20, 0x44, hex"b63240b0", 1, left(0x01), hex"00000000000000000000000000000000000000000000000000000000"
+// gg((uint8,bytes1)): 0x0101, left(0x0101) -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/static_array.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/static_array.sol
@@ -1,0 +1,23 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function gggggggg(uint8[2] calldata s) external pure returns (bytes memory) {
+        s[0]; // only this will validate.
+        return msg.data;
+    }
+    function f(uint256 a, uint256 b) public returns (bytes memory) {
+        uint8[2] memory m = [0,0];
+        assembly {
+            mstore(m, a)
+            mstore(add(m, 0x20), b)
+        }
+        return this.gggggggg(m);
+    }
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// f(uint256,uint256): 1, 1 -> 0x20, 0x44, hex"78b86ac6", 1, 1, hex"00000000000000000000000000000000000000000000000000000000"
+// gggggggg(uint8[2]): 1, 1 -> 0x20, 0x44, hex"78b86ac6", 1, 1, hex"00000000000000000000000000000000000000000000000000000000"
+// f(uint256,uint256): 0x0101, 0x0101 -> 0x20, 0x44, hex"78b86ac6", 1, 1, hex"00000000000000000000000000000000000000000000000000000000"
+// gggggggg(uint8[2]): 0x0101, 0x0101 -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/cleanup/uintx.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/cleanup/uintx.sol
@@ -1,0 +1,115 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function ggg8(uint8 x) external pure returns (uint256) {
+        return x;
+    }
+    function gg16(uint16 x) external pure returns (uint256) {
+        return x;
+    }
+    function gg32(uint32 x) external pure returns (uint256) {
+        return x;
+    }
+    function gg64(uint64 x) external pure returns (uint256) {
+        return x;
+    }
+    function g128(uint128 x) external pure returns (uint256) {
+        return x;
+    }
+    function f8(uint256 a) external view returns (uint256) {
+        uint8 x = 0;
+        assembly { x := a }
+        return this.ggg8(x);
+    }
+    function f16(uint256 a) external view returns (uint256) {
+        uint16 x = 0;
+        assembly { x := a }
+        return this.gg16(x);
+    }
+    function f32(uint256 a) external view returns (uint256) {
+        uint32 x = 0;
+        assembly { x := a }
+        return this.gg32(x);
+    }
+    function f64(uint256 a) external view returns (uint256) {
+        uint64 x = 0;
+        assembly { x := a }
+        return this.gg64(x);
+    }
+    function f128(uint256 a) external view returns (uint256) {
+        uint128 x = 0;
+        assembly { x := a }
+        return this.g128(x);
+    }
+}
+// ----
+// f8(uint256): 0 -> 0
+// ggg8(uint8): 0 -> 0 # test validation as well as sanity check #
+// f8(uint256): 1 -> 1
+// ggg8(uint8): 1 -> 1
+// f8(uint256): 0xFE -> 0xFE
+// ggg8(uint8): 0xFE -> 0xFE
+// f8(uint256): 0xFF -> 0xFF
+// ggg8(uint8): 0xFF -> 0xFF
+// f8(uint256): 0x0100 -> 0x00
+// ggg8(uint8): 0x0100 -> FAILURE
+// f8(uint256): 0x0101 -> 0x01
+// ggg8(uint8): 0x0101 -> FAILURE
+// f8(uint256): -1 -> 0xFF
+// ggg8(uint8): -1 -> FAILURE
+// f16(uint256): 0 -> 0
+// gg16(uint16): 0 -> 0
+// f16(uint256): 1 -> 1
+// gg16(uint16): 1 -> 1
+// f16(uint256): 0xFFFE -> 0xFFFE
+// gg16(uint16): 0xFFFE -> 0xFFFE
+// f16(uint256): 0xFFFF -> 0xFFFF
+// gg16(uint16): 0xFFFF -> 0xFFFF
+// f16(uint256): 0x010000 -> 0x0000
+// gg16(uint16): 0x010000 -> FAILURE
+// f16(uint256): 0x010001 -> 0x0001
+// gg16(uint16): 0x010001 -> FAILURE
+// f16(uint256): -1 -> 0xFFFF
+// gg16(uint16): -1 -> FAILURE
+// f32(uint256): 0 -> 0
+// gg32(uint32): 0 -> 0
+// f32(uint256): 1 -> 1
+// gg32(uint32): 1 -> 1
+// f32(uint256): 0xFFFFFFFE -> 0xFFFFFFFE
+// gg32(uint32): 0xFFFFFFFE -> 0xFFFFFFFE
+// f32(uint256): 0xFFFFFFFF -> 0xFFFFFFFF
+// gg32(uint32): 0xFFFFFFFF -> 0xFFFFFFFF
+// f32(uint256): 0x0100000000 -> 0x00000000
+// gg32(uint32): 0x0100000000 -> FAILURE
+// f32(uint256): 0x0100000001 -> 0x00000001
+// gg32(uint32): 0x0100000001 -> FAILURE
+// f32(uint256): -1 -> 0xFFFFFFFF
+// gg32(uint32): -1 -> FAILURE
+// f64(uint256): 0 -> 0
+// gg64(uint64): 0 -> 0
+// f64(uint256): 1 -> 1
+// gg64(uint64): 1 -> 1
+// f64(uint256): 0xFFFFFFFFFFFFFFFE -> 0xFFFFFFFFFFFFFFFE
+// gg64(uint64): 0xFFFFFFFFFFFFFFFE -> 0xFFFFFFFFFFFFFFFE
+// f64(uint256): 0xFFFFFFFFFFFFFFFF -> 0xFFFFFFFFFFFFFFFF
+// gg64(uint64): 0xFFFFFFFFFFFFFFFF -> 0xFFFFFFFFFFFFFFFF
+// f64(uint256): 0x010000000000000000 -> 0x0000000000000000
+// gg64(uint64): 0x010000000000000000 -> FAILURE
+// f64(uint256): 0x010000000000000001 -> 0x0000000000000001
+// gg64(uint64): 0x010000000000000001 -> FAILURE
+// f64(uint256): -1 -> 0xFFFFFFFFFFFFFFFF
+// gg64(uint64): -1 -> FAILURE
+// f128(uint256): 0 -> 0
+// g128(uint128): 0 -> 0
+// f128(uint256): 1 -> 1
+// g128(uint128): 1 -> 1
+// f128(uint256): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE -> 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE
+// g128(uint128): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE -> 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE
+// f128(uint256): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+// g128(uint128): 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -> 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+// f128(uint256): 0x0100000000000000000000000000000000 -> 0x00000000000000000000000000000000
+// g128(uint128): 0x0100000000000000000000000000000000 -> FAILURE
+// f128(uint256): 0x0100000000000000000000000000000001 -> 0x00000000000000000000000000000001
+// g128(uint128): 0x0100000000000000000000000000000001 -> FAILURE
+// f128(uint256): -1 -> 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+// g128(uint128): -1 -> FAILURE


### PR DESCRIPTION
Fixes #6466.

Are there any other test cases we could add? I think simple one-dimensional arrays and small structs are enough for this.