### PR TITLE
[SMTChecker] Do not report error to the user in case of solver timeout

### DIFF
--- a/libsolidity/formal/Z3CHCInterface.cpp
+++ b/libsolidity/formal/Z3CHCInterface.cpp
@@ -89,7 +89,10 @@ pair<CheckResult, vector<string>> Z3CHCInterface::query(Expression const& _expr)
 	}
 	catch (z3::exception const& _e)
 	{
-		result = CheckResult::ERROR;
+		solAssert(_e.msg(), "Z3 threw without message.");
+		result = string(_e.msg()).find("canceled") == string::npos ?
+			CheckResult::ERROR :
+			CheckResult::UNKNOWN;
 		values.clear();
 	}
 

--- a/libsolidity/formal/Z3Interface.cpp
+++ b/libsolidity/formal/Z3Interface.cpp
@@ -99,9 +99,12 @@ pair<CheckResult, vector<string>> Z3Interface::check(vector<Expression> const& _
 				values.push_back(toString(m.eval(toZ3Expr(e))));
 		}
 	}
-	catch (z3::exception const&)
+	catch (z3::exception const& _e)
 	{
-		result = CheckResult::ERROR;
+		solAssert(_e.msg(), "Z3 threw without message.");
+		result = string(_e.msg()).find("canceled") == string::npos ?
+			CheckResult::ERROR :
+			CheckResult::UNKNOWN;
 		values.clear();
 	}
 


### PR DESCRIPTION
In case of solver timeout, Z3 throws an exception that says "canceled". As pointed in https://github.com/Z3Prover/z3/issues/2425, "canceled covers timeout, resource limit and user-interrupts.".

Currently, if only Z3 is used and it times out the SMTChecker issues a warning to the user `Error trying to invoke SMT solver`. To me we should treat such cases as `unknown`. That's what this PR does.

CVC4 already returns `unknown` for a query if it times out. I asked https://github.com/CVC4/CVC4/issues/3194 to confirm my tests.