### PR TITLE
[SMTChecker] EncodingContext's solver needs to be set dynamically

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -49,6 +49,7 @@ void BMC::analyze(SourceUnit const& _source, shared_ptr<Scanner> const& _scanner
 
 	m_scanner = _scanner;
 
+	m_context.setSolver(m_interface);
 	m_context.clear();
 
 	_source.accept(*this);

--- a/libsolidity/formal/EncodingContext.cpp
+++ b/libsolidity/formal/EncodingContext.cpp
@@ -23,9 +23,8 @@ using namespace std;
 using namespace dev;
 using namespace dev::solidity::smt;
 
-EncodingContext::EncodingContext(std::shared_ptr<SolverInterface> _solver):
-	m_thisAddress(make_unique<SymbolicAddressVariable>("this", *this)),
-	m_solver(_solver)
+EncodingContext::EncodingContext():
+	m_thisAddress(make_unique<SymbolicAddressVariable>("this", *this))
 {
 	auto sort = make_shared<ArraySort>(
 		make_shared<Sort>(Kind::Int),
@@ -214,7 +213,7 @@ void EncodingContext::transfer(Expression _from, Expression _to, Expression _val
 		m_balances->valueAtIndex(indexBefore),
 		m_balances->valueAtIndex(indexAfter)
 	);
-	m_solver->addAssertion(m_balances->currentValue() == newBalances);
+	addAssertion(m_balances->currentValue() == newBalances);
 }
 
 /// Solver.
@@ -256,5 +255,5 @@ void EncodingContext::addBalance(Expression _address, Expression _value)
 		balance(_address) + move(_value)
 	);
 	m_balances->increaseIndex();
-	m_solver->addAssertion(newBalances == m_balances->currentValue());
+	addAssertion(newBalances == m_balances->currentValue());
 }

--- a/libsolidity/formal/EncodingContext.h
+++ b/libsolidity/formal/EncodingContext.h
@@ -36,7 +36,7 @@ namespace smt
 class EncodingContext
 {
 public:
-	EncodingContext(std::shared_ptr<SolverInterface> _solver);
+	EncodingContext();
 
 	/// Resets the entire context except for symbolic variables which stay
 	/// alive because of state variables and inlined function calls.
@@ -45,6 +45,14 @@ public:
 	/// Clears the entire context, erasing everything.
 	/// To be used before a model checking engine starts.
 	void clear();
+
+	/// Sets the current solver used by the current engine for
+	/// SMT variable declaration.
+	void setSolver(std::shared_ptr<SolverInterface> _solver)
+	{
+		solAssert(_solver, "");
+		m_solver = _solver;
+	}
 
 	/// Forwards variable creation to the solver.
 	Expression newVariable(std::string _name, SortPointer _sort)
@@ -133,7 +141,11 @@ public:
 	void pushSolver();
 	void popSolver();
 	void addAssertion(Expression const& _e);
-	std::shared_ptr<SolverInterface> solver() { return m_solver; }
+	std::shared_ptr<SolverInterface> solver()
+	{
+		solAssert(m_solver, "");
+		return m_solver;
+	}
 	//@}
 
 private:

--- a/libsolidity/formal/ModelChecker.cpp
+++ b/libsolidity/formal/ModelChecker.cpp
@@ -24,7 +24,7 @@ using namespace dev::solidity;
 
 ModelChecker::ModelChecker(ErrorReporter& _errorReporter, map<h256, string> const& _smtlib2Responses):
 	m_bmc(m_context, _errorReporter, _smtlib2Responses),
-	m_context(m_bmc.solver())
+	m_context()
 {
 }
 


### PR DESCRIPTION
Since BMC and CHC use different solver instances, it needs to be set dynamically in EncodingContext by BMC and CHC separately.