### PR TITLE
make_vector helper for move initialization

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -346,4 +346,27 @@ inline std::string findAnyOf(std::string const& _haystack, std::vector<std::stri
 			return needle;
 	return "";
 }
+
+
+namespace detail
+{
+template<typename T>
+void variadicEmplaceBack(std::vector<T>&) {}
+template<typename T, typename A, typename... Args>
+void variadicEmplaceBack(std::vector<T>& _vector, A&& _a, Args&&... _args)
+{
+	_vector.emplace_back(std::forward<A>(_a));
+	variadicEmplaceBack(_vector, std::forward<Args>(_args)...);
+}
+}
+
+template<typename T, typename... Args>
+std::vector<T> make_vector(Args&&... _args)
+{
+	std::vector<T> result;
+	result.reserve(sizeof...(_args));
+	detail::variadicEmplaceBack(result, std::forward<Args>(_args)...);
+	return result;
+}
+
 }

--- a/libyul/optimiser/ControlFlowSimplifier.cpp
+++ b/libyul/optimiser/ControlFlowSimplifier.cpp
@@ -72,11 +72,7 @@ OptionalStatements reduceNoCaseSwitch(Switch& _switchStmt)
 
 	auto loc = locationOf(*_switchStmt.expression);
 
-	OptionalStatements s = vector<Statement>{};
-
-	s->emplace_back(makePopExpressionStatement(loc, std::move(*_switchStmt.expression)));
-
-	return s;
+	return make_vector<Statement>(makePopExpressionStatement(loc, std::move(*_switchStmt.expression)));
 }
 
 OptionalStatements reduceSingleCaseSwitch(Switch& _switchStmt)
@@ -86,26 +82,20 @@ OptionalStatements reduceSingleCaseSwitch(Switch& _switchStmt)
 	auto& switchCase = _switchStmt.cases.front();
 	auto loc = locationOf(*_switchStmt.expression);
 	if (switchCase.value)
-	{
-		OptionalStatements s = vector<Statement>{};
-		s->emplace_back(If{
-				std::move(_switchStmt.location),
-				make_unique<Expression>(FunctionalInstruction{
-					std::move(loc),
-					dev::eth::Instruction::EQ,
-					{std::move(*switchCase.value), std::move(*_switchStmt.expression)}
-				}),
-				std::move(switchCase.body)
+		return make_vector<Statement>(If{
+			std::move(_switchStmt.location),
+			make_unique<Expression>(FunctionalInstruction{
+				std::move(loc),
+				dev::eth::Instruction::EQ,
+				{std::move(*switchCase.value), std::move(*_switchStmt.expression)}
+			}),
+			std::move(switchCase.body)
 		});
-		return s;
-	}
 	else
-	{
-		OptionalStatements s = vector<Statement>{};
-		s->emplace_back(makePopExpressionStatement(loc, std::move(*_switchStmt.expression)));
-		s->emplace_back(std::move(switchCase.body));
-		return s;
-	}
+		return make_vector<Statement>(
+			makePopExpressionStatement(loc, std::move(*_switchStmt.expression)),
+			std::move(switchCase.body)
+		);
 }
 
 }

--- a/libyul/optimiser/SSAReverser.cpp
+++ b/libyul/optimiser/SSAReverser.cpp
@@ -56,20 +56,18 @@ void SSAReverser::operator()(Block& _block)
 					identifier &&
 					identifier->name == varDecl->variables.front().name
 				)
-				{
-					vector<Statement> result;
-					result.emplace_back(Assignment{
-						std::move(assignment->location),
-						assignment->variableNames,
-						std::move(varDecl->value)
-					});
-					result.emplace_back(VariableDeclaration{
-						std::move(varDecl->location),
-						std::move(varDecl->variables),
-						std::make_unique<Expression>(std::move(assignment->variableNames.front()))
-					});
-					return { std::move(result) };
-				}
+					return make_vector<Statement>(
+						Assignment{
+							std::move(assignment->location),
+							assignment->variableNames,
+							std::move(varDecl->value)
+						},
+						VariableDeclaration{
+							std::move(varDecl->location),
+							std::move(varDecl->variables),
+							std::make_unique<Expression>(std::move(assignment->variableNames.front()))
+						}
+					);
 			}
 			// Replaces
 			//   let a_1 := E
@@ -89,22 +87,22 @@ void SSAReverser::operator()(Block& _block)
 					)
 				)
 				{
-					vector<Statement> result;
 					auto varIdentifier2 = std::make_unique<Expression>(Identifier{
 						varDecl2->variables.front().location,
 						varDecl2->variables.front().name
 					});
-					result.emplace_back(VariableDeclaration{
-						std::move(varDecl2->location),
-						std::move(varDecl2->variables),
-						std::move(varDecl->value)
-					});
-					result.emplace_back(VariableDeclaration{
-						std::move(varDecl->location),
-						std::move(varDecl->variables),
-						std::move(varIdentifier2)
-					});
-					return { std::move(result) };
+					return make_vector<Statement>(
+						VariableDeclaration{
+							std::move(varDecl2->location),
+							std::move(varDecl2->variables),
+							std::move(varDecl->value)
+						},
+						VariableDeclaration{
+							std::move(varDecl->location),
+							std::move(varDecl->variables),
+							std::move(varIdentifier2)
+						}
+					);
 				}
 			}
 

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -51,12 +51,10 @@ OptionalStatements replaceConstArgSwitch(Switch& _switchStmt, u256 const& _const
 	if (!matchingCaseBlock && defaultCase)
 		matchingCaseBlock = &defaultCase->body;
 
-	OptionalStatements s = vector<Statement>{};
-
 	if (matchingCaseBlock)
-		s->emplace_back(std::move(*matchingCaseBlock));
-
-	return s;
+		return make_vector<Statement>(std::move(*matchingCaseBlock));
+	else
+		return {{}};
 }
 
 }


### PR DESCRIPTION
There are no rvalue initializer_lists which keeps being annoying when dealing with the Yul AST.

In #6777 @sifmelcara used ``boost::assign::list_of`` to compensate for that, but I looked into it and it will still perform a copy and will not work in all cases (``std::vector<Statement> x(boost::assign::list_of(Break{}))`` does work, because it constructs the non-copyable ``Statement``'s in place, but it still has to copy the ``Break``, so e.g. ``boost::assign::list_of(If{...})`` won't work).

~~I violated our coding style and called it ``make_vector`` instead of ``makeVector`` in accordance with ``make_unique``, ``make_shared``, ``make_array``, etc., but I can rename it, if desired.~~

I had a more complex version in #6720 that allowed forwarding constructor arguments as tuples, but for the cases I saw where it can be used now, we don't need that, so I kept it simple - we can extend it later, if desired.