### PR TITLE
CMake error for big endian systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ eth_policy()
 set(PROJECT_VERSION "0.5.10")
 project(solidity VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 
+if (${CMAKE_VERSION} VERSION_LESS "3.9.0")
+	# needed for the big endian test for older cmake versions
+	enable_language(C)
+endif()
+
 include(TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if (IS_BIG_ENDIAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ eth_policy()
 set(PROJECT_VERSION "0.5.10")
 project(solidity VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 
+include(TestBigEndian)
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+if (IS_BIG_ENDIAN)
+	message(FATAL_ERROR "${PROJECT_NAME} currently does not support big endian systems.")
+endif()
+
 option(LLL "Build LLL" OFF)
 option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)
 option(LLLC_LINK_STATIC "Link lllc executable statically on supported platforms" OFF)


### PR DESCRIPTION
Refs #6907, but does not close it, in case we still want to go ahead with big endian support at some point.