### PR TITLE
Fix deprecated option style for docCheck

### DIFF
--- a/test/.solhint.json
+++ b/test/.solhint.json
@@ -2,7 +2,7 @@
     "extends": "solhint:default",
     "plugins": [],
     "rules": {
-        "compiler-fixed": false,
-        "no-inline-assembly": false
+        "compiler-fixed": "off",
+        "no-inline-assembly": "off"
     }
 }


### PR DESCRIPTION
solhint was updated and now warns about deprecated option values