### PR TITLE
Add optimizer rules for multiplication and division by left-shifted one.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Compiler Features:
  * SMTChecker: Inline external function calls to ``this``.
  * Assembler: Encode the compiler version in the deployed bytecode.
  * Yul Optimizer: Simplify single-run ``for`` loops to ``if`` statements.
+ * Optimizer: Add rules for multiplication and division by left-shifted one.
 
 
 Bugfixes:

--- a/libevmasm/RuleList.h
+++ b/libevmasm/RuleList.h
@@ -391,6 +391,31 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 		false
 	});
 
+	rules.push_back({
+		// MUL(X, SHL(Y, 1)) -> SHL(Y, X)
+		{Instruction::MUL, {X, {Instruction::SHL, {Y, u256(1)}}}},
+		[=]() -> Pattern {
+			return {Instruction::SHL, {Y, X}};
+		},
+		false
+	});
+	rules.push_back({
+		// MUL(SHL(X, 1), Y) -> SHL(X, Y)
+		{Instruction::MUL, {{Instruction::SHL, {X, u256(1)}}, Y}},
+		[=]() -> Pattern {
+			return {Instruction::SHL, {X, Y}};
+		},
+		false
+	});
+
+	rules.push_back({
+		// DIV(X, SHL(Y, 1)) -> SHR(Y, X)
+		{Instruction::DIV, {X, {Instruction::SHL, {Y, u256(1)}}}},
+		[=]() -> Pattern {
+			return {Instruction::SHR, {Y, X}};
+		},
+		false
+	});
 
 	std::function<bool()> feasibilityFunction = [=]() {
 		if (B.d() > 256)


### PR DESCRIPTION
@leonardoalt I would expect these to be easy to verify by SMT?