### PR TITLE
Restrict whiskers parameters to regular characters.

### DIFF
--- a/libdevcore/Whiskers.h
+++ b/libdevcore/Whiskers.h
@@ -85,7 +85,8 @@ public:
 	std::string render() const;
 
 private:
-	void checkParameterUnknown(std::string const& _parameter);
+	void checkParameterValid(std::string const& _parameter) const;
+	void checkParameterUnknown(std::string const& _parameter) const;
 
 	static std::string replace(
 		std::string const& _template,
@@ -93,6 +94,8 @@ private:
 		std::map<std::string, bool> const& _conditions,
 		StringListMap const& _listParameters = StringListMap()
 	);
+
+	static std::string paramRegex() { return "[a-zA-Z0-9_$-]+"; }
 
 	/// Joins the two maps throwing an exception if two keys are equal.
 	static StringMap joinMaps(StringMap const& _a, StringMap const& _b);

--- a/test/libdevcore/Whiskers.cpp
+++ b/test/libdevcore/Whiskers.cpp
@@ -116,11 +116,11 @@ BOOST_AUTO_TEST_CASE(conditional_plus_list)
 
 BOOST_AUTO_TEST_CASE(complicated_replacement)
 {
-	string templ = "a <b> x <complicated> \n <nes<ted>>.";
+	string templ = "a <b> x <complicated> \n <nested>>.";
 	string result = Whiskers(templ)
 		("b", "BE")
 		("complicated", "CO<M>PL")
-		("nes<ted", "NEST")
+		("nested", "NEST")
 		.render();
 	BOOST_CHECK_EQUAL(result, "a BE x CO<M>PL \n NEST>.");
 }
@@ -178,6 +178,20 @@ BOOST_AUTO_TEST_CASE(parameter_collision)
 	Whiskers m(templ);
 	m("a", "X")("b", list);
 	BOOST_CHECK_THROW(m.render(), WhiskersError);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_param)
+{
+	string templ = "a <b >";
+	Whiskers m(templ);
+	BOOST_CHECK_THROW(m("b ", "X"), WhiskersError);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_param_rendered)
+{
+	string templ = "a <b >";
+	Whiskers m(templ);
+	BOOST_CHECK_EQUAL(m.render(), templ);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Should allow https://github.com/ethereum/solidity/pull/6929 to use inline comments.