### PR TITLE
Fix handling of structs of dynamic size as constructor parameters.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 
 Compiler Features:
+ * Code Generator: Fix handling of structs of dynamic size as constructor parameters.
  * Optimizer: Add rule to simplify SHL/SHR combinations.
  * SMTChecker: Support inherited state variables.
  * SMTChecker: Support tuples and function calls with multiple return values.

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -1,5 +1,16 @@
 [
     {
+        "name": "DynamicConstructorArgumentsClippedABIV2",
+        "summary": "A contract's constructor that takes structs or arrays that contain dynamically-sized arrays reverts or decodes to invalid data.",
+        "description": "During construction of a contract, constructor parameters are copied from the code section to memory for decoding. The amount of bytes to copy was calculated incorrectly in case all parameters are statically-sized but contain dynamically-sized arrays as struct members or inner arrays. Such types are only available if ABIEncoderV2 is activated.",
+        "introduced": "0.4.16",
+        "fixed": "0.5.9",
+        "severity": "very low",
+        "conditions": {
+            "ABIEncoderV2": true
+        }
+    },
+    {
         "name": "UninitializedFunctionPointerInConstructor",
         "summary": "Calling uninitialized internal function pointers created in the constructor does not always revert and can cause unexpected behaviour.",
         "description": "Uninitialized internal function pointers point to a special piece of code that causes a revert when called. Jump target positions are different during construction and after deployment, but the code for setting this special jump target only considered the situation after deployment.",

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -452,6 +452,7 @@
     },
     "0.4.16": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ExpExponentCleanup",
@@ -462,6 +463,7 @@
     },
     "0.4.17": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ExpExponentCleanup",
@@ -473,6 +475,7 @@
     },
     "0.4.18": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ExpExponentCleanup",
@@ -483,6 +486,7 @@
     },
     "0.4.19": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x",
@@ -510,6 +514,7 @@
     },
     "0.4.20": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x",
@@ -521,6 +526,7 @@
     },
     "0.4.21": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x",
@@ -532,6 +538,7 @@
     },
     "0.4.22": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x",
@@ -543,6 +550,7 @@
     },
     "0.4.23": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x",
@@ -553,6 +561,7 @@
     },
     "0.4.24": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x",
@@ -563,6 +572,7 @@
     },
     "0.4.25": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor_0.4.x",
             "IncorrectEventSignatureInLibraries_0.4.x",
             "ABIEncoderV2PackedStorage_0.4.x"
@@ -570,7 +580,9 @@
         "released": "2018-09-12"
     },
     "0.4.26": {
-        "bugs": [],
+        "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2"
+        ],
         "released": "2019-04-29"
     },
     "0.4.3": {
@@ -677,6 +689,7 @@
     },
     "0.5.0": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage"
@@ -685,6 +698,7 @@
     },
     "0.5.1": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage"
@@ -693,6 +707,7 @@
     },
     "0.5.2": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage"
@@ -701,6 +716,7 @@
     },
     "0.5.3": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage"
@@ -709,6 +725,7 @@
     },
     "0.5.4": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage"
@@ -717,6 +734,7 @@
     },
     "0.5.5": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage",
@@ -727,6 +745,7 @@
     },
     "0.5.6": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries",
             "ABIEncoderV2PackedStorage",
@@ -736,13 +755,16 @@
     },
     "0.5.7": {
         "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2",
             "UninitializedFunctionPointerInConstructor",
             "IncorrectEventSignatureInLibraries"
         ],
         "released": "2019-03-26"
     },
     "0.5.8": {
-        "bugs": [],
+        "bugs": [
+            "DynamicConstructorArgumentsClippedABIV2"
+        ],
         "released": "2019-04-30"
     }
 }

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -176,8 +176,8 @@ BOOST_AUTO_TEST_CASE(store_keccak256)
 	char const* sourceCode = R"(
 		contract test {
 			bytes32 public shaValue;
-			constructor(uint a) public {
-				shaValue = keccak256(abi.encodePacked(a));
+			constructor() public {
+				shaValue = keccak256(abi.encodePacked(this));
 			}
 		}
 	)";

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -9771,7 +9771,7 @@ BOOST_AUTO_TEST_CASE(calldata_offset)
 			}
 		}
 	)";
-	compileAndRun(sourceCode, 0, "CB", encodeArgs(u256(0x20)));
+	compileAndRun(sourceCode, 0, "CB", encodeArgs(u256(0x20), u256(0x00)));
 	ABI_CHECK(callContractFunction("last()", encodeArgs()), encodeDyn(string("nd")));
 }
 


### PR DESCRIPTION
Fixes #6754

Does this deserve an entry in the bug list? The issue is that if all variables are statically sized and at least one is dynamically encoded (but statically sized), not enough data is copied to memory for the decoder.

I think the only types that are statically sized but dynamically encoded are structs or multi-dimensional arrays where the outer arrays is statically-sized.

As far as I know, such types are only supported by ABIV2, so this is not as bad as it sounds.