### PR TITLE
[isoltest] TestFileParser: Fixes access of iterator at and beyond iterator ends

### DIFF
--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -72,6 +72,16 @@ namespace
 	}
 }
 
+char TestFileParser::Scanner::peek() const noexcept
+{
+	if (std::distance(m_char, m_line.end()) < 2)
+		return '\0';
+
+	auto next = m_char;
+	std::advance(next, 1);
+	return *next;
+}
+
 vector<dev::solidity::test::FunctionCall> TestFileParser::parseFunctionCalls()
 {
 	vector<FunctionCall> calls;
@@ -561,7 +571,7 @@ void TestFileParser::Scanner::scanNextToken()
 			else if (isWhiteSpace(current()))
 				token = selectToken(Token::Whitespace);
 			else if (isEndOfLine())
-				token = selectToken(Token::EOS);
+				token = make_pair(Token::EOS, "EOS");
 			else
 				throw Error(
 					Error::Type::ParserError,

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -19,6 +19,7 @@
 #include <liblangutil/Exceptions.h>
 
 #include <iosfwd>
+#include <iterator>
 #include <numeric>
 #include <stdexcept>
 #include <string>
@@ -310,16 +311,30 @@ private:
 		using TokenDesc = std::pair<Token, std::string>;
 
 		/// Advances current position in the input stream.
-		void advance() { ++m_char; }
-		/// Returns the current character.
-		char current() const { return *m_char; }
-		/// Peeks the next character.
-		char peek() const { auto it = m_char; return *(it + 1); }
+		void advance()
+		{
+			solAssert(m_char != m_line.end(), "Cannot advance beyond end.");
+			++m_char;
+		}
+
+		/// Returns the current character or '\0' if at end of input.
+		char current() const noexcept
+		{
+			if (m_char == m_line.end())
+				return '\0';
+
+			return *m_char;
+		}
+
+		/// Retrieves the next character ('\0' if that would be at (or beyond) the end of input)
+		/// without advancing the input stream iterator.
+		char peek() const noexcept;
+
 		/// Returns true if the end of a line is reached, false otherwise.
 		bool isEndOfLine() const { return m_char == m_line.end(); }
 
 		std::string m_line;
-		std::string::iterator m_char;
+		std::string::const_iterator m_char;
 
 		std::string m_currentLiteral;
 


### PR DESCRIPTION
While isoltest/soltest worked on Linux wrt. this class, because GCC/Clang doesn't validate iterator access, MSVC however does. This is how I accidentally spotted it.

NB: I intentionally did not `solAssert()` in `Scanner::current()` nor in `Scanner::peek()` as it would have required more code changes. The current just explicitly states what was already happening on GCC/Clang side, returning the last byte, which is `'\0`.

p.s.: why didn't AppVeyor tell us. hmm