### PR TITLE
Fixed code example which utilizes non-existing function 'abs' - the v…

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -110,7 +110,7 @@ Modulo
 
 The modulo operation ``a % n`` yields the remainder ``r`` after the division of the operand ``a``
 by the operand ``n``, where ``q = int(a / n)`` and ``r = a - (n * q)``. This means that modulo
-results in the same sign as its left operand (or zero) and ``a % n == -(abs(a) % n)`` holds for negative ``a``:
+results in the same sign as its left operand (or zero) and ``a % n == -(-a % n)`` holds for negative ``a``:
 
  * ``int256(5) % int256(2) == int256(1)``
  * ``int256(5) % int256(-2) == int256(1)``


### PR DESCRIPTION
…alue is stated to be negative so abs(a) is the same as -a

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Removed the use of a non-existing function "abs" from documentation and replaced it with a more native approach.
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
