### PR TITLE
yul-format command line tool & pretty-printing Solidity-to-Yul output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(LLL "Build LLL" OFF)
 option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)
 option(LLLC_LINK_STATIC "Link lllc executable statically on supported platforms" OFF)
 option(INSTALL_LLLC "Include lllc executable in installation" ${LLL})
+option(YUL_FORMAT "Build yul-format command line tool" ON)
 
 # Setup cccache.
 include(EthCcache)
@@ -70,6 +71,11 @@ if (NOT EMSCRIPTEN)
 		add_subdirectory(liblll)
 		add_subdirectory(lllc)
 	endif()
+endif()
+
+# tools
+if (YUL_FORMAT)
+	add_subdirectory(tools/yul-format)
 endif()
 
 if (TESTS AND NOT EMSCRIPTEN)

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -116,6 +116,10 @@ public:
 			boost::apply_visitor(*this, s);
 	}
 
+	void operator()(yul::Comment const&)
+	{
+	}
+
 private:
 	void checkInstruction(SourceLocation _location, dev::eth::Instruction _instruction)
 	{

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -45,7 +45,6 @@ using namespace dev::solidity;
 
 pair<string, string> IRGenerator::run(ContractDefinition const& _contract)
 {
-	// TODO Would be nice to pretty-print this while retaining comments.
 	string ir = generate(_contract);
 
 	yul::AssemblyStack asmStack(m_evmVersion, yul::AssemblyStack::Language::StrictAssembly, m_optimiserSettings);
@@ -56,6 +55,10 @@ pair<string, string> IRGenerator::run(ContractDefinition const& _contract)
 			errorMessage += langutil::SourceReferenceFormatter::formatErrorInformation(*error);
 		solAssert(false, "Invalid IR generated:\n" + errorMessage + "\n" + ir);
 	}
+
+	// NB: pretty-print is retaining documentation comments (those with tripple-slash).
+	string const irPrettyPrinted = asmStack.parseTree().toString(true);
+
 	asmStack.optimize();
 
 	string warning =
@@ -66,7 +69,7 @@ pair<string, string> IRGenerator::run(ContractDefinition const& _contract)
 		" *                !USE AT YOUR OWN RISK!               *\n"
 		" *******************************************************/\n\n";
 
-	return {warning + ir, warning + asmStack.print()};
+	return {warning + irPrettyPrinted, warning + asmStack.print()};
 }
 
 string IRGenerator::generate(ContractDefinition const& _contract)

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -94,6 +94,7 @@ public:
 	bool operator()(Break const&);
 	bool operator()(Continue const&);
 	bool operator()(Block const& _block);
+	bool operator()(Comment const& _comment) { return true; }
 
 private:
 	/// Visits the statement and expects it to deposit one item onto the stack.

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -94,7 +94,7 @@ public:
 	bool operator()(Break const&);
 	bool operator()(Continue const&);
 	bool operator()(Block const& _block);
-	bool operator()(Comment const& _comment) { return true; }
+	bool operator()(Comment const&) { return true; }
 
 private:
 	/// Visits the statement and expects it to deposit one item onto the stack.

--- a/libyul/AsmData.h
+++ b/libyul/AsmData.h
@@ -82,6 +82,7 @@ struct ForLoop { langutil::SourceLocation location; Block pre; std::unique_ptr<E
 struct Break { langutil::SourceLocation location; };
 /// Continue statement (valid within for loop)
 struct Continue { langutil::SourceLocation location; };
+struct Comment { langutil::SourceLocation location; std::string text; };
 
 struct LocationExtractor: boost::static_visitor<langutil::SourceLocation>
 {

--- a/libyul/AsmDataForward.h
+++ b/libyul/AsmDataForward.h
@@ -45,10 +45,11 @@ struct Break;
 struct Continue;
 struct ExpressionStatement;
 struct Block;
+struct Comment;
 
 struct TypedName;
 
 using Expression = boost::variant<FunctionalInstruction, FunctionCall, Identifier, Literal>;
-using Statement = boost::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Block>;
+using Statement = boost::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Block, Comment>;
 
 }

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -84,8 +84,22 @@ Block Parser::parseBlock()
 	RecursionGuard recursionGuard(*this);
 	Block block = createWithLocation<Block>();
 	expectToken(Token::LBrace);
+
 	while (currentToken() != Token::RBrace)
+	{
+		if (!m_scanner->currentCommentLiteral().empty())
+			block.statements.emplace_back(
+				Comment{m_scanner->currentCommentLocation(), m_scanner->currentCommentLiteral()}
+			);
+
 		block.statements.emplace_back(parseStatement());
+	}
+
+	if (!m_scanner->currentCommentLiteral().empty())
+		block.statements.emplace_back(
+			Comment{m_scanner->currentCommentLocation(), m_scanner->currentCommentLiteral()}
+		);
+
 	block.location.end = endPosition();
 	advance();
 	return block;

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -258,6 +258,12 @@ string AsmPrinter::operator()(Block const& _block) const
 	}
 }
 
+std::string AsmPrinter::operator()(Comment const& _comment) const
+{
+	// Leading newline for better readability of comments.
+	return "\n// " + _comment.text;
+}
+
 string AsmPrinter::formatTypedName(TypedName _variable) const
 {
 	solAssert(!_variable.name.empty(), "Invalid variable name.");

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -60,6 +60,7 @@ private:
 	std::string appendTypeName(YulString _type) const;
 
 	bool m_yul = false;
+	mutable size_t m_blockStatementIndex;
 };
 
 }

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -53,6 +53,7 @@ public:
 	std::string operator()(Break const& _break) const;
 	std::string operator()(Continue const& _continue) const;
 	std::string operator()(Block const& _block) const;
+	std::string operator()(Comment const& _comment) const;
 
 private:
 	std::string formatTypedName(TypedName _variable) const;

--- a/libyul/AsmScopeFiller.h
+++ b/libyul/AsmScopeFiller.h
@@ -66,6 +66,7 @@ public:
 	bool operator()(Break const&) { return true; }
 	bool operator()(Continue const&) { return true; }
 	bool operator()(Block const& _block);
+	bool operator()(Comment const&) { return true; }
 
 private:
 	bool registerVariable(

--- a/libyul/AssemblyStack.cpp
+++ b/libyul/AssemblyStack.cpp
@@ -75,7 +75,7 @@ Scanner const& AssemblyStack::scanner() const
 	return *m_scanner;
 }
 
-bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string const& _source)
+bool AssemblyStack::parse(std::string const& _sourceName, std::string const& _source)
 {
 	m_errors.clear();
 	m_analysisSuccessful = false;
@@ -85,6 +85,19 @@ bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string 
 		return false;
 	solAssert(m_parserResult, "");
 	solAssert(m_parserResult->code, "");
+	return true;
+}
+
+yul::Object const& AssemblyStack::parseTree() const noexcept
+{
+	yulAssert(m_parserResult, "Parser result must be available.");
+	return *m_parserResult;
+}
+
+bool AssemblyStack::parseAndAnalyze(std::string const& _sourceName, std::string const& _source)
+{
+	if (!parse(_sourceName, _source))
+		return false;
 
 	return analyzeParsed();
 }

--- a/libyul/AssemblyStack.h
+++ b/libyul/AssemblyStack.h
@@ -73,6 +73,8 @@ public:
 	/// @returns the scanner used during parsing
 	langutil::Scanner const& scanner() const;
 
+	bool parse(std::string const& _sourceName, std::string const& _source);
+
 	/// Runs parsing and analysis steps, returns false if input cannot be assembled.
 	/// Multiple calls overwrite the previous state.
 	bool parseAndAnalyze(std::string const& _sourceName, std::string const& _source);
@@ -83,6 +85,9 @@ public:
 
 	/// Run the assembly step (should only be called after parseAndAnalyze).
 	MachineAssemblyObject assemble(Machine _machine) const;
+
+	/// @returns parsed source code as AST.
+	yul::Object const& parseTree() const noexcept;
 
 	/// @returns the errors generated during parsing, analysis (and potentially assembly).
 	langutil::ErrorList const& errors() const { return m_errors; }

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -188,6 +188,7 @@ public:
 	void operator()(Break const&);
 	void operator()(Continue const&);
 	void operator()(Block const& _block);
+	void operator()(Comment const&) {}
 
 private:
 	AbstractAssembly::LabelID labelFromIdentifier(Identifier const& _identifier);

--- a/libyul/backends/wasm/EWasmCodeTransform.cpp
+++ b/libyul/backends/wasm/EWasmCodeTransform.cpp
@@ -264,7 +264,9 @@ vector<wasm::Expression> EWasmCodeTransform::visit(vector<yul::Statement> const&
 {
 	vector<wasm::Expression> ret;
 	for (auto const& s: _statements)
-		ret.emplace_back(visit(s));
+		if (s.type() != typeid(yul::Comment))
+			ret.emplace_back(visit(s));
+
 	return ret;
 }
 

--- a/libyul/backends/wasm/EWasmCodeTransform.h
+++ b/libyul/backends/wasm/EWasmCodeTransform.h
@@ -54,6 +54,7 @@ public:
 	wasm::Expression operator()(yul::Break const&);
 	wasm::Expression operator()(yul::Continue const&);
 	wasm::Expression operator()(yul::Block const& _block);
+	wasm::Expression operator()(yul::Comment const&) { return {}; }
 
 private:
 	EWasmCodeTransform(

--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -153,6 +153,11 @@ Statement ASTCopier::operator ()(Block const& _block)
 	return translate(_block);
 }
 
+Statement ASTCopier::operator()(Comment const& _comment)
+{
+	return Comment{_comment.location, _comment.text};
+}
+
 Expression ASTCopier::translate(Expression const& _expression)
 {
 	return _expression.apply_visitor(static_cast<ExpressionCopier&>(*this));

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -61,6 +61,7 @@ public:
 	virtual Statement operator()(Break const&) = 0;
 	virtual Statement operator()(Continue const&) = 0;
 	virtual Statement operator()(Block const& _block) = 0;
+	virtual Statement operator()(Comment const& _comment) = 0;
 };
 
 /**
@@ -88,6 +89,7 @@ public:
 	Statement operator()(Break const&) override;
 	Statement operator()(Continue const&) override;
 	Statement operator()(Block const& _block) override;
+	Statement operator()(Comment const& _comment) override;
 
 	virtual Expression translate(Expression const& _expression);
 	virtual Statement translate(Statement const& _statement);

--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -59,6 +59,7 @@ public:
 	virtual void operator()(Break const&) {}
 	virtual void operator()(Continue const&) {}
 	virtual void operator()(Block const& _block);
+	virtual void operator()(Comment const&) {}
 
 	virtual void visit(Statement const& _st);
 	virtual void visit(Expression const& _e);
@@ -96,6 +97,7 @@ public:
 	virtual void operator()(Break&);
 	virtual void operator()(Continue&);
 	virtual void operator()(Block& _block);
+	virtual void operator()(Comment&) {}
 
 	virtual void visit(Statement& _st);
 	virtual void visit(Expression& _e);

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -181,6 +181,11 @@ bool SyntacticallyEqual::statementEqual(Block const& _lhs, Block const& _rhs)
 	});
 }
 
+bool SyntacticallyEqual::statementEqual(Comment const& _lhs, Comment const& _rhs)
+{
+	return _lhs.text == _rhs.text;
+}
+
 bool SyntacticallyEqual::visitDeclaration(TypedName const& _lhs, TypedName const& _rhs)
 {
 	if (_lhs.type != _rhs.type)

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -181,11 +181,6 @@ bool SyntacticallyEqual::statementEqual(Block const& _lhs, Block const& _rhs)
 	});
 }
 
-bool SyntacticallyEqual::statementEqual(Comment const& _lhs, Comment const& _rhs)
-{
-	return _lhs.text == _rhs.text;
-}
-
 bool SyntacticallyEqual::visitDeclaration(TypedName const& _lhs, TypedName const& _rhs)
 {
 	if (_lhs.type != _rhs.type)

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -58,6 +58,7 @@ public:
 	bool statementEqual(Break const&, Break const&) { return true; }
 	bool statementEqual(Continue const&, Continue const&) { return true; }
 	bool statementEqual(Block const& _lhs, Block const& _rhs);
+	bool statementEqual(Comment const& _lhs, Comment const& _rhs);
 private:
 	bool statementEqual(Instruction const& _lhs, Instruction const& _rhs);
 	bool statementEqual(Label const& _lhs, Label const& _rhs);

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -58,7 +58,8 @@ public:
 	bool statementEqual(Break const&, Break const&) { return true; }
 	bool statementEqual(Continue const&, Continue const&) { return true; }
 	bool statementEqual(Block const& _lhs, Block const& _rhs);
-	bool statementEqual(Comment const& _lhs, Comment const& _rhs);
+	bool statementEqual(Comment const&, Comment const&) { return true; }
+
 private:
 	bool statementEqual(Instruction const& _lhs, Instruction const& _rhs);
 	bool statementEqual(Label const& _lhs, Label const& _rhs);

--- a/tools/yul-format/CMakeLists.txt
+++ b/tools/yul-format/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(yul-format main.cpp)
+target_link_libraries(yul-format PRIVATE yul ${Boost_PROGRAM_OPTIONS_LIBRARIES})

--- a/tools/yul-format/main.cpp
+++ b/tools/yul-format/main.cpp
@@ -1,0 +1,139 @@
+#include <libyul/AsmParser.h>
+#include <libyul/AsmPrinter.h>
+#include <libyul/AssemblyStack.h>
+#include <libyul/Dialect.h>
+#include <libyul/backends/evm/EVMDialect.h>
+
+#include <liblangutil/ErrorReporter.h>
+#include <liblangutil/SourceReferenceFormatterHuman.h>
+
+#include <libdevcore/CommonIO.h>
+
+#include <cstdlib>
+#include <boost/optional.hpp>
+#include <boost/program_options.hpp>
+
+using boost::optional;
+using namespace std;
+
+namespace po = boost::program_options;
+
+boost::optional<std::string> prettyPrint(
+	std::string const& _sourceCode,
+	std::string const& _sourceName,
+	yul::EVMDialect const& _evmDialect,
+	langutil::ErrorReporter& _errorReporter
+)
+{
+	langutil::EVMVersion const evmVersion = *langutil::EVMVersion::fromString("petersburg");
+	yul::EVMDialect const& evmDialect = yul::EVMDialect::strictAssemblyForEVM(evmVersion);
+	yul::Parser parser{_errorReporter, evmDialect};
+	langutil::CharStream source{_sourceCode, _sourceName};
+	auto scanner = make_shared<langutil::Scanner>(source);
+	shared_ptr<yul::Block> ast = parser.parse(scanner, true);
+
+	if (_errorReporter.hasErrors())
+		return boost::none;
+	else
+		return {yul::AsmPrinter{true}(*ast)};
+}
+
+struct Flags
+{
+	langutil::EVMVersion evmVersion;
+	std::string sourceName;
+	std::string sourceCode;
+};
+
+boost::optional<Flags> parseArgs(int argc, const char* argv[])
+{
+	po::options_description options(
+		R"(yul-format, the Yul source code pretty printer.
+Usage: yul-format [Options] < input
+Reads a single source from stdin and prints it with proper formatting.
+
+Allowed options)",
+		po::options_description::m_default_line_length,
+		po::options_description::m_default_line_length - 23);
+
+	options.add_options()
+		("help", "Show this help screen.")
+		(
+			"evm-version",
+			po::value<string>()->value_name("version"),
+			"Select desired EVM version. Either homestead, tangerineWhistle, spuriousDragon, byzantium, constantinople or petersburg (default)."
+		)
+		("input-file", po::value<string>(), "Input file to format.");
+
+	po::positional_options_description filesPositions;
+	filesPositions.add("input-file", -1);
+
+	po::variables_map arguments;
+	try
+	{
+		po::command_line_parser cmdLineParser(argc, argv);
+		cmdLineParser.options(options).positional(filesPositions);
+		po::store(cmdLineParser.run(), arguments);
+	}
+	catch (po::error const& _exception)
+	{
+		cerr << _exception.what() << endl;
+		return boost::none;
+	}
+
+	if (arguments.count("help"))
+	{
+		cout << options;
+		return boost::none;
+	}
+
+	langutil::EVMVersion evmVersion = *langutil::EVMVersion::fromString("petersburg");
+	if (arguments.count("evm-version"))
+	{
+		string versionOptionStr = arguments["evm-version"].as<string>();
+		boost::optional<langutil::EVMVersion> value = langutil::EVMVersion::fromString(versionOptionStr);
+		if (!value)
+		{
+			cerr << "Invalid option for --evm-version: " << versionOptionStr << endl;
+			return boost::none;
+		}
+		evmVersion = *value;
+	}
+	if (arguments.count("input-file"))
+		return Flags{
+			evmVersion,
+			arguments["input-file"].as<string>(),
+			dev::readFileAsString(arguments["input-file"].as<string>())
+		};
+	else
+		return Flags{
+			evmVersion,
+			"stdin",
+			dev::readStandardInput()
+		};
+}
+
+int main(int argc, const char* argv[])
+{
+	boost::optional<Flags> flags = parseArgs(argc, argv);
+	if (!flags)
+		return EXIT_FAILURE;
+
+	langutil::ErrorList errors;
+	langutil::ErrorReporter errorReporter{errors};
+
+	optional<string> const pretty = prettyPrint(
+		flags->sourceCode,
+		flags->sourceName,
+		yul::EVMDialect::strictAssemblyForEVM(flags->evmVersion),
+		errorReporter
+	);
+
+	if (!errorReporter.hasErrors())
+		cout << *pretty;
+	else
+		for (shared_ptr<langutil::Error const> const& error : errors)
+			langutil::SourceReferenceFormatterHuman{cerr, true}.printErrorInformation(*error);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
* [x] Extend Yul AST by adding `yul::Comment`  (adapt related code accordingly)
* [x] yul-format CLI for command line based reformatting (in spirit of `clang-format`)
* [x] cherry-pick 4843c275ea12d11f7ce6835cb381def3c700059e into its own PR (VS 2019 compilation fix)
* [x] make use of this functionality in solidity-to-yul codegen output to have pretty printed result.
