### PR TITLE
yul: AsmPrinter fix when appending type name but no type-name is available

### DIFF
--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -266,7 +266,7 @@ string AsmPrinter::formatTypedName(TypedName _variable) const
 
 string AsmPrinter::appendTypeName(YulString _type) const
 {
-	if (m_yul)
+	if (m_yul && !_type.empty())
 		return ":" + _type.str();
 	return "";
 }


### PR DESCRIPTION
a small fix related to #6844 where I found out that `yul::AsmPrinter` prints types names even though they are not present. I was asked to split this out. So here we go. :)