### PR TITLE
Fix typo in AssemblySwitch in grammar file

### DIFF
--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -171,7 +171,7 @@ AssemblyVariableDeclaration = 'let' AssemblyIdentifierList ( ':=' AssemblyExpres
 AssemblyAssignment = AssemblyIdentifierList ':=' AssemblyExpression
 AssemblyExpression = AssemblyFunctionCall | Identifier | Literal
 AssemblyIf = 'if' AssemblyExpression AssemblyBlock
-AssemblySwitch = 'switch' AssemblyExpression ( Case+ AssemblyDefault? | AssemblyDefault )
+AssemblySwitch = 'switch' AssemblyExpression ( AssemblyCase+ AssemblyDefault? | AssemblyDefault )
 AssemblyCase = 'case' Literal AssemblyBlock
 AssemblyDefault = 'default' AssemblyBlock
 AssemblyForLoop = 'for' AssemblyBlock AssemblyExpression AssemblyBlock AssemblyBlock


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
