### PR TITLE
Explicitly link against pthreads for static build.

### DIFF
--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -37,3 +37,7 @@ add_library(devcore ${sources})
 target_link_libraries(devcore PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::regex Boost::system)
 target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
 add_dependencies(devcore solidity_BuildInfo.h)
+
+if(SOLC_LINK_STATIC)
+	target_link_libraries(devcore PUBLIC Threads::Threads)
+endif()


### PR DESCRIPTION
This was removed in https://github.com/ethereum/solidity/pull/7205, but is apparently still needed for a static build.
Not sure if we should merge this into the release branch or how to deal with this now...
I started a build to check if this works here: https://launchpad.net/~ekpyron/+archive/ubuntu/ethereum-experimental/+build/17833626