### PR TITLE
[Draft] Yul Block Outliner

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -56,6 +56,8 @@ add_library(yul
 	optimiser/BlockDeepener.h
 	optimiser/BlockFlattener.cpp
 	optimiser/BlockFlattener.h
+	optimiser/BlockHasher.cpp
+	optimiser/BlockHasher.h
 	optimiser/BlockClassFinder.cpp
 	optimiser/BlockClassFinder.h
 	optimiser/BlockOutliner.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -52,6 +52,8 @@ add_library(yul
 	optimiser/ASTCopier.h
 	optimiser/ASTWalker.cpp
 	optimiser/ASTWalker.h
+	optimiser/BlockDeepener.cpp
+	optimiser/BlockDeepener.h
 	optimiser/BlockFlattener.cpp
 	optimiser/BlockFlattener.h
 	optimiser/BlockClassFinder.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -54,6 +54,10 @@ add_library(yul
 	optimiser/ASTWalker.h
 	optimiser/BlockFlattener.cpp
 	optimiser/BlockFlattener.h
+	optimiser/BlockClassFinder.cpp
+	optimiser/BlockClassFinder.h
+	optimiser/BlockOutliner.cpp
+	optimiser/BlockOutliner.h
 	optimiser/CommonSubexpressionEliminator.cpp
 	optimiser/CommonSubexpressionEliminator.h
 	optimiser/ControlFlowSimplifier.cpp

--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -122,6 +122,8 @@ public:
 		return YulStringRepository::instance().idToString(m_handle.id);
 	}
 
+	std::uint64_t hash() const { return m_handle.hash; }
+
 private:
 	/// Handle of the string. Assumes that the empty string has ID zero.
 	YulStringRepository::Handle m_handle{ 0, YulStringRepository::emptyHash() };

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -102,7 +102,7 @@ protected:
 		return _v ? std::make_unique<T>(translate(*_v)) : nullptr;
 	}
 
-	Block translate(Block const& _block);
+	virtual Block translate(Block const& _block);
 	Case translate(Case const& _case);
 	virtual Identifier translate(Identifier const& _identifier);
 	Literal translate(Literal const& _literal);

--- a/libyul/optimiser/BlockClassFinder.cpp
+++ b/libyul/optimiser/BlockClassFinder.cpp
@@ -1,0 +1,248 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that finds classes of equivalent blocks.
+ */
+
+#include <libyul/optimiser/BlockClassFinder.h>
+#include <libyul/optimiser/SyntacticalEquality.h>
+#include <libdevcore/CommonData.h>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+
+namespace {
+static constexpr uint64_t compileTimeLiteralHash(char const* _literal, size_t _N)
+{
+	return (_N == 0) ? 14695981039346656037u : compileTimeLiteralHash(_literal + 1, _N - 1) ^ 1099511628211u;
+}
+
+template<size_t N>
+static constexpr uint64_t compileTimeLiteralHash(char const (&_literal)[N])
+{
+	return compileTimeLiteralHash(_literal, N);
+}
+}
+
+bool BlockClassFinder::isExternal(YulString _identifier) const
+{
+	auto it = m_identifierMapping.find(_identifier);
+	yulAssert(it != m_identifierMapping.end(), "");
+	return (it->second & 1) == 0;
+}
+
+std::vector<BlockClass> BlockClassFinder::run(Block const& _block)
+{
+	GlobalState result;
+	BlockClassFinder blockClassFinder(result);
+	blockClassFinder(_block);
+	return std::move(result.blockClasses);
+}
+
+void BlockClassFinder::operator()(Literal const& _literal)
+{
+	hash(compileTimeLiteralHash("Literal"));
+	hash(_literal.value.hash());
+	hash(_literal.type.hash());
+	hash(static_cast<std::underlying_type_t<LiteralKind>>(_literal.kind));
+}
+
+void BlockClassFinder::operator()(Identifier const& _identifier)
+{
+	hash(compileTimeLiteralHash("Identifier"));
+	size_t id = 0;
+	auto it = m_identifierMapping.find(_identifier.name);
+	if (it == m_identifierMapping.end())
+	{
+		id = 2 * (m_externalIdentifierCount++);
+		m_identifierMapping[_identifier.name] = id;
+		m_externalIdentifiers.emplace_back(_identifier.name);
+	}
+	else
+		id = it->second;
+	if ((id & 1) == 0)
+	{
+		if (m_isAssignmentLHS)
+			m_externalAssignments.insert(_identifier.name);
+		else
+			m_externalReads.insert(_identifier.name);
+	}
+	hash(id);
+}
+
+void BlockClassFinder::operator()(FunctionalInstruction const& _instr)
+{
+	hash(compileTimeLiteralHash("FunctionalInstruction"));
+	hash(static_cast<std::underlying_type_t<eth::Instruction>>(_instr.instruction));
+	// Note that ASTWalker reverses the arguments.
+	walkVector(_instr.arguments);
+}
+
+void BlockClassFinder::operator()(FunctionCall const& _funCall)
+{
+	hash(compileTimeLiteralHash("FunctionCall"));
+	hash(_funCall.arguments.size());
+	hash(_funCall.functionName.name.hash());
+	// Note that ASTWalker reverses the arguments.
+	walkVector(_funCall.arguments);
+}
+
+void BlockClassFinder::operator()(ExpressionStatement const& _statement)
+{
+	hash(compileTimeLiteralHash("ExpressionStatement"));
+	ASTWalker::operator()(_statement);
+}
+
+void BlockClassFinder::operator()(Assignment const& _assignment)
+{
+	hash(compileTimeLiteralHash("Assignment"));
+	hash(_assignment.variableNames.size());
+	m_isAssignmentLHS = true;
+	for (auto const& name: _assignment.variableNames)
+		(*this)(name);
+	m_isAssignmentLHS = false;
+	visit(*_assignment.value);
+}
+
+void BlockClassFinder::operator()(VariableDeclaration const& _varDecl)
+{
+	hash(compileTimeLiteralHash("VariableDeclaration"));
+	hash(_varDecl.variables.size());
+	for (auto const& var: _varDecl.variables)
+	{
+		yulAssert(!m_identifierMapping.count(var.name), "");
+		m_identifierMapping[var.name] = 2 * m_internalIdentifierCount + 1;
+	}
+	ASTWalker::operator()(_varDecl);
+}
+
+void BlockClassFinder::operator()(If const& _if)
+{
+	hash(compileTimeLiteralHash("If"));
+	ASTWalker::operator()(_if);
+}
+
+void BlockClassFinder::operator()(Switch const& _switch)
+{
+	hash(compileTimeLiteralHash("Switch"));
+	hash(_switch.cases.size());
+	ASTWalker::operator()(_switch);
+}
+
+void BlockClassFinder::operator()(FunctionDefinition const& _funDef)
+{
+	hash(compileTimeLiteralHash("FunctionDefinition"));
+	m_functionName = _funDef.name;
+	ASTWalker::operator()(_funDef);
+}
+
+void BlockClassFinder::operator()(ForLoop const& _loop)
+{
+	hash(compileTimeLiteralHash("ForLoop"));
+	++m_loopDepth;
+	ASTWalker::operator()(_loop);
+	--m_loopDepth;
+}
+
+void BlockClassFinder::operator()(Break const& _break)
+{
+	hash(compileTimeLiteralHash("Break"));
+	if (!m_loopDepth)
+		m_hasFreeBreakOrContinue = true;
+	ASTWalker::operator()(_break);
+}
+
+void BlockClassFinder::operator()(Continue const& _continue)
+{
+	hash(compileTimeLiteralHash("Continue"));
+	if (!m_loopDepth)
+		m_hasFreeBreakOrContinue = true;
+	ASTWalker::operator()(_continue);
+}
+
+
+void BlockClassFinder::operator()(Block const& _block)
+{
+	hash(compileTimeLiteralHash("Block"));
+	hash(_block.statements.size());
+	if (_block.statements.empty())
+		return;
+
+	BlockClassFinder subBlockClassFinder(m_globalState);
+	for (auto const& statement: _block.statements)
+		subBlockClassFinder.visit(statement);
+
+	// propagate sub block contents
+	hash(subBlockClassFinder.m_hash);
+	for (auto const& externalIdentifier: subBlockClassFinder.m_externalIdentifiers)
+		(*this)(Identifier{{}, externalIdentifier});
+	for (auto const& externalAssignment: subBlockClassFinder.m_externalAssignments)
+		if (isExternal(externalAssignment))
+			m_externalAssignments.insert(externalAssignment);
+	for (auto const& externalAssignment: subBlockClassFinder.m_externalReads)
+		if (isExternal(externalAssignment))
+			m_externalReads.insert(externalAssignment);
+	if (!m_loopDepth && subBlockClassFinder.m_hasFreeBreakOrContinue)
+		m_hasFreeBreakOrContinue = true;
+
+	// look for existing block class
+	auto& candidateIDs = m_globalState.hashToBlockIDs[subBlockClassFinder.m_hash];
+	for (auto const& candidateID: candidateIDs)
+	{
+		auto const& candidate = m_globalState.block(candidateID);
+		if (subBlockClassFinder.m_externalIdentifiers.size() == candidate.externalReferences.size())
+		{
+			if (
+				SyntacticallyEqual{
+					subBlockClassFinder.m_externalIdentifiers,
+					candidate.externalReferences
+				}.statementEqual(_block, *candidate.block)
+			)
+			{
+				m_globalState.blockToClassID[&_block] = candidateID.blockClass;
+				m_globalState.blockClasses[candidateID.blockClass].members.emplace_back(BlockClassMember{
+					&_block,
+					std::move(subBlockClassFinder.m_externalIdentifiers),
+					std::move(subBlockClassFinder.m_externalAssignments),
+					std::move(subBlockClassFinder.m_externalReads)
+				});
+				if (!m_functionName.empty())
+				{
+					m_globalState.blockClasses[candidateID.blockClass].nameHint = m_functionName;
+					m_functionName = {};
+				}
+				return;
+			}
+		}
+	}
+
+	// create new block class
+	candidateIDs.emplace_back(GlobalState::BlockID{m_globalState.blockClasses.size(), 0});
+	m_globalState.blockToClassID[&_block] = m_globalState.blockClasses.size();
+	m_globalState.blockClasses.emplace_back(BlockClass{
+		make_vector<BlockClassMember>(std::forward_as_tuple(
+			&_block,
+			std::move(subBlockClassFinder.m_externalIdentifiers),
+			std::move(subBlockClassFinder.m_externalAssignments),
+			std::move(subBlockClassFinder.m_externalReads)
+		)),
+		m_functionName,
+		subBlockClassFinder.m_hasFreeBreakOrContinue
+	});
+	m_functionName = {};
+}

--- a/libyul/optimiser/BlockClassFinder.h
+++ b/libyul/optimiser/BlockClassFinder.h
@@ -1,0 +1,118 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that finds classes of equivalent blocks.
+ */
+#pragma once
+
+#include <libyul/optimiser/ASTWalker.h>
+#include <libyul/AsmDataForward.h>
+#include <libyul/YulString.h>
+#include <libyul/AsmData.h>
+
+namespace yul
+{
+
+struct BlockClassMember
+{
+	Block const* block = nullptr;
+	std::vector<YulString> externalReferences;
+	std::set<YulString> externalAssignments;
+	std::set<YulString> externalReads;
+};
+
+struct BlockClass
+{
+	std::vector<BlockClassMember> members;
+	YulString nameHint;
+	bool hasFreeBreakOrContinue = false;
+};
+
+/**
+ * Optimiser component that finds classes of equivalent blocks.
+ *
+ * Prerequisite: Disambiguator
+ *
+ * Works best after running the FunctionHoister and FunctionGrouper
+ */
+class BlockClassFinder: public ASTWalker
+{
+public:
+
+	using ASTWalker::operator();
+
+	void operator()(Literal const&) override;
+	void operator()(Identifier const&) override;
+	void operator()(FunctionalInstruction const& _instr) override;
+	void operator()(FunctionCall const& _funCall) override;
+	void operator()(ExpressionStatement const& _statement) override;
+	void operator()(Assignment const& _assignment) override;
+	void operator()(VariableDeclaration const& _varDecl) override;
+	void operator()(If const& _if) override;
+	void operator()(Switch const& _switch) override;
+	void operator()(FunctionDefinition const&) override;
+	void operator()(ForLoop const&) override;
+	void operator()(Break const&) override;
+	void operator()(Continue const&) override;
+	void operator()(Block const& _block) override;
+
+	static std::vector<BlockClass> run(Block const& _block);
+
+private:
+	struct GlobalState
+	{
+		struct BlockID
+		{
+			size_t blockClass = 0;
+			size_t indexInClass = 0;
+		};
+		std::map<uint64_t, std::vector<BlockID>> hashToBlockIDs;
+		std::map<Block const*, size_t> blockToClassID;
+		std::vector<BlockClass> blockClasses;
+		BlockClassMember const& block(BlockID const& id)
+		{
+			return blockClasses.at(id.blockClass).members.at(id.indexInClass);
+		}
+	};
+
+	BlockClassFinder(GlobalState& _globalState): m_globalState(_globalState) {}
+
+	void hash(uint64_t _value)
+	{
+		m_hash *= 1099511628211u;
+		m_hash ^= _value;
+	}
+
+	GlobalState& m_globalState;
+
+	bool isExternal(YulString _identifier) const;
+
+	uint64_t m_hash = 14695981039346656037u;
+	std::map<YulString, size_t> m_identifierMapping;
+	std::vector<YulString> m_externalIdentifiers;
+	std::set<YulString> m_externalAssignments;
+	std::set<YulString> m_externalReads;
+	size_t m_externalIdentifierCount = 0;
+	size_t m_internalIdentifierCount = 0;
+	bool m_isAssignmentLHS = false;
+	size_t m_loopDepth = 0;
+	bool m_hasFreeBreakOrContinue = false;
+	YulString m_functionName;
+};
+
+
+}

--- a/libyul/optimiser/BlockDeepener.cpp
+++ b/libyul/optimiser/BlockDeepener.cpp
@@ -1,0 +1,47 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <libyul/optimiser/BlockDeepener.h>
+#include <libyul/AsmData.h>
+#include <libdevcore/Visitor.h>
+#include <libdevcore/CommonData.h>
+#include <functional>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+
+void BlockDeepener::operator()(Block& _block)
+{
+	ASTModifier::operator()(_block);
+
+	if (_block.statements.size() <= 1)
+		return ;
+	std::vector<Statement> result;
+	std::vector<Statement> *current = &result;
+	for (std::size_t i = 0; i < _block.statements.size() - 1; ++i)
+	{
+		current->emplace_back(std::move(_block.statements[i]));
+		current->emplace_back(Block{
+			_block.location,
+			{}
+		});
+		current = &boost::get<Block>(current->back()).statements;
+	}
+	current->emplace_back(std::move(_block.statements.back()));
+
+	_block.statements = std::move(result);
+}

--- a/libyul/optimiser/BlockDeepener.h
+++ b/libyul/optimiser/BlockDeepener.h
@@ -1,0 +1,31 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <libyul/optimiser/ASTWalker.h>
+
+namespace yul
+{
+
+class BlockDeepener: public ASTModifier
+{
+public:
+	using ASTModifier::operator();
+	void operator()(Block& _block) override;
+};
+
+}

--- a/libyul/optimiser/BlockHasher.cpp
+++ b/libyul/optimiser/BlockHasher.cpp
@@ -1,0 +1,184 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that calculates hash values for block prefixes.
+ */
+
+#include <libyul/optimiser/BlockHasher.h>
+#include <libyul/optimiser/SyntacticalEquality.h>
+#include <libdevcore/CommonData.h>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+
+namespace {
+static constexpr uint64_t compileTimeLiteralHash(char const* _literal, size_t _N)
+{
+	return (_N == 0) ? 14695981039346656037u : compileTimeLiteralHash(_literal + 1, _N - 1) ^ 1099511628211u;
+}
+
+template<size_t N>
+static constexpr uint64_t compileTimeLiteralHash(char const (&_literal)[N])
+{
+	return compileTimeLiteralHash(_literal, N);
+}
+}
+
+BlockHasher::State BlockHasher::run(Block const& _block)
+{
+	BlockHasher::State result;
+	BlockHasher blockHasher(result);
+	blockHasher(_block);
+	return result;
+}
+
+void BlockHasher::operator()(Literal const& _literal)
+{
+	hash(compileTimeLiteralHash("Literal"));
+	hash(_literal.value.hash());
+	hash(_literal.type.hash());
+	hash(static_cast<uint8_t>(static_cast<std::underlying_type_t<LiteralKind>>(_literal.kind)));
+}
+
+void BlockHasher::operator()(Identifier const& _identifier)
+{
+	hash(compileTimeLiteralHash("Identifier"));
+	auto it = m_variableReferences.find(_identifier.name);
+	if (it == m_variableReferences.end())
+		it = m_variableReferences.emplace(_identifier.name, VariableReference {
+			m_externalIdentifierCount++,
+			true
+		}).first;
+
+	if (it->second.isExternal)
+		hash(compileTimeLiteralHash("external"));
+	else
+		hash(compileTimeLiteralHash("internal"));
+	hash(it->second.id);
+}
+
+void BlockHasher::operator()(FunctionalInstruction const& _instr)
+{
+	hash(compileTimeLiteralHash("FunctionalInstruction"));
+	hash(static_cast<std::underlying_type_t<eth::Instruction>>(_instr.instruction));
+	hash(_instr.arguments.size());
+	ASTWalker::operator()(_instr);
+}
+
+void BlockHasher::operator()(FunctionCall const& _funCall)
+{
+	hash(compileTimeLiteralHash("FunctionCall"));
+	hash(_funCall.arguments.size());
+	hash(_funCall.functionName.name.hash());
+	ASTWalker::operator()(_funCall);
+}
+
+void BlockHasher::operator()(ExpressionStatement const& _statement)
+{
+	hash(compileTimeLiteralHash("ExpressionStatement"));
+	ASTWalker::operator()(_statement);
+}
+
+void BlockHasher::operator()(Assignment const& _assignment)
+{
+	hash(compileTimeLiteralHash("Assignment"));
+	hash(_assignment.variableNames.size());
+	for (auto const& name: _assignment.variableNames)
+		(*this)(name);
+	visit(*_assignment.value);
+}
+
+void BlockHasher::operator()(VariableDeclaration const& _varDecl)
+{
+	hash(compileTimeLiteralHash("VariableDeclaration"));
+	hash(_varDecl.variables.size());
+	for (auto const& var: _varDecl.variables)
+	{
+		yulAssert(!m_variableReferences.count(var.name), "");
+		m_variableReferences[var.name] = VariableReference{
+			m_internalIdentifierCount++,
+			false
+		};
+	}
+	ASTWalker::operator()(_varDecl);
+}
+
+void BlockHasher::operator()(If const& _if)
+{
+	hash(compileTimeLiteralHash("If"));
+	ASTWalker::operator()(_if);
+}
+
+void BlockHasher::operator()(Switch const& _switch)
+{
+	hash(compileTimeLiteralHash("Switch"));
+	hash(_switch.cases.size());
+	ASTWalker::operator()(_switch);
+}
+
+void BlockHasher::operator()(FunctionDefinition const& _funDef)
+{
+	hash(compileTimeLiteralHash("FunctionDefinition"));
+	ASTWalker::operator()(_funDef);
+}
+
+void BlockHasher::operator()(ForLoop const& _loop)
+{
+	hash(compileTimeLiteralHash("ForLoop"));
+	ASTWalker::operator()(_loop);
+}
+
+void BlockHasher::operator()(Break const& _break)
+{
+	hash(compileTimeLiteralHash("Break"));
+	ASTWalker::operator()(_break);
+}
+
+void BlockHasher::operator()(Continue const& _continue)
+{
+	hash(compileTimeLiteralHash("Continue"));
+	ASTWalker::operator()(_continue);
+}
+
+
+void BlockHasher::operator()(Block const& _block)
+{
+	hash(compileTimeLiteralHash("Block"));
+	hash(_block.statements.size());
+	if (_block.statements.empty())
+		return;
+
+	BlockHasher subBlockPrefixHasher(m_state);
+	BlockPart blockPart { &_block, 0 };
+	for (auto const& statement: _block.statements)
+	{
+		subBlockPrefixHasher.visit(statement);
+		++blockPart.length;
+		m_state.blockPrefixHashes[blockPart] = subBlockPrefixHasher.m_hash;
+		m_state.hashClasses[subBlockPrefixHasher.m_hash].emplace_back(blockPart);
+	}
+	// propagate external references in subblock
+	hash(subBlockPrefixHasher.m_hash);
+	std::vector<YulString> externalReferences;
+	for (auto const& variableReference: subBlockPrefixHasher.m_variableReferences)
+		if (variableReference.second.isExternal)
+			externalReferences.emplace_back(variableReference.first);
+	hash(externalReferences.size());
+	for (auto& externalReference: externalReferences)
+		(*this)(Identifier{{}, externalReference});
+}

--- a/libyul/optimiser/BlockHasher.h
+++ b/libyul/optimiser/BlockHasher.h
@@ -1,0 +1,108 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that calculates hash values for block prefixes.
+ */
+#pragma once
+
+#include <libyul/optimiser/ASTWalker.h>
+#include <libyul/AsmDataForward.h>
+#include <libyul/YulString.h>
+#include <libyul/AsmData.h>
+
+namespace yul
+{
+
+struct BlockPart {
+	Block const* block;
+	size_t length;
+	bool operator<(BlockPart const& _rhs) const
+	{
+		return std::make_tuple(_rhs.length, _rhs.block) < std::make_tuple(length, block);
+	}
+};
+
+/**
+ * Optimiser component that calculates hash values for block prefixes.
+ *
+ * Prerequisite: Disambiguator
+ */
+class BlockHasher: public ASTWalker
+{
+public:
+	struct State {
+		std::map<BlockPart, uint64_t> blockPrefixHashes;
+		std::map<uint64_t, std::vector<BlockPart>> hashClasses;
+	};
+
+	using ASTWalker::operator();
+
+	void operator()(Literal const&) override;
+	void operator()(Identifier const&) override;
+	void operator()(FunctionalInstruction const& _instr) override;
+	void operator()(FunctionCall const& _funCall) override;
+	void operator()(ExpressionStatement const& _statement) override;
+	void operator()(Assignment const& _assignment) override;
+	void operator()(VariableDeclaration const& _varDecl) override;
+	void operator()(If const& _if) override;
+	void operator()(Switch const& _switch) override;
+	void operator()(FunctionDefinition const&) override;
+	void operator()(ForLoop const&) override;
+	void operator()(Break const&) override;
+	void operator()(Continue const&) override;
+	void operator()(Block const& _block) override;
+
+	static State run(Block const& _block);
+
+private:
+	State& m_state;
+
+	BlockHasher(State& _state): m_state(_state) {}
+
+	void hash(uint8_t _value)
+	{
+		m_hash *= 1099511628211u;
+		m_hash ^= _value;
+	}
+	void hash(uint16_t _value)
+	{
+		hash(static_cast<uint8_t>(_value & 0xFF));
+		hash(static_cast<uint8_t>(_value >> 8));
+	}
+	void hash(uint32_t _value)
+	{
+		hash(static_cast<uint8_t>(_value & 0xFFFF));
+		hash(static_cast<uint8_t>(_value >> 16));
+	}
+	void hash(uint64_t _value)
+	{
+		hash(static_cast<uint8_t>(_value & 0xFFFFFFFF));
+		hash(static_cast<uint8_t>(_value >> 32));
+	}
+
+	uint64_t m_hash = 14695981039346656037u;
+	struct VariableReference {
+		size_t id = 0;
+		bool isExternal = false;
+	};
+	std::map<YulString, VariableReference> m_variableReferences;
+	size_t m_externalIdentifierCount = 0;
+	size_t m_internalIdentifierCount = 0;
+};
+
+
+}

--- a/libyul/optimiser/BlockOutliner.cpp
+++ b/libyul/optimiser/BlockOutliner.cpp
@@ -1,0 +1,175 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that outlines blocks that occur multiple times.
+ */
+
+#include <libyul/optimiser/BlockOutliner.h>
+#include <libyul/optimiser/ASTCopier.h>
+#include <libyul/optimiser/Metrics.h>
+#include <libyul/AsmData.h>
+#include <libdevcore/CommonData.h>
+#include <libyul/AsmPrinter.h>
+#include <libdevcore/AnsiColorized.h>
+#include <libdevcore/StringUtils.h>
+
+using namespace std;
+using namespace dev;
+using namespace yul;
+
+bool BlockOutliner::shallOutline(BlockClass const& _blockClass)
+{
+	if (_blockClass.hasFreeBreakOrContinue)
+		return false;
+	if (_blockClass.members.size() < 2)
+		return false;
+	// outline everything for now for testing
+	// TODO: find good heuristics
+	return true;
+	/*
+	auto codeSize = CodeSize::codeSize(*_blockClass.members.front().block);
+	auto const& representative = _blockClass.members.front();
+	if (representative.externalAssignments.size() > 5)
+		return false;
+	if (representative.externalReads.size() > 5)
+		return false;
+	if (representative.externalAssignments.size() > 4)
+		return codeSize >= 15;
+	if (representative.externalReads.size() > 4)
+		return codeSize >= 15;
+	return codeSize >= 7;
+	 */
+}
+
+void BlockOutliner::run(Block& _ast, NameDispenser& _nameDispenser)
+{
+	std::vector<BlockClass> blockClasses = BlockClassFinder::run(_ast);
+	std::map<Block const*, Statement> blockToFunctionCall;
+	std::vector<pair<BlockClass const*, YulString>> outlinedBlockClasses;
+
+	for (auto const& blockClass: blockClasses)
+	{
+		if (!shallOutline(blockClass))
+			continue;
+
+		YulString nameHint = blockClass.nameHint;
+		if (nameHint.empty())
+			nameHint = YulString(
+				"outlined$" +
+				to_string(blockClass.members.front().block->location.start) +
+				"$"
+			);
+		outlinedBlockClasses.emplace_back(&blockClass, _nameDispenser.newName(nameHint));
+
+		// generate a function call for each block in the class
+		for (auto const& block: blockClass.members)
+		{
+			auto loc = block.block->location;
+			vector<Expression> arguments;
+			vector<Identifier> identifiers;
+			for (auto const& name: block.externalReferences)
+			{
+				if (block.externalAssignments.count(name))
+					identifiers.emplace_back(Identifier{loc, name});
+				if (block.externalReads.count(name))
+					arguments.emplace_back(Identifier{loc, name});
+			}
+			FunctionCall call{
+				loc,
+				Identifier{loc, outlinedBlockClasses.back().second},
+				std::move(arguments)
+			};
+			if (identifiers.empty())
+				blockToFunctionCall[block.block] = ExpressionStatement{loc, move(call)};
+			else
+				blockToFunctionCall[block.block] = Assignment{
+					loc, move(identifiers), make_unique<Expression>(move(call))
+				};
+		}
+	}
+
+	if (!outlinedBlockClasses.empty())
+	{
+		BlockOutliner outliner{std::move(blockToFunctionCall), _nameDispenser};
+		Block astCopy = boost::get<Block>(outliner(_ast));
+		for (auto const& outline: outlinedBlockClasses)
+			astCopy.statements.emplace_back(
+				outliner.blockClassToFunction(*outline.first, outline.second)
+			);
+		_ast = std::move(astCopy);
+	}
+}
+
+Block BlockOutliner::translate(Block const& _block)
+{
+	auto it = m_blockOutlines.find(&_block);
+	if (it != m_blockOutlines.end())
+		return Block {
+			_block.location,
+			make_vector<Statement>(std::move(it->second))
+		};
+	return ASTCopier::translate(_block);
+}
+
+FunctionDefinition BlockOutliner::blockClassToFunction(
+	BlockClass const& _blockClass,
+	YulString _functionName
+)
+{
+	yulAssert(!_blockClass.members.empty(), "");
+	Block const& _block = *_blockClass.members.front().block;
+	Block body{_block.location, translateVector(_block.statements)};
+
+	TypedNameList parameters;
+	TypedNameList returnVariables;
+	for (auto const& name: _blockClass.members.front().externalReferences)
+	{
+		bool isRead = _blockClass.members.front().externalReads.count(name);
+		bool isWritten = _blockClass.members.front().externalAssignments.count(name);
+		if (isRead)
+			parameters.emplace_back(TypedName{_block.location, name, {}});
+		if (isWritten)
+		{
+			if (!isRead)
+				returnVariables.emplace_back(TypedName{
+					_block.location,
+					name,
+					{}
+				});
+			else
+			{
+				returnVariables.emplace_back(TypedName{
+					_block.location,
+					m_nameDispenser.newName(name),
+					{}
+				});
+				body.statements.emplace_back(Assignment{
+					_block.location,
+					{Identifier{_block.location, returnVariables.back().name}},
+					make_unique<Expression>(Identifier{_block.location, name})
+				});
+			}
+		}
+	}
+	return FunctionDefinition{
+		_block.location,
+		_functionName,
+		move(parameters),
+		move(returnVariables),
+		move(body)
+	};
+}

--- a/libyul/optimiser/BlockOutliner.h
+++ b/libyul/optimiser/BlockOutliner.h
@@ -1,0 +1,62 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Optimiser component that outlines blocks that occur multiple times.
+ */
+#pragma once
+
+#include <libyul/optimiser/ASTCopier.h>
+#include <libyul/optimiser/BlockClassFinder.h>
+#include <libyul/optimiser/NameDispenser.h>
+#include <libyul/AsmDataForward.h>
+#include <map>
+
+namespace yul
+{
+
+/**
+ * Optimiser component that outlines blocks that occur multiple times.
+ *
+ * Prerequisite: Disambiguator, FunctionHoister and FunctionGrouper
+ *
+ */
+class BlockOutliner: public ASTCopier
+{
+public:
+	static void run(Block& _block, NameDispenser& _nameDispenser);
+
+protected:
+	Block translate(Block const& _block) override;
+
+private:
+	BlockOutliner(std::map<Block const*, Statement> _outlines, NameDispenser& _nameDispenser)
+	: m_nameDispenser(_nameDispenser), m_blockOutlines(std::move(_outlines)) {}
+
+	static bool shallOutline(BlockClass const& _blockClass);
+
+	FunctionDefinition blockClassToFunction(
+		BlockClass const& _blockClass,
+		YulString _functionName
+	);
+
+
+	NameDispenser& m_nameDispenser;
+	std::map<Block const*, Statement> m_blockOutlines;
+};
+
+
+}

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -30,6 +30,20 @@ using namespace std;
 using namespace dev;
 using namespace yul;
 
+SyntacticallyEqual::SyntacticallyEqual(
+	vector<YulString> const& _lhsInit,
+	vector<YulString> const& _rhsInit
+)
+{
+	yulAssert(_lhsInit.size() == _rhsInit.size(), "");
+	for (size_t i = 0; i < _lhsInit.size(); ++i)
+	{
+		m_identifiersLHS[_lhsInit[i]] = i;
+		m_identifiersRHS[_rhsInit[i]] = i;
+	}
+	m_idsUsed = _lhsInit.size();
+}
+
 bool SyntacticallyEqual::operator()(Expression const& _lhs, Expression const& _rhs)
 {
 	return boost::apply_visitor([this](auto&& _lhsExpr, auto&& _rhsExpr) -> bool {

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -39,6 +39,9 @@ namespace yul
 class SyntacticallyEqual
 {
 public:
+	SyntacticallyEqual() = default;
+	SyntacticallyEqual(std::vector<YulString> const& _lhsInit, std::vector<YulString> const& _rhsInit);
+
 	bool operator()(Expression const& _lhs, Expression const& _rhs);
 	bool operator()(Statement const& _lhs, Statement const& _rhs);
 

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -20,6 +20,7 @@
 #include <test/Options.h>
 
 #include <libyul/optimiser/BlockFlattener.h>
+#include <libyul/optimiser/BlockOutliner.h>
 #include <libyul/optimiser/VarDeclInitializer.h>
 #include <libyul/optimiser/VarNameCleaner.h>
 #include <libyul/optimiser/ControlFlowSimplifier.h>
@@ -115,6 +116,13 @@ TestCase::TestResult YulOptimizerTest::run(ostream& _stream, string const& _line
 	{
 		disambiguate();
 		BlockFlattener{}(*m_ast);
+	}
+	else if (m_optimizerStep == "blockOutliner")
+	{
+		disambiguate();
+		(FunctionHoister{})(*m_ast);
+		NameDispenser nameDispenser{*m_dialect, *m_ast};
+		BlockOutliner::run(*m_ast, nameDispenser);
 	}
 	else if (m_optimizerStep == "varDeclInitializer")
 		VarDeclInitializer{}(*m_ast);

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -19,6 +19,7 @@
 
 #include <test/Options.h>
 
+#include <libyul/optimiser/BlockDeepener.h>
 #include <libyul/optimiser/BlockFlattener.h>
 #include <libyul/optimiser/BlockOutliner.h>
 #include <libyul/optimiser/VarDeclInitializer.h>
@@ -112,6 +113,11 @@ TestCase::TestResult YulOptimizerTest::run(ostream& _stream, string const& _line
 
 	if (m_optimizerStep == "disambiguator")
 		disambiguate();
+	else if (m_optimizerStep == "blockDeepener")
+	{
+		disambiguate();
+		BlockDeepener{}(*m_ast);
+	}
 	else if (m_optimizerStep == "blockFlattener")
 	{
 		disambiguate();

--- a/test/libyul/yulOptimizerTests/blockDeepener/basic.yul
+++ b/test/libyul/yulOptimizerTests/blockDeepener/basic.yul
@@ -1,0 +1,27 @@
+{
+    let _1 := mload(0)
+    let f_a := mload(1)
+    let f_r
+    f_a := mload(f_a)
+    f_r := add(f_a, calldatasize())
+    let z := mload(2)
+}
+// ====
+// step: blockDeepener
+// ----
+// {
+//     let _1 := mload(0)
+//     {
+//         let f_a := mload(1)
+//         {
+//             let f_r
+//             {
+//                 f_a := mload(f_a)
+//                 {
+//                     f_r := add(f_a, calldatasize())
+//                     { let z := mload(2) }
+//                 }
+//             }
+//         }
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/blockDeepener/for_stmt.yul
+++ b/test/libyul/yulOptimizerTests/blockDeepener/for_stmt.yul
@@ -1,0 +1,14 @@
+{
+    for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) }
+    { a := add(a, 1) a := add(a,1) }
+}
+// ====
+// step: blockDeepener
+// ----
+// {
+//     for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) }
+//     {
+//         a := add(a, 1)
+//         { a := add(a, 1) }
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/blockDeepener/if_stmt.yul
+++ b/test/libyul/yulOptimizerTests/blockDeepener/if_stmt.yul
@@ -1,0 +1,19 @@
+{
+    if add(mload(7), sload(mload(3)))
+    {
+        let y := add(mload(3), 3)
+        y := add(y, 7)
+    }
+    let t := add(3, 9)
+}
+// ====
+// step: blockDeepener
+// ----
+// {
+//     if add(mload(7), sload(mload(3)))
+//     {
+//         let y := add(mload(3), 3)
+//         { y := add(y, 7) }
+//     }
+//     { let t := add(3, 9) }
+// }

--- a/test/libyul/yulOptimizerTests/blockDeepener/many_nested_blocks.yul
+++ b/test/libyul/yulOptimizerTests/blockDeepener/many_nested_blocks.yul
@@ -1,0 +1,35 @@
+{
+    let a := 3
+    let b := 4
+    a := add(b, 3)
+    let c := 5
+    b := add(b, 4)
+    c := add(a, 5)
+    b := add(a, b)
+    a := add(a, c)
+}
+// ====
+// step: blockDeepener
+// ----
+// {
+//     let a := 3
+//     {
+//         let b := 4
+//         {
+//             a := add(b, 3)
+//             {
+//                 let c := 5
+//                 {
+//                     b := add(b, 4)
+//                     {
+//                         c := add(a, 5)
+//                         {
+//                             b := add(a, b)
+//                             { a := add(a, c) }
+//                         }
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/blockDeepener/switch_stmt.yul
+++ b/test/libyul/yulOptimizerTests/blockDeepener/switch_stmt.yul
@@ -1,0 +1,31 @@
+{
+    let a := 1
+    switch calldataload(0)
+    case 0 {
+        mstore(0, 1)
+        a := 8
+    }
+    default {
+        a := 3
+        a := 4
+    }
+    a := 5
+}
+// ====
+// step: blockDeepener
+// ----
+// {
+//     let a := 1
+//     {
+//         switch calldataload(0)
+//         case 0 {
+//             mstore(0, 1)
+//             { a := 8 }
+//         }
+//         default {
+//             a := 3
+//             { a := 4 }
+//         }
+//         { a := 5 }
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/blockOutliner/basic.yul
+++ b/test/libyul/yulOptimizerTests/blockOutliner/basic.yul
@@ -1,0 +1,91 @@
+{
+	{
+		let a let b let c let d
+		{
+			a := mul(c,b)
+			if lt(a,c) {
+				a := add(a,c)
+			}
+		}
+		{
+			if eq(1,2) {
+				d := mul(a,b)
+				if lt(d,a) {
+					d := add(d,a)
+				}
+			}
+			{
+				d := add(d,a)
+			}
+		}
+		{
+			c := mul(a,b)
+			if lt(c,a) {
+				c := add(c,a)
+			}
+		}
+	}
+	function f(a, b) -> r {
+	    {
+			r := mul(a,b)
+			if lt(r, a) {
+			    r := add(r,a)
+			}
+		}
+		function g(x, y) -> z {
+		    z := mul(x,y)
+			if lt(z,x) {
+			    z := add(z,x)
+			}
+		}
+		r := g(b,a)
+	}
+	function h(a) -> r {
+		{
+		    r := add(r,a)
+		}
+		{
+		    r := add(r,a)
+		}
+	}
+}
+// ====
+// step: blockOutliner
+// ----
+// {
+//     {
+//         let a
+//         let b
+//         let c
+//         let d
+//         { a := g_1(a, c, b) }
+//         {
+//             if eq(1, 2) { d := g_1(d, a, b) }
+//             { d := outlined$66$(d, a) }
+//         }
+//         { c := g_1(c, a, b) }
+//     }
+//     function g(x, y) -> z
+//     { z := g_1(z, x, y) }
+//     function f(a_1, b_2) -> r
+//     {
+//         { r := g_1(r, a_1, b_2) }
+//         r := g(b_2, a_1)
+//     }
+//     function h(a_3) -> r_4
+//     {
+//         { r_4 := outlined$66$(r_4, a_3) }
+//         { r_4 := outlined$66$(r_4, a_3) }
+//     }
+//     function outlined$66$(a, c) -> a_2
+//     {
+//         a := add(a, c)
+//         a_2 := a
+//     }
+//     function g_1(a, c, b) -> a_4
+//     {
+//         a := mul(c, b)
+//         if lt(a, c) { a := outlined$66$(a, c) }
+//         a_4 := a
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/blockOutliner/break_continue.yul
+++ b/test/libyul/yulOptimizerTests/blockOutliner/break_continue.yul
@@ -1,0 +1,75 @@
+{
+    let a := 1
+    let b := 2
+    let c := 3
+	{
+		for {} 1 {} {
+			{ a := mul(b,c) }
+			if gt(a,b) { break }
+		}
+	}
+	{
+		for {} 1 {} {
+			{ a := mul(b,c) }
+			if gt(a,b) { break }
+		}
+	}
+	{
+		for {} 1 {} {
+			{ a := mul(b,c) }
+			if gt(a,b) { break }
+		}
+	}
+	{
+		for {} 1 {} {
+			{ a := mul(b,c) }
+			if gt(a,b) { continue }
+		}
+	}
+	{
+		for {} 1 {} {
+			{ a := mul(b,c) }
+			if gt(a,b) { continue }
+		}
+	}
+	{
+		for {} 1 {} {
+			{ a := mul(b,c) }
+			if gt(a,b) { continue }
+		}
+	}
+}
+// ====
+// step: blockOutliner
+// ----
+// {
+//     let a := 1
+//     let b := 2
+//     let c := 3
+//     { a := outlined$48$(a, b, c) }
+//     { a := outlined$48$(a, b, c) }
+//     { a := outlined$48$(a, b, c) }
+//     { a := outlined$261$(a, b, c) }
+//     { a := outlined$261$(a, b, c) }
+//     { a := outlined$261$(a, b, c) }
+//     function outlined$69$(b, c) -> a
+//     { a := mul(b, c) }
+//     function outlined$48$(a, b, c) -> a_1
+//     {
+//         for { } 1 { }
+//         {
+//             { a := outlined$69$(b, c) }
+//             if gt(a, b) { break }
+//         }
+//         a_1 := a
+//     }
+//     function outlined$261$(a, b, c) -> a_2
+//     {
+//         for { } 1 { }
+//         {
+//             { a := outlined$69$(b, c) }
+//             if gt(a, b) { continue }
+//         }
+//         a_2 := a
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/blockOutliner/nested.yul
+++ b/test/libyul/yulOptimizerTests/blockOutliner/nested.yul
@@ -1,0 +1,20 @@
+{
+  {
+    function f() -> x { x := 1 }
+    { mstore(f(), 2) }
+    { mstore(f(), 2) }
+  }
+}
+// ====
+// step: blockOutliner
+// ----
+// {
+//     {
+//         { outlined$43$() }
+//         { outlined$43$() }
+//     }
+//     function f() -> x
+//     { x := 1 }
+//     function outlined$43$()
+//     { mstore(f(), 2) }
+// }

--- a/test/libyul/yulOptimizerTests/blockOutliner/nested_inner.yul
+++ b/test/libyul/yulOptimizerTests/blockOutliner/nested_inner.yul
@@ -1,0 +1,22 @@
+{
+  {
+    function f() -> x { x := 1 }
+    { { mstore(f(), 2) } }
+    { { mstore(f(), 2) } }
+  }
+}
+// ====
+// step: blockOutliner
+// ----
+// {
+//     {
+//         { outlined$43$() }
+//         { outlined$43$() }
+//     }
+//     function f() -> x
+//     { x := 1 }
+//     function outlined$45$()
+//     { mstore(f(), 2) }
+//     function outlined$43$()
+//     { { outlined$45$() } }
+// }

--- a/test/libyul/yulOptimizerTests/blockOutliner/only_assign.yul
+++ b/test/libyul/yulOptimizerTests/blockOutliner/only_assign.yul
@@ -1,0 +1,27 @@
+{
+    let a
+    let b
+    let c
+    {
+        a := mul(b,c)
+    }
+    {
+        b := mul(c,a)
+    }
+    {
+        c := mul(a,b)
+    }
+}
+// ====
+// step: blockOutliner
+// ----
+// {
+//     let a
+//     let b
+//     let c
+//     { a := outlined$36$(b, c) }
+//     { b := outlined$36$(c, a) }
+//     { c := outlined$36$(a, b) }
+//     function outlined$36$(b, c) -> a
+//     { a := mul(b, c) }
+// }


### PR DESCRIPTION
Draft for #6713.
Needs some cleanup and should probably use less vectors of pairs of vectors and such, but it already seems to work quite well.
It'll probably be able to supersede the ``EquivalentFunctionCombiner`` in the end.

The main things that are missing conceptually are:
 - [ ] Define some heuristics to decide when to outline blocks.
 - [x] Distinguish between arguments and return values for the outlined functions instead of passing everything in and out - although that might be done in a separate component as well.

The whole AST is copied with this PR - we can consider whether trying to move/modify could work, but I tend to think it's not worth the effort.
Also missing:
 - [ ] yulopti support
 - [ ] integration into full suite (depends on solving the main issues above)
 - [ ] the actual hashing should still be tuned and the performance should be evaluated