### PR TITLE
fix doc create2

### DIFF
--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -292,7 +292,7 @@ In the grammar, opcodes are represented as pre-defined identifiers.
 | create2(v, p, n, s)     |     | C | create new contract with code mem[p...(p+n)) at address         |
 |                         |     |   | keccak256(0xff . this . s . keccak256(mem[p...(p+n)))           |
 |                         |     |   | and send v wei and return the new address, where ``0xff`` is a  |
-|                         |     |   | 8 byte value, ``this`` is the current contract's address        |
+|                         |     |   | 1 byte value, ``this`` is the current contract's address        |
 |                         |     |   | as a 20 byte value and ``s`` is a big-endian 256-bit value      |
 +-------------------------+-----+---+-----------------------------------------------------------------+
 | call(g, a, v, in,       |     | F | call contract at address a with input mem[in...(in+insize))     |


### PR DESCRIPTION
### Description

Docs of CREATE2 assembly are incorrect - they note that `0xff` is a 8 byte value. I suppose this is a typo where either 8 bit value was meant but I changed it to `1 byte`. 

Reference: 
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1014.md

This notes `0xff` is a byte, not 8 bytes. (To generate the `keccak` hash to figure out the target deployment address).