### PR TITLE
Adjust call to suffixedVariableNameList post refactoring in ABIv2 pro…

### DIFF
--- a/test/tools/ossfuzz/CMakeLists.txt
+++ b/test/tools/ossfuzz/CMakeLists.txt
@@ -38,7 +38,7 @@ if (OSSFUZZ)
 
     add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
     target_include_directories(yul_proto_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
-    target_link_libraries(yul_proto_ossfuzz PRIVATE yul evmasm solidity
+    target_link_libraries(yul_proto_ossfuzz PRIVATE yul
             protobuf-mutator-libfuzzer.a
             protobuf-mutator.a
             protobuf.a
@@ -46,7 +46,7 @@ if (OSSFUZZ)
 
     add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
     target_include_directories(yul_proto_diff_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
-    target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul evmasm
+    target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul
             yulInterpreter
             protobuf-mutator-libfuzzer.a
             protobuf-mutator.a
@@ -88,7 +88,7 @@ else()
 
 #    add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
 #    target_include_directories(yul_proto_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
-#    target_link_libraries(yul_proto_ossfuzz PRIVATE yul evmasm solidity
+#    target_link_libraries(yul_proto_ossfuzz PRIVATE yul
 #            protobuf-mutator-libfuzzer.a
 #            protobuf-mutator.a
 #            protobuf.a
@@ -96,7 +96,7 @@ else()
 #
 #    add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
 #    target_include_directories(yul_proto_diff_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
-#    target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul evmasm
+#    target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul
 #            yulInterpreter
 #            protobuf-mutator-libfuzzer.a
 #            protobuf-mutator.a

--- a/test/tools/ossfuzz/protoToAbiV2.cpp
+++ b/test/tools/ossfuzz/protoToAbiV2.cpp
@@ -2,12 +2,12 @@
 #include <numeric>
 #include <boost/range/adaptor/reversed.hpp>
 #include <test/tools/ossfuzz/protoToAbiV2.h>
-#include <libsolidity/codegen/YulUtilFunctions.h>
+#include <libdevcore/StringUtils.h>
 #include <libdevcore/Whiskers.h>
 #include <liblangutil/Exceptions.h>
 
 using namespace std;
-using namespace dev::solidity;
+using namespace dev;
 using namespace dev::test::abiv2fuzzer;
 
 // Create a new variable declaration and append said variable to function parameter lists
@@ -651,7 +651,7 @@ void ProtoConverter::visit(TestFunction const& _x)
 		return (uint(1000) + this.coder_external(<parameter_names>));
 	}
 	)")
-	("parameter_names", YulUtilFunctions::suffixedVariableNameList(s_varNamePrefix, 0, m_varCounter))
+	("parameter_names", dev::suffixedVariableNameList(s_varNamePrefix, 0, m_varCounter))
 	.render();
 }
 


### PR DESCRIPTION
…to fuzzer and slim down dependencies.

#7053 broke #6880 that this PR fixes.

Also, #7053 did not remove link dependencies (`libsolidity` and for some reason `libevmasm`) that are redundant post #7053 

This PR removes the said dependencies in `test/tools/ossfuzz/CMakeLists.txt`