### PR TITLE
replace boost::optional by std::optional (C++17)

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -25,7 +25,7 @@
 
 #include <libdevcore/Common.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <vector>
 #include <type_traits>
@@ -277,7 +277,7 @@ void iterateReplacing(std::vector<T>& _vector, F const& _f)
 	std::vector<T> modifiedVector;
 	for (size_t i = 0; i < _vector.size(); ++i)
 	{
-		if (boost::optional<std::vector<T>> r = _f(_vector[i]))
+		if (std::optional<std::vector<T>> r = _f(_vector[i]))
 		{
 			if (!useModified)
 			{
@@ -305,7 +305,7 @@ void iterateReplacingWindow(std::vector<T>& _vector, F const& _f, std::index_seq
 	size_t i = 0;
 	for (; i + sizeof...(I) <= _vector.size(); ++i)
 	{
-		if (boost::optional<std::vector<T>> r = _f(_vector[i + I]...))
+		if (std::optional<std::vector<T>> r = _f(_vector[i + I]...))
 		{
 			if (!useModified)
 			{

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -24,7 +24,7 @@
 
 #include <string>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/operators.hpp>
 
 
@@ -51,7 +51,7 @@ public:
 	static EVMVersion istanbul() { return {Version::Istanbul}; }
 	static EVMVersion berlin() { return {Version::Berlin}; }
 
-	static boost::optional<EVMVersion> fromString(std::string const& _version)
+	static std::optional<EVMVersion> fromString(std::string const& _version)
 	{
 		for (auto const& v: {homestead(), tangerineWhistle(), spuriousDragon(), byzantium(), constantinople(), petersburg(), istanbul(), berlin()})
 			if (_version == v.name())

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -53,7 +53,7 @@
 #include <liblangutil/Common.h>
 #include <liblangutil/Exceptions.h>
 #include <liblangutil/Scanner.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include <algorithm>
 #include <ostream>
 #include <tuple>
@@ -187,7 +187,7 @@ bool Scanner::scanHexByte(char& o_scannedByte)
 	return true;
 }
 
-boost::optional<unsigned> Scanner::scanUnicode()
+std::optional<unsigned> Scanner::scanUnicode()
 {
 	unsigned x = 0;
 	for (int i = 0; i < 4; i++)
@@ -694,7 +694,7 @@ bool Scanner::scanEscape()
 		break;
 	case 'u':
 	{
-		if (boost::optional<unsigned> codepoint = scanUnicode())
+		if (std::optional<unsigned> codepoint = scanUnicode())
 			addUnicodeAsUTF8(*codepoint);
 		else
 			return false;

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -207,7 +207,7 @@ private:
 	inline Token selectToken(char _next, Token _then, Token _else);
 
 	bool scanHexByte(char& o_scannedByte);
-	boost::optional<unsigned> scanUnicode();
+	std::optional<unsigned> scanUnicode();
 
 	/// Scans a single Solidity token.
 	void scanToken();

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -122,7 +122,7 @@ bool ReferencesResolver::visit(ElementaryTypeName const& _typeName)
 	if (!_typeName.annotation().type)
 	{
 		_typeName.annotation().type = TypeProvider::fromElementaryTypeName(_typeName.typeName());
-		if (_typeName.stateMutability().is_initialized())
+		if (_typeName.stateMutability().has_value())
 		{
 			// for non-address types this was already caught by the parser
 			solAssert(_typeName.annotation().type->category() == Type::Category::Address, "");

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -323,7 +323,7 @@ bool ReferencesResolver::visit(InlineAssembly const& _inlineAssembly)
 	// Will be re-generated later with correct information
 	// We use the latest EVM version because we will re-run it anyway.
 	yul::AsmAnalysisInfo analysisInfo;
-	boost::optional<Error::Type> errorTypeForLoose = Error::Type::SyntaxError;
+	std::optional<Error::Type> errorTypeForLoose = Error::Type::SyntaxError;
 	yul::AsmAnalyzer(
 		analysisInfo,
 		errorsIgnored,

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -241,7 +241,7 @@ void ViewPureChecker::endVisit(InlineAssembly const& _inlineAssembly)
 void ViewPureChecker::reportMutability(
 	StateMutability _mutability,
 	SourceLocation const& _location,
-	boost::optional<SourceLocation> const& _nestedLocation
+	std::optional<SourceLocation> const& _nestedLocation
 )
 {
 	if (_mutability > m_bestMutabilityAndLocation.mutability)

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -67,7 +67,7 @@ private:
 	void reportMutability(
 		StateMutability _mutability,
 		langutil::SourceLocation const& _location,
-		boost::optional<langutil::SourceLocation> const& _nestedLocation = {}
+		std::optional<langutil::SourceLocation> const& _nestedLocation = {}
 	);
 
 	std::vector<std::shared_ptr<ASTNode>> const& m_ast;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -903,7 +903,7 @@ public:
 	ElementaryTypeName(
 		SourceLocation const& _location,
 		ElementaryTypeNameToken const& _elem,
-		boost::optional<StateMutability> _stateMutability = {}
+		std::optional<StateMutability> _stateMutability = {}
 	): TypeName(_location), m_type(_elem), m_stateMutability(_stateMutability)
 	{
 		solAssert(!_stateMutability.is_initialized() || _elem.token() == Token::Address, "");
@@ -914,11 +914,11 @@ public:
 
 	ElementaryTypeNameToken const& typeName() const { return m_type; }
 
-	boost::optional<StateMutability> const& stateMutability() const { return m_stateMutability; }
+	std::optional<StateMutability> const& stateMutability() const { return m_stateMutability; }
 
 private:
 	ElementaryTypeNameToken m_type;
-	boost::optional<StateMutability> m_stateMutability; ///< state mutability for address type
+	std::optional<StateMutability> m_stateMutability; ///< state mutability for address type
 };
 
 /**

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -906,7 +906,7 @@ public:
 		std::optional<StateMutability> _stateMutability = {}
 	): TypeName(_location), m_type(_elem), m_stateMutability(_stateMutability)
 	{
-		solAssert(!_stateMutability.is_initialized() || _elem.token() == Token::Address, "");
+		solAssert(!_stateMutability.has_value() || _elem.token() == Token::Address, "");
 	}
 
 	void accept(ASTVisitor& _visitor) override;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -26,7 +26,7 @@
 #include <libsolidity/ast/ASTEnums.h>
 #include <libsolidity/ast/ExperimentalFeatures.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <map>
 #include <memory>
@@ -183,7 +183,7 @@ struct ExpressionAnnotation: ASTAnnotation
 
 	/// Types and - if given - names of arguments if the expr. is a function
 	/// that is called, used for overload resoultion
-	boost::optional<FuncCallArguments> arguments;
+	std::optional<FuncCallArguments> arguments;
 };
 
 struct IdentifierAnnotation: ExpressionAnnotation

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -147,7 +147,7 @@ Json::Value ASTJsonConverter::typePointerToJson(TypePointer _tp, bool _short)
 	return typeDescriptions;
 
 }
-Json::Value ASTJsonConverter::typePointerToJson(boost::optional<FuncCallArguments> const& _tps)
+Json::Value ASTJsonConverter::typePointerToJson(std::optional<FuncCallArguments> const& _tps)
 {
 	if (_tps)
 	{

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -169,7 +169,7 @@ private:
 		return json;
 	}
 	static Json::Value typePointerToJson(TypePointer _tp, bool _short = false);
-	static Json::Value typePointerToJson(boost::optional<FuncCallArguments> const& _tps);
+	static Json::Value typePointerToJson(std::optional<FuncCallArguments> const& _tps);
 	void appendExpressionAttributes(
 		std::vector<std::pair<std::string, Json::Value>> &_attributes,
 		ExpressionAnnotation const& _annotation

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1812,10 +1812,10 @@ TypePointer ArrayType::decodingType() const
 
 TypeResult ArrayType::interfaceType(bool _inLibrary) const
 {
-	if (_inLibrary && m_interfaceType_library.is_initialized())
+	if (_inLibrary && m_interfaceType_library.has_value())
 		return *m_interfaceType_library;
 
-	if (!_inLibrary && m_interfaceType.is_initialized())
+	if (!_inLibrary && m_interfaceType.has_value())
 		return *m_interfaceType;
 
 	TypeResult result{TypePointer{}};
@@ -2104,10 +2104,10 @@ MemberList::MemberMap StructType::nativeMembers(ContractDefinition const*) const
 
 TypeResult StructType::interfaceType(bool _inLibrary) const
 {
-	if (_inLibrary && m_interfaceType_library.is_initialized())
+	if (_inLibrary && m_interfaceType_library.has_value())
 		return *m_interfaceType_library;
 
-	if (!_inLibrary && m_interfaceType.is_initialized())
+	if (!_inLibrary && m_interfaceType.has_value())
 		return *m_interfaceType;
 
 	TypeResult result{TypePointer{}};
@@ -2164,7 +2164,7 @@ TypeResult StructType::interfaceType(bool _inLibrary) const
 		}
 	};
 
-	m_recursive = m_recursive.get() || (CycleDetector<StructDefinition>(visitor).run(structDefinition()) != nullptr);
+	m_recursive = m_recursive.value() || (CycleDetector<StructDefinition>(visitor).run(structDefinition()) != nullptr);
 
 	std::string const recursiveErrMsg = "Recursive type not allowed for public or external contract functions.";
 
@@ -2177,13 +2177,13 @@ TypeResult StructType::interfaceType(bool _inLibrary) const
 		else
 			m_interfaceType_library = TypeProvider::withLocation(this, DataLocation::Memory, true);
 
-		if (m_recursive.get())
+		if (m_recursive.value())
 			m_interfaceType = TypeResult::err(recursiveErrMsg);
 
 		return *m_interfaceType_library;
 	}
 
-	if (m_recursive.get())
+	if (m_recursive.value())
 		m_interfaceType = TypeResult::err(recursiveErrMsg);
 	else if (!result.message().empty())
 		m_interfaceType = result;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -31,7 +31,7 @@
 #include <libdevcore/CommonIO.h>
 #include <libdevcore/Result.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/rational.hpp>
 
 #include <map>
@@ -769,8 +769,8 @@ private:
 	Type const* m_baseType;
 	bool m_hasDynamicLength = true;
 	u256 m_length;
-	mutable boost::optional<TypeResult> m_interfaceType;
-	mutable boost::optional<TypeResult> m_interfaceType_library;
+	mutable std::optional<TypeResult> m_interfaceType;
+	mutable std::optional<TypeResult> m_interfaceType_library;
 };
 
 /**
@@ -898,9 +898,9 @@ public:
 private:
 	StructDefinition const& m_struct;
 	// Caches for interfaceType(bool)
-	mutable boost::optional<TypeResult> m_interfaceType;
-	mutable boost::optional<TypeResult> m_interfaceType_library;
-	mutable boost::optional<bool> m_recursive;
+	mutable std::optional<TypeResult> m_interfaceType;
+	mutable std::optional<TypeResult> m_interfaceType_library;
+	mutable std::optional<bool> m_recursive;
 };
 
 /**

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -865,12 +865,12 @@ public:
 
 	bool recursive() const
 	{
-		if (m_recursive.is_initialized())
-			return m_recursive.get();
+		if (m_recursive.has_value())
+			return m_recursive.value();
 
 		interfaceType(false);
 
-		return m_recursive.get();
+		return m_recursive.value();
 	}
 
 	std::unique_ptr<ReferenceType> copyForLocation(DataLocation _location, bool _isPointer) const override;

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -411,7 +411,7 @@ void CompilerContext::appendInlineAssembly(
 		analyzerResult = yul::AsmAnalyzer(
 			analysisInfo,
 			errorReporter,
-			boost::none,
+			std::nullopt,
 			dialect,
 			identifierAccess.resolve
 		).analyze(*parserResult);

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -962,7 +962,7 @@ string YulUtilFunctions::readFromCalldata(Type const& _type)
 	return readFromMemoryOrCalldata(_type, true);
 }
 
-string YulUtilFunctions::updateStorageValueFunction(Type const& _type, boost::optional<unsigned> const& _offset)
+string YulUtilFunctions::updateStorageValueFunction(Type const& _type, std::optional<unsigned> const& _offset)
 {
 	string const functionName =
 		"update_storage_value_" +

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -966,7 +966,7 @@ string YulUtilFunctions::updateStorageValueFunction(Type const& _type, std::opti
 {
 	string const functionName =
 		"update_storage_value_" +
-		(_offset.is_initialized() ? ("offset_" + to_string(*_offset)) : "") +
+		(_offset.has_value() ? ("offset_" + to_string(*_offset)) : "") +
 		_type.identifier();
 
 	return m_functionCollector->createFunction(functionName, [&] {
@@ -983,11 +983,11 @@ string YulUtilFunctions::updateStorageValueFunction(Type const& _type, std::opti
 			)")
 			("functionName", functionName)
 			("update",
-				_offset.is_initialized() ?
+				_offset.has_value() ?
 					updateByteSliceFunction(_type.storageBytes(), *_offset) :
 					updateByteSliceFunctionDynamic(_type.storageBytes())
 			)
-			("offset", _offset.is_initialized() ? "" : "offset, ")
+			("offset", _offset.has_value() ? "" : "offset, ")
 			("prepare", prepareStoreFunction(_type))
 			.render();
 		}

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -197,7 +197,7 @@ public:
 	/// the specified slot and offset. If offset is not given, it is expected as
 	/// runtime parameter.
 	/// signature: (slot, [offset,] value)
-	std::string updateStorageValueFunction(Type const& _type, boost::optional<unsigned> const& _offset = boost::optional<unsigned>());
+	std::string updateStorageValueFunction(Type const& _type, std::optional<unsigned> const& _offset = std::optional<unsigned>());
 
 	/// Returns the name of a function that will write the given value to
 	/// the specified address.

--- a/libsolidity/codegen/ir/IRLValue.cpp
+++ b/libsolidity/codegen/ir/IRLValue.cpp
@@ -115,7 +115,7 @@ string IRStorageItem::storeValue(string const& _value, Type const& _sourceType) 
 	if (m_type->isValueType())
 		solAssert(_sourceType == *m_type, "Different type, but might not be an error.");
 
-	boost::optional<unsigned> offset;
+	std::optional<unsigned> offset;
 
 	if (m_offset.type() == typeid(unsigned))
 		offset = get<unsigned>(m_offset);

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -95,7 +95,7 @@ CompilerStack::~CompilerStack()
 	TypeProvider::reset();
 }
 
-boost::optional<CompilerStack::Remapping> CompilerStack::parseRemapping(string const& _remapping)
+std::optional<CompilerStack::Remapping> CompilerStack::parseRemapping(string const& _remapping)
 {
 	auto eq = find(_remapping.begin(), _remapping.end(), '=');
 	if (eq == _remapping.end())

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -121,7 +121,7 @@ public:
 	void reset(bool _keepSettings = false);
 
 	// Parses a remapping of the format "context:prefix=target".
-	static boost::optional<Remapping> parseRemapping(std::string const& _remapping);
+	static std::optional<Remapping> parseRemapping(std::string const& _remapping);
 
 	/// Sets path remappings.
 	/// Must be set before parsing.

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -31,7 +31,7 @@
 
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <algorithm>
 
 using namespace std;
@@ -317,7 +317,7 @@ Json::Value collectEVMObject(eth::LinkerObject const& _object, string const* _so
 	return output;
 }
 
-boost::optional<Json::Value> checkKeys(Json::Value const& _input, set<string> const& _keys, string const& _name)
+std::optional<Json::Value> checkKeys(Json::Value const& _input, set<string> const& _keys, string const& _name)
 {
 	if (!!_input && !_input.isObject())
 		return formatFatalError("JSONError", "\"" + _name + "\" must be an object");
@@ -326,46 +326,46 @@ boost::optional<Json::Value> checkKeys(Json::Value const& _input, set<string> co
 		if (!_keys.count(member))
 			return formatFatalError("JSONError", "Unknown key \"" + member + "\"");
 
-	return boost::none;
+	return std::nullopt;
 }
 
-boost::optional<Json::Value> checkRootKeys(Json::Value const& _input)
+std::optional<Json::Value> checkRootKeys(Json::Value const& _input)
 {
 	static set<string> keys{"auxiliaryInput", "language", "settings", "sources"};
 	return checkKeys(_input, keys, "root");
 }
 
-boost::optional<Json::Value> checkSourceKeys(Json::Value const& _input, string const& _name)
+std::optional<Json::Value> checkSourceKeys(Json::Value const& _input, string const& _name)
 {
 	static set<string> keys{"content", "keccak256", "urls"};
 	return checkKeys(_input, keys, "sources." + _name);
 }
 
-boost::optional<Json::Value> checkAuxiliaryInputKeys(Json::Value const& _input)
+std::optional<Json::Value> checkAuxiliaryInputKeys(Json::Value const& _input)
 {
 	static set<string> keys{"smtlib2responses"};
 	return checkKeys(_input, keys, "auxiliaryInput");
 }
 
-boost::optional<Json::Value> checkSettingsKeys(Json::Value const& _input)
+std::optional<Json::Value> checkSettingsKeys(Json::Value const& _input)
 {
 	static set<string> keys{"parserErrorRecovery", "evmVersion", "libraries", "metadata", "optimizer", "outputSelection", "remappings"};
 	return checkKeys(_input, keys, "settings");
 }
 
-boost::optional<Json::Value> checkOptimizerKeys(Json::Value const& _input)
+std::optional<Json::Value> checkOptimizerKeys(Json::Value const& _input)
 {
 	static set<string> keys{"details", "enabled", "runs"};
 	return checkKeys(_input, keys, "settings.optimizer");
 }
 
-boost::optional<Json::Value> checkOptimizerDetailsKeys(Json::Value const& _input)
+std::optional<Json::Value> checkOptimizerDetailsKeys(Json::Value const& _input)
 {
 	static set<string> keys{"peephole", "jumpdestRemover", "orderLiterals", "deduplicate", "cse", "constantOptimizer", "yul", "yulDetails"};
 	return checkKeys(_input, keys, "settings.optimizer.details");
 }
 
-boost::optional<Json::Value> checkOptimizerDetail(Json::Value const& _details, std::string const& _name, bool& _setting)
+std::optional<Json::Value> checkOptimizerDetail(Json::Value const& _details, std::string const& _name, bool& _setting)
 {
 	if (_details.isMember(_name))
 	{
@@ -376,7 +376,7 @@ boost::optional<Json::Value> checkOptimizerDetail(Json::Value const& _details, s
 	return {};
 }
 
-boost::optional<Json::Value> checkMetadataKeys(Json::Value const& _input)
+std::optional<Json::Value> checkMetadataKeys(Json::Value const& _input)
 {
 	if (_input.isObject() && _input.isMember("useLiteralContent") && !_input["useLiteralContent"].isBool())
 		return formatFatalError("JSONError", "\"settings.metadata.useLiteralContent\" must be Boolean");
@@ -384,7 +384,7 @@ boost::optional<Json::Value> checkMetadataKeys(Json::Value const& _input)
 	return checkKeys(_input, keys, "settings.metadata");
 }
 
-boost::optional<Json::Value> checkOutputSelection(Json::Value const& _outputSelection)
+std::optional<Json::Value> checkOutputSelection(Json::Value const& _outputSelection)
 {
 	if (!!_outputSelection && !_outputSelection.isObject())
 		return formatFatalError("JSONError", "\"settings.outputSelection\" must be an object");
@@ -426,7 +426,7 @@ boost::optional<Json::Value> checkOutputSelection(Json::Value const& _outputSele
 		}
 	}
 
-	return boost::none;
+	return std::nullopt;
 }
 /// Validates the optimizer settings and returns them in a parsed object.
 /// On error returns the json-formatted error message.
@@ -635,7 +635,7 @@ boost::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompile
 	{
 		if (!settings["evmVersion"].isString())
 			return formatFatalError("JSONError", "evmVersion must be a string.");
-		boost::optional<langutil::EVMVersion> version = langutil::EVMVersion::fromString(settings["evmVersion"].asString());
+		std::optional<langutil::EVMVersion> version = langutil::EVMVersion::fromString(settings["evmVersion"].asString());
 		if (!version)
 			return formatFatalError("JSONError", "Invalid EVM version requested.");
 		ret.evmVersion = *version;

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -24,7 +24,7 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/variant.hpp>
 
 namespace dev

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -872,7 +872,7 @@ ASTPointer<TypeName> Parser::parseTypeName(bool _allowVar)
 		ASTNodeFactory nodeFactory(*this);
 		nodeFactory.markEndPosition();
 		m_scanner->next();
-		auto stateMutability = std::make_optional(elemTypeName.token() == Token::Address, StateMutability::NonPayable);
+		auto stateMutability = elemTypeName.token() == Token::Address ? std::make_optional(StateMutability::NonPayable) : std::nullopt;
 		if (TokenTraits::isStateMutabilitySpecifier(m_scanner->currentToken(), false))
 		{
 			if (elemTypeName.token() == Token::Address)

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -872,7 +872,7 @@ ASTPointer<TypeName> Parser::parseTypeName(bool _allowVar)
 		ASTNodeFactory nodeFactory(*this);
 		nodeFactory.markEndPosition();
 		m_scanner->next();
-		auto stateMutability = boost::make_optional(elemTypeName.token() == Token::Address, StateMutability::NonPayable);
+		auto stateMutability = std::make_optional(elemTypeName.token() == Token::Address, StateMutability::NonPayable);
 		if (TokenTraits::isStateMutabilitySpecifier(m_scanner->currentToken(), false))
 		{
 			if (elemTypeName.token() == Token::Address)

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -31,7 +31,7 @@
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <functional>
 #include <list>
@@ -59,7 +59,7 @@ public:
 	explicit AsmAnalyzer(
 		AsmAnalysisInfo& _analysisInfo,
 		langutil::ErrorReporter& _errorReporter,
-		boost::optional<langutil::Error::Type> _errorTypeForLoose,
+		std::optional<langutil::Error::Type> _errorTypeForLoose,
 		Dialect const& _dialect,
 		ExternalIdentifierAccess::Resolver const& _resolver = ExternalIdentifierAccess::Resolver(),
 		std::set<YulString> const& _dataNames = {}
@@ -127,7 +127,7 @@ private:
 	langutil::ErrorReporter& m_errorReporter;
 	langutil::EVMVersion m_evmVersion;
 	Dialect const& m_dialect;
-	boost::optional<langutil::Error::Type> m_errorTypeForLoose;
+	std::optional<langutil::Error::Type> m_errorTypeForLoose;
 	/// Names of data objects to be referenced by builtin functions with literal arguments.
 	std::set<YulString> m_dataNames;
 	ForLoop const* m_currentForLoop = nullptr;

--- a/libyul/AsmScope.h
+++ b/libyul/AsmScope.h
@@ -27,7 +27,7 @@
 #include <libdevcore/Visitor.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <functional>
 #include <memory>

--- a/libyul/AssemblyStack.cpp
+++ b/libyul/AssemblyStack.cpp
@@ -117,7 +117,7 @@ bool AssemblyStack::analyzeParsed(Object& _object)
 	AsmAnalyzer analyzer(
 		*_object.analysisInfo,
 		m_errorReporter,
-		boost::none,
+		std::nullopt,
 		languageToDialect(m_language, m_evmVersion),
 		{},
 		_object.dataNames()

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -725,7 +725,7 @@ void CodeTransform::visitStatements(vector<Statement> const& _statements)
 {
 	// Workaround boost bug:
 	// https://www.boost.org/doc/libs/1_63_0/libs/optional/doc/html/boost_optional/tutorial/gotchas/false_positive_with__wmaybe_uninitialized.html
-	boost::optional<AbstractAssembly::LabelID> jumpTarget = boost::make_optional(false, AbstractAssembly::LabelID());
+	std::optional<AbstractAssembly::LabelID> jumpTarget = std::make_optional(false, AbstractAssembly::LabelID());
 
 	for (auto const& statement: _statements)
 	{
@@ -740,7 +740,7 @@ void CodeTransform::visitStatements(vector<Statement> const& _statements)
 		else if (!functionDefinition && jumpTarget)
 		{
 			m_assembly.appendLabel(*jumpTarget);
-			jumpTarget = boost::none;
+			jumpTarget = std::nullopt;
 		}
 
 		boost::apply_visitor(*this, statement);

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -723,9 +723,7 @@ void CodeTransform::visitExpression(Expression const& _expression)
 
 void CodeTransform::visitStatements(vector<Statement> const& _statements)
 {
-	// Workaround boost bug:
-	// https://www.boost.org/doc/libs/1_63_0/libs/optional/doc/html/boost_optional/tutorial/gotchas/false_positive_with__wmaybe_uninitialized.html
-	std::optional<AbstractAssembly::LabelID> jumpTarget = std::make_optional(false, AbstractAssembly::LabelID());
+	std::optional<AbstractAssembly::LabelID> jumpTarget;
 
 	for (auto const& statement: _statements)
 	{

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -28,7 +28,7 @@
 #include <libyul/AsmScope.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <stack>
 

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -47,7 +47,7 @@ struct BuiltinContext
 
 struct BuiltinFunctionForEVM: BuiltinFunction
 {
-	boost::optional<dev::eth::Instruction> instruction;
+	std::optional<dev::eth::Instruction> instruction;
 	/// Function to generate code for the given function call and append it to the abstract
 	/// assembly. The fourth parameter is called to visit (and generate code for) the arguments
 	/// from right to left.

--- a/libyul/backends/wasm/EVMToEWasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEWasmTranslator.cpp
@@ -654,7 +654,7 @@ Object EVMToEWasmTranslator::run(Object const& _object)
 
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	AsmAnalyzer analyzer(*ret.analysisInfo, errorReporter, boost::none, WasmDialect::instance(), {}, _object.dataNames());
+	AsmAnalyzer analyzer(*ret.analysisInfo, errorReporter, std::nullopt, WasmDialect::instance(), {}, _object.dataNames());
 	if (!analyzer.analyze(*ret.code))
 	{
 		// TODO the errors here are "wrong" because they have invalid source references!

--- a/libyul/backends/wasm/WordSizeTransform.cpp
+++ b/libyul/backends/wasm/WordSizeTransform.cpp
@@ -82,7 +82,7 @@ void WordSizeTransform::operator()(Block& _block)
 {
 	iterateReplacing(
 		_block.statements,
-		[&](Statement& _s) -> boost::optional<vector<Statement>>
+		[&](Statement& _s) -> std::optional<vector<Statement>>
 		{
 			if (_s.type() == typeid(VariableDeclaration))
 			{
@@ -95,7 +95,7 @@ void WordSizeTransform::operator()(Block& _block)
 				{
 					if (varDecl.value) visit(*varDecl.value);
 					rewriteVarDeclList(varDecl.variables);
-					return boost::none;
+					return std::nullopt;
 				}
 				else if (
 					varDecl.value->type() == typeid(Identifier) ||
@@ -130,7 +130,7 @@ void WordSizeTransform::operator()(Block& _block)
 				{
 					if (assignment.value) visit(*assignment.value);
 					rewriteIdentifierList(assignment.variableNames);
-					return boost::none;
+					return std::nullopt;
 				}
 				else if (
 					assignment.value->type() == typeid(Identifier) ||
@@ -158,7 +158,7 @@ void WordSizeTransform::operator()(Block& _block)
 				return handleSwitch(boost::get<Switch>(_s));
 			else
 				visit(_s);
-			return boost::none;
+			return std::nullopt;
 		}
 	);
 }
@@ -174,7 +174,7 @@ void WordSizeTransform::rewriteVarDeclList(TypedNameList& _nameList)
 {
 	iterateReplacing(
 		_nameList,
-		[&](TypedName const& _n) -> boost::optional<TypedNameList>
+		[&](TypedName const& _n) -> std::optional<TypedNameList>
 		{
 			TypedNameList ret;
 			for (auto newName: generateU64IdentifierNames(_n.name))
@@ -188,7 +188,7 @@ void WordSizeTransform::rewriteIdentifierList(vector<Identifier>& _ids)
 {
 	iterateReplacing(
 		_ids,
-		[&](Identifier const& _id) -> boost::optional<vector<Identifier>>
+		[&](Identifier const& _id) -> std::optional<vector<Identifier>>
 		{
 			vector<Identifier> ret;
 			for (auto newId: m_variableMapping.at(_id.name))
@@ -202,7 +202,7 @@ void WordSizeTransform::rewriteFunctionCallArguments(vector<Expression>& _args)
 {
 	iterateReplacing(
 		_args,
-		[&](Expression& _e) -> boost::optional<vector<Expression>>
+		[&](Expression& _e) -> std::optional<vector<Expression>>
 		{
 			return expandValueToVector(_e);
 		}

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -25,7 +25,7 @@
 #include <libyul/YulString.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <vector>
 #include <set>

--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -26,7 +26,7 @@
 #include <libyul/YulString.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <vector>
 #include <set>

--- a/libyul/optimiser/BlockFlattener.cpp
+++ b/libyul/optimiser/BlockFlattener.cpp
@@ -30,7 +30,7 @@ void BlockFlattener::operator()(Block& _block)
 
 	iterateReplacing(
 		_block.statements,
-		[](Statement& _s) -> boost::optional<vector<Statement>>
+		[](Statement& _s) -> std::optional<vector<Statement>>
 		{
 			if (_s.type() == typeid(Block))
 				return std::move(boost::get<Block>(_s).statements);

--- a/libyul/optimiser/CallGraphGenerator.h
+++ b/libyul/optimiser/CallGraphGenerator.h
@@ -24,7 +24,7 @@
 
 #include <libdevcore/InvertibleMap.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <set>
 #include <map>

--- a/libyul/optimiser/ControlFlowSimplifier.cpp
+++ b/libyul/optimiser/ControlFlowSimplifier.cpp
@@ -29,7 +29,7 @@ using namespace std;
 using namespace dev;
 using namespace yul;
 
-using OptionalStatements = boost::optional<vector<Statement>>;
+using OptionalStatements = std::optional<vector<Statement>>;
 
 namespace
 {

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -354,7 +354,7 @@ bool DataFlowAnalyzer::inScope(YulString _variableName) const
 	return false;
 }
 
-boost::optional<pair<YulString, YulString>> DataFlowAnalyzer::isSimpleStore(
+std::optional<pair<YulString, YulString>> DataFlowAnalyzer::isSimpleStore(
 	dev::eth::Instruction _store,
 	ExpressionStatement const& _statement
 ) const

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -128,7 +128,7 @@ protected:
 	/// Returns true iff the variable is in scope.
 	bool inScope(YulString _variableName) const;
 
-	boost::optional<std::pair<YulString, YulString>> isSimpleStore(
+	std::optional<std::pair<YulString, YulString>> isSimpleStore(
 		dev::eth::Instruction _store,
 		ExpressionStatement const& _statement
 	) const;

--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -26,7 +26,7 @@
 #include <libyul/optimiser/NameDispenser.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <set>
 

--- a/libyul/optimiser/ExpressionInliner.h
+++ b/libyul/optimiser/ExpressionInliner.h
@@ -23,7 +23,7 @@
 #include <libyul/AsmDataForward.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <set>
 

--- a/libyul/optimiser/ExpressionSplitter.cpp
+++ b/libyul/optimiser/ExpressionSplitter.cpp
@@ -79,8 +79,8 @@ void ExpressionSplitter::operator()(Block& _block)
 	vector<Statement> saved;
 	swap(saved, m_statementsToPrefix);
 
-	function<boost::optional<vector<Statement>>(Statement&)> f =
-			[&](Statement& _statement) -> boost::optional<vector<Statement>> {
+	function<std::optional<vector<Statement>>(Statement&)> f =
+			[&](Statement& _statement) -> std::optional<vector<Statement>> {
 		m_statementsToPrefix.clear();
 		visit(_statement);
 		if (m_statementsToPrefix.empty())

--- a/libyul/optimiser/ForLoopInitRewriter.cpp
+++ b/libyul/optimiser/ForLoopInitRewriter.cpp
@@ -27,7 +27,7 @@ void ForLoopInitRewriter::operator()(Block& _block)
 {
 	iterateReplacing(
 		_block.statements,
-		[&](Statement& _stmt) -> boost::optional<vector<Statement>>
+		[&](Statement& _stmt) -> std::optional<vector<Statement>>
 		{
 			if (_stmt.type() == typeid(ForLoop))
 			{

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -142,14 +142,14 @@ bool FullInliner::recursive(FunctionDefinition const& _fun) const
 
 void InlineModifier::operator()(Block& _block)
 {
-	function<boost::optional<vector<Statement>>(Statement&)> f = [&](Statement& _statement) -> boost::optional<vector<Statement>> {
+	function<std::optional<vector<Statement>>(Statement&)> f = [&](Statement& _statement) -> std::optional<vector<Statement>> {
 		visit(_statement);
 		return tryInlineStatement(_statement);
 	};
 	iterateReplacing(_block.statements, f);
 }
 
-boost::optional<vector<Statement>> InlineModifier::tryInlineStatement(Statement& _statement)
+std::optional<vector<Statement>> InlineModifier::tryInlineStatement(Statement& _statement)
 {
 	// Only inline for expression statements, assignments and variable declarations.
 	Expression* e = boost::apply_visitor(GenericFallbackReturnsVisitor<Expression*, ExpressionStatement, Assignment, VariableDeclaration>(

--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -29,7 +29,7 @@
 #include <liblangutil/SourceLocation.h>
 
 #include <boost/variant.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <set>
 
@@ -123,7 +123,7 @@ public:
 	void operator()(Block& _block) override;
 
 private:
-	boost::optional<std::vector<Statement>> tryInlineStatement(Statement& _statement);
+	std::optional<std::vector<Statement>> tryInlineStatement(Statement& _statement);
 	std::vector<Statement> performInline(Statement& _statement, FunctionCall& _funCall);
 
 	YulString m_currentFunction;

--- a/libyul/optimiser/SSAReverser.cpp
+++ b/libyul/optimiser/SSAReverser.cpp
@@ -35,7 +35,7 @@ void SSAReverser::operator()(Block& _block)
 	walkVector(_block.statements);
 	iterateReplacingWindow<2>(
 		_block.statements,
-		[&](Statement& _stmt1, Statement& _stmt2) -> boost::optional<vector<Statement>>
+		[&](Statement& _stmt1, Statement& _stmt2) -> std::optional<vector<Statement>>
 		{
 			auto* varDecl = boost::get<VariableDeclaration>(&_stmt1);
 

--- a/libyul/optimiser/SSATransform.cpp
+++ b/libyul/optimiser/SSATransform.cpp
@@ -58,7 +58,7 @@ void IntroduceSSA::operator()(Block& _block)
 {
 	iterateReplacing(
 		_block.statements,
-		[&](Statement& _s) -> boost::optional<vector<Statement>>
+		[&](Statement& _s) -> std::optional<vector<Statement>>
 		{
 			if (_s.type() == typeid(VariableDeclaration))
 			{
@@ -213,7 +213,7 @@ void IntroduceControlFlowSSA::operator()(Block& _block)
 
 	iterateReplacing(
 		_block.statements,
-		[&](Statement& _s) -> boost::optional<vector<Statement>>
+		[&](Statement& _s) -> std::optional<vector<Statement>>
 		{
 			vector<Statement> toPrepend;
 			for (YulString toReassign: m_variablesToReassign)

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -64,7 +64,7 @@ bool SimplificationRules::isInitialized() const
 	return !m_rules[uint8_t(dev::eth::Instruction::ADD)].empty();
 }
 
-boost::optional<std::pair<dev::eth::Instruction, vector<Expression> const*>>
+std::optional<std::pair<dev::eth::Instruction, vector<Expression> const*>>
 	SimplificationRules::instructionAndArguments(Dialect const& _dialect, Expression const& _expr)
 {
 	if (_expr.type() == typeid(FunctionalInstruction))

--- a/libyul/optimiser/SimplificationRules.h
+++ b/libyul/optimiser/SimplificationRules.h
@@ -26,7 +26,7 @@
 #include <libyul/AsmData.h>
 
 #include <boost/noncopyable.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <functional>
 #include <vector>
@@ -57,7 +57,7 @@ public:
 	/// by the constructor, but we had some issues with static initialization.
 	bool isInitialized() const;
 
-	static boost::optional<std::pair<dev::eth::Instruction, std::vector<Expression> const*>>
+	static std::optional<std::pair<dev::eth::Instruction, std::vector<Expression> const*>>
 	instructionAndArguments(Dialect const& _dialect, Expression const& _expr);
 
 private:

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -76,7 +76,7 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 		},
 		[&](Switch& _switchStmt) -> OptionalStatements {
 			if (std::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
-				return replaceConstArgSwitch(_switchStmt, constExprVal.get());
+				return replaceConstArgSwitch(_switchStmt, constExprVal.value());
 			return {};
 		},
 		[&](ForLoop& _forLoop) -> OptionalStatements {

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -28,7 +28,7 @@ using namespace std;
 using namespace dev;
 using namespace yul;
 
-using OptionalStatements = boost::optional<vector<Statement>>;
+using OptionalStatements = std::optional<vector<Statement>>;
 
 namespace {
 
@@ -75,7 +75,7 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 			return {};
 		},
 		[&](Switch& _switchStmt) -> OptionalStatements {
-			if (boost::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
+			if (std::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
 				return replaceConstArgSwitch(_switchStmt, constExprVal.get());
 			return {};
 		},
@@ -102,7 +102,7 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 
 bool StructuralSimplifier::expressionAlwaysTrue(Expression const& _expression)
 {
-	if (boost::optional<u256> value = hasLiteralValue(_expression))
+	if (std::optional<u256> value = hasLiteralValue(_expression))
 		return *value != 0;
 	else
 		return false;
@@ -110,16 +110,16 @@ bool StructuralSimplifier::expressionAlwaysTrue(Expression const& _expression)
 
 bool StructuralSimplifier::expressionAlwaysFalse(Expression const& _expression)
 {
-	if (boost::optional<u256> value = hasLiteralValue(_expression))
+	if (std::optional<u256> value = hasLiteralValue(_expression))
 		return *value == 0;
 	else
 		return false;
 }
 
-boost::optional<dev::u256> StructuralSimplifier::hasLiteralValue(Expression const& _expression) const
+std::optional<dev::u256> StructuralSimplifier::hasLiteralValue(Expression const& _expression) const
 {
 	if (_expression.type() == typeid(Literal))
 		return valueOfLiteral(boost::get<Literal>(_expression));
 	else
-		return boost::optional<u256>();
+		return std::optional<u256>();
 }

--- a/libyul/optimiser/StructuralSimplifier.h
+++ b/libyul/optimiser/StructuralSimplifier.h
@@ -45,7 +45,7 @@ private:
 	void simplify(std::vector<Statement>& _statements);
 	bool expressionAlwaysTrue(Expression const& _expression);
 	bool expressionAlwaysFalse(Expression const& _expression);
-	boost::optional<dev::u256> hasLiteralValue(Expression const& _expression) const;
+	std::optional<dev::u256> hasLiteralValue(Expression const& _expression) const;
 };
 
 }

--- a/libyul/optimiser/VarDeclInitializer.cpp
+++ b/libyul/optimiser/VarDeclInitializer.cpp
@@ -29,7 +29,7 @@ void VarDeclInitializer::operator()(Block& _block)
 {
 	ASTModifier::operator()(_block);
 
-	using OptionalStatements = boost::optional<vector<Statement>>;
+	using OptionalStatements = std::optional<vector<Statement>>;
 	GenericFallbackReturnsVisitor<OptionalStatements, VariableDeclaration> visitor{
 		[](VariableDeclaration& _varDecl) -> OptionalStatements
 		{

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -869,7 +869,7 @@ bool CommandLineInterface::processInput()
 	if (m_args.count(g_strEVMVersion))
 	{
 		string versionOptionStr = m_args[g_strEVMVersion].as<string>();
-		boost::optional<langutil::EVMVersion> versionOption = langutil::EVMVersion::fromString(versionOptionStr);
+		std::optional<langutil::EVMVersion> versionOption = langutil::EVMVersion::fromString(versionOptionStr);
 		if (!versionOption)
 		{
 			serr() << "Invalid option for --evm-version: " << versionOptionStr << endl;

--- a/test/Metadata.cpp
+++ b/test/Metadata.cpp
@@ -150,7 +150,7 @@ private:
 	bytes const& m_metadata;
 };
 
-boost::optional<map<string, string>> parseCBORMetadata(bytes const& _metadata)
+std::optional<map<string, string>> parseCBORMetadata(bytes const& _metadata)
 {
 	try
 	{

--- a/test/Metadata.h
+++ b/test/Metadata.h
@@ -21,7 +21,7 @@
 
 #include <libdevcore/CommonData.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <map>
 #include <string>
@@ -48,7 +48,7 @@ std::string bytecodeSansMetadata(std::string const& _bytecode);
 /// - bytes into hex strings
 /// - booleans into "true"/"false" strings
 /// - everything else is invalid
-boost::optional<std::map<std::string, std::string>> parseCBORMetadata(bytes const& _metadata);
+std::optional<std::map<std::string, std::string>> parseCBORMetadata(bytes const& _metadata);
 
 /// Expects a serialised metadata JSON and returns true if the
 /// content is valid metadata.

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -184,7 +184,7 @@ bool EVMVersionRestrictedTestCase::validateSettings(langutil::EVMVersion _evmVer
 			break;
 
 	versionString = versionString.substr(versionBegin);
-	boost::optional<langutil::EVMVersion> version = langutil::EVMVersion::fromString(versionString);
+	std::optional<langutil::EVMVersion> version = langutil::EVMVersion::fromString(versionString);
 	if (!version)
 		throw runtime_error("Invalid EVM version: \"" + versionString + "\"");
 

--- a/test/libdevcore/IterateReplacing.cpp
+++ b/test/libdevcore/IterateReplacing.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(IterateReplacing)
 BOOST_AUTO_TEST_CASE(no_replacement)
 {
 	vector<string> v{"abc", "def", "ghi"};
-	function<boost::optional<vector<string>>(string&)> f = [](string&) -> boost::optional<vector<string>> { return {}; };
+	function<std::optional<vector<string>>(string&)> f = [](string&) -> std::optional<vector<string>> { return {}; };
 	iterateReplacing(v, f);
 	vector<string> expectation{"abc", "def", "ghi"};
 	BOOST_CHECK(v == expectation);
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(no_replacement)
 BOOST_AUTO_TEST_CASE(empty_input)
 {
 	vector<string> v;
-	function<boost::optional<vector<string>>(string&)> f = [](string&) -> boost::optional<vector<string>> { return {}; };
+	function<std::optional<vector<string>>(string&)> f = [](string&) -> std::optional<vector<string>> { return {}; };
 	iterateReplacing(v, f);
 	vector<string> expectation;
 	BOOST_CHECK(v == expectation);
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(empty_input)
 BOOST_AUTO_TEST_CASE(delete_some)
 {
 	vector<string> v{"abc", "def", "ghi"};
-	function<boost::optional<vector<string>>(string&)> f = [](string& _s) -> boost::optional<vector<string>> {
+	function<std::optional<vector<string>>(string&)> f = [](string& _s) -> std::optional<vector<string>> {
 		if (_s == "def")
 			return vector<string>();
 		else
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(delete_some)
 BOOST_AUTO_TEST_CASE(inject_some_start)
 {
 	vector<string> v{"abc", "def", "ghi"};
-	function<boost::optional<vector<string>>(string&)> f = [](string& _s) -> boost::optional<vector<string>> {
+	function<std::optional<vector<string>>(string&)> f = [](string& _s) -> std::optional<vector<string>> {
 		if (_s == "abc")
 			return vector<string>{"x", "y"};
 		else
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(inject_some_start)
 BOOST_AUTO_TEST_CASE(inject_some_end)
 {
 	vector<string> v{"abc", "def", "ghi"};
-	function<boost::optional<vector<string>>(string&)> f = [](string& _s) -> boost::optional<vector<string>> {
+	function<std::optional<vector<string>>(string&)> f = [](string& _s) -> std::optional<vector<string>> {
 		if (_s == "ghi")
 			return vector<string>{"x", "y"};
 		else

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -34,7 +34,7 @@
 
 #include <libevmasm/Assembly.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/algorithm/string/replace.hpp>
 
 #include <string>
@@ -54,7 +54,7 @@ namespace test
 namespace
 {
 
-boost::optional<Error> parseAndReturnFirstError(
+std::optional<Error> parseAndReturnFirstError(
 	string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -41,7 +41,7 @@ map<string, string> requireParsedCBORMetadata(bytes const& _bytecode)
 {
 	bytes cborMetadata = dev::test::onlyMetadata(_bytecode);
 	BOOST_REQUIRE(!cborMetadata.empty());
-	boost::optional<map<string, string>> tmp = dev::test::parseCBORMetadata(cborMetadata);
+	std::optional<map<string, string>> tmp = dev::test::parseCBORMetadata(cborMetadata);
 	BOOST_REQUIRE(tmp);
 	return *tmp;
 }

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -104,7 +104,7 @@ public:
 
 	/// @returns the number of instructions in the given bytecode, not taking the metadata hash
 	/// into account.
-	size_t numInstructions(bytes const& _bytecode, boost::optional<Instruction> _which = boost::optional<Instruction>{})
+	size_t numInstructions(bytes const& _bytecode, std::optional<Instruction> _which = std::optional<Instruction>{})
 	{
 		bytes realCode = bytecodeSansMetadata(_bytecode);
 		BOOST_REQUIRE_MESSAGE(!realCode.empty(), "Invalid or missing metadata in bytecode.");

--- a/test/libsolidity/util/ContractABIUtils.cpp
+++ b/test/libsolidity/util/ContractABIUtils.cpp
@@ -141,14 +141,14 @@ string functionSignatureFromABI(Json::Value const& _functionABI)
 
 }
 
-boost::optional<dev::solidity::test::ParameterList> ContractABIUtils::parametersFromJsonOutputs(
+std::optional<dev::solidity::test::ParameterList> ContractABIUtils::parametersFromJsonOutputs(
 	ErrorReporter& _errorReporter,
 	Json::Value const& _contractABI,
 	string const& _functionSignature
 )
 {
 	if (!_contractABI)
-		return boost::none;
+		return std::nullopt;
 
 	for (auto const& function: _contractABI)
 		if (_functionSignature == functionSignatureFromABI(function))
@@ -177,17 +177,17 @@ boost::optional<dev::solidity::test::ParameterList> ContractABIUtils::parameters
 						"Could not convert \"" + type +
 						"\" to internal ABI type representation. Falling back to default encoding."
 					);
-					return boost::none;
+					return std::nullopt;
 				}
 
 				finalParams += inplaceTypeParams;
 
 				inplaceTypeParams.clear();
 			}
-			return boost::optional<ParameterList>(finalParams + dynamicTypeParams);
+			return std::optional<ParameterList>(finalParams + dynamicTypeParams);
 		}
 
-	return boost::none;
+	return std::nullopt;
 }
 
 bool ContractABIUtils::appendTypesFromName(

--- a/test/libsolidity/util/ContractABIUtils.h
+++ b/test/libsolidity/util/ContractABIUtils.h
@@ -42,7 +42,7 @@ public:
 	/// a list of internal type representations of isoltest.
 	/// Creates parameters from Contract ABI and is used to generate values for
 	/// auto-correction during interactive update routine.
-	static boost::optional<ParameterList> parametersFromJsonOutputs(
+	static std::optional<ParameterList> parametersFromJsonOutputs(
 		ErrorReporter& _errorReporter,
 		Json::Value const& _contractABI,
 		std::string const& _functionSignature

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -24,7 +24,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/throw_exception.hpp>
 
 #include <fstream>

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -124,12 +124,12 @@ string TestFunctionCall::format(
 
 			if (!matchesExpectation())
 			{
-				boost::optional<ParameterList> abiParams;
+				std::optional<ParameterList> abiParams;
 
 				if (isFailure)
 				{
 					if (!output.empty())
-						abiParams = boost::make_optional(ContractABIUtils::failureParameters(output));
+						abiParams = std::make_optional(ContractABIUtils::failureParameters(output));
 				}
 				else
 					abiParams = ContractABIUtils::parametersFromJsonOutputs(
@@ -208,7 +208,7 @@ string TestFunctionCall::formatBytesParameters(
 	}
 	else
 	{
-		boost::optional<ParameterList> abiParams = ContractABIUtils::parametersFromJsonOutputs(
+		std::optional<ParameterList> abiParams = ContractABIUtils::parametersFromJsonOutputs(
 			_errorReporter,
 			m_contractABI,
 			_signature
@@ -216,7 +216,7 @@ string TestFunctionCall::formatBytesParameters(
 
 		if (abiParams)
 		{
-			boost::optional<ParameterList> preferredParams = ContractABIUtils::preferredParameters(
+			std::optional<ParameterList> preferredParams = ContractABIUtils::preferredParameters(
 				_errorReporter,
 				_parameters,
 				abiParams.get(),

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -139,7 +139,7 @@ string TestFunctionCall::format(
 					);
 
 				string bytesOutput = abiParams ?
-					BytesUtils::formatRawBytes(output, abiParams.get(), _linePrefix) :
+					BytesUtils::formatRawBytes(output, abiParams.value(), _linePrefix) :
 					BytesUtils::formatRawBytes(
 						output,
 						ContractABIUtils::defaultParameters(ceil(output.size() / 32)),
@@ -219,14 +219,14 @@ string TestFunctionCall::formatBytesParameters(
 			std::optional<ParameterList> preferredParams = ContractABIUtils::preferredParameters(
 				_errorReporter,
 				_parameters,
-				abiParams.get(),
+				abiParams.value(),
 				_bytes
 			);
 
 			if (preferredParams)
 			{
-				ContractABIUtils::overwriteParameters(_errorReporter, preferredParams.get(), abiParams.get());
-				os << BytesUtils::formatBytesRange(_bytes, preferredParams.get(), _highlight);
+				ContractABIUtils::overwriteParameters(_errorReporter, preferredParams.value(), abiParams.value());
+				os << BytesUtils::formatBytesRange(_bytes, preferredParams.value(), _highlight);
 			}
 		}
 		else

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -27,7 +27,7 @@
 
 #include <libsolidity/interface/OptimiserSettings.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/algorithm/string/replace.hpp>
 
 #include <string>
@@ -63,7 +63,7 @@ std::pair<bool, ErrorList> parse(string const& _source)
 	return {false, {}};
 }
 
-boost::optional<Error> parseAndReturnFirstError(string const& _source, bool _allowWarnings = true)
+std::optional<Error> parseAndReturnFirstError(string const& _source, bool _allowWarnings = true)
 {
 	bool success;
 	ErrorList errors;

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -31,7 +31,7 @@
 #include <liblangutil/Scanner.h>
 #include <liblangutil/ErrorReporter.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/algorithm/string/replace.hpp>
 
 #include <string>
@@ -61,7 +61,7 @@ bool parse(string const& _source, Dialect const& _dialect, ErrorReporter& errorR
 			return (yul::AsmAnalyzer(
 				analysisInfo,
 				errorReporter,
-				boost::none,
+				std::nullopt,
 				_dialect
 			)).analyze(*parserResult);
 		}
@@ -73,7 +73,7 @@ bool parse(string const& _source, Dialect const& _dialect, ErrorReporter& errorR
 	return false;
 }
 
-boost::optional<Error> parseAndReturnFirstError(string const& _source, Dialect const& _dialect, bool _allowWarnings = true)
+std::optional<Error> parseAndReturnFirstError(string const& _source, Dialect const& _dialect, bool _allowWarnings = true)
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -350,7 +350,7 @@ void setupTerminal()
 #endif
 }
 
-boost::optional<TestStats> runTestSuite(
+std::optional<TestStats> runTestSuite(
 	TestCreator _testCaseCreator,
 	TestOptions const& _options,
 	fs::path const& _basePath,


### PR DESCRIPTION
### Description

Fixes one of three tasks of #7259 (_Replace boost constructs with their C++17 STL equivalents._)

The replacement was done in three steps, one commit each:

1. automatic replacements through find/sed commands in all .cpp and .h files (`#include <boost/optional.hpp>` -> `#include <optional>`, `boost::optional` -> `std::optional`, `boost::make_optional` -> `std::make_optional`, `boost::none` -> `std::nullopt`)
2. manual replacements of functions to test for initialization and get value (`boost::optional::is_initialized()` -> `std::optional::has_value()`, `boost::optional::get()` -> `std::optional::value()`)

3. manual replacements for conditional `boost::make_optional()` (there is no equivalent in std::optional C++17, see commit message for further explanation)

Compilation tested with clang 6.0.0. Running tests via `./scripts/test.sh` leads to 21 SolidityTests failures:
`*** 21 failures are detected in the test module "SolidityTests"`
but the number was exactly the same as for the latest commit in branch _develop_, hence I conclude that this PR doesn't break anything.