### PR TITLE
inline assembly to AST in json export

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ Breaking changes:
  * Type checker: Resulting type of exponentiation is equal to the type of the base. Also allow signed types for the base.
  * Natspec JSON Interface: Properly support multiple ``@return`` statements in ``@dev`` documentation and enforce named return parameters to be mentioned documentation.
  * Source mappings: Add "modifier depth" as a fifth field in the source mappings.
+ * AST: Inline assembly is exported as structured JSON instead of plain string.
 
 
 
@@ -46,7 +47,6 @@ Compiler Features:
  * SMTChecker: Support assignments to multi-dimensional arrays and mappings.
  * SMTChecker: Support inheritance and function overriding.
  * EWasm: Experimental EWasm binary output.
-
 
 Bugfixes:
  * Type Checker: Disallow constructor of the same class to be used as modifier

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -133,6 +133,7 @@ private:
 		std::string const& _nodeName,
 		std::vector<std::pair<std::string, Json::Value>>&& _attributes
 	);
+	size_t sourceIndexFromLocation(langutil::SourceLocation const& _location) const;
 	std::string sourceLocationToString(langutil::SourceLocation const& _location) const;
 	static std::string namePathToString(std::vector<ASTString> const& _namePath);
 	static Json::Value idOrNull(ASTNode const* _pt)

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -1,0 +1,203 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @date 2019
+ * Converts inline assembly AST to JSON format
+ */
+
+#include <libyul/AsmJsonConverter.h>
+#include <libyul/AsmData.h>
+#include <liblangutil/Exceptions.h>
+#include <libdevcore/CommonData.h>
+
+using namespace std;
+
+namespace yul
+{
+
+Json::Value AsmJsonConverter::operator()(Block const& _node) const
+{
+	Json::Value ret = createAstNode(_node.location, "YulBlock");
+	ret["statements"] = vectorOfVariantsToJson(_node.statements);
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
+{
+	solAssert(!_node.name.empty(), "Invalid variable name.");
+	Json::Value ret = createAstNode(_node.location, "YulTypedName");
+	ret["name"] = _node.name.str();
+	ret["type"] = _node.type.str();
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(Literal const& _node) const
+{
+	Json::Value ret = createAstNode(_node.location, "YulLiteral");
+	switch (_node.kind)
+	{
+	case LiteralKind::Number:
+		solAssert(
+			dev::isValidDecimal(_node.value.str()) || dev::isValidHex(_node.value.str()),
+			"Invalid number literal"
+		);
+		ret["kind"] = "number";
+		break;
+	case LiteralKind::Boolean:
+		ret["kind"] = "bool";
+		break;
+	case LiteralKind::String:
+		ret["kind"] = "string";
+		break;
+	}
+	ret["type"] = _node.type.str();
+	ret["value"] = _node.value.str();
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
+{
+	solAssert(!_node.name.empty(), "Invalid identifier");
+	Json::Value ret = createAstNode(_node.location, "YulIdentifier");
+	ret["name"] = _node.name.str();
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
+{
+	solAssert(_node.variableNames.size() >= 1, "Invalid assignment syntax");
+	Json::Value ret = createAstNode(_node.location, "YulAssignment");
+	for (auto const& var: _node.variableNames)
+		ret["variableNames"].append((*this)(var));
+	ret["value"] = _node.value ? boost::apply_visitor(*this, *_node.value) : Json::nullValue;
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
+{
+	Json::Value ret = createAstNode(_node.location, "YulFunctionCall");
+	ret["functionName"] = (*this)(_node.functionName);
+	ret["arguments"] = vectorOfVariantsToJson(_node.arguments);
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(ExpressionStatement const& _node) const
+{
+	Json::Value ret = createAstNode(_node.location, "YulExpressionStatement");
+	ret["expression"] = boost::apply_visitor(*this, _node.expression);
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
+{
+	Json::Value ret = createAstNode(_node.location, "YulVariableDeclaration");
+	for (auto const& var: _node.variables)
+		ret["variables"].append((*this)(var));
+
+	ret["value"] = _node.value ? boost::apply_visitor(*this, *_node.value) : Json::nullValue;
+
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
+{
+	solAssert(!_node.name.empty(), "Invalid function name.");
+	Json::Value ret = createAstNode(_node.location, "YulFunctionDefinition");
+	ret["name"] = _node.name.str();
+	for (auto const& var: _node.parameters)
+		ret["parameters"].append((*this)(var));
+	for (auto const& var: _node.returnVariables)
+		ret["returnVariables"].append((*this)(var));
+	ret["body"] = (*this)(_node.body);
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(If const& _node) const
+{
+	solAssert(_node.condition, "Invalid if condition.");
+	Json::Value ret = createAstNode(_node.location, "YulIf");
+	ret["condition"] = boost::apply_visitor(*this, *_node.condition);
+	ret["body"] = (*this)(_node.body);
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(Switch const& _node) const
+{
+	solAssert(_node.expression, "Invalid expression pointer.");
+	Json::Value ret = createAstNode(_node.location, "YulSwitch");
+	ret["expression"] = boost::apply_visitor(*this, *_node.expression);
+	for (auto const& var: _node.cases)
+		ret["cases"].append((*this)(var));
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(Case const& _node) const
+{
+	Json::Value ret = createAstNode(_node.location, "YulCase");
+	ret["value"] = _node.value ? (*this)(*_node.value) : "default";
+	ret["body"] = (*this)(_node.body);
+	return ret;
+}
+
+Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
+{
+	solAssert(_node.condition, "Invalid for loop condition.");
+	Json::Value ret = createAstNode(_node.location, "YulForLoop");
+	ret["pre"] = (*this)(_node.pre);
+	ret["condition"] = boost::apply_visitor(*this, *_node.condition);
+	ret["post"] = (*this)(_node.post);
+	ret["body"] = (*this)(_node.body);
+	return ret;
+	}
+
+Json::Value AsmJsonConverter::operator()(Break const& _node) const
+{
+	return createAstNode(_node.location, "YulBreak");
+}
+
+Json::Value AsmJsonConverter::operator()(Continue const& _node) const
+{
+	return createAstNode(_node.location, "YulContinue");
+}
+
+Json::Value AsmJsonConverter::operator()(Leave const& _node) const
+{
+	return createAstNode(_node.location, "YulLeave");
+}
+
+Json::Value AsmJsonConverter::createAstNode(langutil::SourceLocation const& _location, string _nodeType) const
+{
+	Json::Value ret{Json::objectValue};
+	ret["nodeType"] = std::move(_nodeType);
+	int length = -1;
+	if (_location.start >= 0 && _location.end >= 0)
+		length = _location.end - _location.start;
+	ret["src"] = to_string(_location.start) + ":" + to_string(length) + ":" + m_sourceIndex;
+	return ret;
+}
+
+template <class T>
+Json::Value AsmJsonConverter::vectorOfVariantsToJson(vector<T> const& _vec) const
+{
+	Json::Value ret{Json::arrayValue};
+	for (auto const& var: _vec)
+		ret.append(boost::apply_visitor(*this, var));
+
+	return ret;
+}
+
+}

--- a/libyul/AsmJsonConverter.h
+++ b/libyul/AsmJsonConverter.h
@@ -1,0 +1,68 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @date 2019
+ * @author julius <djudju@protonmail.com>
+ * Converts inline assembly AST to JSON format
+ */
+
+#include <libyul/AsmDataForward.h>
+#include <liblangutil/SourceLocation.h>
+#include <json/json.h>
+#include <boost/variant.hpp>
+#include <vector>
+
+namespace yul
+{
+
+/**
+ * Converter of the yul AST into JSON format
+ */
+class AsmJsonConverter: public boost::static_visitor<Json::Value>
+{
+public:
+	/// Create a converter to JSON for any block of inline assembly
+	/// @a _sourceIndex to be used to abbreviate source name in the source locations
+	explicit AsmJsonConverter(size_t _sourceIndex): m_sourceIndex(std::to_string(_sourceIndex)) {}
+
+	Json::Value operator()(Block const& _node) const;
+	Json::Value operator()(TypedName const& _node) const;
+	Json::Value operator()(Literal const& _node) const;
+	Json::Value operator()(Identifier const& _node) const;
+	Json::Value operator()(Assignment const& _node) const;
+	Json::Value operator()(VariableDeclaration const& _node) const;
+	Json::Value operator()(FunctionDefinition const& _node) const;
+	Json::Value operator()(FunctionCall const& _node) const;
+	Json::Value operator()(If const& _node) const;
+	Json::Value operator()(Switch const& _node) const;
+	Json::Value operator()(Case const& _node) const;
+	Json::Value operator()(ForLoop const& _node) const;
+	Json::Value operator()(Break const& _node) const;
+	Json::Value operator()(Continue const& _node) const;
+	Json::Value operator()(Leave const& _node) const;
+	Json::Value operator()(ExpressionStatement const& _node) const;
+	Json::Value operator()(Label const& _node) const;
+
+private:
+	Json::Value createAstNode(langutil::SourceLocation const& _location, std::string _nodeType) const;
+	template <class T>
+	Json::Value vectorOfVariantsToJson(std::vector<T> const& vec) const;
+
+	std::string const m_sourceIndex;
+};
+
+}

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(yul
 	AsmAnalysisInfo.h
 	AsmData.h
 	AsmDataForward.h
+	AsmJsonConverter.h
+	AsmJsonConverter.cpp
 	AsmParser.cpp
 	AsmParser.h
 	AsmPrinter.cpp

--- a/test/libsolidity/ASTJSON/assembly/call.json
+++ b/test/libsolidity/ASTJSON/assembly/call.json
@@ -1,0 +1,168 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      6
+    ]
+  },
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 6,
+      "linearizedBaseContracts":
+      [
+        6
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "37:59:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "56:34:1",
+                  "statements":
+                  [
+                    {
+                      "expression":
+                      {
+                        "arguments":
+                        [
+                          {
+                            "arguments":
+                            [
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "67:1:1",
+                                "type": "",
+                                "value": "0"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "70:1:1",
+                                "type": "",
+                                "value": "1"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "73:1:1",
+                                "type": "",
+                                "value": "2"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "76:1:1",
+                                "type": "",
+                                "value": "3"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "79:1:1",
+                                "type": "",
+                                "value": "4"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "82:1:1",
+                                "type": "",
+                                "value": "5"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "85:1:1",
+                                "type": "",
+                                "value": "6"
+                              }
+                            ],
+                            "functionName":
+                            {
+                              "name": "call",
+                              "nodeType": "YulIdentifier",
+                              "src": "62:4:1"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "62:25:1"
+                          }
+                        ],
+                        "functionName":
+                        {
+                          "name": "pop",
+                          "nodeType": "YulIdentifier",
+                          "src": "58:3:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "58:30:1"
+                      },
+                      "nodeType": "YulExpressionStatement",
+                      "src": "58:30:1"
+                    }
+                  ]
+                },
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "47:43:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "j",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "scope": 6,
+          "src": "17:79:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 7,
+      "src": "0:98:1"
+    }
+  ],
+  "src": "0:99:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/call.sol
+++ b/test/libsolidity/ASTJSON/assembly/call.sol
@@ -1,0 +1,7 @@
+contract C {
+    function j() public {
+        assembly { pop(call(0, 1, 2, 3, 4, 5, 6)) }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/call_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/call_legacy.json
@@ -1,0 +1,121 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        6
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          6
+        ],
+        "name": "C",
+        "scope": 7
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "j",
+            "overrides": null,
+            "scope": 6,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "37:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      null
+                    ],
+                    "operations": "{\n    pop(call(0, 1, 2, 3, 4, 5, 6))\n}"
+                  },
+                  "children": [],
+                  "id": 3,
+                  "name": "InlineAssembly",
+                  "src": "47:43:1"
+                }
+              ],
+              "id": 4,
+              "name": "Block",
+              "src": "37:59:1"
+            }
+          ],
+          "id": 5,
+          "name": "FunctionDefinition",
+          "src": "17:79:1"
+        }
+      ],
+      "id": 6,
+      "name": "ContractDefinition",
+      "src": "0:98:1"
+    }
+  ],
+  "id": 7,
+  "name": "SourceUnit",
+  "src": "0:99:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/function.json
+++ b/test/libsolidity/ASTJSON/assembly/function.json
@@ -1,0 +1,155 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      6
+    ]
+  },
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 6,
+      "linearizedBaseContracts":
+      [
+        6
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:68:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:43:1",
+                  "statements":
+                  [
+                    {
+                      "body":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "76:22:1",
+                        "statements":
+                        [
+                          {
+                            "expression":
+                            {
+                              "arguments":
+                              [
+                                {
+                                  "arguments":
+                                  [
+                                    {
+                                      "kind": "number",
+                                      "nodeType": "YulLiteral",
+                                      "src": "92:2:1",
+                                      "type": "",
+                                      "value": "20"
+                                    }
+                                  ],
+                                  "functionName":
+                                  {
+                                    "name": "blockhash",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "82:9:1"
+                                  },
+                                  "nodeType": "YulFunctionCall",
+                                  "src": "82:13:1"
+                                }
+                              ],
+                              "functionName":
+                              {
+                                "name": "pop",
+                                "nodeType": "YulIdentifier",
+                                "src": "78:3:1"
+                              },
+                              "nodeType": "YulFunctionCall",
+                              "src": "78:18:1"
+                            },
+                            "nodeType": "YulExpressionStatement",
+                            "src": "78:18:1"
+                          }
+                        ]
+                      },
+                      "name": "g",
+                      "nodeType": "YulFunctionDefinition",
+                      "src": "63:35:1"
+                    },
+                    {
+                      "expression":
+                      {
+                        "arguments": [],
+                        "functionName":
+                        {
+                          "name": "g",
+                          "nodeType": "YulIdentifier",
+                          "src": "99:1:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "99:3:1"
+                      },
+                      "nodeType": "YulExpressionStatement",
+                      "src": "99:3:1"
+                    }
+                  ]
+                },
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:52:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "h",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "scope": 6,
+          "src": "17:93:1",
+          "stateMutability": "view",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 7,
+      "src": "0:112:1"
+    }
+  ],
+  "src": "0:113:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/function.sol
+++ b/test/libsolidity/ASTJSON/assembly/function.sol
@@ -1,0 +1,7 @@
+contract C {
+    function h() view public {
+        assembly { function g() { pop(blockhash(20)) } g() }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/function_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/function_legacy.json
@@ -1,0 +1,121 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        6
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          6
+        ],
+        "name": "C",
+        "scope": 7
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "h",
+            "overrides": null,
+            "scope": 6,
+            "stateMutability": "view",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "42:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      null
+                    ],
+                    "operations": "{\n    function g()\n    { pop(blockhash(20)) }\n    g()\n}"
+                  },
+                  "children": [],
+                  "id": 3,
+                  "name": "InlineAssembly",
+                  "src": "52:52:1"
+                }
+              ],
+              "id": 4,
+              "name": "Block",
+              "src": "42:68:1"
+            }
+          ],
+          "id": 5,
+          "name": "FunctionDefinition",
+          "src": "17:93:1"
+        }
+      ],
+      "id": 6,
+      "name": "ContractDefinition",
+      "src": "0:112:1"
+    }
+  ],
+  "id": 7,
+  "name": "SourceUnit",
+  "src": "0:113:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/leave.json
+++ b/test/libsolidity/ASTJSON/assembly/leave.json
@@ -1,0 +1,105 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      6
+    ]
+  },
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 6,
+      "linearizedBaseContracts":
+      [
+        6
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "37:51:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "56:26:1",
+                  "statements":
+                  [
+                    {
+                      "body":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "71:9:1",
+                        "statements":
+                        [
+                          {
+                            "nodeType": "YulLeave",
+                            "src": "73:5:1"
+                          }
+                        ]
+                      },
+                      "name": "f",
+                      "nodeType": "YulFunctionDefinition",
+                      "src": "58:22:1"
+                    }
+                  ]
+                },
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "47:35:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "l",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "scope": 6,
+          "src": "17:71:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 7,
+      "src": "0:90:1"
+    }
+  ],
+  "src": "0:91:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/leave.sol
+++ b/test/libsolidity/ASTJSON/assembly/leave.sol
@@ -1,0 +1,7 @@
+contract C {
+    function l() public {
+        assembly { function f() { leave } }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/leave_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/leave_legacy.json
@@ -1,0 +1,121 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        6
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          6
+        ],
+        "name": "C",
+        "scope": 7
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "l",
+            "overrides": null,
+            "scope": 6,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "37:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      null
+                    ],
+                    "operations": "{\n    function f()\n    { leave }\n}"
+                  },
+                  "children": [],
+                  "id": 3,
+                  "name": "InlineAssembly",
+                  "src": "47:35:1"
+                }
+              ],
+              "id": 4,
+              "name": "Block",
+              "src": "37:51:1"
+            }
+          ],
+          "id": 5,
+          "name": "FunctionDefinition",
+          "src": "17:71:1"
+        }
+      ],
+      "id": 6,
+      "name": "ContractDefinition",
+      "src": "0:90:1"
+    }
+  ],
+  "id": 7,
+  "name": "SourceUnit",
+  "src": "0:91:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/loop.json
+++ b/test/libsolidity/ASTJSON/assembly/loop.json
@@ -1,0 +1,168 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      6
+    ]
+  },
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 6,
+      "linearizedBaseContracts":
+      [
+        6
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:74:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:49:1",
+                  "statements":
+                  [
+                    {
+                      "body":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "90:18:1",
+                        "statements":
+                        [
+                          {
+                            "nodeType": "YulBreak",
+                            "src": "92:5:1"
+                          },
+                          {
+                            "nodeType": "YulContinue",
+                            "src": "98:8:1"
+                          }
+                        ]
+                      },
+                      "condition":
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "70:1:1",
+                        "type": "",
+                        "value": "1"
+                      },
+                      "nodeType": "YulForLoop",
+                      "post":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "72:17:1",
+                        "statements":
+                        [
+                          {
+                            "expression":
+                            {
+                              "arguments":
+                              [
+                                {
+                                  "arguments":
+                                  [
+                                    {
+                                      "kind": "number",
+                                      "nodeType": "YulLiteral",
+                                      "src": "84:1:1",
+                                      "type": "",
+                                      "value": "0"
+                                    }
+                                  ],
+                                  "functionName":
+                                  {
+                                    "name": "sload",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "78:5:1"
+                                  },
+                                  "nodeType": "YulFunctionCall",
+                                  "src": "78:8:1"
+                                }
+                              ],
+                              "functionName":
+                              {
+                                "name": "pop",
+                                "nodeType": "YulIdentifier",
+                                "src": "74:3:1"
+                              },
+                              "nodeType": "YulFunctionCall",
+                              "src": "74:13:1"
+                            },
+                            "nodeType": "YulExpressionStatement",
+                            "src": "74:13:1"
+                          }
+                        ]
+                      },
+                      "pre":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "67:2:1",
+                        "statements": []
+                      },
+                      "src": "63:45:1"
+                    }
+                  ]
+                },
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:58:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "g",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "scope": 6,
+          "src": "17:99:1",
+          "stateMutability": "view",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 7,
+      "src": "0:118:1"
+    }
+  ],
+  "src": "0:119:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/loop.sol
+++ b/test/libsolidity/ASTJSON/assembly/loop.sol
@@ -1,0 +1,7 @@
+contract C {
+    function g() view public {
+        assembly { for {} 1 { pop(sload(0)) } { break continue } }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/loop_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/loop_legacy.json
@@ -1,0 +1,121 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        6
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          6
+        ],
+        "name": "C",
+        "scope": 7
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "g",
+            "overrides": null,
+            "scope": 6,
+            "stateMutability": "view",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "42:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      null
+                    ],
+                    "operations": "{\n    for { } 1 { pop(sload(0)) }\n    {\n        break\n        continue\n    }\n}"
+                  },
+                  "children": [],
+                  "id": 3,
+                  "name": "InlineAssembly",
+                  "src": "52:58:1"
+                }
+              ],
+              "id": 4,
+              "name": "Block",
+              "src": "42:74:1"
+            }
+          ],
+          "id": 5,
+          "name": "FunctionDefinition",
+          "src": "17:99:1"
+        }
+      ],
+      "id": 6,
+      "name": "ContractDefinition",
+      "src": "0:118:1"
+    }
+  ],
+  "id": 7,
+  "name": "SourceUnit",
+  "src": "0:119:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/slot_offset.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset.json
@@ -1,0 +1,236 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      11
+    ]
+  },
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 11,
+      "linearizedBaseContracts":
+      [
+        11
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "canonicalName": "C.S",
+          "id": 3,
+          "members":
+          [
+            {
+              "constant": false,
+              "id": 2,
+              "name": "x",
+              "nodeType": "VariableDeclaration",
+              "overrides": null,
+              "scope": 3,
+              "src": "28:6:1",
+              "stateVariable": false,
+              "storageLocation": "default",
+              "typeDescriptions":
+              {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              },
+              "typeName":
+              {
+                "id": 1,
+                "name": "uint",
+                "nodeType": "ElementaryTypeName",
+                "src": "28:4:1",
+                "typeDescriptions":
+                {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                }
+              },
+              "value": null,
+              "visibility": "internal"
+            }
+          ],
+          "name": "S",
+          "nodeType": "StructDefinition",
+          "scope": 11,
+          "src": "17:20:1",
+          "visibility": "public"
+        },
+        {
+          "constant": false,
+          "id": 5,
+          "name": "s",
+          "nodeType": "VariableDeclaration",
+          "overrides": null,
+          "scope": 11,
+          "src": "42:3:1",
+          "stateVariable": true,
+          "storageLocation": "default",
+          "typeDescriptions":
+          {
+            "typeIdentifier": "t_struct$_S_$3_storage",
+            "typeString": "struct C.S"
+          },
+          "typeName":
+          {
+            "contractScope": null,
+            "id": 4,
+            "name": "S",
+            "nodeType": "UserDefinedTypeName",
+            "referencedDeclaration": 3,
+            "src": "42:1:1",
+            "typeDescriptions":
+            {
+              "typeIdentifier": "t_struct$_S_$3_storage_ptr",
+              "typeString": "struct C.S"
+            }
+          },
+          "value": null,
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "76:70:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "95:45:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "97:17:1",
+                      "value":
+                      {
+                        "name": "s_offset",
+                        "nodeType": "YulIdentifier",
+                        "src": "106:8:1"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "x",
+                          "nodeType": "YulTypedName",
+                          "src": "101:1:1",
+                          "type": ""
+                        }
+                      ]
+                    },
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "115:23:1",
+                      "value":
+                      {
+                        "arguments":
+                        [
+                          {
+                            "name": "s_slot",
+                            "nodeType": "YulIdentifier",
+                            "src": "128:6:1"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "136:1:1",
+                            "type": "",
+                            "value": "2"
+                          }
+                        ],
+                        "functionName":
+                        {
+                          "name": "mul",
+                          "nodeType": "YulIdentifier",
+                          "src": "124:3:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "124:14:1"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "y",
+                          "nodeType": "YulTypedName",
+                          "src": "119:1:1",
+                          "type": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "externalReferences":
+                [
+                  {
+                    "declaration": 5,
+                    "isOffset": true,
+                    "isSlot": false,
+                    "src": "106:8:1",
+                    "valueSize": 1
+                  },
+                  {
+                    "declaration": 5,
+                    "isOffset": false,
+                    "isSlot": true,
+                    "src": "128:6:1",
+                    "valueSize": 1
+                  }
+                ],
+                "id": 8,
+                "nodeType": "InlineAssembly",
+                "src": "86:54:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "e",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 6,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "61:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "76:0:1"
+          },
+          "scope": 11,
+          "src": "51:95:1",
+          "stateMutability": "pure",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 12,
+      "src": "0:148:1"
+    }
+  ],
+  "src": "0:149:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/slot_offset.sol
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset.sol
@@ -1,0 +1,9 @@
+contract C {
+    struct S { uint x; }
+    S s;
+    function e() pure public {
+        assembly { let x := s_offset let y := mul(s_slot, 2) }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/slot_offset_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset_legacy.json
@@ -1,0 +1,211 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        11
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          11
+        ],
+        "name": "C",
+        "scope": 12
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "canonicalName": "C.S",
+            "name": "S",
+            "scope": 11,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "constant": false,
+                "name": "x",
+                "overrides": null,
+                "scope": 3,
+                "stateVariable": false,
+                "storageLocation": "default",
+                "type": "uint256",
+                "value": null,
+                "visibility": "internal"
+              },
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "name": "uint",
+                    "type": "uint256"
+                  },
+                  "id": 1,
+                  "name": "ElementaryTypeName",
+                  "src": "28:4:1"
+                }
+              ],
+              "id": 2,
+              "name": "VariableDeclaration",
+              "src": "28:6:1"
+            }
+          ],
+          "id": 3,
+          "name": "StructDefinition",
+          "src": "17:20:1"
+        },
+        {
+          "attributes":
+          {
+            "constant": false,
+            "name": "s",
+            "overrides": null,
+            "scope": 11,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "type": "struct C.S",
+            "value": null,
+            "visibility": "internal"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "contractScope": null,
+                "name": "S",
+                "referencedDeclaration": 3,
+                "type": "struct C.S"
+              },
+              "id": 4,
+              "name": "UserDefinedTypeName",
+              "src": "42:1:1"
+            }
+          ],
+          "id": 5,
+          "name": "VariableDeclaration",
+          "src": "42:3:1"
+        },
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "e",
+            "overrides": null,
+            "scope": 11,
+            "stateMutability": "pure",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 6,
+              "name": "ParameterList",
+              "src": "61:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 7,
+              "name": "ParameterList",
+              "src": "76:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      {
+                        "declaration": 5,
+                        "isOffset": true,
+                        "isSlot": false,
+                        "src": "106:8:1",
+                        "valueSize": 1
+                      },
+                      {
+                        "declaration": 5,
+                        "isOffset": false,
+                        "isSlot": true,
+                        "src": "128:6:1",
+                        "valueSize": 1
+                      }
+                    ],
+                    "operations": "{\n    let x := s_offset\n    let y := mul(s_slot, 2)\n}"
+                  },
+                  "children": [],
+                  "id": 8,
+                  "name": "InlineAssembly",
+                  "src": "86:54:1"
+                }
+              ],
+              "id": 9,
+              "name": "Block",
+              "src": "76:70:1"
+            }
+          ],
+          "id": 10,
+          "name": "FunctionDefinition",
+          "src": "51:95:1"
+        }
+      ],
+      "id": 11,
+      "name": "ContractDefinition",
+      "src": "0:148:1"
+    }
+  ],
+  "id": 12,
+  "name": "SourceUnit",
+  "src": "0:149:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/stringlit.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit.json
@@ -1,0 +1,109 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      6
+    ]
+  },
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 6,
+      "linearizedBaseContracts":
+      [
+        6
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "37:43:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "56:18:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "58:14:1",
+                      "value":
+                      {
+                        "kind": "string",
+                        "nodeType": "YulLiteral",
+                        "src": "67:5:1",
+                        "type": "",
+                        "value": "abc"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "x",
+                          "nodeType": "YulTypedName",
+                          "src": "62:1:1",
+                          "type": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "47:27:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "m",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "scope": 6,
+          "src": "17:63:1",
+          "stateMutability": "nonpayable",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 7,
+      "src": "0:82:1"
+    }
+  ],
+  "src": "0:83:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/stringlit.sol
+++ b/test/libsolidity/ASTJSON/assembly/stringlit.sol
@@ -1,0 +1,7 @@
+contract C {
+    function m() public {
+        assembly { let x := "abc" }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/stringlit_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit_legacy.json
@@ -1,0 +1,121 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        6
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          6
+        ],
+        "name": "C",
+        "scope": 7
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "m",
+            "overrides": null,
+            "scope": 6,
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "37:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      null
+                    ],
+                    "operations": "{ let x := \"abc\" }"
+                  },
+                  "children": [],
+                  "id": 3,
+                  "name": "InlineAssembly",
+                  "src": "47:27:1"
+                }
+              ],
+              "id": 4,
+              "name": "Block",
+              "src": "37:43:1"
+            }
+          ],
+          "id": 5,
+          "name": "FunctionDefinition",
+          "src": "17:63:1"
+        }
+      ],
+      "id": 6,
+      "name": "ContractDefinition",
+      "src": "0:82:1"
+    }
+  ],
+  "id": 7,
+  "name": "SourceUnit",
+  "src": "0:83:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/switch.json
+++ b/test/libsolidity/ASTJSON/assembly/switch.json
@@ -1,0 +1,201 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      6
+    ]
+  },
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 6,
+      "linearizedBaseContracts":
+      [
+        6
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:154:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:129:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "75:10:1",
+                      "value":
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "84:1:1",
+                        "type": "",
+                        "value": "0"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "f",
+                          "nodeType": "YulTypedName",
+                          "src": "79:1:1",
+                          "type": ""
+                        }
+                      ]
+                    },
+                    {
+                      "cases":
+                      [
+                        {
+                          "body":
+                          {
+                            "nodeType": "YulBlock",
+                            "src": "139:10:1",
+                            "statements":
+                            [
+                              {
+                                "nodeType": "YulAssignment",
+                                "src": "141:6:1",
+                                "value":
+                                {
+                                  "kind": "number",
+                                  "nodeType": "YulLiteral",
+                                  "src": "146:1:1",
+                                  "type": "",
+                                  "value": "1"
+                                },
+                                "variableNames":
+                                [
+                                  {
+                                    "name": "f",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "141:1:1"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "nodeType": "YulCase",
+                          "src": "132:17:1",
+                          "value":
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "137:1:1",
+                            "type": "",
+                            "value": "0"
+                          }
+                        },
+                        {
+                          "body":
+                          {
+                            "nodeType": "YulBlock",
+                            "src": "170:10:1",
+                            "statements":
+                            [
+                              {
+                                "nodeType": "YulAssignment",
+                                "src": "172:6:1",
+                                "value":
+                                {
+                                  "kind": "number",
+                                  "nodeType": "YulLiteral",
+                                  "src": "177:1:1",
+                                  "type": "",
+                                  "value": "2"
+                                },
+                                "variableNames":
+                                [
+                                  {
+                                    "name": "f",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "172:1:1"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "nodeType": "YulCase",
+                          "src": "162:18:1",
+                          "value": "default"
+                        }
+                      ],
+                      "expression":
+                      {
+                        "arguments": [],
+                        "functionName":
+                        {
+                          "name": "calldatasize",
+                          "nodeType": "YulIdentifier",
+                          "src": "105:12:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "105:14:1"
+                      },
+                      "nodeType": "YulSwitch",
+                      "src": "98:82:1"
+                    }
+                  ]
+                },
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:138:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "scope": 6,
+          "src": "17:179:1",
+          "stateMutability": "pure",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 7,
+      "src": "0:198:1"
+    }
+  ],
+  "src": "0:199:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/switch.sol
+++ b/test/libsolidity/ASTJSON/assembly/switch.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f() pure public {
+        assembly {
+            let f := 0
+            switch calldatasize()
+            case 0 { f := 1 }
+            default { f := 2 }
+        }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/switch_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_legacy.json
@@ -1,0 +1,121 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        6
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          6
+        ],
+        "name": "C",
+        "scope": 7
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 6,
+            "stateMutability": "pure",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "42:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      null
+                    ],
+                    "operations": "{\n    let f := 0\n    switch calldatasize()\n    case 0 { f := 1 }\n    default { f := 2 }\n}"
+                  },
+                  "children": [],
+                  "id": 3,
+                  "name": "InlineAssembly",
+                  "src": "52:138:1"
+                }
+              ],
+              "id": 4,
+              "name": "Block",
+              "src": "42:154:1"
+            }
+          ],
+          "id": 5,
+          "name": "FunctionDefinition",
+          "src": "17:179:1"
+        }
+      ],
+      "id": 6,
+      "name": "ContractDefinition",
+      "src": "0:198:1"
+    }
+  ],
+  "id": 7,
+  "name": "SourceUnit",
+  "src": "0:199:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/var_access.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access.json
@@ -1,0 +1,160 @@
+{
+  "absolutePath": "a",
+  "exportedSymbols":
+  {
+    "C":
+    [
+      9
+    ]
+  },
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation": null,
+      "fullyImplemented": true,
+      "id": 9,
+      "linearizedBaseContracts":
+      [
+        9
+      ],
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 7,
+            "nodeType": "Block",
+            "src": "42:51:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "overrides": null,
+                    "scope": 7,
+                    "src": "52:6:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions":
+                    {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "uint",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "52:4:1",
+                      "typeDescriptions":
+                      {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "value": null,
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 5,
+                "initialValue": null,
+                "nodeType": "VariableDeclarationStatement",
+                "src": "52:6:1"
+              },
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "77:10:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulAssignment",
+                      "src": "79:6:1",
+                      "value":
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "84:1:1",
+                        "type": "",
+                        "value": "7"
+                      },
+                      "variableNames":
+                      [
+                        {
+                          "name": "x",
+                          "nodeType": "YulIdentifier",
+                          "src": "79:1:1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "externalReferences":
+                [
+                  {
+                    "declaration": 4,
+                    "isOffset": false,
+                    "isSlot": false,
+                    "src": "79:1:1",
+                    "valueSize": 1
+                  }
+                ],
+                "id": 6,
+                "nodeType": "InlineAssembly",
+                "src": "68:19:1"
+              }
+            ]
+          },
+          "documentation": null,
+          "id": 8,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides": null,
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "scope": 9,
+          "src": "17:76:1",
+          "stateMutability": "pure",
+          "superFunction": null,
+          "visibility": "public"
+        }
+      ],
+      "scope": 10,
+      "src": "0:95:1"
+    }
+  ],
+  "src": "0:96:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/var_access.sol
+++ b/test/libsolidity/ASTJSON/assembly/var_access.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() pure public {
+        uint x;
+        assembly { x := 7 }
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/assembly/var_access_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access_legacy.json
@@ -1,0 +1,173 @@
+{
+  "attributes":
+  {
+    "absolutePath": "a",
+    "exportedSymbols":
+    {
+      "C":
+      [
+        9
+      ]
+    }
+  },
+  "children":
+  [
+    {
+      "attributes":
+      {
+        "abstract": false,
+        "baseContracts":
+        [
+          null
+        ],
+        "contractDependencies":
+        [
+          null
+        ],
+        "contractKind": "contract",
+        "documentation": null,
+        "fullyImplemented": true,
+        "linearizedBaseContracts":
+        [
+          9
+        ],
+        "name": "C",
+        "scope": 10
+      },
+      "children":
+      [
+        {
+          "attributes":
+          {
+            "documentation": null,
+            "implemented": true,
+            "isConstructor": false,
+            "kind": "function",
+            "modifiers":
+            [
+              null
+            ],
+            "name": "f",
+            "overrides": null,
+            "scope": 9,
+            "stateMutability": "pure",
+            "superFunction": null,
+            "visibility": "public"
+          },
+          "children":
+          [
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 1,
+              "name": "ParameterList",
+              "src": "27:2:1"
+            },
+            {
+              "attributes":
+              {
+                "parameters":
+                [
+                  null
+                ]
+              },
+              "children": [],
+              "id": 2,
+              "name": "ParameterList",
+              "src": "42:0:1"
+            },
+            {
+              "children":
+              [
+                {
+                  "attributes":
+                  {
+                    "assignments":
+                    [
+                      4
+                    ],
+                    "initialValue": null
+                  },
+                  "children":
+                  [
+                    {
+                      "attributes":
+                      {
+                        "constant": false,
+                        "name": "x",
+                        "overrides": null,
+                        "scope": 7,
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "type": "uint256",
+                        "value": null,
+                        "visibility": "internal"
+                      },
+                      "children":
+                      [
+                        {
+                          "attributes":
+                          {
+                            "name": "uint",
+                            "type": "uint256"
+                          },
+                          "id": 3,
+                          "name": "ElementaryTypeName",
+                          "src": "52:4:1"
+                        }
+                      ],
+                      "id": 4,
+                      "name": "VariableDeclaration",
+                      "src": "52:6:1"
+                    }
+                  ],
+                  "id": 5,
+                  "name": "VariableDeclarationStatement",
+                  "src": "52:6:1"
+                },
+                {
+                  "attributes":
+                  {
+                    "externalReferences":
+                    [
+                      {
+                        "declaration": 4,
+                        "isOffset": false,
+                        "isSlot": false,
+                        "src": "79:1:1",
+                        "valueSize": 1
+                      }
+                    ],
+                    "operations": "{ x := 7 }"
+                  },
+                  "children": [],
+                  "id": 6,
+                  "name": "InlineAssembly",
+                  "src": "68:19:1"
+                }
+              ],
+              "id": 7,
+              "name": "Block",
+              "src": "42:51:1"
+            }
+          ],
+          "id": 8,
+          "name": "FunctionDefinition",
+          "src": "17:76:1"
+        }
+      ],
+      "id": 9,
+      "name": "ContractDefinition",
+      "src": "0:95:1"
+    }
+  ],
+  "id": 10,
+  "name": "SourceUnit",
+  "src": "0:96:1"
+}


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description
resolves #2419 

creates different kinds of Json nodes for each kind of AsmData-struct.
similar to the solidityAST, there is a "nodeType" field and a "src"-location. 

Goal: It should be possible to recreate the AsmData from the Json.

TEST added: I added a contract with a bunch of inlineAssembly (assebly.sol from the syntaxTests) to ```/test/libsolidity/ASTJSON```
Then I ran the testsuite and used its output from the error-message to create ```assembly.json``` and ```assembly_legacy.json```.

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
   -> left a note on #7387
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
