### PR TITLE
GCC 9.1 build fix. error: redundant move in return statement

### DIFF
--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -437,7 +437,7 @@ boost::variant<OptimiserSettings, Json::Value> parseOptimizerSettings(Json::Valu
 				return *error;
 		}
 	}
-	return std::move(settings);
+	return { std::move(settings) };
 }
 
 }
@@ -663,7 +663,7 @@ boost::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompile
 
 	ret.outputSelection = std::move(outputSelection);
 
-	return std::move(ret);
+	return { std::move(ret) };
 }
 
 Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inputsAndSettings)

--- a/libyul/backends/wasm/EWasmCodeTransform.cpp
+++ b/libyul/backends/wasm/EWasmCodeTransform.cpp
@@ -63,7 +63,7 @@ wasm::Expression EWasmCodeTransform::generateMultiAssignment(
 	wasm::LocalAssignment assignment{move(_variableNames.front()), std::move(_firstValue)};
 
 	if (_variableNames.size() == 1)
-		return move(assignment);
+		return { std::move(assignment) };
 
 	wasm::Block block;
 	block.statements.emplace_back(move(assignment));
@@ -72,7 +72,7 @@ wasm::Expression EWasmCodeTransform::generateMultiAssignment(
 			move(_variableNames.at(i)),
 			make_unique<wasm::Expression>(wasm::GlobalVariable{m_globalVariables.at(i - 1).variableName})
 		});
-	return move(block);
+	return { std::move(block) };
 }
 
 wasm::Expression EWasmCodeTransform::operator()(VariableDeclaration const& _varDecl)
@@ -192,7 +192,7 @@ wasm::Expression EWasmCodeTransform::operator()(Switch const& _switch)
 			*currentBlock += visit(c.body.statements);
 		}
 	}
-	return move(block);
+	return { std::move(block) };
 }
 
 wasm::Expression EWasmCodeTransform::operator()(FunctionDefinition const&)
@@ -224,7 +224,7 @@ wasm::Expression EWasmCodeTransform::operator()(ForLoop const& _for)
 
 	wasm::Block breakBlock{breakLabel, {}};
 	breakBlock.statements.emplace_back(move(loop));
-	return move(breakBlock);
+	return { std::move(breakBlock) };
 }
 
 wasm::Expression EWasmCodeTransform::operator()(Break const&)

--- a/libyul/optimiser/ForLoopInitRewriter.cpp
+++ b/libyul/optimiser/ForLoopInitRewriter.cpp
@@ -38,7 +38,7 @@ void ForLoopInitRewriter::operator()(Block& _block)
 				vector<Statement> rewrite;
 				swap(rewrite, forLoop.pre.statements);
 				rewrite.emplace_back(move(forLoop));
-				return std::move(rewrite);
+				return { std::move(rewrite) };
 			}
 			else
 			{

--- a/libyul/optimiser/SSATransform.cpp
+++ b/libyul/optimiser/SSATransform.cpp
@@ -106,7 +106,7 @@ void SSATransform::operator()(Block& _block)
 					});
 				}
 				boost::get<VariableDeclaration>(statements.front()).variables = std::move(newVariables);
-				return std::move(statements);
+				return { std::move(statements) };
 			}
 			else if (_s.type() == typeid(Assignment))
 			{
@@ -133,7 +133,7 @@ void SSATransform::operator()(Block& _block)
 					});
 				}
 				boost::get<VariableDeclaration>(statements.front()).variables = std::move(newVariables);
-				return std::move(statements);
+				return { std::move(statements) };
 			}
 			else
 				visit(_s);


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

Fix new default warning in GCC 9.1 `-Werror=redundant-move`

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages