### PR TITLE
[Yul] Side effects propagator

### DIFF
--- a/libsolidity/analysis/ControlFlowAnalyzer.cpp
+++ b/libsolidity/analysis/ControlFlowAnalyzer.cpp
@@ -151,22 +151,22 @@ void ControlFlowAnalyzer::checkUninitializedAccess(CFGNode const* _entry, CFGNod
 void ControlFlowAnalyzer::checkUnreachable(CFGNode const* _entry, CFGNode const* _exit, CFGNode const* _revert) const
 {
 	// collect all nodes reachable from the entry point
-	std::set<CFGNode const*> reachable = BreadthFirstSearch<CFGNode>{{_entry}}.run(
-		[](CFGNode const& _node, auto&& _addChild) {
-			for (CFGNode const* exit: _node.exits)
-				_addChild(*exit);
+	std::set<CFGNode const*> reachable = BreadthFirstSearch<CFGNode const*>{{_entry}}.run(
+		[](CFGNode const* _node, auto&& _addChild) {
+			for (CFGNode const* exit: _node->exits)
+				_addChild(exit);
 		}
 	).visited;
 
 	// traverse all paths backwards from exit and revert
 	// and extract (valid) source locations of unreachable nodes into sorted set
 	std::set<SourceLocation> unreachable;
-	BreadthFirstSearch<CFGNode>{{_exit, _revert}}.run(
-		[&](CFGNode const& _node, auto&& _addChild) {
-			if (!reachable.count(&_node) && !_node.location.isEmpty())
-				unreachable.insert(_node.location);
-			for (CFGNode const* entry: _node.entries)
-				_addChild(*entry);
+	BreadthFirstSearch<CFGNode const*>{{_exit, _revert}}.run(
+		[&](CFGNode const* _node, auto&& _addChild) {
+			if (!reachable.count(_node) && !_node->location.isEmpty())
+				unreachable.insert(_node->location);
+			for (CFGNode const* entry: _node->entries)
+				_addChild(entry);
 		}
 	);
 

--- a/libyul/SideEffects.h
+++ b/libyul/SideEffects.h
@@ -73,6 +73,16 @@ struct SideEffects
 		*this = *this + _other;
 		return *this;
 	}
+
+	bool operator==(SideEffects const& _other) const
+	{
+		return
+			movable == _other.movable &&
+			sideEffectFree == _other.sideEffectFree &&
+			sideEffectFreeIfNoMSize == _other.sideEffectFreeIfNoMSize &&
+			invalidatesStorage == _other.invalidatesStorage &&
+			invalidatesMemory == _other.invalidatesMemory;
+	}
 };
 
 }

--- a/libyul/optimiser/CallGraphGenerator.h
+++ b/libyul/optimiser/CallGraphGenerator.h
@@ -40,8 +40,7 @@ namespace yul
 class CallGraphGenerator: public ASTWalker
 {
 public:
-	/// @returns the call graph of the visited AST.
-	InvertibleRelation<YulString> const& callGraph() const { return m_callGraph; }
+	static std::map<YulString, std::set<YulString>> callGraph(Block const& _ast);
 
 	using ASTWalker::operator();
 	void operator()(FunctionalInstruction const& _functionalInstruction) override;
@@ -49,7 +48,9 @@ public:
 	void operator()(FunctionDefinition const& _functionDefinition) override;
 
 private:
-	InvertibleRelation<YulString> m_callGraph;
+	CallGraphGenerator();
+
+	std::map<YulString, std::set<YulString>> m_callGraph;
 	/// The name of the function we are currently visiting during traversal.
 	YulString m_currentFunction;
 };

--- a/libyul/optimiser/Semantics.h
+++ b/libyul/optimiser/Semantics.h
@@ -63,6 +63,21 @@ private:
 };
 
 /**
+ * This class can be used to determine the side-effects of user-defined functions.
+ *
+ * It is given a dialect and a mapping that represents the direct calls from user-defined
+ * functions to other user-defined functions and built-in functions.
+ */
+class SideEffectsPropagator
+{
+public:
+	static std::map<YulString, SideEffects> sideEffects(
+		Dialect const& _dialect,
+		std::map<YulString, std::set<YulString>> const& _directCallGraph
+	);
+};
+
+/**
  * Class that can be used to find out if certain code contains the MSize instruction.
  *
  * Note that this is a purely syntactic property meaning that even if this is false,

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -27,6 +27,7 @@
 #include <test/libyul/YulOptimizerTest.h>
 #include <test/libyul/YulInterpreterTest.h>
 #include <test/libyul/ObjectCompilerTest.h>
+#include <test/libyul/FunctionSideEffects.h>
 
 #include <boost/filesystem.hpp>
 
@@ -56,6 +57,7 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"Yul Optimizer",       "libyul",      "yulOptimizerTests",   false, false, &yul::test::YulOptimizerTest::create},
 	{"Yul Interpreter",     "libyul",      "yulInterpreterTests", false, false, &yul::test::YulInterpreterTest::create},
 	{"Yul Object Compiler", "libyul",      "objectCompiler",      false, false, &yul::test::ObjectCompilerTest::create},
+	{"Function Side Effects","libyul",     "functionSideEffects", false, false, &yul::test::FunctionSideEffects::create},
 	{"Syntax",              "libsolidity", "syntaxTests",         false, false, &SyntaxTest::create},
 	{"Error Recovery",      "libsolidity", "errorRecoveryTests",  false, false, &SyntaxTest::createErrorRecovery},
 	{"Semantic",            "libsolidity", "semanticTests",       false, true,  &SemanticTest::create},

--- a/test/libyul/FunctionSideEffects.cpp
+++ b/test/libyul/FunctionSideEffects.cpp
@@ -1,0 +1,125 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/libyul/FunctionSideEffects.h>
+#include <test/Options.h>
+#include <test/libyul/Common.h>
+
+#include <libdevcore/AnsiColorized.h>
+
+#include <libyul/SideEffects.h>
+#include <libyul/optimiser/CallGraphGenerator.h>
+#include <libyul/optimiser/Semantics.h>
+#include <libyul/Object.h>
+#include <libyul/backends/evm/EVMDialect.h>
+
+#include <libdevcore/StringUtils.h>
+
+#include <boost/algorithm/string.hpp>
+
+
+using namespace dev;
+using namespace langutil;
+using namespace yul;
+using namespace yul::test;
+using namespace dev::solidity;
+using namespace dev::solidity::test;
+using namespace std;
+
+namespace
+{
+string toString(SideEffects const& _sideEffects)
+{
+	vector<string> ret;
+	if (_sideEffects.movable)
+		ret.push_back("movable");
+	if (_sideEffects.sideEffectFree)
+		ret.push_back("sideEffectFree");
+	if (_sideEffects.sideEffectFreeIfNoMSize)
+		ret.push_back("sideEffectFreeIfNoMSize");
+	if (_sideEffects.invalidatesStorage)
+		ret.push_back("invalidatesStorage");
+	if (_sideEffects.invalidatesMemory)
+		ret.push_back("invalidatesMemory");
+	return joinHumanReadable(ret);
+}
+}
+
+FunctionSideEffects::FunctionSideEffects(string const& _filename)
+{
+	ifstream file(_filename);
+	if (!file)
+		BOOST_THROW_EXCEPTION(runtime_error("Cannot open test input: \"" + _filename + "\"."));
+	file.exceptions(ios::badbit);
+
+	m_source = parseSourceAndSettings(file);
+	m_expectation = parseSimpleExpectations(file);}
+
+TestCase::TestResult FunctionSideEffects::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+{
+	Object obj;
+	std::tie(obj.code, obj.analysisInfo) = yul::test::parse(m_source, false);
+	if (!obj.code)
+		BOOST_THROW_EXCEPTION(runtime_error("Parsing input failed."));
+
+	map<YulString, SideEffects> functionSideEffects = SideEffectsPropagator::sideEffects(
+		EVMDialect::strictAssemblyForEVM(langutil::EVMVersion()),
+		CallGraphGenerator::callGraph(*obj.code)
+	);
+
+	std::map<std::string, std::string> functionSideEffectsStr;
+	for (auto const& fun: functionSideEffects)
+		functionSideEffectsStr[fun.first.str()] = toString(fun.second);
+
+	m_obtainedResult.clear();
+	for (auto const& fun: functionSideEffectsStr)
+		m_obtainedResult += fun.first + ": " + fun.second + "\n";
+
+	if (m_expectation != m_obtainedResult)
+	{
+		string nextIndentLevel = _linePrefix + "  ";
+		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::CYAN}) << _linePrefix << "Expected result:" << endl;
+		printIndented(_stream, m_expectation, nextIndentLevel);
+		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::CYAN}) << _linePrefix << "Obtained result:" << endl;
+		printIndented(_stream, m_obtainedResult, nextIndentLevel);
+		return TestResult::Failure;
+	}
+	return TestResult::Success;
+}
+
+
+void FunctionSideEffects::printSource(ostream& _stream, string const& _linePrefix, bool const) const
+{
+	printIndented(_stream, m_source, _linePrefix);
+}
+
+void FunctionSideEffects::printUpdatedExpectations(ostream& _stream, string const& _linePrefix) const
+{
+	printIndented(_stream, m_obtainedResult, _linePrefix);
+}
+
+void FunctionSideEffects::printIndented(ostream& _stream, string const& _output, string const& _linePrefix) const
+{
+	stringstream output(_output);
+	string line;
+	while (getline(output, line))
+		if (line.empty())
+			// Avoid trailing spaces.
+			_stream << boost::trim_right_copy(_linePrefix) << endl;
+		else
+			_stream << _linePrefix << line << endl;
+}

--- a/test/libyul/FunctionSideEffects.h
+++ b/test/libyul/FunctionSideEffects.h
@@ -1,0 +1,54 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libdevcore/AnsiColorized.h>
+#include <test/TestCase.h>
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace yul
+{
+namespace test
+{
+
+class FunctionSideEffects: public dev::solidity::test::TestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(Config const& _config)
+	{ return std::unique_ptr<TestCase>(new FunctionSideEffects(_config.filename)); }
+	explicit FunctionSideEffects(std::string const& _filename);
+
+	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+
+	void printSource(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) const override;
+	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
+
+private:
+	void printIndented(std::ostream& _stream, std::string const& _output, std::string const& _linePrefix = "") const;
+
+	std::string m_source;
+	std::string m_expectation;
+	std::string m_obtainedResult;
+};
+
+}
+}

--- a/test/libyul/functionSideEffects/cyclic_graph.yul
+++ b/test/libyul/functionSideEffects/cyclic_graph.yul
@@ -1,0 +1,10 @@
+{
+    function a() { b() }
+    function b() { c() }
+    function c() { b() }
+}
+// ----
+// : movable, sideEffectFree, sideEffectFreeIfNoMSize
+// a: movable, sideEffectFree, sideEffectFreeIfNoMSize
+// b: movable, sideEffectFree, sideEffectFreeIfNoMSize
+// c: movable, sideEffectFree, sideEffectFreeIfNoMSize

--- a/test/libyul/functionSideEffects/doubly_recursive_function.yul
+++ b/test/libyul/functionSideEffects/doubly_recursive_function.yul
@@ -1,0 +1,8 @@
+{
+    function a() { b() }
+    function b() { a() }
+}
+// ----
+// : movable, sideEffectFree, sideEffectFreeIfNoMSize
+// a: movable, sideEffectFree, sideEffectFreeIfNoMSize
+// b: movable, sideEffectFree, sideEffectFreeIfNoMSize

--- a/test/libyul/functionSideEffects/empty.yul
+++ b/test/libyul/functionSideEffects/empty.yul
@@ -1,0 +1,4 @@
+{
+}
+// ----
+// : movable, sideEffectFree, sideEffectFreeIfNoMSize

--- a/test/libyul/functionSideEffects/empty_with_sstore.yul
+++ b/test/libyul/functionSideEffects/empty_with_sstore.yul
@@ -1,0 +1,5 @@
+{
+    sstore(0, 1)
+}
+// ----
+// : invalidatesStorage

--- a/test/libyul/functionSideEffects/multi_calls.yul
+++ b/test/libyul/functionSideEffects/multi_calls.yul
@@ -1,0 +1,22 @@
+{
+    function a() {
+        b()
+    }
+    function b() {
+        sstore(0, 1)
+        b()
+    }
+    function c() {
+        mstore(0, 1)
+        a()
+        d()
+    }
+    function d() {
+    }
+}
+// ----
+// : movable, sideEffectFree, sideEffectFreeIfNoMSize
+// a: invalidatesStorage
+// b: invalidatesStorage
+// c: invalidatesStorage, invalidatesMemory
+// d: movable, sideEffectFree, sideEffectFreeIfNoMSize

--- a/test/libyul/functionSideEffects/recursive_function.yul
+++ b/test/libyul/functionSideEffects/recursive_function.yul
@@ -1,0 +1,6 @@
+{
+    function a() { a() }
+}
+// ----
+// : movable, sideEffectFree, sideEffectFreeIfNoMSize
+// a: movable, sideEffectFree, sideEffectFreeIfNoMSize

--- a/test/libyul/functionSideEffects/simple_functions.yul
+++ b/test/libyul/functionSideEffects/simple_functions.yul
@@ -1,0 +1,14 @@
+{
+    function a() {}
+    function f() { mstore(0, 1) }
+    function g() { sstore(0, 1) }
+    function h() { let x := msize() }
+    function i() { let z := mload(0) }
+}
+// ----
+// : movable, sideEffectFree, sideEffectFreeIfNoMSize
+// a: movable, sideEffectFree, sideEffectFreeIfNoMSize
+// f: invalidatesMemory
+// g: invalidatesStorage
+// h: sideEffectFree, sideEffectFreeIfNoMSize
+// i: sideEffectFreeIfNoMSize

--- a/test/libyul/functionSideEffects/structures.yul
+++ b/test/libyul/functionSideEffects/structures.yul
@@ -1,0 +1,40 @@
+{
+    if calldataload(0)
+    {
+        f()
+    }
+    g()
+
+    function f() {
+        pop(mload(0))
+    }
+    function g() {
+        if sload(0)
+        {
+            h()
+        }
+    }
+    function h() {
+        switch t()
+        case 1 {
+            i()
+        }
+    }
+    function t() -> x {
+        mstore(0, 1)
+    }
+    function i() {
+        sstore(0, 1)
+    }
+    function r(a) -> b {
+        b := mul(a, 2)
+    }
+}
+// ----
+// : invalidatesStorage, invalidatesMemory
+// f: sideEffectFreeIfNoMSize
+// g: invalidatesStorage, invalidatesMemory
+// h: invalidatesStorage, invalidatesMemory
+// i: invalidatesStorage
+// r: movable, sideEffectFree, sideEffectFreeIfNoMSize
+// t: invalidatesMemory

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -30,6 +30,8 @@ add_executable(isoltest
 	../libsolidity/ABIJsonTest.cpp
 	../libsolidity/ASTJSONTest.cpp
 	../libsolidity/SMTCheckerJSONTest.cpp
+	../libyul/Common.cpp
+	../libyul/FunctionSideEffects.cpp
 	../libyul/ObjectCompilerTest.cpp
 	../libyul/YulOptimizerTest.cpp
 	../libyul/YulInterpreterTest.cpp


### PR DESCRIPTION
Depends on https://github.com/ethereum/solidity/pull/7234

After this, we can use the callgraph generator and the side effects propagator to get a mapping from user-defined function to side effects. This mapping can be supplied to all components that can make use of that information.