### PR TITLE
Add static z3 ppa script and update release PPA script.

### DIFF
--- a/scripts/install_static_z3.sh
+++ b/scripts/install_static_z3.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+git clone --depth 1 --branch z3-4.8.1 https://github.com/Z3Prover/z3.git
+cd z3
+mkdir build
+cd build
+LDFLAGS="-static" cmake -DBUILD_LIBZ3_SHARED=OFF ..
+make -j 4
+make install


### PR DESCRIPTION
Adds a script that triggers a PPA build for static Z3.
For now it uses my experimental PPA repository (https://launchpad.net/~ekpyron/+archive/ubuntu/ethereum-experimental-static/+packages), but the builds seem to work. Next step would be to let the static build depend on the PPA repo containing the static Z3 build - I'll try that in an experimental PPA repo as well. If the resulting binary works, we can move forward.

Later the PPA repo and GPG keys have to be changed and we have to decide in which repo to put the static Z3 build.

~~Depends on #6891.~~ (merged)