### PR TITLE
Cope with constants without value in inline assembly.

### DIFF
--- a/test/libsolidity/syntaxTests/inlineAssembly/constant_access_non_initialized.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/constant_access_non_initialized.sol
@@ -1,0 +1,11 @@
+contract C {
+    uint constant x;
+    function f() public pure {
+        assembly {
+            let c1 := x
+        }
+    }
+}
+// ----
+// TypeError: (17-32): Uninitialized "constant" variable.
+// TypeError: (106-107): Constant has no value.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7060

No changelog entry because the bug was introduced after the last release.