### PR TITLE
[DOCS] Fix miss-placed warnings

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -305,10 +305,6 @@ You might want to install ccache to speed up repeated builds.
 CMake will pick it up automatically.
 Building Solidity is quite similar on Linux, macOS and other Unices:
 
-.. warning::
-
-    BSD builds should work, but are untested by the Solidity team.
-
 .. code-block:: bash
 
     mkdir build
@@ -321,6 +317,10 @@ or even easier on Linux and macOS, you can run:
 
     #note: this will install binaries solc and soltest at usr/local/bin
     ./scripts/build.sh
+
+.. warning::
+
+    BSD builds should work, but are untested by the Solidity team.
 
 And for Windows:
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -165,16 +165,6 @@ Mathematical and Cryptographic Functions
 ``keccak256(bytes memory) returns (bytes32)``:
     compute the Keccak-256 hash of the input
 
-.. warning::
-
-    If you use ``ecrecover``, be aware that a valid signature can be turned into a different valid signature without
-    requiring knowledge of the corresponding private key. In the Homestead hard fork, this issue was fixed
-    for _transaction_ signatures (see `EIP-2 <http://eips.ethereum.org/EIPS/eip-2#specification>`_), but
-    the ecrecover function remained unchanged.
-
-    This is usually not a problem unless you require signatures to be unique or
-    use them to identify items. OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.org/v2.3.0/api/cryptography#ecdsa>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
-
 .. note::
 
     There used to be an alias for ``keccak256`` called ``sha3``, which was removed in version 0.5.0.
@@ -197,6 +187,16 @@ Mathematical and Cryptographic Functions
     conversion, in case you need to transfer funds to the recovered address.
 
     For further details, read `example usage <https://ethereum.stackexchange.com/q/1777/222>`_.
+
+.. warning::
+
+    If you use ``ecrecover``, be aware that a valid signature can be turned into a different valid signature without
+    requiring knowledge of the corresponding private key. In the Homestead hard fork, this issue was fixed
+    for _transaction_ signatures (see `EIP-2 <http://eips.ethereum.org/EIPS/eip-2#specification>`_), but
+    the ecrecover function remained unchanged.
+
+    This is usually not a problem unless you require signatures to be unique or
+    use them to identify items. OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.org/v2.3.0/api/cryptography#ecdsa>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
 
 .. note::
 


### PR DESCRIPTION
### Description

Fixes miss-placed warnings introduced by - https://github.com/ethereum/solidity/pull/6889

Others were fixed in https://github.com/ethereum/solidity/pull/6846

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
