### PR TITLE
[Trivial] Test scripts: Make build dir a variable

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -29,6 +29,7 @@
 set -e
 
 REPO_ROOT="$(dirname "$0")/.."
+SOLIDITY_BUILD_DIR="${SOLIDITY_BUILD_DIR:-build}"
 
 source "${REPO_ROOT}/scripts/common.sh"
 
@@ -120,7 +121,7 @@ do
         fi
 
         set +e
-        "$REPO_ROOT"/build/test/soltest --show-progress $log -- --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $force_abiv2_flag
+        "$REPO_ROOT"/${SOLIDITY_BUILD_DIR}/test/soltest --show-progress $log -- --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $force_abiv2_flag
 
         if test "0" -ne "$?"; then
             exit 1

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -31,8 +31,9 @@ set -e
 ## GLOBAL VARIABLES
 
 REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
 source "${REPO_ROOT}/scripts/common.sh"
-SOLC="$REPO_ROOT/build/solc/solc"
+SOLC="$REPO_ROOT/${SOLIDITY_BUILD_DIR}/solc/solc"
 INTERACTIVE=true
 if ! tty -s || [ "$CI" ]
 then
@@ -439,8 +440,8 @@ SOLTMPDIR=$(mktemp -d)
     "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/test/
     "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/ docs
 
-    echo *.sol | xargs -P 4 -n 50 "$REPO_ROOT"/build/test/tools/solfuzzer --quiet --input-files
-    echo *.sol | xargs -P 4 -n 50 "$REPO_ROOT"/build/test/tools/solfuzzer --without-optimizer --quiet --input-files
+    echo *.sol | xargs -P 4 -n 50 "$REPO_ROOT"/${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer --quiet --input-files
+    echo *.sol | xargs -P 4 -n 50 "$REPO_ROOT"/${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer --without-optimizer --quiet --input-files
 )
 rm -rf "$SOLTMPDIR"
 


### PR DESCRIPTION
Motivation: When building in docker we often don't want to use our existing build dir as that is created for our local environment instead of the docker environment.
This makes it easier to just use a dedicated docker build dir.