### PR TITLE
Change URL for fetching boost sources.

### DIFF
--- a/scripts/travis-emscripten/install_deps.sh
+++ b/scripts/travis-emscripten/install_deps.sh
@@ -33,7 +33,7 @@ echo -en 'travis_fold:start:installing_dependencies\\r'
 test -e boost_1_70_0_install/include/boost/version.hpp || (
 rm -rf boost_1_70_0
 rm -f boost.tar.gz
-wget -q 'https://sourceforge.net/projects/boost/files/boost/1.70.0/boost_1_70_0.tar.gz/download'\
+wget -q 'https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.gz'\
  -O boost.tar.gz
 test "$(shasum boost.tar.gz)" = "7804c782deb00f36ac80b1000b71a3707eadb620  boost.tar.gz"
 tar -xzf boost.tar.gz


### PR DESCRIPTION
I noticed the emscripten build failing in https://github.com/ethereum/solidity/pull/7331 - that's due to the old URL https://downloads.sourceforge.net/project/boost/boost/1.70.0/boost_1_70_0.tar.gz currently pointing to an error page - that might only be temporary, but I'd still suggest to switch to the URL linked on https://boost.org.
Note that the hash is unchanged, so it's in fact the same source archive as it used to be.