### PR TITLE
Allow  underscores in hex strings.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Breaking changes:
 
 Language Features:
  * Allow global enums and structs.
+ * Allow underscores as delimiters in hex strings.
 
 
 Compiler Features:

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -499,7 +499,7 @@ terminate the string literal. Newline only terminates the string literal if it i
 Hexadecimal Literals
 --------------------
 
-Hexadecimal literals are prefixed with the keyword ``hex`` and are enclosed in double or single-quotes (``hex"001122FF"``). Their content must be a hexadecimal string and their value will be the binary representation of those values.
+Hexadecimal literals are prefixed with the keyword ``hex`` and are enclosed in double or single-quotes (``hex"001122FF"``, ``hex'0011_22_FF'``). Their content must be hexadecimal digits which can optionally use a single underscore as separator between byte boundaries. The value of the literal will be the binary representation of the hexadecimal sequence.
 
 Hexadecimal literals behave like :ref:`string literals <string_literals>` and have the same convertibility restrictions.
 

--- a/test/libsolidity/semanticTests/literals/hex_string_with_underscore.sol
+++ b/test/libsolidity/semanticTests/literals/hex_string_with_underscore.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure returns(bytes memory) {
+        return hex"12_34_5678_9A";
+    }
+}
+// ----
+// f() -> 32, 5, left(0x123456789A)

--- a/test/libsolidity/syntaxTests/literals/hex_string_duplicate_underscore.sol
+++ b/test/libsolidity/syntaxTests/literals/hex_string_duplicate_underscore.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        hex"12__34";
+    }
+}
+// ----
+// ParserError: (52-60): Invalid use of number separator '_'.

--- a/test/libsolidity/syntaxTests/literals/hex_string_leading_underscore.sol
+++ b/test/libsolidity/syntaxTests/literals/hex_string_leading_underscore.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        hex"_1234";
+    }
+}
+// ----
+// ParserError: (52-57): Invalid use of number separator '_'.

--- a/test/libsolidity/syntaxTests/literals/hex_string_misaligned_underscore.sol
+++ b/test/libsolidity/syntaxTests/literals/hex_string_misaligned_underscore.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        hex"1_234";
+    }
+}
+// ----
+// ParserError: (52-56): Expected even number of hex-nibbles.

--- a/test/libsolidity/syntaxTests/literals/hex_string_trailing_underscore.sol
+++ b/test/libsolidity/syntaxTests/literals/hex_string_trailing_underscore.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        hex"1234_";
+    }
+}
+// ----
+// ParserError: (52-61): Invalid use of number separator '_'.

--- a/test/libsolidity/syntaxTests/literals/hex_string_underscores_valid.sol
+++ b/test/libsolidity/syntaxTests/literals/hex_string_underscores_valid.sol
@@ -1,0 +1,3 @@
+contract C {
+    bytes constant c = hex"12_3456_789012";
+}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7290