### PR TITLE
Make member-access to `msg.sender` pure

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,22 @@
+### 0.5.12 (unreleased)
+
+Important Bugfixes:
+
+
+
+Compiler Features:
+ * View pure checker: Makes member-access to `msg.sender` pure.
+
+
+Bugfixes:
+
+
+
+Build System:
+
+
+
+
 ### 0.5.11 (unreleased)
 
 

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -357,6 +357,7 @@ void ViewPureChecker::endVisit(MemberAccess const& _memberAccess)
 			{MagicType::Kind::ABI, "encodeWithSignature"},
 			{MagicType::Kind::Block, "blockhash"},
 			{MagicType::Kind::Message, "data"},
+			{MagicType::Kind::Message, "sender"},
 			{MagicType::Kind::Message, "sig"},
 			{MagicType::Kind::MetaType, "creationCode"},
 			{MagicType::Kind::MetaType, "runtimeCode"},

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -50,7 +50,6 @@ BOOST_AUTO_TEST_CASE(environment_access)
 		"blockhash(7)",
 		"gasleft()",
 		"msg.value",
-		"msg.sender",
 		"tx.origin",
 		"tx.gasprice",
 		"this",
@@ -64,6 +63,7 @@ BOOST_AUTO_TEST_CASE(environment_access)
 	vector<string> pure{
 		"msg.data",
 		"msg.data[0]",
+		"msg.sender",
 		"msg.sig",
 		"msg",
 		"block",

--- a/test/libsolidity/smtCheckerTests/special/msg_sender_1.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_sender_1.sol
@@ -2,7 +2,7 @@ pragma experimental SMTChecker;
 
 contract C
 {
-	function f() public view {
+	function f() public pure {
 		address a = msg.sender;
 		address b = msg.sender;
 		assert(a == b);

--- a/test/libsolidity/smtCheckerTests/special/msg_sender_2.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_sender_2.sol
@@ -2,7 +2,7 @@ pragma experimental SMTChecker;
 
 contract C
 {
-	function f() public view {
+	function f() public pure {
 		require(msg.sender != address(0));
 		address a = msg.sender;
 		address b = msg.sender;

--- a/test/libsolidity/smtCheckerTests/special/msg_sender_fail_1.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_sender_fail_1.sol
@@ -2,7 +2,7 @@ pragma experimental SMTChecker;
 
 contract C
 {
-	function f(address c) public view {
+	function f(address c) public pure {
 		address a = msg.sender;
 		address b = msg.sender;
 		assert(a == b);

--- a/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions_restrict_warning.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions_restrict_warning.sol
@@ -15,7 +15,15 @@ contract C {
         assert(true);
         x; y; z;
     }
+    function h() public view returns (address) {
+        return msg.sender;
+    }
+    function i() public view returns (bytes memory) {
+        return msg.data;
+    }
 }
 // ----
 // Warning: (17-288): Function state mutability can be restricted to pure
 // Warning: (293-559): Function state mutability can be restricted to pure
+// Warning: (564-641): Function state mutability can be restricted to pure
+// Warning: (646-726): Function state mutability can be restricted to pure


### PR DESCRIPTION
Fixes #7135.