### PR TITLE
[DOCS] State default value of enum in example

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -298,8 +298,8 @@ Scoping and Declarations
 A variable which is declared will have an initial default value whose byte-representation is all zeros.
 The "default values" of variables are the typical "zero-state" of whatever the type is. For example, the default value for a ``bool``
 is ``false``. The default value for the ``uint`` or ``int`` types is ``0``. For statically-sized arrays and ``bytes1`` to ``bytes32``, each individual
-element will be initialized to the default value corresponding to its type. Finally, for dynamically-sized arrays, ``bytes``
-and ``string``, the default value is an empty array or string.
+element will be initialized to the default value corresponding to its type. For dynamically-sized arrays, ``bytes``
+and ``string``, the default value is an empty array or string. For the ``enum`` type, the default value is its first member.
 
 Scoping in Solidity follows the widespread scoping rules of C99
 (and many other languages): Variables are visible from the point right after their declaration

--- a/docs/examples/safe-remote.rst
+++ b/docs/examples/safe-remote.rst
@@ -13,6 +13,7 @@ Safe Remote Purchase
         address payable public seller;
         address payable public buyer;
         enum State { Created, Locked, Inactive }
+        // The state variable has a default value of the first member, `State.created`
         State public state;
 
         // Ensure that `msg.value` is an even number.

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -512,7 +512,7 @@ Enums
 Enums are one way to create a user-defined type in Solidity. They are explicitly convertible
 to and from all integer types but implicit conversion is not allowed.  The explicit conversion
 from integer checks at runtime that the value lies inside the range of the enum and causes a failing assert otherwise.
-Enums needs at least one member.
+Enums require at least one member, and its default value when declared is the first member.
 
 The data representation is the same as for enums in C: The options are represented by
 subsequent unsigned integer values starting from ``0``.


### PR DESCRIPTION
### Description

Closes https://github.com/ethereum/solidity/issues/3849 this updates the example, but regarding https://github.com/ethereum/solidity/issues/3849#issuecomment-396665015 I can't seem to find a section that mentions default values. If this is missing I'll create a separate issue, but maybe I just couldn't find it.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
