### PR TITLE
[DOCS] Make libraries code examples conform to style guide

### DIFF
--- a/docs/contracts/libraries.rst
+++ b/docs/contracts/libraries.rst
@@ -49,45 +49,47 @@ more advanced example to implement a set).
 
     pragma solidity >=0.4.22 <0.7.0;
 
+
     library Set {
-      // We define a new struct datatype that will be used to
-      // hold its data in the calling contract.
-      struct Data { mapping(uint => bool) flags; }
+        // We define a new struct datatype that will be used to
+        // hold its data in the calling contract.
+        struct Data { mapping(uint => bool) flags; }
 
-      // Note that the first parameter is of type "storage
-      // reference" and thus only its storage address and not
-      // its contents is passed as part of the call.  This is a
-      // special feature of library functions.  It is idiomatic
-      // to call the first parameter `self`, if the function can
-      // be seen as a method of that object.
-      function insert(Data storage self, uint value)
-          public
-          returns (bool)
-      {
-          if (self.flags[value])
-              return false; // already there
-          self.flags[value] = true;
-          return true;
-      }
+        // Note that the first parameter is of type "storage
+        // reference" and thus only its storage address and not
+        // its contents is passed as part of the call.  This is a
+        // special feature of library functions.  It is idiomatic
+        // to call the first parameter `self`, if the function can
+        // be seen as a method of that object.
+        function insert(Data storage self, uint value)
+            public
+            returns (bool)
+        {
+            if (self.flags[value])
+                return false; // already there
+            self.flags[value] = true;
+            return true;
+        }
 
-      function remove(Data storage self, uint value)
-          public
-          returns (bool)
-      {
-          if (!self.flags[value])
-              return false; // not there
-          self.flags[value] = false;
-          return true;
-      }
+        function remove(Data storage self, uint value)
+            public
+            returns (bool)
+        {
+            if (!self.flags[value])
+                return false; // not there
+            self.flags[value] = false;
+            return true;
+        }
 
-      function contains(Data storage self, uint value)
-          public
-          view
-          returns (bool)
-      {
-          return self.flags[value];
-      }
+        function contains(Data storage self, uint value)
+            public
+            view
+            returns (bool)
+        {
+            return self.flags[value];
+        }
     }
+
 
     contract C {
         Set.Data knownValues;


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in the libraries doc that violate the style guide.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
