### PR TITLE
[circleci] Add t_osx_soltest.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,21 +427,44 @@ jobs:
     environment:
       TERM: xterm
       CMAKE_BUILD_TYPE: Debug
-      CMAKE_OPTIONS: -DLLL=ON
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
       - run:
           name: Install build dependencies
-          command: |
-            brew unlink python
-            brew install z3
-            brew install boost
-            brew install cmake
-            brew install wget
-            ./scripts/install_obsolete_jsoncpp_1_7_4.sh
+          command: ./.circleci/osx_install_dependencies.sh
+      - save_cache:
+          key: dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - /usr/local/bin
+            - /usr/local/sbin
+            - /usr/local/lib
+            - /usr/local/include
+            - /usr/local/Cellar
+            - /usr/local/Homebrew
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *artifacts_build_dir
+
+  t_osx_soltest:
+    macos:
+      xcode: "11.0.0"
+    environment:
+      EVM: constantinople
+      OPTIMIZE: 0
+      TERM: xterm
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+      - attach_workspace:
+          at: build
+      - run: *run_soltest
+      - store_test_results: *store_test_results
+      - store_artifacts: *artifacts_test_results
 
   t_osx_cli:
     macos:
@@ -450,13 +473,11 @@ jobs:
       TERM: xterm
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
       - attach_workspace:
           at: build
-      - run:
-          name: Install dependencies
-          command: |
-            brew unlink python
-            brew install z3
       - run: *run_cmdline_tests
       - store_artifacts: *artifacts_test_results
 
@@ -660,6 +681,7 @@ workflows:
       # OS/X build and tests
       - b_osx: *workflow_trigger_on_tags
       - t_osx_cli: *workflow_osx
+      - t_osx_soltest: *workflow_osx
 
       # Ubuntu build and tests
       - b_ubu: *workflow_trigger_on_tags

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+#------------------------------------------------------------------------------
+# Bash script to install osx dependencies
+#
+# The documentation for solidity is hosted at:
+#
+#     https://solidity.readthedocs.org
+#
+# ------------------------------------------------------------------------------
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2019 solidity contributors.
+# ------------------------------------------------------------------------------
+
+# note that the following directories may be cached by circleci:
+# - /usr/local/bin
+# - /usr/local/sbin
+# - /usr/local/lib
+# - /usr/local/include
+# - /usr/local/Cellar
+# - /usr/local/Homebrew
+
+if [ ! -f /usr/local/lib/libz3.a ] # if this file does not exists (cache was not restored), rebuild dependencies
+then
+  brew unlink python
+  brew install boost
+  brew install cmake
+  brew install wget
+  brew install coreutils
+  ./scripts/install_obsolete_jsoncpp_1_7_4.sh
+
+  # z3
+  wget https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-osx-10.14.2.zip
+  unzip z3-4.8.5-x64-osx-10.14.2.zip
+  rm -f z3-4.8.5-x64-osx-10.14.2.zip
+  cp z3-4.8.5-x64-osx-10.14.2/bin/libz3.a /usr/local/lib
+  cp z3-4.8.5-x64-osx-10.14.2/bin/z3 /usr/local/bin
+  cp z3-4.8.5-x64-osx-10.14.2/include/* /usr/local/include
+  rm -rf z3-4.8.5-x64-osx-10.14.2
+
+  # evmone
+  wget https://github.com/ethereum/evmone/releases/download/v0.1.0/evmone-0.1.0-darwin-x86_64.tar.gz
+  tar xzpf evmone-0.1.0-darwin-x86_64.tar.gz -C /usr/local
+  rm -f evmone-0.1.0-darwin-x86_64.tar.gz
+fi
+

--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -55,7 +55,7 @@ get_logfile_basename() {
 }
 
 BOOST_TEST_ARGS="--color_output=no --show_progress=yes --logger=JUNIT,error,test_results/`get_logfile_basename`.xml"
-SOLTEST_ARGS="--evm-version=$EVM --evmonepath /usr/lib/libevmone.so $SOLTEST_FLAGS"
+SOLTEST_ARGS="--evm-version=$EVM $SOLTEST_FLAGS"
 test "${OPTIMIZE}" = "1" && SOLTEST_ARGS="${SOLTEST_ARGS} --optimize"
 test "${ABI_ENCODER_V2}" = "1" && SOLTEST_ARGS="${SOLTEST_ARGS} --abiencoderv2 --optimize-yul"
 


### PR DESCRIPTION
`soltest` is currently showing different test results in macOS and Linux. 

On macOS `soltest` fails because of lower-case/upper-case issues inside hexadecimal numbers, see https://circleci.com/gh/ethereum/solidity/180943?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link .