### PR TITLE
AsmParser: Disallow trailing commas in function call arguments.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Yul / Inline Assembly Parser: Disallow trailing commas in function call arguments.
 
 
 Build System:

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -550,13 +550,14 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		solAssert(arguments.size() > 0, "Expected at least one parameter for require/assert");
 		solAssert(arguments.size() <= 2, "Expected no more than two parameters for require/assert");
 
+		Type const* messageArgumentType = arguments.size() > 1 ? arguments[1]->annotation().type : nullptr;
 		string requireOrAssertFunction = m_utils.requireOrAssertFunction(
 			functionType->kind() == FunctionType::Kind::Assert,
-			arguments.size() > 1 ? arguments[1]->annotation().type : nullptr
+			messageArgumentType
 		);
 
 		m_code << move(requireOrAssertFunction) << "(" << m_context.variable(*arguments[0]);
-		if (arguments.size() > 1)
+		if (messageArgumentType && messageArgumentType->sizeOnStack() > 0)
 			m_code << ", " << m_context.variable(*arguments[1]);
 		m_code << ")\n";
 

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -609,12 +609,14 @@ Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 		else
 			ret = std::move(boost::get<FunctionCall>(_initialOp));
 		expectToken(Token::LParen);
-		while (currentToken() != Token::RParen)
+		if (currentToken() != Token::RParen)
 		{
 			ret.arguments.emplace_back(parseExpression());
-			if (currentToken() == Token::RParen)
-				break;
-			expectToken(Token::Comma);
+			while (currentToken() != Token::RParen)
+			{
+				expectToken(Token::Comma);
+				ret.arguments.emplace_back(parseExpression());
+			}
 		}
 		ret.location.end = endPosition();
 		expectToken(Token::RParen);

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/empty_fun_arg_beginning.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/empty_fun_arg_beginning.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public pure {
+    assembly {
+      function f(a, b) {}
+      f()
+      f(,1)
+    }
+  }
+}
+// ----
+// ParserError: (101-102): Literal, identifier or instruction expected.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/empty_fun_arg_end.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/empty_fun_arg_end.sol
@@ -4,9 +4,8 @@ contract C {
       function f(a, b) {}
       f()
       f(1,)
-      f(,1)
     }
   }
 }
 // ----
-// ParserError: (113-114): Literal, identifier or instruction expected.
+// ParserError: (103-104): Literal, identifier or instruction expected.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/empty_fun_arg_middle.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/empty_fun_arg_middle.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      function f(a, b, c) {}
+      f(1,,1)
+    }
+  }
+}
+// ----
+// ParserError: (96-97): Literal, identifier or instruction expected.


### PR DESCRIPTION
Supercedes and closes #6910.
