### PR TITLE
[SMTChecker] Fix SMT name for function identifiers

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -621,8 +621,8 @@ void SMTEncoder::visitFunctionIdentifier(Identifier const& _identifier)
 	auto const& fType = dynamic_cast<FunctionType const&>(*_identifier.annotation().type);
 	if (fType.returnParameterTypes().size() == 1)
 	{
-		defineGlobalVariable(fType.richIdentifier(), _identifier);
-		m_context.createExpression(_identifier, m_context.globalSymbol(fType.richIdentifier()));
+		defineGlobalVariable(fType.identifier(), _identifier);
+		m_context.createExpression(_identifier, m_context.globalSymbol(fType.identifier()));
 	}
 }
 


### PR DESCRIPTION
We need to use `richIdentifier` there to be precise, but those have `(` and `)` in the name. Although that is fine for expressions built via the API, it breaks the query when using the `SMTLib2Interface`.