### PR TITLE
Compile succeeding syntax tests.

### DIFF
--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -83,7 +83,21 @@ TestCase::TestResult SyntaxTest::run(ostream& _stream, string const& _linePrefix
 		OptimiserSettings::minimal()
 	);
 	if (compiler().parse())
-		compiler().analyze();
+		if (compiler().analyze())
+			try
+			{
+				if (!compiler().compile())
+					BOOST_THROW_EXCEPTION(runtime_error("Compilation failed even though analysis was successful."));
+			}
+			catch (UnimplementedFeatureError const& _e)
+			{
+				m_errorList.emplace_back(SyntaxTestError{
+					"UnimplementedFeatureError",
+					errorMessage(_e),
+					-1,
+					-1
+				});
+			}
 
 	for (auto const& currentError: filterErrors(compiler().errors(), true))
 	{

--- a/test/libsolidity/syntaxTests/constants/mod_div_rational.sol
+++ b/test/libsolidity/syntaxTests/constants/mod_div_rational.sol
@@ -4,3 +4,5 @@ contract C {
     fixed a3 = 0 / 0.123;
     fixed a4 = 0 / -0.123;
 }
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_fixed_types.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_fixed_types.sol
@@ -4,5 +4,6 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (50-67): Unused local variable.
 // Warning: (20-119): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_rationals.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_rationals.sol
@@ -4,5 +4,6 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (50-73): Unused local variable.
 // Warning: (20-118): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/303_fixed_type_int_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/303_fixed_type_int_conversion.sol
@@ -8,4 +8,5 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (20-147): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/304_fixed_type_rational_int_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/304_fixed_type_rational_int_conversion.sol
@@ -6,4 +6,5 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (20-104): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/305_fixed_type_rational_fraction_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/305_fixed_type_rational_fraction_conversion.sol
@@ -6,4 +6,5 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (20-108): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/307_rational_unary_minus_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/307_rational_unary_minus_operation.sol
@@ -5,3 +5,5 @@ contract test {
         a; b;
     }
 }
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/312_leading_zero_rationals_convert.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/312_leading_zero_rationals_convert.sol
@@ -7,3 +7,5 @@ contract A {
         a; b; c; d;
     }
 }
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/314_fixed_type_zero_handling.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/314_fixed_type_zero_handling.sol
@@ -5,4 +5,5 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (20-104): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol
@@ -6,4 +6,5 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (20-182): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/323_mapping_with_fixed_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/323_mapping_with_fixed_literal.sol
@@ -4,3 +4,5 @@ contract test {
         fixedString[0.5] = "Half";
     }
 }
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/324_fixed_points_inside_structs.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/324_fixed_points_inside_structs.sol
@@ -5,3 +5,5 @@ contract test {
     }
     myStruct a = myStruct(3.125, 3);
 }
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/328_rational_to_fixed_literal_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/328_rational_to_fixed_literal_expression.sol
@@ -11,5 +11,6 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (238-252): This declaration shadows an existing declaration.
 // Warning: (20-339): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/343_integer_and_fixed_interaction.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/343_integer_and_fixed_interaction.sol
@@ -4,5 +4,6 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (50-58): Unused local variable.
 // Warning: (20-89): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/parsing/declaring_fixed_and_ufixed_variables.sol
+++ b/test/libsolidity/syntaxTests/parsing/declaring_fixed_and_ufixed_variables.sol
@@ -6,6 +6,7 @@ contract A {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning: (52-60): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning: (62-74): Unused function parameter. Remove or comment out the variable name to silence this warning.
 // Warning: (93-104): Unused local variable.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed.sol
@@ -7,3 +7,4 @@ contract C {
   }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/signed_rational_modulus.sol
+++ b/test/libsolidity/syntaxTests/signed_rational_modulus.sol
@@ -6,3 +6,5 @@ contract test {
         a; b; c;
     }
 }
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/types/rational_number_literal_to_fixed_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_literal_to_fixed_implicit.sol
@@ -13,3 +13,4 @@ contract C {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.


### PR DESCRIPTION
Came up in https://github.com/ethereum/solidity/pull/7271, since the import tests were compiled.
