### PR TITLE
[DOCS] Bring value types code examples inline with style guide

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -624,100 +624,116 @@ Example that shows how to use the members::
 
     pragma solidity >=0.4.16 <0.7.0;
 
+
     contract Example {
-      function f() public payable returns (bytes4) {
-        return this.f.selector;
-      }
-      function g() public {
-        this.f.gas(10).value(800)();
-      }
+        function f() public payable returns (bytes4) {
+            return this.f.selector;
+        }
+
+        function g() public {
+            this.f.gas(10).value(800)();
+        }
     }
 
 Example that shows how to use internal function types::
 
     pragma solidity >=0.4.16 <0.7.0;
 
+
     library ArrayUtils {
-      // internal functions can be used in internal library functions because
-      // they will be part of the same code context
-      function map(uint[] memory self, function (uint) pure returns (uint) f)
-        internal
-        pure
-        returns (uint[] memory r)
-      {
-        r = new uint[](self.length);
-        for (uint i = 0; i < self.length; i++) {
-          r[i] = f(self[i]);
+        // internal functions can be used in internal library functions because
+        // they will be part of the same code context
+        function map(uint[] memory self, function (uint) pure returns (uint) f)
+            internal
+            pure
+            returns (uint[] memory r)
+        {
+            r = new uint[](self.length);
+            for (uint i = 0; i < self.length; i++) {
+                r[i] = f(self[i]);
+            }
         }
-      }
-      function reduce(
-        uint[] memory self,
-        function (uint, uint) pure returns (uint) f
-      )
-        internal
-        pure
-        returns (uint r)
-      {
-        r = self[0];
-        for (uint i = 1; i < self.length; i++) {
-          r = f(r, self[i]);
+
+        function reduce(
+            uint[] memory self,
+            function (uint, uint) pure returns (uint) f
+        )
+            internal
+            pure
+            returns (uint r)
+        {
+            r = self[0];
+            for (uint i = 1; i < self.length; i++) {
+                r = f(r, self[i]);
+            }
         }
-      }
-      function range(uint length) internal pure returns (uint[] memory r) {
-        r = new uint[](length);
-        for (uint i = 0; i < r.length; i++) {
-          r[i] = i;
+
+        function range(uint length) internal pure returns (uint[] memory r) {
+            r = new uint[](length);
+            for (uint i = 0; i < r.length; i++) {
+                r[i] = i;
+            }
         }
-      }
     }
 
+
     contract Pyramid {
-      using ArrayUtils for *;
-      function pyramid(uint l) public pure returns (uint) {
-        return ArrayUtils.range(l).map(square).reduce(sum);
-      }
-      function square(uint x) internal pure returns (uint) {
-        return x * x;
-      }
-      function sum(uint x, uint y) internal pure returns (uint) {
-        return x + y;
-      }
+        using ArrayUtils for *;
+
+        function pyramid(uint l) public pure returns (uint) {
+            return ArrayUtils.range(l).map(square).reduce(sum);
+        }
+
+        function square(uint x) internal pure returns (uint) {
+            return x * x;
+        }
+
+        function sum(uint x, uint y) internal pure returns (uint) {
+            return x + y;
+        }
     }
 
 Another example that uses external function types::
 
     pragma solidity >=0.4.22 <0.7.0;
 
+
     contract Oracle {
-      struct Request {
-        bytes data;
-        function(uint) external callback;
-      }
-      Request[] requests;
-      event NewRequest(uint);
-      function query(bytes memory data, function(uint) external callback) public {
-        requests.push(Request(data, callback));
-        emit NewRequest(requests.length - 1);
-      }
-      function reply(uint requestID, uint response) public {
-        // Here goes the check that the reply comes from a trusted source
-        requests[requestID].callback(response);
-      }
+        struct Request {
+            bytes data;
+            function(uint) external callback;
+        }
+
+        Request[] private requests;
+        event NewRequest(uint);
+
+        function query(bytes memory data, function(uint) external callback) public {
+            requests.push(Request(data, callback));
+            emit NewRequest(requests.length - 1);
+        }
+
+        function reply(uint requestID, uint response) public {
+            // Here goes the check that the reply comes from a trusted source
+            requests[requestID].callback(response);
+        }
     }
 
+
     contract OracleUser {
-      Oracle constant oracle = Oracle(0x1234567); // known contract
-      uint exchangeRate;
-      function buySomething() public {
-        oracle.query("USD", this.oracleResponse);
-      }
-      function oracleResponse(uint response) public {
-        require(
-            msg.sender == address(oracle),
-            "Only oracle can call this."
-        );
-        exchangeRate = response;
-      }
+        Oracle constant private ORACLE_CONST = Oracle(0x1234567); // known contract
+        uint private exchangeRate;
+
+        function buySomething() public {
+            ORACLE_CONST.query("USD", this.oracleResponse);
+        }
+
+        function oracleResponse(uint response) public {
+            require(
+                msg.sender == address(ORACLE_CONST),
+                "Only oracle can call this."
+            );
+            exchangeRate = response;
+        }
     }
 
 .. note::


### PR DESCRIPTION
### Description

As part of #4580 and #4581 this PR fixes code examples in the value types doc that violate the style guide.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
