### PR TITLE
[SMTChecker] Collect assertions in EncodingContext

### DIFF
--- a/libsolidity/formal/EncodingContext.h
+++ b/libsolidity/formal/EncodingContext.h
@@ -36,12 +36,12 @@ namespace smt
 class EncodingContext
 {
 public:
-	EncodingContext(SolverInterface& _solver);
+	EncodingContext(std::shared_ptr<SolverInterface> _solver);
 
 	/// Resets the entire context.
 	void reset();
 
-	/// Methods related to variables.
+	/// Variables.
 	//@{
 	/// @returns the symbolic representation of a program variable.
 	std::shared_ptr<SymbolicVariable> variable(solidity::VariableDeclaration const& _varDecl);
@@ -74,7 +74,7 @@ public:
 	void setUnknownValue(SymbolicVariable& _variable);
 	//@}
 
-	/// Methods related to expressions.
+	/// Expressions.
 	////@{
 	/// @returns the symbolic representation of an AST node expression.
 	std::shared_ptr<SymbolicVariable> expression(solidity::Expression const& _e);
@@ -88,12 +88,13 @@ public:
 	bool knownExpression(solidity::Expression const& _e) const;
 	//@}
 
-	/// Methods related to global variables and functions.
+	/// Global variables and functions.
 	//@{
 	/// Global variables and functions.
 	std::shared_ptr<SymbolicVariable> globalSymbol(std::string const& _name);
-	/// @returns all symbolic variables.
+	/// @returns all symbolic globals.
 	std::unordered_map<std::string, std::shared_ptr<SymbolicVariable>> const& globalSymbols() const { return m_globalContext; }
+
 	/// Defines a new global variable or function
 	/// and @returns true if type was abstracted.
 	bool createGlobalSymbol(std::string const& _name, solidity::Expression const& _expr);
@@ -101,7 +102,7 @@ public:
 	bool knownGlobalSymbol(std::string const& _var) const;
 	//@}
 
-	/// Blockchain related methods.
+	/// Blockchain.
 	//@{
 	/// Value of `this` address.
 	Expression thisAddress();
@@ -113,12 +114,22 @@ public:
 	void transfer(Expression _from, Expression _to, Expression _value);
 	//@}
 
+	/// Solver.
+	//@{
+	/// @returns conjunction of all added assertions.
+	Expression assertions();
+	void pushSolver();
+	void popSolver();
+	void addAssertion(Expression const& _e);
+	std::shared_ptr<SolverInterface> solver() { return m_solver; }
+	//@}
+
 private:
 	/// Adds _value to _account's balance.
 	void addBalance(Expression _account, Expression _value);
 
-	SolverInterface& m_solver;
-
+	/// Symbolic expressions.
+	//{@
 	/// Symbolic variables.
 	std::unordered_map<solidity::VariableDeclaration const*, std::shared_ptr<SymbolicVariable>> m_variables;
 
@@ -134,6 +145,16 @@ private:
 
 	/// Symbolic balances.
 	std::unique_ptr<SymbolicVariable> m_balances;
+	//@}
+
+	/// Solver related.
+	//@{
+	/// Solver can be SMT solver or Horn solver in the future.
+	std::shared_ptr<SolverInterface> m_solver;
+
+	/// Assertion stack.
+	std::vector<Expression> m_assertions;
+	//@}
 };
 
 }

--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -53,7 +53,7 @@ public:
 	/// This is used if the SMT solver is not directly linked into this binary.
 	/// @returns a list of inputs to the SMT solver that were not part of the argument to
 	/// the constructor.
-	std::vector<std::string> unhandledQueries() { return m_interface.unhandledQueries(); }
+	std::vector<std::string> unhandledQueries() { return m_interface->unhandledQueries(); }
 
 	/// @returns the FunctionDefinition of a called function if possible and should inline,
 	/// otherwise nullptr.
@@ -90,10 +90,6 @@ private:
 	bool visit(MemberAccess const& _node) override;
 	void endVisit(IndexAccess const& _node) override;
 	bool visit(InlineAssembly const& _node) override;
-
-	smt::Expression assertions() { return m_interface.assertions(); }
-	void push() { m_interface.push(); }
-	void pop() { m_interface.pop(); }
 
 	/// Do not visit subtree if node is a RationalNumber.
 	/// Symbolic _expr is the rational literal.
@@ -274,7 +270,7 @@ private:
 	/// @returns the VariableDeclaration referenced by an Identifier or nullptr.
 	VariableDeclaration const* identifierToVariable(Expression const& _expr);
 
-	smt::SMTPortfolio m_interface;
+	std::shared_ptr<smt::SolverInterface> m_interface;
 	smt::VariableUsage m_variableUsage;
 	bool m_loopExecutionHappened = false;
 	bool m_arrayAssignmentHappened = false;

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -43,21 +43,18 @@ SMTPortfolio::SMTPortfolio(map<h256, string> const& _smtlib2Responses)
 
 void SMTPortfolio::reset()
 {
-	m_assertions.clear();
 	for (auto const& s: m_solvers)
 		s->reset();
 }
 
 void SMTPortfolio::push()
 {
-	m_assertions.push_back(Expression(true));
 	for (auto const& s: m_solvers)
 		s->push();
 }
 
 void SMTPortfolio::pop()
 {
-	m_assertions.pop_back();
 	for (auto const& s: m_solvers)
 		s->pop();
 }
@@ -70,21 +67,8 @@ void SMTPortfolio::declareVariable(string const& _name, Sort const& _sort)
 
 void SMTPortfolio::addAssertion(Expression const& _expr)
 {
-	if (m_assertions.empty())
-		m_assertions.push_back(_expr);
-	else
-		m_assertions.back() = _expr && move(m_assertions.back());
-
 	for (auto const& s: m_solvers)
 		s->addAssertion(_expr);
-}
-
-Expression SMTPortfolio::assertions()
-{
-	if (m_assertions.empty())
-		return Expression(true);
-
-	return m_assertions.back();
 }
 
 /*

--- a/libsolidity/formal/SMTPortfolio.h
+++ b/libsolidity/formal/SMTPortfolio.h
@@ -53,8 +53,6 @@ public:
 
 	void addAssertion(Expression const& _expr) override;
 
-	Expression assertions();
-
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 	std::vector<std::string> unhandledQueries() override;


### PR DESCRIPTION
Move collecting assertions pre-solver from SMTPortfolio to EncodingContext.
Still not used as intended (next PRs)