### PR TITLE
Allow extracted semantics tests to run with and without yul.

### DIFF
--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -65,6 +65,8 @@ public:
 private:
 	std::string m_source;
 	std::vector<TestFunctionCall> m_tests;
+	bool m_runWithYul = false;
+	bool m_runWithoutYul = true;
 };
 
 }


### PR DESCRIPTION
The need for this came up in #6888 and #6909.
This is a quick and dirty solution which we can approve upon later, but which will allow us to continue with #6888 soon.