### PR TITLE
Set state mutability of function type members ``gas`` and ``value`` to pure.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 
 Bugfixes:
  * Yul / Inline Assembly Parser: Disallow trailing commas in function call arguments.
+ * Set state mutability of the function type members ``gas`` and ``value`` to pure (while their return type inherits state mutability from the function type).
 
 
 Build System:

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2912,7 +2912,7 @@ MemberList::MemberMap FunctionType::nativeMembers(ContractDefinition const*) con
 						strings(1, ""),
 						Kind::SetValue,
 						false,
-						StateMutability::NonPayable,
+						StateMutability::Pure,
 						nullptr,
 						m_gasSet,
 						m_valueSet
@@ -2929,7 +2929,7 @@ MemberList::MemberMap FunctionType::nativeMembers(ContractDefinition const*) con
 					strings(1, ""),
 					Kind::SetGas,
 					false,
-					StateMutability::NonPayable,
+					StateMutability::Pure,
 					nullptr,
 					m_gasSet,
 					m_valueSet

--- a/test/libsolidity/syntaxTests/viewPureChecker/gas_value_without_call.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/gas_value_without_call.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f() external payable {}
+	function g(address a) external pure {
+		a.call.value(42);
+		a.call.gas(42);
+		a.staticcall.gas(42);
+		a.delegatecall.gas(42);
+	}
+	function h() external view {
+		this.f.value(42);
+		this.f.gas(42);
+	}
+}

--- a/test/libsolidity/syntaxTests/viewPureChecker/gas_with_call_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/gas_with_call_nonpayable.sol
@@ -1,0 +1,16 @@
+contract C {
+	function f(address a) external view returns (bool success) {
+		(success,) = a.call.gas(42)("");
+	}
+	function g(address a) external view returns (bool success) {
+		(success,) = a.call.gas(42)("");
+	}
+	function h() external payable {}
+	function i() external view {
+		this.h.gas(42)();
+	}
+}
+// ----
+// TypeError: (90-108): Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.
+// TypeError: (190-208): Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.
+// TypeError: (279-295): Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.

--- a/test/libsolidity/syntaxTests/viewPureChecker/staticcall_gas_view.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/staticcall_gas_view.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() external view {}
+	function test(address a) external view returns (bool status) {
+		// This used to incorrectly raise an error about violating the view mutability.
+		(status,) = a.staticcall.gas(42)("");
+		this.f.gas(42)();
+	}
+}
+// ====
+// EVMVersion: >=byzantium
+// ----

--- a/test/libsolidity/syntaxTests/viewPureChecker/value_with_call_nonpayable.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/value_with_call_nonpayable.sol
@@ -1,0 +1,16 @@
+contract C {
+	function f(address a) external view returns (bool success) {
+		(success,) = a.call.value(42)("");
+	}
+	function g(address a) external view returns (bool success) {
+		(success,) = a.call.value(42)("");
+	}
+	function h() external payable {}
+	function i() external view {
+		this.h.value(42)();
+	}
+}
+// ----
+// TypeError: (90-110): Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.
+// TypeError: (192-212): Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.
+// TypeError: (283-301): Function declared as view, but this expression (potentially) modifies the state and thus requires non-payable (the default) or payable.


### PR DESCRIPTION
Closes #6901.

The ``gas`` and ``value`` members themselves do not change state or even read from state - they just return another function type and in that sense are pure just like addition is pure.
The function type they *return* has always correctly inherited the state mutability of the original function, so no change needed there, but I added some tests.