### PR TITLE
Fixes codespell

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -244,14 +244,14 @@ We will use a destructuring notation for the AST nodes.
                 G1, L1, mode
     E(G, L, FunctionDefinition) =
         G, L, regular
-    E(G, L, <let var1, ..., varn := rhs>: VariableDeclaration) =
-        E(G, L, <var1, ..., varn := rhs>: Assignment)
-    E(G, L, <let var1, ..., varn>: VariableDeclaration) =
-        let L1 be a copy of L where L1[$vari] = 0 for i = 1, ..., n
+    E(G, L, <let var_1, ..., var_n := rhs>: VariableDeclaration) =
+        E(G, L, <var_1, ..., var_n := rhs>: Assignment)
+    E(G, L, <let var_1, ..., var_n>: VariableDeclaration) =
+        let L1 be a copy of L where L1[$var_i] = 0 for i = 1, ..., n
         G, L1, regular
-    E(G, L, <var1, ..., varn := rhs>: Assignment) =
+    E(G, L, <var_1, ..., var_n := rhs>: Assignment) =
         let G1, L1, v1, ..., vn = E(G, L, rhs)
-        let L2 be a copy of L1 where L2[$vari] = vi for i = 1, ..., n
+        let L2 be a copy of L1 where L2[$var_i] = vi for i = 1, ..., n
         G, L2, regular
     E(G, L, <for { i1, ..., in } condition post body>: ForLoop) =
         if n >= 1:

--- a/scripts/codespell_whitelist.txt
+++ b/scripts/codespell_whitelist.txt
@@ -9,3 +9,4 @@ ba
 fo
 compilability
 errorstring
+hist

--- a/test/compilationTests/corion/provider.sol
+++ b/test/compilationTests/corion/provider.sol
@@ -149,7 +149,7 @@ contract provider is module, safeMath, announcementTypes {
     }
     function getUserDetails(address payable addr, uint256 schellingRound) public view returns (address ProviderAddress, uint256 ProviderHeight, uint256 ConnectedOn, uint256 value) {
         /*
-            Collecting the datas of the client.
+            Collecting the data of the client.
 
             @addr               Address of the client.
             @schellingRound     Number of the schelling round. If it is not defined then the current one.
@@ -272,7 +272,7 @@ contract provider is module, safeMath, announcementTypes {
     }
     function setProviderDetails(address payable addr, string calldata website, string calldata country, string calldata info, uint8 rate, address payable admin) isReady external {
         /*
-            Modifying the datas of the provider.
+            Modifying the data of the provider.
             This can only be invited by the provider’s admin.
             The emission rate is only valid for the next schelling round for this one it is not.
             The admin can only be changed by the address of the provider.
@@ -323,7 +323,7 @@ contract provider is module, safeMath, announcementTypes {
     }
     function getProviderDetails(address payable addr, uint256 height) public view returns (uint8 rate, bool isForRent, uint256 clientsCount, bool priv, bool getInterest, bool valid) {
         /*
-            Asking for the datas of the provider.
+            Asking for the data of the provider.
             In case the height is unknown then the system will use the last known height.
 
             @addr           Address of the provider


### PR DESCRIPTION
Fixes:
```
./libevmasm/RuleList.h:51: hist  ==> heist, his
./libevmasm/RuleList.h:51: hist  ==> heist, his
./docs/yul.rst:247: varn  ==> warn
./docs/yul.rst:248: varn  ==> warn
./docs/yul.rst:249: varn  ==> warn
./docs/yul.rst:252: varn  ==> warn
./test/compilationTests/corion/provider.sol:152: datas  ==> data
./test/compilationTests/corion/provider.sol:275: datas  ==> data
./test/compilationTests/corion/provider.sol:326: datas  ==> data
```