### PR TITLE
Remove ubuntu cosmic (EOL July 18, 2019) from release script.

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -55,9 +55,9 @@ keyid=70D110489D66E2F6
 email=builds@ethereum.org
 packagename=solc
 
-static_build_distribution=cosmic
+static_build_distribution=disco
 
-DISTRIBUTIONS="bionic cosmic disco"
+DISTRIBUTIONS="bionic disco"
 
 if is_release
 then


### PR DESCRIPTION
Launchpad won't accept cosmic uploads anymore, so we can't provide a cosmic release build anymore and have to switch away from cosmic for the static build.