### PR TITLE
Split calldataEncodedSize.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ Compiler Features:
 
 Bugfixes:
  * ABI decoder: Ensure that decoded arrays always point to distinct memory locations.
+ * Code Generator: Treat dynamically encoded but statically sized arrays and structs in calldata properly.
  * SMTChecker: Fix internal error when inlining functions that contain tuple expressions.
  * SMTChecker: Fix pointer knowledge erasing in loops.
  * SMTChecker: Fix internal error when using compound bitwise assignment operators inside branches.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1647,15 +1647,13 @@ bool ArrayType::validForCalldata() const
 	if (auto arrayBaseType = dynamic_cast<ArrayType const*>(baseType()))
 		if (!arrayBaseType->validForCalldata())
 			return false;
-	return unlimitedCalldataEncodedSize(true) <= numeric_limits<unsigned>::max();
+	return isDynamicallySized() || unlimitedStaticCalldataSize(true) <= numeric_limits<unsigned>::max();
 }
 
-bigint ArrayType::unlimitedCalldataEncodedSize(bool _padded) const
+bigint ArrayType::unlimitedStaticCalldataSize(bool _padded) const
 {
-	if (isDynamicallySized())
-		return 32;
-	// Array elements are always padded.
-	bigint size = bigint(length()) * (isByteArray() ? 1 : baseType()->calldataEncodedSize(true));
+	solAssert(!isDynamicallySized(), "");
+	bigint size = bigint(length()) * calldataStride();
 	if (_padded)
 		size = ((size + 31) / 32) * 32;
 	return size;
@@ -1663,7 +1661,20 @@ bigint ArrayType::unlimitedCalldataEncodedSize(bool _padded) const
 
 unsigned ArrayType::calldataEncodedSize(bool _padded) const
 {
-	bigint size = unlimitedCalldataEncodedSize(_padded);
+	solAssert(!isDynamicallyEncoded(), "");
+	bigint size = unlimitedStaticCalldataSize(_padded);
+	solAssert(size <= numeric_limits<unsigned>::max(), "Array size does not fit unsigned.");
+	return unsigned(size);
+}
+
+unsigned ArrayType::calldataEncodedTailSize() const
+{
+	solAssert(isDynamicallyEncoded(), "");
+	if (isDynamicallySized())
+		// We do not know the dynamic length itself, but at least the uint256 containing the
+		// length must still be present.
+		return 32;
+	bigint size = unlimitedStaticCalldataSize(false);
 	solAssert(size <= numeric_limits<unsigned>::max(), "Array size does not fit unsigned.");
 	return unsigned(size);
 }
@@ -1832,10 +1843,11 @@ TypeResult ArrayType::interfaceType(bool _inLibrary) const
 	return result;
 }
 
-u256 ArrayType::memorySize() const
+u256 ArrayType::memoryDataSize() const
 {
 	solAssert(!isDynamicallySized(), "");
 	solAssert(m_location == DataLocation::Memory, "");
+	solAssert(!isByteArray(), "");
 	bigint size = bigint(m_length) * m_baseType->memoryHeadSize();
 	solAssert(size <= numeric_limits<unsigned>::max(), "Array size does not fit u256.");
 	return u256(size);
@@ -1992,20 +2004,33 @@ bool StructType::operator==(Type const& _other) const
 	return ReferenceType::operator==(other) && other.m_struct == m_struct;
 }
 
+
 unsigned StructType::calldataEncodedSize(bool) const
 {
+	solAssert(!isDynamicallyEncoded(), "");
+
 	unsigned size = 0;
 	for (auto const& member: members(nullptr))
-		if (!member.type->canLiveOutsideStorage())
-			return 0;
-		else
-		{
-			// Struct members are always padded.
-			unsigned memberSize = member.type->calldataEncodedSize(true);
-			if (memberSize == 0)
-				return 0;
-			size += memberSize;
-		}
+	{
+		solAssert(member.type->canLiveOutsideStorage(), "");
+		// Struct members are always padded.
+		size += member.type->calldataEncodedSize();
+	}
+	return size;
+}
+
+
+unsigned StructType::calldataEncodedTailSize() const
+{
+	solAssert(isDynamicallyEncoded(), "");
+
+	unsigned size = 0;
+	for (auto const& member: members(nullptr))
+	{
+		solAssert(member.type->canLiveOutsideStorage(), "");
+		// Struct members are always padded.
+		size += member.type->calldataHeadSize();
+	}
 	return size;
 }
 
@@ -2017,12 +2042,8 @@ unsigned StructType::calldataOffsetOfMember(std::string const& _member) const
 		solAssert(member.type->canLiveOutsideStorage(), "");
 		if (member.name == _member)
 			return offset;
-		{
-			// Struct members are always padded.
-			unsigned memberSize = member.type->calldataEncodedSize(true);
-			solAssert(memberSize != 0, "");
-			offset += memberSize;
-		}
+		// Struct members are always padded.
+		offset += member.type->calldataHeadSize();
 	}
 	solAssert(false, "Struct member not found.");
 }
@@ -2040,7 +2061,7 @@ bool StructType::isDynamicallyEncoded() const
 	return false;
 }
 
-u256 StructType::memorySize() const
+u256 StructType::memoryDataSize() const
 {
 	u256 size;
 	for (auto const& t: memoryMemberTypes())

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -317,7 +317,7 @@ bool ExpressionCompiler::visit(TupleExpression const& _tuple)
 		ArrayType const& arrayType = dynamic_cast<ArrayType const&>(*_tuple.annotation().type);
 
 		solAssert(!arrayType.isDynamicallySized(), "Cannot create dynamically sized inline array.");
-		utils().allocateMemory(max(u256(32u), arrayType.memorySize()));
+		utils().allocateMemory(max(u256(32u), arrayType.memoryDataSize()));
 		m_context << Instruction::DUP1;
 
 		for (auto const& component: _tuple.components())
@@ -526,7 +526,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		TypeType const& type = dynamic_cast<TypeType const&>(*_functionCall.expression().annotation().type);
 		auto const& structType = dynamic_cast<StructType const&>(*type.actualType());
 
-		utils().allocateMemory(max(u256(32u), structType.memorySize()));
+		utils().allocateMemory(max(u256(32u), structType.memoryDataSize()));
 		m_context << Instruction::DUP1;
 
 		for (unsigned i = 0; i < arguments.size(); ++i)

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -652,11 +652,11 @@ string YulUtilFunctions::arrayConvertLengthToSize(ArrayType const& _type)
 						<?byteArray>
 							size := length
 						<!byteArray>
-							size := <mul>(length, <elementSize>)
+							size := <mul>(length, <stride>)
 						</byteArray>
 					})")
 					("functionName", functionName)
-					("elementSize", to_string(_type.location() == DataLocation::Memory ? baseType.memoryHeadSize() : baseType.calldataEncodedSize()))
+					("stride", to_string(_type.location() == DataLocation::Memory ? _type.memoryStride() : _type.calldataStride()))
 					("byteArray", _type.isByteArray())
 					("mul", overflowCheckedIntMulFunction(*TypeProvider::uint256()))
 					.render();
@@ -812,10 +812,7 @@ string YulUtilFunctions::nextArrayElementFunction(ArrayType const& _type)
 		}
 		case DataLocation::CallData:
 		{
-			u256 size =
-				_type.baseType()->isDynamicallyEncoded() ?
-				32 :
-				_type.baseType()->calldataEncodedSize();
+			u256 size = _type.calldataStride();
 			solAssert(size >= 32 && size % 32 == 0, "");
 			templ("advance", toCompactHexWithPrefix(size));
 			break;

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_dynamic_static_short_decode.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_dynamic_static_short_decode.sol
@@ -1,0 +1,11 @@
+pragma experimental ABIEncoderV2;
+contract C {
+    function f(uint256[][2][] calldata x) external returns (uint256) {
+        x[0]; // trigger bounds checks
+        return 23;
+    }
+}
+// ----
+// f(uint256[][2][]): 0x20, 0x01, 0x20, 0x40, 0x60, 0x00, 0x00 -> 23 # this is the common encoding for x.length == 1 && x[0][0].length == 0 && x[0][1].length == 0 #
+// f(uint256[][2][]): 0x20, 0x01, 0x20, 0x00, 0x00 -> 23 # exotic, but still valid encoding #
+// f(uint256[][2][]): 0x20, 0x01, 0x20, 0x00 -> FAILURE # invalid (too short) encoding, but no failure due to this PR #

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_dynamic_static_short_reencode.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_dynamic_static_short_reencode.sol
@@ -1,0 +1,13 @@
+pragma experimental ABIEncoderV2;
+contract C {
+    function f(uint256[][2][] calldata x) external returns (uint256) {
+        return 42;
+    }
+    function g(uint256[][2][] calldata x) external returns (uint256) {
+        return this.f(x);
+    }
+}
+// ----
+// g(uint256[][2][]): 0x20, 0x01, 0x20, 0x40, 0x60, 0x00, 0x00 -> 42
+// g(uint256[][2][]): 0x20, 0x01, 0x20, 0x00, 0x00 -> 42
+// g(uint256[][2][]): 0x20, 0x01, 0x20, 0x00 -> FAILURE

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_struct_member_offset.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_struct_member_offset.sol
@@ -1,0 +1,23 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    struct A {
+        uint256 a;
+        uint256[] b;
+    }
+    struct B {
+        A a;
+        uint256 b;
+    }
+    function g(B calldata b) external pure returns(uint256) {
+        return b.b;
+    }
+    function f() public view returns(uint256, uint256) {
+        uint256[] memory arr = new uint256[](20);
+        arr[0] = 31; arr[2] = 84;
+        B memory b = B(A(420, arr), 11);
+        return (b.b, this.g(b));
+    }
+}
+// ----
+// f() -> 11, 11


### PR DESCRIPTION
This is just a first go at making things work with such a split - every instance of ``calldataEncodedSize`` has yet to be rechecked to verify which value is actually needed.

EDIT: this is based on #7072 and I'll push this on top of #7072, once it's in a reasonable state - this PR is meant to allow early discussion of this update of #7072.

EDIT: since I now squashed this here already, this just closes #7072.