### PR TITLE
Array slice syntax (with implementation for dynamic calldata arrays)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Language Features:
  * Allow global enums and structs.
  * Allow underscores as delimiters in hex strings.
  * Allow explicit conversions from ``address`` to ``address payable`` via ``payable(...)``.
+ * Introduce syntax for array slices and implement them for dynamic calldata arrays.
 
 
 Compiler Features:

--- a/docs/grammar.txt
+++ b/docs/grammar.txt
@@ -86,6 +86,7 @@ Expression
   = Expression ('++' | '--')
   | NewExpression
   | IndexAccess
+  | IndexRangeAccess
   | MemberAccess
   | FunctionCall
   | '(' Expression ')'
@@ -123,6 +124,7 @@ FunctionCallArguments = '{' NameValueList? '}'
 NewExpression = 'new' TypeName
 MemberAccess = Expression '.' Identifier
 IndexAccess = Expression '[' Expression? ']'
+IndexRangeAccess = Expression '[' Expression? ':' Expression? ']'
 
 BooleanLiteral = 'true' | 'false'
 NumberLiteral = ( HexNumber | DecimalNumber ) (' ' NumberUnit)?

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -136,6 +136,7 @@ private:
 	void endVisit(NewExpression const& _newExpression) override;
 	bool visit(MemberAccess const& _memberAccess) override;
 	bool visit(IndexAccess const& _indexAccess) override;
+	bool visit(IndexRangeAccess const& _indexRangeAccess) override;
 	bool visit(Identifier const& _identifier) override;
 	void endVisit(ElementaryTypeNameExpression const& _expr) override;
 	void endVisit(Literal const& _literal) override;

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -413,6 +413,13 @@ void ViewPureChecker::endVisit(IndexAccess const& _indexAccess)
 	}
 }
 
+void ViewPureChecker::endVisit(IndexRangeAccess const& _indexRangeAccess)
+{
+	bool writes = _indexRangeAccess.annotation().lValueRequested;
+	if (_indexRangeAccess.baseExpression().annotation().type->dataStoredIn(DataLocation::Storage))
+		reportMutability(writes ? StateMutability::NonPayable : StateMutability::View, _indexRangeAccess.location());
+}
+
 void ViewPureChecker::endVisit(ModifierInvocation const& _modifier)
 {
 	solAssert(_modifier.name(), "");

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -58,6 +58,7 @@ private:
 	bool visit(MemberAccess const& _memberAccess) override;
 	void endVisit(MemberAccess const& _memberAccess) override;
 	void endVisit(IndexAccess const& _indexAccess) override;
+	void endVisit(IndexRangeAccess const& _indexAccess) override;
 	void endVisit(ModifierInvocation const& _modifier) override;
 	void endVisit(FunctionCall const& _functionCall) override;
 	void endVisit(InlineAssembly const& _inlineAssembly) override;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1643,6 +1643,32 @@ private:
 };
 
 /**
+ * Index range access to an array. Example: a[2:3]
+ */
+class IndexRangeAccess: public Expression
+{
+public:
+	IndexRangeAccess(
+		SourceLocation const& _location,
+		ASTPointer<Expression> const& _base,
+		ASTPointer<Expression> const& _start,
+		ASTPointer<Expression> const& _end
+	):
+		Expression(_location), m_base(_base), m_start(_start), m_end(_end) {}
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+
+	Expression const& baseExpression() const { return *m_base; }
+	Expression const* startExpression() const { return m_start.get(); }
+	Expression const* endExpression() const { return m_end.get(); }
+
+private:
+	ASTPointer<Expression> m_base;
+	ASTPointer<Expression> m_start;
+	ASTPointer<Expression> m_end;
+};
+
+/**
  * Primary expression, i.e. an expression that cannot be divided any further. Examples are literals
  * or variable references.
  */

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -694,6 +694,18 @@ bool ASTJsonConverter::visit(IndexAccess const& _node)
 	return false;
 }
 
+bool ASTJsonConverter::visit(IndexRangeAccess const& _node)
+{
+	std::vector<pair<string, Json::Value>> attributes = {
+		make_pair("baseExpression", toJson(_node.baseExpression())),
+		make_pair("startExpression", toJsonOrNull(_node.startExpression())),
+		make_pair("endExpression", toJsonOrNull(_node.endExpression())),
+	};
+	appendExpressionAttributes(attributes, _node.annotation());
+	setJsonNode(_node, "IndexRangeAccess", std::move(attributes));
+	return false;
+}
+
 bool ASTJsonConverter::visit(Identifier const& _node)
 {
 	Json::Value overloads(Json::arrayValue);

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -111,6 +111,7 @@ public:
 	bool visit(NewExpression const& _node) override;
 	bool visit(MemberAccess const& _node) override;
 	bool visit(IndexAccess const& _node) override;
+	bool visit(IndexRangeAccess const& _node) override;
 	bool visit(Identifier const& _node) override;
 	bool visit(ElementaryTypeNameExpression const& _node) override;
 	bool visit(Literal const& _node) override;

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -87,6 +87,7 @@ public:
 	virtual bool visit(NewExpression& _node) { return visitNode(_node); }
 	virtual bool visit(MemberAccess& _node) { return visitNode(_node); }
 	virtual bool visit(IndexAccess& _node) { return visitNode(_node); }
+	virtual bool visit(IndexRangeAccess& _node) { return visitNode(_node); }
 	virtual bool visit(Identifier& _node) { return visitNode(_node); }
 	virtual bool visit(ElementaryTypeNameExpression& _node) { return visitNode(_node); }
 	virtual bool visit(Literal& _node) { return visitNode(_node); }
@@ -134,6 +135,7 @@ public:
 	virtual void endVisit(NewExpression& _node) { endVisitNode(_node); }
 	virtual void endVisit(MemberAccess& _node) { endVisitNode(_node); }
 	virtual void endVisit(IndexAccess& _node) { endVisitNode(_node); }
+	virtual void endVisit(IndexRangeAccess& _node) { endVisitNode(_node); }
 	virtual void endVisit(Identifier& _node) { endVisitNode(_node); }
 	virtual void endVisit(ElementaryTypeNameExpression& _node) { endVisitNode(_node); }
 	virtual void endVisit(Literal& _node) { endVisitNode(_node); }
@@ -194,6 +196,7 @@ public:
 	virtual bool visit(NewExpression const& _node) { return visitNode(_node); }
 	virtual bool visit(MemberAccess const& _node) { return visitNode(_node); }
 	virtual bool visit(IndexAccess const& _node) { return visitNode(_node); }
+	virtual bool visit(IndexRangeAccess const& _node) { return visitNode(_node); }
 	virtual bool visit(Identifier const& _node) { return visitNode(_node); }
 	virtual bool visit(ElementaryTypeNameExpression const& _node) { return visitNode(_node); }
 	virtual bool visit(Literal const& _node) { return visitNode(_node); }
@@ -241,6 +244,7 @@ public:
 	virtual void endVisit(NewExpression const& _node) { endVisitNode(_node); }
 	virtual void endVisit(MemberAccess const& _node) { endVisitNode(_node); }
 	virtual void endVisit(IndexAccess const& _node) { endVisitNode(_node); }
+	virtual void endVisit(IndexRangeAccess const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Identifier const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ElementaryTypeNameExpression const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Literal const& _node) { endVisitNode(_node); }

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -783,6 +783,32 @@ void IndexAccess::accept(ASTConstVisitor& _visitor) const
 	_visitor.endVisit(*this);
 }
 
+void IndexRangeAccess::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+	{
+		m_base->accept(_visitor);
+		if (m_start)
+			m_start->accept(_visitor);
+		if (m_end)
+			m_end->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void IndexRangeAccess::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+	{
+		m_base->accept(_visitor);
+		if (m_start)
+			m_start->accept(_visitor);
+		if (m_end)
+			m_end->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
 void Identifier::accept(ASTVisitor& _visitor)
 {
 	_visitor.visit(*this);

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -31,6 +31,7 @@ InaccessibleDynamicType const TypeProvider::m_inaccessibleDynamic{};
 /// they rely on `byte` being available which we cannot guarantee in the static init context.
 unique_ptr<ArrayType> TypeProvider::m_bytesStorage;
 unique_ptr<ArrayType> TypeProvider::m_bytesMemory;
+unique_ptr<ArrayType> TypeProvider::m_bytesCalldata;
 unique_ptr<ArrayType> TypeProvider::m_stringStorage;
 unique_ptr<ArrayType> TypeProvider::m_stringMemory;
 
@@ -177,6 +178,7 @@ void TypeProvider::reset()
 	clearCache(m_inaccessibleDynamic);
 	clearCache(m_bytesStorage);
 	clearCache(m_bytesMemory);
+	clearCache(m_bytesCalldata);
 	clearCache(m_stringStorage);
 	clearCache(m_stringMemory);
 	clearCache(m_emptyTuple);
@@ -312,6 +314,13 @@ ArrayType const* TypeProvider::bytesMemory()
 	if (!m_bytesMemory)
 		m_bytesMemory = make_unique<ArrayType>(DataLocation::Memory, false);
 	return m_bytesMemory.get();
+}
+
+ArrayType const* TypeProvider::bytesCalldata()
+{
+	if (!m_bytesCalldata)
+		m_bytesCalldata = make_unique<ArrayType>(DataLocation::CallData, false);
+	return m_bytesCalldata.get();
 }
 
 ArrayType const* TypeProvider::stringStorage()
@@ -498,6 +507,11 @@ ArrayType const* TypeProvider::array(DataLocation _location, Type const* _baseTy
 ArrayType const* TypeProvider::array(DataLocation _location, Type const* _baseType, u256 const& _length)
 {
 	return createAndGet<ArrayType>(_location, _baseType, _length);
+}
+
+ArraySliceType const* TypeProvider::arraySlice(ArrayType const& _arrayType)
+{
+	return createAndGet<ArraySliceType>(_arrayType);
 }
 
 ContractType const* TypeProvider::contract(ContractDefinition const& _contractDef, bool _isSuper)

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -68,6 +68,7 @@ public:
 
 	static ArrayType const* bytesStorage();
 	static ArrayType const* bytesMemory();
+	static ArrayType const* bytesCalldata();
 	static ArrayType const* stringStorage();
 	static ArrayType const* stringMemory();
 
@@ -79,6 +80,8 @@ public:
 
 	/// Constructor for a fixed-size array type ("type[20]")
 	static ArrayType const* array(DataLocation _location, Type const* _baseType, u256 const& _length);
+
+	static ArraySliceType const* arraySlice(ArrayType const& _arrayType);
 
 	static AddressType const* payableAddress() noexcept { return &m_payableAddress; }
 	static AddressType const* address() noexcept { return &m_address; }
@@ -203,6 +206,7 @@ private:
 	/// These are lazy-initialized because they depend on `byte` being available.
 	static std::unique_ptr<ArrayType> m_bytesStorage;
 	static std::unique_ptr<ArrayType> m_bytesMemory;
+	static std::unique_ptr<ArrayType> m_bytesCalldata;
 	static std::unique_ptr<ArrayType> m_stringStorage;
 	static std::unique_ptr<ArrayType> m_stringMemory;
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1869,6 +1869,30 @@ std::unique_ptr<ReferenceType> ArrayType::copyForLocation(DataLocation _location
 	return copy;
 }
 
+BoolResult ArraySliceType::isImplicitlyConvertibleTo(Type const& _other) const
+{
+	if (m_arrayType.location() == DataLocation::CallData && m_arrayType.isDynamicallySized() && m_arrayType == _other)
+		return true;
+	return (*this) == _other;
+}
+
+string ArraySliceType::richIdentifier() const
+{
+	return m_arrayType.richIdentifier() + "_slice";
+}
+
+bool ArraySliceType::operator==(Type const& _other) const
+{
+	if (auto const* other = dynamic_cast<ArraySliceType const*>(&_other))
+		return m_arrayType == other->m_arrayType;
+	return false;
+}
+
+string ArraySliceType::toString(bool _short) const
+{
+	return m_arrayType.toString(_short) + " slice";
+}
+
 string ContractType::richIdentifier() const
 {
 	return (m_super ? "t_super" : "t_contract") + parenthesizeUserIdentifier(m_contract.name()) + to_string(m_contract.id());

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -161,7 +161,7 @@ public:
 
 	enum class Category
 	{
-		Address, Integer, RationalNumber, StringLiteral, Bool, FixedPoint, Array,
+		Address, Integer, RationalNumber, StringLiteral, Bool, FixedPoint, Array, ArraySlice,
 		FixedBytes, Contract, Struct, Function, Enum, Tuple,
 		Mapping, TypeType, Modifier, Magic, Module,
 		InaccessibleDynamic
@@ -771,6 +771,35 @@ private:
 	u256 m_length;
 	mutable boost::optional<TypeResult> m_interfaceType;
 	mutable boost::optional<TypeResult> m_interfaceType_library;
+};
+
+class ArraySliceType: public ReferenceType
+{
+public:
+	explicit ArraySliceType(ArrayType const& _arrayType): ReferenceType(_arrayType.location()), m_arrayType(_arrayType) {}
+	Category category() const override { return Category::ArraySlice; }
+
+	BoolResult isImplicitlyConvertibleTo(Type const& _other) const override;
+	std::string richIdentifier() const override;
+	bool operator==(Type const& _other) const override;
+	unsigned calldataEncodedSize(bool) const override { solAssert(false, ""); }
+	unsigned calldataEncodedTailSize() const override { return 32; }
+	bool isDynamicallySized() const override { return true; }
+	bool isDynamicallyEncoded() const override { return true; }
+	bool canLiveOutsideStorage() const override { return m_arrayType.canLiveOutsideStorage(); }
+	unsigned sizeOnStack() const override { return 2; }
+	std::string toString(bool _short) const override;
+
+	/// @returns true if this is valid to be stored in calldata
+	bool validForCalldata() const { return m_arrayType.validForCalldata(); }
+
+	ArrayType const& arrayType() const { return m_arrayType; }
+	u256 memoryDataSize() const override { solAssert(false, ""); }
+
+	std::unique_ptr<ReferenceType> copyForLocation(DataLocation, bool) const override { solAssert(false, ""); }
+
+private:
+	ArrayType const& m_arrayType;
 };
 
 /**

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -981,6 +981,17 @@ void CompilerUtils::convertType(
 		}
 		break;
 	}
+	case Type::Category::ArraySlice:
+	{
+		auto& typeOnStack = dynamic_cast<ArraySliceType const&>(_typeOnStack);
+		solAssert(_targetType == typeOnStack.arrayType(), "");
+		solUnimplementedAssert(
+			typeOnStack.arrayType().location() == DataLocation::CallData &&
+			typeOnStack.arrayType().isDynamicallySized(),
+			""
+		);
+		break;
+	}
 	case Type::Category::Struct:
 	{
 		solAssert(targetTypeCategory == stackTypeCategory, "");

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -80,6 +80,7 @@ private:
 	bool visit(NewExpression const& _newExpression) override;
 	bool visit(MemberAccess const& _memberAccess) override;
 	bool visit(IndexAccess const& _indexAccess) override;
+	bool visit(IndexRangeAccess const& _indexAccess) override;
 	void endVisit(Identifier const& _identifier) override;
 	void endVisit(Literal const& _literal) override;
 

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -823,11 +823,6 @@ string YulUtilFunctions::memoryArrayIndexAccessFunction(ArrayType const& _type)
 	});
 }
 
-string YulUtilFunctions::calldataArrayIndexAccessFunction(ArrayType const& /*_type*/)
-{
-	solUnimplemented("Calldata arrays not yet implemented!");
-}
-
 string YulUtilFunctions::nextArrayElementFunction(ArrayType const& _type)
 {
 	solAssert(!_type.isByteArray(), "");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -941,6 +941,11 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 		solAssert(false, "Index access only allowed for mappings or arrays.");
 }
 
+void IRGeneratorForStatements::endVisit(IndexRangeAccess const&)
+{
+	solUnimplementedAssert(false, "Index range accesses not yet implemented.");
+}
+
 void IRGeneratorForStatements::endVisit(Identifier const& _identifier)
 {
 	Declaration const* declaration = _identifier.annotation().referencedDeclaration;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -63,6 +63,7 @@ public:
 	void endVisit(MemberAccess const& _memberAccess) override;
 	bool visit(InlineAssembly const& _inlineAsm) override;
 	void endVisit(IndexAccess const& _indexAccess) override;
+	void endVisit(IndexRangeAccess const& _indexRangeAccess) override;
 	void endVisit(Identifier const& _identifier) override;
 	bool visit(Literal const& _literal) override;
 

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -767,6 +767,15 @@ void SMTEncoder::endVisit(IndexAccess const& _indexAccess)
 	m_uninterpretedTerms.insert(&_indexAccess);
 }
 
+void SMTEncoder::endVisit(IndexRangeAccess const& _indexRangeAccess)
+{
+	createExpr(_indexRangeAccess);
+	m_errorReporter.warning(
+		_indexRangeAccess.location(),
+		"Assertion checker does not yet implement this expression."
+	);
+}
+
 void SMTEncoder::arrayAssignment()
 {
 	m_arrayAssignmentHappened = true;

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -86,6 +86,7 @@ protected:
 	void endVisit(Return const& _node) override;
 	bool visit(MemberAccess const& _node) override;
 	void endVisit(IndexAccess const& _node) override;
+	void endVisit(IndexRangeAccess const& _node) override;
 	bool visit(InlineAssembly const& _node) override;
 
 	/// Do not visit subtree if node is a RationalNumber.

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -162,8 +162,14 @@ private:
 	/// or to a type name. For this to be valid, path cannot be empty, but indices can be empty.
 	struct IndexAccessedPath
 	{
+		struct Index
+		{
+			ASTPointer<Expression> start;
+			std::optional<ASTPointer<Expression>> end;
+			langutil::SourceLocation location;
+		};
 		std::vector<ASTPointer<PrimaryExpression>> path;
-		std::vector<std::pair<ASTPointer<Expression>, langutil::SourceLocation>> indices;
+		std::vector<Index> indices;
 		bool empty() const;
 	};
 

--- a/test/libsolidity/semanticTests/abiDecodeV1/decode_slice.sol
+++ b/test/libsolidity/semanticTests/abiDecodeV1/decode_slice.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(uint256 a, uint256 b) external returns (uint256 c, uint256 d, uint256 e, uint256 f) {
+        (c, d) = abi.decode(msg.data[4:], (uint256, uint256));
+        e = abi.decode(msg.data[4 : 4 + 32], (uint256));
+        f = abi.decode(msg.data[4 + 32 : 4 + 32 + 32], (uint256));
+    }
+}
+// ----
+// f(uint256,uint256): 42, 23 -> 42, 23, 42, 23

--- a/test/libsolidity/semanticTests/array/calldata_slice_access.sol
+++ b/test/libsolidity/semanticTests/array/calldata_slice_access.sol
@@ -1,0 +1,44 @@
+contract C {
+    function f(uint256[] calldata x, uint256 start, uint256 end) external pure {
+        x[start:end];
+    }
+    function g(uint256[] calldata x, uint256 start, uint256 end, uint256 index) external pure returns (uint256, uint256, uint256) {
+        return (x[start:end][index], x[start:][0:end-start][index], x[:end][start:][index]);
+    }
+}
+// ----
+// f(uint256[],uint256,uint256): 0x80, 0, 0, 0, 1, 42 ->
+// f(uint256[],uint256,uint256): 0x80, 0, 1, 0, 1, 42 ->
+// f(uint256[],uint256,uint256): 0x80, 0, 2, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 1, 0, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 1, 1, 0, 1, 42 ->
+// f(uint256[],uint256,uint256): 0x80, 1, 2, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 2, 0, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 2, 1, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 2, 2, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 0, 2, 1, 0, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, 1, 2, 0, 2, 42, 23 ->
+// f(uint256[],uint256,uint256): 0x80, 1, 3, 0, 2, 42, 23 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, -1, 0, 0, 1, 42 -> FAILURE
+// f(uint256[],uint256,uint256): 0x80, -1, -1, 0, 1, 42 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 1, 0, 1, 42 -> 42, 42, 42
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 1, 1, 1, 42 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 0, 0, 1, 42 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 1, 1, 0, 1, 42 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 5, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4201, 0x4201, 0x4201
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 5, 4, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4205, 0x4205, 0x4205
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 5, 5, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 1, 5, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4202, 0x4202, 0x4202
+// g(uint256[],uint256,uint256,uint256): 0x80, 1, 5, 3, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4205, 0x4205, 0x4205
+// g(uint256[],uint256,uint256,uint256): 0x80, 1, 5, 4, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 4, 5, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4205, 0x4205, 0x4205
+// g(uint256[],uint256,uint256,uint256): 0x80, 4, 5, 1, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 5, 5, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 1, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4201, 0x4201, 0x4201
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 1, 1, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 1, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4201, 0x4201, 0x4201
+// g(uint256[],uint256,uint256,uint256): 0x80, 0, 1, 1, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 1, 2, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4202, 0x4202, 0x4202
+// g(uint256[],uint256,uint256,uint256): 0x80, 1, 2, 1, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE
+// g(uint256[],uint256,uint256,uint256): 0x80, 4, 5, 0, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> 0x4205, 0x4205, 0x4205
+// g(uint256[],uint256,uint256,uint256): 0x80, 4, 5, 1, 5, 0x4201, 0x4202, 0x4203, 0x4204, 0x4205 -> FAILURE

--- a/test/libsolidity/syntaxTests/array/slice/bytes_calldata.sol
+++ b/test/libsolidity/syntaxTests/array/slice/bytes_calldata.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f(bytes calldata x) external pure {
+        x[1:2];
+    }
+}

--- a/test/libsolidity/syntaxTests/array/slice/bytes_memory.sol
+++ b/test/libsolidity/syntaxTests/array/slice/bytes_memory.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(bytes memory x) public pure {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (66-72): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/bytes_storage.sol
+++ b/test/libsolidity/syntaxTests/array/slice/bytes_storage.sol
@@ -1,0 +1,8 @@
+contract C {
+    bytes x;
+    function f() public view {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (65-71): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f(uint256[] calldata x) external pure {
+        x[1:2];
+    }
+}

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_access.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_access.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(uint256[] calldata x) external pure {
+        x[1:2][0];
+        x[1:][0];
+        x[1:][1:2][0];
+        x[1:2][1:][0];
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_convert_to_memory.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_convert_to_memory.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(bytes calldata x) external {
+        bytes memory y = x[1:2];
+    }
+}
+// ----
+// TypeError: (65-88): Type bytes calldata slice is not implicitly convertible to expected type bytes memory.

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_encode.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_encode.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(uint256[] calldata x) external pure {
+        abi.encode(x[1:2]);
+    }
+}
+// ----
+// TypeError: (85-91): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_forward.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_forward.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(bytes calldata x) external {
+        return this.f(x[1:2]);
+    }
+}
+// ----
+// TypeError: (79-85): Invalid type for argument in function call. Invalid implicit conversion from bytes calldata slice to bytes memory requested.

--- a/test/libsolidity/syntaxTests/array/slice/calldata_static.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_static.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(uint256[42] calldata x) external pure {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (76-82): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/memory_dynamic.sol
+++ b/test/libsolidity/syntaxTests/array/slice/memory_dynamic.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(uint256[] memory x) public pure {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (70-76): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/memory_static.sol
+++ b/test/libsolidity/syntaxTests/array/slice/memory_static.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f(uint256[42] memory x) public pure {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (72-78): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/slice_literal.sol
+++ b/test/libsolidity/syntaxTests/array/slice/slice_literal.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        1[1:];
+    }
+}
+// ----
+// TypeError: (52-57): Index range access is only possible for arrays and array slices.

--- a/test/libsolidity/syntaxTests/array/slice/slice_memory_bytes.sol
+++ b/test/libsolidity/syntaxTests/array/slice/slice_memory_bytes.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        bytes memory y;
+        y[1:2];
+    }
+}
+// ----
+// TypeError: (76-82): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/slice_memory_string.sol
+++ b/test/libsolidity/syntaxTests/array/slice/slice_memory_string.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        string memory y;
+        y[1:2];
+    }
+}
+// ----
+// TypeError: (77-83): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/slice_string.sol
+++ b/test/libsolidity/syntaxTests/array/slice/slice_string.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        ""[1:];
+    }
+}
+// ----
+// TypeError: (52-58): Index range access is only possible for arrays and array slices.

--- a/test/libsolidity/syntaxTests/array/slice/storage_dynamic.sol
+++ b/test/libsolidity/syntaxTests/array/slice/storage_dynamic.sol
@@ -1,0 +1,8 @@
+contract C {
+    uint256[] x;
+    function f() public view {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (69-75): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/array/slice/storage_static.sol
+++ b/test/libsolidity/syntaxTests/array/slice/storage_static.sol
@@ -1,0 +1,8 @@
+contract C {
+    uint256[42] x;
+    function f() public view {
+        x[1:2];
+    }
+}
+// ----
+// TypeError: (71-77): Index range access is only supported for dynamic calldata arrays.

--- a/test/libsolidity/syntaxTests/parsing/array_range_and_ternary.sol
+++ b/test/libsolidity/syntaxTests/parsing/array_range_and_ternary.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(bool cond, bytes calldata x) external pure {
+        bytes1 a = x[cond ? 1 : 2]; a;
+        abi.decode(x[cond ? 1 : 2 : ], (uint256));
+        abi.decode(x[cond ? 1 : 2 : cond ? 3 : 4], (uint256));
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/array_range_conversion.sol
+++ b/test/libsolidity/syntaxTests/parsing/array_range_conversion.sol
@@ -1,0 +1,14 @@
+contract C {
+    function f() public pure {
+        uint[] memory x;
+        uint[1:](x);
+        uint[1:2](x);
+        uint[][1:](x);
+    }
+}
+// ----
+// TypeError: (77-85): Types cannot be sliced.
+// TypeError: (77-88): Explicit type conversion not allowed from "uint256[] memory" to "uint256".
+// TypeError: (98-107): Types cannot be sliced.
+// TypeError: (98-110): Explicit type conversion not allowed from "uint256[] memory" to "uint256".
+// TypeError: (120-130): Types cannot be sliced.

--- a/test/libsolidity/syntaxTests/parsing/array_range_nested.sol
+++ b/test/libsolidity/syntaxTests/parsing/array_range_nested.sol
@@ -1,0 +1,12 @@
+pragma experimental ABIEncoderV2;
+contract C {
+    function f(uint256[][] calldata x) external pure {
+        x[0][1:2];
+        x[1:2][1:2];
+        uint256 a = x[1:2][1:2][1:][3:][0][2];
+        uint256 b = x[1:][3:4][1][1:][2:3][0];
+        a; b;
+    }
+}
+// ----
+// Warning: (0-33): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/parsing/array_range_no_start.sol
+++ b/test/libsolidity/syntaxTests/parsing/array_range_no_start.sol
@@ -1,0 +1,6 @@
+contract C {
+    function f(uint256[] calldata x) external pure {
+        x[:][:10];
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/array_type_range.sol
+++ b/test/libsolidity/syntaxTests/parsing/array_type_range.sol
@@ -1,0 +1,14 @@
+contract C {
+    function f() public pure {
+        uint[][1:] memory x;
+        uint[][1:2] memory x;
+        uint[1:] memory x;
+        uint[1:2] memory x;
+    }
+}
+
+// ----
+// ParserError: (52-62): Expected array length expression.
+// ParserError: (81-92): Expected array length expression.
+// ParserError: (111-119): Expected array length expression.
+// ParserError: (138-147): Expected array length expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_arg_type.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_arg_type.sol
@@ -4,5 +4,5 @@ contract C {
   }
 }
 // ----
-// TypeError: (57-61): Invalid type for argument in function call. Invalid implicit conversion from type(uint256) to bytes memory requested.
+// TypeError: (57-61): The first argument to "abi.decode" must be implicitly convertible to bytes memory or bytes calldata, but is of type type(uint256).
 // TypeError: (63-67): The second argument to "abi.decode" has to be a tuple of types.


### PR DESCRIPTION
So far ~~``x.slice``~~ ``x[start:end]`` is an error for everything but dynamic calldata arrays and slices of them.
For calldata slices ~~only~~ implicit conversions back to calldata arrays are implemented, which means that they can be passed to ``abi.decode`` and nothing besides that (no other conversions, ~~no index access~~, no members). Index accesses for calldata slices are implemented as well.

So rather incomplete, but already Fixes #6012.