### PR TITLE
Abiv2 proto fuzzer: Crop at least 32 bytes if last dynamically encoded parameter is right padded

### DIFF
--- a/test/tools/ossfuzz/protoToAbiV2.cpp
+++ b/test/tools/ossfuzz/protoToAbiV2.cpp
@@ -63,8 +63,6 @@ void ProtoConverter::visitType(
 	std::string varName, paramName;
 	createDeclAndParamList(_type, _dataType, varName, paramName);
 	addCheckedVarDef(_dataType, varName, paramName, _value);
-	// Update right padding of type
-	m_isLastParamRightPadded = isDataTypeBytesOrString(_dataType);
 }
 
 void ProtoConverter::appendVarDeclToOutput(
@@ -451,6 +449,8 @@ void ProtoConverter::visit(DynamicByteArrayType const& _x)
 			isBytes
 		)
 	);
+	// Update right padding of type
+	m_isLastDynParamRightPadded = true;
 }
 
 // TODO: Implement struct visitor
@@ -658,23 +658,23 @@ void ProtoConverter::visit(ArrayType const& _x)
 	{
 	case ArrayType::kInty:
 		baseType = getIntTypeAsString(_x.inty());
-		m_isLastParamRightPadded = false;
+		m_isLastDynParamRightPadded = false;
 		break;
 	case ArrayType::kByty:
 		baseType = getFixedByteTypeAsString(_x.byty());
-		m_isLastParamRightPadded = false;
+		m_isLastDynParamRightPadded = false;
 		break;
 	case ArrayType::kAdty:
 		baseType = getAddressTypeAsString(_x.adty());
-		m_isLastParamRightPadded = false;
+		m_isLastDynParamRightPadded = false;
 		break;
 	case ArrayType::kBoolty:
 		baseType = getBoolTypeAsString();
-		m_isLastParamRightPadded = false;
+		m_isLastDynParamRightPadded = false;
 		break;
 	case ArrayType::kDynbytesty:
 		baseType = bytesArrayTypeAsString(_x.dynbytesty());
-		m_isLastParamRightPadded = true;
+		m_isLastDynParamRightPadded = true;
 		break;
 	case ArrayType::kStty:
 	case ArrayType::BASE_TYPE_ONEOF_NOT_SET:
@@ -861,7 +861,7 @@ void ProtoConverter::visit(TestFunction const& _x)
 	)")
 	("parameterNames", dev::suffixedVariableNameList(s_varNamePrefix, 0, m_varCounter))
 	("invalidLengthFuzz", std::to_string(_x.invalid_encoding_length()))
-	("isRightPadded", isLastParamRightPadded() ? "true" : "false")
+	("isRightPadded", isLastDynParamRightPadded() ? "true" : "false")
 	("atLeastOneVar", m_varCounter > 0)
 	.render();
 }

--- a/test/tools/ossfuzz/protoToAbiV2.h
+++ b/test/tools/ossfuzz/protoToAbiV2.h
@@ -103,7 +103,7 @@ public:
 		m_counter(0),
 		m_varCounter(0),
 		m_returnValue(1),
-		m_isLastParamRightPadded(false)
+		m_isLastDynParamRightPadded(false)
 	{}
 
 	ProtoConverter(ProtoConverter const&) = delete;
@@ -274,9 +274,9 @@ private:
 		return ((isValueType(_dataType) || m_isStateVar) ? "" : "memory");
 	}
 
-	bool isLastParamRightPadded()
+	bool isLastDynParamRightPadded()
 	{
-		return m_isLastParamRightPadded;
+		return m_isLastDynParamRightPadded;
 	}
 
 	// Static declarations
@@ -466,10 +466,10 @@ private:
 	unsigned m_varCounter;
 	/// Monotonically increasing return value for error reporting
 	unsigned m_returnValue;
-	/// Flag that indicates if last parameter passed to a function call
-	/// is of a type that is going to be right padded by the ABI
-	/// encoder.
-	bool m_isLastParamRightPadded;
+	/// Flag that indicates if last dynamically encoded parameter
+	/// passed to a function call is of a type that is going to be
+	/// right padded by the ABI encoder.
+	bool m_isLastDynParamRightPadded;
 	static unsigned constexpr s_maxArrayLength = 4;
 	static unsigned constexpr s_maxArrayDimensions = 4;
 	static unsigned constexpr s_maxDynArrayLength = 256;


### PR DESCRIPTION
Fixes #7355 