### PR TITLE
Remove trailing spaces from JSON output

### DIFF
--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -24,6 +24,7 @@
 #include <libsolidity/ast/AST.h>
 #include <libyul/AsmData.h>
 #include <libyul/AsmPrinter.h>
+#include <libdevcore/JSON.h>
 #include <libdevcore/UTF8.h>
 #include <boost/algorithm/string/join.hpp>
 
@@ -189,7 +190,7 @@ Json::Value ASTJsonConverter::inlineAssemblyIdentifierToJson(pair<yul::Identifie
 
 void ASTJsonConverter::print(ostream& _stream, ASTNode const& _node)
 {
-	_stream << toJson(_node);
+	_stream << jsonPrettyPrint(toJson(_node));
 }
 
 Json::Value&& ASTJsonConverter::toJson(ASTNode const& _node)

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -6,7 +6,7 @@
 REPO_ROOT="$(dirname "$0")"/..
 cd $REPO_ROOT
 
-WHITESPACE=$(git grep -n -I -E "^.*[[:space:]]+$" | grep -v "test/libsolidity/ASTJSON\|test/libsolidity/ASTRecoveryTests\|test/compilationTests/zeppelin/LICENSE\|test/cmdlineTests/recovery_ast_constructor/output")
+WHITESPACE=$(git grep -n -I -E "^.*[[:space:]]+$" | grep -v "test/libsolidity/ASTJSON\|test/libsolidity/ASTRecoveryTests\|test/compilationTests/zeppelin/LICENSE")
 
 if [[ "$WHITESPACE" != "" ]]
 then

--- a/test/cmdlineTests/recovery_ast_constructor/output
+++ b/test/cmdlineTests/recovery_ast_constructor/output
@@ -3,242 +3,242 @@ JSON AST:
 
 ======= recovery_ast_constructor/input.sol =======
 {
-	"attributes" : 
-	{
-		"absolutePath" : "recovery_ast_constructor/input.sol",
-		"exportedSymbols" : 
-		{
-			"Error1" : 
-			[
-				18
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"literals" : 
-				[
-					"solidity",
-					">=",
-					"0.0",
-					".0"
-				]
-			},
-			"id" : 1,
-			"name" : "PragmaDirective",
-			"src" : "0:24:0"
-		},
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					18
-				],
-				"name" : "Error1",
-				"scope" : 19
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : true,
-						"kind" : "constructor",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "",
-						"overrides" : null,
-						"scope" : 18,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "57:2:0"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 3,
-							"name" : "ParameterList",
-							"src" : "67:0:0"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 8,
-							"name" : "Block",
-							"src" : "67:49:0"
-						}
-					],
-					"id" : 9,
-					"name" : "FunctionDefinition",
-					"src" : "46:70:0"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "five",
-						"overrides" : null,
-						"scope" : 18,
-						"stateMutability" : "view",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 10,
-							"name" : "ParameterList",
-							"src" : "382:2:0"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "",
-										"overrides" : null,
-										"scope" : 17,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "uint256",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"name" : "uint",
-												"type" : "uint256"
-											},
-											"id" : 11,
-											"name" : "ElementaryTypeName",
-											"src" : "405:4:0"
-										}
-									],
-									"id" : 12,
-									"name" : "VariableDeclaration",
-									"src" : "405:4:0"
-								}
-							],
-							"id" : 13,
-							"name" : "ParameterList",
-							"src" : "404:6:0"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"functionReturnParameters" : 13
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"hexvalue" : "35",
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : true,
-												"lValueRequested" : false,
-												"subdenomination" : null,
-												"token" : "number",
-												"type" : "int_const 5",
-												"value" : "5"
-											},
-											"id" : 14,
-											"name" : "Literal",
-											"src" : "424:1:0"
-										}
-									],
-									"id" : 15,
-									"name" : "Return",
-									"src" : "417:8:0"
-								}
-							],
-							"id" : 16,
-							"name" : "Block",
-							"src" : "411:19:0"
-						}
-					],
-					"id" : 17,
-					"name" : "FunctionDefinition",
-					"src" : "369:61:0"
-				}
-			],
-			"id" : 18,
-			"name" : "ContractDefinition",
-			"src" : "26:406:0"
-		}
-	],
-	"id" : 19,
-	"name" : "SourceUnit",
-	"src" : "0:433:0"
+  "attributes":
+  {
+    "absolutePath": "recovery_ast_constructor/input.sol",
+    "exportedSymbols":
+    {
+      "Error1":
+      [
+        18
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "literals":
+        [
+          "solidity",
+          ">=",
+          "0.0",
+          ".0"
+        ]
+      },
+      "id": 1,
+      "name": "PragmaDirective",
+      "src": "0:24:0"
+    },
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          18
+        ],
+        "name": "Error1",
+        "scope": 19
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": true,
+            "kind": "constructor",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "",
+            "overrides": null,
+            "scope": 18,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "57:2:0"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 3,
+              "name": "ParameterList",
+              "src": "67:0:0"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 8,
+              "name": "Block",
+              "src": "67:49:0"
+            }
+          ],
+          "id": 9,
+          "name": "FunctionDefinition",
+          "src": "46:70:0"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "five",
+            "overrides": null,
+            "scope": 18,
+            "stateMutability": "view",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 10,
+              "name": "ParameterList",
+              "src": "382:2:0"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "",
+                    "overrides": null,
+                    "scope": 17,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "uint256",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "name": "uint",
+                        "type": "uint256"
+                      },
+                      "id": 11,
+                      "name": "ElementaryTypeName",
+                      "src": "405:4:0"
+                    }
+                  ],
+                  "id": 12,
+                  "name": "VariableDeclaration",
+                  "src": "405:4:0"
+                }
+              ],
+              "id": 13,
+              "name": "ParameterList",
+              "src": "404:6:0"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "functionReturnParameters": 13
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "hexvalue": "35",
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "subdenomination": null,
+                        "token": "number",
+                        "type": "int_const 5",
+                        "value": "5"
+                      },
+                      "id": 14,
+                      "name": "Literal",
+                      "src": "424:1:0"
+                    }
+                  ],
+                  "id": 15,
+                  "name": "Return",
+                  "src": "417:8:0"
+                }
+              ],
+              "id": 16,
+              "name": "Block",
+              "src": "411:19:0"
+            }
+          ],
+          "id": 17,
+          "name": "FunctionDefinition",
+          "src": "369:61:0"
+        }
+      ],
+      "id": 18,
+      "name": "ContractDefinition",
+      "src": "26:406:0"
+    }
+  ],
+  "id": 19,
+  "name": "SourceUnit",
+  "src": "0:433:0"
 }

--- a/test/libsolidity/ASTJSON/address_payable.json
+++ b/test/libsolidity/ASTJSON/address_payable.json
@@ -1,568 +1,568 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			39
-		]
-	},
-	"id" : 40,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 39,
-			"linearizedBaseContracts" : 
-			[
-				39
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"constant" : false,
-					"id" : 4,
-					"name" : "m",
-					"nodeType" : "VariableDeclaration",
-					"overrides" : null,
-					"scope" : 39,
-					"src" : "17:44:1",
-					"stateVariable" : true,
-					"storageLocation" : "default",
-					"typeDescriptions" : 
-					{
-						"typeIdentifier" : "t_mapping$_t_address_$_t_address_payable_$",
-						"typeString" : "mapping(address => address payable)"
-					},
-					"typeName" : 
-					{
-						"id" : 3,
-						"keyType" : 
-						{
-							"id" : 1,
-							"name" : "address",
-							"nodeType" : "ElementaryTypeName",
-							"src" : "25:7:1",
-							"typeDescriptions" : 
-							{
-								"typeIdentifier" : "t_address",
-								"typeString" : "address"
-							}
-						},
-						"nodeType" : "Mapping",
-						"src" : "17:35:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_mapping$_t_address_$_t_address_payable_$",
-							"typeString" : "mapping(address => address payable)"
-						},
-						"valueType" : 
-						{
-							"id" : 2,
-							"name" : "address",
-							"nodeType" : "ElementaryTypeName",
-							"src" : "36:15:1",
-							"stateMutability" : "payable",
-							"typeDescriptions" : 
-							{
-								"typeIdentifier" : "t_address_payable",
-								"typeString" : "address payable"
-							}
-						}
-					},
-					"value" : null,
-					"visibility" : "public"
-				},
-				{
-					"body" : 
-					{
-						"id" : 37,
-						"nodeType" : "Block",
-						"src" : "134:122:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									12
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 12,
-										"name" : "a",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 37,
-										"src" : "144:17:1",
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address_payable",
-											"typeString" : "address payable"
-										},
-										"typeName" : 
-										{
-											"id" : 11,
-											"name" : "address",
-											"nodeType" : "ElementaryTypeName",
-											"src" : "144:15:1",
-											"stateMutability" : "payable",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_address_payable",
-												"typeString" : "address payable"
-											}
-										},
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 16,
-								"initialValue" : 
-								{
-									"argumentTypes" : null,
-									"baseExpression" : 
-									{
-										"argumentTypes" : null,
-										"id" : 13,
-										"name" : "m",
-										"nodeType" : "Identifier",
-										"overloadedDeclarations" : [],
-										"referencedDeclaration" : 4,
-										"src" : "164:1:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_mapping$_t_address_$_t_address_payable_$",
-											"typeString" : "mapping(address => address payable)"
-										}
-									},
-									"id" : 15,
-									"indexExpression" : 
-									{
-										"argumentTypes" : null,
-										"id" : 14,
-										"name" : "arg",
-										"nodeType" : "Identifier",
-										"overloadedDeclarations" : [],
-										"referencedDeclaration" : 6,
-										"src" : "166:3:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address_payable",
-											"typeString" : "address payable"
-										}
-									},
-									"isConstant" : false,
-									"isLValue" : true,
-									"isPure" : false,
-									"lValueRequested" : false,
-									"nodeType" : "IndexAccess",
-									"src" : "164:6:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_address_payable",
-										"typeString" : "address payable"
-									}
-								},
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "144:26:1"
-							},
-							{
-								"expression" : 
-								{
-									"argumentTypes" : null,
-									"id" : 19,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : false,
-									"lValueRequested" : false,
-									"leftHandSide" : 
-									{
-										"argumentTypes" : null,
-										"id" : 17,
-										"name" : "r",
-										"nodeType" : "Identifier",
-										"overloadedDeclarations" : [],
-										"referencedDeclaration" : 9,
-										"src" : "180:1:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address_payable",
-											"typeString" : "address payable"
-										}
-									},
-									"nodeType" : "Assignment",
-									"operator" : "=",
-									"rightHandSide" : 
-									{
-										"argumentTypes" : null,
-										"id" : 18,
-										"name" : "arg",
-										"nodeType" : "Identifier",
-										"overloadedDeclarations" : [],
-										"referencedDeclaration" : 6,
-										"src" : "184:3:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address_payable",
-											"typeString" : "address payable"
-										}
-									},
-									"src" : "180:7:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_address_payable",
-										"typeString" : "address payable"
-									}
-								},
-								"id" : 20,
-								"nodeType" : "ExpressionStatement",
-								"src" : "180:7:1"
-							},
-							{
-								"assignments" : 
-								[
-									22
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 22,
-										"name" : "c",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 37,
-										"src" : "197:9:1",
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address",
-											"typeString" : "address"
-										},
-										"typeName" : 
-										{
-											"id" : 21,
-											"name" : "address",
-											"nodeType" : "ElementaryTypeName",
-											"src" : "197:7:1",
-											"stateMutability" : "nonpayable",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_address",
-												"typeString" : "address"
-											}
-										},
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 27,
-								"initialValue" : 
-								{
-									"argumentTypes" : null,
-									"arguments" : 
-									[
-										{
-											"argumentTypes" : null,
-											"id" : 25,
-											"name" : "this",
-											"nodeType" : "Identifier",
-											"overloadedDeclarations" : [],
-											"referencedDeclaration" : 68,
-											"src" : "217:4:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_contract$_C_$39",
-												"typeString" : "contract C"
-											}
-										}
-									],
-									"expression" : 
-									{
-										"argumentTypes" : 
-										[
-											{
-												"typeIdentifier" : "t_contract$_C_$39",
-												"typeString" : "contract C"
-											}
-										],
-										"id" : 24,
-										"isConstant" : false,
-										"isLValue" : false,
-										"isPure" : true,
-										"lValueRequested" : false,
-										"nodeType" : "ElementaryTypeNameExpression",
-										"src" : "209:7:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_type$_t_address_$",
-											"typeString" : "type(address)"
-										},
-										"typeName" : "address"
-									},
-									"id" : 26,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : false,
-									"kind" : "typeConversion",
-									"lValueRequested" : false,
-									"names" : [],
-									"nodeType" : "FunctionCall",
-									"src" : "209:13:1",
-									"tryCall" : false,
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_address",
-										"typeString" : "address"
-									}
-								},
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "197:25:1"
-							},
-							{
-								"expression" : 
-								{
-									"argumentTypes" : null,
-									"id" : 35,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : false,
-									"lValueRequested" : false,
-									"leftHandSide" : 
-									{
-										"argumentTypes" : null,
-										"baseExpression" : 
-										{
-											"argumentTypes" : null,
-											"id" : 28,
-											"name" : "m",
-											"nodeType" : "Identifier",
-											"overloadedDeclarations" : [],
-											"referencedDeclaration" : 4,
-											"src" : "232:1:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_mapping$_t_address_$_t_address_payable_$",
-												"typeString" : "mapping(address => address payable)"
-											}
-										},
-										"id" : 30,
-										"indexExpression" : 
-										{
-											"argumentTypes" : null,
-											"id" : 29,
-											"name" : "c",
-											"nodeType" : "Identifier",
-											"overloadedDeclarations" : [],
-											"referencedDeclaration" : 22,
-											"src" : "234:1:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_address",
-												"typeString" : "address"
-											}
-										},
-										"isConstant" : false,
-										"isLValue" : true,
-										"isPure" : false,
-										"lValueRequested" : true,
-										"nodeType" : "IndexAccess",
-										"src" : "232:4:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address_payable",
-											"typeString" : "address payable"
-										}
-									},
-									"nodeType" : "Assignment",
-									"operator" : "=",
-									"rightHandSide" : 
-									{
-										"argumentTypes" : null,
-										"arguments" : 
-										[
-											{
-												"argumentTypes" : null,
-												"hexValue" : "30",
-												"id" : 33,
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : true,
-												"kind" : "number",
-												"lValueRequested" : false,
-												"nodeType" : "Literal",
-												"src" : "247:1:1",
-												"subdenomination" : null,
-												"typeDescriptions" : 
-												{
-													"typeIdentifier" : "t_rational_0_by_1",
-													"typeString" : "int_const 0"
-												},
-												"value" : "0"
-											}
-										],
-										"expression" : 
-										{
-											"argumentTypes" : 
-											[
-												{
-													"typeIdentifier" : "t_rational_0_by_1",
-													"typeString" : "int_const 0"
-												}
-											],
-											"id" : 32,
-											"isConstant" : false,
-											"isLValue" : false,
-											"isPure" : true,
-											"lValueRequested" : false,
-											"nodeType" : "ElementaryTypeNameExpression",
-											"src" : "239:7:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_type$_t_address_$",
-												"typeString" : "type(address)"
-											},
-											"typeName" : "address"
-										},
-										"id" : 34,
-										"isConstant" : false,
-										"isLValue" : false,
-										"isPure" : true,
-										"kind" : "typeConversion",
-										"lValueRequested" : false,
-										"names" : [],
-										"nodeType" : "FunctionCall",
-										"src" : "239:10:1",
-										"tryCall" : false,
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_address_payable",
-											"typeString" : "address payable"
-										}
-									},
-									"src" : "232:17:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_address_payable",
-										"typeString" : "address payable"
-									}
-								},
-								"id" : 36,
-								"nodeType" : "ExpressionStatement",
-								"src" : "232:17:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 38,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 7,
-						"nodeType" : "ParameterList",
-						"parameters" : 
-						[
-							{
-								"constant" : false,
-								"id" : 6,
-								"name" : "arg",
-								"nodeType" : "VariableDeclaration",
-								"overrides" : null,
-								"scope" : 38,
-								"src" : "78:19:1",
-								"stateVariable" : false,
-								"storageLocation" : "default",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_address_payable",
-									"typeString" : "address payable"
-								},
-								"typeName" : 
-								{
-									"id" : 5,
-									"name" : "address",
-									"nodeType" : "ElementaryTypeName",
-									"src" : "78:15:1",
-									"stateMutability" : "payable",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_address_payable",
-										"typeString" : "address payable"
-									}
-								},
-								"value" : null,
-								"visibility" : "internal"
-							}
-						],
-						"src" : "77:21:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 10,
-						"nodeType" : "ParameterList",
-						"parameters" : 
-						[
-							{
-								"constant" : false,
-								"id" : 9,
-								"name" : "r",
-								"nodeType" : "VariableDeclaration",
-								"overrides" : null,
-								"scope" : 38,
-								"src" : "115:17:1",
-								"stateVariable" : false,
-								"storageLocation" : "default",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_address_payable",
-									"typeString" : "address payable"
-								},
-								"typeName" : 
-								{
-									"id" : 8,
-									"name" : "address",
-									"nodeType" : "ElementaryTypeName",
-									"src" : "115:15:1",
-									"stateMutability" : "payable",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_address_payable",
-										"typeString" : "address payable"
-									}
-								},
-								"value" : null,
-								"visibility" : "internal"
-							}
-						],
-						"src" : "114:19:1"
-					},
-					"scope" : 39,
-					"src" : "67:189:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 40,
-			"src" : "0:258:1"
-		}
-	],
-	"src" : "0:259:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      39
+    ]
+  },
+  "id": 40,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 39,
+      "linearizedBaseContracts":
+      [
+        39
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 4,
+          "name": "m",
+          "nodeType": "VariableDeclaration",
+          "overrides": null,
+          "scope": 39,
+          "src": "17:44:1",
+          "stateVariable": true,
+          "storageLocation": "default",
+          "typeDescriptions":
+          {
+            "typeIdentifier": "t_mapping$_t_address_$_t_address_payable_$",
+            "typeString": "mapping(address => address payable)"
+          },
+          "typeName":
+          {
+            "id": 3,
+            "keyType":
+            {
+              "id": 1,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "25:7:1",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "nodeType": "Mapping",
+            "src": "17:35:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_mapping$_t_address_$_t_address_payable_$",
+              "typeString": "mapping(address => address payable)"
+            },
+            "valueType":
+            {
+              "id": 2,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "36:15:1",
+              "stateMutability": "payable",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_address_payable",
+                "typeString": "address payable"
+              }
+            }
+          },
+          "value": null,
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 37,
+            "nodeType": "Block",
+            "src": "134:122:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  12
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 12,
+                    "name": "a",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 37,
+                    "src": "144:17:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    },
+                    "typeName":
+                    {
+                      "id": 11,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "144:15:1",
+                      "stateMutability": "payable",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_address_payable",
+                        "typeString": "address payable"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 16,
+                "initialValue":
+                {
+                  "argumentTypes": null,
+                  "baseExpression":
+                  {
+                    "argumentTypes": null,
+                    "id": 13,
+                    "name": "m",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 4,
+                    "src": "164:1:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_mapping$_t_address_$_t_address_payable_$",
+                      "typeString": "mapping(address => address payable)"
+                    }
+                  },
+                  "id": 15,
+                  "indexExpression":
+                  {
+                    "argumentTypes": null,
+                    "id": 14,
+                    "name": "arg",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 6,
+                    "src": "166:3:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "isConstant": false,
+                  "isLValue": true,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "nodeType": "IndexAccess",
+                  "src": "164:6:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  }
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "144:26:1"
+              },
+              {
+                "expression":
+                {
+                  "argumentTypes": null,
+                  "id": 19,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "leftHandSide":
+                  {
+                    "argumentTypes": null,
+                    "id": 17,
+                    "name": "r",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 9,
+                    "src": "180:1:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "nodeType": "Assignment",
+                  "operator": "=",
+                  "rightHandSide":
+                  {
+                    "argumentTypes": null,
+                    "id": 18,
+                    "name": "arg",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 6,
+                    "src": "184:3:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "src": "180:7:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  }
+                },
+                "id": 20,
+                "nodeType": "ExpressionStatement",
+                "src": "180:7:1"
+              },
+              {
+                "assignments":
+                [
+                  22
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 22,
+                    "name": "c",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 37,
+                    "src": "197:9:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    },
+                    "typeName":
+                    {
+                      "id": 21,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "197:7:1",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 27,
+                "initialValue":
+                {
+                  "argumentTypes": null,
+                  "arguments":
+                  [
+                    {
+                      "argumentTypes": null,
+                      "id": 25,
+                      "name": "this",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 68,
+                      "src": "217:4:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_contract$_C_$39",
+                        "typeString": "contract C"
+                      }
+                    }
+                  ],
+                  "expression":
+                  {
+                    "argumentTypes":
+                    [
+                      {
+                        "typeIdentifier": "t_contract$_C_$39",
+                        "typeString": "contract C"
+                      }
+                    ],
+                    "id": 24,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "nodeType": "ElementaryTypeNameExpression",
+                    "src": "209:7:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_type$_t_address_$",
+                      "typeString": "type(address)"
+                    },
+                    "typeName": "address"
+                  },
+                  "id": 26,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "typeConversion",
+                  "lValueRequested": false,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "209:13:1",
+                  "tryCall": false,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "197:25:1"
+              },
+              {
+                "expression":
+                {
+                  "argumentTypes": null,
+                  "id": 35,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "leftHandSide":
+                  {
+                    "argumentTypes": null,
+                    "baseExpression":
+                    {
+                      "argumentTypes": null,
+                      "id": 28,
+                      "name": "m",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 4,
+                      "src": "232:1:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_mapping$_t_address_$_t_address_payable_$",
+                        "typeString": "mapping(address => address payable)"
+                      }
+                    },
+                    "id": 30,
+                    "indexExpression":
+                    {
+                      "argumentTypes": null,
+                      "id": 29,
+                      "name": "c",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 22,
+                      "src": "234:1:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "isConstant": false,
+                    "isLValue": true,
+                    "isPure": false,
+                    "lValueRequested": true,
+                    "nodeType": "IndexAccess",
+                    "src": "232:4:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "nodeType": "Assignment",
+                  "operator": "=",
+                  "rightHandSide":
+                  {
+                    "argumentTypes": null,
+                    "arguments":
+                    [
+                      {
+                        "argumentTypes": null,
+                        "hexValue": "30",
+                        "id": 33,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "number",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "247:1:1",
+                        "subdenomination": null,
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_rational_0_by_1",
+                          "typeString": "int_const 0"
+                        },
+                        "value": "0"
+                      }
+                    ],
+                    "expression":
+                    {
+                      "argumentTypes":
+                      [
+                        {
+                          "typeIdentifier": "t_rational_0_by_1",
+                          "typeString": "int_const 0"
+                        }
+                      ],
+                      "id": 32,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "239:7:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_type$_t_address_$",
+                        "typeString": "type(address)"
+                      },
+                      "typeName": "address"
+                    },
+                    "id": 34,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "kind": "typeConversion",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "239:10:1",
+                    "tryCall": false,
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "src": "232:17:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  }
+                },
+                "id": 36,
+                "nodeType": "ExpressionStatement",
+                "src": "232:17:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 38,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 6,
+                "name": "arg",
+                "nodeType": "VariableDeclaration",
+                "overrides": null,
+                "scope": 38,
+                "src": "78:19:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_address_payable",
+                  "typeString": "address payable"
+                },
+                "typeName":
+                {
+                  "id": 5,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "78:15:1",
+                  "stateMutability": "payable",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "src": "77:21:1"
+          },
+          "returnParameters":
+          {
+            "id": 10,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 9,
+                "name": "r",
+                "nodeType": "VariableDeclaration",
+                "overrides": null,
+                "scope": 38,
+                "src": "115:17:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_address_payable",
+                  "typeString": "address payable"
+                },
+                "typeName":
+                {
+                  "id": 8,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "115:15:1",
+                  "stateMutability": "payable",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "src": "114:19:1"
+          },
+          "scope": 39,
+          "src": "67:189:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 40,
+      "src": "0:258:1"
+    }
+  ],
+  "src": "0:259:1"
 }

--- a/test/libsolidity/ASTJSON/address_payable_legacy.json
+++ b/test/libsolidity/ASTJSON/address_payable_legacy.json
@@ -1,609 +1,609 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				39
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					39
-				],
-				"name" : "C",
-				"scope" : 40
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"constant" : false,
-						"name" : "m",
-						"overrides" : null,
-						"scope" : 39,
-						"stateVariable" : true,
-						"storageLocation" : "default",
-						"type" : "mapping(address => address payable)",
-						"value" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"type" : "mapping(address => address payable)"
-							},
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"name" : "address",
-										"type" : "address"
-									},
-									"id" : 1,
-									"name" : "ElementaryTypeName",
-									"src" : "25:7:1"
-								},
-								{
-									"attributes" : 
-									{
-										"name" : "address",
-										"stateMutability" : "payable",
-										"type" : "address payable"
-									},
-									"id" : 2,
-									"name" : "ElementaryTypeName",
-									"src" : "36:15:1"
-								}
-							],
-							"id" : 3,
-							"name" : "Mapping",
-							"src" : "17:35:1"
-						}
-					],
-					"id" : 4,
-					"name" : "VariableDeclaration",
-					"src" : "17:44:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 39,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "arg",
-										"overrides" : null,
-										"scope" : 38,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "address payable",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"name" : "address",
-												"stateMutability" : "payable",
-												"type" : "address payable"
-											},
-											"id" : 5,
-											"name" : "ElementaryTypeName",
-											"src" : "78:15:1"
-										}
-									],
-									"id" : 6,
-									"name" : "VariableDeclaration",
-									"src" : "78:19:1"
-								}
-							],
-							"id" : 7,
-							"name" : "ParameterList",
-							"src" : "77:21:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "r",
-										"overrides" : null,
-										"scope" : 38,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "address payable",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"name" : "address",
-												"stateMutability" : "payable",
-												"type" : "address payable"
-											},
-											"id" : 8,
-											"name" : "ElementaryTypeName",
-											"src" : "115:15:1"
-										}
-									],
-									"id" : 9,
-									"name" : "VariableDeclaration",
-									"src" : "115:17:1"
-								}
-							],
-							"id" : 10,
-							"name" : "ParameterList",
-							"src" : "114:19:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											12
-										]
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "a",
-												"overrides" : null,
-												"scope" : 37,
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"type" : "address payable",
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"name" : "address",
-														"stateMutability" : "payable",
-														"type" : "address payable"
-													},
-													"id" : 11,
-													"name" : "ElementaryTypeName",
-													"src" : "144:15:1"
-												}
-											],
-											"id" : 12,
-											"name" : "VariableDeclaration",
-											"src" : "144:17:1"
-										},
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"isConstant" : false,
-												"isLValue" : true,
-												"isPure" : false,
-												"lValueRequested" : false,
-												"type" : "address payable"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"overloadedDeclarations" : 
-														[
-															null
-														],
-														"referencedDeclaration" : 4,
-														"type" : "mapping(address => address payable)",
-														"value" : "m"
-													},
-													"id" : 13,
-													"name" : "Identifier",
-													"src" : "164:1:1"
-												},
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"overloadedDeclarations" : 
-														[
-															null
-														],
-														"referencedDeclaration" : 6,
-														"type" : "address payable",
-														"value" : "arg"
-													},
-													"id" : 14,
-													"name" : "Identifier",
-													"src" : "166:3:1"
-												}
-											],
-											"id" : 15,
-											"name" : "IndexAccess",
-											"src" : "164:6:1"
-										}
-									],
-									"id" : 16,
-									"name" : "VariableDeclarationStatement",
-									"src" : "144:26:1"
-								},
-								{
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : false,
-												"lValueRequested" : false,
-												"operator" : "=",
-												"type" : "address payable"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"overloadedDeclarations" : 
-														[
-															null
-														],
-														"referencedDeclaration" : 9,
-														"type" : "address payable",
-														"value" : "r"
-													},
-													"id" : 17,
-													"name" : "Identifier",
-													"src" : "180:1:1"
-												},
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"overloadedDeclarations" : 
-														[
-															null
-														],
-														"referencedDeclaration" : 6,
-														"type" : "address payable",
-														"value" : "arg"
-													},
-													"id" : 18,
-													"name" : "Identifier",
-													"src" : "184:3:1"
-												}
-											],
-											"id" : 19,
-											"name" : "Assignment",
-											"src" : "180:7:1"
-										}
-									],
-									"id" : 20,
-									"name" : "ExpressionStatement",
-									"src" : "180:7:1"
-								},
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											22
-										]
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "c",
-												"overrides" : null,
-												"scope" : 37,
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"type" : "address",
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"name" : "address",
-														"stateMutability" : "nonpayable",
-														"type" : "address"
-													},
-													"id" : 21,
-													"name" : "ElementaryTypeName",
-													"src" : "197:7:1"
-												}
-											],
-											"id" : 22,
-											"name" : "VariableDeclaration",
-											"src" : "197:9:1"
-										},
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : false,
-												"isStructConstructorCall" : false,
-												"lValueRequested" : false,
-												"names" : 
-												[
-													null
-												],
-												"tryCall" : false,
-												"type" : "address",
-												"type_conversion" : true
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : 
-														[
-															{
-																"typeIdentifier" : "t_contract$_C_$39",
-																"typeString" : "contract C"
-															}
-														],
-														"isConstant" : false,
-														"isLValue" : false,
-														"isPure" : true,
-														"lValueRequested" : false,
-														"type" : "type(address)",
-														"value" : "address"
-													},
-													"id" : 24,
-													"name" : "ElementaryTypeNameExpression",
-													"src" : "209:7:1"
-												},
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"overloadedDeclarations" : 
-														[
-															null
-														],
-														"referencedDeclaration" : 68,
-														"type" : "contract C",
-														"value" : "this"
-													},
-													"id" : 25,
-													"name" : "Identifier",
-													"src" : "217:4:1"
-												}
-											],
-											"id" : 26,
-											"name" : "FunctionCall",
-											"src" : "209:13:1"
-										}
-									],
-									"id" : 27,
-									"name" : "VariableDeclarationStatement",
-									"src" : "197:25:1"
-								},
-								{
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : false,
-												"lValueRequested" : false,
-												"operator" : "=",
-												"type" : "address payable"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"isConstant" : false,
-														"isLValue" : true,
-														"isPure" : false,
-														"lValueRequested" : true,
-														"type" : "address payable"
-													},
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"argumentTypes" : null,
-																"overloadedDeclarations" : 
-																[
-																	null
-																],
-																"referencedDeclaration" : 4,
-																"type" : "mapping(address => address payable)",
-																"value" : "m"
-															},
-															"id" : 28,
-															"name" : "Identifier",
-															"src" : "232:1:1"
-														},
-														{
-															"attributes" : 
-															{
-																"argumentTypes" : null,
-																"overloadedDeclarations" : 
-																[
-																	null
-																],
-																"referencedDeclaration" : 22,
-																"type" : "address",
-																"value" : "c"
-															},
-															"id" : 29,
-															"name" : "Identifier",
-															"src" : "234:1:1"
-														}
-													],
-													"id" : 30,
-													"name" : "IndexAccess",
-													"src" : "232:4:1"
-												},
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"isConstant" : false,
-														"isLValue" : false,
-														"isPure" : true,
-														"isStructConstructorCall" : false,
-														"lValueRequested" : false,
-														"names" : 
-														[
-															null
-														],
-														"tryCall" : false,
-														"type" : "address payable",
-														"type_conversion" : true
-													},
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"argumentTypes" : 
-																[
-																	{
-																		"typeIdentifier" : "t_rational_0_by_1",
-																		"typeString" : "int_const 0"
-																	}
-																],
-																"isConstant" : false,
-																"isLValue" : false,
-																"isPure" : true,
-																"lValueRequested" : false,
-																"type" : "type(address)",
-																"value" : "address"
-															},
-															"id" : 32,
-															"name" : "ElementaryTypeNameExpression",
-															"src" : "239:7:1"
-														},
-														{
-															"attributes" : 
-															{
-																"argumentTypes" : null,
-																"hexvalue" : "30",
-																"isConstant" : false,
-																"isLValue" : false,
-																"isPure" : true,
-																"lValueRequested" : false,
-																"subdenomination" : null,
-																"token" : "number",
-																"type" : "int_const 0",
-																"value" : "0"
-															},
-															"id" : 33,
-															"name" : "Literal",
-															"src" : "247:1:1"
-														}
-													],
-													"id" : 34,
-													"name" : "FunctionCall",
-													"src" : "239:10:1"
-												}
-											],
-											"id" : 35,
-											"name" : "Assignment",
-											"src" : "232:17:1"
-										}
-									],
-									"id" : 36,
-									"name" : "ExpressionStatement",
-									"src" : "232:17:1"
-								}
-							],
-							"id" : 37,
-							"name" : "Block",
-							"src" : "134:122:1"
-						}
-					],
-					"id" : 38,
-					"name" : "FunctionDefinition",
-					"src" : "67:189:1"
-				}
-			],
-			"id" : 39,
-			"name" : "ContractDefinition",
-			"src" : "0:258:1"
-		}
-	],
-	"id" : 40,
-	"name" : "SourceUnit",
-	"src" : "0:259:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        39
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          39
+        ],
+        "name": "C",
+        "scope": 40
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "constant": false,
+            "name": "m",
+            "overrides": null,
+            "scope": 39,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "type": "mapping(address => address payable)",
+            "value": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "type": "mapping(address => address payable)"
+              },
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "name": "address",
+                    "type": "address"
+                  },
+                  "id": 1,
+                  "name": "ElementaryTypeName",
+                  "src": "25:7:1"
+                },
+                {
+                  "attributes":
+                  {
+                    "name": "address",
+                    "stateMutability": "payable",
+                    "type": "address payable"
+                  },
+                  "id": 2,
+                  "name": "ElementaryTypeName",
+                  "src": "36:15:1"
+                }
+              ],
+              "id": 3,
+              "name": "Mapping",
+              "src": "17:35:1"
+            }
+          ],
+          "id": 4,
+          "name": "VariableDeclaration",
+          "src": "17:44:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 39,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "arg",
+                    "overrides": null,
+                    "scope": 38,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "address payable",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "name": "address",
+                        "stateMutability": "payable",
+                        "type": "address payable"
+                      },
+                      "id": 5,
+                      "name": "ElementaryTypeName",
+                      "src": "78:15:1"
+                    }
+                  ],
+                  "id": 6,
+                  "name": "VariableDeclaration",
+                  "src": "78:19:1"
+                }
+              ],
+              "id": 7,
+              "name": "ParameterList",
+              "src": "77:21:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "r",
+                    "overrides": null,
+                    "scope": 38,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "address payable",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "name": "address",
+                        "stateMutability": "payable",
+                        "type": "address payable"
+                      },
+                      "id": 8,
+                      "name": "ElementaryTypeName",
+                      "src": "115:15:1"
+                    }
+                  ],
+                  "id": 9,
+                  "name": "VariableDeclaration",
+                  "src": "115:17:1"
+                }
+              ],
+              "id": 10,
+              "name": "ParameterList",
+              "src": "114:19:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      12
+                    ]
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "a",
+                        "overrides": null,
+                        "scope": 37,
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "type": "address payable",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "name": "address",
+                            "stateMutability": "payable",
+                            "type": "address payable"
+                          },
+                          "id": 11,
+                          "name": "ElementaryTypeName",
+                          "src": "144:15:1"
+                        }
+                      ],
+                      "id": 12,
+                      "name": "VariableDeclaration",
+                      "src": "144:17:1"
+                    },
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "type": "address payable"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "overloadedDeclarations":
+                            [
+                              null
+                            ],
+                            "referencedDeclaration": 4,
+                            "type": "mapping(address => address payable)",
+                            "value": "m"
+                          },
+                          "id": 13,
+                          "name": "Identifier",
+                          "src": "164:1:1"
+                        },
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "overloadedDeclarations":
+                            [
+                              null
+                            ],
+                            "referencedDeclaration": 6,
+                            "type": "address payable",
+                            "value": "arg"
+                          },
+                          "id": 14,
+                          "name": "Identifier",
+                          "src": "166:3:1"
+                        }
+                      ],
+                      "id": 15,
+                      "name": "IndexAccess",
+                      "src": "164:6:1"
+                    }
+                  ],
+                  "id": 16,
+                  "name": "VariableDeclarationStatement",
+                  "src": "144:26:1"
+                },
+                {
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "operator": "=",
+                        "type": "address payable"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "overloadedDeclarations":
+                            [
+                              null
+                            ],
+                            "referencedDeclaration": 9,
+                            "type": "address payable",
+                            "value": "r"
+                          },
+                          "id": 17,
+                          "name": "Identifier",
+                          "src": "180:1:1"
+                        },
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "overloadedDeclarations":
+                            [
+                              null
+                            ],
+                            "referencedDeclaration": 6,
+                            "type": "address payable",
+                            "value": "arg"
+                          },
+                          "id": 18,
+                          "name": "Identifier",
+                          "src": "184:3:1"
+                        }
+                      ],
+                      "id": 19,
+                      "name": "Assignment",
+                      "src": "180:7:1"
+                    }
+                  ],
+                  "id": 20,
+                  "name": "ExpressionStatement",
+                  "src": "180:7:1"
+                },
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      22
+                    ]
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "c",
+                        "overrides": null,
+                        "scope": 37,
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "type": "address",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "name": "address",
+                            "stateMutability": "nonpayable",
+                            "type": "address"
+                          },
+                          "id": 21,
+                          "name": "ElementaryTypeName",
+                          "src": "197:7:1"
+                        }
+                      ],
+                      "id": 22,
+                      "name": "VariableDeclaration",
+                      "src": "197:9:1"
+                    },
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "isStructConstructorCall": false,
+                        "lValueRequested": false,
+                        "names":
+                        [
+                          null
+                        ],
+                        "tryCall": false,
+                        "type": "address",
+                        "type_conversion": true
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes":
+                            [
+                              {
+                                "typeIdentifier": "t_contract$_C_$39",
+                                "typeString": "contract C"
+                              }
+                            ],
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "type": "type(address)",
+                            "value": "address"
+                          },
+                          "id": 24,
+                          "name": "ElementaryTypeNameExpression",
+                          "src": "209:7:1"
+                        },
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "overloadedDeclarations":
+                            [
+                              null
+                            ],
+                            "referencedDeclaration": 68,
+                            "type": "contract C",
+                            "value": "this"
+                          },
+                          "id": 25,
+                          "name": "Identifier",
+                          "src": "217:4:1"
+                        }
+                      ],
+                      "id": 26,
+                      "name": "FunctionCall",
+                      "src": "209:13:1"
+                    }
+                  ],
+                  "id": 27,
+                  "name": "VariableDeclarationStatement",
+                  "src": "197:25:1"
+                },
+                {
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "operator": "=",
+                        "type": "address payable"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "isConstant": false,
+                            "isLValue": true,
+                            "isPure": false,
+                            "lValueRequested": true,
+                            "type": "address payable"
+                          },
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "argumentTypes": null,
+                                "overloadedDeclarations":
+                                [
+                                  null
+                                ],
+                                "referencedDeclaration": 4,
+                                "type": "mapping(address => address payable)",
+                                "value": "m"
+                              },
+                              "id": 28,
+                              "name": "Identifier",
+                              "src": "232:1:1"
+                            },
+                            {
+                              "attributes":
+                              {
+                                "argumentTypes": null,
+                                "overloadedDeclarations":
+                                [
+                                  null
+                                ],
+                                "referencedDeclaration": 22,
+                                "type": "address",
+                                "value": "c"
+                              },
+                              "id": 29,
+                              "name": "Identifier",
+                              "src": "234:1:1"
+                            }
+                          ],
+                          "id": 30,
+                          "name": "IndexAccess",
+                          "src": "232:4:1"
+                        },
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "isStructConstructorCall": false,
+                            "lValueRequested": false,
+                            "names":
+                            [
+                              null
+                            ],
+                            "tryCall": false,
+                            "type": "address payable",
+                            "type_conversion": true
+                          },
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "argumentTypes":
+                                [
+                                  {
+                                    "typeIdentifier": "t_rational_0_by_1",
+                                    "typeString": "int_const 0"
+                                  }
+                                ],
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "lValueRequested": false,
+                                "type": "type(address)",
+                                "value": "address"
+                              },
+                              "id": 32,
+                              "name": "ElementaryTypeNameExpression",
+                              "src": "239:7:1"
+                            },
+                            {
+                              "attributes":
+                              {
+                                "argumentTypes": null,
+                                "hexvalue": "30",
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "lValueRequested": false,
+                                "subdenomination": null,
+                                "token": "number",
+                                "type": "int_const 0",
+                                "value": "0"
+                              },
+                              "id": 33,
+                              "name": "Literal",
+                              "src": "247:1:1"
+                            }
+                          ],
+                          "id": 34,
+                          "name": "FunctionCall",
+                          "src": "239:10:1"
+                        }
+                      ],
+                      "id": 35,
+                      "name": "Assignment",
+                      "src": "232:17:1"
+                    }
+                  ],
+                  "id": 36,
+                  "name": "ExpressionStatement",
+                  "src": "232:17:1"
+                }
+              ],
+              "id": 37,
+              "name": "Block",
+              "src": "134:122:1"
+            }
+          ],
+          "id": 38,
+          "name": "FunctionDefinition",
+          "src": "67:189:1"
+        }
+      ],
+      "id": 39,
+      "name": "ContractDefinition",
+      "src": "0:258:1"
+    }
+  ],
+  "id": 40,
+  "name": "SourceUnit",
+  "src": "0:259:1"
 }

--- a/test/libsolidity/ASTJSON/array_type_name.json
+++ b/test/libsolidity/ASTJSON/array_type_name.json
@@ -1,77 +1,77 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			4
-		]
-	},
-	"id" : 5,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 4,
-			"linearizedBaseContracts" : 
-			[
-				4
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"constant" : false,
-					"id" : 3,
-					"name" : "i",
-					"nodeType" : "VariableDeclaration",
-					"overrides" : null,
-					"scope" : 4,
-					"src" : "13:8:1",
-					"stateVariable" : true,
-					"storageLocation" : "default",
-					"typeDescriptions" : 
-					{
-						"typeIdentifier" : "t_array$_t_uint256_$dyn_storage",
-						"typeString" : "uint256[]"
-					},
-					"typeName" : 
-					{
-						"baseType" : 
-						{
-							"id" : 1,
-							"name" : "uint",
-							"nodeType" : "ElementaryTypeName",
-							"src" : "13:4:1",
-							"typeDescriptions" : 
-							{
-								"typeIdentifier" : "t_uint256",
-								"typeString" : "uint256"
-							}
-						},
-						"id" : 2,
-						"length" : null,
-						"nodeType" : "ArrayTypeName",
-						"src" : "13:6:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_array$_t_uint256_$dyn_storage_ptr",
-							"typeString" : "uint256[]"
-						}
-					},
-					"value" : null,
-					"visibility" : "internal"
-				}
-			],
-			"scope" : 5,
-			"src" : "0:24:1"
-		}
-	],
-	"src" : "0:25:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      4
+    ]
+  },
+  "id": 5,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 4,
+      "linearizedBaseContracts":
+      [
+        4
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 3,
+          "name": "i",
+          "nodeType": "VariableDeclaration",
+          "overrides": null,
+          "scope": 4,
+          "src": "13:8:1",
+          "stateVariable": true,
+          "storageLocation": "default",
+          "typeDescriptions":
+          {
+            "typeIdentifier": "t_array$_t_uint256_$dyn_storage",
+            "typeString": "uint256[]"
+          },
+          "typeName":
+          {
+            "baseType":
+            {
+              "id": 1,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "13:4:1",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "id": 2,
+            "length": null,
+            "nodeType": "ArrayTypeName",
+            "src": "13:6:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+              "typeString": "uint256[]"
+            }
+          },
+          "value": null,
+          "visibility": "internal"
+        }
+      ],
+      "scope": 5,
+      "src": "0:24:1"
+    }
+  ],
+  "src": "0:25:1"
 }

--- a/test/libsolidity/ASTJSON/array_type_name_legacy.json
+++ b/test/libsolidity/ASTJSON/array_type_name_legacy.json
@@ -1,90 +1,90 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				4
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					4
-				],
-				"name" : "C",
-				"scope" : 5
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"constant" : false,
-						"name" : "i",
-						"overrides" : null,
-						"scope" : 4,
-						"stateVariable" : true,
-						"storageLocation" : "default",
-						"type" : "uint256[]",
-						"value" : null,
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"length" : null,
-								"type" : "uint256[]"
-							},
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"name" : "uint",
-										"type" : "uint256"
-									},
-									"id" : 1,
-									"name" : "ElementaryTypeName",
-									"src" : "13:4:1"
-								}
-							],
-							"id" : 2,
-							"name" : "ArrayTypeName",
-							"src" : "13:6:1"
-						}
-					],
-					"id" : 3,
-					"name" : "VariableDeclaration",
-					"src" : "13:8:1"
-				}
-			],
-			"id" : 4,
-			"name" : "ContractDefinition",
-			"src" : "0:24:1"
-		}
-	],
-	"id" : 5,
-	"name" : "SourceUnit",
-	"src" : "0:25:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        4
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          4
+        ],
+        "name": "C",
+        "scope": 5
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "constant": false,
+            "name": "i",
+            "overrides": null,
+            "scope": 4,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "type": "uint256[]",
+            "value": null,
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "length": null,
+                "type": "uint256[]"
+              },
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "name": "uint",
+                    "type": "uint256"
+                  },
+                  "id": 1,
+                  "name": "ElementaryTypeName",
+                  "src": "13:4:1"
+                }
+              ],
+              "id": 2,
+              "name": "ArrayTypeName",
+              "src": "13:6:1"
+            }
+          ],
+          "id": 3,
+          "name": "VariableDeclaration",
+          "src": "13:8:1"
+        }
+      ],
+      "id": 4,
+      "name": "ContractDefinition",
+      "src": "0:24:1"
+    }
+  ],
+  "id": 5,
+  "name": "SourceUnit",
+  "src": "0:25:1"
 }

--- a/test/libsolidity/ASTJSON/constructor.json
+++ b/test/libsolidity/ASTJSON/constructor.json
@@ -1,71 +1,71 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			5
-		]
-	},
-	"id" : 6,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 5,
-			"linearizedBaseContracts" : 
-			[
-				5
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 3,
-						"nodeType" : "Block",
-						"src" : "35:4:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 4,
-					"implemented" : true,
-					"kind" : "constructor",
-					"modifiers" : [],
-					"name" : "",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "25:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "35:0:1"
-					},
-					"scope" : 5,
-					"src" : "14:25:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 6,
-			"src" : "0:41:1"
-		}
-	],
-	"src" : "0:42:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      5
+    ]
+  },
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 5,
+      "linearizedBaseContracts":
+      [
+        5
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "35:4:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 4,
+          "implemented": true,
+          "kind": "constructor",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "25:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "35:0:1"
+          },
+          "scope": 5,
+          "src": "14:25:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 6,
+      "src": "0:41:1"
+    }
+  ],
+  "src": "0:42:1"
 }

--- a/test/libsolidity/ASTJSON/constructor_legacy.json
+++ b/test/libsolidity/ASTJSON/constructor_legacy.json
@@ -1,111 +1,111 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				5
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					5
-				],
-				"name" : "C",
-				"scope" : 6
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : true,
-						"kind" : "constructor",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "",
-						"overrides" : null,
-						"scope" : 5,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "25:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "35:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 3,
-							"name" : "Block",
-							"src" : "35:4:1"
-						}
-					],
-					"id" : 4,
-					"name" : "FunctionDefinition",
-					"src" : "14:25:1"
-				}
-			],
-			"id" : 5,
-			"name" : "ContractDefinition",
-			"src" : "0:41:1"
-		}
-	],
-	"id" : 6,
-	"name" : "SourceUnit",
-	"src" : "0:42:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        5
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          5
+        ],
+        "name": "C",
+        "scope": 6
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": true,
+            "kind": "constructor",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "",
+            "overrides": null,
+            "scope": 5,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "25:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "35:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 3,
+              "name": "Block",
+              "src": "35:4:1"
+            }
+          ],
+          "id": 4,
+          "name": "FunctionDefinition",
+          "src": "14:25:1"
+        }
+      ],
+      "id": 5,
+      "name": "ContractDefinition",
+      "src": "0:41:1"
+    }
+  ],
+  "id": 6,
+  "name": "SourceUnit",
+  "src": "0:42:1"
 }

--- a/test/libsolidity/ASTJSON/contract_dep_order.json
+++ b/test/libsolidity/ASTJSON/contract_dep_order.json
@@ -1,233 +1,233 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"A" : 
-		[
-			1
-		],
-		"B" : 
-		[
-			4
-		],
-		"C" : 
-		[
-			7
-		],
-		"D" : 
-		[
-			10
-		],
-		"E" : 
-		[
-			13
-		]
-	},
-	"id" : 14,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 1,
-			"linearizedBaseContracts" : 
-			[
-				1
-			],
-			"name" : "A",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 14,
-			"src" : "0:14:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 2,
-						"name" : "A",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 1,
-						"src" : "29:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_A_$1",
-							"typeString" : "contract A"
-						}
-					},
-					"id" : 3,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "29:1:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				1
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 4,
-			"linearizedBaseContracts" : 
-			[
-				4,
-				1
-			],
-			"name" : "B",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 14,
-			"src" : "15:19:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 5,
-						"name" : "B",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 4,
-						"src" : "49:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_B_$4",
-							"typeString" : "contract B"
-						}
-					},
-					"id" : 6,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "49:1:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				1,
-				4
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 7,
-			"linearizedBaseContracts" : 
-			[
-				7,
-				4,
-				1
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 14,
-			"src" : "35:19:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 8,
-						"name" : "C",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 7,
-						"src" : "69:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_C_$7",
-							"typeString" : "contract C"
-						}
-					},
-					"id" : 9,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "69:1:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				1,
-				4,
-				7
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 10,
-			"linearizedBaseContracts" : 
-			[
-				10,
-				7,
-				4,
-				1
-			],
-			"name" : "D",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 14,
-			"src" : "55:19:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 11,
-						"name" : "D",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 10,
-						"src" : "89:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_D_$10",
-							"typeString" : "contract D"
-						}
-					},
-					"id" : 12,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "89:1:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				1,
-				4,
-				7,
-				10
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 13,
-			"linearizedBaseContracts" : 
-			[
-				13,
-				10,
-				7,
-				4,
-				1
-			],
-			"name" : "E",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 14,
-			"src" : "75:19:1"
-		}
-	],
-	"src" : "0:95:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "A":
+    [
+      1
+    ],
+    "B":
+    [
+      4
+    ],
+    "C":
+    [
+      7
+    ],
+    "D":
+    [
+      10
+    ],
+    "E":
+    [
+      13
+    ]
+  },
+  "id": 14,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 1,
+      "linearizedBaseContracts":
+      [
+        1
+      ],
+      "name": "A",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 14,
+      "src": "0:14:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 2,
+            "name": "A",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 1,
+            "src": "29:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_A_$1",
+              "typeString": "contract A"
+            }
+          },
+          "id": 3,
+          "nodeType": "InheritanceSpecifier",
+          "src": "29:1:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        1
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 4,
+      "linearizedBaseContracts":
+      [
+        4,
+        1
+      ],
+      "name": "B",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 14,
+      "src": "15:19:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 5,
+            "name": "B",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 4,
+            "src": "49:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_B_$4",
+              "typeString": "contract B"
+            }
+          },
+          "id": 6,
+          "nodeType": "InheritanceSpecifier",
+          "src": "49:1:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        1,
+        4
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 7,
+      "linearizedBaseContracts":
+      [
+        7,
+        4,
+        1
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 14,
+      "src": "35:19:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 8,
+            "name": "C",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 7,
+            "src": "69:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_C_$7",
+              "typeString": "contract C"
+            }
+          },
+          "id": 9,
+          "nodeType": "InheritanceSpecifier",
+          "src": "69:1:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        1,
+        4,
+        7
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 10,
+      "linearizedBaseContracts":
+      [
+        10,
+        7,
+        4,
+        1
+      ],
+      "name": "D",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 14,
+      "src": "55:19:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 11,
+            "name": "D",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 10,
+            "src": "89:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_D_$10",
+              "typeString": "contract D"
+            }
+          },
+          "id": 12,
+          "nodeType": "InheritanceSpecifier",
+          "src": "89:1:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        1,
+        4,
+        7,
+        10
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 13,
+      "linearizedBaseContracts":
+      [
+        13,
+        10,
+        7,
+        4,
+        1
+      ],
+      "name": "E",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 14,
+      "src": "75:19:1"
+    }
+  ],
+  "src": "0:95:1"
 }

--- a/test/libsolidity/ASTJSON/contract_dep_order_legacy.json
+++ b/test/libsolidity/ASTJSON/contract_dep_order_legacy.json
@@ -1,288 +1,288 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"A" : 
-			[
-				1
-			],
-			"B" : 
-			[
-				4
-			],
-			"C" : 
-			[
-				7
-			],
-			"D" : 
-			[
-				10
-			],
-			"E" : 
-			[
-				13
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					1
-				],
-				"name" : "A",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 14
-			},
-			"id" : 1,
-			"name" : "ContractDefinition",
-			"src" : "0:14:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					1
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					4,
-					1
-				],
-				"name" : "B",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 14
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "A",
-								"referencedDeclaration" : 1,
-								"type" : "contract A"
-							},
-							"id" : 2,
-							"name" : "UserDefinedTypeName",
-							"src" : "29:1:1"
-						}
-					],
-					"id" : 3,
-					"name" : "InheritanceSpecifier",
-					"src" : "29:1:1"
-				}
-			],
-			"id" : 4,
-			"name" : "ContractDefinition",
-			"src" : "15:19:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					1,
-					4
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					7,
-					4,
-					1
-				],
-				"name" : "C",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 14
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "B",
-								"referencedDeclaration" : 4,
-								"type" : "contract B"
-							},
-							"id" : 5,
-							"name" : "UserDefinedTypeName",
-							"src" : "49:1:1"
-						}
-					],
-					"id" : 6,
-					"name" : "InheritanceSpecifier",
-					"src" : "49:1:1"
-				}
-			],
-			"id" : 7,
-			"name" : "ContractDefinition",
-			"src" : "35:19:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					1,
-					4,
-					7
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					10,
-					7,
-					4,
-					1
-				],
-				"name" : "D",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 14
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "C",
-								"referencedDeclaration" : 7,
-								"type" : "contract C"
-							},
-							"id" : 8,
-							"name" : "UserDefinedTypeName",
-							"src" : "69:1:1"
-						}
-					],
-					"id" : 9,
-					"name" : "InheritanceSpecifier",
-					"src" : "69:1:1"
-				}
-			],
-			"id" : 10,
-			"name" : "ContractDefinition",
-			"src" : "55:19:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					1,
-					4,
-					7,
-					10
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					13,
-					10,
-					7,
-					4,
-					1
-				],
-				"name" : "E",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 14
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "D",
-								"referencedDeclaration" : 10,
-								"type" : "contract D"
-							},
-							"id" : 11,
-							"name" : "UserDefinedTypeName",
-							"src" : "89:1:1"
-						}
-					],
-					"id" : 12,
-					"name" : "InheritanceSpecifier",
-					"src" : "89:1:1"
-				}
-			],
-			"id" : 13,
-			"name" : "ContractDefinition",
-			"src" : "75:19:1"
-		}
-	],
-	"id" : 14,
-	"name" : "SourceUnit",
-	"src" : "0:95:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "A":
+      [
+        1
+      ],
+      "B":
+      [
+        4
+      ],
+      "C":
+      [
+        7
+      ],
+      "D":
+      [
+        10
+      ],
+      "E":
+      [
+        13
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          1
+        ],
+        "name": "A",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 14
+      },
+      "id": 1,
+      "name": "ContractDefinition",
+      "src": "0:14:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          1
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          4,
+          1
+        ],
+        "name": "B",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 14
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "A",
+                "referencedDeclaration": 1,
+                "type": "contract A"
+              },
+              "id": 2,
+              "name": "UserDefinedTypeName",
+              "src": "29:1:1"
+            }
+          ],
+          "id": 3,
+          "name": "InheritanceSpecifier",
+          "src": "29:1:1"
+        }
+      ],
+      "id": 4,
+      "name": "ContractDefinition",
+      "src": "15:19:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          1,
+          4
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          7,
+          4,
+          1
+        ],
+        "name": "C",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 14
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "B",
+                "referencedDeclaration": 4,
+                "type": "contract B"
+              },
+              "id": 5,
+              "name": "UserDefinedTypeName",
+              "src": "49:1:1"
+            }
+          ],
+          "id": 6,
+          "name": "InheritanceSpecifier",
+          "src": "49:1:1"
+        }
+      ],
+      "id": 7,
+      "name": "ContractDefinition",
+      "src": "35:19:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          1,
+          4,
+          7
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          10,
+          7,
+          4,
+          1
+        ],
+        "name": "D",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 14
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "C",
+                "referencedDeclaration": 7,
+                "type": "contract C"
+              },
+              "id": 8,
+              "name": "UserDefinedTypeName",
+              "src": "69:1:1"
+            }
+          ],
+          "id": 9,
+          "name": "InheritanceSpecifier",
+          "src": "69:1:1"
+        }
+      ],
+      "id": 10,
+      "name": "ContractDefinition",
+      "src": "55:19:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          1,
+          4,
+          7,
+          10
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          13,
+          10,
+          7,
+          4,
+          1
+        ],
+        "name": "E",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 14
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "D",
+                "referencedDeclaration": 10,
+                "type": "contract D"
+              },
+              "id": 11,
+              "name": "UserDefinedTypeName",
+              "src": "89:1:1"
+            }
+          ],
+          "id": 12,
+          "name": "InheritanceSpecifier",
+          "src": "89:1:1"
+        }
+      ],
+      "id": 13,
+      "name": "ContractDefinition",
+      "src": "75:19:1"
+    }
+  ],
+  "id": 14,
+  "name": "SourceUnit",
+  "src": "0:95:1"
 }

--- a/test/libsolidity/ASTJSON/documentation.json
+++ b/test/libsolidity/ASTJSON/documentation.json
@@ -1,181 +1,181 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			1
-		]
-	},
-	"id" : 2,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : "This contract is empty",
-			"fullyImplemented" : true,
-			"id" : 1,
-			"linearizedBaseContracts" : 
-			[
-				1
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 2,
-			"src" : "28:13:1"
-		}
-	],
-	"src" : "28:14:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      1
+    ]
+  },
+  "id": 2,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": "This contract is empty",
+      "fullyImplemented": true,
+      "id": 1,
+      "linearizedBaseContracts":
+      [
+        1
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 2,
+      "src": "28:13:1"
+    }
+  ],
+  "src": "28:14:1"
 },
 {
-	"absolutePath" : "b",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			3
-		]
-	},
-	"id" : 4,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : "This contract is empty\nand has a line-breaking comment.",
-			"fullyImplemented" : true,
-			"id" : 3,
-			"linearizedBaseContracts" : 
-			[
-				3
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 4,
-			"src" : "62:13:2"
-		}
-	],
-	"src" : "62:14:2"
+  "absolutePath": "b",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      3
+    ]
+  },
+  "id": 4,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": "This contract is empty\nand has a line-breaking comment.",
+      "fullyImplemented": true,
+      "id": 3,
+      "linearizedBaseContracts":
+      [
+        3
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 4,
+      "src": "62:13:2"
+    }
+  ],
+  "src": "62:14:2"
 },
 {
-	"absolutePath" : "c",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			15
-		]
-	},
-	"id" : 16,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 15,
-			"linearizedBaseContracts" : 
-			[
-				15
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"anonymous" : false,
-					"documentation" : "Some comment on Evt.",
-					"id" : 6,
-					"name" : "Evt",
-					"nodeType" : "EventDefinition",
-					"parameters" : 
-					{
-						"id" : 5,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "51:2:3"
-					},
-					"src" : "42:12:3"
-				},
-				{
-					"body" : 
-					{
-						"id" : 9,
-						"nodeType" : "Block",
-						"src" : "99:6:3",
-						"statements" : 
-						[
-							{
-								"id" : 8,
-								"nodeType" : "PlaceholderStatement",
-								"src" : "101:1:3"
-							}
-						]
-					},
-					"documentation" : "Some comment on mod.",
-					"id" : 10,
-					"name" : "mod",
-					"nodeType" : "ModifierDefinition",
-					"parameters" : 
-					{
-						"id" : 7,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "96:2:3"
-					},
-					"src" : "84:21:3",
-					"visibility" : "internal"
-				},
-				{
-					"body" : 
-					{
-						"id" : 13,
-						"nodeType" : "Block",
-						"src" : "155:2:3",
-						"statements" : []
-					},
-					"documentation" : "Some comment on fn.",
-					"id" : 14,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "fn",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 11,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "145:2:3"
-					},
-					"returnParameters" : 
-					{
-						"id" : 12,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "155:0:3"
-					},
-					"scope" : 15,
-					"src" : "134:23:3",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 16,
-			"src" : "0:159:3"
-		}
-	],
-	"src" : "0:160:3"
+  "absolutePath": "c",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      15
+    ]
+  },
+  "id": 16,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 15,
+      "linearizedBaseContracts":
+      [
+        15
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "anonymous": false,
+          "documentation": "Some comment on Evt.",
+          "id": 6,
+          "name": "Evt",
+          "nodeType": "EventDefinition",
+          "parameters":
+          {
+            "id": 5,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "51:2:3"
+          },
+          "src": "42:12:3"
+        },
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "99:6:3",
+            "statements":
+            [
+              {
+                "id": 8,
+                "nodeType": "PlaceholderStatement",
+                "src": "101:1:3"
+              }
+            ]
+          },
+          "documentation": "Some comment on mod.",
+          "id": 10,
+          "name": "mod",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "96:2:3"
+          },
+          "src": "84:21:3",
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 13,
+            "nodeType": "Block",
+            "src": "155:2:3",
+            "statements": []
+          },
+          "documentation": "Some comment on fn.",
+          "id": 14,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "fn",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "145:2:3"
+          },
+          "returnParameters":
+          {
+            "id": 12,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "155:0:3"
+          },
+          "scope": 15,
+          "src": "134:23:3",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 16,
+      "src": "0:159:3"
+    }
+  ],
+  "src": "0:160:3"
 }

--- a/test/libsolidity/ASTJSON/documentation_legacy.json
+++ b/test/libsolidity/ASTJSON/documentation_legacy.json
@@ -1,178 +1,178 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "c",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				15
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					15
-				],
-				"name" : "C",
-				"scope" : 16
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"anonymous" : false,
-						"documentation" : "Some comment on Evt.",
-						"name" : "Evt"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 5,
-							"name" : "ParameterList",
-							"src" : "51:2:3"
-						}
-					],
-					"id" : 6,
-					"name" : "EventDefinition",
-					"src" : "42:12:3"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : "Some comment on mod.",
-						"name" : "mod",
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 7,
-							"name" : "ParameterList",
-							"src" : "96:2:3"
-						},
-						{
-							"children" : 
-							[
-								{
-									"id" : 8,
-									"name" : "PlaceholderStatement",
-									"src" : "101:1:3"
-								}
-							],
-							"id" : 9,
-							"name" : "Block",
-							"src" : "99:6:3"
-						}
-					],
-					"id" : 10,
-					"name" : "ModifierDefinition",
-					"src" : "84:21:3"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : "Some comment on fn.",
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "fn",
-						"overrides" : null,
-						"scope" : 15,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 11,
-							"name" : "ParameterList",
-							"src" : "145:2:3"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 12,
-							"name" : "ParameterList",
-							"src" : "155:0:3"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 13,
-							"name" : "Block",
-							"src" : "155:2:3"
-						}
-					],
-					"id" : 14,
-					"name" : "FunctionDefinition",
-					"src" : "134:23:3"
-				}
-			],
-			"id" : 15,
-			"name" : "ContractDefinition",
-			"src" : "0:159:3"
-		}
-	],
-	"id" : 16,
-	"name" : "SourceUnit",
-	"src" : "0:160:3"
+  "attributes":
+  {
+    "absolutePath": "c",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        15
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          15
+        ],
+        "name": "C",
+        "scope": 16
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "anonymous": false,
+            "documentation": "Some comment on Evt.",
+            "name": "Evt"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 5,
+              "name": "ParameterList",
+              "src": "51:2:3"
+            }
+          ],
+          "id": 6,
+          "name": "EventDefinition",
+          "src": "42:12:3"
+        },
+        {
+          "attributes":
+          {
+            "documentation": "Some comment on mod.",
+            "name": "mod",
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 7,
+              "name": "ParameterList",
+              "src": "96:2:3"
+            },
+            {
+              "children":
+              [
+                {
+                  "id": 8,
+                  "name": "PlaceholderStatement",
+                  "src": "101:1:3"
+                }
+              ],
+              "id": 9,
+              "name": "Block",
+              "src": "99:6:3"
+            }
+          ],
+          "id": 10,
+          "name": "ModifierDefinition",
+          "src": "84:21:3"
+        },
+        {
+          "attributes":
+          {
+            "documentation": "Some comment on fn.",
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "fn",
+            "overrides": null,
+            "scope": 15,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 11,
+              "name": "ParameterList",
+              "src": "145:2:3"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 12,
+              "name": "ParameterList",
+              "src": "155:0:3"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 13,
+              "name": "Block",
+              "src": "155:2:3"
+            }
+          ],
+          "id": 14,
+          "name": "FunctionDefinition",
+          "src": "134:23:3"
+        }
+      ],
+      "id": 15,
+      "name": "ContractDefinition",
+      "src": "0:159:3"
+    }
+  ],
+  "id": 16,
+  "name": "SourceUnit",
+  "src": "0:160:3"
 }

--- a/test/libsolidity/ASTJSON/enum_value.json
+++ b/test/libsolidity/ASTJSON/enum_value.json
@@ -1,57 +1,57 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			4
-		]
-	},
-	"id" : 5,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 4,
-			"linearizedBaseContracts" : 
-			[
-				4
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"canonicalName" : "C.E",
-					"id" : 3,
-					"members" : 
-					[
-						{
-							"id" : 1,
-							"name" : "A",
-							"nodeType" : "EnumValue",
-							"src" : "22:1:1"
-						},
-						{
-							"id" : 2,
-							"name" : "B",
-							"nodeType" : "EnumValue",
-							"src" : "25:1:1"
-						}
-					],
-					"name" : "E",
-					"nodeType" : "EnumDefinition",
-					"src" : "13:15:1"
-				}
-			],
-			"scope" : 5,
-			"src" : "0:30:1"
-		}
-	],
-	"src" : "0:31:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      4
+    ]
+  },
+  "id": 5,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 4,
+      "linearizedBaseContracts":
+      [
+        4
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "canonicalName": "C.E",
+          "id": 3,
+          "members":
+          [
+            {
+              "id": 1,
+              "name": "A",
+              "nodeType": "EnumValue",
+              "src": "22:1:1"
+            },
+            {
+              "id": 2,
+              "name": "B",
+              "nodeType": "EnumValue",
+              "src": "25:1:1"
+            }
+          ],
+          "name": "E",
+          "nodeType": "EnumDefinition",
+          "src": "13:15:1"
+        }
+      ],
+      "scope": 5,
+      "src": "0:30:1"
+    }
+  ],
+  "src": "0:31:1"
 }

--- a/test/libsolidity/ASTJSON/enum_value_legacy.json
+++ b/test/libsolidity/ASTJSON/enum_value_legacy.json
@@ -1,78 +1,78 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				4
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					4
-				],
-				"name" : "C",
-				"scope" : 5
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"canonicalName" : "C.E",
-						"name" : "E"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"name" : "A"
-							},
-							"id" : 1,
-							"name" : "EnumValue",
-							"src" : "22:1:1"
-						},
-						{
-							"attributes" : 
-							{
-								"name" : "B"
-							},
-							"id" : 2,
-							"name" : "EnumValue",
-							"src" : "25:1:1"
-						}
-					],
-					"id" : 3,
-					"name" : "EnumDefinition",
-					"src" : "13:15:1"
-				}
-			],
-			"id" : 4,
-			"name" : "ContractDefinition",
-			"src" : "0:30:1"
-		}
-	],
-	"id" : 5,
-	"name" : "SourceUnit",
-	"src" : "0:31:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        4
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          4
+        ],
+        "name": "C",
+        "scope": 5
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "canonicalName": "C.E",
+            "name": "E"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "name": "A"
+              },
+              "id": 1,
+              "name": "EnumValue",
+              "src": "22:1:1"
+            },
+            {
+              "attributes":
+              {
+                "name": "B"
+              },
+              "id": 2,
+              "name": "EnumValue",
+              "src": "25:1:1"
+            }
+          ],
+          "id": 3,
+          "name": "EnumDefinition",
+          "src": "13:15:1"
+        }
+      ],
+      "id": 4,
+      "name": "ContractDefinition",
+      "src": "0:30:1"
+    }
+  ],
+  "id": 5,
+  "name": "SourceUnit",
+  "src": "0:31:1"
 }

--- a/test/libsolidity/ASTJSON/event_definition.json
+++ b/test/libsolidity/ASTJSON/event_definition.json
@@ -1,50 +1,50 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			3
-		]
-	},
-	"id" : 4,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 3,
-			"linearizedBaseContracts" : 
-			[
-				3
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"anonymous" : false,
-					"documentation" : null,
-					"id" : 2,
-					"name" : "E",
-					"nodeType" : "EventDefinition",
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "20:2:1"
-					},
-					"src" : "13:10:1"
-				}
-			],
-			"scope" : 4,
-			"src" : "0:25:1"
-		}
-	],
-	"src" : "0:26:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      3
+    ]
+  },
+  "id": 4,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 3,
+      "linearizedBaseContracts":
+      [
+        3
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "anonymous": false,
+          "documentation": null,
+          "id": 2,
+          "name": "E",
+          "nodeType": "EventDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "20:2:1"
+          },
+          "src": "13:10:1"
+        }
+      ],
+      "scope": 4,
+      "src": "0:25:1"
+    }
+  ],
+  "src": "0:26:1"
 }

--- a/test/libsolidity/ASTJSON/event_definition_legacy.json
+++ b/test/libsolidity/ASTJSON/event_definition_legacy.json
@@ -1,74 +1,74 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				3
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					3
-				],
-				"name" : "C",
-				"scope" : 4
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"anonymous" : false,
-						"documentation" : null,
-						"name" : "E"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "20:2:1"
-						}
-					],
-					"id" : 2,
-					"name" : "EventDefinition",
-					"src" : "13:10:1"
-				}
-			],
-			"id" : 3,
-			"name" : "ContractDefinition",
-			"src" : "0:25:1"
-		}
-	],
-	"id" : 4,
-	"name" : "SourceUnit",
-	"src" : "0:26:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        3
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          3
+        ],
+        "name": "C",
+        "scope": 4
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "anonymous": false,
+            "documentation": null,
+            "name": "E"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "20:2:1"
+            }
+          ],
+          "id": 2,
+          "name": "EventDefinition",
+          "src": "13:10:1"
+        }
+      ],
+      "id": 3,
+      "name": "ContractDefinition",
+      "src": "0:25:1"
+    }
+  ],
+  "id": 4,
+  "name": "SourceUnit",
+  "src": "0:26:1"
 }

--- a/test/libsolidity/ASTJSON/fallback.json
+++ b/test/libsolidity/ASTJSON/fallback.json
@@ -1,71 +1,71 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			5
-		]
-	},
-	"id" : 6,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 5,
-			"linearizedBaseContracts" : 
-			[
-				5
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 3,
-						"nodeType" : "Block",
-						"src" : "43:5:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 4,
-					"implemented" : true,
-					"kind" : "fallback",
-					"modifiers" : [],
-					"name" : "",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "23:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "43:0:1"
-					},
-					"scope" : 5,
-					"src" : "15:33:1",
-					"stateMutability" : "payable",
-					"superFunction" : null,
-					"visibility" : "external"
-				}
-			],
-			"scope" : 6,
-			"src" : "0:50:1"
-		}
-	],
-	"src" : "0:51:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      5
+    ]
+  },
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 5,
+      "linearizedBaseContracts":
+      [
+        5
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "43:5:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 4,
+          "implemented": true,
+          "kind": "fallback",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "43:0:1"
+          },
+          "scope": 5,
+          "src": "15:33:1",
+          "stateMutability": "payable",
+          "superFunction": null,
+          "visibility": "external"
+        }
+      ],
+      "scope": 6,
+      "src": "0:50:1"
+    }
+  ],
+  "src": "0:51:1"
 }

--- a/test/libsolidity/ASTJSON/fallback_legacy.json
+++ b/test/libsolidity/ASTJSON/fallback_legacy.json
@@ -1,111 +1,111 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				5
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					5
-				],
-				"name" : "C",
-				"scope" : 6
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "fallback",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "",
-						"overrides" : null,
-						"scope" : 5,
-						"stateMutability" : "payable",
-						"superFunction" : null,
-						"visibility" : "external"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "23:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "43:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 3,
-							"name" : "Block",
-							"src" : "43:5:1"
-						}
-					],
-					"id" : 4,
-					"name" : "FunctionDefinition",
-					"src" : "15:33:1"
-				}
-			],
-			"id" : 5,
-			"name" : "ContractDefinition",
-			"src" : "0:50:1"
-		}
-	],
-	"id" : 6,
-	"name" : "SourceUnit",
-	"src" : "0:51:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        5
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          5
+        ],
+        "name": "C",
+        "scope": 6
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "fallback",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "",
+            "overrides": null,
+            "scope": 5,
+            "stateMutability": "payable",
+            "superFunction": null,
+            "visibility": "external"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "23:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "43:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 3,
+              "name": "Block",
+              "src": "43:5:1"
+            }
+          ],
+          "id": 4,
+          "name": "FunctionDefinition",
+          "src": "15:33:1"
+        }
+      ],
+      "id": 5,
+      "name": "ContractDefinition",
+      "src": "0:50:1"
+    }
+  ],
+  "id": 6,
+  "name": "SourceUnit",
+  "src": "0:51:1"
 }

--- a/test/libsolidity/ASTJSON/fallback_payable.json
+++ b/test/libsolidity/ASTJSON/fallback_payable.json
@@ -1,71 +1,71 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			5
-		]
-	},
-	"id" : 6,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 5,
-			"linearizedBaseContracts" : 
-			[
-				5
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 3,
-						"nodeType" : "Block",
-						"src" : "34:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 4,
-					"implemented" : true,
-					"kind" : "fallback",
-					"modifiers" : [],
-					"name" : "",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "22:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "34:0:1"
-					},
-					"scope" : 5,
-					"src" : "14:22:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "external"
-				}
-			],
-			"scope" : 6,
-			"src" : "0:38:1"
-		}
-	],
-	"src" : "0:39:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      5
+    ]
+  },
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 5,
+      "linearizedBaseContracts":
+      [
+        5
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "34:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 4,
+          "implemented": true,
+          "kind": "fallback",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "22:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "34:0:1"
+          },
+          "scope": 5,
+          "src": "14:22:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "external"
+        }
+      ],
+      "scope": 6,
+      "src": "0:38:1"
+    }
+  ],
+  "src": "0:39:1"
 }

--- a/test/libsolidity/ASTJSON/fallback_payable_legacy.json
+++ b/test/libsolidity/ASTJSON/fallback_payable_legacy.json
@@ -1,111 +1,111 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				5
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					5
-				],
-				"name" : "C",
-				"scope" : 6
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "fallback",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "",
-						"overrides" : null,
-						"scope" : 5,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "external"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "22:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "34:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 3,
-							"name" : "Block",
-							"src" : "34:2:1"
-						}
-					],
-					"id" : 4,
-					"name" : "FunctionDefinition",
-					"src" : "14:22:1"
-				}
-			],
-			"id" : 5,
-			"name" : "ContractDefinition",
-			"src" : "0:38:1"
-		}
-	],
-	"id" : 6,
-	"name" : "SourceUnit",
-	"src" : "0:39:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        5
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          5
+        ],
+        "name": "C",
+        "scope": 6
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "fallback",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "",
+            "overrides": null,
+            "scope": 5,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "external"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "22:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "34:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 3,
+              "name": "Block",
+              "src": "34:2:1"
+            }
+          ],
+          "id": 4,
+          "name": "FunctionDefinition",
+          "src": "14:22:1"
+        }
+      ],
+      "id": 5,
+      "name": "ContractDefinition",
+      "src": "0:38:1"
+    }
+  ],
+  "id": 6,
+  "name": "SourceUnit",
+  "src": "0:39:1"
 }

--- a/test/libsolidity/ASTJSON/function_type.json
+++ b/test/libsolidity/ASTJSON/function_type.json
@@ -1,229 +1,229 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			17
-		]
-	},
-	"id" : 18,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 17,
-			"linearizedBaseContracts" : 
-			[
-				17
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 15,
-						"nodeType" : "Block",
-						"src" : "120:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 16,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 7,
-						"nodeType" : "ParameterList",
-						"parameters" : 
-						[
-							{
-								"constant" : false,
-								"id" : 6,
-								"name" : "x",
-								"nodeType" : "VariableDeclaration",
-								"overrides" : null,
-								"scope" : 16,
-								"src" : "24:44:1",
-								"stateVariable" : false,
-								"storageLocation" : "default",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_function_external_payable$__$returns$_t_uint256_$",
-									"typeString" : "function () payable external returns (uint256)"
-								},
-								"typeName" : 
-								{
-									"id" : 5,
-									"nodeType" : "FunctionTypeName",
-									"parameterTypes" : 
-									{
-										"id" : 1,
-										"nodeType" : "ParameterList",
-										"parameters" : [],
-										"src" : "32:2:1"
-									},
-									"returnParameterTypes" : 
-									{
-										"id" : 4,
-										"nodeType" : "ParameterList",
-										"parameters" : 
-										[
-											{
-												"constant" : false,
-												"id" : 3,
-												"name" : "",
-												"nodeType" : "VariableDeclaration",
-												"overrides" : null,
-												"scope" : 5,
-												"src" : "61:4:1",
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"typeDescriptions" : 
-												{
-													"typeIdentifier" : "t_uint256",
-													"typeString" : "uint256"
-												},
-												"typeName" : 
-												{
-													"id" : 2,
-													"name" : "uint",
-													"nodeType" : "ElementaryTypeName",
-													"src" : "61:4:1",
-													"typeDescriptions" : 
-													{
-														"typeIdentifier" : "t_uint256",
-														"typeString" : "uint256"
-													}
-												},
-												"value" : null,
-												"visibility" : "internal"
-											}
-										],
-										"src" : "60:6:1"
-									},
-									"src" : "24:44:1",
-									"stateMutability" : "payable",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_function_external_payable$__$returns$_t_uint256_$",
-										"typeString" : "function () payable external returns (uint256)"
-									},
-									"visibility" : "external"
-								},
-								"value" : null,
-								"visibility" : "internal"
-							}
-						],
-						"src" : "23:46:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 14,
-						"nodeType" : "ParameterList",
-						"parameters" : 
-						[
-							{
-								"constant" : false,
-								"id" : 13,
-								"name" : "",
-								"nodeType" : "VariableDeclaration",
-								"overrides" : null,
-								"scope" : 16,
-								"src" : "79:40:1",
-								"stateVariable" : false,
-								"storageLocation" : "default",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_function_external_view$__$returns$_t_uint256_$",
-									"typeString" : "function () view external returns (uint256)"
-								},
-								"typeName" : 
-								{
-									"id" : 12,
-									"nodeType" : "FunctionTypeName",
-									"parameterTypes" : 
-									{
-										"id" : 8,
-										"nodeType" : "ParameterList",
-										"parameters" : [],
-										"src" : "87:2:1"
-									},
-									"returnParameterTypes" : 
-									{
-										"id" : 11,
-										"nodeType" : "ParameterList",
-										"parameters" : 
-										[
-											{
-												"constant" : false,
-												"id" : 10,
-												"name" : "",
-												"nodeType" : "VariableDeclaration",
-												"overrides" : null,
-												"scope" : 12,
-												"src" : "113:4:1",
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"typeDescriptions" : 
-												{
-													"typeIdentifier" : "t_uint256",
-													"typeString" : "uint256"
-												},
-												"typeName" : 
-												{
-													"id" : 9,
-													"name" : "uint",
-													"nodeType" : "ElementaryTypeName",
-													"src" : "113:4:1",
-													"typeDescriptions" : 
-													{
-														"typeIdentifier" : "t_uint256",
-														"typeString" : "uint256"
-													}
-												},
-												"value" : null,
-												"visibility" : "internal"
-											}
-										],
-										"src" : "112:6:1"
-									},
-									"src" : "79:40:1",
-									"stateMutability" : "view",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_function_external_view$__$returns$_t_uint256_$",
-										"typeString" : "function () view external returns (uint256)"
-									},
-									"visibility" : "external"
-								},
-								"value" : null,
-								"visibility" : "internal"
-							}
-						],
-						"src" : "78:41:1"
-					},
-					"scope" : 17,
-					"src" : "13:109:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 18,
-			"src" : "0:124:1"
-		}
-	],
-	"src" : "0:125:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      17
+    ]
+  },
+  "id": 18,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 17,
+      "linearizedBaseContracts":
+      [
+        17
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 15,
+            "nodeType": "Block",
+            "src": "120:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 16,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 6,
+                "name": "x",
+                "nodeType": "VariableDeclaration",
+                "overrides": null,
+                "scope": 16,
+                "src": "24:44:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_function_external_payable$__$returns$_t_uint256_$",
+                  "typeString": "function () payable external returns (uint256)"
+                },
+                "typeName":
+                {
+                  "id": 5,
+                  "nodeType": "FunctionTypeName",
+                  "parameterTypes":
+                  {
+                    "id": 1,
+                    "nodeType": "ParameterList",
+                    "parameters": [],
+                    "src": "32:2:1"
+                  },
+                  "returnParameterTypes":
+                  {
+                    "id": 4,
+                    "nodeType": "ParameterList",
+                    "parameters":
+                    [
+                      {
+                        "constant": false,
+                        "id": 3,
+                        "name": "",
+                        "nodeType": "VariableDeclaration",
+                        "overrides": null,
+                        "scope": 5,
+                        "src": "61:4:1",
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "typeName":
+                        {
+                          "id": 2,
+                          "name": "uint",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "61:4:1",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "value": null,
+                        "visibility": "internal"
+                      }
+                    ],
+                    "src": "60:6:1"
+                  },
+                  "src": "24:44:1",
+                  "stateMutability": "payable",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_function_external_payable$__$returns$_t_uint256_$",
+                    "typeString": "function () payable external returns (uint256)"
+                  },
+                  "visibility": "external"
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:46:1"
+          },
+          "returnParameters":
+          {
+            "id": 14,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 13,
+                "name": "",
+                "nodeType": "VariableDeclaration",
+                "overrides": null,
+                "scope": 16,
+                "src": "79:40:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_function_external_view$__$returns$_t_uint256_$",
+                  "typeString": "function () view external returns (uint256)"
+                },
+                "typeName":
+                {
+                  "id": 12,
+                  "nodeType": "FunctionTypeName",
+                  "parameterTypes":
+                  {
+                    "id": 8,
+                    "nodeType": "ParameterList",
+                    "parameters": [],
+                    "src": "87:2:1"
+                  },
+                  "returnParameterTypes":
+                  {
+                    "id": 11,
+                    "nodeType": "ParameterList",
+                    "parameters":
+                    [
+                      {
+                        "constant": false,
+                        "id": 10,
+                        "name": "",
+                        "nodeType": "VariableDeclaration",
+                        "overrides": null,
+                        "scope": 12,
+                        "src": "113:4:1",
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "typeName":
+                        {
+                          "id": 9,
+                          "name": "uint",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "113:4:1",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "value": null,
+                        "visibility": "internal"
+                      }
+                    ],
+                    "src": "112:6:1"
+                  },
+                  "src": "79:40:1",
+                  "stateMutability": "view",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_function_external_view$__$returns$_t_uint256_$",
+                    "typeString": "function () view external returns (uint256)"
+                  },
+                  "visibility": "external"
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "src": "78:41:1"
+          },
+          "scope": 17,
+          "src": "13:109:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 18,
+      "src": "0:124:1"
+    }
+  ],
+  "src": "0:125:1"
 }

--- a/test/libsolidity/ASTJSON/function_type_legacy.json
+++ b/test/libsolidity/ASTJSON/function_type_legacy.json
@@ -1,271 +1,271 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				17
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					17
-				],
-				"name" : "C",
-				"scope" : 18
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 17,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "x",
-										"overrides" : null,
-										"scope" : 16,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "function () payable external returns (uint256)",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"stateMutability" : "payable",
-												"type" : "function () payable external returns (uint256)",
-												"visibility" : "external"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"parameters" : 
-														[
-															null
-														]
-													},
-													"children" : [],
-													"id" : 1,
-													"name" : "ParameterList",
-													"src" : "32:2:1"
-												},
-												{
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"constant" : false,
-																"name" : "",
-																"overrides" : null,
-																"scope" : 5,
-																"stateVariable" : false,
-																"storageLocation" : "default",
-																"type" : "uint256",
-																"value" : null,
-																"visibility" : "internal"
-															},
-															"children" : 
-															[
-																{
-																	"attributes" : 
-																	{
-																		"name" : "uint",
-																		"type" : "uint256"
-																	},
-																	"id" : 2,
-																	"name" : "ElementaryTypeName",
-																	"src" : "61:4:1"
-																}
-															],
-															"id" : 3,
-															"name" : "VariableDeclaration",
-															"src" : "61:4:1"
-														}
-													],
-													"id" : 4,
-													"name" : "ParameterList",
-													"src" : "60:6:1"
-												}
-											],
-											"id" : 5,
-											"name" : "FunctionTypeName",
-											"src" : "24:44:1"
-										}
-									],
-									"id" : 6,
-									"name" : "VariableDeclaration",
-									"src" : "24:44:1"
-								}
-							],
-							"id" : 7,
-							"name" : "ParameterList",
-							"src" : "23:46:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "",
-										"overrides" : null,
-										"scope" : 16,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "function () view external returns (uint256)",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"stateMutability" : "view",
-												"type" : "function () view external returns (uint256)",
-												"visibility" : "external"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"parameters" : 
-														[
-															null
-														]
-													},
-													"children" : [],
-													"id" : 8,
-													"name" : "ParameterList",
-													"src" : "87:2:1"
-												},
-												{
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"constant" : false,
-																"name" : "",
-																"overrides" : null,
-																"scope" : 12,
-																"stateVariable" : false,
-																"storageLocation" : "default",
-																"type" : "uint256",
-																"value" : null,
-																"visibility" : "internal"
-															},
-															"children" : 
-															[
-																{
-																	"attributes" : 
-																	{
-																		"name" : "uint",
-																		"type" : "uint256"
-																	},
-																	"id" : 9,
-																	"name" : "ElementaryTypeName",
-																	"src" : "113:4:1"
-																}
-															],
-															"id" : 10,
-															"name" : "VariableDeclaration",
-															"src" : "113:4:1"
-														}
-													],
-													"id" : 11,
-													"name" : "ParameterList",
-													"src" : "112:6:1"
-												}
-											],
-											"id" : 12,
-											"name" : "FunctionTypeName",
-											"src" : "79:40:1"
-										}
-									],
-									"id" : 13,
-									"name" : "VariableDeclaration",
-									"src" : "79:40:1"
-								}
-							],
-							"id" : 14,
-							"name" : "ParameterList",
-							"src" : "78:41:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 15,
-							"name" : "Block",
-							"src" : "120:2:1"
-						}
-					],
-					"id" : 16,
-					"name" : "FunctionDefinition",
-					"src" : "13:109:1"
-				}
-			],
-			"id" : 17,
-			"name" : "ContractDefinition",
-			"src" : "0:124:1"
-		}
-	],
-	"id" : 18,
-	"name" : "SourceUnit",
-	"src" : "0:125:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        17
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          17
+        ],
+        "name": "C",
+        "scope": 18
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 17,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "x",
+                    "overrides": null,
+                    "scope": 16,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "function () payable external returns (uint256)",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "stateMutability": "payable",
+                        "type": "function () payable external returns (uint256)",
+                        "visibility": "external"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "parameters":
+                            [
+                              null
+                            ]
+                          },
+                          "children": [],
+                          "id": 1,
+                          "name": "ParameterList",
+                          "src": "32:2:1"
+                        },
+                        {
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "constant": false,
+                                "name": "",
+                                "overrides": null,
+                                "scope": 5,
+                                "stateVariable": false,
+                                "storageLocation": "default",
+                                "type": "uint256",
+                                "value": null,
+                                "visibility": "internal"
+                              },
+                              "children":
+                              [
+                                {
+                                  "attributes":
+                                  {
+                                    "name": "uint",
+                                    "type": "uint256"
+                                  },
+                                  "id": 2,
+                                  "name": "ElementaryTypeName",
+                                  "src": "61:4:1"
+                                }
+                              ],
+                              "id": 3,
+                              "name": "VariableDeclaration",
+                              "src": "61:4:1"
+                            }
+                          ],
+                          "id": 4,
+                          "name": "ParameterList",
+                          "src": "60:6:1"
+                        }
+                      ],
+                      "id": 5,
+                      "name": "FunctionTypeName",
+                      "src": "24:44:1"
+                    }
+                  ],
+                  "id": 6,
+                  "name": "VariableDeclaration",
+                  "src": "24:44:1"
+                }
+              ],
+              "id": 7,
+              "name": "ParameterList",
+              "src": "23:46:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "",
+                    "overrides": null,
+                    "scope": 16,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "function () view external returns (uint256)",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "stateMutability": "view",
+                        "type": "function () view external returns (uint256)",
+                        "visibility": "external"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "parameters":
+                            [
+                              null
+                            ]
+                          },
+                          "children": [],
+                          "id": 8,
+                          "name": "ParameterList",
+                          "src": "87:2:1"
+                        },
+                        {
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "constant": false,
+                                "name": "",
+                                "overrides": null,
+                                "scope": 12,
+                                "stateVariable": false,
+                                "storageLocation": "default",
+                                "type": "uint256",
+                                "value": null,
+                                "visibility": "internal"
+                              },
+                              "children":
+                              [
+                                {
+                                  "attributes":
+                                  {
+                                    "name": "uint",
+                                    "type": "uint256"
+                                  },
+                                  "id": 9,
+                                  "name": "ElementaryTypeName",
+                                  "src": "113:4:1"
+                                }
+                              ],
+                              "id": 10,
+                              "name": "VariableDeclaration",
+                              "src": "113:4:1"
+                            }
+                          ],
+                          "id": 11,
+                          "name": "ParameterList",
+                          "src": "112:6:1"
+                        }
+                      ],
+                      "id": 12,
+                      "name": "FunctionTypeName",
+                      "src": "79:40:1"
+                    }
+                  ],
+                  "id": 13,
+                  "name": "VariableDeclaration",
+                  "src": "79:40:1"
+                }
+              ],
+              "id": 14,
+              "name": "ParameterList",
+              "src": "78:41:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 15,
+              "name": "Block",
+              "src": "120:2:1"
+            }
+          ],
+          "id": 16,
+          "name": "FunctionDefinition",
+          "src": "13:109:1"
+        }
+      ],
+      "id": 17,
+      "name": "ContractDefinition",
+      "src": "0:124:1"
+    }
+  ],
+  "id": 18,
+  "name": "SourceUnit",
+  "src": "0:125:1"
 }

--- a/test/libsolidity/ASTJSON/global_enum.json
+++ b/test/libsolidity/ASTJSON/global_enum.json
@@ -1,32 +1,32 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"E" : 
-		[
-			2
-		]
-	},
-	"id" : 3,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"canonicalName" : "E",
-			"id" : 2,
-			"members" : 
-			[
-				{
-					"id" : 1,
-					"name" : "A",
-					"nodeType" : "EnumValue",
-					"src" : "9:1:1"
-				}
-			],
-			"name" : "E",
-			"nodeType" : "EnumDefinition",
-			"src" : "0:12:1"
-		}
-	],
-	"src" : "0:13:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "E":
+    [
+      2
+    ]
+  },
+  "id": 3,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "canonicalName": "E",
+      "id": 2,
+      "members":
+      [
+        {
+          "id": 1,
+          "name": "A",
+          "nodeType": "EnumValue",
+          "src": "9:1:1"
+        }
+      ],
+      "name": "E",
+      "nodeType": "EnumDefinition",
+      "src": "0:12:1"
+    }
+  ],
+  "src": "0:13:1"
 }

--- a/test/libsolidity/ASTJSON/global_enum_legacy.json
+++ b/test/libsolidity/ASTJSON/global_enum_legacy.json
@@ -1,41 +1,41 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"E" : 
-			[
-				2
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"canonicalName" : "E",
-				"name" : "E"
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"name" : "A"
-					},
-					"id" : 1,
-					"name" : "EnumValue",
-					"src" : "9:1:1"
-				}
-			],
-			"id" : 2,
-			"name" : "EnumDefinition",
-			"src" : "0:12:1"
-		}
-	],
-	"id" : 3,
-	"name" : "SourceUnit",
-	"src" : "0:13:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "E":
+      [
+        2
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "canonicalName": "E",
+        "name": "E"
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "name": "A"
+          },
+          "id": 1,
+          "name": "EnumValue",
+          "src": "9:1:1"
+        }
+      ],
+      "id": 2,
+      "name": "EnumDefinition",
+      "src": "0:12:1"
+    }
+  ],
+  "id": 3,
+  "name": "SourceUnit",
+  "src": "0:13:1"
 }

--- a/test/libsolidity/ASTJSON/global_struct.json
+++ b/test/libsolidity/ASTJSON/global_struct.json
@@ -1,58 +1,58 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"S" : 
-		[
-			3
-		]
-	},
-	"id" : 4,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"canonicalName" : "S",
-			"id" : 3,
-			"members" : 
-			[
-				{
-					"constant" : false,
-					"id" : 2,
-					"name" : "a",
-					"nodeType" : "VariableDeclaration",
-					"overrides" : null,
-					"scope" : 3,
-					"src" : "11:9:1",
-					"stateVariable" : false,
-					"storageLocation" : "default",
-					"typeDescriptions" : 
-					{
-						"typeIdentifier" : "t_uint256",
-						"typeString" : "uint256"
-					},
-					"typeName" : 
-					{
-						"id" : 1,
-						"name" : "uint256",
-						"nodeType" : "ElementaryTypeName",
-						"src" : "11:7:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_uint256",
-							"typeString" : "uint256"
-						}
-					},
-					"value" : null,
-					"visibility" : "internal"
-				}
-			],
-			"name" : "S",
-			"nodeType" : "StructDefinition",
-			"scope" : 4,
-			"src" : "0:23:1",
-			"visibility" : "public"
-		}
-	],
-	"src" : "0:24:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "S":
+    [
+      3
+    ]
+  },
+  "id": 4,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "canonicalName": "S",
+      "id": 3,
+      "members":
+      [
+        {
+          "constant": false,
+          "id": 2,
+          "name": "a",
+          "nodeType": "VariableDeclaration",
+          "overrides": null,
+          "scope": 3,
+          "src": "11:9:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions":
+          {
+            "typeIdentifier": "t_uint256",
+            "typeString": "uint256"
+          },
+          "typeName":
+          {
+            "id": 1,
+            "name": "uint256",
+            "nodeType": "ElementaryTypeName",
+            "src": "11:7:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            }
+          },
+          "value": null,
+          "visibility": "internal"
+        }
+      ],
+      "name": "S",
+      "nodeType": "StructDefinition",
+      "scope": 4,
+      "src": "0:23:1",
+      "visibility": "public"
+    }
+  ],
+  "src": "0:24:1"
 }

--- a/test/libsolidity/ASTJSON/global_struct_legacy.json
+++ b/test/libsolidity/ASTJSON/global_struct_legacy.json
@@ -1,64 +1,64 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"S" : 
-			[
-				3
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"canonicalName" : "S",
-				"name" : "S",
-				"scope" : 4,
-				"visibility" : "public"
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"constant" : false,
-						"name" : "a",
-						"overrides" : null,
-						"scope" : 3,
-						"stateVariable" : false,
-						"storageLocation" : "default",
-						"type" : "uint256",
-						"value" : null,
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"name" : "uint256",
-								"type" : "uint256"
-							},
-							"id" : 1,
-							"name" : "ElementaryTypeName",
-							"src" : "11:7:1"
-						}
-					],
-					"id" : 2,
-					"name" : "VariableDeclaration",
-					"src" : "11:9:1"
-				}
-			],
-			"id" : 3,
-			"name" : "StructDefinition",
-			"src" : "0:23:1"
-		}
-	],
-	"id" : 4,
-	"name" : "SourceUnit",
-	"src" : "0:24:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "S":
+      [
+        3
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "canonicalName": "S",
+        "name": "S",
+        "scope": 4,
+        "visibility": "public"
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "constant": false,
+            "name": "a",
+            "overrides": null,
+            "scope": 3,
+            "stateVariable": false,
+            "storageLocation": "default",
+            "type": "uint256",
+            "value": null,
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "name": "uint256",
+                "type": "uint256"
+              },
+              "id": 1,
+              "name": "ElementaryTypeName",
+              "src": "11:7:1"
+            }
+          ],
+          "id": 2,
+          "name": "VariableDeclaration",
+          "src": "11:9:1"
+        }
+      ],
+      "id": 3,
+      "name": "StructDefinition",
+      "src": "0:23:1"
+    }
+  ],
+  "id": 4,
+  "name": "SourceUnit",
+  "src": "0:24:1"
 }

--- a/test/libsolidity/ASTJSON/inheritance_specifier.json
+++ b/test/libsolidity/ASTJSON/inheritance_specifier.json
@@ -1,80 +1,80 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C1" : 
-		[
-			1
-		],
-		"C2" : 
-		[
-			4
-		]
-	},
-	"id" : 5,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 1,
-			"linearizedBaseContracts" : 
-			[
-				1
-			],
-			"name" : "C1",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 5,
-			"src" : "0:14:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 2,
-						"name" : "C1",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 1,
-						"src" : "30:2:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_C1_$1",
-							"typeString" : "contract C1"
-						}
-					},
-					"id" : 3,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "30:2:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				1
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 4,
-			"linearizedBaseContracts" : 
-			[
-				4,
-				1
-			],
-			"name" : "C2",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 5,
-			"src" : "15:20:1"
-		}
-	],
-	"src" : "0:36:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C1":
+    [
+      1
+    ],
+    "C2":
+    [
+      4
+    ]
+  },
+  "id": 5,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 1,
+      "linearizedBaseContracts":
+      [
+        1
+      ],
+      "name": "C1",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 5,
+      "src": "0:14:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 2,
+            "name": "C1",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 1,
+            "src": "30:2:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_C1_$1",
+              "typeString": "contract C1"
+            }
+          },
+          "id": 3,
+          "nodeType": "InheritanceSpecifier",
+          "src": "30:2:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        1
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 4,
+      "linearizedBaseContracts":
+      [
+        4,
+        1
+      ],
+      "name": "C2",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 5,
+      "src": "15:20:1"
+    }
+  ],
+  "src": "0:36:1"
 }

--- a/test/libsolidity/ASTJSON/inheritance_specifier_legacy.json
+++ b/test/libsolidity/ASTJSON/inheritance_specifier_legacy.json
@@ -1,105 +1,105 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C1" : 
-			[
-				1
-			],
-			"C2" : 
-			[
-				4
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					1
-				],
-				"name" : "C1",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 5
-			},
-			"id" : 1,
-			"name" : "ContractDefinition",
-			"src" : "0:14:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					1
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					4,
-					1
-				],
-				"name" : "C2",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 5
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "C1",
-								"referencedDeclaration" : 1,
-								"type" : "contract C1"
-							},
-							"id" : 2,
-							"name" : "UserDefinedTypeName",
-							"src" : "30:2:1"
-						}
-					],
-					"id" : 3,
-					"name" : "InheritanceSpecifier",
-					"src" : "30:2:1"
-				}
-			],
-			"id" : 4,
-			"name" : "ContractDefinition",
-			"src" : "15:20:1"
-		}
-	],
-	"id" : 5,
-	"name" : "SourceUnit",
-	"src" : "0:36:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C1":
+      [
+        1
+      ],
+      "C2":
+      [
+        4
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          1
+        ],
+        "name": "C1",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 5
+      },
+      "id": 1,
+      "name": "ContractDefinition",
+      "src": "0:14:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          1
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          4,
+          1
+        ],
+        "name": "C2",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 5
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "C1",
+                "referencedDeclaration": 1,
+                "type": "contract C1"
+              },
+              "id": 2,
+              "name": "UserDefinedTypeName",
+              "src": "30:2:1"
+            }
+          ],
+          "id": 3,
+          "name": "InheritanceSpecifier",
+          "src": "30:2:1"
+        }
+      ],
+      "id": 4,
+      "name": "ContractDefinition",
+      "src": "15:20:1"
+    }
+  ],
+  "id": 5,
+  "name": "SourceUnit",
+  "src": "0:36:1"
 }

--- a/test/libsolidity/ASTJSON/long_type_name_binary_operation.json
+++ b/test/libsolidity/ASTJSON/long_type_name_binary_operation.json
@@ -1,177 +1,177 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"c" : 
-		[
-			11
-		]
-	},
-	"id" : 12,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 11,
-			"linearizedBaseContracts" : 
-			[
-				11
-			],
-			"name" : "c",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 9,
-						"nodeType" : "Block",
-						"src" : "33:19:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									4
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 4,
-										"name" : "a",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 9,
-										"src" : "35:6:1",
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_uint256",
-											"typeString" : "uint256"
-										},
-										"typeName" : 
-										{
-											"id" : 3,
-											"name" : "uint",
-											"nodeType" : "ElementaryTypeName",
-											"src" : "35:4:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_uint256",
-												"typeString" : "uint256"
-											}
-										},
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 8,
-								"initialValue" : 
-								{
-									"argumentTypes" : null,
-									"commonType" : 
-									{
-										"typeIdentifier" : "t_rational_5_by_1",
-										"typeString" : "int_const 5"
-									},
-									"id" : 7,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : true,
-									"lValueRequested" : false,
-									"leftExpression" : 
-									{
-										"argumentTypes" : null,
-										"hexValue" : "32",
-										"id" : 5,
-										"isConstant" : false,
-										"isLValue" : false,
-										"isPure" : true,
-										"kind" : "number",
-										"lValueRequested" : false,
-										"nodeType" : "Literal",
-										"src" : "44:1:1",
-										"subdenomination" : null,
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_rational_2_by_1",
-											"typeString" : "int_const 2"
-										},
-										"value" : "2"
-									},
-									"nodeType" : "BinaryOperation",
-									"operator" : "+",
-									"rightExpression" : 
-									{
-										"argumentTypes" : null,
-										"hexValue" : "33",
-										"id" : 6,
-										"isConstant" : false,
-										"isLValue" : false,
-										"isPure" : true,
-										"kind" : "number",
-										"lValueRequested" : false,
-										"nodeType" : "Literal",
-										"src" : "48:1:1",
-										"subdenomination" : null,
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_rational_3_by_1",
-											"typeString" : "int_const 3"
-										},
-										"value" : "3"
-									},
-									"src" : "44:5:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_rational_5_by_1",
-										"typeString" : "int_const 5"
-									}
-								},
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "35:14:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 10,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "23:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "33:0:1"
-					},
-					"scope" : 11,
-					"src" : "13:39:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 12,
-			"src" : "0:54:1"
-		}
-	],
-	"src" : "0:55:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "c":
+    [
+      11
+    ]
+  },
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 11,
+      "linearizedBaseContracts":
+      [
+        11
+      ],
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "33:19:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "name": "a",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 9,
+                    "src": "35:6:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "uint",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "35:4:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 8,
+                "initialValue":
+                {
+                  "argumentTypes": null,
+                  "commonType":
+                  {
+                    "typeIdentifier": "t_rational_5_by_1",
+                    "typeString": "int_const 5"
+                  },
+                  "id": 7,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "lValueRequested": false,
+                  "leftExpression":
+                  {
+                    "argumentTypes": null,
+                    "hexValue": "32",
+                    "id": 5,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "kind": "number",
+                    "lValueRequested": false,
+                    "nodeType": "Literal",
+                    "src": "44:1:1",
+                    "subdenomination": null,
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_rational_2_by_1",
+                      "typeString": "int_const 2"
+                    },
+                    "value": "2"
+                  },
+                  "nodeType": "BinaryOperation",
+                  "operator": "+",
+                  "rightExpression":
+                  {
+                    "argumentTypes": null,
+                    "hexValue": "33",
+                    "id": 6,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "kind": "number",
+                    "lValueRequested": false,
+                    "nodeType": "Literal",
+                    "src": "48:1:1",
+                    "subdenomination": null,
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_rational_3_by_1",
+                      "typeString": "int_const 3"
+                    },
+                    "value": "3"
+                  },
+                  "src": "44:5:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_rational_5_by_1",
+                    "typeString": "int_const 5"
+                  }
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:14:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "scope": 11,
+          "src": "13:39:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 12,
+      "src": "0:54:1"
+    }
+  ],
+  "src": "0:55:1"
 }

--- a/test/libsolidity/ASTJSON/long_type_name_binary_operation_legacy.json
+++ b/test/libsolidity/ASTJSON/long_type_name_binary_operation_legacy.json
@@ -1,210 +1,210 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"c" : 
-			[
-				11
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					11
-				],
-				"name" : "c",
-				"scope" : 12
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 11,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "23:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "33:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											4
-										]
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "a",
-												"overrides" : null,
-												"scope" : 9,
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"type" : "uint256",
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"name" : "uint",
-														"type" : "uint256"
-													},
-													"id" : 3,
-													"name" : "ElementaryTypeName",
-													"src" : "35:4:1"
-												}
-											],
-											"id" : 4,
-											"name" : "VariableDeclaration",
-											"src" : "35:6:1"
-										},
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"commonType" : 
-												{
-													"typeIdentifier" : "t_rational_5_by_1",
-													"typeString" : "int_const 5"
-												},
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : true,
-												"lValueRequested" : false,
-												"operator" : "+",
-												"type" : "int_const 5"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"hexvalue" : "32",
-														"isConstant" : false,
-														"isLValue" : false,
-														"isPure" : true,
-														"lValueRequested" : false,
-														"subdenomination" : null,
-														"token" : "number",
-														"type" : "int_const 2",
-														"value" : "2"
-													},
-													"id" : 5,
-													"name" : "Literal",
-													"src" : "44:1:1"
-												},
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"hexvalue" : "33",
-														"isConstant" : false,
-														"isLValue" : false,
-														"isPure" : true,
-														"lValueRequested" : false,
-														"subdenomination" : null,
-														"token" : "number",
-														"type" : "int_const 3",
-														"value" : "3"
-													},
-													"id" : 6,
-													"name" : "Literal",
-													"src" : "48:1:1"
-												}
-											],
-											"id" : 7,
-											"name" : "BinaryOperation",
-											"src" : "44:5:1"
-										}
-									],
-									"id" : 8,
-									"name" : "VariableDeclarationStatement",
-									"src" : "35:14:1"
-								}
-							],
-							"id" : 9,
-							"name" : "Block",
-							"src" : "33:19:1"
-						}
-					],
-					"id" : 10,
-					"name" : "FunctionDefinition",
-					"src" : "13:39:1"
-				}
-			],
-			"id" : 11,
-			"name" : "ContractDefinition",
-			"src" : "0:54:1"
-		}
-	],
-	"id" : 12,
-	"name" : "SourceUnit",
-	"src" : "0:55:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "c":
+      [
+        11
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          11
+        ],
+        "name": "c",
+        "scope": 12
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 11,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "23:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "33:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      4
+                    ]
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "a",
+                        "overrides": null,
+                        "scope": 9,
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "type": "uint256",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "name": "uint",
+                            "type": "uint256"
+                          },
+                          "id": 3,
+                          "name": "ElementaryTypeName",
+                          "src": "35:4:1"
+                        }
+                      ],
+                      "id": 4,
+                      "name": "VariableDeclaration",
+                      "src": "35:6:1"
+                    },
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "commonType":
+                        {
+                          "typeIdentifier": "t_rational_5_by_1",
+                          "typeString": "int_const 5"
+                        },
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "operator": "+",
+                        "type": "int_const 5"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "hexvalue": "32",
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "subdenomination": null,
+                            "token": "number",
+                            "type": "int_const 2",
+                            "value": "2"
+                          },
+                          "id": 5,
+                          "name": "Literal",
+                          "src": "44:1:1"
+                        },
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "hexvalue": "33",
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "subdenomination": null,
+                            "token": "number",
+                            "type": "int_const 3",
+                            "value": "3"
+                          },
+                          "id": 6,
+                          "name": "Literal",
+                          "src": "48:1:1"
+                        }
+                      ],
+                      "id": 7,
+                      "name": "BinaryOperation",
+                      "src": "44:5:1"
+                    }
+                  ],
+                  "id": 8,
+                  "name": "VariableDeclarationStatement",
+                  "src": "35:14:1"
+                }
+              ],
+              "id": 9,
+              "name": "Block",
+              "src": "33:19:1"
+            }
+          ],
+          "id": 10,
+          "name": "FunctionDefinition",
+          "src": "13:39:1"
+        }
+      ],
+      "id": 11,
+      "name": "ContractDefinition",
+      "src": "0:54:1"
+    }
+  ],
+  "id": 12,
+  "name": "SourceUnit",
+  "src": "0:55:1"
 }

--- a/test/libsolidity/ASTJSON/long_type_name_identifier.json
+++ b/test/libsolidity/ASTJSON/long_type_name_identifier.json
@@ -1,184 +1,184 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"c" : 
-		[
-			15
-		]
-	},
-	"id" : 16,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 15,
-			"linearizedBaseContracts" : 
-			[
-				15
-			],
-			"name" : "c",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"constant" : false,
-					"id" : 3,
-					"name" : "a",
-					"nodeType" : "VariableDeclaration",
-					"overrides" : null,
-					"scope" : 15,
-					"src" : "13:8:1",
-					"stateVariable" : true,
-					"storageLocation" : "default",
-					"typeDescriptions" : 
-					{
-						"typeIdentifier" : "t_array$_t_uint256_$dyn_storage",
-						"typeString" : "uint256[]"
-					},
-					"typeName" : 
-					{
-						"baseType" : 
-						{
-							"id" : 1,
-							"name" : "uint",
-							"nodeType" : "ElementaryTypeName",
-							"src" : "13:4:1",
-							"typeDescriptions" : 
-							{
-								"typeIdentifier" : "t_uint256",
-								"typeString" : "uint256"
-							}
-						},
-						"id" : 2,
-						"length" : null,
-						"nodeType" : "ArrayTypeName",
-						"src" : "13:6:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_array$_t_uint256_$dyn_storage_ptr",
-							"typeString" : "uint256[]"
-						}
-					},
-					"value" : null,
-					"visibility" : "internal"
-				},
-				{
-					"body" : 
-					{
-						"id" : 13,
-						"nodeType" : "Block",
-						"src" : "43:25:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									10
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 10,
-										"name" : "b",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 13,
-										"src" : "45:16:1",
-										"stateVariable" : false,
-										"storageLocation" : "storage",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_array$_t_uint256_$dyn_storage_ptr",
-											"typeString" : "uint256[]"
-										},
-										"typeName" : 
-										{
-											"baseType" : 
-											{
-												"id" : 8,
-												"name" : "uint",
-												"nodeType" : "ElementaryTypeName",
-												"src" : "45:4:1",
-												"typeDescriptions" : 
-												{
-													"typeIdentifier" : "t_uint256",
-													"typeString" : "uint256"
-												}
-											},
-											"id" : 9,
-											"length" : null,
-											"nodeType" : "ArrayTypeName",
-											"src" : "45:6:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_array$_t_uint256_$dyn_storage_ptr",
-												"typeString" : "uint256[]"
-											}
-										},
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 12,
-								"initialValue" : 
-								{
-									"argumentTypes" : null,
-									"id" : 11,
-									"name" : "a",
-									"nodeType" : "Identifier",
-									"overloadedDeclarations" : [],
-									"referencedDeclaration" : 3,
-									"src" : "64:1:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_array$_t_uint256_$dyn_storage",
-										"typeString" : "uint256[] storage ref"
-									}
-								},
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "45:20:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 14,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 4,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "33:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 5,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "43:0:1"
-					},
-					"scope" : 15,
-					"src" : "23:45:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 16,
-			"src" : "0:70:1"
-		}
-	],
-	"src" : "0:71:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "c":
+    [
+      15
+    ]
+  },
+  "id": 16,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 15,
+      "linearizedBaseContracts":
+      [
+        15
+      ],
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 3,
+          "name": "a",
+          "nodeType": "VariableDeclaration",
+          "overrides": null,
+          "scope": 15,
+          "src": "13:8:1",
+          "stateVariable": true,
+          "storageLocation": "default",
+          "typeDescriptions":
+          {
+            "typeIdentifier": "t_array$_t_uint256_$dyn_storage",
+            "typeString": "uint256[]"
+          },
+          "typeName":
+          {
+            "baseType":
+            {
+              "id": 1,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "13:4:1",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "id": 2,
+            "length": null,
+            "nodeType": "ArrayTypeName",
+            "src": "13:6:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+              "typeString": "uint256[]"
+            }
+          },
+          "value": null,
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 13,
+            "nodeType": "Block",
+            "src": "43:25:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  10
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 10,
+                    "name": "b",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 13,
+                    "src": "45:16:1",
+                    "stateVariable": false,
+                    "storageLocation": "storage",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                      "typeString": "uint256[]"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 8,
+                        "name": "uint",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "45:4:1",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      "id": 9,
+                      "length": null,
+                      "nodeType": "ArrayTypeName",
+                      "src": "45:6:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                        "typeString": "uint256[]"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 12,
+                "initialValue":
+                {
+                  "argumentTypes": null,
+                  "id": 11,
+                  "name": "a",
+                  "nodeType": "Identifier",
+                  "overloadedDeclarations": [],
+                  "referencedDeclaration": 3,
+                  "src": "64:1:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_array$_t_uint256_$dyn_storage",
+                    "typeString": "uint256[] storage ref"
+                  }
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "45:20:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 14,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 4,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 5,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "43:0:1"
+          },
+          "scope": 15,
+          "src": "23:45:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 16,
+      "src": "0:70:1"
+    }
+  ],
+  "src": "0:71:1"
 }

--- a/test/libsolidity/ASTJSON/long_type_name_identifier_legacy.json
+++ b/test/libsolidity/ASTJSON/long_type_name_identifier_legacy.json
@@ -1,223 +1,223 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"c" : 
-			[
-				15
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					15
-				],
-				"name" : "c",
-				"scope" : 16
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"constant" : false,
-						"name" : "a",
-						"overrides" : null,
-						"scope" : 15,
-						"stateVariable" : true,
-						"storageLocation" : "default",
-						"type" : "uint256[]",
-						"value" : null,
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"length" : null,
-								"type" : "uint256[]"
-							},
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"name" : "uint",
-										"type" : "uint256"
-									},
-									"id" : 1,
-									"name" : "ElementaryTypeName",
-									"src" : "13:4:1"
-								}
-							],
-							"id" : 2,
-							"name" : "ArrayTypeName",
-							"src" : "13:6:1"
-						}
-					],
-					"id" : 3,
-					"name" : "VariableDeclaration",
-					"src" : "13:8:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 15,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 4,
-							"name" : "ParameterList",
-							"src" : "33:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 5,
-							"name" : "ParameterList",
-							"src" : "43:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											10
-										]
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "b",
-												"overrides" : null,
-												"scope" : 13,
-												"stateVariable" : false,
-												"storageLocation" : "storage",
-												"type" : "uint256[]",
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"length" : null,
-														"type" : "uint256[]"
-													},
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"name" : "uint",
-																"type" : "uint256"
-															},
-															"id" : 8,
-															"name" : "ElementaryTypeName",
-															"src" : "45:4:1"
-														}
-													],
-													"id" : 9,
-													"name" : "ArrayTypeName",
-													"src" : "45:6:1"
-												}
-											],
-											"id" : 10,
-											"name" : "VariableDeclaration",
-											"src" : "45:16:1"
-										},
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"overloadedDeclarations" : 
-												[
-													null
-												],
-												"referencedDeclaration" : 3,
-												"type" : "uint256[] storage ref",
-												"value" : "a"
-											},
-											"id" : 11,
-											"name" : "Identifier",
-											"src" : "64:1:1"
-										}
-									],
-									"id" : 12,
-									"name" : "VariableDeclarationStatement",
-									"src" : "45:20:1"
-								}
-							],
-							"id" : 13,
-							"name" : "Block",
-							"src" : "43:25:1"
-						}
-					],
-					"id" : 14,
-					"name" : "FunctionDefinition",
-					"src" : "23:45:1"
-				}
-			],
-			"id" : 15,
-			"name" : "ContractDefinition",
-			"src" : "0:70:1"
-		}
-	],
-	"id" : 16,
-	"name" : "SourceUnit",
-	"src" : "0:71:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "c":
+      [
+        15
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          15
+        ],
+        "name": "c",
+        "scope": 16
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "constant": false,
+            "name": "a",
+            "overrides": null,
+            "scope": 15,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "type": "uint256[]",
+            "value": null,
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "length": null,
+                "type": "uint256[]"
+              },
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "name": "uint",
+                    "type": "uint256"
+                  },
+                  "id": 1,
+                  "name": "ElementaryTypeName",
+                  "src": "13:4:1"
+                }
+              ],
+              "id": 2,
+              "name": "ArrayTypeName",
+              "src": "13:6:1"
+            }
+          ],
+          "id": 3,
+          "name": "VariableDeclaration",
+          "src": "13:8:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 15,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 4,
+              "name": "ParameterList",
+              "src": "33:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 5,
+              "name": "ParameterList",
+              "src": "43:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      10
+                    ]
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "b",
+                        "overrides": null,
+                        "scope": 13,
+                        "stateVariable": false,
+                        "storageLocation": "storage",
+                        "type": "uint256[]",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "length": null,
+                            "type": "uint256[]"
+                          },
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "name": "uint",
+                                "type": "uint256"
+                              },
+                              "id": 8,
+                              "name": "ElementaryTypeName",
+                              "src": "45:4:1"
+                            }
+                          ],
+                          "id": 9,
+                          "name": "ArrayTypeName",
+                          "src": "45:6:1"
+                        }
+                      ],
+                      "id": 10,
+                      "name": "VariableDeclaration",
+                      "src": "45:16:1"
+                    },
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "overloadedDeclarations":
+                        [
+                          null
+                        ],
+                        "referencedDeclaration": 3,
+                        "type": "uint256[] storage ref",
+                        "value": "a"
+                      },
+                      "id": 11,
+                      "name": "Identifier",
+                      "src": "64:1:1"
+                    }
+                  ],
+                  "id": 12,
+                  "name": "VariableDeclarationStatement",
+                  "src": "45:20:1"
+                }
+              ],
+              "id": 13,
+              "name": "Block",
+              "src": "43:25:1"
+            }
+          ],
+          "id": 14,
+          "name": "FunctionDefinition",
+          "src": "23:45:1"
+        }
+      ],
+      "id": 15,
+      "name": "ContractDefinition",
+      "src": "0:70:1"
+    }
+  ],
+  "id": 16,
+  "name": "SourceUnit",
+  "src": "0:71:1"
 }

--- a/test/libsolidity/ASTJSON/modifier_definition.json
+++ b/test/libsolidity/ASTJSON/modifier_definition.json
@@ -1,176 +1,176 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			14
-		]
-	},
-	"id" : 15,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 14,
-			"linearizedBaseContracts" : 
-			[
-				14
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 5,
-						"nodeType" : "Block",
-						"src" : "32:6:1",
-						"statements" : 
-						[
-							{
-								"id" : 4,
-								"nodeType" : "PlaceholderStatement",
-								"src" : "34:1:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 6,
-					"name" : "M",
-					"nodeType" : "ModifierDefinition",
-					"parameters" : 
-					{
-						"id" : 3,
-						"nodeType" : "ParameterList",
-						"parameters" : 
-						[
-							{
-								"constant" : false,
-								"id" : 2,
-								"name" : "i",
-								"nodeType" : "VariableDeclaration",
-								"overrides" : null,
-								"scope" : 6,
-								"src" : "24:6:1",
-								"stateVariable" : false,
-								"storageLocation" : "default",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_uint256",
-									"typeString" : "uint256"
-								},
-								"typeName" : 
-								{
-									"id" : 1,
-									"name" : "uint",
-									"nodeType" : "ElementaryTypeName",
-									"src" : "24:4:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_uint256",
-										"typeString" : "uint256"
-									}
-								},
-								"value" : null,
-								"visibility" : "internal"
-							}
-						],
-						"src" : "23:8:1"
-					},
-					"src" : "13:25:1",
-					"visibility" : "internal"
-				},
-				{
-					"body" : 
-					{
-						"id" : 12,
-						"nodeType" : "Block",
-						"src" : "64:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 13,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : 
-					[
-						{
-							"arguments" : 
-							[
-								{
-									"argumentTypes" : null,
-									"hexValue" : "31",
-									"id" : 9,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : true,
-									"kind" : "number",
-									"lValueRequested" : false,
-									"nodeType" : "Literal",
-									"src" : "54:1:1",
-									"subdenomination" : null,
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_rational_1_by_1",
-										"typeString" : "int_const 1"
-									},
-									"value" : "1"
-								}
-							],
-							"id" : 10,
-							"modifierName" : 
-							{
-								"argumentTypes" : null,
-								"id" : 8,
-								"name" : "M",
-								"nodeType" : "Identifier",
-								"overloadedDeclarations" : [],
-								"referencedDeclaration" : 6,
-								"src" : "52:1:1",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_modifier$_t_uint256_$",
-									"typeString" : "modifier (uint256)"
-								}
-							},
-							"nodeType" : "ModifierInvocation",
-							"src" : "52:4:1"
-						}
-					],
-					"name" : "F",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 7,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "49:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 11,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "64:0:1"
-					},
-					"scope" : 14,
-					"src" : "39:27:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 15,
-			"src" : "0:68:1"
-		}
-	],
-	"src" : "0:69:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      14
+    ]
+  },
+  "id": 15,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 14,
+      "linearizedBaseContracts":
+      [
+        14
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 5,
+            "nodeType": "Block",
+            "src": "32:6:1",
+            "statements":
+            [
+              {
+                "id": 4,
+                "nodeType": "PlaceholderStatement",
+                "src": "34:1:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 6,
+          "name": "M",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 3,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 2,
+                "name": "i",
+                "nodeType": "VariableDeclaration",
+                "overrides": null,
+                "scope": 6,
+                "src": "24:6:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName":
+                {
+                  "id": 1,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "24:4:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:8:1"
+          },
+          "src": "13:25:1",
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 12,
+            "nodeType": "Block",
+            "src": "64:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 13,
+          "implemented": true,
+          "kind": "function",
+          "modifiers":
+          [
+            {
+              "arguments":
+              [
+                {
+                  "argumentTypes": null,
+                  "hexValue": "31",
+                  "id": 9,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "kind": "number",
+                  "lValueRequested": false,
+                  "nodeType": "Literal",
+                  "src": "54:1:1",
+                  "subdenomination": null,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_rational_1_by_1",
+                    "typeString": "int_const 1"
+                  },
+                  "value": "1"
+                }
+              ],
+              "id": 10,
+              "modifierName":
+              {
+                "argumentTypes": null,
+                "id": 8,
+                "name": "M",
+                "nodeType": "Identifier",
+                "overloadedDeclarations": [],
+                "referencedDeclaration": 6,
+                "src": "52:1:1",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_modifier$_t_uint256_$",
+                  "typeString": "modifier (uint256)"
+                }
+              },
+              "nodeType": "ModifierInvocation",
+              "src": "52:4:1"
+            }
+          ],
+          "name": "F",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "49:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "64:0:1"
+          },
+          "scope": 14,
+          "src": "39:27:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 15,
+      "src": "0:68:1"
+    }
+  ],
+  "src": "0:69:1"
 }

--- a/test/libsolidity/ASTJSON/modifier_definition_legacy.json
+++ b/test/libsolidity/ASTJSON/modifier_definition_legacy.json
@@ -1,214 +1,214 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				14
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					14
-				],
-				"name" : "C",
-				"scope" : 15
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"name" : "M",
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "i",
-										"overrides" : null,
-										"scope" : 6,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "uint256",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"name" : "uint",
-												"type" : "uint256"
-											},
-											"id" : 1,
-											"name" : "ElementaryTypeName",
-											"src" : "24:4:1"
-										}
-									],
-									"id" : 2,
-									"name" : "VariableDeclaration",
-									"src" : "24:6:1"
-								}
-							],
-							"id" : 3,
-							"name" : "ParameterList",
-							"src" : "23:8:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"id" : 4,
-									"name" : "PlaceholderStatement",
-									"src" : "34:1:1"
-								}
-							],
-							"id" : 5,
-							"name" : "Block",
-							"src" : "32:6:1"
-						}
-					],
-					"id" : 6,
-					"name" : "ModifierDefinition",
-					"src" : "13:25:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"name" : "F",
-						"overrides" : null,
-						"scope" : 14,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 7,
-							"name" : "ParameterList",
-							"src" : "49:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 11,
-							"name" : "ParameterList",
-							"src" : "64:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"argumentTypes" : null,
-										"overloadedDeclarations" : 
-										[
-											null
-										],
-										"referencedDeclaration" : 6,
-										"type" : "modifier (uint256)",
-										"value" : "M"
-									},
-									"id" : 8,
-									"name" : "Identifier",
-									"src" : "52:1:1"
-								},
-								{
-									"attributes" : 
-									{
-										"argumentTypes" : null,
-										"hexvalue" : "31",
-										"isConstant" : false,
-										"isLValue" : false,
-										"isPure" : true,
-										"lValueRequested" : false,
-										"subdenomination" : null,
-										"token" : "number",
-										"type" : "int_const 1",
-										"value" : "1"
-									},
-									"id" : 9,
-									"name" : "Literal",
-									"src" : "54:1:1"
-								}
-							],
-							"id" : 10,
-							"name" : "ModifierInvocation",
-							"src" : "52:4:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 12,
-							"name" : "Block",
-							"src" : "64:2:1"
-						}
-					],
-					"id" : 13,
-					"name" : "FunctionDefinition",
-					"src" : "39:27:1"
-				}
-			],
-			"id" : 14,
-			"name" : "ContractDefinition",
-			"src" : "0:68:1"
-		}
-	],
-	"id" : 15,
-	"name" : "SourceUnit",
-	"src" : "0:69:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        14
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          14
+        ],
+        "name": "C",
+        "scope": 15
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "name": "M",
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "i",
+                    "overrides": null,
+                    "scope": 6,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "uint256",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "name": "uint",
+                        "type": "uint256"
+                      },
+                      "id": 1,
+                      "name": "ElementaryTypeName",
+                      "src": "24:4:1"
+                    }
+                  ],
+                  "id": 2,
+                  "name": "VariableDeclaration",
+                  "src": "24:6:1"
+                }
+              ],
+              "id": 3,
+              "name": "ParameterList",
+              "src": "23:8:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "id": 4,
+                  "name": "PlaceholderStatement",
+                  "src": "34:1:1"
+                }
+              ],
+              "id": 5,
+              "name": "Block",
+              "src": "32:6:1"
+            }
+          ],
+          "id": 6,
+          "name": "ModifierDefinition",
+          "src": "13:25:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "name": "F",
+            "overrides": null,
+            "scope": 14,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 7,
+              "name": "ParameterList",
+              "src": "49:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 11,
+              "name": "ParameterList",
+              "src": "64:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "argumentTypes": null,
+                    "overloadedDeclarations":
+                    [
+                      null
+                    ],
+                    "referencedDeclaration": 6,
+                    "type": "modifier (uint256)",
+                    "value": "M"
+                  },
+                  "id": 8,
+                  "name": "Identifier",
+                  "src": "52:1:1"
+                },
+                {
+                  "attributes":
+                  {
+                    "argumentTypes": null,
+                    "hexvalue": "31",
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "subdenomination": null,
+                    "token": "number",
+                    "type": "int_const 1",
+                    "value": "1"
+                  },
+                  "id": 9,
+                  "name": "Literal",
+                  "src": "54:1:1"
+                }
+              ],
+              "id": 10,
+              "name": "ModifierInvocation",
+              "src": "52:4:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 12,
+              "name": "Block",
+              "src": "64:2:1"
+            }
+          ],
+          "id": 13,
+          "name": "FunctionDefinition",
+          "src": "39:27:1"
+        }
+      ],
+      "id": 14,
+      "name": "ContractDefinition",
+      "src": "0:68:1"
+    }
+  ],
+  "id": 15,
+  "name": "SourceUnit",
+  "src": "0:69:1"
 }

--- a/test/libsolidity/ASTJSON/modifier_invocation.json
+++ b/test/libsolidity/ASTJSON/modifier_invocation.json
@@ -1,176 +1,176 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			14
-		]
-	},
-	"id" : 15,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 14,
-			"linearizedBaseContracts" : 
-			[
-				14
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 5,
-						"nodeType" : "Block",
-						"src" : "32:6:1",
-						"statements" : 
-						[
-							{
-								"id" : 4,
-								"nodeType" : "PlaceholderStatement",
-								"src" : "34:1:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 6,
-					"name" : "M",
-					"nodeType" : "ModifierDefinition",
-					"parameters" : 
-					{
-						"id" : 3,
-						"nodeType" : "ParameterList",
-						"parameters" : 
-						[
-							{
-								"constant" : false,
-								"id" : 2,
-								"name" : "i",
-								"nodeType" : "VariableDeclaration",
-								"overrides" : null,
-								"scope" : 6,
-								"src" : "24:6:1",
-								"stateVariable" : false,
-								"storageLocation" : "default",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_uint256",
-									"typeString" : "uint256"
-								},
-								"typeName" : 
-								{
-									"id" : 1,
-									"name" : "uint",
-									"nodeType" : "ElementaryTypeName",
-									"src" : "24:4:1",
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_uint256",
-										"typeString" : "uint256"
-									}
-								},
-								"value" : null,
-								"visibility" : "internal"
-							}
-						],
-						"src" : "23:8:1"
-					},
-					"src" : "13:25:1",
-					"visibility" : "internal"
-				},
-				{
-					"body" : 
-					{
-						"id" : 12,
-						"nodeType" : "Block",
-						"src" : "64:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 13,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : 
-					[
-						{
-							"arguments" : 
-							[
-								{
-									"argumentTypes" : null,
-									"hexValue" : "31",
-									"id" : 9,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : true,
-									"kind" : "number",
-									"lValueRequested" : false,
-									"nodeType" : "Literal",
-									"src" : "54:1:1",
-									"subdenomination" : null,
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_rational_1_by_1",
-										"typeString" : "int_const 1"
-									},
-									"value" : "1"
-								}
-							],
-							"id" : 10,
-							"modifierName" : 
-							{
-								"argumentTypes" : null,
-								"id" : 8,
-								"name" : "M",
-								"nodeType" : "Identifier",
-								"overloadedDeclarations" : [],
-								"referencedDeclaration" : 6,
-								"src" : "52:1:1",
-								"typeDescriptions" : 
-								{
-									"typeIdentifier" : "t_modifier$_t_uint256_$",
-									"typeString" : "modifier (uint256)"
-								}
-							},
-							"nodeType" : "ModifierInvocation",
-							"src" : "52:4:1"
-						}
-					],
-					"name" : "F",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 7,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "49:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 11,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "64:0:1"
-					},
-					"scope" : 14,
-					"src" : "39:27:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 15,
-			"src" : "0:68:1"
-		}
-	],
-	"src" : "0:69:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      14
+    ]
+  },
+  "id": 15,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 14,
+      "linearizedBaseContracts":
+      [
+        14
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 5,
+            "nodeType": "Block",
+            "src": "32:6:1",
+            "statements":
+            [
+              {
+                "id": 4,
+                "nodeType": "PlaceholderStatement",
+                "src": "34:1:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 6,
+          "name": "M",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 3,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 2,
+                "name": "i",
+                "nodeType": "VariableDeclaration",
+                "overrides": null,
+                "scope": 6,
+                "src": "24:6:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName":
+                {
+                  "id": 1,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "24:4:1",
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "value": null,
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:8:1"
+          },
+          "src": "13:25:1",
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 12,
+            "nodeType": "Block",
+            "src": "64:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 13,
+          "implemented": true,
+          "kind": "function",
+          "modifiers":
+          [
+            {
+              "arguments":
+              [
+                {
+                  "argumentTypes": null,
+                  "hexValue": "31",
+                  "id": 9,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "kind": "number",
+                  "lValueRequested": false,
+                  "nodeType": "Literal",
+                  "src": "54:1:1",
+                  "subdenomination": null,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_rational_1_by_1",
+                    "typeString": "int_const 1"
+                  },
+                  "value": "1"
+                }
+              ],
+              "id": 10,
+              "modifierName":
+              {
+                "argumentTypes": null,
+                "id": 8,
+                "name": "M",
+                "nodeType": "Identifier",
+                "overloadedDeclarations": [],
+                "referencedDeclaration": 6,
+                "src": "52:1:1",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_modifier$_t_uint256_$",
+                  "typeString": "modifier (uint256)"
+                }
+              },
+              "nodeType": "ModifierInvocation",
+              "src": "52:4:1"
+            }
+          ],
+          "name": "F",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "49:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "64:0:1"
+          },
+          "scope": 14,
+          "src": "39:27:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 15,
+      "src": "0:68:1"
+    }
+  ],
+  "src": "0:69:1"
 }

--- a/test/libsolidity/ASTJSON/modifier_invocation_legacy.json
+++ b/test/libsolidity/ASTJSON/modifier_invocation_legacy.json
@@ -1,214 +1,214 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				14
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					14
-				],
-				"name" : "C",
-				"scope" : 15
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"name" : "M",
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"constant" : false,
-										"name" : "i",
-										"overrides" : null,
-										"scope" : 6,
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"type" : "uint256",
-										"value" : null,
-										"visibility" : "internal"
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"name" : "uint",
-												"type" : "uint256"
-											},
-											"id" : 1,
-											"name" : "ElementaryTypeName",
-											"src" : "24:4:1"
-										}
-									],
-									"id" : 2,
-									"name" : "VariableDeclaration",
-									"src" : "24:6:1"
-								}
-							],
-							"id" : 3,
-							"name" : "ParameterList",
-							"src" : "23:8:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"id" : 4,
-									"name" : "PlaceholderStatement",
-									"src" : "34:1:1"
-								}
-							],
-							"id" : 5,
-							"name" : "Block",
-							"src" : "32:6:1"
-						}
-					],
-					"id" : 6,
-					"name" : "ModifierDefinition",
-					"src" : "13:25:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"name" : "F",
-						"overrides" : null,
-						"scope" : 14,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 7,
-							"name" : "ParameterList",
-							"src" : "49:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 11,
-							"name" : "ParameterList",
-							"src" : "64:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"argumentTypes" : null,
-										"overloadedDeclarations" : 
-										[
-											null
-										],
-										"referencedDeclaration" : 6,
-										"type" : "modifier (uint256)",
-										"value" : "M"
-									},
-									"id" : 8,
-									"name" : "Identifier",
-									"src" : "52:1:1"
-								},
-								{
-									"attributes" : 
-									{
-										"argumentTypes" : null,
-										"hexvalue" : "31",
-										"isConstant" : false,
-										"isLValue" : false,
-										"isPure" : true,
-										"lValueRequested" : false,
-										"subdenomination" : null,
-										"token" : "number",
-										"type" : "int_const 1",
-										"value" : "1"
-									},
-									"id" : 9,
-									"name" : "Literal",
-									"src" : "54:1:1"
-								}
-							],
-							"id" : 10,
-							"name" : "ModifierInvocation",
-							"src" : "52:4:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 12,
-							"name" : "Block",
-							"src" : "64:2:1"
-						}
-					],
-					"id" : 13,
-					"name" : "FunctionDefinition",
-					"src" : "39:27:1"
-				}
-			],
-			"id" : 14,
-			"name" : "ContractDefinition",
-			"src" : "0:68:1"
-		}
-	],
-	"id" : 15,
-	"name" : "SourceUnit",
-	"src" : "0:69:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        14
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          14
+        ],
+        "name": "C",
+        "scope": 15
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "name": "M",
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "constant": false,
+                    "name": "i",
+                    "overrides": null,
+                    "scope": 6,
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "type": "uint256",
+                    "value": null,
+                    "visibility": "internal"
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "name": "uint",
+                        "type": "uint256"
+                      },
+                      "id": 1,
+                      "name": "ElementaryTypeName",
+                      "src": "24:4:1"
+                    }
+                  ],
+                  "id": 2,
+                  "name": "VariableDeclaration",
+                  "src": "24:6:1"
+                }
+              ],
+              "id": 3,
+              "name": "ParameterList",
+              "src": "23:8:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "id": 4,
+                  "name": "PlaceholderStatement",
+                  "src": "34:1:1"
+                }
+              ],
+              "id": 5,
+              "name": "Block",
+              "src": "32:6:1"
+            }
+          ],
+          "id": 6,
+          "name": "ModifierDefinition",
+          "src": "13:25:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "name": "F",
+            "overrides": null,
+            "scope": 14,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 7,
+              "name": "ParameterList",
+              "src": "49:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 11,
+              "name": "ParameterList",
+              "src": "64:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "argumentTypes": null,
+                    "overloadedDeclarations":
+                    [
+                      null
+                    ],
+                    "referencedDeclaration": 6,
+                    "type": "modifier (uint256)",
+                    "value": "M"
+                  },
+                  "id": 8,
+                  "name": "Identifier",
+                  "src": "52:1:1"
+                },
+                {
+                  "attributes":
+                  {
+                    "argumentTypes": null,
+                    "hexvalue": "31",
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "subdenomination": null,
+                    "token": "number",
+                    "type": "int_const 1",
+                    "value": "1"
+                  },
+                  "id": 9,
+                  "name": "Literal",
+                  "src": "54:1:1"
+                }
+              ],
+              "id": 10,
+              "name": "ModifierInvocation",
+              "src": "52:4:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 12,
+              "name": "Block",
+              "src": "64:2:1"
+            }
+          ],
+          "id": 13,
+          "name": "FunctionDefinition",
+          "src": "39:27:1"
+        }
+      ],
+      "id": 14,
+      "name": "ContractDefinition",
+      "src": "0:68:1"
+    }
+  ],
+  "id": 15,
+  "name": "SourceUnit",
+  "src": "0:69:1"
 }

--- a/test/libsolidity/ASTJSON/non_utf8.json
+++ b/test/libsolidity/ASTJSON/non_utf8.json
@@ -1,124 +1,124 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			8
-		]
-	},
-	"id" : 9,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 8,
-			"linearizedBaseContracts" : 
-			[
-				8
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 6,
-						"nodeType" : "Block",
-						"src" : "33:20:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									3
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 3,
-										"name" : "x",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 6,
-										"src" : "35:5:1",
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_string_memory_ptr",
-											"typeString" : "string"
-										},
-										"typeName" : null,
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 5,
-								"initialValue" : 
-								{
-									"argumentTypes" : null,
-									"hexValue" : "ff",
-									"id" : 4,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : true,
-									"kind" : "string",
-									"lValueRequested" : false,
-									"nodeType" : "Literal",
-									"src" : "43:7:1",
-									"subdenomination" : null,
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_stringliteral_8b1a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9",
-										"typeString" : "literal_string (contains invalid UTF-8 sequence at position 0)"
-									},
-									"value" : null
-								},
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "35:15:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 7,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "23:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "33:0:1"
-					},
-					"scope" : 8,
-					"src" : "13:40:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 9,
-			"src" : "0:55:1"
-		}
-	],
-	"src" : "0:56:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      8
+    ]
+  },
+  "id": 9,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 8,
+      "linearizedBaseContracts":
+      [
+        8
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 6,
+            "nodeType": "Block",
+            "src": "33:20:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  3
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 3,
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 6,
+                    "src": "35:5:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_string_memory_ptr",
+                      "typeString": "string"
+                    },
+                    "typeName": null,
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 5,
+                "initialValue":
+                {
+                  "argumentTypes": null,
+                  "hexValue": "ff",
+                  "id": 4,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "kind": "string",
+                  "lValueRequested": false,
+                  "nodeType": "Literal",
+                  "src": "43:7:1",
+                  "subdenomination": null,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_stringliteral_8b1a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9",
+                    "typeString": "literal_string (contains invalid UTF-8 sequence at position 0)"
+                  },
+                  "value": null
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:15:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 7,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "scope": 8,
+          "src": "13:40:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 9,
+      "src": "0:55:1"
+    }
+  ],
+  "src": "0:56:1"
 }

--- a/test/libsolidity/ASTJSON/non_utf8_legacy.json
+++ b/test/libsolidity/ASTJSON/non_utf8_legacy.json
@@ -1,158 +1,158 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				8
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					8
-				],
-				"name" : "C",
-				"scope" : 9
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 8,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "23:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "33:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											3
-										]
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "x",
-												"overrides" : null,
-												"scope" : 6,
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"type" : "string",
-												"typeName" : null,
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : [],
-											"id" : 3,
-											"name" : "VariableDeclaration",
-											"src" : "35:5:1"
-										},
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"hexvalue" : "ff",
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : true,
-												"lValueRequested" : false,
-												"subdenomination" : null,
-												"token" : "string",
-												"type" : "literal_string (contains invalid UTF-8 sequence at position 0)",
-												"value" : null
-											},
-											"id" : 4,
-											"name" : "Literal",
-											"src" : "43:7:1"
-										}
-									],
-									"id" : 5,
-									"name" : "VariableDeclarationStatement",
-									"src" : "35:15:1"
-								}
-							],
-							"id" : 6,
-							"name" : "Block",
-							"src" : "33:20:1"
-						}
-					],
-					"id" : 7,
-					"name" : "FunctionDefinition",
-					"src" : "13:40:1"
-				}
-			],
-			"id" : 8,
-			"name" : "ContractDefinition",
-			"src" : "0:55:1"
-		}
-	],
-	"id" : 9,
-	"name" : "SourceUnit",
-	"src" : "0:56:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        8
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          8
+        ],
+        "name": "C",
+        "scope": 9
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 8,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "23:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "33:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      3
+                    ]
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "x",
+                        "overrides": null,
+                        "scope": 6,
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "type": "string",
+                        "typeName": null,
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children": [],
+                      "id": 3,
+                      "name": "VariableDeclaration",
+                      "src": "35:5:1"
+                    },
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "hexvalue": "ff",
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "subdenomination": null,
+                        "token": "string",
+                        "type": "literal_string (contains invalid UTF-8 sequence at position 0)",
+                        "value": null
+                      },
+                      "id": 4,
+                      "name": "Literal",
+                      "src": "43:7:1"
+                    }
+                  ],
+                  "id": 5,
+                  "name": "VariableDeclarationStatement",
+                  "src": "35:15:1"
+                }
+              ],
+              "id": 6,
+              "name": "Block",
+              "src": "33:20:1"
+            }
+          ],
+          "id": 7,
+          "name": "FunctionDefinition",
+          "src": "13:40:1"
+        }
+      ],
+      "id": 8,
+      "name": "ContractDefinition",
+      "src": "0:55:1"
+    }
+  ],
+  "id": 9,
+  "name": "SourceUnit",
+  "src": "0:56:1"
 }

--- a/test/libsolidity/ASTJSON/override.json
+++ b/test/libsolidity/ASTJSON/override.json
@@ -1,337 +1,337 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"A" : 
-		[
-			5
-		],
-		"B" : 
-		[
-			16
-		],
-		"C" : 
-		[
-			31
-		]
-	},
-	"id" : 32,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 5,
-			"linearizedBaseContracts" : 
-			[
-				5
-			],
-			"name" : "A",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 3,
-						"nodeType" : "Block",
-						"src" : "36:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 4,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "faa",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "26:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "36:0:1"
-					},
-					"scope" : 5,
-					"src" : "14:24:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 32,
-			"src" : "0:40:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 6,
-						"name" : "A",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 5,
-						"src" : "55:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_A_$5",
-							"typeString" : "contract A"
-						}
-					},
-					"id" : 7,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "55:1:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				5
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : false,
-			"id" : 16,
-			"linearizedBaseContracts" : 
-			[
-				16,
-				5
-			],
-			"name" : "B",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : null,
-					"documentation" : null,
-					"id" : 10,
-					"implemented" : false,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "foo",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 8,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "72:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 9,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "81:0:1"
-					},
-					"scope" : 16,
-					"src" : "60:22:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				},
-				{
-					"body" : 
-					{
-						"id" : 14,
-						"nodeType" : "Block",
-						"src" : "115:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 15,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "faa",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : [],
-					"parameters" : 
-					{
-						"id" : 11,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "96:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 13,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "115:0:1"
-					},
-					"scope" : 16,
-					"src" : "84:33:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : 4,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 32,
-			"src" : "41:78:1"
-		},
-		{
-			"baseContracts" : 
-			[
-				{
-					"arguments" : null,
-					"baseName" : 
-					{
-						"contractScope" : null,
-						"id" : 17,
-						"name" : "B",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 16,
-						"src" : "134:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_B_$16",
-							"typeString" : "contract B"
-						}
-					},
-					"id" : 18,
-					"nodeType" : "InheritanceSpecifier",
-					"src" : "134:1:1"
-				}
-			],
-			"contractDependencies" : 
-			[
-				5,
-				16
-			],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 31,
-			"linearizedBaseContracts" : 
-			[
-				31,
-				16,
-				5
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 22,
-						"nodeType" : "Block",
-						"src" : "170:3:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 23,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "foo",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : [],
-					"parameters" : 
-					{
-						"id" : 19,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "151:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 21,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "170:0:1"
-					},
-					"scope" : 31,
-					"src" : "139:34:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : 10,
-					"visibility" : "public"
-				},
-				{
-					"body" : 
-					{
-						"id" : 29,
-						"nodeType" : "Block",
-						"src" : "212:2:1",
-						"statements" : []
-					},
-					"documentation" : null,
-					"id" : 30,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "faa",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : 
-					[
-						{
-							"contractScope" : null,
-							"id" : 25,
-							"name" : "A",
-							"nodeType" : "UserDefinedTypeName",
-							"referencedDeclaration" : 5,
-							"src" : "206:1:1",
-							"typeDescriptions" : 
-							{
-								"typeIdentifier" : "t_contract$_A_$5",
-								"typeString" : "contract A"
-							}
-						},
-						{
-							"contractScope" : null,
-							"id" : 26,
-							"name" : "B",
-							"nodeType" : "UserDefinedTypeName",
-							"referencedDeclaration" : 16,
-							"src" : "209:1:1",
-							"typeDescriptions" : 
-							{
-								"typeIdentifier" : "t_contract$_B_$16",
-								"typeString" : "contract B"
-							}
-						}
-					],
-					"parameters" : 
-					{
-						"id" : 24,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "187:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 28,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "212:0:1"
-					},
-					"scope" : 31,
-					"src" : "175:39:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : 15,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 32,
-			"src" : "120:96:1"
-		}
-	],
-	"src" : "0:217:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "A":
+    [
+      5
+    ],
+    "B":
+    [
+      16
+    ],
+    "C":
+    [
+      31
+    ]
+  },
+  "id": 32,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 5,
+      "linearizedBaseContracts":
+      [
+        5
+      ],
+      "name": "A",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "36:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 4,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "faa",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "26:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "36:0:1"
+          },
+          "scope": 5,
+          "src": "14:24:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 32,
+      "src": "0:40:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 6,
+            "name": "A",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 5,
+            "src": "55:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_A_$5",
+              "typeString": "contract A"
+            }
+          },
+          "id": 7,
+          "nodeType": "InheritanceSpecifier",
+          "src": "55:1:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        5
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": false,
+      "id": 16,
+      "linearizedBaseContracts":
+      [
+        16,
+        5
+      ],
+      "name": "B",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body": null,
+          "documentation": null,
+          "id": 10,
+          "implemented": false,
+          "kind": "function",
+          "modifiers": [],
+          "name": "foo",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 8,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "72:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 9,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "81:0:1"
+          },
+          "scope": 16,
+          "src": "60:22:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 14,
+            "nodeType": "Block",
+            "src": "115:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 15,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "faa",
+          "nodeType": "FunctionDefinition",
+          "overrides": [],
+          "parameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "96:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 13,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "115:0:1"
+          },
+          "scope": 16,
+          "src": "84:33:1",
+          "stateMutability": "nonpayable",
+          "superFunction": 4,
+          "visibility": "public"
+        }
+      ],
+      "scope": 32,
+      "src": "41:78:1"
+    },
+    {
+      "baseContracts":
+      [
+        {
+          "arguments": null,
+          "baseName":
+          {
+            "contractScope": null,
+            "id": 17,
+            "name": "B",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 16,
+            "src": "134:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_B_$16",
+              "typeString": "contract B"
+            }
+          },
+          "id": 18,
+          "nodeType": "InheritanceSpecifier",
+          "src": "134:1:1"
+        }
+      ],
+      "contractDependencies":
+      [
+        5,
+        16
+      ],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 31,
+      "linearizedBaseContracts":
+      [
+        31,
+        16,
+        5
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 22,
+            "nodeType": "Block",
+            "src": "170:3:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 23,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "foo",
+          "nodeType": "FunctionDefinition",
+          "overrides": [],
+          "parameters":
+          {
+            "id": 19,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "151:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 21,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "170:0:1"
+          },
+          "scope": 31,
+          "src": "139:34:1",
+          "stateMutability": "nonpayable",
+          "superFunction": 10,
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 29,
+            "nodeType": "Block",
+            "src": "212:2:1",
+            "statements": []
+          },
+          "documentation": null,
+          "id": 30,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "faa",
+          "nodeType": "FunctionDefinition",
+          "overrides":
+          [
+            {
+              "contractScope": null,
+              "id": 25,
+              "name": "A",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 5,
+              "src": "206:1:1",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_contract$_A_$5",
+                "typeString": "contract A"
+              }
+            },
+            {
+              "contractScope": null,
+              "id": 26,
+              "name": "B",
+              "nodeType": "UserDefinedTypeName",
+              "referencedDeclaration": 16,
+              "src": "209:1:1",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_contract$_B_$16",
+                "typeString": "contract B"
+              }
+            }
+          ],
+          "parameters":
+          {
+            "id": 24,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "187:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 28,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "212:0:1"
+          },
+          "scope": 31,
+          "src": "175:39:1",
+          "stateMutability": "nonpayable",
+          "superFunction": 15,
+          "visibility": "public"
+        }
+      ],
+      "scope": 32,
+      "src": "120:96:1"
+    }
+  ],
+  "src": "0:217:1"
 }

--- a/test/libsolidity/ASTJSON/override_legacy.json
+++ b/test/libsolidity/ASTJSON/override_legacy.json
@@ -1,492 +1,492 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"A" : 
-			[
-				5
-			],
-			"B" : 
-			[
-				16
-			],
-			"C" : 
-			[
-				31
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					5
-				],
-				"name" : "A",
-				"scope" : 32
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "faa",
-						"overrides" : null,
-						"scope" : 5,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "26:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "36:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 3,
-							"name" : "Block",
-							"src" : "36:2:1"
-						}
-					],
-					"id" : 4,
-					"name" : "FunctionDefinition",
-					"src" : "14:24:1"
-				}
-			],
-			"id" : 5,
-			"name" : "ContractDefinition",
-			"src" : "0:40:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					5
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : false,
-				"linearizedBaseContracts" : 
-				[
-					16,
-					5
-				],
-				"name" : "B",
-				"scope" : 32
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "A",
-								"referencedDeclaration" : 5,
-								"type" : "contract A"
-							},
-							"id" : 6,
-							"name" : "UserDefinedTypeName",
-							"src" : "55:1:1"
-						}
-					],
-					"id" : 7,
-					"name" : "InheritanceSpecifier",
-					"src" : "55:1:1"
-				},
-				{
-					"attributes" : 
-					{
-						"body" : null,
-						"documentation" : null,
-						"implemented" : false,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "foo",
-						"overrides" : null,
-						"scope" : 16,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 8,
-							"name" : "ParameterList",
-							"src" : "72:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 9,
-							"name" : "ParameterList",
-							"src" : "81:0:1"
-						}
-					],
-					"id" : 10,
-					"name" : "FunctionDefinition",
-					"src" : "60:22:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "faa",
-						"overrides" : 
-						[
-							null
-						],
-						"scope" : 16,
-						"stateMutability" : "nonpayable",
-						"superFunction" : 4,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 11,
-							"name" : "ParameterList",
-							"src" : "96:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 13,
-							"name" : "ParameterList",
-							"src" : "115:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 14,
-							"name" : "Block",
-							"src" : "115:2:1"
-						}
-					],
-					"id" : 15,
-					"name" : "FunctionDefinition",
-					"src" : "84:33:1"
-				}
-			],
-			"id" : 16,
-			"name" : "ContractDefinition",
-			"src" : "41:78:1"
-		},
-		{
-			"attributes" : 
-			{
-				"contractDependencies" : 
-				[
-					5,
-					16
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					31,
-					16,
-					5
-				],
-				"name" : "C",
-				"scope" : 32
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"arguments" : null
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "B",
-								"referencedDeclaration" : 16,
-								"type" : "contract B"
-							},
-							"id" : 17,
-							"name" : "UserDefinedTypeName",
-							"src" : "134:1:1"
-						}
-					],
-					"id" : 18,
-					"name" : "InheritanceSpecifier",
-					"src" : "134:1:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "foo",
-						"overrides" : 
-						[
-							null
-						],
-						"scope" : 31,
-						"stateMutability" : "nonpayable",
-						"superFunction" : 10,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 19,
-							"name" : "ParameterList",
-							"src" : "151:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 21,
-							"name" : "ParameterList",
-							"src" : "170:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 22,
-							"name" : "Block",
-							"src" : "170:3:1"
-						}
-					],
-					"id" : 23,
-					"name" : "FunctionDefinition",
-					"src" : "139:34:1"
-				},
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "faa",
-						"scope" : 31,
-						"stateMutability" : "nonpayable",
-						"superFunction" : 15,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "A",
-								"referencedDeclaration" : 5,
-								"type" : "contract A"
-							},
-							"id" : 25,
-							"name" : "UserDefinedTypeName",
-							"src" : "206:1:1"
-						},
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "B",
-								"referencedDeclaration" : 16,
-								"type" : "contract B"
-							},
-							"id" : 26,
-							"name" : "UserDefinedTypeName",
-							"src" : "209:1:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 24,
-							"name" : "ParameterList",
-							"src" : "187:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 28,
-							"name" : "ParameterList",
-							"src" : "212:0:1"
-						},
-						{
-							"attributes" : 
-							{
-								"statements" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 29,
-							"name" : "Block",
-							"src" : "212:2:1"
-						}
-					],
-					"id" : 30,
-					"name" : "FunctionDefinition",
-					"src" : "175:39:1"
-				}
-			],
-			"id" : 31,
-			"name" : "ContractDefinition",
-			"src" : "120:96:1"
-		}
-	],
-	"id" : 32,
-	"name" : "SourceUnit",
-	"src" : "0:217:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "A":
+      [
+        5
+      ],
+      "B":
+      [
+        16
+      ],
+      "C":
+      [
+        31
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          5
+        ],
+        "name": "A",
+        "scope": 32
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "faa",
+            "overrides": null,
+            "scope": 5,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "26:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "36:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 3,
+              "name": "Block",
+              "src": "36:2:1"
+            }
+          ],
+          "id": 4,
+          "name": "FunctionDefinition",
+          "src": "14:24:1"
+        }
+      ],
+      "id": 5,
+      "name": "ContractDefinition",
+      "src": "0:40:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          5
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": false,
+        "linearizedBaseContracts":
+        [
+          16,
+          5
+        ],
+        "name": "B",
+        "scope": 32
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "A",
+                "referencedDeclaration": 5,
+                "type": "contract A"
+              },
+              "id": 6,
+              "name": "UserDefinedTypeName",
+              "src": "55:1:1"
+            }
+          ],
+          "id": 7,
+          "name": "InheritanceSpecifier",
+          "src": "55:1:1"
+        },
+        {
+          "attributes":
+          {
+            "body": null,
+            "documentation": null,
+            "implemented": false,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "foo",
+            "overrides": null,
+            "scope": 16,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 8,
+              "name": "ParameterList",
+              "src": "72:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 9,
+              "name": "ParameterList",
+              "src": "81:0:1"
+            }
+          ],
+          "id": 10,
+          "name": "FunctionDefinition",
+          "src": "60:22:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "faa",
+            "overrides":
+            [
+              null
+            ],
+            "scope": 16,
+            "stateMutability": "nonpayable",
+            "superFunction": 4,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 11,
+              "name": "ParameterList",
+              "src": "96:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 13,
+              "name": "ParameterList",
+              "src": "115:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 14,
+              "name": "Block",
+              "src": "115:2:1"
+            }
+          ],
+          "id": 15,
+          "name": "FunctionDefinition",
+          "src": "84:33:1"
+        }
+      ],
+      "id": 16,
+      "name": "ContractDefinition",
+      "src": "41:78:1"
+    },
+    {
+      "attributes":
+      {
+        "contractDependencies":
+        [
+          5,
+          16
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          31,
+          16,
+          5
+        ],
+        "name": "C",
+        "scope": 32
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "arguments": null
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "B",
+                "referencedDeclaration": 16,
+                "type": "contract B"
+              },
+              "id": 17,
+              "name": "UserDefinedTypeName",
+              "src": "134:1:1"
+            }
+          ],
+          "id": 18,
+          "name": "InheritanceSpecifier",
+          "src": "134:1:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "foo",
+            "overrides":
+            [
+              null
+            ],
+            "scope": 31,
+            "stateMutability": "nonpayable",
+            "superFunction": 10,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 19,
+              "name": "ParameterList",
+              "src": "151:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 21,
+              "name": "ParameterList",
+              "src": "170:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 22,
+              "name": "Block",
+              "src": "170:3:1"
+            }
+          ],
+          "id": 23,
+          "name": "FunctionDefinition",
+          "src": "139:34:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "faa",
+            "scope": 31,
+            "stateMutability": "nonpayable",
+            "superFunction": 15,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "A",
+                "referencedDeclaration": 5,
+                "type": "contract A"
+              },
+              "id": 25,
+              "name": "UserDefinedTypeName",
+              "src": "206:1:1"
+            },
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "B",
+                "referencedDeclaration": 16,
+                "type": "contract B"
+              },
+              "id": 26,
+              "name": "UserDefinedTypeName",
+              "src": "209:1:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 24,
+              "name": "ParameterList",
+              "src": "187:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 28,
+              "name": "ParameterList",
+              "src": "212:0:1"
+            },
+            {
+              "attributes":
+              {
+                "statements":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 29,
+              "name": "Block",
+              "src": "212:2:1"
+            }
+          ],
+          "id": 30,
+          "name": "FunctionDefinition",
+          "src": "175:39:1"
+        }
+      ],
+      "id": 31,
+      "name": "ContractDefinition",
+      "src": "120:96:1"
+    }
+  ],
+  "id": 32,
+  "name": "SourceUnit",
+  "src": "0:217:1"
 }

--- a/test/libsolidity/ASTJSON/placeholder_statement.json
+++ b/test/libsolidity/ASTJSON/placeholder_statement.json
@@ -1,64 +1,64 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			5
-		]
-	},
-	"id" : 6,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 5,
-			"linearizedBaseContracts" : 
-			[
-				5
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 3,
-						"nodeType" : "Block",
-						"src" : "24:6:1",
-						"statements" : 
-						[
-							{
-								"id" : 2,
-								"nodeType" : "PlaceholderStatement",
-								"src" : "26:1:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 4,
-					"name" : "M",
-					"nodeType" : "ModifierDefinition",
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "24:0:1"
-					},
-					"src" : "13:17:1",
-					"visibility" : "internal"
-				}
-			],
-			"scope" : 6,
-			"src" : "0:32:1"
-		}
-	],
-	"src" : "0:33:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      5
+    ]
+  },
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 5,
+      "linearizedBaseContracts":
+      [
+        5
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "24:6:1",
+            "statements":
+            [
+              {
+                "id": 2,
+                "nodeType": "PlaceholderStatement",
+                "src": "26:1:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 4,
+          "name": "M",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "24:0:1"
+          },
+          "src": "13:17:1",
+          "visibility": "internal"
+        }
+      ],
+      "scope": 6,
+      "src": "0:32:1"
+    }
+  ],
+  "src": "0:33:1"
 }

--- a/test/libsolidity/ASTJSON/placeholder_statement_legacy.json
+++ b/test/libsolidity/ASTJSON/placeholder_statement_legacy.json
@@ -1,87 +1,87 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				5
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					5
-				],
-				"name" : "C",
-				"scope" : 6
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"name" : "M",
-						"visibility" : "internal"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "24:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"id" : 2,
-									"name" : "PlaceholderStatement",
-									"src" : "26:1:1"
-								}
-							],
-							"id" : 3,
-							"name" : "Block",
-							"src" : "24:6:1"
-						}
-					],
-					"id" : 4,
-					"name" : "ModifierDefinition",
-					"src" : "13:17:1"
-				}
-			],
-			"id" : 5,
-			"name" : "ContractDefinition",
-			"src" : "0:32:1"
-		}
-	],
-	"id" : 6,
-	"name" : "SourceUnit",
-	"src" : "0:33:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        5
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          5
+        ],
+        "name": "C",
+        "scope": 6
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "name": "M",
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "24:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "id": 2,
+                  "name": "PlaceholderStatement",
+                  "src": "26:1:1"
+                }
+              ],
+              "id": 3,
+              "name": "Block",
+              "src": "24:6:1"
+            }
+          ],
+          "id": 4,
+          "name": "ModifierDefinition",
+          "src": "13:17:1"
+        }
+      ],
+      "id": 5,
+      "name": "ContractDefinition",
+      "src": "0:32:1"
+    }
+  ],
+  "id": 6,
+  "name": "SourceUnit",
+  "src": "0:33:1"
 }

--- a/test/libsolidity/ASTJSON/short_type_name.json
+++ b/test/libsolidity/ASTJSON/short_type_name.json
@@ -1,128 +1,128 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"c" : 
-		[
-			11
-		]
-	},
-	"id" : 12,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 11,
-			"linearizedBaseContracts" : 
-			[
-				11
-			],
-			"name" : "c",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 9,
-						"nodeType" : "Block",
-						"src" : "33:20:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									7
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 7,
-										"name" : "x",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 9,
-										"src" : "35:15:1",
-										"stateVariable" : false,
-										"storageLocation" : "memory",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_array$_t_uint256_$dyn_memory_ptr",
-											"typeString" : "uint256[]"
-										},
-										"typeName" : 
-										{
-											"baseType" : 
-											{
-												"id" : 5,
-												"name" : "uint",
-												"nodeType" : "ElementaryTypeName",
-												"src" : "35:4:1",
-												"typeDescriptions" : 
-												{
-													"typeIdentifier" : "t_uint256",
-													"typeString" : "uint256"
-												}
-											},
-											"id" : 6,
-											"length" : null,
-											"nodeType" : "ArrayTypeName",
-											"src" : "35:6:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_array$_t_uint256_$dyn_storage_ptr",
-												"typeString" : "uint256[]"
-											}
-										},
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 8,
-								"initialValue" : null,
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "35:15:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 10,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "23:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "33:0:1"
-					},
-					"scope" : 11,
-					"src" : "13:40:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 12,
-			"src" : "0:55:1"
-		}
-	],
-	"src" : "0:56:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "c":
+    [
+      11
+    ]
+  },
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 11,
+      "linearizedBaseContracts":
+      [
+        11
+      ],
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "33:20:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  7
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 7,
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 9,
+                    "src": "35:15:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_array$_t_uint256_$dyn_memory_ptr",
+                      "typeString": "uint256[]"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 5,
+                        "name": "uint",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "35:4:1",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      "id": 6,
+                      "length": null,
+                      "nodeType": "ArrayTypeName",
+                      "src": "35:6:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                        "typeString": "uint256[]"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 8,
+                "initialValue": null,
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:15:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "scope": 11,
+          "src": "13:40:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 12,
+      "src": "0:55:1"
+    }
+  ],
+  "src": "0:56:1"
 }

--- a/test/libsolidity/ASTJSON/short_type_name_legacy.json
+++ b/test/libsolidity/ASTJSON/short_type_name_legacy.json
@@ -1,165 +1,165 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"c" : 
-			[
-				11
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					11
-				],
-				"name" : "c",
-				"scope" : 12
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 11,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "23:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "33:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											7
-										],
-										"initialValue" : null
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "x",
-												"overrides" : null,
-												"scope" : 9,
-												"stateVariable" : false,
-												"storageLocation" : "memory",
-												"type" : "uint256[]",
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"length" : null,
-														"type" : "uint256[]"
-													},
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"name" : "uint",
-																"type" : "uint256"
-															},
-															"id" : 5,
-															"name" : "ElementaryTypeName",
-															"src" : "35:4:1"
-														}
-													],
-													"id" : 6,
-													"name" : "ArrayTypeName",
-													"src" : "35:6:1"
-												}
-											],
-											"id" : 7,
-											"name" : "VariableDeclaration",
-											"src" : "35:15:1"
-										}
-									],
-									"id" : 8,
-									"name" : "VariableDeclarationStatement",
-									"src" : "35:15:1"
-								}
-							],
-							"id" : 9,
-							"name" : "Block",
-							"src" : "33:20:1"
-						}
-					],
-					"id" : 10,
-					"name" : "FunctionDefinition",
-					"src" : "13:40:1"
-				}
-			],
-			"id" : 11,
-			"name" : "ContractDefinition",
-			"src" : "0:55:1"
-		}
-	],
-	"id" : 12,
-	"name" : "SourceUnit",
-	"src" : "0:56:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "c":
+      [
+        11
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          11
+        ],
+        "name": "c",
+        "scope": 12
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 11,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "23:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "33:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      7
+                    ],
+                    "initialValue": null
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "x",
+                        "overrides": null,
+                        "scope": 9,
+                        "stateVariable": false,
+                        "storageLocation": "memory",
+                        "type": "uint256[]",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "length": null,
+                            "type": "uint256[]"
+                          },
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "name": "uint",
+                                "type": "uint256"
+                              },
+                              "id": 5,
+                              "name": "ElementaryTypeName",
+                              "src": "35:4:1"
+                            }
+                          ],
+                          "id": 6,
+                          "name": "ArrayTypeName",
+                          "src": "35:6:1"
+                        }
+                      ],
+                      "id": 7,
+                      "name": "VariableDeclaration",
+                      "src": "35:15:1"
+                    }
+                  ],
+                  "id": 8,
+                  "name": "VariableDeclarationStatement",
+                  "src": "35:15:1"
+                }
+              ],
+              "id": 9,
+              "name": "Block",
+              "src": "33:20:1"
+            }
+          ],
+          "id": 10,
+          "name": "FunctionDefinition",
+          "src": "13:40:1"
+        }
+      ],
+      "id": 11,
+      "name": "ContractDefinition",
+      "src": "0:55:1"
+    }
+  ],
+  "id": 12,
+  "name": "SourceUnit",
+  "src": "0:56:1"
 }

--- a/test/libsolidity/ASTJSON/short_type_name_ref.json
+++ b/test/libsolidity/ASTJSON/short_type_name_ref.json
@@ -1,140 +1,140 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"c" : 
-		[
-			12
-		]
-	},
-	"id" : 13,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 12,
-			"linearizedBaseContracts" : 
-			[
-				12
-			],
-			"name" : "c",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 10,
-						"nodeType" : "Block",
-						"src" : "33:25:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									8
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 8,
-										"name" : "rows",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 10,
-										"src" : "35:20:1",
-										"stateVariable" : false,
-										"storageLocation" : "memory",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_array$_t_array$_t_uint256_$dyn_memory_$dyn_memory_ptr",
-											"typeString" : "uint256[][]"
-										},
-										"typeName" : 
-										{
-											"baseType" : 
-											{
-												"baseType" : 
-												{
-													"id" : 5,
-													"name" : "uint",
-													"nodeType" : "ElementaryTypeName",
-													"src" : "35:4:1",
-													"typeDescriptions" : 
-													{
-														"typeIdentifier" : "t_uint256",
-														"typeString" : "uint256"
-													}
-												},
-												"id" : 6,
-												"length" : null,
-												"nodeType" : "ArrayTypeName",
-												"src" : "35:6:1",
-												"typeDescriptions" : 
-												{
-													"typeIdentifier" : "t_array$_t_uint256_$dyn_storage_ptr",
-													"typeString" : "uint256[]"
-												}
-											},
-											"id" : 7,
-											"length" : null,
-											"nodeType" : "ArrayTypeName",
-											"src" : "35:8:1",
-											"typeDescriptions" : 
-											{
-												"typeIdentifier" : "t_array$_t_array$_t_uint256_$dyn_storage_$dyn_storage_ptr",
-												"typeString" : "uint256[][]"
-											}
-										},
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 9,
-								"initialValue" : null,
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "35:20:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 11,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "23:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "33:0:1"
-					},
-					"scope" : 12,
-					"src" : "13:45:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 13,
-			"src" : "0:60:1"
-		}
-	],
-	"src" : "0:61:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "c":
+    [
+      12
+    ]
+  },
+  "id": 13,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 12,
+      "linearizedBaseContracts":
+      [
+        12
+      ],
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 10,
+            "nodeType": "Block",
+            "src": "33:25:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  8
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 8,
+                    "name": "rows",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 10,
+                    "src": "35:20:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_array$_t_array$_t_uint256_$dyn_memory_$dyn_memory_ptr",
+                      "typeString": "uint256[][]"
+                    },
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "baseType":
+                        {
+                          "id": 5,
+                          "name": "uint",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "35:4:1",
+                          "typeDescriptions":
+                          {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "id": 6,
+                        "length": null,
+                        "nodeType": "ArrayTypeName",
+                        "src": "35:6:1",
+                        "typeDescriptions":
+                        {
+                          "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                          "typeString": "uint256[]"
+                        }
+                      },
+                      "id": 7,
+                      "length": null,
+                      "nodeType": "ArrayTypeName",
+                      "src": "35:8:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_array$_t_array$_t_uint256_$dyn_storage_$dyn_storage_ptr",
+                        "typeString": "uint256[][]"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 9,
+                "initialValue": null,
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:20:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 11,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "scope": 12,
+          "src": "13:45:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 13,
+      "src": "0:60:1"
+    }
+  ],
+  "src": "0:61:1"
 }

--- a/test/libsolidity/ASTJSON/short_type_name_ref_legacy.json
+++ b/test/libsolidity/ASTJSON/short_type_name_ref_legacy.json
@@ -1,178 +1,178 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"c" : 
-			[
-				12
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					12
-				],
-				"name" : "c",
-				"scope" : 13
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 12,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "23:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "33:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											8
-										],
-										"initialValue" : null
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "rows",
-												"overrides" : null,
-												"scope" : 10,
-												"stateVariable" : false,
-												"storageLocation" : "memory",
-												"type" : "uint256[][]",
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"length" : null,
-														"type" : "uint256[][]"
-													},
-													"children" : 
-													[
-														{
-															"attributes" : 
-															{
-																"length" : null,
-																"type" : "uint256[]"
-															},
-															"children" : 
-															[
-																{
-																	"attributes" : 
-																	{
-																		"name" : "uint",
-																		"type" : "uint256"
-																	},
-																	"id" : 5,
-																	"name" : "ElementaryTypeName",
-																	"src" : "35:4:1"
-																}
-															],
-															"id" : 6,
-															"name" : "ArrayTypeName",
-															"src" : "35:6:1"
-														}
-													],
-													"id" : 7,
-													"name" : "ArrayTypeName",
-													"src" : "35:8:1"
-												}
-											],
-											"id" : 8,
-											"name" : "VariableDeclaration",
-											"src" : "35:20:1"
-										}
-									],
-									"id" : 9,
-									"name" : "VariableDeclarationStatement",
-									"src" : "35:20:1"
-								}
-							],
-							"id" : 10,
-							"name" : "Block",
-							"src" : "33:25:1"
-						}
-					],
-					"id" : 11,
-					"name" : "FunctionDefinition",
-					"src" : "13:45:1"
-				}
-			],
-			"id" : 12,
-			"name" : "ContractDefinition",
-			"src" : "0:60:1"
-		}
-	],
-	"id" : 13,
-	"name" : "SourceUnit",
-	"src" : "0:61:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "c":
+      [
+        12
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          12
+        ],
+        "name": "c",
+        "scope": 13
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 12,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "23:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "33:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      8
+                    ],
+                    "initialValue": null
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "rows",
+                        "overrides": null,
+                        "scope": 10,
+                        "stateVariable": false,
+                        "storageLocation": "memory",
+                        "type": "uint256[][]",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "length": null,
+                            "type": "uint256[][]"
+                          },
+                          "children":
+                          [
+                            {
+                              "attributes":
+                              {
+                                "length": null,
+                                "type": "uint256[]"
+                              },
+                              "children":
+                              [
+                                {
+                                  "attributes":
+                                  {
+                                    "name": "uint",
+                                    "type": "uint256"
+                                  },
+                                  "id": 5,
+                                  "name": "ElementaryTypeName",
+                                  "src": "35:4:1"
+                                }
+                              ],
+                              "id": 6,
+                              "name": "ArrayTypeName",
+                              "src": "35:6:1"
+                            }
+                          ],
+                          "id": 7,
+                          "name": "ArrayTypeName",
+                          "src": "35:8:1"
+                        }
+                      ],
+                      "id": 8,
+                      "name": "VariableDeclaration",
+                      "src": "35:20:1"
+                    }
+                  ],
+                  "id": 9,
+                  "name": "VariableDeclarationStatement",
+                  "src": "35:20:1"
+                }
+              ],
+              "id": 10,
+              "name": "Block",
+              "src": "33:25:1"
+            }
+          ],
+          "id": 11,
+          "name": "FunctionDefinition",
+          "src": "13:45:1"
+        }
+      ],
+      "id": 12,
+      "name": "ContractDefinition",
+      "src": "0:60:1"
+    }
+  ],
+  "id": 13,
+  "name": "SourceUnit",
+  "src": "0:61:1"
 }

--- a/test/libsolidity/ASTJSON/smoke.json
+++ b/test/libsolidity/ASTJSON/smoke.json
@@ -1,33 +1,33 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			1
-		]
-	},
-	"id" : 2,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 1,
-			"linearizedBaseContracts" : 
-			[
-				1
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 2,
-			"src" : "0:13:1"
-		}
-	],
-	"src" : "0:14:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      1
+    ]
+  },
+  "id": 2,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 1,
+      "linearizedBaseContracts":
+      [
+        1
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 2,
+      "src": "0:13:1"
+    }
+  ],
+  "src": "0:14:1"
 }

--- a/test/libsolidity/ASTJSON/smoke_legacy.json
+++ b/test/libsolidity/ASTJSON/smoke_legacy.json
@@ -1,48 +1,48 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				1
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					1
-				],
-				"name" : "C",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 2
-			},
-			"id" : 1,
-			"name" : "ContractDefinition",
-			"src" : "0:13:1"
-		}
-	],
-	"id" : 2,
-	"name" : "SourceUnit",
-	"src" : "0:14:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        1
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          1
+        ],
+        "name": "C",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 2
+      },
+      "id": 1,
+      "name": "ContractDefinition",
+      "src": "0:13:1"
+    }
+  ],
+  "id": 2,
+  "name": "SourceUnit",
+  "src": "0:14:1"
 }

--- a/test/libsolidity/ASTJSON/source_location.json
+++ b/test/libsolidity/ASTJSON/source_location.json
@@ -1,162 +1,162 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			11
-		]
-	},
-	"id" : 12,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 11,
-			"linearizedBaseContracts" : 
-			[
-				11
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"body" : 
-					{
-						"id" : 9,
-						"nodeType" : "Block",
-						"src" : "26:19:1",
-						"statements" : 
-						[
-							{
-								"assignments" : 
-								[
-									3
-								],
-								"declarations" : 
-								[
-									{
-										"constant" : false,
-										"id" : 3,
-										"name" : "x",
-										"nodeType" : "VariableDeclaration",
-										"overrides" : null,
-										"scope" : 9,
-										"src" : "28:5:1",
-										"stateVariable" : false,
-										"storageLocation" : "default",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_uint8",
-											"typeString" : "uint8"
-										},
-										"typeName" : null,
-										"value" : null,
-										"visibility" : "internal"
-									}
-								],
-								"id" : 5,
-								"initialValue" : 
-								{
-									"argumentTypes" : null,
-									"hexValue" : "32",
-									"id" : 4,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : true,
-									"kind" : "number",
-									"lValueRequested" : false,
-									"nodeType" : "Literal",
-									"src" : "36:1:1",
-									"subdenomination" : null,
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_rational_2_by_1",
-										"typeString" : "int_const 2"
-									},
-									"value" : "2"
-								},
-								"nodeType" : "VariableDeclarationStatement",
-								"src" : "28:9:1"
-							},
-							{
-								"expression" : 
-								{
-									"argumentTypes" : null,
-									"id" : 7,
-									"isConstant" : false,
-									"isLValue" : false,
-									"isPure" : false,
-									"lValueRequested" : false,
-									"nodeType" : "UnaryOperation",
-									"operator" : "++",
-									"prefix" : false,
-									"src" : "39:3:1",
-									"subExpression" : 
-									{
-										"argumentTypes" : null,
-										"id" : 6,
-										"name" : "x",
-										"nodeType" : "Identifier",
-										"overloadedDeclarations" : [],
-										"referencedDeclaration" : 3,
-										"src" : "39:1:1",
-										"typeDescriptions" : 
-										{
-											"typeIdentifier" : "t_uint8",
-											"typeString" : "uint8"
-										}
-									},
-									"typeDescriptions" : 
-									{
-										"typeIdentifier" : "t_uint8",
-										"typeString" : "uint8"
-									}
-								},
-								"id" : 8,
-								"nodeType" : "ExpressionStatement",
-								"src" : "39:3:1"
-							}
-						]
-					},
-					"documentation" : null,
-					"id" : 10,
-					"implemented" : true,
-					"kind" : "function",
-					"modifiers" : [],
-					"name" : "f",
-					"nodeType" : "FunctionDefinition",
-					"overrides" : null,
-					"parameters" : 
-					{
-						"id" : 1,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "23:2:1"
-					},
-					"returnParameters" : 
-					{
-						"id" : 2,
-						"nodeType" : "ParameterList",
-						"parameters" : [],
-						"src" : "26:0:1"
-					},
-					"scope" : 11,
-					"src" : "13:32:1",
-					"stateMutability" : "nonpayable",
-					"superFunction" : null,
-					"visibility" : "public"
-				}
-			],
-			"scope" : 12,
-			"src" : "0:47:1"
-		}
-	],
-	"src" : "0:48:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      11
+    ]
+  },
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 11,
+      "linearizedBaseContracts":
+      [
+        11
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "26:19:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  3
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 3,
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 9,
+                    "src": "28:5:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    },
+                    "typeName": null,
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 5,
+                "initialValue":
+                {
+                  "argumentTypes": null,
+                  "hexValue": "32",
+                  "id": 4,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "kind": "number",
+                  "lValueRequested": false,
+                  "nodeType": "Literal",
+                  "src": "36:1:1",
+                  "subdenomination": null,
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_rational_2_by_1",
+                    "typeString": "int_const 2"
+                  },
+                  "value": "2"
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "28:9:1"
+              },
+              {
+                "expression":
+                {
+                  "argumentTypes": null,
+                  "id": 7,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "nodeType": "UnaryOperation",
+                  "operator": "++",
+                  "prefix": false,
+                  "src": "39:3:1",
+                  "subExpression":
+                  {
+                    "argumentTypes": null,
+                    "id": 6,
+                    "name": "x",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 3,
+                    "src": "39:1:1",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint8",
+                      "typeString": "uint8"
+                    }
+                  },
+                  "typeDescriptions":
+                  {
+                    "typeIdentifier": "t_uint8",
+                    "typeString": "uint8"
+                  }
+                },
+                "id": 8,
+                "nodeType": "ExpressionStatement",
+                "src": "39:3:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "26:0:1"
+          },
+          "scope": 11,
+          "src": "13:32:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 12,
+      "src": "0:47:1"
+    }
+  ],
+  "src": "0:48:1"
 }

--- a/test/libsolidity/ASTJSON/source_location_legacy.json
+++ b/test/libsolidity/ASTJSON/source_location_legacy.json
@@ -1,201 +1,201 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				11
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					11
-				],
-				"name" : "C",
-				"scope" : 12
-			},
-			"children" : 
-			[
-				{
-					"attributes" : 
-					{
-						"documentation" : null,
-						"implemented" : true,
-						"isConstructor" : false,
-						"kind" : "function",
-						"modifiers" : 
-						[
-							null
-						],
-						"name" : "f",
-						"overrides" : null,
-						"scope" : 11,
-						"stateMutability" : "nonpayable",
-						"superFunction" : null,
-						"visibility" : "public"
-					},
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 1,
-							"name" : "ParameterList",
-							"src" : "23:2:1"
-						},
-						{
-							"attributes" : 
-							{
-								"parameters" : 
-								[
-									null
-								]
-							},
-							"children" : [],
-							"id" : 2,
-							"name" : "ParameterList",
-							"src" : "26:0:1"
-						},
-						{
-							"children" : 
-							[
-								{
-									"attributes" : 
-									{
-										"assignments" : 
-										[
-											3
-										]
-									},
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"constant" : false,
-												"name" : "x",
-												"overrides" : null,
-												"scope" : 9,
-												"stateVariable" : false,
-												"storageLocation" : "default",
-												"type" : "uint8",
-												"typeName" : null,
-												"value" : null,
-												"visibility" : "internal"
-											},
-											"children" : [],
-											"id" : 3,
-											"name" : "VariableDeclaration",
-											"src" : "28:5:1"
-										},
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"hexvalue" : "32",
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : true,
-												"lValueRequested" : false,
-												"subdenomination" : null,
-												"token" : "number",
-												"type" : "int_const 2",
-												"value" : "2"
-											},
-											"id" : 4,
-											"name" : "Literal",
-											"src" : "36:1:1"
-										}
-									],
-									"id" : 5,
-									"name" : "VariableDeclarationStatement",
-									"src" : "28:9:1"
-								},
-								{
-									"children" : 
-									[
-										{
-											"attributes" : 
-											{
-												"argumentTypes" : null,
-												"isConstant" : false,
-												"isLValue" : false,
-												"isPure" : false,
-												"lValueRequested" : false,
-												"operator" : "++",
-												"prefix" : false,
-												"type" : "uint8"
-											},
-											"children" : 
-											[
-												{
-													"attributes" : 
-													{
-														"argumentTypes" : null,
-														"overloadedDeclarations" : 
-														[
-															null
-														],
-														"referencedDeclaration" : 3,
-														"type" : "uint8",
-														"value" : "x"
-													},
-													"id" : 6,
-													"name" : "Identifier",
-													"src" : "39:1:1"
-												}
-											],
-											"id" : 7,
-											"name" : "UnaryOperation",
-											"src" : "39:3:1"
-										}
-									],
-									"id" : 8,
-									"name" : "ExpressionStatement",
-									"src" : "39:3:1"
-								}
-							],
-							"id" : 9,
-							"name" : "Block",
-							"src" : "26:19:1"
-						}
-					],
-					"id" : 10,
-					"name" : "FunctionDefinition",
-					"src" : "13:32:1"
-				}
-			],
-			"id" : 11,
-			"name" : "ContractDefinition",
-			"src" : "0:47:1"
-		}
-	],
-	"id" : 12,
-	"name" : "SourceUnit",
-	"src" : "0:48:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        11
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          11
+        ],
+        "name": "C",
+        "scope": 12
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 11,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "23:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "26:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      3
+                    ]
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "x",
+                        "overrides": null,
+                        "scope": 9,
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "type": "uint8",
+                        "typeName": null,
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children": [],
+                      "id": 3,
+                      "name": "VariableDeclaration",
+                      "src": "28:5:1"
+                    },
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "hexvalue": "32",
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "subdenomination": null,
+                        "token": "number",
+                        "type": "int_const 2",
+                        "value": "2"
+                      },
+                      "id": 4,
+                      "name": "Literal",
+                      "src": "36:1:1"
+                    }
+                  ],
+                  "id": 5,
+                  "name": "VariableDeclarationStatement",
+                  "src": "28:9:1"
+                },
+                {
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "argumentTypes": null,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "operator": "++",
+                        "prefix": false,
+                        "type": "uint8"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "argumentTypes": null,
+                            "overloadedDeclarations":
+                            [
+                              null
+                            ],
+                            "referencedDeclaration": 3,
+                            "type": "uint8",
+                            "value": "x"
+                          },
+                          "id": 6,
+                          "name": "Identifier",
+                          "src": "39:1:1"
+                        }
+                      ],
+                      "id": 7,
+                      "name": "UnaryOperation",
+                      "src": "39:3:1"
+                    }
+                  ],
+                  "id": 8,
+                  "name": "ExpressionStatement",
+                  "src": "39:3:1"
+                }
+              ],
+              "id": 9,
+              "name": "Block",
+              "src": "26:19:1"
+            }
+          ],
+          "id": 10,
+          "name": "FunctionDefinition",
+          "src": "13:32:1"
+        }
+      ],
+      "id": 11,
+      "name": "ContractDefinition",
+      "src": "0:47:1"
+    }
+  ],
+  "id": 12,
+  "name": "SourceUnit",
+  "src": "0:48:1"
 }

--- a/test/libsolidity/ASTJSON/using_for_directive.json
+++ b/test/libsolidity/ASTJSON/using_for_directive.json
@@ -1,87 +1,87 @@
 {
-	"absolutePath" : "a",
-	"exportedSymbols" : 
-	{
-		"C" : 
-		[
-			5
-		],
-		"L" : 
-		[
-			1
-		]
-	},
-	"id" : 6,
-	"nodeType" : "SourceUnit",
-	"nodes" : 
-	[
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "library",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 1,
-			"linearizedBaseContracts" : 
-			[
-				1
-			],
-			"name" : "L",
-			"nodeType" : "ContractDefinition",
-			"nodes" : [],
-			"scope" : 6,
-			"src" : "0:12:1"
-		},
-		{
-			"baseContracts" : [],
-			"contractDependencies" : [],
-			"contractKind" : "contract",
-			"documentation" : null,
-			"fullyImplemented" : true,
-			"id" : 5,
-			"linearizedBaseContracts" : 
-			[
-				5
-			],
-			"name" : "C",
-			"nodeType" : "ContractDefinition",
-			"nodes" : 
-			[
-				{
-					"id" : 4,
-					"libraryName" : 
-					{
-						"contractScope" : null,
-						"id" : 2,
-						"name" : "L",
-						"nodeType" : "UserDefinedTypeName",
-						"referencedDeclaration" : 1,
-						"src" : "32:1:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_contract$_L_$1",
-							"typeString" : "library L"
-						}
-					},
-					"nodeType" : "UsingForDirective",
-					"src" : "26:17:1",
-					"typeName" : 
-					{
-						"id" : 3,
-						"name" : "uint",
-						"nodeType" : "ElementaryTypeName",
-						"src" : "38:4:1",
-						"typeDescriptions" : 
-						{
-							"typeIdentifier" : "t_uint256",
-							"typeString" : "uint256"
-						}
-					}
-				}
-			],
-			"scope" : 6,
-			"src" : "13:32:1"
-		}
-	],
-	"src" : "0:46:1"
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      5
+    ],
+    "L":
+    [
+      1
+    ]
+  },
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "library",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 1,
+      "linearizedBaseContracts":
+      [
+        1
+      ],
+      "name": "L",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "scope": 6,
+      "src": "0:12:1"
+    },
+    {
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 5,
+      "linearizedBaseContracts":
+      [
+        5
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "id": 4,
+          "libraryName":
+          {
+            "contractScope": null,
+            "id": 2,
+            "name": "L",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 1,
+            "src": "32:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_contract$_L_$1",
+              "typeString": "library L"
+            }
+          },
+          "nodeType": "UsingForDirective",
+          "src": "26:17:1",
+          "typeName":
+          {
+            "id": 3,
+            "name": "uint",
+            "nodeType": "ElementaryTypeName",
+            "src": "38:4:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            }
+          }
+        }
+      ],
+      "scope": 6,
+      "src": "13:32:1"
+    }
+  ],
+  "src": "0:46:1"
 }

--- a/test/libsolidity/ASTJSON/using_for_directive_legacy.json
+++ b/test/libsolidity/ASTJSON/using_for_directive_legacy.json
@@ -1,110 +1,110 @@
 {
-	"attributes" : 
-	{
-		"absolutePath" : "a",
-		"exportedSymbols" : 
-		{
-			"C" : 
-			[
-				5
-			],
-			"L" : 
-			[
-				1
-			]
-		}
-	},
-	"children" : 
-	[
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "library",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					1
-				],
-				"name" : "L",
-				"nodes" : 
-				[
-					null
-				],
-				"scope" : 6
-			},
-			"id" : 1,
-			"name" : "ContractDefinition",
-			"src" : "0:12:1"
-		},
-		{
-			"attributes" : 
-			{
-				"baseContracts" : 
-				[
-					null
-				],
-				"contractDependencies" : 
-				[
-					null
-				],
-				"contractKind" : "contract",
-				"documentation" : null,
-				"fullyImplemented" : true,
-				"linearizedBaseContracts" : 
-				[
-					5
-				],
-				"name" : "C",
-				"scope" : 6
-			},
-			"children" : 
-			[
-				{
-					"children" : 
-					[
-						{
-							"attributes" : 
-							{
-								"contractScope" : null,
-								"name" : "L",
-								"referencedDeclaration" : 1,
-								"type" : "library L"
-							},
-							"id" : 2,
-							"name" : "UserDefinedTypeName",
-							"src" : "32:1:1"
-						},
-						{
-							"attributes" : 
-							{
-								"name" : "uint",
-								"type" : "uint256"
-							},
-							"id" : 3,
-							"name" : "ElementaryTypeName",
-							"src" : "38:4:1"
-						}
-					],
-					"id" : 4,
-					"name" : "UsingForDirective",
-					"src" : "26:17:1"
-				}
-			],
-			"id" : 5,
-			"name" : "ContractDefinition",
-			"src" : "13:32:1"
-		}
-	],
-	"id" : 6,
-	"name" : "SourceUnit",
-	"src" : "0:46:1"
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        5
+      ],
+      "L":
+      [
+        1
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "library",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          1
+        ],
+        "name": "L",
+        "nodes":
+        [
+          null
+        ],
+        "scope": 6
+      },
+      "id": 1,
+      "name": "ContractDefinition",
+      "src": "0:12:1"
+    },
+    {
+      "attributes":
+      {
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          5
+        ],
+        "name": "C",
+        "scope": 6
+      },
+      "children":
+      [
+        {
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "L",
+                "referencedDeclaration": 1,
+                "type": "library L"
+              },
+              "id": 2,
+              "name": "UserDefinedTypeName",
+              "src": "32:1:1"
+            },
+            {
+              "attributes":
+              {
+                "name": "uint",
+                "type": "uint256"
+              },
+              "id": 3,
+              "name": "ElementaryTypeName",
+              "src": "38:4:1"
+            }
+          ],
+          "id": 4,
+          "name": "UsingForDirective",
+          "src": "26:17:1"
+        }
+      ],
+      "id": 5,
+      "name": "ContractDefinition",
+      "src": "13:32:1"
+    }
+  ],
+  "id": 6,
+  "name": "SourceUnit",
+  "src": "0:46:1"
 }


### PR DESCRIPTION
Use `jsonPrettyPrint` for printing JSON AST, so that trailing spaces are not added in JSON output.

Closes #7373 