### PR TITLE
Fixes doxygen style multiline comment parsing for files with CRLF

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Compiler Features:
 Bugfixes:
  * Fix internal error when popping a dynamic storage array of mappings.
  * Yul Optimizer: Fix reordering bug in connection with shifted one and mul/div-instructions in for loop conditions.
+ * Scanner: Fix multi-line natspec comment parsing with triple slashes when file is encoded with CRLF instead of LF.
 
 
 ### 0.5.11 (2019-08-12)

--- a/liblangutil/Common.h
+++ b/liblangutil/Common.h
@@ -30,11 +30,6 @@ inline bool isHexDigit(char c)
 		('A' <= c && c <= 'F');
 }
 
-inline bool isLineTerminator(char c)
-{
-	return c == '\n';
-}
-
 inline bool isWhiteSpace(char c)
 {
 	return c == ' ' || c == '\n' || c == '\t' || c == '\r';

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -219,6 +219,12 @@ private:
 	Token skipSingleLineComment();
 	Token skipMultiLineComment();
 
+	/// Tests if current source position is CR, LF or CRLF.
+	bool atEndOfLine() const;
+
+	/// Tries to consume CR, LF or CRLF line terminators and returns success or failure.
+	bool tryScanEndOfLine();
+
 	void scanDecimalDigits();
 	Token scanNumber(char _charSeen = 0);
 	std::tuple<Token, unsigned, unsigned> scanIdentifierOrKeyword();


### PR DESCRIPTION
Fixes doxygen style multiline comment parsing for files with CRLF as line terminators.

Fixes #7150
Related: #4885

### Summary
So this PR is now treating CR, LF, and CRLF as newlines in Scanner.cpp. I added one test wrt multiline comments, and extended some others that only cared about CR and LF as line terminators.

### Old Behavior
Only CR and LF alone was treated as newline, hence, a CRLF have been two newlines.

### New Behavior
Along with CR and LF, also CRLF is treated as newline.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] Used meaningful commit messages
- [x] ~~README / documentation was extended, if necessary~~
- [x] Changelog entry (if change is visible to the user)
