### PR TITLE
[isoltest] Fix auto-update when function reverts

### DIFF
--- a/test/libsolidity/semanticTests/smoke/failure.sol
+++ b/test/libsolidity/semanticTests/smoke/failure.sol
@@ -9,6 +9,9 @@ contract C {
     function g(bool _value) public pure {
         require(_value, "Value is false.");
     }
+    function h() public pure returns (uint) {
+        assert(false);
+    }
 }
 // ====
 // EVMVersion: >homestead
@@ -17,3 +20,4 @@ contract C {
 // e() -> FAILURE, hex"08c379a0", 0x20, 19, "Transaction failed."
 // f(bool): false -> FAILURE, hex"08c379a0", 0x20, 0
 // g(bool): false -> FAILURE, hex"08c379a0", 0x20, 15, "Value is false."
+// h() -> FAILURE

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -126,8 +126,11 @@ string TestFunctionCall::format(
 			{
 				boost::optional<ParameterList> abiParams;
 
-				if (isFailure && !output.empty())
-					abiParams = boost::make_optional(ContractABIUtils::failureParameters(output));
+				if (isFailure)
+				{
+					if (!output.empty())
+						abiParams = boost::make_optional(ContractABIUtils::failureParameters(output));
+				}
 				else
 					abiParams = ContractABIUtils::parametersFromJsonOutputs(
 						_errorReporter,


### PR DESCRIPTION
### Description

Fixes an exception that's thrown for
```
contract C {
     function h() public pure returns (uint) {
          assert(false);
     }
}
// ----
// h() -> 1
```