### PR TITLE
[SMTChecker] Refactor function inlining

### DIFF
--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -62,9 +62,8 @@ public:
 	/// the constructor.
 	std::vector<std::string> unhandledQueries() { return m_interface->unhandledQueries(); }
 
-	/// @returns the FunctionDefinition of a called function if possible and should inline,
-	/// otherwise nullptr.
-	static FunctionDefinition const* inlinedFunctionCallToDefinition(FunctionCall const& _funCall);
+	/// @returns true if _funCall should be inlined, otherwise false.
+	static bool shouldInlineFunctionCall(FunctionCall const& _funCall);
 
 	std::shared_ptr<smt::SolverInterface> solver() { return m_interface; }
 

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1354,3 +1354,25 @@ string SMTEncoder::extraComment()
 			"You can re-introduce information using require().";
 	return extra;
 }
+
+FunctionDefinition const* SMTEncoder::functionCallToDefinition(FunctionCall const& _funCall)
+{
+	if (_funCall.annotation().kind != FunctionCallKind::FunctionCall)
+		return nullptr;
+
+	FunctionDefinition const* funDef = nullptr;
+	Expression const* calledExpr = &_funCall.expression();
+
+	if (TupleExpression const* fun = dynamic_cast<TupleExpression const*>(&_funCall.expression()))
+	{
+		solAssert(fun->components().size() == 1, "");
+		calledExpr = fun->components().front().get();
+	}
+
+	if (Identifier const* fun = dynamic_cast<Identifier const*>(calledExpr))
+		funDef = dynamic_cast<FunctionDefinition const*>(fun->annotation().referencedDeclaration);
+	else if (MemberAccess const* fun = dynamic_cast<MemberAccess const*>(calledExpr))
+		funDef = dynamic_cast<FunctionDefinition const*>(fun->annotation().referencedDeclaration);
+
+	return funDef;
+}

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -55,6 +55,10 @@ public:
 	/// @returns the leftmost identifier in a multi-d IndexAccess.
 	static Expression const* leftmostBase(IndexAccess const& _indexAccess);
 
+	/// @returns the FunctionDefinition of a FunctionCall
+	/// if possible or nullptr.
+	static FunctionDefinition const* functionCallToDefinition(FunctionCall const& _funCall);
+
 protected:
 	// TODO: Check that we do not have concurrent reads and writes to a variable,
 	// because the order of expression evaluation is undefined

--- a/libsolidity/formal/VariableUsage.cpp
+++ b/libsolidity/formal/VariableUsage.cpp
@@ -58,9 +58,12 @@ void VariableUsage::endVisit(IndexAccess const& _indexAccess)
 void VariableUsage::endVisit(FunctionCall const& _funCall)
 {
 	if (m_inlineFunctionCalls)
-		if (auto const& funDef = BMC::inlinedFunctionCallToDefinition(_funCall))
+		if (auto const& funDef = SMTEncoder::functionCallToDefinition(_funCall))
+		{
+			solAssert(funDef, "");
 			if (find(m_callStack.begin(), m_callStack.end(), funDef) == m_callStack.end())
 				funDef->accept(*this);
+		}
 }
 
 bool VariableUsage::visit(FunctionDefinition const& _function)


### PR DESCRIPTION
Split the inlining function into two, one in SMTEncoder that simply returns the FunctionDefinition pointer out of a FunctionCall (will be used by CHC as well) and one that decides whether a function should be inlined (part of BMC).