### PR TITLE
[DOCS] Bring code examples for Style Guide inline with style guide

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -757,19 +757,25 @@ No::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // Base contracts just to make this compile
     contract B {
         constructor(uint) public {
         }
     }
+
+
     contract C {
         constructor(uint, uint) public {
         }
     }
+
+
     contract D {
         constructor(uint) public {
         }
     }
+
 
     contract A is B, C, D {
         uint x;
@@ -778,11 +784,11 @@ No::
         B(param1)
         C(param2, param3)
         D(param4)
-        public
-        {
+        public {
             x = param5;
         }
     }
+
 
     contract X is B, C, D {
         uint x;
@@ -792,9 +798,10 @@ No::
             C(param2, param3)
             D(param4)
             public {
-            x = param5;
-        }
+                x = param5;
+            }
     }
+
 
 When declaring short functions with a single statement, it is permissible to do it on a single line.
 
@@ -973,26 +980,31 @@ Yes::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // Owned.sol
     contract Owned {
-         address public owner;
+        address public owner;
 
-         constructor() public {
-             owner = msg.sender;
-         }
+        constructor() public {
+            owner = msg.sender;
+        }
 
-         modifier onlyOwner {
-             require(msg.sender == owner);
-             _;
-         }
+        modifier onlyOwner {
+            require(msg.sender == owner);
+            _;
+        }
 
-         function transferOwnership(address newOwner) public onlyOwner {
-             owner = newOwner;
-         }
+        function transferOwnership(address newOwner) public onlyOwner {
+            owner = newOwner;
+        }
     }
 
-    // Congress.sol
+and in ``Congress.sol``::
+
+    pragma solidity >=0.4.0 <0.7.0;
+
     import "./Owned.sol";
+
 
     contract Congress is Owned, TokenRecipient {
         //...
@@ -1002,31 +1014,33 @@ No::
 
     pragma solidity >=0.4.0 <0.7.0;
 
+
     // owned.sol
     contract owned {
-         address public owner;
+        address public owner;
 
-         constructor() public {
-             owner = msg.sender;
-         }
+        constructor() public {
+            owner = msg.sender;
+        }
 
-         modifier onlyOwner {
-             require(msg.sender == owner);
-             _;
-         }
+        modifier onlyOwner {
+            require(msg.sender == owner);
+            _;
+        }
 
-         function transferOwnership(address newOwner) public onlyOwner {
-             owner = newOwner;
-         }
+        function transferOwnership(address newOwner) public onlyOwner {
+            owner = newOwner;
+        }
     }
 
-    // Congress.sol
+and in ``Congress.sol``::
+
     import "./owned.sol";
+
 
     contract Congress is owned, tokenRecipient {
         //...
     }
-
 
 Struct Names
 ==========================
@@ -1103,6 +1117,7 @@ For example, the contract from `a simple smart contract <simple-smart-contract>`
 added looks like the one below::
 
     pragma solidity >=0.4.0 <0.7.0;
+
 
     /// @author The Solidity Team
     /// @title A simple storage example


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in the style guide(!) doc that violate the style guide.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
