### PR TITLE
clang-format: add "UseTab: ForIndentation" @ develop

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,7 @@ PenaltyBreakBeforeFirstCallParameter: 2000
 SpaceAfterCStyleCast: true
 SpaceBeforeParens: ControlStatements
 TabWidth: 4
+UseTab: ForIndentation
 
 # Local Variables:
 # mode: yaml


### PR DESCRIPTION
This will ensure that some IDE's will use tabs for indention.