### PR TITLE
[SMTChecker] Fix wrong assertion in callstack message

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1264,8 +1264,6 @@ SecondarySourceLocation SMTEncoder::callStackMessage(vector<CallStackEntry> cons
 	for (auto const& call: _callStack | boost::adaptors::reversed)
 		if (call.second)
 			callStackLocation.append("", call.second->location());
-	// The first function in the tx has no FunctionCall.
-	solAssert(_callStack.front().second == nullptr, "");
 	return callStackLocation;
 }
 

--- a/test/libsolidity/smtCheckerTests/functions/function_call_state_var_init.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_call_state_var_init.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x = f(2);
+
+	function f(uint y) internal pure returns (uint) {
+		assert(y > 1000);
+		return y;
+	}
+}
+// ----
+// Warning: (116-132): Assertion violation happens here
+// Warning: (116-132): Assertion violation happens here


### PR DESCRIPTION
Depends on #7001 

This assertion is not true because inlined function calls in state var init will be the root of the callstack.