### PR TITLE
[SMTChecker] Fix ICE in unsupported function calls with multi return values

### DIFF
--- a/libsolidity/formal/SMTChecker.cpp
+++ b/libsolidity/formal/SMTChecker.cpp
@@ -335,7 +335,9 @@ void SMTChecker::endVisit(VariableDeclarationStatement const& _varDecl)
 			solAssert(symbTuple, "");
 			auto const& components = symbTuple->components();
 			auto const& declarations = _varDecl.declarations();
-			if (components.size() == declarations.size())
+			if (!components.empty())
+			{
+				solAssert(components.size() == declarations.size(), "");
 				for (unsigned i = 0; i < declarations.size(); ++i)
 					if (
 						components.at(i) &&
@@ -343,6 +345,7 @@ void SMTChecker::endVisit(VariableDeclarationStatement const& _varDecl)
 						m_context.knownVariable(*declarations.at(i))
 					)
 						assignment(*declarations.at(i), components.at(i)->currentValue(), declarations.at(i)->location());
+			}
 		}
 	}
 	else if (m_context.knownVariable(*_varDecl.declarations().front()))
@@ -633,6 +636,7 @@ void SMTChecker::endVisit(BinaryOperation const& _op)
 void SMTChecker::endVisit(FunctionCall const& _funCall)
 {
 	solAssert(_funCall.annotation().kind != FunctionCallKind::Unset, "");
+	createExpr(_funCall);
 	if (_funCall.annotation().kind == FunctionCallKind::StructConstructorCall)
 	{
 		m_errorReporter.warning(
@@ -694,7 +698,6 @@ void SMTChecker::endVisit(FunctionCall const& _funCall)
 		checkCondition(thisBalance < expr(*value), _funCall.location(), "Insufficient funds", "address(this).balance", &thisBalance);
 
 		m_context.transfer(m_context.thisAddress(), expr(address), expr(*value));
-		createExpr(_funCall);
 		break;
 	}
 	default:
@@ -741,14 +744,8 @@ void SMTChecker::visitGasLeft(FunctionCall const& _funCall)
 void SMTChecker::inlineFunctionCall(FunctionCall const& _funCall)
 {
 	FunctionDefinition const* funDef = inlinedFunctionCallToDefinition(_funCall);
-	if (!funDef)
-	{
-		m_errorReporter.warning(
-			_funCall.location(),
-			"Assertion checker does not yet implement this type of function call."
-		);
-	}
-	else if (visitedFunction(funDef))
+	solAssert(funDef, "");
+	if (visitedFunction(funDef))
 		m_errorReporter.warning(
 			_funCall.location(),
 			"Assertion checker does not support recursive function calls.",
@@ -779,7 +776,6 @@ void SMTChecker::inlineFunctionCall(FunctionCall const& _funCall)
 		// The callstack entry is popped only in endVisit(FunctionDefinition) instead of here
 		// as well to avoid code duplication (not all entries are from inlined function calls).
 
-		createExpr(_funCall);
 		auto const& returnParams = funDef->returnParameters();
 		if (returnParams.size() > 1)
 		{
@@ -866,7 +862,6 @@ void SMTChecker::visitTypeConversion(FunctionCall const& _funCall)
 		defineExpr(_funCall, expr(*argument));
 	else
 	{
-		createExpr(_funCall);
 		m_context.setUnknownValue(*m_context.expression(_funCall));
 		auto const& funCallCategory = _funCall.annotation().type->category();
 		// TODO: truncating and bytesX needs a different approach because of right padding.
@@ -1365,10 +1360,13 @@ void SMTChecker::assignment(
 	else if (auto tuple = dynamic_cast<TupleExpression const*>(&_left))
 	{
 		auto const& components = tuple->components();
-		solAssert(_right.size() == components.size(), "");
-		for (unsigned i = 0; i < _right.size(); ++i)
-			if (auto component = components.at(i))
-				assignment(*component, {_right.at(i)}, component->annotation().type, component->location());
+		if (!_right.empty())
+		{
+			solAssert(_right.size() == components.size(), "");
+			for (unsigned i = 0; i < _right.size(); ++i)
+				if (auto component = components.at(i))
+					assignment(*component, {_right.at(i)}, component->annotation().type, component->location());
+		}
 	}
 	else
 		m_errorReporter.warning(

--- a/test/libsolidity/smtCheckerTests/complex/MerkleProof.sol
+++ b/test/libsolidity/smtCheckerTests/complex/MerkleProof.sol
@@ -36,8 +36,6 @@ library MerkleProof {
 // ----
 // Warning: (755-767): Assertion checker does not yet support this expression.
 // Warning: (988-1032): Assertion checker does not yet implement this type of function call.
-// Warning: (988-1032): Internal error: Expression undefined for SMT solver.
 // Warning: (1175-1219): Assertion checker does not yet implement this type of function call.
-// Warning: (1175-1219): Internal error: Expression undefined for SMT solver.
 // Warning: (755-767): Assertion checker does not yet support this expression.
 // Warning: (769-772): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
+++ b/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
@@ -83,12 +83,10 @@ contract InternalCall {
 // Warning: (1144-1206): Function state mutability can be restricted to pure
 // Warning: (1212-1274): Function state mutability can be restricted to pure
 // Warning: (1280-1342): Function state mutability can be restricted to pure
-// Warning: (714-749): Internal error: Expression undefined for SMT solver.
 // Warning: (799-811): Assertion checker does not yet support the type of this literal (literal_string "helloTwo()").
 // Warning: (782-813): Type conversion is not yet fully supported and might yield false positives.
 // Warning: (771-814): Assertion checker does not yet implement this type of function call.
 // Warning: (825-830): Assertion checker does not yet support the type of this variable.
-// Warning: (887-919): Internal error: Expression undefined for SMT solver.
 // Warning: (690-750): Underflow (resulting value less than 0) happens here
 // Warning: (690-750): Overflow (resulting value larger than 2**160 - 1) happens here
 // Warning: (1057-1068): Assertion checker does not yet implement type function () returns (uint256)

--- a/test/libsolidity/smtCheckerTests/complex/warn_on_struct.sol
+++ b/test/libsolidity/smtCheckerTests/complex/warn_on_struct.sol
@@ -9,6 +9,5 @@ contract C {
 // ----
 // Warning: (133-143): Unused local variable.
 // Warning: (133-143): Assertion checker does not yet support the type of this variable.
-// Warning: (146-163): Assertion checker does not yet implement this expression.
-// Warning: (146-163): Internal error: Expression undefined for SMT solver.
 // Warning: (146-163): Assertion checker does not yet implement this type.
+// Warning: (146-163): Assertion checker does not yet implement this expression.

--- a/test/libsolidity/smtCheckerTests/functions/abi_encode_functions.sol
+++ b/test/libsolidity/smtCheckerTests/functions/abi_encode_functions.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;pragma experimental ABIEncoderV2;
+contract C {
+    function f() public pure returns (bytes memory, bytes memory) {
+        return (abi.encode(""), abi.encodePacked( "7?8r"));
+    }
+}
+// ----
+// Warning: (31-64): Experimental features are turned on. Do not use experimental features on live deployments.
+// Warning: (173-175): Assertion checker does not yet support the type of this literal (literal_string "").
+// Warning: (162-176): Assertion checker does not yet implement this type of function call.
+// Warning: (196-202): Assertion checker does not yet support the type of this literal (literal_string "7?8r").
+// Warning: (178-203): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/functions/functions_external_4.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_external_4.sol
@@ -16,5 +16,4 @@ contract D
 	}
 }
 // ----
-// Warning: (180-187): Internal error: Expression undefined for SMT solver.
 // Warning: (191-206): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/functions/recursive_multi_return.sol
+++ b/test/libsolidity/smtCheckerTests/functions/recursive_multi_return.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C {
+	function g() public pure returns (uint, uint) {
+		uint a;
+		uint b;
+		(a, b) = g();
+	}
+}
+//
+// ----
+// Warning: (126-129): Assertion checker does not support recursive function calls.

--- a/test/libsolidity/smtCheckerTests/functions/recursive_multi_return_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/recursive_multi_return_2.sol
@@ -1,0 +1,28 @@
+pragma experimental SMTChecker;
+
+contract c { function f() public pure {22237625-86535-0+1;
+    555565-3*51;
+}
+}contract C {
+	function g() public pure returns (
+		uint,
+		uint,
+		uint,
+		uint,
+		uint,
+		uint,
+		uint,
+		uint,
+		uint,
+		uint,
+int, uint, bytes14) {
+		uint
+a;
+		uint b;
+		(,,,,,,,a,b,,,,) = g();
+	}
+}
+// ----
+// Warning: (72-90): Statement has no effect.
+// Warning: (96-107): Statement has no effect.
+// Warning: (304-307): Assertion checker does not support recursive function calls.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_multi_functions_recursive.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_multi_functions_recursive.sol
@@ -18,7 +18,5 @@ contract C
 }
 // ----
 // Warning: (86-93): Assertion checker does not support recursive function calls.
-// Warning: (86-93): Internal error: Expression undefined for SMT solver.
 // Warning: (86-93): Assertion checker does not support recursive function calls.
-// Warning: (86-93): Internal error: Expression undefined for SMT solver.
 // Warning: (253-266): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/struct_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/struct_1.sol
@@ -17,8 +17,8 @@ contract C
 // Warning: (157-170): Unused local variable.
 // Warning: (157-170): Assertion checker does not yet support the type of this variable.
 // Warning: (139-146): Assertion checker does not yet implement this type.
+// Warning: (149-153): Assertion checker does not yet implement this type.
 // Warning: (149-153): Assertion checker does not yet implement this expression.
 // Warning: (139-153): Assertion checker does not yet implement type struct C.S storage ref
-// Warning: (173-177): Assertion checker does not yet implement this expression.
-// Warning: (173-177): Internal error: Expression undefined for SMT solver.
 // Warning: (173-177): Assertion checker does not yet implement this type.
+// Warning: (173-177): Assertion checker does not yet implement this expression.


### PR DESCRIPTION
Fixes #6759 #6760 

Create symbolic expressions for any function call, even if abstracted. If it is abstracted and has multi return values, its SymbolicTupleExpression will have an empty `components`, so need to handle that too.