### PR TITLE
[Do not merge] Fix nested array copy from calldata to storage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+
+ * Fix assertion failure when copy nested calldata dynamic arrays from calldata to storage.
+
 ### 0.5.11 (unreleased)
 
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -7486,6 +7486,12 @@ BOOST_AUTO_TEST_CASE(calldata_array_two_dimensional)
 				function reenc()" + arrayType + R"( calldata a, uint256 i, uint256 j) external returns (uint256) {
 					return this.test(a, i, j);
 				}
+				)" + arrayType + R"( tmp_storage;
+				function storage_assign_reenc()" + arrayType + R"( calldata a, uint256 i, uint256 j) external returns (uint256) {
+					delete tmp_storage;
+					tmp_storage = a;
+					return this.test(tmp_storage, i, j);
+				}
 			}
 		)";
 		compileAndRun(sourceCode, 0, "C");
@@ -7504,8 +7510,18 @@ BOOST_AUTO_TEST_CASE(calldata_array_two_dimensional)
 			ABI_CHECK(callContractFunction("test(" + arrayType + ",uint256)", 0x40, i, encoding), encodeArgs(data[i].size()));
 			for (size_t j = 0; j < data[i].size(); j++)
 			{
-				ABI_CHECK(callContractFunction("test(" + arrayType + ",uint256,uint256)", 0x60, i, j, encoding), encodeArgs(data[i][j]));
-				ABI_CHECK(callContractFunction("reenc(" + arrayType + ",uint256,uint256)", 0x60, i, j, encoding), encodeArgs(data[i][j]));
+				ABI_CHECK(
+					callContractFunction("test(" + arrayType + ",uint256,uint256)", 0x60, i, j, encoding),
+					encodeArgs(data[i][j])
+				);
+				ABI_CHECK(
+					callContractFunction("reenc(" + arrayType + ",uint256,uint256)", 0x60, i, j, encoding),
+					encodeArgs(data[i][j])
+				);
+				ABI_CHECK(
+					callContractFunction("storage_assign_reenc(" + arrayType + ",uint256,uint256)", 0x60, i, j, encoding),
+					encodeArgs(data[i][j])
+				);
 			}
 			// out of bounds access
 			ABI_CHECK(callContractFunction("test(" + arrayType + ",uint256,uint256)", 0x60, i, data[i].size(), encoding), encodeArgs());
@@ -7559,6 +7575,12 @@ BOOST_AUTO_TEST_CASE(calldata_array_dynamic_three_dimensional)
 				function reenc()" + arrayType + R"( calldata a, uint256 i, uint256 j, uint256 k) external returns (uint256) {
 					return this.test(a, i, j, k);
 				}
+				)" + arrayType + R"( tmp_storage;
+				function storage_assign_reenc()" + arrayType + R"( calldata a, uint256 i, uint256 j, uint256 k) external returns (uint256) {
+					delete tmp_storage;
+					tmp_storage = a;
+					return this.test(tmp_storage, i, j, k);
+				}
 			}
 		)";
 		compileAndRun(sourceCode, 0, "C");
@@ -7586,8 +7608,18 @@ BOOST_AUTO_TEST_CASE(calldata_array_dynamic_three_dimensional)
 				ABI_CHECK(callContractFunction("test(" + arrayType + ",uint256,uint256)", 0x60, i, j, encoding), encodeArgs(data[i][j].size()));
 				for (size_t k = 0; k < data[i][j].size(); k++)
 				{
-					ABI_CHECK(callContractFunction("test(" + arrayType + ",uint256,uint256,uint256)", 0x80, i, j, k, encoding), encodeArgs(data[i][j][k]));
-					ABI_CHECK(callContractFunction("reenc(" + arrayType + ",uint256,uint256,uint256)", 0x80, i, j, k, encoding), encodeArgs(data[i][j][k]));
+					ABI_CHECK(
+						callContractFunction("test(" + arrayType + ",uint256,uint256,uint256)", 0x80, i, j, k, encoding),
+						encodeArgs(data[i][j][k])
+					);
+					ABI_CHECK(
+						callContractFunction("reenc(" + arrayType + ",uint256,uint256,uint256)", 0x80, i, j, k, encoding),
+						encodeArgs(data[i][j][k])
+					);
+					ABI_CHECK(
+						callContractFunction("storage_assign_reenc(" + arrayType + ",uint256,uint256,uint256)", 0x80, i, j, k, encoding),
+						encodeArgs(data[i][j][k])
+					);
 				}
 				// out of bounds access
 				ABI_CHECK(callContractFunction("test(" + arrayType + ",uint256,uint256,uint256)", 0x80, i, j, data[i][j].size(), encoding), encodeArgs());

--- a/test/libsolidity/semanticTests/abiEncoderV2/storage_array_encoding.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/storage_array_encoding.sol
@@ -3,6 +3,16 @@ pragma experimental ABIEncoderV2;
 // tests encoding from storage arrays
 
 contract C {
+    uint256[][] tmp_f;
+    function f(uint256[][] calldata s) external returns (bytes memory) {
+        tmp_f = s;
+        return abi.encode(tmp_f);
+    }
+    uint256[][2] tmp_g;
+    function g(uint256[][2] calldata s) external returns (bytes memory) {
+        tmp_g = s;
+        return abi.encode(tmp_g);
+    }
     uint256[2][] tmp_h;
     function h(uint256[2][] calldata s) external returns (bytes memory) {
         tmp_h = s;
@@ -13,9 +23,17 @@ contract C {
         tmp_i = s;
         return abi.encode(tmp_i);
     }
+    bytes[2] tmp_j;
+    function j(bytes[2] calldata s) external returns (bytes memory) {
+        tmp_j = s;
+        return abi.encode(tmp_j);
+    }
 }
 // ====
 // EVMVersion: >homestead
 // ----
+// f(uint256[][])  : 0x20, 2, 0x40, 0xC0, 3, 13, 17, 23, 4, 27, 31, 37, 41 -> 32, 416, 32, 2, 64, 192, 3, 13, 17, 23, 4, 27, 31, 37, 41
+// g(uint256[][2]) : 0x20, 0x40, 0xC0, 3, 123, 124, 125, 3, 223, 224, 225 -> 32, 352, 0x20, 0x40, 0xC0, 3, 123, 124, 125, 3, 223, 224, 225
 // h(uint256[2][]) : 0x20, 3, 123, 124, 223, 224, 323, 324 -> 32, 256, 0x20, 3, 123, 124, 223, 224, 323, 324
 // i(uint256[2][2]): 123, 124, 223, 224 -> 32, 128, 123, 124, 223, 224
+// j(bytes[2])     : 0x20, 0x40, 0x66, 6, hex"123ABC456DEF", 4, hex"FED65432" -> 32, 224, 0x20, 0x40, 0x80, 6, left(0x123ABC456DEF), 4, left(0xFED65432)


### PR DESCRIPTION
### Description

This PR is similar to #6881 , but fixes nested calldata dynamic array's assignment to storage. (#6881 fixes assignment to memory)

The `Changelog.md` update reflects both this PR and #6881 's change.

I only tested some basic cases so please review carefully.

By the way, the codegen of other dynamic types that need calldata tail pointer access are guarded by `solUnimplementedAssert`, and for array types it should always cause stack height assertion failure (because calldata dynamic array's length is also stored on stack). So the bug fixed by these 2 PRs probably did not lead to vulnerability in previous compiler releases.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
