### PR TITLE
[SMTChecker] EncodingContext config flag to accumulate assertions

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -52,6 +52,7 @@ void BMC::analyze(SourceUnit const& _source, shared_ptr<Scanner> const& _scanner
 	m_safeAssertions += move(_safeAssertions);
 	m_context.setSolver(m_interface);
 	m_context.clear();
+	m_context.setAssertionAccumulation(true);
 	m_variableUsage.setFunctionInlining(true);
 
 	_source.accept(*this);

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -50,6 +50,7 @@ void CHC::analyze(SourceUnit const& _source, shared_ptr<Scanner> const& _scanner
 	solAssert(z3Interface, "");
 	m_context.setSolver(z3Interface->z3Interface());
 	m_context.clear();
+	m_context.setAssertionAccumulation(false);
 	m_variableUsage.setFunctionInlining(false);
 
 	_source.accept(*this);

--- a/libsolidity/formal/EncodingContext.cpp
+++ b/libsolidity/formal/EncodingContext.cpp
@@ -228,7 +228,10 @@ Expression EncodingContext::assertions()
 
 void EncodingContext::pushSolver()
 {
-	m_assertions.push_back(assertions());
+	if (m_accumulateAssertions)
+		m_assertions.push_back(assertions());
+	else
+		m_assertions.push_back(smt::Expression(true));
 }
 
 void EncodingContext::popSolver()

--- a/libsolidity/formal/EncodingContext.h
+++ b/libsolidity/formal/EncodingContext.h
@@ -54,6 +54,9 @@ public:
 		m_solver = _solver;
 	}
 
+	/// Sets whether the context should conjoin assertions in the assertion stack.
+	void setAssertionAccumulation(bool _acc) { m_accumulateAssertions = _acc; }
+
 	/// Forwards variable creation to the solver.
 	Expression newVariable(std::string _name, SortPointer _sort)
 	{
@@ -178,6 +181,9 @@ private:
 
 	/// Assertion stack.
 	std::vector<Expression> m_assertions;
+
+	/// Whether to conjoin assertions in the assertion stack.
+	bool m_accumulateAssertions = true;
 	//@}
 };
 


### PR DESCRIPTION
BMC uses accumulated (conjoined) assertions because the queries are stored for later.
CHC uses non-accumulated assertions because each block has its own context with input and output vars.