### PR TITLE
[isoltest] Add source location to parser errors

### DIFF
--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -62,16 +62,19 @@ bool TestCase::validateSettings(langutil::EVMVersion)
 	return true;
 }
 
-string TestCase::parseSourceAndSettings(istream& _stream)
+pair<string, size_t> TestCase::parseSourceAndSettingsWithLineNumbers(istream& _stream)
 {
 	string source;
 	string line;
+	size_t lineNumber = 1;
 	static string const comment("// ");
 	static string const settingsDelimiter("// ====");
 	static string const delimiter("// ----");
 	bool sourcePart = true;
 	while (getline(_stream, line))
 	{
+		lineNumber++;
+
 		if (boost::algorithm::starts_with(line, delimiter))
 			break;
 		else if (boost::algorithm::starts_with(line, settingsDelimiter))
@@ -92,7 +95,12 @@ string TestCase::parseSourceAndSettings(istream& _stream)
 		else
 			throw runtime_error(string("Expected \"//\" or \"// ---\" to terminate settings and source."));
 	}
-	return source;
+	return make_pair(source, lineNumber);
+}
+
+string TestCase::parseSourceAndSettings(istream& _stream)
+{
+	return get<0>(parseSourceAndSettingsWithLineNumbers(_stream));
 }
 
 string TestCase::parseSimpleExpectations(std::istream& _file)

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -89,6 +89,7 @@ public:
 	virtual bool validateSettings(langutil::EVMVersion /*_evmVersion*/);
 
 protected:
+	std::pair<std::string, std::size_t> parseSourceAndSettingsWithLineNumbers(std::istream& _file);
 	std::string parseSourceAndSettings(std::istream& _file);
 	static void expect(std::string::iterator& _it, std::string::iterator _end, std::string::value_type _c);
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -43,7 +43,8 @@ SemanticTest::SemanticTest(string const& _filename, string const& _ipcPath, lang
 	soltestAssert(file, "Cannot open test contract: \"" + _filename + "\".");
 	file.exceptions(ios::badbit);
 
-	m_source = parseSourceAndSettings(file);
+	std::tie(m_source, m_lineOffset) = parseSourceAndSettingsWithLineNumbers(file);
+
 	if (m_settings.count("compileViaYul"))
 	{
 		if (m_settings["compileViaYul"] == "also")
@@ -163,7 +164,7 @@ void SemanticTest::printUpdatedExpectations(ostream& _stream, string const&) con
 void SemanticTest::parseExpectations(istream& _stream)
 {
 	TestFileParser parser{_stream};
-	auto functionCalls = parser.parseFunctionCalls();
+	auto functionCalls = parser.parseFunctionCalls(m_lineOffset);
 	std::move(functionCalls.begin(), functionCalls.end(), back_inserter(m_tests));
 }
 

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -64,6 +64,7 @@ public:
 
 private:
 	std::string m_source;
+	std::size_t m_lineOffset;
 	std::vector<TestFunctionCall> m_tests;
 	bool m_runWithYul = false;
 	bool m_runWithoutYul = true;

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -59,7 +59,9 @@ public:
 	/// Throws an exception if a function call cannot be parsed because of its
 	/// incorrect structure, an invalid or unsupported encoding
 	/// of its arguments or expected results.
-	std::vector<FunctionCall> parseFunctionCalls();
+	/// Passes the source line offset, such that parsing errors can be enhanced
+	/// with a line number it occurred in.
+	std::vector<FunctionCall> parseFunctionCalls(std::size_t _lineOffset);
 
 private:
 	using Token = soltest::Token;
@@ -179,6 +181,10 @@ private:
 
 	/// A scanner instance
 	Scanner m_scanner;
+
+	/// The current line number. Incremented when Token::Newline (//) is found and
+	/// used to enhance parser error messages.
+	size_t m_lineNumber = 0;
 };
 
 }

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -44,7 +44,7 @@ vector<FunctionCall> parse(string const& _source)
 {
 	istringstream stream{_source, ios_base::out};
 	TestFileParser parser{stream};
-	return parser.parseFunctionCalls();
+	return parser.parseFunctionCalls(0);
 }
 
 void testFunctionCall(


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/6669.

Passes the line number offset after parsing source and settings and generates parser errors that contain the line in the source file it occurred. 

In conjunction with https://github.com/ethereum/solidity/pull/7091/, which does not swallow detailed parser exceptions anymore.