### PR TITLE
Produce AST even when there are parser errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Compiler Features:
  * Standard JSON Interface: Compile only selected sources and contracts.
  * Standard JSON Interface: Provide secondary error locations (e.g. the source position of other conflicting declarations).
  * SMTChecker: Do not erase knowledge about storage pointers if another storage pointer is assigned.
+ * Standard JSON Interface: Provide AST even on errors if ``--error-recovery`` commandline switch or StandardCompiler `settings.parserErrorRecovery` is true.
  * Yul Optimizer: Do not inline function if it would result in expressions being duplicated that are not cheap.
 
 
@@ -39,7 +40,7 @@ Important Bugfixes:
 
 
 Compiler Features:
- * Commandline Interface: Experimental parser error recovery via the ``--error-recovery`` commandline switch.
+ * Commandline Interface: Experimental parser error recovery via the ``--error-recovery`` commandline switch or StandardCompiler `settings.parserErrorRecovery` boolean.
  * Optimizer: Add rule to simplify ``SUB(~0, X)`` to ``NOT(X)``.
  * Yul Optimizer: Make the optimizer work for all dialects of Yul including eWasm.
 

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -79,13 +79,15 @@ public:
 	static void listAccept(std::vector<T> const& _list, ASTVisitor& _visitor)
 	{
 		for (T const& element: _list)
-			element->accept(_visitor);
+			if (element)
+				element->accept(_visitor);
 	}
 	template <class T>
 	static void listAccept(std::vector<T> const& _list, ASTConstVisitor& _visitor)
 	{
 		for (T const& element: _list)
-			element->accept(_visitor);
+			if (element)
+				element->accept(_visitor);
 	}
 
 	/// @returns a copy of the vector containing only the nodes which derive from T.

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -78,6 +78,8 @@ class DeclarationContainer;
  * Easy to use and self-contained Solidity compiler with as few header dependencies as possible.
  * It holds state and can be used to either step through the compilation stages (and abort e.g.
  * before compilation to bytecode) or run the whole compilation in one call.
+ * If error recovery is active, it is possible to progress through the stages even when
+ * there are errors. In any case, producing code is only possible without errors.
  */
 class CompilerStack: boost::noncopyable
 {
@@ -85,8 +87,8 @@ public:
 	enum State {
 		Empty,
 		SourcesSet,
-		ParsingSuccessful,
-		AnalysisSuccessful,
+		ParsingPerformed,
+		AnalysisPerformed,
 		CompilationSuccessful
 	};
 
@@ -109,6 +111,10 @@ public:
 
 	/// @returns the current state.
 	State state() const { return m_stackState; }
+
+	bool hasError() const { return m_hasError; }
+
+	bool compilationSuccessful() const { return m_stackState >= CompilationSuccessful; }
 
 	/// Resets the compiler to an empty state. Unless @a _keepSettings is set to true,
 	/// all settings are reset as well.
@@ -414,6 +420,9 @@ private:
 	bool m_metadataLiteralSources = false;
 	bool m_parserErrorRecovery = false;
 	State m_stackState = Empty;
+	/// Whether or not there has been an error during processing.
+	/// If this is true, the stack will refuse to generate code.
+	bool m_hasError = false;
 	bool m_release = VersionIsRelease;
 };
 

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -6,7 +6,7 @@
 REPO_ROOT="$(dirname "$0")"/..
 cd $REPO_ROOT
 
-WHITESPACE=$(git grep -n -I -E "^.*[[:space:]]+$" | grep -v "test/libsolidity/ASTJSON\|test/compilationTests/zeppelin/LICENSE")
+WHITESPACE=$(git grep -n -I -E "^.*[[:space:]]+$" | grep -v "test/libsolidity/ASTJSON\|test/libsolidity/ASTRecoveryTests\|test/compilationTests/zeppelin/LICENSE")
 
 if [[ "$WHITESPACE" != "" ]]
 then

--- a/test/cmdlineTests/recovery_ast_constructor/args
+++ b/test/cmdlineTests/recovery_ast_constructor/args
@@ -1,0 +1,1 @@
+--error-recovery --ast  --hashes

--- a/test/cmdlineTests/recovery_ast_constructor/err
+++ b/test/cmdlineTests/recovery_ast_constructor/err
@@ -1,0 +1,8 @@
+recovery_ast_constructor/input.sol:5:27: Error: Expected primary expression.
+    balances[tx.origin] = ; // missing RHS.
+                          ^
+recovery_ast_constructor/input.sol:5:27: Warning: Recovered in Statement at ';'.
+    balances[tx.origin] = ; // missing RHS.
+                          ^
+
+Compilation halted after AST generation due to errors.

--- a/test/cmdlineTests/recovery_ast_constructor/input.sol
+++ b/test/cmdlineTests/recovery_ast_constructor/input.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.0.0;
+
+contract Error1 {
+  constructor() public {
+    balances[tx.origin] = ; // missing RHS.
+  }
+
+  // Without error recovery we stop due to the above error.
+  // Error recovery however recovers at the above ';'
+  // There should be an AST for the above, albeit with error
+  // nodes.
+
+  // This function parses properly and should give AST info.
+  function five() public view returns(uint) {
+    return 5;
+  }
+}

--- a/test/cmdlineTests/recovery_ast_constructor/output
+++ b/test/cmdlineTests/recovery_ast_constructor/output
@@ -1,0 +1,34 @@
+Syntax trees:
+
+
+======= recovery_ast_constructor/input.sol =======
+PragmaDirective
+   Source: "pragma solidity >=0.0.0;"
+ContractDefinition "Error1"
+   Source: "contract Error1 {\n  constructor() public {\n    balances[tx.origin] = ; // missing RHS.\n  }\n\n  // Without error recovery we stop due to the above error.\n  // Error recovery however recovers at the above ';'\n  // There should be an AST for the above, albeit with error\n  // nodes.\n\n  // This function parses properly and should give AST info.\n  function five() public view returns(uint) {\n    return 5;\n  }\n}"
+  FunctionDefinition "" - public
+     Source: "constructor() public {\n    balances[tx.origin] = ; // missing RHS.\n  }"
+    ParameterList
+       Source: "()"
+    ParameterList
+       Source: ""
+    Block
+       Source: "{\n    balances[tx.origin] = ; // missing RHS.\n  }"
+  FunctionDefinition "five" - public - const
+     Source: "function five() public view returns(uint) {\n    return 5;\n  }"
+    ParameterList
+       Source: "()"
+    ParameterList
+       Source: "(uint)"
+      VariableDeclaration ""
+         Type: uint256
+         Source: "uint"
+        ElementaryTypeName uint
+           Source: "uint"
+    Block
+       Source: "{\n    return 5;\n  }"
+      Return
+         Source: "return 5"
+        Literal, token: [no token] value: 5
+           Type: int_const 5
+           Source: "5"

--- a/test/cmdlineTests/recovery_standard_json/input.json
+++ b/test/cmdlineTests/recovery_standard_json/input.json
@@ -1,0 +1,18 @@
+{
+	"language": "Solidity",
+	"sources":
+	{
+		"A":
+		{
+			"content": "pragma solidity >=0.0; contract Errort6 { using foo for  ; /* missing type name */ }"
+		}
+	},
+	"settings":
+	{
+		"parserErrorRecovery": true,
+		"outputSelection":
+		{
+			"*": { "": ["ast"] }
+		}
+	}
+}

--- a/test/cmdlineTests/recovery_standard_json/output.json
+++ b/test/cmdlineTests/recovery_standard_json/output.json
@@ -1,0 +1,7 @@
+{"errors":[{"component":"general","formattedMessage":"A:1:58: ParserError: Expected type name
+pragma solidity >=0.0; contract Errort6 { using foo for  ; /* missing type name */ }
+                                                         ^
+","message":"Expected type name","severity":"error","sourceLocation":{"end":58,"file":"A","start":57},"type":"ParserError"},{"component":"general","formattedMessage":"A:1:84: Warning: Recovered in ContractDefinition at '}'.
+pragma solidity >=0.0; contract Errort6 { using foo for  ; /* missing type name */ }
+                                                                                   ^
+","message":"Recovered in ContractDefinition at '}'.","severity":"warning","sourceLocation":{"end":84,"file":"A","start":83},"type":"Warning"}],"sources":{"A":{"ast":{"absolutePath":"A","exportedSymbols":{"Errort6":[3]},"id":4,"nodeType":"SourceUnit","nodes":[{"id":1,"literals":["solidity",">=","0.0"],"nodeType":"PragmaDirective","src":"0:22:0"},{"baseContracts":[],"contractDependencies":[],"contractKind":"contract","documentation":null,"fullyImplemented":true,"id":3,"linearizedBaseContracts":[3],"name":"Errort6","nodeType":"ContractDefinition","nodes":[],"scope":4,"src":"23:35:0"}],"src":"0:84:0"},"id":0}}}


### PR DESCRIPTION
### Description

Allow AST creation even when there are parser errors

TODO: write tests and increase coverage to ensure no SEGVs.

### Checklist
- [x] Code compiles correctly
- [x] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
