### PR TITLE
Build System: Try to find Z3 using CONFIG_MODE and stock cmake files before manual search.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ Compiler Features:
 Bugfixes:
 
 
+Build System:
+ * Attempt to use stock Z3 cmake files to find Z3 and only fall back to manual discovery.
+
+
 
 ### 0.5.9 (2019-05-28)
 

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -1,29 +1,45 @@
 if (USE_Z3)
-    find_path(Z3_INCLUDE_DIR NAMES z3++.h PATH_SUFFIXES z3)
-    find_library(Z3_LIBRARY NAMES z3)
-    find_program(Z3_EXECUTABLE z3 PATH_SUFFIXES bin)
-
-    if(Z3_INCLUDE_DIR AND Z3_LIBRARY AND Z3_EXECUTABLE)
-        execute_process (COMMAND ${Z3_EXECUTABLE} -version
-            OUTPUT_VARIABLE libz3_version_str
-            ERROR_QUIET
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-        string(REGEX REPLACE "^Z3 version ([0-9.]+).*" "\\1"
-               Z3_VERSION_STRING "${libz3_version_str}")
-        unset(libz3_version_str)
-    endif()
-    mark_as_advanced(Z3_VERSION_STRING z3_DIR)
+    # Save and clear Z3_FIND_VERSION, since the
+    # Z3 config module cannot handle version requirements.
+    set(Z3_FIND_VERSION_ORIG ${Z3_FIND_VERSION})
+    set(Z3_FIND_VERSION)
+    # Try to find Z3 using its stock cmake files.
+    find_package(Z3 QUIET CONFIG)
+    # Restore Z3_FIND_VERSION for find_package_handle_standard_args.
+    set(Z3_FIND_VERSION ${Z3_FIND_VERSION_ORIG})
+    set(Z3_FIND_VERSION_ORIG)
 
     include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(Z3
-        REQUIRED_VARS Z3_LIBRARY Z3_INCLUDE_DIR
-        VERSION_VAR Z3_VERSION_STRING)
 
-    if (NOT TARGET Z3::Z3)
-        add_library(Z3::Z3 UNKNOWN IMPORTED)
-        set_property(TARGET Z3::Z3 PROPERTY IMPORTED_LOCATION ${Z3_LIBRARY})
-        set_property(TARGET Z3::Z3 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Z3_INCLUDE_DIR})
+    if (Z3_FOUND)
+        set(Z3_VERSION ${Z3_VERSION_STRING})
+        find_package_handle_standard_args(Z3 CONFIG_MODE)
+    else()
+        find_path(Z3_INCLUDE_DIR NAMES z3++.h PATH_SUFFIXES z3)
+        find_library(Z3_LIBRARY NAMES z3)
+        find_program(Z3_EXECUTABLE z3 PATH_SUFFIXES bin)
+
+        if(Z3_INCLUDE_DIR AND Z3_LIBRARY AND Z3_EXECUTABLE)
+            execute_process (COMMAND ${Z3_EXECUTABLE} -version
+                OUTPUT_VARIABLE libz3_version_str
+                ERROR_QUIET
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+            string(REGEX REPLACE "^Z3 version ([0-9.]+).*" "\\1"
+                   Z3_VERSION_STRING "${libz3_version_str}")
+            unset(libz3_version_str)
+        endif()
+        mark_as_advanced(Z3_VERSION_STRING z3_DIR)
+
+        find_package_handle_standard_args(Z3
+            REQUIRED_VARS Z3_LIBRARY Z3_INCLUDE_DIR
+            VERSION_VAR Z3_VERSION_STRING)
+
+        if (NOT TARGET z3::libz3)
+            add_library(z3::libz3 UNKNOWN IMPORTED)
+            set_property(TARGET z3::libz3 PROPERTY IMPORTED_LOCATION ${Z3_LIBRARY})
+            set_property(TARGET z3::libz3 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Z3_INCLUDE_DIR})
+        endif()
     endif()
 else()
     set(Z3_FOUND FALSE)

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -140,7 +140,7 @@ add_library(solidity ${sources} ${z3_SRCS} ${cvc4_SRCS})
 target_link_libraries(solidity PUBLIC yul evmasm langutil devcore ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (${Z3_FOUND})
-  target_link_libraries(solidity PUBLIC Z3::Z3)
+  target_link_libraries(solidity PUBLIC z3::libz3)
 endif()
 
 if (${CVC4_FOUND})


### PR DESCRIPTION
If Z3 is built using cmake it does produce its own cmake files which can be used to find it without a manual search - that's preferable, if available, and should help in https://github.com/ethereum/solidity/pull/6884, since the Z3 provided cmake files should be aware that the build is static and automatically declare pthreads as its dependency.

We still need to fall back to manually searching for Z3 for the case that there are no Z3 provided cmake configuration files.