### PR TITLE
cmake: Minor refactoring of SANITIZE flag

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -144,7 +144,13 @@ else ()
 endif ()
 
 if (SANITIZE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZE}")
+	# Perform case-insensitive string compare
+	string(TOLOWER "${SANITIZE}" san)
+	# -fno-omit-frame-pointer gives more informative stack trace in case of an error
+	# -fsanitize-address-use-after-scope throws an error when a variable is used beyond its scope
+	if (san STREQUAL "address")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope")
+	endif()
 endif()
 
 # Code coverage support.


### PR DESCRIPTION
closes #5934 

Earlier, we simply relayed the value of the `SANITIZE` cmake flag to clang's `-fsanitize=<value>`.

Now, we do a case insensitive check of the value of cmake's `SANITIZE` flag and set compiler options accordingly.

Pros
  - `-DSANITIZE=Address`, `-DSANITIZE=ADDRESS` and `-DSANITIZE=address` work the same way
  - By decoupling the value passed to `-DSANITIZE` and the actual compiler flags, we can customize the sanitizer flags we need
    - I added `-fsanitize-address-use-after-scope` that warns when an object is used beyond it's scope.
    - If ASan becomes more powerful in the future, we can enable similar checks under the `address` if statement

