### PR TITLE
[SMTChecker] CHC basic loop support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Language Features:
 Compiler Features:
  * ABI Output: Change sorting order of functions from selector to kind, name.
  * Optimizer: Add rule that replaces the BYTE opcode by 0 if the first argument is larger than 31.
+ * SMTChecker: Add loop support to the CHC engine.
  * Yul Optimizer: Take side-effect-freeness of user-defined functions into account.
  * Yul Optimizer: Remove redundant mload/sload operations.
 

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -953,18 +953,21 @@ pair<smt::Expression, smt::Expression> SMTEncoder::arithmeticOperation(
 
 	smt::Expression intValueRange = (0 - smt::minValue(intType)) + smt::maxValue(intType) + 1;
 	auto value = smt::Expression::ite(
-		valueNoMod > smt::maxValue(intType) || valueNoMod < smt::minValue(intType),
+		valueNoMod > smt::maxValue(intType),
 		valueNoMod % intValueRange,
-		valueNoMod
+		smt::Expression::ite(
+			valueNoMod < smt::minValue(intType),
+			valueNoMod % intValueRange,
+			valueNoMod
+		)
 	);
+
 	if (intType.isSigned())
-	{
 		value = smt::Expression::ite(
 			value > smt::maxValue(intType),
 			value - intValueRange,
 			value
 		);
-	}
 
 	return {value, valueNoMod};
 }

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -87,6 +87,8 @@ protected:
 	bool visit(MemberAccess const& _node) override;
 	void endVisit(IndexAccess const& _node) override;
 	bool visit(InlineAssembly const& _node) override;
+	void endVisit(Break const&) override {}
+	void endVisit(Continue const&) override {}
 
 	/// Do not visit subtree if node is a RationalNumber.
 	/// Symbolic _expr is the rational literal.

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -295,7 +295,6 @@ Expression zeroValue(solidity::TypePointer const& _type)
 			auto mappingType = dynamic_cast<MappingType const*>(_type);
 			solAssert(mappingType, "");
 			return Expression::const_array(Expression(mappingType), zeroValue(mappingType->valueType()));
-
 		}
 		solAssert(false, "");
 	}

--- a/libsolidity/formal/Z3CHCInterface.cpp
+++ b/libsolidity/formal/Z3CHCInterface.cpp
@@ -41,6 +41,7 @@ Z3CHCInterface::Z3CHCInterface():
 	// These are useful for solving problems with arrays and loops.
 	// Use quantified lemma generalizer.
 	p.set("fp.spacer.q3.use_qgen", true);
+	p.set("fp.spacer.mbqi", false);
 	// Ground pobs by using values from a model.
 	p.set("fp.spacer.ground_pobs", false);
 	m_solver.set(p);
@@ -100,7 +101,7 @@ pair<CheckResult, vector<string>> Z3CHCInterface::query(Expression const& _expr)
 		}
 		// TODO retrieve model / invariants
 	}
-	catch (z3::exception const& _e)
+	catch (z3::exception const&)
 	{
 		result = CheckResult::ERROR;
 		values.clear();

--- a/test/libsolidity/smtCheckerTests/invariants/loop_array.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/loop_array.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract Simple {
+	uint[] a;
+	function f(uint n) public {
+		uint i;
+		while (i < n)
+		{
+			a[i] = i;
+			++i;
+		}
+		require(n > 1);
+		// Assertion is safe but current solver version cannot solve it.
+		// Keep test for next solver release.
+		assert(a[n-1] > a[n-2]);
+	}
+}
+// ----
+// Warning: (273-296): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/invariants/loop_array_for.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/loop_array_for.sol
@@ -1,0 +1,16 @@
+pragma experimental SMTChecker;
+
+contract Simple {
+	uint[] a;
+	function f(uint n) public {
+		uint i;
+		for (i = 0; i < n; ++i)
+			a[i] = i;
+		require(n > 1);
+		// Assertion is safe but current solver version cannot solve it.
+		// Keep test for next solver release.
+		assert(a[n-1] > a[n-2]);
+	}
+}
+// ----
+// Warning: (267-290): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/invariants/loop_basic.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/loop_basic.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract Simple {
+	function f(uint x) public pure {
+		uint y;
+		require(x > 0);
+		while (y < x)
+			++y;
+		assert(y == x);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/invariants/loop_basic_for.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/loop_basic_for.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract Simple {
+	function f(uint x) public pure {
+		uint y;
+		for (y = 0; y < x; ++y) {}
+		assert(y == x);
+	}
+}
+// ----

--- a/test/libsolidity/smtCheckerTests/invariants/loop_nested.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/loop_nested.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract Simple {
+	function f() public pure {
+		uint x = 10;
+		uint y;
+		while (y < x)
+		{
+			++y;
+			x = 0;
+			while (x < 10)
+				++x;
+			assert(x == 10);
+		}
+		assert(y == x);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/invariants/loop_nested_for.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/loop_nested_for.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract Simple {
+	function f() public pure {
+		uint x;
+		uint y;
+		for (x = 10; y < x; ++y)
+		{
+			for (x = 0; x < 10; ++x) {}
+			assert(x == 10);
+		}
+		assert(y == x);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/loops/do_while_1_false_positives.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_1_false_positives.sol
@@ -15,4 +15,3 @@ contract C
 }
 // ----
 // Warning: (150-155): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (269-282): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
@@ -8,10 +8,12 @@ contract C
 			// Overflows due to resetting x.
 			x = x + 1;
 		}
-		// The assertion is true but x is touched and reset.
+		// Assertion is safe but current solver version cannot solve it.
+		// Keep test for next solver release.
 		assert(x > 0);
 	}
 }
 // ----
+// Warning: (296-309): Error trying to invoke SMT solver.
 // Warning: (176-181): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (244-257): Assertion violation happens here
+// Warning: (296-309): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_6.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_6.sol
@@ -10,4 +10,3 @@ contract C {
     }
 }
 // ----
-// Warning: (213-226): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_memory.sol
@@ -18,5 +18,4 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (265-285): Assertion violation happens here
 // Warning: (312-331): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
@@ -18,6 +18,5 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (266-286): Assertion violation happens here
 // Warning: (290-309): Assertion violation happens here
 // Warning: (313-332): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_trivial_condition_3.sol
@@ -15,4 +15,3 @@ contract C {
 }
 // ----
 // Warning: (115-121): Unused local variable.
-// Warning: (356-370): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1.sol
@@ -14,4 +14,3 @@ contract C
 	}
 }
 // ----
-// Warning: (177-190): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1_break.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1_break.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x, bool b) public pure {
+		require(x < 10);
+		while (x < 10) {
+			if (b)
+				++x;
+			else {
+				x = 20;
+				break;
+			}
+		}
+		// Assertion is safe but break is unsupported for now
+		// so knowledge is erased.
+		assert(x >= 10);
+	}
+}
+// ----
+// Warning: (274-289): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1_break_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1_break_fail.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x, bool b) public pure {
+		require(x < 10);
+		while (x < 10) {
+			if (b)
+				++x;
+			else {
+				break;
+			}
+		}
+		// Fails because the loop might break.
+		assert(x >= 10);
+	}
+}
+// ----
+// Warning: (218-233): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1_continue.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1_continue.sol
@@ -1,0 +1,22 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x, bool b) public pure {
+		require(x < 100);
+		while (x < 10) {
+			if (b) {
+				x = 15;
+				continue;
+			}
+			else
+				x = 20;
+
+		}
+		// Should be safe, but fails due to continue being unsupported
+		// and erasing all knowledge.
+		assert(x >= 15);
+	}
+}
+// ----
+// Warning: (294-309): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1_continue_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1_continue_fail.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x, bool b) public pure {
+		require(x < 100);
+		while (x < 10) {
+			if (b) {
+				x = 15;
+				continue;
+			}
+			else
+				x = 20;
+
+		}
+		// Fails due to the if.
+		assert(x >= 17);
+	}
+}
+// ----
+// Warning: (223-238): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_1_infinite.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_1_infinite.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x, bool b) public pure {
+		require(x < 100);
+		while (x < 10) {
+			if (b)
+				x = x + 1;
+			else
+				x = 0;
+		}
+		// CHC proves it safe because
+		// 1- if it doesn't go in the loop in the first place, x >= 10
+		// 2- if it goes in the loop and b == true, x increases until >= 10
+		// 3- if it goes in the loop and b == false, it's an infinite loop, therefore
+		//    the assertion and the error are unreachable.
+		assert(x > 0);
+	}
+}
+// ----

--- a/test/libsolidity/smtCheckerTests/loops/while_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_2.sol
@@ -6,9 +6,8 @@ contract C {
 			if (x > 10)
 				x = 2;
 			else
-				x = 10;
+				--x;
 		}
-		assert(x == 2);
+		assert(x < 2);
 	}
 }
-// ----

--- a/test/libsolidity/smtCheckerTests/loops/while_2_break.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_2_break.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f() public pure {
+		uint x = 0;
+		while (x == 0) {
+			++x;
+			break;
+			++x;
+		}
+		// Assertion is safe but break is unsupported for now
+		// so knowledge is erased.
+		assert(x == 1);
+	}
+}
+// ----
+// Warning: (128-131): Unreachable code.
+// Warning: (224-238): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_2_break_fail.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_2_break_fail.sol
@@ -1,0 +1,16 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	function f(uint x) public pure {
+		while (x == 0) {
+			++x;
+			break;
+			++x;
+		}
+		assert(x == 2);
+	}
+}
+// ----
+// Warning: (120-123): Unreachable code.
+// Warning: (131-145): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_memory_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_memory_storage.sol
@@ -13,11 +13,13 @@ contract LoopFor2 {
 			c[i] = b[i];
 			++i;
 		}
+		// Fails due to aliasing, since both b and c are
+		// memory references of same type.
 		assert(b[0] == c[0]);
 		assert(a[0] == 900);
 		assert(b[0] == 900);
 	}
 }
 // ----
-// Warning: (274-294): Assertion violation happens here
-// Warning: (321-340): Assertion violation happens here
+// Warning: (362-382): Assertion violation happens here
+// Warning: (409-428): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_memory.sol
@@ -20,5 +20,4 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (265-285): Assertion violation happens here
 // Warning: (312-331): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
@@ -20,6 +20,5 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (266-286): Assertion violation happens here
 // Warning: (290-309): Assertion violation happens here
 // Warning: (313-332): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_simple_4.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_simple_4.sol
@@ -8,4 +8,3 @@ contract C {
     }
 }
 // ----
-// Warning: (199-213): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTestsJSON/multi.json
+++ b/test/libsolidity/smtCheckerTestsJSON/multi.json
@@ -4,7 +4,6 @@
 		"smtlib2responses":
 		{
 			"0x047d0c67d7e03c5ac96ca227d1e19ba63257f4ab19cef30029413219ec8963af": "sat\n((|EVALEXPR_0| 0))\n",
-			"0x21d5b49d1416d788fe34b1d2a10a99ea92b007e17a977604afd7b2ff01a055cd": "unsat\n",
 			"0xada7569fb01a9b3e2823517ed40dcc99b11fb1e433e6e3ec8a8713f6f95753d3": "sat\n((|EVALEXPR_0| 1))\n"
 		}
 	}


### PR DESCRIPTION
Depends on #7132 #7107 #7121 

This PR adds basic support to `while`, `dowhile` and `for` loops in the CHC engine.
The encoding is:
Let `f_i` the function block before the loop. Create the following blocks:
- `loop_header`, containing constraints created by the condition (potential side effect statements).
- `loop_body`, containing constraints from the loop body.
- `f_j`, the function block after the loop
Create the following edges:
- `f_i -> loop_header`
- `loop_header -> loop_body`
- `loop_header -> f_j`
- `loop_body -> loop_header`, if there were no nested loops inside this loop body.
- `f_k -> loop_header`, f_k -> loop_header, if there was at least one nested loop inside this loop body, where `f_k` is the function body block after the latest nested loop.

For now `break` and `continue` are unsupported and erase all knowledge, including local variables.
`for` statements will have a similar behavior but it'll be added in a different PR.