### PR TITLE
[DOCS] Add details of team calls

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -21,6 +21,17 @@ In particular, we need help in the following areas:
 
 Please note that this project is released with a `Contributor Code of Conduct <https://raw.githubusercontent.com/ethereum/solidity/develop/CODE_OF_CONDUCT.md>`_. By participating in this project - in the issues, pull requests, or Gitter channels - you agree to abide by its terms.
 
+Team Calls
+==========
+
+If you have issues or pull requests to discuss, or are interested in hearing what
+the team and contributors are working on, you can join our public team calls:
+
+- Monday at 12pm CET
+- Wednesday at 3pm CET
+
+Both calls take place on `Google Hangouts <https://hangouts.google.com/hangouts/_/ethereum.org/solidity-weekly>`_.
+
 How to Report Issues
 ====================
 


### PR DESCRIPTION
### Description

Closes https://github.com/ethereum/solidity/issues/3850 where we have now undertaken most of the tasks here already, but I felt we could add details of our team calls, not necessary though. The testing tasks remain to be completed, but am waiting for changes before diving back into that.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
