### PR TITLE
Do not require payable for callvalue instruction.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Compiler Features:
  * SMTChecker: Support tuples and function calls with multiple return values.
  * SMTChecker: Support ``delete``.
  * SMTChecker: Inline external function calls to ``this``.
+ * Inline Assembly: Revert change introduced in 0.5.7: The ``callvalue()`` instruction does not require ``payable`` anymore.
  * Metadata: Add IPFS hashes of source files.
  * Assembler: Encode the compiler version in the deployed bytecode.
  * Yul Optimizer: Simplify single-run ``for`` loops to ``if`` statements.

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -112,8 +112,6 @@ private:
 	{
 		if (eth::SemanticInformation::invalidInViewFunctions(_instruction))
 			m_reportMutability(StateMutability::NonPayable, _location);
-		else if (_instruction == dev::eth::Instruction::CALLVALUE)
-			m_reportMutability(StateMutability::Payable, _location);
 		else if (eth::SemanticInformation::invalidInPureFunctions(_instruction))
 			m_reportMutability(StateMutability::View, _location);
 	}

--- a/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_fallback.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_fallback.sol
@@ -8,4 +8,3 @@ contract C
     }
 }
 // ----
-// TypeError: (92-103): "msg.value" and "callvalue()" can only be used in payable public functions. Make the function "payable" or use an internal function to avoid this error.

--- a/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_function.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_function.sol
@@ -7,4 +7,4 @@ contract C
     }
 }
 // ----
-// TypeError: (81-92): "msg.value" and "callvalue()" can only be used in payable public functions. Make the function "payable" or use an internal function to avoid this error.
+// Warning: (17-108): Function state mutability can be restricted to view

--- a/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_function_internal.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_function_internal.sol
@@ -9,3 +9,5 @@ contract C
 		return f();
 	}
 }
+// ----
+// Warning: (17-121): Function state mutability can be restricted to view

--- a/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_function_modifier.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/callvalue_nonpayable_assembly_function_modifier.sol
@@ -11,4 +11,3 @@ contract C
     }
 }
 // ----
-// TypeError: (99-100): This modifier uses "msg.value" or "callvalue()" and thus the function has to be payable or internal.


### PR DESCRIPTION
Fixes #6581 