### PR TITLE
Properly set storage and memory after erasing potentially destroyed keys

### DIFF
--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -43,7 +43,6 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 	if (auto vars = isSimpleStore(dev::eth::Instruction::SSTORE, _statement))
 	{
 		ASTModifier::operator()(_statement);
-		m_storage.set(vars->first, vars->second);
 		set<YulString> keysToErase;
 		for (auto const& item: m_storage.values)
 			if (!(
@@ -53,6 +52,7 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 				keysToErase.insert(item.first);
 		for (YulString const& key: keysToErase)
 			m_storage.eraseKey(key);
+		m_storage.set(vars->first, vars->second);
 	}
 	else if (auto vars = isSimpleStore(dev::eth::Instruction::MSTORE, _statement))
 	{
@@ -61,11 +61,9 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 		for (auto const& item: m_memory.values)
 			if (!m_knowledgeBase.knownToBeDifferentByAtLeast32(vars->first, item.first))
 				keysToErase.insert(item.first);
-		// TODO is it fine to do that here?
-		// can we also move the storage above?
-		m_memory.set(vars->first, vars->second);
 		for (YulString const& key: keysToErase)
 			m_memory.eraseKey(key);
+		m_memory.set(vars->first, vars->second);
 	}
 	else
 	{

--- a/test/libyul/yulOptimizerTests/loadResolver/re_store_memory.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/re_store_memory.yul
@@ -1,0 +1,21 @@
+{
+    let a := 0
+    let b := 1
+    let c := 2
+    mstore(a, b)
+    sstore(0, mload(a))
+    mstore(a, c)
+    sstore(10, mload(a))
+}
+// ====
+// step: loadResolver
+// ----
+// {
+//     let a := 0
+//     let b := 1
+//     let c := 2
+//     mstore(a, b)
+//     sstore(a, b)
+//     mstore(a, c)
+//     sstore(10, c)
+// }

--- a/test/libyul/yulOptimizerTests/loadResolver/re_store_storage.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/re_store_storage.yul
@@ -1,0 +1,21 @@
+{
+    let a := 0
+    let b := 1
+    let c := 2
+    sstore(a, b)
+    mstore(0, sload(a))
+    sstore(a, c)
+    mstore(32, sload(a))
+}
+// ====
+// step: loadResolver
+// ----
+// {
+//     let a := 0
+//     let b := 1
+//     let c := 2
+//     sstore(a, b)
+//     mstore(a, b)
+//     sstore(a, c)
+//     mstore(32, c)
+// }


### PR DESCRIPTION
No changelog entry needed because this feature is not active in the optimizer yet.