### PR TITLE
Adds reserved keywords `virtual`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Breaking changes:
  * ABI: the ``type`` field is now required and no longer specified to default to ``function``.
  * Commandline interface: remove the text-based ast printer (``--ast``).
  * General: Disallow explicit conversions from external function types to ``address`` and add a member called ``address`` to them as replacement.
+ * General: New reserved keywords: ``virtual``.
  * Type checker: Resulting type of exponentiation is equal to the type of the base. Also allow signed types for the base.
  * Command line interface: Switch to the new error reporter by default. ``--old-reporter`` falls back to the deprecated old error reporter.
 

--- a/docs/060-breaking-changes.rst
+++ b/docs/060-breaking-changes.rst
@@ -17,6 +17,8 @@ This section lists purely syntactic changes that do not affect the behavior of e
 * Conversions from external function types to ``address`` are now disallowed. Instead external
   function types have a member called ``address``, similar to the existing ``selector`` member.
 
+* New reserved keywords: ``virtual``.
+
 Semantic Only Changes
 =====================
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -450,7 +450,7 @@ These keywords are reserved in Solidity. They might become part of the syntax in
 ``define``, ``final``, ``immutable``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
 ``mutable``, ``null``, ``of``, ``override``, ``partial``, ``promise``, ``reference``, ``relocatable``,
 ``sealed``, ``sizeof``, ``static``, ``supports``, ``switch``, ``try``, ``typedef``, ``typeof``,
-``unchecked``.
+``unchecked``, ``virtual``.
 
 Language Grammar
 ================

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -262,6 +262,7 @@ namespace langutil
 	K(Typedef, "typedef", 0)                                           \
 	K(TypeOf, "typeof", 0)                                             \
 	K(Unchecked, "unchecked", 0)                                       \
+	K(Virtual, "virtual", 0)                                           \
 	\
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \
@@ -310,7 +311,7 @@ namespace TokenTraits
 
 	constexpr bool isEtherSubdenomination(Token op) { return op == Token::SubWei || op == Token::SubSzabo || op == Token::SubFinney || op == Token::SubEther; }
 	constexpr bool isTimeSubdenomination(Token op) { return op == Token::SubSecond || op == Token::SubMinute || op == Token::SubHour || op == Token::SubDay || op == Token::SubWeek || op == Token::SubYear; }
-	constexpr bool isReservedKeyword(Token op) { return (Token::Abstract <= op && op <= Token::Unchecked); }
+	constexpr bool isReservedKeyword(Token op) { return (Token::Abstract <= op && op <= Token::Virtual); }
 
 	inline Token AssignmentToBinaryOp(Token op)
 	{


### PR DESCRIPTION
Closes #6040 

Simply adds those keywords to the reserved-keywords list, adjusting documentation and ChangeLog to it.

There is a `/docs/050-breaking-changes.rst` but none for 0.6.0 yet, at lest I didn't find any changelog in the docs/ folder for 0.6.0 just yet - maybe someone can give me a hint in case I overlooked that, so I can adapt that.