### PR TITLE
A pragma version mismatch is not fatal if ...

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -118,12 +118,15 @@ void Parser::parsePragmaVersion(SourceLocation const& _location, vector<Token> c
 	static SemVerVersion const currentVersion{string(VersionString)};
 	// FIXME: only match for major version incompatibility
 	if (!matchExpression.matches(currentVersion))
-		m_errorReporter.fatalParserError(
-			_location,
-			"Source file requires different compiler version (current compiler is " +
-			string(VersionString) + " - note that nightly builds are considered to be "
-			"strictly less than the released version"
-		);
+		// If m_parserErrorRecovery is true, the same message will appear from SyntaxChecker::visit(),
+		// so we don't need to report anything here.
+		if (!m_parserErrorRecovery)
+			m_errorReporter.fatalParserError(
+				_location,
+				"Source file requires different compiler version (current compiler is " +
+				string(VersionString) + " - note that nightly builds are considered to be "
+				"strictly less than the released version"
+			);
 }
 
 ASTPointer<PragmaDirective> Parser::parsePragmaDirective()


### PR DESCRIPTION
error recovery is desired.

Fixes #7085

### Description

If option `--error-recovery` is given (or `parserErrorRecovery` is set in StandardCompiler) we warn but do not stop if there is a pragma mismatch.

### Checklist
- [x ] Code compiles correctly
- [x ] All tests are passing (there was a SMT failure that seems to have nothing to do with this PR)
- [x ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x ] Used meaningful commit messages
