### PR TITLE
--evmonepath option for non-Linux platforms

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,12 +94,12 @@ The test system will automatically try to discover the location of ``libevmone.s
 starting from the current directory. If it does not find it, the relevant tests
 are skipped. To run all tests, download the library from
 `Github <https://github.com/ethereum/evmone/releases/download/v0.1.0/evmone-0.1.0-linux-x86_64.tar.gz>`_
-and either place it in the project root path or inside the ``deps`` folder.
+On Linux, you may place it in the project root path or inside the ``deps`` folder.  On other platforms, use the ``--evmonepath`` option to specify the location of the library.
 
 If you do not have libz3 installed on your system, you should disable the SMT tests:
 ``./scripts/soltest.sh --no-smt``.
 
-``./build/test/soltest --help`` has extensive help on all of the options available.
+``./build/test/soltest --help`` has extensive help on some of the options available.
 See especially:
 
 - `show_progress (-p) <https://www.boost.org/doc/libs/1_69_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/show_progress.html>`_ to show test completion,


### PR DESCRIPTION
On my Macintosh, auto-discovery of libevmone.dylib didn’t work; so suggest --evmonepath option, documented in the resulting error message.
