### PR TITLE
[DOCS] Bring Style guide code examples inline with style guide

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -757,19 +757,25 @@ No::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // Base contracts just to make this compile
     contract B {
         constructor(uint) public {
         }
     }
+
+
     contract C {
         constructor(uint, uint) public {
         }
     }
+
+
     contract D {
         constructor(uint) public {
         }
     }
+
 
     contract A is B, C, D {
         uint x;
@@ -777,12 +783,11 @@ No::
         constructor(uint param1, uint param2, uint param3, uint param4, uint param5)
         B(param1)
         C(param2, param3)
-        D(param4)
-        public
-        {
+        D(param4) {
             x = param5;
         }
     }
+
 
     contract X is B, C, D {
         uint x;
@@ -790,11 +795,11 @@ No::
         constructor(uint param1, uint param2, uint param3, uint param4, uint param5)
             B(param1)
             C(param2, param3)
-            D(param4)
-            public {
-            x = param5;
-        }
+            D(param4) {
+                x = param5;
+            }
     }
+
 
 When declaring short functions with a single statement, it is permissible to do it on a single line.
 
@@ -973,26 +978,31 @@ Yes::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // Owned.sol
     contract Owned {
-         address public owner;
+        address public owner;
 
-         constructor() public {
-             owner = msg.sender;
-         }
+        constructor() public {
+            owner = msg.sender;
+        }
 
-         modifier onlyOwner {
-             require(msg.sender == owner);
-             _;
-         }
+        modifier onlyOwner {
+            require(msg.sender == owner);
+            _;
+        }
 
-         function transferOwnership(address newOwner) public onlyOwner {
-             owner = newOwner;
-         }
+        function transferOwnership(address newOwner) public onlyOwner {
+            owner = newOwner;
+        }
     }
 
-    // Congress.sol
+and in ``Congress.sol``::
+
+    pragma solidity >=0.4.0 <0.7.0;
+
     import "./Owned.sol";
+
 
     contract Congress is Owned, TokenRecipient {
         //...
@@ -1002,31 +1012,33 @@ No::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // owned.sol
     contract owned {
-         address public owner;
+        address public owner;
 
-         constructor() public {
-             owner = msg.sender;
-         }
+        constructor() public {
+            owner = msg.sender;
+        }
 
-         modifier onlyOwner {
-             require(msg.sender == owner);
-             _;
-         }
+        modifier onlyOwner {
+            require(msg.sender == owner);
+            _;
+        }
 
-         function transferOwnership(address newOwner) public onlyOwner {
-             owner = newOwner;
-         }
+        function transferOwnership(address newOwner) public onlyOwner {
+            owner = newOwner;
+        }
     }
 
-    // Congress.sol
+and in ``Congress.sol``::
+
     import "./owned.sol";
+
 
     contract Congress is owned, tokenRecipient {
         //...
     }
-
 
 Struct Names
 ==========================
@@ -1103,6 +1115,7 @@ For example, the contract from `a simple smart contract <simple-smart-contract>`
 added looks like the one below::
 
     pragma solidity >=0.4.0 <0.7.0;
+
 
     /// @author The Solidity Team
     /// @title A simple storage example

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -757,44 +757,49 @@ No::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // Base contracts just to make this compile
     contract B {
         constructor(uint) public {
         }
     }
+
+
     contract C {
         constructor(uint, uint) public {
         }
     }
+
+
     contract D {
         constructor(uint) public {
         }
     }
 
+
     contract A is B, C, D {
-        uint x;
+        uint private x;
 
         constructor(uint param1, uint param2, uint param3, uint param4, uint param5)
         B(param1)
         C(param2, param3)
-        D(param4)
-        public
-        {
+        D(param4) {
             x = param5;
         }
     }
 
+
     contract X is B, C, D {
-        uint x;
+        uint private x;
 
         constructor(uint param1, uint param2, uint param3, uint param4, uint param5)
             B(param1)
             C(param2, param3)
-            D(param4)
-            public {
-            x = param5;
-        }
+            D(param4) {
+                x = param5;
+            }
     }
+
 
 When declaring short functions with a single statement, it is permissible to do it on a single line.
 
@@ -973,26 +978,31 @@ Yes::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // Owned.sol
     contract Owned {
-         address public owner;
+        address public owner;
 
-         constructor() public {
-             owner = msg.sender;
-         }
+        constructor() public {
+            owner = msg.sender;
+        }
 
-         modifier onlyOwner {
-             require(msg.sender == owner);
-             _;
-         }
+        modifier onlyOwner {
+            require(msg.sender == owner);
+            _;
+        }
 
-         function transferOwnership(address newOwner) public onlyOwner {
-             owner = newOwner;
-         }
+        function transferOwnership(address newOwner) public onlyOwner {
+            owner = newOwner;
+        }
     }
 
-    // Congress.sol
+and in ``Congress.sol``::
+
+    pragma solidity >=0.4.0 <0.7.0;
+
     import "./Owned.sol";
+
 
     contract Congress is Owned, TokenRecipient {
         //...
@@ -1002,31 +1012,33 @@ No::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // owned.sol
     contract owned {
-         address public owner;
+        address public owner;
 
-         constructor() public {
-             owner = msg.sender;
-         }
+        constructor() public {
+            owner = msg.sender;
+        }
 
-         modifier onlyOwner {
-             require(msg.sender == owner);
-             _;
-         }
+        modifier onlyOwner {
+            require(msg.sender == owner);
+            _;
+        }
 
-         function transferOwnership(address newOwner) public onlyOwner {
-             owner = newOwner;
-         }
+        function transferOwnership(address newOwner) public onlyOwner {
+            owner = newOwner;
+        }
     }
 
-    // Congress.sol
+and in ``Congress.sol``::
+
     import "./owned.sol";
+
 
     contract Congress is owned, tokenRecipient {
         //...
     }
-
 
 Struct Names
 ==========================
@@ -1104,10 +1116,11 @@ added looks like the one below::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     /// @author The Solidity Team
     /// @title A simple storage example
     contract SimpleStorage {
-        uint storedData;
+        uint private storedData;
 
         /// Store `x`.
         /// @param x the new value to store
@@ -1126,4 +1139,4 @@ added looks like the one below::
 
 It is recommended that Solidity contracts are fully annontated using `NatSpec <natspec>`_ for all public interfaces (everything in the ABI).
 
-Please see the section about `NatSpec <natspec>`_ for a detailed explanation.
+Please see the sectian about `NatSpec <natspec>`_ for a detailed explanation.


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in the style guide(!) doc that violate the style guide.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
