### PR TITLE
[DOCS] Make Creating contracts code examples match style guide

### DIFF
--- a/docs/contracts/creating-contracts.rst
+++ b/docs/contracts/creating-contracts.rst
@@ -35,6 +35,7 @@ This means that cyclic creation dependencies are impossible.
 
     pragma solidity >=0.4.22 <0.7.0;
 
+
     contract OwnedToken {
         // `TokenCreator` is a contract type that is defined below.
         // It is fine to reference it as long as it is not used
@@ -86,10 +87,11 @@ This means that cyclic creation dependencies are impossible.
         }
     }
 
+
     contract TokenCreator {
         function createToken(bytes32 name)
-           public
-           returns (OwnedToken tokenAddress)
+            public
+            returns (OwnedToken tokenAddress)
         {
             // Create a new `Token` contract and return its address.
             // From the JavaScript side, the return type is


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in creating contracts doc that violate the style guide.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
