### PR TITLE
Link ossfuzz targets with -fsanitize=fuzzer instead of libFuzzingEngine

### DIFF
--- a/test/tools/ossfuzz/CMakeLists.txt
+++ b/test/tools/ossfuzz/CMakeLists.txt
@@ -17,24 +17,29 @@ if (OSSFUZZ)
 endif()
 
 if (OSSFUZZ)
-    #[[FuzzingEngine.a is provided by oss-fuzz's Dockerized build environment]]
     add_executable(solc_opt_ossfuzz solc_opt_ossfuzz.cpp ../fuzzer_common.cpp)
-    target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
+    target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm)
+    set_target_properties(solc_opt_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(solc_noopt_ossfuzz solc_noopt_ossfuzz.cpp ../fuzzer_common.cpp)
-    target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
+    target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm)
+    set_target_properties(solc_noopt_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(const_opt_ossfuzz const_opt_ossfuzz.cpp ../fuzzer_common.cpp)
-    target_link_libraries(const_opt_ossfuzz PRIVATE libsolc evmasm FuzzingEngine.a)
+    target_link_libraries(const_opt_ossfuzz PRIVATE libsolc evmasm)
+    set_target_properties(const_opt_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(strictasm_diff_ossfuzz strictasm_diff_ossfuzz.cpp yulFuzzerCommon.cpp)
-    target_link_libraries(strictasm_diff_ossfuzz PRIVATE libsolc evmasm yulInterpreter FuzzingEngine.a)
+    target_link_libraries(strictasm_diff_ossfuzz PRIVATE libsolc evmasm yulInterpreter)
+    set_target_properties(strictasm_diff_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(strictasm_opt_ossfuzz strictasm_opt_ossfuzz.cpp)
-    target_link_libraries(strictasm_opt_ossfuzz PRIVATE yul FuzzingEngine.a)
+    target_link_libraries(strictasm_opt_ossfuzz PRIVATE yul)
+    set_target_properties(strictasm_opt_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(strictasm_assembly_ossfuzz strictasm_assembly_ossfuzz.cpp)
-    target_link_libraries(strictasm_assembly_ossfuzz PRIVATE yul FuzzingEngine.a)
+    target_link_libraries(strictasm_assembly_ossfuzz PRIVATE yul)
+    set_target_properties(strictasm_assembly_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(yul_proto_ossfuzz yulProtoFuzzer.cpp protoToYul.cpp yulProto.pb.cc)
     target_include_directories(yul_proto_ossfuzz PRIVATE /usr/include/libprotobuf-mutator)
@@ -42,7 +47,8 @@ if (OSSFUZZ)
             protobuf-mutator-libfuzzer.a
             protobuf-mutator.a
             protobuf.a
-            FuzzingEngine.a)
+    )
+    set_target_properties(yul_proto_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(yul_proto_diff_ossfuzz yulProto_diff_ossfuzz.cpp yulFuzzerCommon.cpp protoToYul.cpp yulProto.pb.cc)
     target_include_directories(yul_proto_diff_ossfuzz PRIVATE /usr/include/libprotobuf-mutator)
@@ -51,7 +57,8 @@ if (OSSFUZZ)
             protobuf-mutator-libfuzzer.a
             protobuf-mutator.a
             protobuf.a
-            FuzzingEngine.a)
+    )
+    set_target_properties(yul_proto_diff_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 
     add_executable(abiv2_proto_ossfuzz
             ../../EVMHost.cpp
@@ -68,8 +75,8 @@ if (OSSFUZZ)
             protobuf-mutator-libfuzzer.a
             protobuf-mutator.a
             protobuf.a
-            FuzzingEngine.a
     )
+    set_target_properties(abiv2_proto_ossfuzz PROPERTIES LINK_FLAGS "-fsanitize=fuzzer")
 else()
     add_library(solc_opt_ossfuzz
             solc_opt_ossfuzz.cpp


### PR DESCRIPTION
fixes #7412 