### PR TITLE
Add optimization rule SUB(~0, X) -> NOT(X).

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 
 Compiler Features:
+ * Optimizer: Add rule to simplify SUB(~0, X) to NOT(X).
 
 
 

--- a/libevmasm/RuleList.h
+++ b/libevmasm/RuleList.h
@@ -124,6 +124,7 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart2(
 		{{Instruction::ADD, {X, 0}}, [=]{ return X; }, false},
 		{{Instruction::ADD, {0, X}}, [=]{ return X; }, false},
 		{{Instruction::SUB, {X, 0}}, [=]{ return X; }, false},
+		{{Instruction::SUB, {~u256(0), X}}, [=]() -> Pattern { return {Instruction::NOT, {X}}; }, false},
 		{{Instruction::MUL, {X, 0}}, [=]{ return u256(0); }, true},
 		{{Instruction::MUL, {0, X}}, [=]{ return u256(0); }, true},
 		{{Instruction::MUL, {X, 1}}, [=]{ return X; }, false},

--- a/test/formal/sub_not_zero_x_to_not_x_256.py
+++ b/test/formal/sub_not_zero_x_to_not_x_256.py
@@ -1,0 +1,26 @@
+from rule import Rule
+from opcodes import *
+
+"""
+Rule:
+SUB(~0, X) -> NOT(X)
+Requirements:
+"""
+
+rule = Rule()
+
+n_bits = 256
+
+# Input vars
+X = BitVec('X', n_bits)
+
+# Constants
+ZERO = BitVecVal(0, n_bits)
+
+# Non optimized result
+nonopt = SUB(~ZERO, X)
+
+# Optimized result
+opt = NOT(X)
+
+rule.check(nonopt, opt)


### PR DESCRIPTION
Came up in https://github.com/ethereum/solidity/pull/6929. ``SUB(~0, X)`` is likely to occur in overflow checked arithmetic, if we don't add case-distinctions between short and full integer types.
In some sense, it's the symmetric rule for ``ADD(0,X)->X``.

~~The correctness of the rule is proven in https://github.com/leonardoalt/solidity_proofs/pull/5.~~ We moved the proofs to our repo now, so the correctness proof is now in this PR in the second commit.