### PR TITLE
Refactor ExpressionCompiler with acceptAndConvert helper.

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -121,6 +121,8 @@ private:
 	/// operation.
 	static bool cleanupNeededForOp(Type::Category _type, Token _op);
 
+	void acceptAndConvert(Expression const& _expression, Type const& _type, bool _cleanupNeeded = false);
+
 	/// @returns the CompilerUtils object containing the current context.
 	CompilerUtils utils();
 


### PR DESCRIPTION
Came up in https://github.com/ethereum/solidity/pull/7340.

I changed the base to ``develop`` now - would be nice to merge back to ``develop_060`` afterwards...