### PR TITLE
[SMTChecker] Delay all checks

### DIFF
--- a/libsolidity/formal/SMTChecker.h
+++ b/libsolidity/formal/SMTChecker.h
@@ -103,7 +103,7 @@ private:
 		smt::Expression const& _left,
 		smt::Expression const& _right,
 		TypePointer const& _commonType,
-		langutil::SourceLocation const& _location
+		Expression const& _expression
 	);
 	void compareOperation(BinaryOperation const& _op);
 	void booleanOperation(BinaryOperation const& _op);
@@ -163,57 +163,68 @@ private:
 	VariableIndices visitBranch(ASTNode const* _statement, smt::Expression const* _condition = nullptr);
 	VariableIndices visitBranch(ASTNode const* _statement, smt::Expression _condition);
 
+	using CallStackEntry = std::pair<CallableDeclaration const*, ASTNode const*>;
+
+	/// Verification targets.
+	//@{
+	struct VerificationTarget
+	{
+		enum class Type { ConstantCondition, Underflow, Overflow, UnderOverflow, DivByZero, Balance, Assert } type;
+		smt::Expression value;
+		smt::Expression constraints;
+		Expression const* expression;
+		std::vector<CallStackEntry> callStack;
+		std::pair<std::vector<smt::Expression>, std::vector<std::string>> modelExpressions;
+	};
+
+	void checkVerificationTargets(smt::Expression const& _constraints);
+	void checkVerificationTarget(VerificationTarget& _target, smt::Expression const& _constraints = smt::Expression(true));
+	void checkConstantCondition(VerificationTarget& _target);
+	void checkUnderflow(VerificationTarget& _target, smt::Expression const& _constraints);
+	void checkOverflow(VerificationTarget& _target, smt::Expression const& _constraints);
+	void checkDivByZero(VerificationTarget& _target);
+	void checkBalance(VerificationTarget& _target);
+	void checkAssert(VerificationTarget& _target);
+	void addVerificationTarget(
+		VerificationTarget::Type _type,
+		smt::Expression const& _value,
+		Expression const* _expression
+	);
+	//@}
+
+	/// Solver related.
+	//@{
+
+	std::pair<std::vector<smt::Expression>, std::vector<std::string>> modelExpressions();
 	/// Check that a condition can be satisfied.
 	void checkCondition(
-		smt::Expression _condition,
+		smt::Expression const& _condition,
+		std::vector<CallStackEntry> const& callStack,
+		std::pair<std::vector<smt::Expression>, std::vector<std::string>> const& _modelExpressions,
 		langutil::SourceLocation const& _location,
 		std::string const& _description,
 		std::string const& _additionalValueName = "",
 		smt::Expression const* _additionalValue = nullptr
 	);
-	/// Checks that a boolean condition is not constant. Do not warn if the expression
-	/// is a literal constant.
+	/// Checks whether a Boolean condition is constant.
+	/// Do not warn if the expression is a literal constant.
+	/// @param _condition the Solidity expression, used to check whether it is a Literal and for location.
+	/// @param _constraints the program constraints, including control-flow.
+	/// @param _value the Boolean term to be checked.
+	/// @param _callStack the callStack to be shown with the model if applicable.
 	/// @param _description the warning string, $VALUE will be replaced by the constant value.
 	void checkBooleanNotConstant(
 		Expression const& _condition,
+		smt::Expression const& _constraints,
+		smt::Expression const& _value,
+		std::vector<CallStackEntry> const& _callStack,
 		std::string const& _description
 	);
-
-	using CallStackEntry = std::pair<CallableDeclaration const*, ASTNode const*>;
-
-	struct OverflowTarget
-	{
-		enum class Type { Underflow, Overflow, All } type;
-		TypePointer intType;
-		smt::Expression value;
-		smt::Expression path;
-		langutil::SourceLocation const& location;
-		std::vector<CallStackEntry> callStack;
-
-		OverflowTarget(Type _type, TypePointer _intType, smt::Expression _value, smt::Expression _path, langutil::SourceLocation const& _location, std::vector<CallStackEntry> _callStack):
-			type(_type),
-			intType(_intType),
-			value(_value),
-			path(_path),
-			location(_location),
-			callStack(move(_callStack))
-		{
-			solAssert(dynamic_cast<IntegerType const*>(intType), "");
-		}
-	};
-
-	/// Checks that the value is in the range given by the type.
-	void checkUnderflow(OverflowTarget& _target);
-	void checkOverflow(OverflowTarget& _target);
-	/// Calls the functions above for all elements in m_overflowTargets accordingly.
-	void checkUnderOverflow();
-	/// Adds an overflow target for lazy check at the end of the function.
-	void addOverflowTarget(OverflowTarget::Type _type, TypePointer _intType, smt::Expression _value, langutil::SourceLocation const& _location);
-
 	std::pair<smt::CheckResult, std::vector<std::string>>
 	checkSatisfiableAndGenerateModel(std::vector<smt::Expression> const& _expressionsToEvaluate);
 
 	smt::CheckResult checkSatisfiable();
+	//@}
 
 	void initializeLocalVariables(FunctionDefinition const& _function);
 	void initializeFunctionCallParameters(CallableDeclaration const& _function, std::vector<smt::Expression> const& _callArgs);
@@ -248,8 +259,8 @@ private:
 	void popPathCondition();
 	/// Returns the conjunction of all path conditions or True if empty
 	smt::Expression currentPathConditions();
-	/// Returns the current callstack. Used for models.
-	langutil::SecondarySourceLocation currentCallStack();
+	/// @returns a human-readable call stack. Used for models.
+	langutil::SecondarySourceLocation callStackMessage(std::vector<CallStackEntry> const& _callStack);
 	/// Copies and pops the last called node.
 	CallStackEntry popCallStack();
 	/// Adds (_definition, _node) to the callstack.
@@ -300,7 +311,7 @@ private:
 	/// Returns true if _funDef was already visited.
 	bool visitedFunction(FunctionDefinition const* _funDef);
 
-	std::vector<OverflowTarget> m_overflowTargets;
+	std::vector<VerificationTarget> m_verificationTargets;
 
 	/// Depth of visit to modifiers.
 	/// When m_modifierDepth == #modifiers the function can be visited

--- a/test/libsolidity/smtCheckerTests/complex/MerkleProof.sol
+++ b/test/libsolidity/smtCheckerTests/complex/MerkleProof.sol
@@ -38,4 +38,3 @@ library MerkleProof {
 // Warning: (988-1032): Assertion checker does not yet implement this type of function call.
 // Warning: (1175-1219): Assertion checker does not yet implement this type of function call.
 // Warning: (755-767): Assertion checker does not yet support this expression.
-// Warning: (769-772): Overflow (resulting value larger than 2**256 - 1) happens here

--- a/test/libsolidity/smtCheckerTests/functions/functions_trivial_condition_for.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_trivial_condition_for.sol
@@ -5,4 +5,4 @@ contract C
 	function f(bool x) public pure { require(x); for (;x;) {} }
 }
 // ----
-// Warning: (98-99): For loop condition is always true.
+// Warning: (98-99): Condition is always true.

--- a/test/libsolidity/smtCheckerTests/functions/functions_trivial_condition_while.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_trivial_condition_while.sol
@@ -5,4 +5,4 @@ contract C
 	function f(bool x) public pure { require(x); while (x) {} }
 }
 // ----
-// Warning: (99-100): While loop condition is always true.
+// Warning: (99-100): Condition is always true.

--- a/test/libsolidity/smtCheckerTests/loops/do_while_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_1_fail.sol
@@ -12,5 +12,5 @@ contract C
 	}
 }
 // ----
-// Warning: (179-193): Assertion violation happens here
 // Warning: (150-155): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (179-193): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/do_while_1_false_positives.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_1_false_positives.sol
@@ -14,5 +14,5 @@ contract C
 	}
 }
 // ----
-// Warning: (269-282): Assertion violation happens here
 // Warning: (150-155): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (269-282): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_fail.sol
@@ -12,7 +12,5 @@ contract C
 	}
 }
 // ----
-// Warning: (189-203): Assertion violation happens here
-// Warning: (176-181): Underflow (resulting value less than 0) happens here
 // Warning: (176-181): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (126-129): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (189-203): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
@@ -13,7 +13,5 @@ contract C
 	}
 }
 // ----
-// Warning: (244-257): Assertion violation happens here
-// Warning: (176-181): Underflow (resulting value less than 0) happens here
 // Warning: (176-181): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (126-129): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (244-257): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_1.sol
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// Warning: (122-128): For loop condition is always true.
+// Warning: (122-128): Condition is always true.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_2.sol
@@ -10,4 +10,4 @@ contract C {
     }
 }
 // ----
-// Warning: (138-144): For loop condition is always true.
+// Warning: (138-144): Condition is always true.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_unreachable_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_unreachable_1.sol
@@ -7,4 +7,4 @@ contract C {
     }
 }
 // ----
-// Warning: (122-127): For loop condition is always false.
+// Warning: (122-127): Condition is always false.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_different_size_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_different_size_1.sol
@@ -19,8 +19,8 @@ contract C
 }
 // ----
 // Warning: (186-195): Type conversion is not yet fully supported and might yield false positives.
-// Warning: (280-303): Assertion violation happens here
 // Warning: (317-333): Type conversion is not yet fully supported and might yield false positives.
-// Warning: (414-431): Assertion violation happens here
 // Warning: (451-460): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (280-303): Assertion violation happens here
+// Warning: (414-431): Assertion violation happens here
 // Warning: (542-559): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/address_balance.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_balance.sol
@@ -9,5 +9,5 @@ contract C
 }
 // ----
 // Warning: (96-102): Unused local variable.
-// Warning: (131-160): Assertion violation happens here
 // Warning: (105-127): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (131-160): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTestsJSON/multi.json
+++ b/test/libsolidity/smtCheckerTestsJSON/multi.json
@@ -3,9 +3,9 @@
 	{
 		"smtlib2responses":
 		{
-			"0x0a0e9583fd983e7ce82e96bd95f7c0eb831e2dd3ce3364035e30bf1d22823b34": "sat\n((|EVALEXPR_0| 1))\n",
-			"0x15353582486fb1dac47801edbb366ae40a59ef0191ebe7c09ca32bdabecc2f1a": "unsat\n",
-			"0xa66d08de30c873ca7d0e7e9e426f278640e0ee463a1aed2e4e80baee916b6869": "sat\n((|EVALEXPR_0| 0))\n"
+			"0x5c4a8addfb72cd6eedbd143f0d402faa2833363b9c8c3f4ed5d9b01ff8fdeee0": "unsat\n",
+			"0xf04f3df4fcb1dcab2a20ff50621679f88608a48addeedfd3792fd652e7115d2f": "sat\n((|EVALEXPR_0| 0))\n",
+			"0xf7f1fe2ee1dced3b4ee90b7f1babcfb9ca520344b39c592f4a378761775705bd": "sat\n((|EVALEXPR_0| 1))\n"
 		}
 	}
 }

--- a/test/libsolidity/smtCheckerTestsJSON/simple.json
+++ b/test/libsolidity/smtCheckerTestsJSON/simple.json
@@ -3,7 +3,7 @@
 	{
 		"smtlib2responses":
 		{
-			"0xa66d08de30c873ca7d0e7e9e426f278640e0ee463a1aed2e4e80baee916b6869": "sat\n((|EVALEXPR_0| 0))\n"
+			"0xf38a3b8e5fd03ea30ca7df1b566b1f76a5d6e0b8c46f58ff7bf576f537a4c366": "sat\n((|EVALEXPR_0| 0))\n"
 		}
 	}
 }


### PR DESCRIPTION
Depends on #6993 

This PR adds code that delays all checks to end the of the function except for constant conditions which need to be checked on the fly.

In order to do that, this code
- adds a more general VerificationTarget removing OverflowTarget
- uses the assertion stack from EncodingContext
- makes functions `checkCondition` and `checkBooleanNotConstant` almost free, using only `m_interface` from the class

It's hard to separate these things in different PRs because they are intertwined, so hopefully this PR is reviewable as it is.