### PR TITLE
Try to fix appveyor run by chaning bytecode pull output from stderr to stdout.

### DIFF
--- a/scripts/bytecodecompare/storebytecode.bat
+++ b/scripts/bytecodecompare/storebytecode.bat
@@ -39,5 +39,5 @@ set REPORT=%DIRECTORY%/windows.txt
 cp ../report.txt %REPORT%
 git add %REPORT%
 git commit -a -m "Added report."
-git pull --rebase
+git pull --rebase 2>&1
 git push origin 2>&1


### PR DESCRIPTION
Should fix errors like https://ci.appveyor.com/project/ethereum-free/solidity/builds/27151440

github.com resolves to a whole range of changing IP addresses - I think the warning occurs, if the IP address changes between the clone and the pull in the script. And any output to stderr seems to be considered an error.

The line itself was only added to fix the tests, so it should be safe to ignore warnings (and errors for that matter) in it, right? The really relevant thing is the return code of the git push?