### PR TITLE
Removes the optionality on `output` in ABI docs.

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -444,17 +444,17 @@ JSON
 The JSON format for a contract's interface is given by an array of function and/or event descriptions.
 A function description is a JSON object with the fields:
 
-- ``type``: ``"function"``, ``"constructor"``, or ``"fallback"`` (the :ref:`unnamed "default" function <fallback-function>`);
-- ``name``: the name of the function;
+- ``type``: ``"function"``, ``"constructor"``, or ``"fallback"`` (the :ref:`unnamed "default" function <fallback-function>`).
+- ``name``: the name of the function.
 - ``inputs``: an array of objects, each of which contains:
 
-  * ``name``: the name of the parameter;
+  * ``name``: the name of the parameter.
   * ``type``: the canonical type of the parameter (more below).
   * ``components``: used for tuple types (more below).
 
-- ``outputs``: an array of objects similar to ``inputs``, can be omitted if function doesn't return anything;
-- ``stateMutability``: a string with one of the following values: ``pure`` (:ref:`specified to not read blockchain state <pure-functions>`), ``view`` (:ref:`specified to not modify the blockchain state <view-functions>`), ``nonpayable`` (function does not accept Ether) and ``payable`` (function accepts Ether);
-- ``payable``: ``true`` if function accepts Ether, ``false`` otherwise;
+- ``outputs``: an array of objects similar to ``inputs``.
+- ``stateMutability``: a string with one of the following values: ``pure`` (:ref:`specified to not read blockchain state <pure-functions>`), ``view`` (:ref:`specified to not modify the blockchain state <view-functions>`), ``nonpayable`` (function does not accept Ether) and ``payable`` (function accepts Ether).
+- ``payable``: ``true`` if function accepts Ether, ``false`` otherwise.
 - ``constant``: ``true`` if function is either ``pure`` or ``view``, ``false`` otherwise.
 
 ``type`` can be omitted, defaulting to ``"function"``, likewise ``payable`` and ``constant`` can be omitted, both defaulting to ``false``.
@@ -470,10 +470,10 @@ Constructor and fallback function never have ``name`` or ``outputs``. Fallback f
 An event description is a JSON object with fairly similar fields:
 
 - ``type``: always ``"event"``
-- ``name``: the name of the event;
+- ``name``: the name of the event.
 - ``inputs``: an array of objects, each of which contains:
 
-  * ``name``: the name of the parameter;
+  * ``name``: the name of the parameter.
   * ``type``: the canonical type of the parameter (more below).
   * ``components``: used for tuple types (more below).
   * ``indexed``: ``true`` if the field is part of the log's topics, ``false`` if it one of the log's data segment.


### PR DESCRIPTION
I _believe_ (someone more knowledgable than I should verify this claim) that Solidity will always write out an `output` member.  If there are no return parameters, then the array will be empty, but the `output` property will be present.

If this is not correct, I will withdraw this PR, but if the assertion is correct then the docs should reflect that so people can rely on the `output` property being present when writing ABI processors.

I also fixed some inconsistency in line termination character.  It was sometimes `.` and sometimes `;`.  I picked `.`, but don't really care which as long as it is consistent.

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
