### PR TITLE
[SMTChecker] CHC create function returned expressions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ Bugfixes:
  * SMTChecker: Fix internal error when inlining functions that contain tuple expressions.
  * SMTChecker: Fix pointer knowledge erasing in loops.
  * SMTChecker: Fix internal error when using compound bitwise assignment operators inside branches.
+ * SMTChecker: Fix internal error when inlining a function that returns a tuple containing an unsupported type inside a branch.
  * View/Pure Checker: Properly detect state variable access through base class.
  * Yul analyzer: Check availability of data objects already in analysis phase.
  * Yul Optimizer: Fix an issue where memory-accessing code was removed even though ``msize`` was used in the program.

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -426,21 +426,7 @@ void BMC::inlineFunctionCall(FunctionCall const& _funCall)
 			initFunction(*funDef);
 		funDef->accept(*this);
 
-		auto const& returnParams = funDef->returnParameters();
-		if (returnParams.size() > 1)
-		{
-			vector<shared_ptr<smt::SymbolicVariable>> components;
-			for (auto param: returnParams)
-			{
-				solAssert(m_context.variable(*param), "");
-				components.push_back(m_context.variable(*param));
-			}
-			auto const& symbTuple = dynamic_pointer_cast<smt::SymbolicTupleVariable>(m_context.expression(_funCall));
-			solAssert(symbTuple, "");
-			symbTuple->setComponents(move(components));
-		}
-		else if (returnParams.size() == 1)
-			defineExpr(_funCall, currentValue(*returnParams.front()));
+		createReturnedExpressions(_funCall);
 	}
 }
 

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -123,6 +123,8 @@ void CHC::endVisit(FunctionCall const& _funCall)
 	}
 
 	SMTEncoder::endVisit(_funCall);
+
+	createReturnedExpressions(_funCall);
 }
 
 void CHC::visitAssert(FunctionCall const&)

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -208,6 +208,10 @@ protected:
 	/// @returns the VariableDeclaration referenced by an Identifier or nullptr.
 	VariableDeclaration const* identifierToVariable(Expression const& _expr);
 
+	/// Creates symbolic expressions for the returned values
+	/// and set them as the components of the symbolic tuple.
+	void createReturnedExpressions(FunctionCall const& _funCall);
+
 	/// @returns a note to be added to warnings.
 	std::string extraComment();
 

--- a/test/libsolidity/smtCheckerTests/types/tuple_return_branch.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_return_branch.sol
@@ -1,0 +1,23 @@
+pragma experimental SMTChecker;
+
+contract C {
+	struct S { uint x; }
+
+	function g() internal pure returns (uint, S memory) {
+		return (2, S(3));
+	}
+	function f(uint a) public pure {
+		uint x;
+		S memory y;
+		if (a > 100)
+			(x, y) = g();
+	}
+}
+// ----
+// Warning: (112-120): Assertion checker does not yet support the type of this variable.
+// Warning: (137-141): Assertion checker does not yet implement type struct C.S memory
+// Warning: (137-141): Assertion checker does not yet implement this expression.
+// Warning: (193-203): Assertion checker does not yet support the type of this variable.
+// Warning: (137-141): Assertion checker does not yet implement type struct C.S memory
+// Warning: (137-141): Assertion checker does not yet implement this expression.
+// Warning: (227-228): Assertion checker does not yet implement type struct C.S memory


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7164

Depends on #7171 

Since CHC does not inline function calls, its resulting tuple was never created which broke the SSA scheme in certain cases.