### PR TITLE
Prevent build path from ending up in binaries.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -23,6 +23,9 @@ endif()
 
 eth_add_cxx_compiler_flag_if_supported(-Wimplicit-fallthrough)
 
+# Prevent the path of the source directory from ending up in the binary via __FILE__ macros.
+eth_add_cxx_compiler_flag_if_supported("-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=/solidity")
+
 if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
 	# Enables all the warnings about constructions that some users consider questionable,
 	# and that are easy to avoid.  Also enable some extra warning flags that are not


### PR DESCRIPTION
Where supported this change will replace the source path in ``__FILE__`` macros (implicitly used during our assertions) with ``/solidity``, whenever this is supported by the compiler.

Almost fixes, i.e. refs https://github.com/ethereum/solidity/issues/6230
In a stripped binary there's still some references to the source path remaining caused by json-cpp, which is built as an external subproject, so we'd need more involved checks for compiler support (resp. force a specific compiler for the subproject).

This is a step towards reproducible binaries and will reduce binary size.