### PR TITLE
[DOCS] Change link in using compiler

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -363,7 +363,7 @@ Output Description
           // If the language used has no contract names, this field should equal to an empty string.
           "ContractName": {
             // The Ethereum Contract ABI. If empty, it is represented as an empty array.
-            // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+            // See https://solidity.readthedocs.io/en/develop/abi-spec.html
             "abi": [],
             // See the Metadata Output documentation (serialised JSON string)
             "metadata": "{...}",


### PR DESCRIPTION
### Description

@Marenz Pointed out that in this document we link to a link that then redirects people back to the Solidity docs, so fixed the link.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
