### PR TITLE
Remove trailing zeros from the output of BytesUtils::formatBytes

### DIFF
--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -263,7 +263,7 @@ string BytesUtils::formatBytes(
 		os << formatHexString(_bytes);
 		break;
 	case ABIType::String:
-		os << formatString(_bytes);
+		os << formatString(_bytes, _bytes.size() - countRightPaddedZeros(_bytes));
 		break;
 	case ABIType::Failure:
 		break;
@@ -309,5 +309,14 @@ string BytesUtils::formatBytesRange(
 	}
 
 	return os.str();
+}
+
+size_t BytesUtils::countRightPaddedZeros(bytes const& _bytes)
+{
+	return find_if(
+		_bytes.rbegin(),
+		_bytes.rend(),
+		[](uint8_t b) { return b != '\0'; }
+	) - _bytes.rbegin();
 }
 

--- a/test/libsolidity/util/BytesUtils.h
+++ b/test/libsolidity/util/BytesUtils.h
@@ -122,6 +122,10 @@ public:
 		ParameterList const& _parameters,
 		bool _highlight
 	);
+
+	/// Count the number of zeros between the last non-zero byte and the end of
+	/// \param _bytes.
+	static size_t countRightPaddedZeros(bytes const& _bytes);
 };
 
 }

--- a/test/libsolidity/util/TestFunctionCall.h
+++ b/test/libsolidity/util/TestFunctionCall.h
@@ -50,7 +50,7 @@ public:
 	TestFunctionCall(FunctionCall _call): m_call(std::move(_call)) {}
 
 	/// Formats this function call test and applies the format that was detected during parsing.
-	/// If _renderResult is false, the expected result of the call will is used, if it's false
+	/// If _renderResult is false, the expected result of the call will be used, if it's true
 	/// the actual result is used.
 	/// If _highlight is false, it's formatted without colorized highlighting. If it's true, AnsiColorized is
 	/// used to apply a colorized highlighting.


### PR DESCRIPTION
Closes #7198