### PR TITLE
[SMTChecker] Add "as const: function to SMTLib2Interface

### DIFF
--- a/test/libsolidity/smtCheckerTestsJSON/multi.json
+++ b/test/libsolidity/smtCheckerTestsJSON/multi.json
@@ -3,8 +3,8 @@
 	{
 		"smtlib2responses":
 		{
-			"0x047d0c67d7e03c5ac96ca227d1e19ba63257f4ab19cef30029413219ec8963af": "sat\n((|EVALEXPR_0| 0))\n",
-			"0xada7569fb01a9b3e2823517ed40dcc99b11fb1e433e6e3ec8a8713f6f95753d3": "sat\n((|EVALEXPR_0| 1))\n"
+			"0x82fb8ee094f0f56b7a63a74177b54a1710d6fc531d426f288c18f36b76cf6a8b": "sat\n((|EVALEXPR_0| 1))\n",
+			"0xb524e7c577188e2e36f0e67fead51269fa0f8b8fb41bff2d973dcf584d38cd1e": "sat\n((|EVALEXPR_0| 0))\n"
 		}
 	}
 }

--- a/test/libsolidity/smtCheckerTestsJSON/simple.json
+++ b/test/libsolidity/smtCheckerTestsJSON/simple.json
@@ -3,7 +3,7 @@
 	{
 		"smtlib2responses":
 		{
-			"0x2e32517a1410b1a16decd448bb9bac7789d7cf1c6f98703ed6bacfcad6abebfb": "sat\n((|EVALEXPR_0| 0))\n"
+			"0x45c37a9829e623d7838d82b547d297cd446d6b5faff36c53a56862fcee50fb41": "sat\n((|EVALEXPR_0| 0))\n"
 		}
 	}
 }


### PR DESCRIPTION
Forgot to add this to `SMTLib2Interface` when added to Z3 and CVC4.

This function needs to be handled separately because it actually uses 2 functions: `((as const <Sort>) <value>)`
`(as const <Sort>)` takes a sort as an argument and returns the function that actually takes the value and finally returns a const array.

Changed the logic to `ALL` because `Z3` doesn't like `QF_AUFLIA` with `(as const)` and `CVC4` issues warnings if no logic is used.

I tested this on the upcoming `solc-js` PR that runs the `smtCheckerTests` via the `SMTLib2Interface`.