### PR TITLE
[DOCS] Bring code examples inline with style guide in assembly doc

### DIFF
--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -104,47 +104,48 @@ efficient code, for example:
 
     pragma solidity >=0.4.16 <0.7.0;
 
+
     library VectorSum {
         // This function is less efficient because the optimizer currently fails to
         // remove the bounds checks in array access.
-        function sumSolidity(uint[] memory _data) public pure returns (uint o_sum) {
+        function sumSolidity(uint[] memory _data) public pure returns (uint sum) {
             for (uint i = 0; i < _data.length; ++i)
-                o_sum += _data[i];
+                sum += _data[i];
         }
 
         // We know that we only access the array in bounds, so we can avoid the check.
         // 0x20 needs to be added to an array because the first slot contains the
         // array length.
-        function sumAsm(uint[] memory _data) public pure returns (uint o_sum) {
+        function sumAsm(uint[] memory _data) public pure returns (uint sum) {
             for (uint i = 0; i < _data.length; ++i) {
                 assembly {
-                    o_sum := add(o_sum, mload(add(add(_data, 0x20), mul(i, 0x20))))
+                    sum := add(sum, mload(add(add(_data, 0x20), mul(i, 0x20))))
                 }
             }
         }
 
         // Same as above, but accomplish the entire code within inline assembly.
-        function sumPureAsm(uint[] memory _data) public pure returns (uint o_sum) {
+        function sumPureAsm(uint[] memory _data) public pure returns (uint sum) {
             assembly {
-               // Load the length (first 32 bytes)
-               let len := mload(_data)
+                // Load the length (first 32 bytes)
+                let len := mload(_data)
 
-               // Skip over the length field.
-               //
-               // Keep temporary variable so it can be incremented in place.
-               //
-               // NOTE: incrementing _data would result in an unusable
-               //       _data variable after this assembly block
-               let data := add(_data, 0x20)
+                // Skip over the length field.
+                //
+                // Keep temporary variable so it can be incremented in place.
+                //
+                // NOTE: incrementing _data would result in an unusable
+                //       _data variable after this assembly block
+                let data := add(_data, 0x20)
 
-               // Iterate until the bound is not met.
-               for
-                   { let end := add(data, mul(len, 0x20)) }
-                   lt(data, end)
-                   { data := add(data, 0x20) }
-               {
-                   o_sum := add(o_sum, mload(data))
-               }
+                // Iterate until the bound is not met.
+                for
+                    { let end := add(data, mul(len, 0x20)) }
+                    lt(data, end)
+                    { data := add(data, 0x20) }
+                {
+                    sum := add(sum, mload(data))
+                }
             }
         }
     }
@@ -693,12 +694,13 @@ We consider the runtime bytecode of the following Solidity program::
 
     pragma solidity >=0.4.16 <0.7.0;
 
+
     contract C {
-      function f(uint x) public pure returns (uint y) {
-        y = 1;
-        for (uint i = 0; i < x; i++)
-          y = 2 * y;
-      }
+        function f(uint x) public pure returns (uint y) {
+            y = 1;
+            for (uint i = 0; i < x; i++)
+                y = 2 * y;
+        }
     }
 
 The following assembly will be generated::


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in assembly doc that violate the style guide.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
