### PR TITLE
[SMTChecker] Move solver from SMTEncoder to BMC

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -28,8 +28,9 @@ using namespace langutil;
 using namespace dev::solidity;
 
 BMC::BMC(smt::EncodingContext& _context, ErrorReporter& _errorReporter, map<h256, string> const& _smtlib2Responses):
-	SMTEncoder(_context, _smtlib2Responses),
-	m_outerErrorReporter(_errorReporter)
+	SMTEncoder(_context),
+	m_outerErrorReporter(_errorReporter),
+	m_interface(make_shared<smt::SMTPortfolio>(_smtlib2Responses))
 {
 #if defined (HAVE_Z3) || defined (HAVE_CVC4)
 	if (!_smtlib2Responses.empty())

--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -30,7 +30,7 @@
 
 #include <libsolidity/formal/EncodingContext.h>
 #include <libsolidity/formal/SMTEncoder.h>
-#include <libsolidity/formal/SMTPortfolio.h>
+#include <libsolidity/formal/SolverInterface.h>
 
 #include <libsolidity/interface/ReadFile.h>
 #include <liblangutil/ErrorReporter.h>
@@ -174,6 +174,8 @@ private:
 	langutil::ErrorReporter& m_outerErrorReporter;
 
 	std::vector<VerificationTarget> m_verificationTargets;
+
+	std::shared_ptr<smt::SolverInterface> m_interface;
 };
 
 }

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -24,7 +24,6 @@
 
 
 #include <libsolidity/formal/EncodingContext.h>
-#include <libsolidity/formal/SMTPortfolio.h>
 #include <libsolidity/formal/SymbolicVariables.h>
 #include <libsolidity/formal/VariableUsage.h>
 
@@ -51,7 +50,7 @@ namespace solidity
 class SMTEncoder: public ASTConstVisitor
 {
 public:
-	SMTEncoder(smt::EncodingContext& _context, std::map<h256, std::string> const& _smtlib2Responses);
+	SMTEncoder(smt::EncodingContext& _context);
 
 	/// @returns the leftmost identifier in a multi-d IndexAccess.
 	static Expression const* leftmostBase(IndexAccess const& _indexAccess);
@@ -208,7 +207,6 @@ protected:
 	/// @returns a note to be added to warnings.
 	std::string extraComment();
 
-	std::shared_ptr<smt::SolverInterface> m_interface;
 	smt::VariableUsage m_variableUsage;
 	bool m_arrayAssignmentHappened = false;
 	// True if the "No SMT solver available" warning was already created.


### PR DESCRIPTION
The instantiated solver depends on the model checking engine so it belongs there and not in the encoder.