### PR TITLE
Build cvc4 when packaging the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,4 +57,4 @@ parts:
       ./configure.sh --prefix=$SNAPCRAFT_STAGE/usr
       cd build
       make -j -l $(grep -c "^processor" /proc/cpuinfo)
-      make install DESTDIR=$SNAPCRAFT_STAGE
+      make install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,7 +26,7 @@ parts:
     source: .
     source-type: git
     plugin: cmake
-    build-packages: [build-essential, libboost-all-dev, libcvc4-dev]
+    build-packages: [build-essential, libboost-all-dev]
     stage-packages: [libicu60]
     override-build: |
       if git describe --exact-match --tags 2> /dev/null
@@ -34,7 +34,7 @@ parts:
         echo -n > ../src/prerelease.txt
       fi
       snapcraftctl build
-    after: [z3]
+    after: [z3, cvc4]
   z3:
     source: https://github.com/Z3Prover/z3.git
     source-tag: z3-4.8.4
@@ -47,3 +47,14 @@ parts:
       cd build
       make -j -l $(grep -c "^processor" /proc/cpuinfo)
       make install DESTDIR=$SNAPCRAFT_PART_INSTALL
+  cvc4:
+    source: https://github.com/CVC4/CVC4.git
+    source-tag: "1.7"
+    plugin: nil
+    build-packages: [python, cmake, openjdk-11-jre, libgmp-dev]
+    override-build: |
+      ./contrib/get-antlr-3.4
+      ./configure.sh --prefix=$SNAPCRAFT_STAGE/usr
+      cd build
+      make -j -l $(grep -c "^processor" /proc/cpuinfo)
+      make install DESTDIR=$SNAPCRAFT_STAGE

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,3 +58,5 @@ parts:
       cd build
       make -j -l $(grep -c "^processor" /proc/cpuinfo)
       make install
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/lib/
+      cp $SNAPCRAFT_STAGE/usr/lib/libcvc4.so.6 $SNAPCRAFT_PART_INSTALL/usr/lib/


### PR DESCRIPTION
### Description

Since the migration to c++17, the build of the snap started to fail because of cvc4:
https://launchpadlibrarian.net/437242532/buildlog_snap_ubuntu_bionic_i386_solc-candidate_BUILDING.txt.gz

There is a new upstream version of cvc4 that is not yet in the ubuntu archives, so it's good to take that one. Also I have been wanting to do this for a long time to see if it fixes the builds in arm, but I haven't tested that.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
