### PR TITLE
Update fuzzing deps in docker image and ossfuzz CMakeLists.txt

### DIFF
--- a/.circleci/docker/Dockerfile.ubuntu1904
+++ b/.circleci/docker/Dockerfile.ubuntu1904
@@ -60,21 +60,23 @@ RUN set -ex; \
 	ninja install/strip; \
 	rm -rf /usr/src/z3
 
-# OSSFUZZ: LPM package (do not remove build dirs as solidity compiles/links against that dir)
+# OSSFUZZ: libprotobuf-mutator
 RUN set -ex; \
-	mkdir /src; \
-	cd /src; \
-	git clone https://github.com/google/libprotobuf-mutator.git; \
-	cd libprotobuf-mutator; \
+	git clone https://github.com/google/libprotobuf-mutator.git \
+	    /usr/src/libprotobuf-mutator; \
+	cd /usr/src/libprotobuf-mutator; \
 	git checkout d1fe8a7d8ae18f3d454f055eba5213c291986f21; \
-	mkdir ../LPM; \
-	cd ../LPM; \
-	cmake ../libprotobuf-mutator -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release; \
+	mkdir build; \
+	cd build; \
+	cmake .. -GNinja -DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=ON \
+        -DLIB_PROTO_MUTATOR_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="/usr"; \
 	ninja; \
 	cp -vpr external.protobuf/bin/* /usr/bin/; \
 	cp -vpr external.protobuf/include/* /usr/include/; \
 	cp -vpr external.protobuf/lib/* /usr/lib/; \
-	ninja install/strip
+	ninja install/strip; \
+	rm -rf /usr/src/libprotobuf-mutator
 
 # OSSFUZZ: libfuzzer
 RUN set -ex; \

--- a/test/tools/ossfuzz/CMakeLists.txt
+++ b/test/tools/ossfuzz/CMakeLists.txt
@@ -1,6 +1,3 @@
-if (OSSFUZZ)
-    link_directories(/src/LPM/src /src/LPM/src/libfuzzer /src/LPM/external.protobuf/lib)
-endif()
 add_custom_target(ossfuzz)
 add_dependencies(ossfuzz
         solc_opt_ossfuzz
@@ -37,7 +34,7 @@ if (OSSFUZZ)
     target_link_libraries(strictasm_assembly_ossfuzz PRIVATE yul FuzzingEngine.a)
 
     add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
-    target_include_directories(yul_proto_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
+    target_include_directories(yul_proto_ossfuzz PRIVATE /usr/include/libprotobuf-mutator)
     target_link_libraries(yul_proto_ossfuzz PRIVATE yul
             protobuf-mutator-libfuzzer.a
             protobuf-mutator.a
@@ -45,7 +42,7 @@ if (OSSFUZZ)
             FuzzingEngine.a)
 
     add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
-    target_include_directories(yul_proto_diff_ossfuzz PRIVATE /src/libprotobuf-mutator /src/LPM/external.protobuf/include)
+    target_include_directories(yul_proto_diff_ossfuzz PRIVATE /usr/include/libprotobuf-mutator)
     target_link_libraries(yul_proto_diff_ossfuzz PRIVATE yul
             yulInterpreter
             protobuf-mutator-libfuzzer.a


### PR DESCRIPTION
fixes #7110  

~~Do not merge until the new docker image has been pushed upstream~~

The docker image has been updated upstream. Merge if all CIs passed.