### PR TITLE
Remove dependency on boost::regex from Whiskers

### DIFF
--- a/.circleci/docker/Dockerfile.clang.ubuntu1904
+++ b/.circleci/docker/Dockerfile.clang.ubuntu1904
@@ -57,7 +57,7 @@ RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git 
     ./bootstrap.sh --with-toolset=clang --prefix=/usr; \
     ./b2 toolset=clang headers; \
     ./b2 toolset=clang variant=release \
-        system regex filesystem unit_test_framework program_options \
+        system filesystem unit_test_framework program_options \
         install -j $(($(nproc)/2)); \
     rm -rf /usr/src/boost
 

--- a/.circleci/docker/Dockerfile.ubuntu1804
+++ b/.circleci/docker/Dockerfile.ubuntu1804
@@ -34,7 +34,7 @@ RUN set -ex; \
 		build-essential \
 		software-properties-common \
 		cmake ninja-build clang++-8 \
-		libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev \
+		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		libjsoncpp-dev \
 		llvm-8-dev libz3-static-dev \

--- a/.circleci/docker/Dockerfile.ubuntu1904
+++ b/.circleci/docker/Dockerfile.ubuntu1904
@@ -34,7 +34,7 @@ RUN set -ex; \
 		build-essential \
 		software-properties-common \
 		cmake ninja-build clang++-8 libc++-8-dev libc++abi-8-dev \
-		libboost-regex-dev libboost-filesystem-dev libboost-test-dev libboost-system-dev \
+		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		libjsoncpp-dev \
 		llvm-8-dev libcvc4-dev libz3-static-dev libleveldb1d \

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -133,6 +133,8 @@ elseif (DEFINED MSVC)
 	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
 	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
 	add_compile_options(/utf-8)					# enable utf-8 encoding (solves warning 4819)
+	add_compile_options(-DBOOST_REGEX_NO_LIB)		# disable automatic boost::regex library selection
+	add_compile_options(-D_REGEX_MAX_STACK_COUNT=200000L)	# increase std::regex recursion depth limit
 
 	# disable empty object file warning
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -26,7 +26,7 @@ set(ETH_SCRIPTS_DIR ${ETH_CMAKE_DIR}/scripts)
 set(Boost_USE_MULTITHREADED ON)
 option(Boost_USE_STATIC_LIBS "Link Boost statically" ON)
 
-set(BOOST_COMPONENTS "regex;filesystem;unit_test_framework;program_options;system")
+set(BOOST_COMPONENTS "filesystem;unit_test_framework;program_options;system")
 
 find_package(Boost 1.65.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 

--- a/libdevcore/CMakeLists.txt
+++ b/libdevcore/CMakeLists.txt
@@ -34,7 +34,7 @@ set(sources
 )
 
 add_library(devcore ${sources})
-target_link_libraries(devcore PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::regex Boost::system)
+target_link_libraries(devcore PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system)
 target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
 add_dependencies(devcore solidity_BuildInfo.h)
 

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -67,7 +67,7 @@ echo -en 'travis_fold:start:compiling_boost\\r'
 test -e "$WORKSPACE"/boost_1_70_0_install/include/boost/version.hpp || (
 cd "$WORKSPACE"/boost_1_70_0
 ./b2 toolset=emscripten link=static variant=release threading=single runtime-link=static \
-       --with-system --with-regex --with-filesystem --with-test --with-program_options cxxflags="-Wno-unused-local-typedef -Wno-variadic-macros -Wno-c99-extensions -Wno-all" \
+       --with-system --with-filesystem --with-test --with-program_options cxxflags="-Wno-unused-local-typedef -Wno-variadic-macros -Wno-c99-extensions -Wno-all" \
        --prefix="$WORKSPACE"/boost_1_70_0_install install
 )
 ln -sf "$WORKSPACE"/boost_1_70_0_install/lib/* /emsdk_portable/sdk/system/lib


### PR DESCRIPTION
### Description

#### TL;DR

Thanks in advance for advices :)

- Whiskers regex - **as-is**, with `boost::regex`:
   ```javascript
   /<([a-zA-Z0-9_$-]+)>|<#([a-zA-Z0-9_$-]+)>(.*?)</\2>|<\?([a-zA-Z0-9_$-]+)>(.*?)(<!\4>(.*?))?</\4>/g
   ```
- Whiskers regex - **to-be**, with `std::regex`:
  ```javascript
  /<([a-zA-Z0-9_$-]+)>|<#([a-zA-Z0-9_$-]+)>((?:.|\r|\n)*?)</\2>|<\?([a-zA-Z0-9_$-]+)>((?:.|\n|\r)*?)(<!\4>((?:.|\n|\r)*?))?</\4>/g
  ```

#### Details

This PR replaces `boost::regex` with `std::regex`, as suggested in #6971 and #6997.
The biggest difference between `boost::regex` and `std::regex` is the behavior of dots:
- In `boost::regex`, `.*` matches over line  breaks
- In `std::regex`, `.*` does not match newline characters(`\r`, `\n`).

To address the issue, a change is made to the Whiskers regular expression:
1. Replace **`.`** with non-capturing group **`(?:.|\r|\n)`**

And two compilation options are added to the _MSVC_ case:

1. `-DBOOST_REGEX_NO_LIB `: It prevents _automatic_ linking to `libboost_regex`.
2. `-D_REGEX_MAX_STACK_COUNT=200000L`: Microsoft implementation of `std::regex` has too tight recursion depth limit. This option increases it to 200,000 - which, IMHO, is sufficient for every sane use case.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (*if possible*)
- [x] README / documentation was extended, *if necessary*
- [x] Changelog entry (*if change is visible to the user*)
- [x] Used meaningful commit messages

Part of #7259.