### PR TITLE
Fixes compilation on Visual Studio 2019

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,14 @@ add_executable(soltest ${sources} ${headers}
 )
 target_link_libraries(soltest PRIVATE libsolc yul solidity yulInterpreter evmasm devcore Boost::boost Boost::program_options Boost::unit_test_framework)
 
+# Special compilation flag for Visual Studio (version 2019 at least affected)
+# in order to compile SolidityEndToEndTest.cpp, which is quite huge.
+# We can remove this flag once we've extracted the tests.
+# TODO: Remove this option as soon as we have reduced the SLoC's in SolidityEndToEndTest.cpp
+if (MSVC)
+    target_compile_options(soltest PUBLIC "/bigobj")
+endif()
+
 if (LLL)
     target_link_libraries(soltest PRIVATE lll)
     target_compile_definitions(soltest PRIVATE HAVE_LLL=1)


### PR DESCRIPTION
another PR split-out that affects Windows builds. This PR ensures solidity can be fully compiled (including tests) on MSVC; Visual Studio 2019 (I don't think VS 2017 has this issue, because otherwise we would have noticed in AppVeyor?)