### PR TITLE
Make the boost cmake workaround compatible with older versions of cmake.

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -36,7 +36,7 @@ find_package(Boost 1.65.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 if (NOT TARGET Boost::boost) # header only target
 	add_library(Boost::boost INTERFACE IMPORTED)
-	target_include_directories(Boost::boost INTERFACE ${Boost_INCLUDE_DIRS})
+	set_property(TARGET Boost::boost APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Boost_INCLUDE_DIRS})
 endif()
 get_property(LOCATION TARGET Boost::boost PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "Found Boost headers in ${LOCATION}")


### PR DESCRIPTION
Follow up after an oversight in #6914.

``target_include_directories`` on imported targets was only allowed in cmake 3.11, so we need to use the older syntax to stay backwards compatible.