### PR TITLE
FunctionType: Return correct stacksize for transfer/send

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2837,6 +2837,8 @@ unsigned FunctionType::sizeOnStack() const
 	case Kind::ArrayPush:
 	case Kind::ArrayPop:
 	case Kind::ByteArrayPush:
+	case Kind::Transfer:
+	case Kind::Send:
 		size = 1;
 		break;
 	default:

--- a/test/libsolidity/semanticTests/expressions/uncalled_address_transfer_send.sol
+++ b/test/libsolidity/semanticTests/expressions/uncalled_address_transfer_send.sol
@@ -1,0 +1,12 @@
+contract TransferTest {
+	function() external payable {
+		// This used to cause an ICE
+		address(this).transfer;
+	}
+
+	function f() pure public {}
+}
+// ====
+// compileViaYul: also
+// ----
+// f() ->


### PR DESCRIPTION
This is missing tests. I tried creating a syntaxTest and a semanticTest but it seems to run a completely different logic flow not triggering this bug at all.

fixes #7155