### PR TITLE
[DOCS] Bring Using For code examples inline with style guide

### DIFF
--- a/docs/contracts/using-for.rst
+++ b/docs/contracts/using-for.rst
@@ -33,38 +33,40 @@ Let us rewrite the set example from the
 
     pragma solidity >=0.4.16 <0.7.0;
 
+
     // This is the same code as before, just without comments
     library Set {
-      struct Data { mapping(uint => bool) flags; }
+        struct Data { mapping(uint => bool) flags; }
 
-      function insert(Data storage self, uint value)
-          public
-          returns (bool)
-      {
-          if (self.flags[value])
-            return false; // already there
-          self.flags[value] = true;
-          return true;
-      }
+        function insert(Data storage self, uint value)
+            public
+            returns (bool)
+        {
+            if (self.flags[value])
+                return false; // already there
+            self.flags[value] = true;
+            return true;
+        }
 
-      function remove(Data storage self, uint value)
-          public
-          returns (bool)
-      {
-          if (!self.flags[value])
-              return false; // not there
-          self.flags[value] = false;
-          return true;
-      }
+        function remove(Data storage self, uint value)
+            public
+            returns (bool)
+        {
+            if (!self.flags[value])
+                return false; // not there
+            self.flags[value] = false;
+            return true;
+        }
 
-      function contains(Data storage self, uint value)
-          public
-          view
-          returns (bool)
-      {
-          return self.flags[value];
-      }
+        function contains(Data storage self, uint value)
+            public
+            view
+            returns (bool)
+        {
+            return self.flags[value];
+        }
     }
+
 
     contract C {
         using Set for Set.Data; // this is the crucial change


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in the Using for doc that violate the style guide.


### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
