### PR TITLE
Enable c++17 in cmake toolchain file used by ossfuzz builder

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -7,8 +7,8 @@ The docker images are build locally on the developer machine:
 ```!sh
 cd .circleci/docker/
 
-docker build -t ethereum/solc-buildpack-deps:ubuntu1904 -f Dockerfile.ubuntu1904 .
-docker push solidity/solc-buildpack-deps:ubuntu1904
+docker build -t ethereum/solidity-buildpack-deps:ubuntu1904 -f Dockerfile.ubuntu1904 .
+docker push ethereum/solidity-buildpack-deps:ubuntu1904
 ```
 
 which you can find on Dockerhub after the push at:
@@ -16,3 +16,13 @@ which you can find on Dockerhub after the push at:
     https://hub.docker.com/r/ethereum/solidity-buildpack-deps
 
 where the image tag reflects the target OS to build Solidity and run its test on.
+
+### Testing docker images locally
+
+```!sh
+cd solidity
+# Mounts your local solidity directory in docker container for testing
+docker run -v `pwd`:/src/solidity -ti ethereum/solidity-buildpack-deps:ubuntu1904 /bin/bash
+cd /src/solidity
+<commands_to_test_build_with_new_docker_image>
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
       TERM: xterm
       CC: /usr/bin/clang-8
       CXX: /usr/bin/clang++-8
-      CMAKE_OPTIONS: -DOSSFUZZ=1 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/libfuzzer.cmake
+      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/libfuzzer.cmake
     steps:
       - checkout
       - run: *setup_prerelease_commit_hash

--- a/.circleci/docker/Dockerfile.ubuntu1904
+++ b/.circleci/docker/Dockerfile.ubuntu1904
@@ -33,7 +33,7 @@ RUN set -ex; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential \
 		software-properties-common \
-		cmake ninja-build clang++-8 \
+		cmake ninja-build clang++-8 libc++-8-dev libc++abi-8-dev \
 		libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		libjsoncpp-dev \

--- a/cmake/toolchains/libfuzzer.cmake
+++ b/cmake/toolchains/libfuzzer.cmake
@@ -1,2 +1,9 @@
-# Require libfuzzer specific flags
-set(CMAKE_CXX_FLAGS "-O1 -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libstdc++ -fopenmp=libgomp")
+# Inherit default options
+include("${CMAKE_CURRENT_LIST_DIR}/default.cmake")
+# Disable Z3 and CVC4 since none of the existing fuzzers need them
+set(USE_Z3 OFF CACHE BOOL "" FORCE)
+set(USE_CVC4 OFF CACHE BOOL "" FORCE)
+# Build fuzzing binaries
+set(OSSFUZZ 1)
+# clang/libfuzzer specific flags for ASan instrumentation
+set(CMAKE_CXX_FLAGS "-O1 -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libstdc++")


### PR DESCRIPTION
fixes #7253

The ossfuzz CI failure should hopefully be fixed once #7246 is merged and the updated docker image is pushed to dockerhub

CC @christianparpart @ekpyron 