### PR TITLE
[SMTChecker] Relax expectations for complex nonlinear tests

### DIFF
--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -153,6 +153,19 @@ do \
 } \
 while(0)
 
+#define CHECK_SUCCESS_OR_WARNING(text, substring) \
+do \
+{ \
+	auto sourceAndError = parseAnalyseAndReturnError((text), true); \
+	auto const& errors = sourceAndError.second; \
+	if (!errors.empty()) \
+	{ \
+		auto message = searchErrors(errors, {{(Error::Type::Warning), (substring)}}); \
+		BOOST_CHECK_MESSAGE(message.empty(), message); \
+	} \
+} \
+while(0)
+
 }
 }
 }

--- a/test/libsolidity/SMTChecker.cpp
+++ b/test/libsolidity/SMTChecker.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(division)
 			}
 		}
 	)";
-	CHECK_SUCCESS_NO_WARNINGS(text);
+	CHECK_SUCCESS_OR_WARNING(text, "might happen");
 	text = R"(
 		contract C {
 			function mul(uint256 a, uint256 b) internal pure returns (uint256) {


### PR DESCRIPTION
This specific test is quite complex for SMT solvers even though it looks simple ;)
As it happens now, one solver is able to prove it within the timeout whereas the other can't, so we relax the expectation to either succeed or report "assertion failure might happen" (which means the solver couldn't prove it). In that case, the test fails if one solver actually gives a counterexample.