### PR TITLE
Fix reference links in types.rst

### DIFF
--- a/docs/types/operators.rst
+++ b/docs/types/operators.rst
@@ -7,6 +7,8 @@ If ``a`` is an LValue (i.e. a variable or something that can be assigned to), th
 
 ``a += e`` is equivalent to ``a = a + e``. The operators ``-=``, ``*=``, ``/=``, ``%=``, ``|=``, ``&=`` and ``^=`` are defined accordingly. ``a++`` and ``a--`` are equivalent to ``a += 1`` / ``a -= 1`` but the expression itself still has the previous value of ``a``. In contrast, ``--a`` and ``++a`` have the same effect on ``a`` but return the value after the change.
 
+.. _delete:
+
 delete
 ------
 

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -217,13 +217,13 @@ Array Members
     For dynamically-sized arrays (only available for storage), this member can be assigned to resize the array.
     Accessing elements outside the current length does not automatically resize the array and instead causes a failing assertion.
     Increasing the length adds new zero-initialised elements to the array.
-    Reducing the length performs an implicit :ref:``delete`` on each of the
+    Reducing the length performs an implicit :ref:`delete<delete>` on each of the
     removed elements. If you try to resize a non-dynamic array that isn't in
     storage, you receive a ``Value must be an lvalue`` error.
 **push**:
      Dynamic storage arrays and ``bytes`` (not ``string``) have a member function called ``push`` that you can use to append an element at the end of the array. The element will be zero-initialised. The function returns the new length.
 **pop**:
-     Dynamic storage arrays and ``bytes`` (not ``string``) have a member function called ``pop`` that you can use to remove an element from the end of the array. This also implicitly calls :ref:``delete`` on the removed element.
+     Dynamic storage arrays and ``bytes`` (not ``string``) have a member function called ``pop`` that you can use to remove an element from the end of the array. This also implicitly calls :ref:`delete<delete>` on the removed element.
 
 .. warning::
     If you use ``.length--`` on an empty array, it causes an underflow and
@@ -234,7 +234,7 @@ Array Members
     storage is assumed to be zero-initialised, while decreasing
     the length has at least linear cost (but in most cases worse than linear),
     because it includes explicitly clearing the removed
-    elements similar to calling :ref:``delete`` on them.
+    elements similar to calling :ref:`delete<delete>` on them.
 
 .. note::
     It is not yet possible to use arrays of arrays in external functions


### PR DESCRIPTION
### Description


Link to section `delete` is currently rendered as ":ref:`delete`" in https://solidity.readthedocs.io/en/v0.5.8/types.html. I guess this is not expected behavior?

I think there is no easy way to link to that section, because that section is actually in different `.rst`. The best I can do is to give up linking to that section.

Please feels free to close this PR if you get a better solution :)

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
