### PR TITLE
[isoltest] Pass ether along with constructor

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -80,7 +80,7 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 		{
 			if (&test == &m_tests.front())
 				if (test.call().isConstructor)
-					deploy("", 0, test.call().arguments.rawBytes());
+					deploy("", test.call().value, test.call().arguments.rawBytes());
 				else
 					soltestAssert(deploy("", 0, bytes()), "Failed to deploy contract.");
 			else

--- a/test/libsolidity/semanticTests/smoke_test.sol
+++ b/test/libsolidity/semanticTests/smoke_test.sol
@@ -1,7 +1,10 @@
 contract C {
     uint public state = 0;
-    constructor(uint _state) public {
+    constructor(uint _state) public payable {
         state = _state;
+    }
+    function balance() payable public returns (uint256) {
+        return address(this).balance;
     }
     function f() payable public returns (uint) {
         return 2;
@@ -38,8 +41,9 @@ contract C {
     }
 }
 // ----
-// constructor(): 3 ->
+// constructor(), 2 ether: 3 ->
 // state() -> 3
+// balance() -> 2
 // _() -> FAILURE
 // f() -> 2
 // f(), 1 ether -> 2


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/6669.

Ether value passed with constructor calls is now used during contract deployment:
`// constructor(), 2 ether` is now supported