### PR TITLE
ArrayType::calldataEncodedSize() should return size of pointer for dynamically encoded types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Language Features:
 
 
 Compiler Features:
+ * Code Generator: Treat dynamically encoded but statically sized arrays and structs properly.
  * eWasm: Highly experimental eWasm output using ``--ewasm`` in the commandline interface or output selection of ``ewasm.wast`` in standard-json.
  * Metadata: Update the swarm hash, changes ``bzzr0`` to ``bzzr1`` and urls to use ``bzz-raw://``.
  * Standard JSON Interface: Compile only selected sources and contracts.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1652,7 +1652,7 @@ bool ArrayType::validForCalldata() const
 
 bigint ArrayType::unlimitedCalldataEncodedSize(bool _padded) const
 {
-	if (isDynamicallySized())
+	if (isDynamicallyEncoded())
 		return 32;
 	// Array elements are always padded.
 	bigint size = bigint(length()) * (isByteArray() ? 1 : baseType()->calldataEncodedSize(true));
@@ -1994,6 +1994,9 @@ bool StructType::operator==(Type const& _other) const
 
 unsigned StructType::calldataEncodedSize(bool) const
 {
+	if (isDynamicallyEncoded())
+		return 32;
+
 	unsigned size = 0;
 	for (auto const& member: members(nullptr))
 		if (!member.type->canLiveOutsideStorage())

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1832,10 +1832,11 @@ TypeResult ArrayType::interfaceType(bool _inLibrary) const
 	return result;
 }
 
-u256 ArrayType::memorySize() const
+u256 ArrayType::memoryDataSize() const
 {
 	solAssert(!isDynamicallySized(), "");
 	solAssert(m_location == DataLocation::Memory, "");
+	solAssert(!isByteArray(), "");
 	bigint size = bigint(m_length) * m_baseType->memoryHeadSize();
 	solAssert(size <= numeric_limits<unsigned>::max(), "Array size does not fit u256.");
 	return u256(size);
@@ -2043,7 +2044,7 @@ bool StructType::isDynamicallyEncoded() const
 	return false;
 }
 
-u256 StructType::memorySize() const
+u256 StructType::memoryDataSize() const
 {
 	u256 size;
 	for (auto const& t: memoryMemberTypes())

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -216,6 +216,9 @@ public:
 	/// @returns the size of this data type in bytes when stored in memory. For memory-reference
 	/// types, this is the size of the memory pointer.
 	virtual unsigned memoryHeadSize() const { return calldataEncodedSize(); }
+	/// @returns the size of this data type in bytes when stored in memory. For memory-reference
+	/// types, this is the size of the actual data area, if it is statically-sized.
+	virtual u256 memoryDataSize() const { return calldataEncodedSize(); }
 	/// Convenience version of @see calldataEncodedSize(bool)
 	unsigned calldataEncodedSize() const { return calldataEncodedSize(true); }
 	/// @returns true if the type is a dynamic array
@@ -634,6 +637,7 @@ public:
 		return nullptr;
 	}
 	unsigned memoryHeadSize() const override { return 32; }
+	u256 memoryDataSize() const override = 0;
 
 	/// @returns a copy of this type with location (recursively) changed to @a _location,
 	/// whereas isPointer is only shallowly changed - the deep copy is always a bound reference.
@@ -724,7 +728,7 @@ public:
 	bool isString() const { return m_arrayKind == ArrayKind::String; }
 	Type const* baseType() const { solAssert(!!m_baseType, ""); return m_baseType; }
 	u256 const& length() const { return m_length; }
-	u256 memorySize() const;
+	u256 memoryDataSize() const;
 
 	std::unique_ptr<ReferenceType> copyForLocation(DataLocation _location, bool _isPointer) const override;
 
@@ -831,7 +835,7 @@ public:
 	bool operator==(Type const& _other) const override;
 	unsigned calldataEncodedSize(bool _padded) const override;
 	bool isDynamicallyEncoded() const override;
-	u256 memorySize() const;
+	u256 memoryDataSize() const;
 	u256 storageSize() const override;
 	bool canLiveOutsideStorage() const override { return true; }
 	std::string toString(bool _short) const override;

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -691,6 +691,7 @@ string ABIFunctions::abiEncodingFunctionCompactStorageArray(
 			// Multiple items per slot
 			solAssert(_from.baseType()->storageBytes() <= 16, "");
 			solAssert(!_from.baseType()->isDynamicallyEncoded(), "");
+			solAssert(!_to.baseType()->isDynamicallyEncoded(), "");
 			solAssert(_from.baseType()->isValueType(), "");
 			bool dynamic = _to.isDynamicallyEncoded();
 			size_t storageBytes = _from.baseType()->storageBytes();
@@ -1202,6 +1203,7 @@ string ABIFunctions::abiDecodingFunctionCalldataArray(ArrayType const& _type)
 		Whiskers w{templ};
 		w("functionName", functionName);
 		w("readableTypeName", _type.toString(true));
+		// TODO this might make a difference
 		w("baseEncodedSize", toCompactHexWithPrefix(_type.isByteArray() ? 1 : _type.baseType()->calldataEncodedSize()));
 		if (!_type.isDynamicallySized())
 			w("length", toCompactHexWithPrefix(_type.length()));
@@ -1404,6 +1406,7 @@ string ABIFunctions::calldataAccessFunction(Type const& _type)
 				w("handleLength", "");
 				w("return", "value");
 			}
+			// TODO this makes a difference!
 			w("neededLength", toCompactHexWithPrefix(baseEncodedSize));
 			w("functionName", functionName);
 			return w.render();

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -1293,8 +1293,8 @@ string ABIFunctions::abiDecodingFunctionStruct(StructType const& _type, bool _fr
 		templ("functionName", functionName);
 		templ("readableTypeName", _type.toString(true));
 		templ("allocate", m_utils.allocationFunction());
-		solAssert(_type.memorySize() < u256("0xffffffffffffffff"), "");
-		templ("memorySize", toCompactHexWithPrefix(_type.memorySize()));
+		solAssert(_type.memoryDataSize() < u256("0xffffffffffffffff"), "");
+		templ("memorySize", toCompactHexWithPrefix(_type.memoryDataSize()));
 		size_t headPos = 0;
 		vector<map<string, string>> members;
 		for (auto const& member: _type.members(nullptr))

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -88,7 +88,7 @@ string ABIFunctions::tupleEncoder(
 			elementTempl("pos", to_string(headPos));
 			elementTempl("abiEncode", abiEncodingFunction(*_givenTypes[i], *_targetTypes[i], options));
 			encodeElements += elementTempl.render();
-			headPos += dynamic ? 0x20 : _targetTypes[i]->calldataEncodedSize();
+			headPos += _targetTypes[i]->calldataEncodedSize();
 			stackPos += sizeOnStack;
 		}
 		solAssert(headPos == headSize_, "");
@@ -225,7 +225,7 @@ string ABIFunctions::tupleDecoder(TypePointers const& _types, bool _fromMemory)
 			elementTempl("pos", to_string(headPos));
 			elementTempl("abiDecode", abiDecodingFunction(*_types[i], _fromMemory, true));
 			decodeElements += elementTempl.render();
-			headPos += dynamic ? 0x20 : decodingTypes[i]->calldataEncodedSize();
+			headPos += decodingTypes[i]->calldataEncodedSize();
 		}
 		templ("valueReturnParams", boost::algorithm::join(valueReturnParams, ", "));
 		templ("arrow", valueReturnParams.empty() ? "" : "->");
@@ -915,7 +915,7 @@ string ABIFunctions::abiEncodingFunctionStruct(
 				);
 				encodeTempl("memberValues", memberValues);
 				encodeTempl("encodingOffset", toCompactHexWithPrefix(encodingOffset));
-				encodingOffset += dynamicMember ? 0x20 : memberTypeTo->calldataEncodedSize();
+				encodingOffset += memberTypeTo->calldataEncodedSize();
 				encodeTempl("abiEncode", abiEncodingFunction(*memberTypeFrom, *memberTypeTo, subOptions));
 				encode = encodeTempl.render();
 			}
@@ -1324,7 +1324,7 @@ string ABIFunctions::abiDecodingFunctionStruct(StructType const& _type, bool _fr
 			members.push_back({});
 			members.back()["decode"] = memberTempl.render();
 			members.back()["memberName"] = member.name;
-			headPos += dynamic ? 0x20 : decodingType->calldataEncodedSize();
+			headPos += decodingType->calldataEncodedSize();
 		}
 		templ("members", members);
 		templ("minimumSize", toCompactHexWithPrefix(headPos));
@@ -1486,12 +1486,7 @@ size_t ABIFunctions::headSize(TypePointers const& _targetTypes)
 {
 	size_t headSize = 0;
 	for (auto const& t: _targetTypes)
-	{
-		if (t->isDynamicallyEncoded())
-			headSize += 0x20;
-		else
-			headSize += t->calldataEncodedSize();
-	}
+		headSize += t->calldataEncodedSize();
 
 	return headSize;
 }

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -294,20 +294,13 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		"Nested dynamic arrays not implemented here."
 	);
 	CompilerUtils utils(m_context);
-	unsigned baseSize = 1;
-	if (!_sourceType.isByteArray())
-	{
-		// We always pad the elements, regardless of _padToWordBoundaries.
-		baseSize = _sourceType.baseType()->calldataEncodedSize();
-		solAssert(baseSize >= 0x20, "");
-	}
 
 	if (_sourceType.location() == DataLocation::CallData)
 	{
 		if (!_sourceType.isDynamicallySized())
 			m_context << _sourceType.length();
-		if (baseSize > 1)
-			m_context << u256(baseSize) << Instruction::MUL;
+		if (!_sourceType.isByteArray())
+			convertLengthToSize(_sourceType);
 
 		string routine = "calldatacopy(target, source, len)\n";
 		if (_padToWordBoundaries)
@@ -358,15 +351,14 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 			m_context << Instruction::SWAP1 << u256(32) << Instruction::ADD;
 			m_context << Instruction::SWAP1;
 		}
-		// convert length to size
-		if (baseSize > 1)
-			m_context << u256(baseSize) << Instruction::MUL;
+		if (!_sourceType.isByteArray())
+			convertLengthToSize(_sourceType);
 		// stack: <target> <source> <size>
 		m_context << Instruction::DUP1 << Instruction::DUP4 << Instruction::DUP4;
 		// We can resort to copying full 32 bytes only if
 		// - the length is known to be a multiple of 32 or
 		// - we will pad to full 32 bytes later anyway.
-		if (((baseSize % 32) == 0) || _padToWordBoundaries)
+		if (!_sourceType.isByteArray() || _padToWordBoundaries)
 			utils.memoryCopy32();
 		else
 			utils.memoryCopy();
@@ -374,11 +366,8 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		m_context << Instruction::SWAP1 << Instruction::POP;
 		// stack: <target> <size>
 
-		bool paddingNeeded = false;
-		if (_sourceType.isDynamicallySized())
-			paddingNeeded = _padToWordBoundaries && ((baseSize % 32) != 0);
-		else
-			paddingNeeded = _padToWordBoundaries && (((_sourceType.length() * baseSize) % 32) != 0);
+		bool paddingNeeded = _padToWordBoundaries && _sourceType.isByteArray();
+
 		if (paddingNeeded)
 		{
 			// stack: <target> <size>
@@ -455,10 +444,10 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 			m_context.appendJumpTo(loopEnd);
 			m_context << longByteArray;
 		}
-		// compute memory end offset
-		if (baseSize > 1)
+		else
 			// convert length to memory size
-			m_context << u256(baseSize) << Instruction::MUL;
+			m_context << _sourceType.baseType()->memoryHeadSize() << Instruction::MUL;
+
 		m_context << Instruction::DUP3 << Instruction::ADD << Instruction::SWAP2;
 		if (_sourceType.isDynamicallySized())
 		{
@@ -515,7 +504,12 @@ void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWord
 		// stack here: memory_end_offset storage_data_offset [storage_byte_offset] memory_offset
 		if (haveByteOffset)
 			m_context << Instruction::SWAP1 << Instruction::POP;
-		if (_padToWordBoundaries && baseSize % 32 != 0)
+		if (!_sourceType.isByteArray())
+		{
+			solAssert(_sourceType.baseType()->calldataEncodedSize() % 32 == 0, "");
+			solAssert(_sourceType.baseType()->memoryHeadSize() % 32 == 0, "");
+		}
+		if (_padToWordBoundaries && _sourceType.isByteArray())
 		{
 			// memory_end_offset - start is the actual length (we want to compute the ceil of).
 			// memory_offset - start is its next multiple of 32, but it might be off by 32.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -317,7 +317,7 @@ bool ExpressionCompiler::visit(TupleExpression const& _tuple)
 		ArrayType const& arrayType = dynamic_cast<ArrayType const&>(*_tuple.annotation().type);
 
 		solAssert(!arrayType.isDynamicallySized(), "Cannot create dynamically sized inline array.");
-		utils().allocateMemory(max(u256(32u), arrayType.memorySize()));
+		utils().allocateMemory(max(u256(32u), arrayType.memoryDataSize()));
 		m_context << Instruction::DUP1;
 
 		for (auto const& component: _tuple.components())
@@ -526,7 +526,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		TypeType const& type = dynamic_cast<TypeType const&>(*_functionCall.expression().annotation().type);
 		auto const& structType = dynamic_cast<StructType const&>(*type.actualType());
 
-		utils().allocateMemory(max(u256(32u), structType.memorySize()));
+		utils().allocateMemory(max(u256(32u), structType.memoryDataSize()));
 		m_context << Instruction::DUP1;
 
 		for (unsigned i = 0; i < arguments.size(); ++i)

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -812,10 +812,7 @@ string YulUtilFunctions::nextArrayElementFunction(ArrayType const& _type)
 		}
 		case DataLocation::CallData:
 		{
-			u256 size =
-				_type.baseType()->isDynamicallyEncoded() ?
-				32 :
-				_type.baseType()->calldataEncodedSize();
+			u256 size = _type.baseType()->calldataEncodedSize();
 			solAssert(size >= 32 && size % 32 == 0, "");
 			templ("advance", toCompactHexWithPrefix(size));
 			break;


### PR DESCRIPTION
### Description

I discovered this issue when writing 3-dimensional array test for #6983 , and it turns out #6983 is indeed problematic when assigning 3 dimensional array. (thankfully @ekpyron suggested to test 3 dimensional array).

The problem happens when an array's base type is `uint256[][2]`, that base type's `calldataEncodedSize()` will incorrectly return 64, then we advance source pointer by 64 bytes and corrupt the source pointer. (We should only advance 32 bytes).

But the fix included in this PR makes some runtime test failing, and the reason does not look obvious to me.

Gitter chat log:
```
mingchuan @sifmelcara 21:49
What is the correct value of calldataEncodedSize() of uint256[][2]?
According to comments in libsolidity/Types.h, it should be 32 because it is dynamic type. But it currently returns 64.
But if I "fix" the implementation of calldataEncodedSize() to let it return 32, there will be 4~5 runtime test failing
(And the reason of test failure is not obvious to me)

chriseth @chriseth 21:53
@sifmelcara calldataEncodedSize should only be used for statically-encoded types. Still, maybe we should make it work for both. Which tests are failing?
There are some places in the code that call isDynamicallySized when they should actually call isDynamicallyEncoded, because that only really makes a difference if ABIEncoderV2 is active.

mingchuan @sifmelcara 21:54
Tests related to encoding/decoding of nested array are failing
Why calldataEncodedSize should only be used for statically-encoded types? https://github.com/ethereum/solidity/blob/develop/libsolidity/ast/Types.h#L211-L213 Here it says it should return the size of pointer

chriseth @chriseth 22:00
@sifmelcara can you check if changing Types.cpp:1655 from if (isDynamicallySized()) to if (isDynamicallyEncoded()) fixes it?
or is that what you mean by fix?

mingchuan @sifmelcara 22:00
Yes, that is what I mean by fix
```

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
