### PR TITLE
Require gcc >= 5.0.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Bugfixes:
 
 Build System:
  * Attempt to use stock Z3 cmake files to find Z3 and only fall back to manual discovery.
+ * Generate a cmake error for gcc versions older than 5.0.
 
 
 

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -41,11 +41,11 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 	# Additional GCC-specific compiler settings.
 	if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-		# Check that we've got GCC 4.7 or newer.
+		# Check that we've got GCC 5.0 or newer.
 		execute_process(
 			COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-		if (NOT (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7))
-			message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.7 or greater.")
+		if (NOT (GCC_VERSION VERSION_GREATER 5.0 OR GCC_VERSION VERSION_EQUAL 5.0))
+			message(FATAL_ERROR "${PROJECT_NAME} requires g++ 5.0 or greater.")
 		endif ()
 
 	# Additional Clang-specific compiler settings.


### PR DESCRIPTION
gcc 4.9 might work as well (it's mainly library features missing from older libstdc++, not language features missing from gcc itself I think, but for library features the minimal versions are not all that well documented as far as I can see). 5.0 should definitely be fine, though, and I don't think there's much harm in requiring it.
If we move to C++17, we'll need to increase again anyways.

Do we want and need something similar for clang? What about MSVC?

Anyways, I'd say this is a reasonable first step in any case.