### PR TITLE
[DOCS] Clarify that interfaces only support enum since 0.5.0

### DIFF
--- a/docs/contracts/interfaces.rst
+++ b/docs/contracts/interfaces.rst
@@ -34,3 +34,8 @@ Contracts can inherit interfaces as they would inherit other contracts.
 
 Types defined inside interfaces and other contract-like structures
 can be accessed from other contracts: ``Token.TokenType`` or ``Token.Coin``.
+
+.. warning:
+
+    Interfaces have supported ``enum`` types since :doc:`Solidity version 0.5.0 <050-breaking-changes>`, make
+    sure the pragma version specifies this version as a minimum.


### PR DESCRIPTION
### Description

Closes https://github.com/ethereum/solidity/issues/5673 by adding a warning that enums are only supported since 0.5.0. As this was an older issue, it may be that it's not needed anymore as 0.5.0 has been out for a little while now.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
