### PR TITLE
Avoid aggregate initialization of EWasmToText class

### DIFF
--- a/libyul/backends/wasm/EWasmCodeTransform.cpp
+++ b/libyul/backends/wasm/EWasmCodeTransform.cpp
@@ -55,7 +55,7 @@ string EWasmCodeTransform::run(Dialect const& _dialect, yul::Block const& _ast)
 	std::vector<wasm::FunctionImport> imports;
 	for (auto& imp: transform.m_functionsToImport)
 		imports.emplace_back(std::move(imp.second));
-	return EWasmToText{}.run(
+	return EWasmToText().run(
 		transform.m_globalVariables,
 		imports,
 		functions


### PR DESCRIPTION
fixes #7245 by using value initialization instead of aggregate initialization.

