### PR TITLE
[ossfuzz] Refactor build system so that ossfuzz harnesses can be built locally

### DIFF
--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -1,6 +1,4 @@
-if (OSSFUZZ)
-    add_subdirectory(ossfuzz)
-endif()
+add_subdirectory(ossfuzz)
 
 add_subdirectory(yulInterpreter)
 add_executable(yulrun yulrun.cpp)

--- a/test/tools/ossfuzz/CMakeLists.txt
+++ b/test/tools/ossfuzz/CMakeLists.txt
@@ -1,4 +1,6 @@
-link_directories(/src/LPM/src /src/LPM/src/libfuzzer /src/LPM/external.protobuf/lib)
+if (OSSFUZZ)
+    link_directories(/src/LPM/src /src/LPM/src/libfuzzer /src/LPM/external.protobuf/lib)
+endif()
 add_custom_target(ossfuzz)
 add_dependencies(ossfuzz
         solc_opt_ossfuzz
@@ -9,41 +11,95 @@ add_dependencies(ossfuzz
         strictasm_assembly_ossfuzz
         )
 
+if (OSSFUZZ)
 add_custom_target(ossfuzz_proto)
 add_dependencies(ossfuzz_proto yul_proto_ossfuzz yul_proto_diff_ossfuzz)
+endif()
 
-#[[FuzzingEngine.a is provided by oss-fuzz's Dockerized build environment]]
-add_executable(solc_opt_ossfuzz solc_opt_ossfuzz.cpp ../fuzzer_common.cpp)
-target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
+if (OSSFUZZ)
+    #[[FuzzingEngine.a is provided by oss-fuzz's Dockerized build environment]]
+    add_executable(solc_opt_ossfuzz solc_opt_ossfuzz.cpp ../fuzzer_common.cpp)
+    target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
 
-add_executable(solc_noopt_ossfuzz solc_noopt_ossfuzz.cpp ../fuzzer_common.cpp)
-target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
+    add_executable(solc_noopt_ossfuzz solc_noopt_ossfuzz.cpp ../fuzzer_common.cpp)
+    target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
 
-add_executable(const_opt_ossfuzz const_opt_ossfuzz.cpp ../fuzzer_common.cpp)
-target_link_libraries(const_opt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
+    add_executable(const_opt_ossfuzz const_opt_ossfuzz.cpp ../fuzzer_common.cpp)
+    target_link_libraries(const_opt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
 
-add_executable(strictasm_diff_ossfuzz strictasm_diff_ossfuzz.cpp yulFuzzerCommon.cpp)
-target_link_libraries(strictasm_diff_ossfuzz PRIVATE libsolc evmasm yulInterpreter FuzzingEngine.a)
+    add_executable(strictasm_diff_ossfuzz strictasm_diff_ossfuzz.cpp yulFuzzerCommon.cpp)
+    target_link_libraries(strictasm_diff_ossfuzz PRIVATE libsolc evmasm yulInterpreter FuzzingEngine.a)
 
-add_executable(strictasm_opt_ossfuzz strictasm_opt_ossfuzz.cpp)
-target_link_libraries(strictasm_opt_ossfuzz PRIVATE yul FuzzingEngine.a)
+    add_executable(strictasm_opt_ossfuzz strictasm_opt_ossfuzz.cpp)
+    target_link_libraries(strictasm_opt_ossfuzz PRIVATE yul FuzzingEngine.a)
 
-add_executable(strictasm_assembly_ossfuzz strictasm_assembly_ossfuzz.cpp)
-target_link_libraries(strictasm_assembly_ossfuzz PRIVATE yul FuzzingEngine.a)
+    add_executable(strictasm_assembly_ossfuzz strictasm_assembly_ossfuzz.cpp)
+    target_link_libraries(strictasm_assembly_ossfuzz PRIVATE yul FuzzingEngine.a)
 
-add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
-target_include_directories(yul_proto_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
-target_link_libraries(yul_proto_ossfuzz PRIVATE yul evmasm solidity
-        protobuf-mutator-libfuzzer.a
-        protobuf-mutator.a
-        protobuf.a
-        FuzzingEngine.a)
+    add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
+    target_include_directories(yul_proto_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
+    target_link_libraries(yul_proto_ossfuzz PRIVATE yul evmasm solidity
+            protobuf-mutator-libfuzzer.a
+            protobuf-mutator.a
+            protobuf.a
+            FuzzingEngine.a)
 
-add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
-target_include_directories(yul_proto_diff_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
-target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul evmasm
-        yulInterpreter
-        protobuf-mutator-libfuzzer.a
-        protobuf-mutator.a
-        protobuf.a
-        FuzzingEngine.a)
+    add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
+    target_include_directories(yul_proto_diff_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
+    target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul evmasm
+            yulInterpreter
+            protobuf-mutator-libfuzzer.a
+            protobuf-mutator.a
+            protobuf.a
+            FuzzingEngine.a)
+else()
+    add_library(solc_opt_ossfuzz
+            solc_opt_ossfuzz.cpp
+            ../fuzzer_common.cpp
+            )
+    target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm)
+
+    add_library(solc_noopt_ossfuzz
+            solc_noopt_ossfuzz.cpp
+            ../fuzzer_common.cpp
+            )
+    target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm)
+
+    add_library(const_opt_ossfuzz
+            const_opt_ossfuzz.cpp
+            ../fuzzer_common.cpp)
+    target_link_libraries(const_opt_ossfuzz PRIVATE libsolc evmasm)
+
+    add_library(strictasm_diff_ossfuzz
+            strictasm_diff_ossfuzz.cpp
+            yulFuzzerCommon.cpp
+            )
+    target_link_libraries(strictasm_diff_ossfuzz PRIVATE libsolc evmasm yulInterpreter)
+
+    add_library(strictasm_opt_ossfuzz
+            strictasm_opt_ossfuzz.cpp
+            )
+    target_link_libraries(strictasm_opt_ossfuzz PRIVATE yul)
+
+    add_library(strictasm_assembly_ossfuzz
+            strictasm_assembly_ossfuzz.cpp
+            )
+    target_link_libraries(strictasm_assembly_ossfuzz PRIVATE yul)
+
+#    add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
+#    target_include_directories(yul_proto_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
+#    target_link_libraries(yul_proto_ossfuzz PRIVATE yul evmasm solidity
+#            protobuf-mutator-libfuzzer.a
+#            protobuf-mutator.a
+#            protobuf.a
+#            FuzzingEngine.a)
+#
+#    add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
+#    target_include_directories(yul_proto_diff_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
+#    target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul evmasm
+#            yulInterpreter
+#            protobuf-mutator-libfuzzer.a
+#            protobuf-mutator.a
+#            protobuf.a
+#            FuzzingEngine.a)
+endif()


### PR DESCRIPTION
closes #6653 

- How do we deal with proto fuzzer compilation?
  - Proto fuzzer includes headers from dependencies (libprotobuf-mutator, and libprotobuf)
  - Proto fuzzer contains [proto to yul translator](https://github.com/ethereum/solidity/blob/develop/test/tools/ossfuzz/protoToYul.cpp) that depends on C++ helper source/header file pair that is auto generated by protobuf's `protoc` compiler
   - These are called `yulProto.pb.h` and `yulProto.pb.cc` respectively

