### PR TITLE
[soltest] Adds support for constructor arguments

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -55,7 +55,7 @@ SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath, lang
 
 TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
-	soltestAssert(deploy("", 0, bytes()), "Failed to deploy contract.");
+
 
 	bool success = true;
 	for (auto& test: m_tests)
@@ -63,18 +63,34 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 
 	for (auto& test: m_tests)
 	{
-		bytes output = callContractFunctionWithValueNoEncoding(
-			test.call().signature,
-			test.call().value,
-			test.call().arguments.rawBytes()
-		);
+		if (&test == &m_tests.front())
+			if (test.call().isConstructor)
+				soltestAssert(deploy("", 0, test.call().arguments.rawBytes()), "Failed to deploy contract with additional constructor arguments.");
+			else
+				soltestAssert(deploy("", 0, bytes()), "Failed to deploy contract.");
+		else
+			soltestAssert(!test.call().isConstructor, "Constructor has to be the first function call.");
 
-		if ((m_transactionSuccessful == test.call().expectations.failure) || (output != test.call().expectations.rawBytes()))
-			success = false;
+		if (test.call().isConstructor)
+		{
+			test.setFailure(false);
+			test.setRawBytes(bytes());
+		}
+		else
+		{
+			bytes output = callContractFunctionWithValueNoEncoding(
+				test.call().signature,
+				test.call().value,
+				test.call().arguments.rawBytes()
+			);
 
-		test.setFailure(!m_transactionSuccessful);
-		test.setRawBytes(std::move(output));
-		test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName()));
+			if ((m_transactionSuccessful == test.call().expectations.failure) || (output != test.call().expectations.rawBytes()))
+				success = false;
+
+			test.setFailure(!m_transactionSuccessful);
+			test.setRawBytes(std::move(output));
+			test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName()));
+		}
 	}
 
 	if (!success)

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -65,7 +65,7 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 	{
 		if (&test == &m_tests.front())
 			if (test.call().isConstructor)
-				soltestAssert(deploy("", 0, test.call().arguments.rawBytes()), "Failed to deploy contract with additional constructor arguments.");
+				deploy("", 0, test.call().arguments.rawBytes());
 			else
 				soltestAssert(deploy("", 0, bytes()), "Failed to deploy contract.");
 		else
@@ -73,7 +73,10 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 
 		if (test.call().isConstructor)
 		{
-			test.setFailure(false);
+			if (m_transactionSuccessful == test.call().expectations.failure)
+				success = false;
+
+			test.setFailure(!m_transactionSuccessful);
 			test.setRawBytes(bytes());
 		}
 		else

--- a/test/libsolidity/semanticTests/smoke_test.sol
+++ b/test/libsolidity/semanticTests/smoke_test.sol
@@ -1,4 +1,8 @@
 contract C {
+    uint public state = 0;
+    constructor(uint _state) public {
+        state = _state;
+    }
     function f() payable public returns (uint) {
         return 2;
     }
@@ -31,6 +35,8 @@ contract C {
     }
 }
 // ----
+// constructor(): 3 ->
+// state() -> 3
 // _() -> FAILURE
 // f() -> 2
 // f(), 1 ether -> 2

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -116,6 +116,9 @@ vector<dev::solidity::test::FunctionCall> TestFileParser::parseFunctionCalls()
 				accept(Token::Newline, true);
 				call.expectations.comment = parseComment();
 
+				if (call.signature == "constructor()")
+					call.isConstructor = true;
+
 				calls.emplace_back(std::move(call));
 			}
 		}

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -248,6 +248,8 @@ struct FunctionCall
 		MultiLine
 	};
 	DisplayMode displayMode = DisplayMode::SingleLine;
+	/// Marks this function call as the constructor.
+	bool isConstructor = false;
 };
 
 /**


### PR DESCRIPTION
This PR adds support for constructor arguments. Constructors in `isoltest` don't have arguments in their signature and are therefore defined by just using `constructor(): <args> ->`. They also don't have expectations:
```
contract C {
    uint public state = 0;
    constructor(uint _state) public {
        state = _state;
    }
}
// ----
// constructor(): 3 ->
// state() -> 3
```
Constructors can also return a `FAILURE` if the deploy is reverted:
```
contract C {
    uint public state = 0;
    constructor(uint _state) public {
        revert();
    }
}
// constructor(): 3 -> FAILURE
```