### PR TITLE
adding FUNDING.yml through Unlock

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://donate.unlock-protocol.com/?r=ethereum/solidity

--- a/.unlock-protocol.config.json
+++ b/.unlock-protocol.config.json
@@ -1,0 +1,13 @@
+{
+   "persistentCheckout": true,
+   "callToAction": {
+     "default": "Please support work on Solidity by purchasing a key to our Lock on Ethereum!",
+     "pending": "Thank you for your support. It means a lot to us!",
+     "confirmed": "Thank you for your support. It means a lot to us!"
+   },
+   "locks": {
+     "0x38Ad3BEA0FA53A7Ac63Ba56CAA88ce1DE690E1Ea": {
+       "name": "Solidity Supporters"
+     }
+   }
+ }


### PR DESCRIPTION
Hello!

First of all, thanks for your (hard) work!

### Description

As an OpenSource project, I believe Web3.js should have a `FUNDING.yml` file which lets people make donations if they enjoy the software.

This pull requests adds donation thru an [Unlock](https://unlock-protocol.com/) lock. Locks are smart contract which let people become members by purchasing a key. The key itself is a non fungible token: 🗝 . (you can view the NFT on [OpenSea](https://opensea.io/assets/0x38Ad3BEA0FA53A7Ac63Ba56CAA88ce1DE690E1Ea/1) for example)

This specific lock is at [`0x38Ad3BEA0FA53A7Ac63Ba56CAA88ce1DE690E1Ea`](https://etherscan.io/address/0x38Ad3BEA0FA53A7Ac63Ba56CAA88ce1DE690E1Ea). The current key price is 1 Ether. I currently own the lock but I'll happily transfer its ownership to you if you can send me an address ;) Keys are valid for 1 month and there can be an infinite number of keys.

The pull-request adds 2 files: `FUNDING.yml` which is a github standard file to add a "donation button" with the right links when people click on it and a file which includes the configuration for the donation page.

Here is what it looks like :

<img width="795" alt="image" src="https://user-images.githubusercontent.com/17735/63723090-a38ed180-c822-11e9-8c60-bf1eae9399c1.png">

You can try this on another project which already uses the donation button such as [Unlock](https://github.com/unlock-protocol/unlock/), [MyCrypto](https://github.com/mycryptohq/mycrypto), or [WalletConnect](https://github.com/WalletConnect/walletconnect-monorepo/)...

When/if you merge this you also need to enable donations in the settings (see https://github.com/ethereum/web3.js/settings): 

<img width="747" alt="image" src="https://user-images.githubusercontent.com/17735/63268593-88d8bd80-c262-11e9-92f7-2d458c07e74f.png">


### Checklist
- [X] Code compiles correctly
- [X] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [X] Used meaningful commit messages
