### PR TITLE
[SMTChecker] Remove overflow check for assignments

### DIFF
--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -140,9 +140,9 @@ private:
 	/// of rounding for signed division.
 	smt::Expression division(smt::Expression _left, smt::Expression _right, IntegerType const& _type);
 
-	void assignment(VariableDeclaration const& _variable, Expression const& _value, langutil::SourceLocation const& _location);
+	void assignment(VariableDeclaration const& _variable, Expression const& _value);
 	/// Handles assignments to variables of different types.
-	void assignment(VariableDeclaration const& _variable, smt::Expression const& _value, langutil::SourceLocation const& _location);
+	void assignment(VariableDeclaration const& _variable, smt::Expression const& _value);
 	/// Handles assignments between generic expressions.
 	/// Will also be used for assignments of tuple components.
 	void assignment(

--- a/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
+++ b/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
@@ -87,8 +87,6 @@ contract InternalCall {
 // Warning: (782-813): Type conversion is not yet fully supported and might yield false positives.
 // Warning: (771-814): Assertion checker does not yet implement this type of function call.
 // Warning: (825-830): Assertion checker does not yet support the type of this variable.
-// Warning: (690-750): Underflow (resulting value less than 0) happens here
-// Warning: (690-750): Overflow (resulting value larger than 2**160 - 1) happens here
 // Warning: (1057-1068): Assertion checker does not yet implement type function () returns (uint256)
 // Warning: (1120-1131): Assertion checker does not yet implement type function () returns (uint256)
 // Warning: (1403-1408): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/loops/for_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_fail.sol
@@ -15,6 +15,4 @@ contract C
 // Warning: (189-203): Assertion violation happens here
 // Warning: (176-181): Underflow (resulting value less than 0) happens here
 // Warning: (176-181): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (172-181): Underflow (resulting value less than 0) happens here
-// Warning: (172-181): Overflow (resulting value larger than 2**256 - 1) happens here
 // Warning: (126-129): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
@@ -16,6 +16,4 @@ contract C
 // Warning: (244-257): Assertion violation happens here
 // Warning: (176-181): Underflow (resulting value less than 0) happens here
 // Warning: (176-181): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (172-181): Underflow (resulting value less than 0) happens here
-// Warning: (172-181): Overflow (resulting value larger than 2**256 - 1) happens here
 // Warning: (126-129): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_4.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_4.sol
@@ -8,5 +8,3 @@ contract C {
 }
 // ----
 // Warning: (136-150): Assertion violation happens here
-// Warning: (115-120): Underflow (resulting value less than 0) happens here
-// Warning: (115-120): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_5.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_5.sol
@@ -10,5 +10,3 @@ contract C {
 }
 // ----
 // Warning: (167-181): Assertion violation happens here
-// Warning: (142-147): Underflow (resulting value less than 0) happens here
-// Warning: (142-147): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_6.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_6.sol
@@ -11,5 +11,3 @@ contract C {
 }
 // ----
 // Warning: (213-226): Assertion violation happens here
-// Warning: (142-147): Underflow (resulting value less than 0) happens here
-// Warning: (142-147): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_2.sol
@@ -11,5 +11,3 @@ contract C {
 }
 // ----
 // Warning: (138-144): For loop condition is always true.
-// Warning: (161-166): Underflow (resulting value less than 0) happens here
-// Warning: (161-166): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_3.sol
@@ -16,5 +16,3 @@ contract C {
 // ----
 // Warning: (115-121): Unused local variable.
 // Warning: (356-370): Assertion violation happens here
-// Warning: (285-290): Underflow (resulting value less than 0) happens here
-// Warning: (285-290): Overflow (resulting value larger than 2**256 - 1) happens here


### PR DESCRIPTION
The removed checks should be done explicitly where the targets are created.
The only use case at the moment was for unary inc/dec, so the overflow check was moved there.
The same should be done for type conversion in the future.
This is part of the refactoring.