### PR TITLE
[isoltest] Support empty revert message

### DIFF
--- a/test/libsolidity/semanticTests/smoke/failure.sol
+++ b/test/libsolidity/semanticTests/smoke/failure.sol
@@ -1,6 +1,13 @@
 contract C {
-    function e() public {
+    function e() public pure {
         revert("Transaction failed.");
+    }
+    function f(bool _value) public pure {
+        string memory message;
+        require(_value, message);
+    }
+    function g(bool _value) public pure {
+        require(_value, "Value is false.");
     }
 }
 // ====
@@ -8,3 +15,5 @@ contract C {
 // ----
 // _() -> FAILURE
 // e() -> FAILURE, hex"08c379a0", 0x20, 19, "Transaction failed."
+// f(bool): false -> FAILURE, hex"08c379a0", 0x20, 0
+// g(bool): false -> FAILURE, hex"08c379a0", 0x20, 15, "Value is false."

--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -208,7 +208,11 @@ string BytesUtils::formatRawBytes(
 	dev::solidity::test::ParameterList const& _parameters,
 	string _linePrefix)
 {
-	soltestAssert(_bytes.size() == ContractABIUtils::encodingSize(_parameters), "");
+	soltestAssert(
+		_bytes.size() == ContractABIUtils::encodingSize(_parameters),
+		"Got " + to_string(_bytes.size()) + " bytes, but expected " +
+		to_string(ContractABIUtils::encodingSize(_parameters)) + " bytes."
+	);
 
 	stringstream os;
 	auto it = _bytes.begin();
@@ -275,7 +279,11 @@ string BytesUtils::formatBytesRange(
 	bool _highlight
 )
 {
-	soltestAssert(_bytes.size() == ContractABIUtils::encodingSize(_parameters), "");
+	soltestAssert(
+		_bytes.size() == ContractABIUtils::encodingSize(_parameters),
+		"Got " + to_string(_bytes.size()) + " bytes, but expected " +
+		to_string(ContractABIUtils::encodingSize(_parameters)) + " bytes."
+	);
 
 	stringstream os;
 	auto it = _bytes.begin();

--- a/test/libsolidity/util/ContractABIUtils.cpp
+++ b/test/libsolidity/util/ContractABIUtils.cpp
@@ -313,14 +313,18 @@ dev::solidity::test::ParameterList ContractABIUtils::defaultParameters(size_t co
 	return parameters;
 }
 
-dev::solidity::test::ParameterList ContractABIUtils::failureParameters()
+dev::solidity::test::ParameterList ContractABIUtils::failureParameters(bytes const _bytes)
 {
 	ParameterList parameters;
 
 	parameters.push_back(Parameter{bytes(), "", ABIType{ABIType::HexString, ABIType::AlignNone, 4}, FormatInfo{}});
 	parameters.push_back(Parameter{bytes(), "", ABIType{ABIType::Hex}, FormatInfo{}});
 	parameters.push_back(Parameter{bytes(), "", ABIType{ABIType::UnsignedDec}, FormatInfo{}});
-	parameters.push_back(Parameter{bytes(), "", ABIType{ABIType::String}, FormatInfo{}});
+
+	/// If _bytes contains at least a 1 byte message (function selector + tail pointer + message length + message)
+	/// append an additional string parameter to represent that message.
+	if (_bytes.size() > 68)
+		parameters.push_back(Parameter{bytes(), "", ABIType{ABIType::String}, FormatInfo{}});
 
 	return parameters;
 }

--- a/test/libsolidity/util/ContractABIUtils.h
+++ b/test/libsolidity/util/ContractABIUtils.h
@@ -66,8 +66,10 @@ public:
 	);
 
 	/// Returns a list of parameters corresponding to the encoding of
-	/// returned values in case of a failure.
-	static ParameterList failureParameters();
+	/// returned values in case of a failure. Creates an additional parameter
+	/// for the error message if _bytes is larger than 68 bytes
+	/// (function_selector + tail_ptr + message_length).
+	static ParameterList failureParameters(bytes const _bytes);
 
 	/// Returns _count parameters with their type set to ABIType::UnsignedDec
 	/// and their size set to 32 bytes.

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -127,7 +127,7 @@ string TestFunctionCall::format(
 				boost::optional<ParameterList> abiParams;
 
 				if (isFailure && !output.empty())
-					abiParams = boost::make_optional(ContractABIUtils::failureParameters());
+					abiParams = boost::make_optional(ContractABIUtils::failureParameters(output));
 				else
 					abiParams = ContractABIUtils::parametersFromJsonOutputs(
 						_errorReporter,
@@ -193,7 +193,7 @@ string TestFunctionCall::formatBytesParameters(
 	{
 		os << BytesUtils::formatBytesRange(
 			_bytes,
-			ContractABIUtils::failureParameters(),
+			ContractABIUtils::failureParameters(_bytes),
 			_highlight
 		);
 


### PR DESCRIPTION
Fixes an issue when revert message is empty:
```
contract c
    function f(bool _value) public pure {
        string memory message;
        require(_value, message);
    }
    function g(bool _value) public pure {
        require(_value, "Value is false.");
    }
}
// ----
// f(bool): false -> FAILURE, hex"08c379a0", 0x20, 0
// g(bool): false -> FAILURE, hex"08c379a0", 0x20, 15, "Value is false."
```