### PR TITLE
[isoltest] Introduce shorthand declaration: make `->` optional.

### DIFF
--- a/test/libsolidity/semanticTests/smoke_test.sol
+++ b/test/libsolidity/semanticTests/smoke_test.sol
@@ -6,6 +6,9 @@ contract C {
     function balance() payable public returns (uint256) {
         return address(this).balance;
     }
+    function e(uint a) public {
+        state = a;
+    }
     function f() payable public returns (uint) {
         return 2;
     }
@@ -45,6 +48,7 @@ contract C {
 // state() -> 3
 // balance() -> 2
 // _() -> FAILURE
+// e(uint256): 4
 // f() -> 2
 // f(), 1 ether -> 2
 // g() -> 2, 3

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -249,6 +249,9 @@ struct FunctionCall
 	DisplayMode displayMode = DisplayMode::SingleLine;
 	/// Marks this function call as the constructor.
 	bool isConstructor = false;
+	/// Marks this function call as "short-handed", meaning
+	/// no `->` declared.
+	bool omitsArrow = true;
 };
 
 }

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -86,7 +86,7 @@ vector<dev::solidity::test::FunctionCall> TestFileParser::parseFunctionCalls(siz
 						call.displayMode = FunctionCall::DisplayMode::MultiLine;
 						m_lineNumber++;
 					}
-					
+
 					call.arguments.comment = parseComment();
 
 					if (accept(Token::Newline, true))
@@ -94,13 +94,13 @@ vector<dev::solidity::test::FunctionCall> TestFileParser::parseFunctionCalls(siz
 						call.displayMode = FunctionCall::DisplayMode::MultiLine;
 						m_lineNumber++;
 					}
-				
+
 					if (accept(Token::Arrow, true))
 					{
 						call.omitsArrow = false;
 						call.expectations = parseFunctionCallExpectations();
 						if (accept(Token::Newline, true))
-						m_lineNumber++;
+							m_lineNumber++;
 					}
 					else
 					{

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -86,7 +86,7 @@ vector<dev::solidity::test::FunctionCall> TestFileParser::parseFunctionCalls(siz
 						call.displayMode = FunctionCall::DisplayMode::MultiLine;
 						m_lineNumber++;
 					}
-
+					
 					call.arguments.comment = parseComment();
 
 					if (accept(Token::Newline, true))
@@ -94,12 +94,20 @@ vector<dev::solidity::test::FunctionCall> TestFileParser::parseFunctionCalls(siz
 						call.displayMode = FunctionCall::DisplayMode::MultiLine;
 						m_lineNumber++;
 					}
-
-					expect(Token::Arrow);
-					call.expectations = parseFunctionCallExpectations();
-
-					if (accept(Token::Newline, true))
+				
+					if (accept(Token::Arrow, true))
+					{
+						call.omitsArrow = false;
+						call.expectations = parseFunctionCallExpectations();
+						if (accept(Token::Newline, true))
 						m_lineNumber++;
+					}
+					else
+					{
+						call.expectations.failure = false;
+						call.displayMode = FunctionCall::DisplayMode::SingleLine;
+					}
+
 					call.expectations.comment = parseComment();
 
 					if (call.signature == "constructor()")

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -695,13 +695,6 @@ BOOST_AUTO_TEST_CASE(call_arguments_tuple_invalid_parantheses)
 	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
 }
 
-BOOST_AUTO_TEST_CASE(call_expectations_missing)
-{
-	char const* source = R"(
-		// f())";
-	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
-}
-
 BOOST_AUTO_TEST_CASE(call_ether_value_expectations_missing)
 {
 	char const* source = R"(
@@ -803,7 +796,7 @@ BOOST_AUTO_TEST_CASE(call_arguments_newline_colon)
 BOOST_AUTO_TEST_CASE(call_arrow_missing)
 {
 	char const* source = R"(
-		// h256()
+		// h256() FAILURE
 	)";
 	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
 }

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -74,7 +74,16 @@ string TestFunctionCall::format(
 		{
 			if (!m_call.arguments.comment.empty())
 				stream << ws << comment << m_call.arguments.comment << comment;
-			stream << ws << arrow << ws;
+
+			if (m_call.omitsArrow)
+			{
+				if (_renderResult && (m_failure || !matchesExpectation()))
+					stream << ws << arrow << ws;
+			}
+			else
+			{
+				stream << ws << arrow << ws;
+			}
 		}
 		else
 		{

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -62,7 +62,7 @@ string TestFunctionCall::format(
 		{
 			string output = formatRawParameters(m_call.arguments.parameters, _linePrefix);
 			stream << colon;
-			if (_singleLine)
+			if (!m_call.arguments.parameters.at(0).format.newline)
 				stream << ws;
 			stream << output;
 
@@ -78,12 +78,10 @@ string TestFunctionCall::format(
 			if (m_call.omitsArrow)
 			{
 				if (_renderResult && (m_failure || !matchesExpectation()))
-					stream << ws << arrow << ws;
+					stream << ws << arrow;
 			}
 			else
-			{
-				stream << ws << arrow << ws;
-			}
+				stream << ws << arrow;
 		}
 		else
 		{
@@ -93,7 +91,7 @@ string TestFunctionCall::format(
 				 stream << comment << m_call.arguments.comment << comment;
 				 stream << endl << _linePrefix << newline << ws;
 			}
-			stream << arrow << ws;
+			stream << arrow;
 		}
 
 		/// Format either the expected output or the actual result output
@@ -105,7 +103,8 @@ string TestFunctionCall::format(
 			result = isFailure ?
 				failure :
 				formatRawParameters(m_call.expectations.result);
-			AnsiColorized(stream, highlight, {dev::formatting::RED_BACKGROUND}) << result;
+			if (!result.empty())
+				AnsiColorized(stream, highlight, {dev::formatting::RED_BACKGROUND}) << ws << result;
 		}
 		else
 		{
@@ -124,9 +123,11 @@ string TestFunctionCall::format(
 					);
 
 			if (isFailure)
-				AnsiColorized(stream, highlight, {dev::formatting::RED_BACKGROUND}) << result;
+				AnsiColorized(stream, highlight, {dev::formatting::RED_BACKGROUND}) << ws << result;
 			else
-				stream << result;
+				if (!result.empty())
+					stream << ws << result;
+
 		}
 
 		/// Format comments on expectations taking the display-mode into account.
@@ -292,7 +293,12 @@ string TestFunctionCall::formatRawParameters(
 			os << endl << _linePrefix << "// ";
 		os << param.rawString;
 		if (&param != &_params.back())
-			os << ", ";
+		{
+			if (param.format.newline)
+				os << ",";
+			else
+				os << ", ";
+		}
 	}
 	return os.str();
 }

--- a/test/libsolidity/util/TestFunctionCallTests.cpp
+++ b/test/libsolidity/util/TestFunctionCallTests.cpp
@@ -44,6 +44,8 @@ BOOST_AUTO_TEST_CASE(format_unsigned_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", 0, arguments, expectations};
+	call.omitsArrow = false;
+
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(uint8): 1 -> 1");
@@ -62,6 +64,8 @@ BOOST_AUTO_TEST_CASE(format_unsigned_singleline_signed_encoding)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", 0, arguments, expectations};
+	call.omitsArrow = false;
+
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(uint8): 1 -> 1");
@@ -80,6 +84,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_multiline)
 	FunctionCallExpectations expectations{vector<Parameter>{result}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{}, string{}};
 	FunctionCall call{"f(uint8)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	call.displayMode = FunctionCall::DisplayMode::MultiLine;
 	TestFunctionCall test{call};
 
@@ -94,6 +99,7 @@ BOOST_AUTO_TEST_CASE(format_multiple_unsigned_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param, param}, string{}};
 	FunctionCall call{"f(uint8, uint8)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(uint8, uint8): 1, 1 -> 1, 1");
@@ -107,6 +113,7 @@ BOOST_AUTO_TEST_CASE(format_signed_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(int8)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(int8): -1 -> -1");
@@ -126,6 +133,7 @@ BOOST_AUTO_TEST_CASE(format_hex_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bytes32)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(bytes32): 0x31 -> 0x31");
@@ -146,6 +154,7 @@ BOOST_AUTO_TEST_CASE(format_hex_string_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(string)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(string): hex\"4200ef\" -> hex\"4200ef\"");
@@ -159,6 +168,7 @@ BOOST_AUTO_TEST_CASE(format_bool_true_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(bool): true -> true");
@@ -179,6 +189,7 @@ BOOST_AUTO_TEST_CASE(format_bool_false_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(bool): false -> false");
@@ -192,6 +203,7 @@ BOOST_AUTO_TEST_CASE(format_bool_left_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(bool): left(false) -> left(false)");
@@ -206,6 +218,7 @@ BOOST_AUTO_TEST_CASE(format_hex_number_right_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(bool): right(0x42) -> right(0x42)");
@@ -219,6 +232,7 @@ BOOST_AUTO_TEST_CASE(format_empty_byte_range)
 	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{}, string{}};
 	FunctionCall call{"f()", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f() -> 1");
@@ -232,6 +246,7 @@ BOOST_AUTO_TEST_CASE(format_failure_singleline)
 	FunctionCallExpectations expectations{vector<Parameter>{}, true, string{}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", 0, arguments, expectations};
+	call.omitsArrow = false;
 	TestFunctionCall test{call};
 
 	BOOST_REQUIRE_EQUAL(test.format(), "// f(uint8): 1 -> FAILURE");


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/6669.