### PR TITLE
Wasm binary translation

### DIFF
--- a/libevmasm/RuleList.h
+++ b/libevmasm/RuleList.h
@@ -49,31 +49,26 @@ template <class S> S modWorkaround(S const& _a, S const& _b)
 // https://www.boost.org/doc/libs/1_68_0/libs/multiprecision/doc/html/boost_multiprecision/map/hist.html#boost_multiprecision.map.hist.multiprecision_2_3_1_boost_1_64
 template <class S> S shlWorkaround(S const& _x, unsigned _amount)
 {
-	return u256((bigint(_x) << _amount) & u256(-1));
+	return S((bigint(_x) << _amount) & S(-1));
+}
+
+inline bool bitTest(u256 const& _x, unsigned _bit)
+{
+	return boost::multiprecision::bit_test(_x, _bit);
+}
+
+inline bool bitTest(uint64_t const& _x, unsigned _bit)
+{
+	return (_x & (uint64_t(1) << _bit)) != 0;
 }
 
 template <class Pattern>
-std::vector<SimplificationRule<Pattern>> simplificationRuleListUnified(
-	Pattern A,
-	Pattern B,
-	Pattern ,//C,
-	Pattern,
-	Pattern,
-	Pattern,
-	Pattern
-)
+std::vector<Pattern> swapShiftArgs(Pattern _a, Pattern _b)
 {
-	return std::vector<SimplificationRule<Pattern>> {
-		// arithmetic on constants
-		{{Pattern::Builtins::ADD, {A, B}}, [=]{ return A.d() + B.d(); }, false},
-		{{Pattern::Builtins::MUL, {A, B}}, [=]{ return A.d() * B.d(); }, false},
-//		{{Pattern::Builtins::SUB, {A, B}}, [=]{ return A.d() - B.d(); }, false},
-//		{{Pattern::Builtins::NOT, {A}}, [=]{ return ~A.d(); }, false},
-//		{{Pattern::Builtins::LT, {A, B}}, [=]() -> u256 { return A.d() < B.d() ? 1 : 0; }, false},
-//		{{Pattern::Builtins::GT, {A, B}}, [=]() -> u256 { return A.d() > B.d() ? 1 : 0; }, false},
-//		{{Pattern::Builtins::EQ, {A, B}}, [=]() -> u256 { return A.d() == B.d() ? 1 : 0; }, false},
-//		{{Pattern::Builtins::ISZERO, {A}}, [=]() -> u256 { return A.d() == 0 ? 1 : 0; }, false},
-	};
+	if (Pattern::isEWasm)
+		return {std::move(_a), std::move(_b)};
+	else
+		return {std::move(_b), std::move(_a)};
 }
 
 // simplificationRuleList below was split up into parts to prevent
@@ -89,53 +84,60 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart1(
 )
 {
 	using Word = typename Pattern::Word;
-	using Builtins = typename Pattern::Builtins;
-	return std::vector<SimplificationRule<Pattern>> {
+	std::vector<SimplificationRule<Pattern>> ret{
 		// arithmetic on constants
-		{Builtins::ADD(A, B), [=]{ return A.d() + B.d(); }, false},
-		{Builtins::MUL(A, B), [=]{ return A.d() * B.d(); }, false},
-		{Builtins::SUB(A, B), [=]{ return A.d() - B.d(); }, false},
-		{Builtins::DIV(A, B), [=]{ return B.d() == 0 ? 0 : divWorkaround(A.d(), B.d()); }, false},
-		{Builtins::SDIV(A, B), [=]{ return B.d() == 0 ? 0 : s2u(divWorkaround(u2s(A.d()), u2s(B.d()))); }, false},
-		{Builtins::MOD(A, B), [=]{ return B.d() == 0 ? 0 : modWorkaround(A.d(), B.d()); }, false},
-		{Builtins::SMOD(A, B), [=]{ return B.d() == 0 ? 0 : s2u(modWorkaround(u2s(A.d()), u2s(B.d()))); }, false},
-		{Builtins::EXP(A, B), [=]{ return Word(boost::multiprecision::powm(bigint(A.d()), bigint(B.d()), bigint(1) << Pattern::WordSize)); }, false},
-		{Builtins::NOT(A), [=]{ return ~A.d(); }, false},
-		{Builtins::LT(A, B), [=]() -> Word { return A.d() < B.d() ? 1 : 0; }, false},
-		{Builtins::GT(A, B), [=]() -> Word { return A.d() > B.d() ? 1 : 0; }, false},
-		{Builtins::SLT(A, B), [=]() -> Word { return u2s(A.d()) < u2s(B.d()) ? 1 : 0; }, false},
-		{Builtins::SGT(A, B), [=]() -> Word { return u2s(A.d()) > u2s(B.d()) ? 1 : 0; }, false},
-		{Builtins::EQ(A, B), [=]() -> Word { return A.d() == B.d() ? 1 : 0; }, false},
-		{Builtins::ISZERO(A), [=]() -> Word { return A.d() == 0 ? 1 : 0; }, false},
-		{Builtins::AND(A, B), [=]{ return A.d() & B.d(); }, false},
-		{Builtins::OR(A, B), [=]{ return A.d() | B.d(); }, false},
-		{Builtins::XOR(A, B), [=]{ return A.d() ^ B.d(); }, false},
-		{Builtins::BYTE(A, B), [=]{
-			return
-				A.d() >= Pattern::WordSize / 8 ?
-				0 :
-				(B.d() >> unsigned(8 * (Pattern::WordSize / 8 - 1 - A.d()))) & 0xff;
-		}, false},
-		{Builtins::ADDMOD(A, B, C), [=]{ return C.d() == 0 ? 0 : Word((bigint(A.d()) + bigint(B.d())) % C.d()); }, false},
-		{Builtins::MULMOD(A, B, C), [=]{ return C.d() == 0 ? 0 : Word((bigint(A.d()) * bigint(B.d())) % C.d()); }, false},
-		{Builtins::SIGNEXTEND(A, B), [=]() -> Word {
-			if (A.d() >= Pattern::WordSize / 8 - 1)
-				return B.d();
-			unsigned testBit = unsigned(A.d()) * 8 + 7;
-			Word mask = (Word(1) << testBit) - 1;
-			return boost::multiprecision::bit_test(B.d(), testBit) ? B.d() | ~mask : B.d() & mask;
-		}, false},
-		{Builtins::SHL(A, B), [=]{
-			if (A.d() >= Pattern::WordSize)
-				return Word(0);
-			return shlWorkaround(B.d(), unsigned(A.d()));
-		}, false},
-		{Builtins::SHR(A, B), [=]{
-			if (A.d() >= Pattern::WordSize)
-				return Word(0);
-			return B.d() >> unsigned(A.d());
-		}, false}
+		{{Pattern::Builtins::ADD, {A, B}}, [=]{ return A.d() + B.d(); }, false},
+		{{Pattern::Builtins::MUL, {A, B}}, [=]{ return A.d() * B.d(); }, false},
+		{{Pattern::Builtins::SUB, {A, B}}, [=]{ return A.d() - B.d(); }, false},
+		{{Pattern::Builtins::DIV, {A, B}}, [=]{ return B.d() == 0 ? 0 : divWorkaround(A.d(), B.d()); }, false},
+		{{Pattern::Builtins::MOD, {A, B}}, [=]{ return B.d() == 0 ? 0 : modWorkaround(A.d(), B.d()); }, false},
+		{{Pattern::Builtins::LT, {A, B}}, [=]() -> Word { return A.d() < B.d() ? 1 : 0; }, false},
+		{{Pattern::Builtins::GT, {A, B}}, [=]() -> Word { return A.d() > B.d() ? 1 : 0; }, false},
+		{{Pattern::Builtins::ISZERO, {A}}, [=]() -> Word { return A.d() == 0 ? 1 : 0; }, false},
+		{{Pattern::Builtins::EQ, {A, B}}, [=]() -> Word { return A.d() == B.d() ? 1 : 0; }, false},
+		{{Pattern::Builtins::AND, {A, B}}, [=]{ return A.d() & B.d(); }, false},
+		{{Pattern::Builtins::OR, {A, B}}, [=]{ return A.d() | B.d(); }, false},
+		{{Pattern::Builtins::XOR, {A, B}}, [=]{ return A.d() ^ B.d(); }, false},
 	};
+	if (Pattern::isEWasm)
+		ret += std::vector<SimplificationRule<Pattern>>{
+			{{Pattern::Builtins::SHL, {A, B}}, [=]() -> Word {
+				return Word{A.d()} << uint64_t{B.d()};
+			}, false},
+			{{Pattern::Builtins::SHR, {A, B}}, [=]() -> Word {
+				return Word{A.d()} >> uint64_t{B.d()};
+			}, false},
+		};
+	else
+		ret += std::vector<SimplificationRule<Pattern>>{
+//			{{Pattern::Builtins::SHL, {A, B}}, [=]() -> Word {
+//				if (A.d() >= 265)
+//					return 0;
+//				return shlWorkaround(B.d(), unsigned(A.d()));
+//			}, false},
+//			{{Pattern::Builtins::SHR, {A, B}}, [=]() -> Word {
+//				if (A.d() >= 265)
+//					return 0;
+//				return B.d() >> unsigned(A.d());
+//			}, false},
+//			{{Pattern::Builtins::SDIV, {A, B}}, [=]{ return B.d() == 0 ? 0 : s2u(divWorkaround(u2s(A.d()), u2s(B.d()))); }, false},
+//			{{Pattern::Builtins::SMOD, {A, B}}, [=]{ return B.d() == 0 ? 0 : s2u(modWorkaround(u2s(A.d()), u2s(B.d()))); }, false},
+//			{{Pattern::Builtins::EXP, {A, B}}, [=]{ return Word(boost::multiprecision::powm(bigint(A.d()), bigint(B.d()), bigint(1) << 256)); }, false},
+//			{{Pattern::Builtins::NOT, {A}}, [=]{ return ~A.d(); }, false},
+//			{{Pattern::Builtins::SLT, {A, B}}, [=]() { return u2s(A.d()) < u2s(B.d()) ? Word(1) : 0; }, false},
+//			{{Pattern::Builtins::SGT, {A, B}}, [=]() { return u2s(A.d()) > u2s(B.d()) ? Word(1) : 0; }, false},
+			{{Pattern::Builtins::BYTE, {A, B}}, [=]{ return A.d() >= 32 ? 0 : (B.d() >> unsigned(8 * (31 - A.d()))) & 0xff; }, false},
+			{{Pattern::Builtins::ADDMOD, {A, B, C}}, [=]{ return C.d() == 0 ? 0 : Word((bigint(A.d()) + bigint(B.d())) % C.d()); }, false},
+			{{Pattern::Builtins::MULMOD, {A, B, C}}, [=]{ return C.d() == 0 ? 0 : Word((bigint(A.d()) * bigint(B.d())) % C.d()); }, false},
+//			{{Pattern::Builtins::SIGNEXTEND, {A, B}}, [=]() -> Word {
+//				if (A.d() >= 31)
+//					return B.d();
+//				unsigned testBit = unsigned(A.d()) * 8 + 7;
+//				Word mask = (Word(1) << testBit) - 1;
+//				return bitTest(B.d(), testBit) ? B.d() | ~mask : B.d() & mask;
+//			}, false},
+		};
+	return ret;
 }
 
 
@@ -149,51 +151,52 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart2(
 )
 {
 	using Word = typename Pattern::Word;
-	using Builtins = typename Pattern::Builtins;
-	return std::vector<SimplificationRule<Pattern>> {
+	return std::vector<SimplificationRule<Pattern>>{
 		// invariants involving known constants
-		{Builtins::ADD(X, 0), [=]{ return X; }, false},
-		{Builtins::ADD(0, X), [=]{ return X; }, false},
-		{Builtins::SUB(X, 0), [=]{ return X; }, false},
-		{Builtins::SUB(~Word(0), X), [=]() -> Pattern { return Builtins::NOT(X); }, false},
-		{Builtins::MUL(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::MUL(0, X), [=]{ return Word(0); }, true},
-		{Builtins::MUL(X, 1), [=]{ return X; }, false},
-		{Builtins::MUL(1, X), [=]{ return X; }, false},
-		{Builtins::MUL(X, Word(-1)), [=]() -> Pattern { return Builtins::SUB(0, X); }, false},
-		{Builtins::MUL(Word(-1), X), [=]() -> Pattern { return Builtins::SUB(0, X); }, false},
-		{Builtins::DIV(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::DIV(0, X), [=]{ return Word(0); }, true},
-		{Builtins::DIV(X, 1), [=]{ return X; }, false},
-		{Builtins::SDIV(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::SDIV(0, X), [=]{ return Word(0); }, true},
-		{Builtins::SDIV(X, 1), [=]{ return X; }, false},
-		{Builtins::AND(X, ~Word(0)), [=]{ return X; }, false},
-		{Builtins::AND(~Word(0), X), [=]{ return X; }, false},
-		{Builtins::AND(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::AND(0, X), [=]{ return Word(0); }, true},
-		{Builtins::OR(X, 0), [=]{ return X; }, false},
-		{Builtins::OR(0, X), [=]{ return X; }, false},
-		{Builtins::OR(X, ~Word(0)), [=]{ return ~Word(0); }, true},
-		{Builtins::OR(~Word(0), X), [=]{ return ~Word(0); }, true},
-		{Builtins::XOR(X, 0), [=]{ return X; }, false},
-		{Builtins::XOR(0, X), [=]{ return X; }, false},
-		{Builtins::MOD(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::MOD(0, X), [=]{ return Word(0); }, true},
-		{Builtins::EQ(X, 0), [=]() -> Pattern { return Builtins::ISZERO(X); }, false },
-		{Builtins::EQ(0, X), [=]() -> Pattern { return Builtins::ISZERO(X); }, false },
-		{Builtins::SHL(0, X), [=]{ return X; }, false},
-		{Builtins::SHR(0, X), [=]{ return X; }, false},
-		{Builtins::SHL(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::SHR(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::GT(X, 0), [=]() -> Pattern { return Builtins::ISZERO(Builtins::ISZERO(X)); }, false},
-		{Builtins::LT(0, X), [=]() -> Pattern { return Builtins::ISZERO(Builtins::ISZERO(X)); }, false},
-		{Builtins::GT(X, ~Word(0)), [=]{ return Word(0); }, true},
-		{Builtins::LT(~Word(0), X), [=]{ return Word(0); }, true},
-		{Builtins::GT(0, X), [=]{ return Word(0); }, true},
-		{Builtins::LT(X, 0), [=]{ return Word(0); }, true},
-		{Builtins::AND(Builtins::BYTE(X, Y), Word(0xff)), [=]() -> Pattern { return Builtins::BYTE(X, Y); }, false},
-		{Builtins::BYTE(Word(Pattern::WordSize / 8 - 1), X), [=]() -> Pattern { return Builtins::AND(X, Word(0xff)); }, false}
+		{{Pattern::Builtins::ADD, {X, Word{0}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::ADD, {Word{0}, X}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::SUB, {X, Word{0}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::SUB, {~Word(0), X}}, [=]() -> Pattern { return {Pattern::Builtins::NOT, {X}}; }, false},
+		{{Pattern::Builtins::MUL, {X, Word{0}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::MUL, {Word{0}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::MUL, {X, Word{1}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::MUL, {Word{1}, X}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::MUL, {X, Word(-1)}}, [=]() -> Pattern { return {Pattern::Builtins::SUB, {Word{0}, X}}; }, false},
+		{{Pattern::Builtins::MUL, {Word(-1), X}}, [=]() -> Pattern { return {Pattern::Builtins::SUB, {Word{0}, X}}; }, false},
+		// TODO true for ewasm?
+		{{Pattern::Builtins::DIV, {X, Word{0}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::DIV, {Word{0}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::DIV, {X, Word{1}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::SDIV, {X, Word{0}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::SDIV, {Word{0}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::SDIV, {X, Word{1}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::AND, {X, ~Word(0)}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::AND, {~Word(0), X}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::AND, {X, Word{0}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::AND, {Word{0}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::OR, {X, Word{0}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::OR, {Word{0}, X}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::OR, {X, ~Word(0)}}, [=]{ return ~Word(0); }, true},
+		{{Pattern::Builtins::OR, {~Word(0), X}}, [=]{ return ~Word(0); }, true},
+		{{Pattern::Builtins::XOR, {X, Word{0}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::XOR, {Word{0}, X}}, [=]{ return X; }, false},
+		// TODO true for ewasm?
+		{{Pattern::Builtins::MOD, {X, Word{0}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::MOD, {Word{0}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::EQ, {X, Word{0}}}, [=]() -> Pattern { return {Pattern::Builtins::ISZERO, {X}}; }, false },
+		{{Pattern::Builtins::EQ, {Word{0}, X}}, [=]() -> Pattern { return {Pattern::Builtins::ISZERO, {X}}; }, false },
+		{{Pattern::Builtins::SHL, swapShiftArgs<Pattern>(Word{0}, X)}, [=]{ return Word{0}; }, true},
+		{{Pattern::Builtins::SHR, swapShiftArgs<Pattern>(Word{0}, X)}, [=]{ return Word{0}; }, true},
+		{{Pattern::Builtins::SHL, swapShiftArgs<Pattern>(X, Word{0})}, [=]{ return X; }, false},
+		{{Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, Word{0})}, [=]{ return X; }, false},
+		{{Pattern::Builtins::GT, {X, Word{0}}}, [=]() -> Pattern { return {Pattern::Builtins::ISZERO, {{Pattern::Builtins::ISZERO, {X}}}}; }, false},
+		{{Pattern::Builtins::LT, {Word{0}, X}}, [=]() -> Pattern { return {Pattern::Builtins::ISZERO, {{Pattern::Builtins::ISZERO, {X}}}}; }, false},
+		{{Pattern::Builtins::GT, {X, ~Word(0)}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::LT, {~Word(0), X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::GT, {Word{0}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::LT, {X, Word{0}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::AND, {{Pattern::Builtins::BYTE, {X, Y}}, {Word(0xff)}}}, [=]() -> Pattern { return {Pattern::Builtins::BYTE, {X, Y}}; }, false},
+		{{Pattern::Builtins::BYTE, {Word{31}, X}}, [=]() -> Pattern { return {Pattern::Builtins::AND, {X, Word(0xff)}}; }, false}
 	};
 }
 
@@ -220,7 +223,6 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart3(
 		{Builtins::GT(X, X), [=]{ return Word(0); }, true},
 		{Builtins::SGT(X, X), [=]{ return Word(0); }, true},
 		{Builtins::MOD(X, X), [=]{ return Word(0); }, true}
-	};
 }
 
 template <class Pattern>
@@ -233,26 +235,25 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart4(
 )
 {
 	using Word = typename Pattern::Word;
-	using Builtins = typename Pattern::Builtins;
 	return std::vector<SimplificationRule<Pattern>> {
 		// logical instruction combinations
-		{Builtins::NOT(Builtins::NOT(X)), [=]{ return X; }, false},
-		{Builtins::XOR(X, Builtins::XOR(X, Y)), [=]{ return Y; }, true},
-		{Builtins::XOR(X, Builtins::XOR(Y, X)), [=]{ return Y; }, true},
-		{Builtins::XOR(Builtins::XOR(X, Y), X), [=]{ return Y; }, true},
-		{Builtins::XOR(Builtins::XOR(Y, X), X), [=]{ return Y; }, true},
-		{Builtins::OR(X, Builtins::AND(X, Y)), [=]{ return X; }, true},
-		{Builtins::OR(X, Builtins::AND(Y, X)), [=]{ return X; }, true},
-		{Builtins::OR(Builtins::AND(X, Y), X), [=]{ return X; }, true},
-		{Builtins::OR(Builtins::AND(Y, X), X), [=]{ return X; }, true},
-		{Builtins::AND(X, Builtins::OR(X, Y)), [=]{ return X; }, true},
-		{Builtins::AND(X, Builtins::OR(Y, X)), [=]{ return X; }, true},
-		{Builtins::AND(Builtins::OR(X, Y), X), [=]{ return X; }, true},
-		{Builtins::AND(Builtins::OR(Y, X), X), [=]{ return X; }, true},
-		{Builtins::AND(X, Builtins::NOT(X)), [=]{ return Word(0); }, true},
-		{Builtins::AND(Builtins::NOT(X), X), [=]{ return Word(0); }, true},
-		{Builtins::OR(X, Builtins::NOT(X)), [=]{ return ~Word(0); }, true},
-		{Builtins::OR(Builtins::NOT(X), X), [=]{ return ~Word(0); }, true},
+		{{Pattern::Builtins::NOT, {{Pattern::Builtins::NOT, {X}}}}, [=]{ return X; }, false},
+		{{Pattern::Builtins::XOR, {X, {Pattern::Builtins::XOR, {X, Y}}}}, [=]{ return Y; }, true},
+		{{Pattern::Builtins::XOR, {X, {Pattern::Builtins::XOR, {Y, X}}}}, [=]{ return Y; }, true},
+		{{Pattern::Builtins::XOR, {{Pattern::Builtins::XOR, {X, Y}}, X}}, [=]{ return Y; }, true},
+		{{Pattern::Builtins::XOR, {{Pattern::Builtins::XOR, {Y, X}}, X}}, [=]{ return Y; }, true},
+		{{Pattern::Builtins::OR, {X, {Pattern::Builtins::AND, {X, Y}}}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::OR, {X, {Pattern::Builtins::AND, {Y, X}}}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::OR, {{Pattern::Builtins::AND, {X, Y}}, X}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::OR, {{Pattern::Builtins::AND, {Y, X}}, X}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::AND, {X, {Pattern::Builtins::OR, {X, Y}}}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::AND, {X, {Pattern::Builtins::OR, {Y, X}}}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::AND, {{Pattern::Builtins::OR, {X, Y}}, X}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::AND, {{Pattern::Builtins::OR, {Y, X}}, X}}, [=]{ return X; }, true},
+		{{Pattern::Builtins::AND, {X, {Pattern::Builtins::NOT, {X}}}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::AND, {{Pattern::Builtins::NOT, {X}}, X}}, [=]{ return Word(0); }, true},
+		{{Pattern::Builtins::OR, {X, {Pattern::Builtins::NOT, {X}}}}, [=]{ return ~Word(0); }, true},
+		{{Pattern::Builtins::OR, {{Pattern::Builtins::NOT, {X}}, X}}, [=]{ return ~Word(0); }, true},
 	};
 }
 
@@ -267,8 +268,6 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart5(
 )
 {
 	using Word = typename Pattern::Word;
-	using Builtins = typename Pattern::Builtins;
-
 	std::vector<SimplificationRule<Pattern>> rules;
 
 	// Replace MOD X, <power-of-two> with AND X, <power-of-two> - 1
@@ -276,15 +275,15 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart5(
 	{
 		Word value = Word(1) << i;
 		rules.push_back({
-			Builtins::MOD(X, value),
-			[=]() -> Pattern { return Builtins::AND(X, value - 1); },
+			{Pattern::Builtins::MOD, {X, value}},
+			[=]() -> Pattern { return {Pattern::Builtins::AND, {X, value - 1}}; },
 			false
 		});
 	}
 
 	// Replace SHL >=256, X with 0
 	rules.push_back({
-		Builtins::SHL(A, X),
+		{Pattern::Builtins::SHL, swapShiftArgs(X, A)},
 		[=]() -> Pattern { return Word(0); },
 		true,
 		[=]() { return A.d() >= Pattern::WordSize; }
@@ -292,7 +291,7 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart5(
 
 	// Replace SHR >=256, X with 0
 	rules.push_back({
-		Builtins::SHR(A, X),
+		{Pattern::Builtins::SHR, swapShiftArgs(X, A)},
 		[=]() -> Pattern { return Word(0); },
 		true,
 		[=]() { return A.d() >= Pattern::WordSize; }
@@ -300,32 +299,31 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart5(
 
 	// Replace BYTE(A, X), A >= 32 with 0
 	rules.push_back({
-		Builtins::BYTE(A, X),
+		{Pattern::Builtins::BYTE, {A, X}},
 		[=]() -> Pattern { return Word(0); },
 		true,
 		[=]() { return A.d() >= Pattern::WordSize / 8; }
 	});
 
-	for (auto instr: {
-		Instruction::ADDRESS,
-		Instruction::CALLER,
-		Instruction::ORIGIN,
-		Instruction::COINBASE
-	})
-	{
-		assertThrow(Pattern::WordSize > 160, OptimizerException, "");
-		Word const mask = (Word(1) << 160) - 1;
-		rules.push_back({
-			Builtins::AND(Pattern{instr}, mask),
-			[=]() -> Pattern { return {instr}; },
-			false
-		});
-		rules.push_back({
-			Builtins::AND(mask, Pattern{instr}),
-			[=]() -> Pattern { return {instr}; },
-			false
-		});
-	}
+//	for (auto const& op: std::vector<typename Pattern::Builtins::InstrType>{
+//		Pattern::Builtins::ADDRESS,
+//		Pattern::Builtins::CALLER,
+//		Pattern::Builtins::ORIGIN,
+//		Pattern::Builtins::COINBASE
+//	})
+//	{
+//		Word const mask = (Word(1) << 160) - 1;
+//		rules.push_back({
+//			{Pattern::Builtins::AND, {{op, mask}}},
+//			[=]() -> Pattern { return op; },
+//			false
+//		});
+//		rules.push_back({
+//			{Pattern::Builtins::AND, {{mask, op}}},
+//			[=]() -> Pattern { return op; },
+//			false
+//		});
+//	}
 
 	return rules;
 }
@@ -343,31 +341,31 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart6(
 
 	std::vector<SimplificationRule<Pattern>> rules;
 	// Double negation of opcodes with boolean result
-	for (auto instr: {
-		Instruction::EQ,
-		Instruction::LT,
-		Instruction::SLT,
-		Instruction::GT,
-		Instruction::SGT
+	for (auto const& op: std::vector<typename Pattern::Builtins::InstrType>{
+		Pattern::Builtins::EQ,
+		Pattern::Builtins::LT,
+		Pattern::Builtins::SLT,
+		Pattern::Builtins::GT,
+		Pattern::Builtins::SGT
 	})
 	{
 		typename Builtins::PatternGeneratorInstance op{instr};
 		rules.push_back({
-			Builtins::ISZERO(Builtins::ISZERO(op(X, Y))),
-			[=]() -> Pattern { return op(X, Y); },
+			{Pattern::Builtins::ISZERO, {{Pattern::Builtins::ISZERO, {{op, {X, Y}}}}}},
+			[=]() -> Pattern { return {op, {X, Y}}; },
 			false
 		});
 	}
 
 	rules.push_back({
-		Builtins::ISZERO(Builtins::ISZERO(Builtins::ISZERO(X))),
-		[=]() -> Pattern { return Builtins::ISZERO(X); },
+		{Pattern::Builtins::ISZERO, {{Pattern::Builtins::ISZERO, {{Pattern::Builtins::ISZERO, {X}}}}}},
+		[=]() -> Pattern { return {Pattern::Builtins::ISZERO, {X}}; },
 		false
 	});
 
 	rules.push_back({
-		Builtins::ISZERO(Builtins::XOR(X, Y)),
-		[=]() -> Pattern { return Builtins::EQ(X, Y); },
+		{Pattern::Builtins::ISZERO, {{Pattern::Builtins::XOR, {X, Y}}}},
+		[=]() -> Pattern { return { Pattern::Builtins::EQ, {X, Y} }; },
 		false
 	});
 
@@ -384,16 +382,14 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 )
 {
 	using Word = typename Pattern::Word;
-	using Builtins = typename Pattern::Builtins;
-
 	std::vector<SimplificationRule<Pattern>> rules;
 	// Associative operations
-	for (auto&& instrAndFunc: std::vector<std::pair<Instruction, std::function<Word(Word, Word)>>>{
-		{Instruction::ADD, std::plus<Word>()},
-		{Instruction::MUL, std::multiplies<Word>()},
-		{Instruction::AND, std::bit_and<Word>()},
-		{Instruction::OR, std::bit_or<Word>()},
-		{Instruction::XOR, std::bit_xor<Word>()}
+	for (auto const& opFun: std::vector<std::pair<typename Pattern::Builtins::InstrType, std::function<Word(Word const&,Word const&)>>>{
+		{Pattern::Builtins::ADD, std::plus<Word>()},
+		{Pattern::Builtins::MUL, std::multiplies<Word>()},
+		{Pattern::Builtins::AND, std::bit_and<Word>()},
+		{Pattern::Builtins::OR, std::bit_or<Word>()},
+		{Pattern::Builtins::XOR, std::bit_xor<Word>()}
 	})
 	{
 		typename Builtins::PatternGeneratorInstance op{instrAndFunc.first};
@@ -430,13 +426,13 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 	// Combine two SHL by constant
 	rules.push_back({
 		// SHL(B, SHL(A, X)) -> SHL(min(A+B, 256), X)
-		Builtins::SHL(B, Builtins::SHL(A, X)),
+		{Pattern::Builtins::SHL, swapShiftArgs<Pattern>({Pattern::Builtins::SHL, swapShiftArgs<Pattern>(X, A)}, {B})},
 		[=]() -> Pattern {
 			bigint sum = bigint(A.d()) + B.d();
 			if (sum >= Pattern::WordSize)
-				return Builtins::AND(X, Word(0));
+				return {Pattern::Builtins::AND, {X, Word(0)}};
 			else
-				return Builtins::SHL(Word(sum), X);
+				return {Pattern::Builtins::SHL, swapShiftArgs<Pattern>(Word(sum), X)};
 		},
 		false
 	});
@@ -444,13 +440,13 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 	// Combine two SHR by constant
 	rules.push_back({
 		// SHR(B, SHR(A, X)) -> SHR(min(A+B, 256), X)
-		Builtins::SHR(B, Builtins::SHR(A, X)),
+		{Pattern::Builtins::SHR, swapShiftArgs<Pattern>({Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, A)}, B)},
 		[=]() -> Pattern {
 			bigint sum = bigint(A.d()) + B.d();
 			if (sum >= Pattern::WordSize)
-				return Builtins::AND(X, Word(0));
+				return {Pattern::Builtins::AND, {X, Word(0)}};
 			else
-				return Builtins::SHR(Word(sum), X);
+				return {Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, Word(sum))};
 		},
 		false
 	});
@@ -458,16 +454,16 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 	// Combine SHL-SHR by constant
 	rules.push_back({
 		// SHR(B, SHL(A, X)) -> AND(SH[L/R]([B - A / A - B], X), Mask)
-		Builtins::SHR(B, Builtins::SHL(A, X)),
+		{Pattern::Builtins::SHR, swapShiftArgs<Pattern>({Pattern::Builtins::SHL, swapShiftArgs<Pattern>(X, A)}, B)},
 		[=]() -> Pattern {
-			Word mask = shlWorkaround(~Word(0), unsigned(A.d())) >> unsigned(B.d());
+			Word mask = shlWorkaround(Word(-1), unsigned(A.d())) >> unsigned(B.d());
 
 			if (A.d() > B.d())
-				return Builtins::AND(Builtins::SHL(A.d() - B.d(), X), mask);
+				return {Pattern::Builtins::AND, {{Pattern::Builtins::SHL, swapShiftArgs<Pattern>(X, A.d() - B.d())}, mask}};
 			else if (B.d() > A.d())
-				return Builtins::AND(Builtins::SHR(B.d() - A.d(), X), mask);
+				return {Pattern::Builtins::AND, {{Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, B.d() - A.d())}, mask}};
 			else
-				return Builtins::AND(X, mask);
+				return {Pattern::Builtins::AND, {X, mask}};
 		},
 		false,
 		[=] { return A.d() < Pattern::WordSize && B.d() < Pattern::WordSize; }
@@ -476,42 +472,42 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 	// Combine SHR-SHL by constant
 	rules.push_back({
 		// SHL(B, SHR(A, X)) -> AND(SH[L/R]([B - A / A - B], X), Mask)
-		Builtins::SHL(B, Builtins::SHR(A, X)),
+		{Pattern::Builtins::SHL, swapShiftArgs<Pattern>({Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, A)}, B)},
 		[=]() -> Pattern {
-			Word mask = shlWorkaround((~Word(0)) >> unsigned(A.d()), unsigned(B.d()));
+			Word mask = shlWorkaround(Word(-1) >> unsigned(A.d()), unsigned(B.d()));
 
 			if (A.d() > B.d())
-				return Builtins::AND(Builtins::SHR(A.d() - B.d(), X), mask);
+				return {Pattern::Builtins::AND, {{Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, A.d() - B.d())}, mask}};
 			else if (B.d() > A.d())
-				return Builtins::AND(Builtins::SHL(B.d() - A.d(), X), mask);
+				return {Pattern::Builtins::AND, {{Pattern::Builtins::SHL, swapShiftArgs<Pattern>(X, B.d() - A.d())}, mask}};
 			else
-				return Builtins::AND(X, mask);
+				return {Pattern::Builtins::AND, {X, mask}};
 		},
 		false,
 		[=] { return A.d() < Pattern::WordSize && B.d() < Pattern::WordSize; }
 	});
 
 	// Move AND with constant across SHL and SHR by constant
-	for (auto instr: {Instruction::SHL, Instruction::SHR})
+	for (auto shiftOp: {Pattern::Builtins::SHL, Pattern::Builtins::SHR})
 	{
 		typename Builtins::PatternGeneratorInstance shiftOp{instr};
 		auto replacement = [=]() -> Pattern {
 			Word mask =
-				instr == Instruction::SHL ?
+				shiftOp == Pattern::Builtins::SHL ?
 				shlWorkaround(A.d(), unsigned(B.d())) :
 				A.d() >> unsigned(B.d());
-			return Builtins::AND(shiftOp(B.d(), X), std::move(mask));
+			return {Pattern::Builtins::AND, {{shiftOp, swapShiftArgs<Pattern>(X, B.d())}, std::move(mask)}};
 		};
 		rules.push_back({
 			// SH[L/R](B, AND(X, A)) -> AND(SH[L/R](B, X), [ A << B / A >> B ])
-			shiftOp(B, Builtins::AND(X, A)),
+			{shiftOp, swapShiftArgs<Pattern>({Pattern::Builtins::AND, {{X}, {A}}}, B)},
 			replacement,
 			false,
 			[=] { return B.d() < Pattern::WordSize; }
 		});
 		rules.push_back({
 			// SH[L/R](B, AND(A, X)) -> AND(SH[L/R](B, X), [ A << B / A >> B ])
-			shiftOp(B, Builtins::AND(A, X)),
+			{shiftOp, swapShiftArgs<Pattern>({Pattern::Builtins::AND, {{A}, {X}}}, B)},
 			replacement,
 			false,
 			[=] { return B.d() < Pattern::WordSize; }
@@ -520,27 +516,27 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 
 	rules.push_back({
 		// MUL(X, SHL(Y, 1)) -> SHL(Y, X)
-		Builtins::MUL(X, Builtins::SHL(Y, Word(1))),
+		{Pattern::Builtins::MUL, {X, {Pattern::Builtins::SHL, swapShiftArgs<Pattern>(Word(1), Y)}}},
 		[=]() -> Pattern {
-			return Builtins::SHL(Y, X);
+			return {Pattern::Builtins::SHL, swapShiftArgs<Pattern>(X, Y)};
 		},
 		// Actually only changes the order, does not remove.
 		true
 	});
 	rules.push_back({
 		// MUL(SHL(X, 1), Y) -> SHL(X, Y)
-		Builtins::MUL(Builtins::SHL(X, Word(1)), Y),
+		{Pattern::Builtins::MUL, {{Pattern::Builtins::SHL, swapShiftArgs<Pattern>(Word(1), X)}, Y}},
 		[=]() -> Pattern {
-			return Builtins::SHL(X, Y);
+			return {Pattern::Builtins::SHL, swapShiftArgs<Pattern>(Y, X)};
 		},
 		false
 	});
 
 	rules.push_back({
 		// DIV(X, SHL(Y, 1)) -> SHR(Y, X)
-		Builtins::DIV(X, Builtins::SHL(Y, Word(1))),
+		{Pattern::Builtins::DIV, {X, {Pattern::Builtins::SHL, swapShiftArgs<Pattern>(Word(1), Y)}}},
 		[=]() -> Pattern {
-			return Builtins::SHR(Y, X);
+			return {Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, Y)};
 		},
 		// Actually only changes the order, does not remove.
 		true
@@ -550,21 +546,21 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 		if (B.d() > Pattern::WordSize)
 			return false;
 		unsigned bAsUint = static_cast<unsigned>(B.d());
-		return (A.d() & ((~Word(0)) >> bAsUint)) == ((~Word(0)) >> bAsUint);
+		return (A.d() & (Word(-1) >> bAsUint)) == (Word(-1) >> bAsUint);
 	};
 
 	rules.push_back({
 		// AND(A, SHR(B, X)) -> A & ((2^256-1) >> B) == ((2^256-1) >> B)
-		Builtins::AND(A, Builtins::SHR(B, X)),
-		[=]() -> Pattern { return Builtins::SHR(B, X); },
+		{Pattern::Builtins::AND, {A, {Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, B)}}},
+		[=]() -> Pattern { return {Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, B)}; },
 		false,
 		feasibilityFunction
 	});
 
 	rules.push_back({
 		// AND(SHR(B, X), A) -> ((2^256-1) >> B) & A == ((2^256-1) >> B)
-		Builtins::AND(Builtins::SHR(B, X), A),
-		[=]() -> Pattern { return Builtins::SHR(B, X); },
+		{Pattern::Builtins::AND, {{Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, B)}, A}},
+		[=]() -> Pattern { return {Pattern::Builtins::SHR, swapShiftArgs<Pattern>(X, B)}; },
 		false,
 		feasibilityFunction
 	});
@@ -588,28 +584,28 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart8(
 	rules += std::vector<SimplificationRule<Pattern>>{
 		{
 			// X - A -> X + (-A)
-			Builtins::SUB(X, A),
-			[=]() -> Pattern { return Builtins::ADD(X, 0 - A.d()); },
+			{Pattern::Builtins::SUB, {X, A}},
+			[=]() -> Pattern { return {Pattern::Builtins::ADD, {X, 0 - A.d()}}; },
 			false
 		}, {
 			// (X + A) - Y -> (X - Y) + A
-			Builtins::SUB(Builtins::ADD(X, A), Y),
-			[=]() -> Pattern { return Builtins::ADD(Builtins::SUB(X, Y), A); },
+			{Pattern::Builtins::SUB, {{Pattern::Builtins::ADD, {X, A}}, Y}},
+			[=]() -> Pattern { return {Pattern::Builtins::ADD, {{Pattern::Builtins::SUB, {X, Y}}, A}}; },
 			false
 		}, {
 			// (A + X) - Y -> (X - Y) + A
-			Builtins::SUB(Builtins::ADD(A, X), Y),
-			[=]() -> Pattern { return Builtins::ADD(Builtins::SUB(X, Y), A); },
+			{Pattern::Builtins::SUB, {{Pattern::Builtins::ADD, {A, X}}, Y}},
+			[=]() -> Pattern { return {Pattern::Builtins::ADD, {{Pattern::Builtins::SUB, {X, Y}}, A}}; },
 			false
 		}, {
 			// X - (Y + A) -> (X - Y) + (-A)
-			Builtins::SUB(X, Builtins::ADD(Y, A)),
-			[=]() -> Pattern { return Builtins::ADD(Builtins::SUB(X, Y), 0 - A.d()); },
+			{Pattern::Builtins::SUB, {X, {Pattern::Builtins::ADD, {Y, A}}}},
+			[=]() -> Pattern { return {Pattern::Builtins::ADD, {{Pattern::Builtins::SUB, {X, Y}}, 0 - A.d()}}; },
 			false
 		}, {
 			// X - (A + Y) -> (X - Y) + (-A)
-			Builtins::SUB(X, Builtins::ADD(A, Y)),
-			[=]() -> Pattern { return Builtins::ADD(Builtins::SUB(X, Y), 0 - A.d()); },
+			{Pattern::Builtins::SUB, {X, {Pattern::Builtins::ADD, {A, Y}}}},
+			[=]() -> Pattern { return {Pattern::Builtins::ADD, {{Pattern::Builtins::SUB, {X, Y}}, 0 - A.d()}}; },
 			false
 		}
 	};
@@ -621,40 +617,38 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart9(
 	Pattern,
 	Pattern,
 	Pattern,
-	Pattern W,
-	Pattern X,
-	Pattern Y,
-	Pattern Z
+	Pattern /*W*/,
+	Pattern /*X*/,
+	Pattern /*Y*/,
+	Pattern /*Z*/
 )
 {
-	using Word = typename Pattern::Word;
-	using Builtins = typename Pattern::Builtins;
+//	using Word = typename Pattern::Word;
 	std::vector<SimplificationRule<Pattern>> rules;
 
-	assertThrow(Pattern::WordSize > 160, OptimizerException, "");
-	Word const mask = (Word(1) << 160) - 1;
-	// CREATE
-	rules.push_back({
-		Builtins::AND(Builtins::CREATE(W, X, Y), mask),
-		[=]() -> Pattern { return Builtins::CREATE(W, X, Y); },
-		false
-	});
-	rules.push_back({
-		Builtins::AND(mask, Builtins::CREATE(W, X, Y)),
-		[=]() -> Pattern { return Builtins::CREATE(W, X, Y); },
-		false
-	});
-	// CREATE2
-	rules.push_back({
-		Builtins::AND(Builtins::CREATE2(W, X, Y, Z), mask),
-		[=]() -> Pattern { return Builtins::CREATE2(W, X, Y, Z); },
-		false
-	});
-	rules.push_back({
-		Builtins::AND(mask, Builtins::CREATE2(W, X, Y, Z)),
-		[=]() -> Pattern { return Builtins::CREATE2(W, X, Y, Z); },
-		false
-	});
+//	Word const mask = (Word(1) << 160) - 1;
+//	// CREATE
+//	rules.push_back({
+//		{Pattern::Builtins::AND, {{Pattern::Builtins::CREATE, {W, X, Y}}, mask}},
+//		[=]() -> Pattern { return {Pattern::Builtins::CREATE, {W, X, Y}}; },
+//		false
+//	});
+//	rules.push_back({
+//		{Pattern::Builtins::AND, {{mask, {Pattern::Builtins::CREATE, {W, X, Y}}}}},
+//		[=]() -> Pattern { return {Pattern::Builtins::CREATE, {W, X, Y}}; },
+//		false
+//	});
+//	// CREATE2
+//	rules.push_back({
+//		{Pattern::Builtins::AND, {{Pattern::Builtins::CREATE2, {W, X, Y, Z}}, mask}},
+//		[=]() -> Pattern { return {Pattern::Builtins::CREATE2, {W, X, Y, Z}}; },
+//		false
+//	});
+//	rules.push_back({
+//		{Pattern::Builtins::AND, {{mask, {Pattern::Builtins::CREATE2, {W, X, Y, Z}}}}},
+//		[=]() -> Pattern { return {Pattern::Builtins::CREATE2, {W, X, Y, Z}}; },
+//		false
+//	});
 
 	return rules;
 }

--- a/libevmasm/RuleList.h
+++ b/libevmasm/RuleList.h
@@ -52,6 +52,30 @@ template <class S> S shlWorkaround(S const& _x, unsigned _amount)
 	return u256((bigint(_x) << _amount) & u256(-1));
 }
 
+template <class Pattern>
+std::vector<SimplificationRule<Pattern>> simplificationRuleListUnified(
+	Pattern A,
+	Pattern B,
+	Pattern ,//C,
+	Pattern,
+	Pattern,
+	Pattern,
+	Pattern
+)
+{
+	return std::vector<SimplificationRule<Pattern>> {
+		// arithmetic on constants
+		{{Pattern::Builtins::ADD, {A, B}}, [=]{ return A.d() + B.d(); }, false},
+		{{Pattern::Builtins::MUL, {A, B}}, [=]{ return A.d() * B.d(); }, false},
+//		{{Pattern::Builtins::SUB, {A, B}}, [=]{ return A.d() - B.d(); }, false},
+//		{{Pattern::Builtins::NOT, {A}}, [=]{ return ~A.d(); }, false},
+//		{{Pattern::Builtins::LT, {A, B}}, [=]() -> u256 { return A.d() < B.d() ? 1 : 0; }, false},
+//		{{Pattern::Builtins::GT, {A, B}}, [=]() -> u256 { return A.d() > B.d() ? 1 : 0; }, false},
+//		{{Pattern::Builtins::EQ, {A, B}}, [=]() -> u256 { return A.d() == B.d() ? 1 : 0; }, false},
+//		{{Pattern::Builtins::ISZERO, {A}}, [=]() -> u256 { return A.d() == 0 ? 1 : 0; }, false},
+	};
+}
+
 // simplificationRuleList below was split up into parts to prevent
 // stack overflows in the JavaScript optimizer for emscripten builds
 // that affected certain browser versions.

--- a/libevmasm/SimplificationRules.h
+++ b/libevmasm/SimplificationRules.h
@@ -89,6 +89,7 @@ public:
 
 	using Builtins = evmasm::EVMBuiltins<Pattern>;
 	static constexpr size_t WordSize = 256;
+	static constexpr bool isEWasm = false;
 	using Word = u256;
 
 	// Matches a specific constant value.

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -249,7 +249,9 @@ string IRGenerator::dispatchRoutine(ContractDefinition const& _contract)
 	Whiskers t(R"X(
 		if iszero(lt(calldatasize(), 4))
 		{
-			let selector := <shr224>(calldataload(0))
+			mstore(0, 0)
+			calldatacopy(28, 0, 4)
+			let selector := mload(0)
 			switch selector
 			<#cases>
 			case <functionSelector>

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1135,9 +1135,22 @@ void CompilerStack::generateEwasm(ContractDefinition const& _contract)
 	stack.translate(yul::AssemblyStack::Language::Ewasm);
 	stack.optimize();
 
+	cout << "=============== ewasm ================" << endl;
+	cout << ewasmObject.toString(false) << endl;
+
+	// Re-inject into an assembly stack for the eWasm dialect
+	yul::AssemblyStack stack(m_evmVersion, yul::AssemblyStack::Language::EWasm, m_optimiserSettings);
+	// TODO this is a hack for now - provide as structured AST!
+	stack.parseAndAnalyze("", "{}");
+	*stack.parserResult() = move(ewasmObject);
+	stack.optimize();
+
+	cout << "=============== ewasm OPT ================" << endl;
+	cout << stack.parserResult()->toString(false) << endl;
+
 	//cout << yul::AsmPrinter{}(*stack.parserResult()->code) << endl;
 
-	// Turn into Ewasm text representation.
+	// Turn into eWasm text representation.
 	auto result = stack.assemble(yul::AssemblyStack::Machine::Ewasm);
 	compiledContract.ewasm = std::move(result.assembly);
 	compiledContract.ewasmObject = std::move(*result.bytecode);

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -143,7 +143,7 @@ protected:
 	bool inScope(YulString _variableName) const;
 
 	std::optional<std::pair<YulString, YulString>> isSimpleStore(
-		evmasm::Instruction _store,
+		bool _toStorage,
 		ExpressionStatement const& _statement
 	) const;
 

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -102,11 +102,11 @@ bool FullInliner::shallInline(FunctionCall const& _funCall, YulString _callSite)
 
 	// Inline really, really tiny functions
 	size_t size = m_functionSizes.at(calledFunction->name);
-	if (size <= 1)
+	if (size <= 5)
 		return true;
 
 	// Do not inline into already big functions.
-	if (m_functionSizes.at(_callSite) > 45)
+	if (m_functionSizes.at(_callSite) > 245)
 		return false;
 
 	if (m_singleUse.count(calledFunction->name))
@@ -124,7 +124,7 @@ bool FullInliner::shallInline(FunctionCall const& _funCall, YulString _callSite)
 			break;
 		}
 
-	return (size < 6 || (constantArg && size < 12));
+	return (size < 6 || (constantArg && size < 180));
 }
 
 void FullInliner::tentativelyUpdateCodeSize(YulString _function, YulString _callSite)

--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -51,7 +51,7 @@ bool KnowledgeBase::knownToBeDifferent(YulString _a, YulString _b)
 	return false;
 }
 
-bool KnowledgeBase::knownToBeDifferentByAtLeast32(YulString _a, YulString _b)
+bool KnowledgeBase::knownToBeDifferentByAtLeastConstant(YulString _a, YulString _b, unsigned _amount)
 {
 	// Try to use the simplification rules together with the
 	// current values to turn `sub(_a, _b)` into a constant whose absolute value is at least 32.
@@ -59,8 +59,8 @@ bool KnowledgeBase::knownToBeDifferentByAtLeast32(YulString _a, YulString _b)
 	Expression expr1 = simplify(FunctionCall{{}, {{}, "sub"_yulstring}, util::make_vector<Expression>(Identifier{{}, _a}, Identifier{{}, _b})});
 	if (holds_alternative<Literal>(expr1))
 	{
-		u256 val = valueOfLiteral(std::get<Literal>(expr1));
-		return val >= 32 && val <= u256(0) - 32;
+		u256 val = valueOfLiteral(boost::get<Literal>(expr1));
+		return val >= _amount && val <= u256(0) - _amount;
 	}
 
 	return false;

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -44,7 +44,7 @@ public:
 	{}
 
 	bool knownToBeDifferent(YulString _a, YulString _b);
-	bool knownToBeDifferentByAtLeast32(YulString _a, YulString _b);
+	bool knownToBeDifferentByAtLeastConstant(YulString _a, YulString _b, unsigned _amount);
 	bool knownToBeEqual(YulString _a, YulString _b) const { return _a == _b; }
 
 private:

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -74,8 +74,10 @@ SimplificationRule<yul::PatternEWasm> const* SimplificationRules::findFirstMatch
 		if (_dialect.builtin(boost::get<FunctionCall>(_expr).functionName.name))
 		{
 			YulString funName = boost::get<FunctionCall>(_expr).functionName.name;
+			cout << "searching for rule for " << funName.str() << endl;
 			for (auto const& rule: rules.m_rulesEWasm[funName])
 			{
+				cout << "searching for rule for " << funName.str() << endl;
 				rules.resetMatchGroups();
 				if (rule.pattern.matches(_expr, _dialect, _ssaValues))
 					if (!rule.feasible || rule.feasible())
@@ -115,7 +117,8 @@ void SimplificationRules::addRule(SimplificationRule<Pattern> const& _rule)
 
 void SimplificationRules::addRule(SimplificationRule<PatternEWasm> const& _rule)
 {
-	m_rulesEWasm[_rule.pattern.builtin()].push_back(_rule);
+	if (!_rule.pattern.builtin().empty())
+		m_rulesEWasm[_rule.pattern.builtin()].push_back(_rule);
 }
 
 SimplificationRules::SimplificationRules()
@@ -161,14 +164,21 @@ SimplificationRules::SimplificationRules()
 		Y.setMatchGroup(6, m_matchGroups);
 		Z.setMatchGroup(7, m_matchGroups);
 
-		for (auto const& r: simplificationRuleListUnified(A, B, C, W, X, Y, Z))
-			addRule(r);
 		using R = dev::eth::SimplificationRule<PatternEWasm>;
-		addRule(R{{"i64.shr_u"_yulstring, {A, B}}, [=]{
-			if (A.d() > 64)
-				return uint64_t(0);
-			return B.d() >> uint64_t(A.d());
+		addRule(R{{"i64.ne"_yulstring, {X, X}}, [=]{ return 0; }, true});
+		addRule(R{{"i64.ne"_yulstring, {A, B}}, [=]{ return A.d() != B.d(); }, false});
+		addRule(R{{"i64.shl"_yulstring, {A, B}}, [=]() -> uint64_t {
+			if (B.d() >= 64)
+				return 0;
+			return A.d() << B.d();
 		}, false});
+		addRule(R{{"i64.shr_u"_yulstring, {A, B}}, [=]() -> uint64_t {
+			if (B.d() >= 64)
+				return 0;
+			return A.d() >> B.d();
+		}, false});
+		for (auto const& r: simplificationRuleList(A, B, C, W, X, Y, Z))
+			addRule(r);
 	}
 	assertThrow(isInitialized(), OptimizerException, "Rule list not properly initialized.");
 }
@@ -285,15 +295,11 @@ Expression Pattern::toExpression(SourceLocation const& _location) const
 		vector<Expression> arguments;
 		for (auto const& arg: m_arguments)
 			arguments.emplace_back(arg.toExpression(_location));
-
+		// TODO convert to FunctionCall
 		string name = instructionInfo(m_instruction).name;
-		transform(begin(name), end(name), begin(name), [](auto _c) { return tolower(_c); });
+		transform(name.begin(), name.end(), name.begin(), [](unsigned char _c) { return tolower(_c); });
 
-		return FunctionCall{
-			_location,
-			Identifier{_location, YulString{name}},
-			std::move(arguments)
-		};
+		return FunctionCall{_location, {_location, YulString{name}}, std::move(arguments)};
 	}
 	assertThrow(false, OptimizerException, "Pattern of kind 'any', but no match group.");
 }

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -74,10 +74,8 @@ SimplificationRule<yul::PatternEWasm> const* SimplificationRules::findFirstMatch
 		if (_dialect.builtin(boost::get<FunctionCall>(_expr).functionName.name))
 		{
 			YulString funName = boost::get<FunctionCall>(_expr).functionName.name;
-			cout << "searching for rule for " << funName.str() << endl;
 			for (auto const& rule: rules.m_rulesEWasm[funName])
 			{
-				cout << "searching for rule for " << funName.str() << endl;
 				rules.resetMatchGroups();
 				if (rule.pattern.matches(_expr, _dialect, _ssaValues))
 					if (!rule.feasible || rule.feasible())
@@ -167,6 +165,9 @@ SimplificationRules::SimplificationRules()
 		using R = dev::eth::SimplificationRule<PatternEWasm>;
 		addRule(R{{"i64.ne"_yulstring, {X, X}}, [=]{ return 0; }, true});
 		addRule(R{{"i64.ne"_yulstring, {A, B}}, [=]{ return A.d() != B.d(); }, false});
+		addRule(R{{"i64.ne"_yulstring, {X, uint64_t(0)}}, [=]{ return X; }, false});
+		addRule(R{{"i64.ne"_yulstring, {uint64_t(0), X}}, [=]{ return X; }, false});
+		addRule(R{{"i64.ge_u"_yulstring, {A, B}}, [=]{ return A.d() >= B.d(); }, false});
 		addRule(R{{"i64.shl"_yulstring, {A, B}}, [=]() -> uint64_t {
 			if (B.d() >= 64)
 				return 0;

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -25,6 +25,7 @@
 #include <libyul/optimiser/SyntacticalEquality.h>
 #include <libyul/optimiser/DataFlowAnalyzer.h>
 #include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/backends/wasm/WasmDialect.h>
 #include <libyul/AsmData.h>
 #include <libyul/Utilities.h>
 
@@ -42,12 +43,12 @@ SimplificationRule<yul::Pattern> const* SimplificationRules::findFirstMatch(
 	map<YulString, AssignedValue> const& _ssaValues
 )
 {
+	static SimplificationRules rules;
+	assertThrow(rules.isInitialized(), OptimizerException, "Rule list not properly initialized.");
+
 	auto instruction = instructionAndArguments(_dialect, _expr);
 	if (!instruction)
 		return nullptr;
-
-	static SimplificationRules rules;
-	assertThrow(rules.isInitialized(), OptimizerException, "Rule list not properly initialized.");
 
 	for (auto const& rule: rules.m_rules[uint8_t(instruction->first)])
 	{
@@ -56,6 +57,31 @@ SimplificationRule<yul::Pattern> const* SimplificationRules::findFirstMatch(
 			if (!rule.feasible || rule.feasible())
 				return &rule;
 	}
+
+	return nullptr;
+}
+
+SimplificationRule<yul::PatternEWasm> const* SimplificationRules::findFirstMatchEWasm(
+	Expression const& _expr,
+	Dialect const& _dialect,
+	map<YulString, Expression const*> const& _ssaValues
+)
+{
+	static SimplificationRules rules;
+	assertThrow(rules.isInitialized(), OptimizerException, "Rule list not properly initialized.");
+
+	if (_expr.type() == typeid(FunctionCall))
+		if (_dialect.builtin(boost::get<FunctionCall>(_expr).functionName.name))
+		{
+			YulString funName = boost::get<FunctionCall>(_expr).functionName.name;
+			for (auto const& rule: rules.m_rulesEWasm[funName])
+			{
+				rules.resetMatchGroups();
+				if (rule.pattern.matches(_expr, _dialect, _ssaValues))
+					if (!rule.feasible || rule.feasible())
+						return &rule;
+			}
+		}
 	return nullptr;
 }
 
@@ -87,27 +113,63 @@ void SimplificationRules::addRule(SimplificationRule<Pattern> const& _rule)
 	m_rules[uint8_t(_rule.pattern.instruction())].push_back(_rule);
 }
 
+void SimplificationRules::addRule(SimplificationRule<PatternEWasm> const& _rule)
+{
+	m_rulesEWasm[_rule.pattern.builtin()].push_back(_rule);
+}
+
 SimplificationRules::SimplificationRules()
 {
-	// Multiple occurrences of one of these inside one rule must match the same equivalence class.
-	// Constants.
-	Pattern A(PatternKind::Constant);
-	Pattern B(PatternKind::Constant);
-	Pattern C(PatternKind::Constant);
-	// Anything.
-	Pattern W;
-	Pattern X;
-	Pattern Y;
-	Pattern Z;
-	A.setMatchGroup(1, m_matchGroups);
-	B.setMatchGroup(2, m_matchGroups);
-	C.setMatchGroup(3, m_matchGroups);
-	W.setMatchGroup(4, m_matchGroups);
-	X.setMatchGroup(5, m_matchGroups);
-	Y.setMatchGroup(6, m_matchGroups);
-	Z.setMatchGroup(7, m_matchGroups);
+	{
+		// Multiple occurrences of one of these inside one rule must match the same equivalence class.
+		// Constants.
+		Pattern A(PatternKind::Constant);
+		Pattern B(PatternKind::Constant);
+		Pattern C(PatternKind::Constant);
+		// Anything.
+		Pattern W;
+		Pattern X;
+		Pattern Y;
+		Pattern Z;
+		A.setMatchGroup(1, m_matchGroups);
+		B.setMatchGroup(2, m_matchGroups);
+		C.setMatchGroup(3, m_matchGroups);
+		W.setMatchGroup(4, m_matchGroups);
+		X.setMatchGroup(5, m_matchGroups);
+		Y.setMatchGroup(6, m_matchGroups);
+		Z.setMatchGroup(7, m_matchGroups);
 
-	addRules(simplificationRuleList(A, B, C, W, X, Y, Z));
+		addRules(simplificationRuleList(A, B, C, W, X, Y, Z));
+	}
+
+	{
+		// Multiple occurrences of one of these inside one rule must match the same equivalence class.
+		// Constants.
+		PatternEWasm A(PatternKind::Constant);
+		PatternEWasm B(PatternKind::Constant);
+		PatternEWasm C(PatternKind::Constant);
+		// Anything.
+		PatternEWasm W;
+		PatternEWasm X;
+		PatternEWasm Y;
+		PatternEWasm Z;
+		A.setMatchGroup(1, m_matchGroups);
+		B.setMatchGroup(2, m_matchGroups);
+		C.setMatchGroup(3, m_matchGroups);
+		W.setMatchGroup(4, m_matchGroups);
+		X.setMatchGroup(5, m_matchGroups);
+		Y.setMatchGroup(6, m_matchGroups);
+		Z.setMatchGroup(7, m_matchGroups);
+
+		for (auto const& r: simplificationRuleListUnified(A, B, C, W, X, Y, Z))
+			addRule(r);
+		using R = dev::eth::SimplificationRule<PatternEWasm>;
+		addRule(R{{"i64.shr_u"_yulstring, {A, B}}, [=]{
+			if (A.d() > 64)
+				return uint64_t(0);
+			return B.d() >> uint64_t(A.d());
+		}, false});
+	}
 	assertThrow(isInitialized(), OptimizerException, "Rule list not properly initialized.");
 }
 
@@ -242,6 +304,142 @@ u256 Pattern::d() const
 }
 
 Expression const& Pattern::matchGroupValue() const
+{
+	assertThrow(m_matchGroup > 0, OptimizerException, "");
+	assertThrow(!!m_matchGroups, OptimizerException, "");
+	assertThrow((*m_matchGroups)[m_matchGroup], OptimizerException, "");
+	return *(*m_matchGroups)[m_matchGroup];
+}
+
+
+yul::PatternEWasm::PatternEWasm(YulString _builtin, vector<PatternEWasm> const& _arguments):
+	m_kind(PatternKind::Operation),
+	m_instruction(_builtin),
+	m_arguments(_arguments)
+{
+}
+
+void PatternEWasm::setMatchGroup(unsigned _group, map<unsigned, Expression const*>& _matchGroups)
+{
+	m_matchGroup = _group;
+	m_matchGroups = &_matchGroups;
+}
+
+bool PatternEWasm::matches(
+	Expression const& _expr,
+	Dialect const& _dialect,
+	map<YulString, Expression const*> const& _ssaValues
+) const
+{
+	Expression const* expr = &_expr;
+
+	// Resolve the variable if possible.
+	// Do not do it for "Any" because we can check identity better for variables.
+	if (m_kind != PatternKind::Any && _expr.type() == typeid(Identifier))
+	{
+		YulString varName = boost::get<Identifier>(_expr).name;
+		if (_ssaValues.count(varName))
+			if (Expression const* new_expr = _ssaValues.at(varName))
+				expr = new_expr;
+	}
+	assertThrow(expr, OptimizerException, "");
+
+	if (m_kind == PatternKind::Constant)
+	{
+		if (expr->type() != typeid(Literal))
+			return false;
+		Literal const& literal = boost::get<Literal>(*expr);
+		if (literal.kind != LiteralKind::Number)
+			return false;
+		// TODO overflow
+		if (m_data && *m_data != uint64_t(u256(literal.value.str())))
+			return false;
+		assertThrow(m_arguments.empty(), OptimizerException, "");
+	}
+	else if (m_kind == PatternKind::Operation)
+	{
+		if (expr->type() != typeid(FunctionCall))
+			return false;
+		if (!_dialect.builtin(boost::get<FunctionCall>(*expr).functionName.name))
+			return false;
+		if (m_instruction != boost::get<FunctionCall>(*expr).functionName.name)
+			return false;
+		vector<Expression> const* args = &boost::get<FunctionCall>(*expr).arguments;
+		assertThrow(m_arguments.size() == args->size(), OptimizerException, "");
+		for (size_t i = 0; i < m_arguments.size(); ++i)
+			if (!m_arguments[i].matches(args->at(i), _dialect, _ssaValues))
+				return false;
+	}
+	else
+	{
+		assertThrow(m_arguments.empty(), OptimizerException, "\"Any\" should not have arguments.");
+	}
+
+	if (m_matchGroup)
+	{
+		// We support matching multiple expressions that require the same value
+		// based on identical ASTs, which have to be movable.
+
+		// TODO: add tests:
+		// - { let x := mload(0) let y := and(x, x) }
+		// - { let x := 4 let y := and(x, y) }
+
+		// This code uses `_expr` again for "Any", because we want the comparison to be done
+		// on the variables and not their values.
+		// The assumption is that CSE or local value numbering has been done prior to this step.
+
+		if (m_matchGroups->count(m_matchGroup))
+		{
+			assertThrow(m_kind == PatternKind::Any, OptimizerException, "Match group repetition for non-any.");
+			Expression const* firstMatch = (*m_matchGroups)[m_matchGroup];
+			assertThrow(firstMatch, OptimizerException, "Match set but to null.");
+			return
+				SyntacticallyEqual{}(*firstMatch, _expr) &&
+				SideEffectsCollector(_dialect, _expr).movable();
+		}
+		else if (m_kind == PatternKind::Any)
+			(*m_matchGroups)[m_matchGroup] = &_expr;
+		else
+		{
+			assertThrow(m_kind == PatternKind::Constant, OptimizerException, "Match group set for operation.");
+			// We do not use _expr here, because we want the actual number.
+			(*m_matchGroups)[m_matchGroup] = expr;
+		}
+	}
+	return true;
+}
+
+YulString PatternEWasm::builtin() const
+{
+	assertThrow(m_kind == PatternKind::Operation, OptimizerException, "");
+	return m_instruction;
+}
+
+Expression PatternEWasm::toExpression(SourceLocation const& _location) const
+{
+	if (matchGroup())
+		return ASTCopier().translate(matchGroupValue());
+	if (m_kind == PatternKind::Constant)
+	{
+		assertThrow(m_data, OptimizerException, "No match group and no constant value given.");
+		return Literal{_location, LiteralKind::Number, YulString{formatNumber(u256(*m_data))}, {}};
+	}
+	else if (m_kind == PatternKind::Operation)
+	{
+		vector<Expression> arguments;
+		for (auto const& arg: m_arguments)
+			arguments.emplace_back(arg.toExpression(_location));
+		return FunctionCall{_location, {_location, m_instruction}, std::move(arguments)};
+	}
+	assertThrow(false, OptimizerException, "Pattern of kind 'any', but no match group.");
+}
+
+uint64_t PatternEWasm::d() const
+{
+	return uint64_t(valueOfNumberLiteral(boost::get<Literal>(matchGroupValue())));
+}
+
+Expression const& PatternEWasm::matchGroupValue() const
 {
 	assertThrow(m_matchGroup > 0, OptimizerException, "");
 	assertThrow(!!m_matchGroups, OptimizerException, "");

--- a/libyul/optimiser/SimplificationRules.h
+++ b/libyul/optimiser/SimplificationRules.h
@@ -98,6 +98,7 @@ class Pattern
 public:
 	using Builtins = evmasm::EVMBuiltins<Pattern>;
 	static constexpr size_t WordSize = 256;
+	static constexpr bool isEWasm = false;
 	using Word = u256;
 
 	/// Matches any expression.
@@ -145,15 +146,51 @@ private:
 
 struct EWasmBuiltins
 {
-	using InstrType = YulString;
+	using InstrType = char const*;
 	static constexpr auto ADD = "i64.add";
+	static constexpr auto SUB = "i64.sub";
 	static constexpr auto MUL = "i64.mul";
+	// TODO check if semantics are equivalent
+	static constexpr auto DIV = "i64.div_u";
+	// TODO check if semantics are equivalent
+	static constexpr auto MOD = "i64.rem_u";
+	static constexpr auto AND = "i64.and";
+	static constexpr auto OR = "i64.or";
+	static constexpr auto XOR = "i64.xor";
+	static constexpr auto SHL = "i64.shl";
+	// TODO check if semantics are equivalent
+	static constexpr auto SHR = "i64.shr_u";
+	static constexpr auto ISZERO = "i64.eqz";
+	static constexpr auto EQ = "i64.eq";
+	static constexpr auto LT = "i64.lt_u";
+	static constexpr auto GT = "i64.gt_u";
+
+	// TODO
+	static constexpr auto SDIV = "";
+	static constexpr auto SMOD = "";
+	static constexpr auto EXP = "";
+	static constexpr auto NOT = "";
+	static constexpr auto SLT = "";
+	static constexpr auto SGT = "";
+	static constexpr auto BYTE = "";
+	static constexpr auto ADDMOD = "";
+	static constexpr auto MULMOD = "";
+	static constexpr auto SIGNEXTEND = "";
+
+	// They cannot be used because they do not return values for eWasm.
+	static constexpr auto ADDRESS = "";
+	static constexpr auto CALLER = "";
+	static constexpr auto ORIGIN = "";
+	static constexpr auto COINBASE = "";
 };
 
 class PatternEWasm
 {
 public:
 	using Builtins = EWasmBuiltins;
+	static constexpr size_t WordSize = 64;
+	using Word = uint64_t;
+	static constexpr bool isEWasm = true;
 
 	/// Matches any expression.
 	PatternEWasm(PatternKind _kind = PatternKind::Any): m_kind(_kind) {}

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -112,12 +112,18 @@ void OptimiserSuite::run(
 	// None of the above can make stack problems worse.
 
 	size_t codeSize = 0;
-	for (size_t rounds = 0; rounds < 30; ++rounds)
+	size_t sizeStableForRounds = 0;
+	for (size_t rounds = 0; rounds < 50; ++rounds)
 	{
 		{
 			size_t newSize = CodeSize::codeSizeIncludingFunctions(ast);
 			if (newSize == codeSize)
-				break;
+			{
+				if (++sizeStableForRounds > 4)
+					break;
+			}
+			else
+				sizeStableForRounds = 0;
 			codeSize = newSize;
 		}
 

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -88,7 +88,7 @@ void OptimiserSuite::run(
 	)(*_object.code));
 	Block& ast = *_object.code;
 
-	OptimiserSuite suite(_dialect, reservedIdentifiers, Debug::None, ast);
+	OptimiserSuite suite(_dialect, reservedIdentifiers, Debug::PrintChanges, ast);
 
 	suite.runSequence({
 		VarDeclInitializer::name,
@@ -112,7 +112,7 @@ void OptimiserSuite::run(
 	// None of the above can make stack problems worse.
 
 	size_t codeSize = 0;
-	for (size_t rounds = 0; rounds < 12; ++rounds)
+	for (size_t rounds = 0; rounds < 30; ++rounds)
 	{
 		{
 			size_t newSize = CodeSize::codeSizeIncludingFunctions(ast);

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -50,7 +50,9 @@ bytes SolidityExecutionFramework::compileContract(
 	m_compiler.setRevertStringBehaviour(m_revertStrings);
 	m_compiler.setEVMVersion(m_evmVersion);
 	m_compiler.setOptimiserSettings(m_optimiserSettings);
+	m_compiler.setOptimiserSettings(OptimiserSettings::full());
 	m_compiler.enableIRGeneration(m_compileViaYul);
+	m_compiler.enableEWasmGeneration(true);
 	if (!m_compiler.compile())
 	{
 		langutil::SourceReferenceFormatter formatter(std::cerr);
@@ -60,7 +62,10 @@ bytes SolidityExecutionFramework::compileContract(
 		BOOST_ERROR("Compiling contract failed");
 	}
 	evmasm::LinkerObject obj;
-	if (m_compileViaYul)
+	bool viaEWasm = true;
+	if (viaEWasm)
+		obj = m_compiler.eWasmObject(_contractName.empty() ? m_compiler.lastContractName() : _contractName);
+	else if (m_compileViaYul)
 	{
 		yul::AssemblyStack asmStack(
 					m_evmVersion,

--- a/test/libyul/YulOptimizerTest.h
+++ b/test/libyul/YulOptimizerTest.h
@@ -69,6 +69,8 @@ private:
 	static void printErrors(std::ostream& _stream, langutil::ErrorList const& _errors);
 
 	std::string m_source;
+	bool m_yul = false;
+	bool m_eWasm = false;
 	std::string m_optimizerStep;
 	std::string m_expectation;
 


### PR DESCRIPTION
This is being split up into individual PRs.
Still to do:
 - [x] rule list / optimizer / data flow analyzer / expression simplifier / full inliner / knowledge base / load resolver / simplification rules: #7652
 - [ ] suite.cpp ("stable for X rounds")
 - [ ] Use calldatacopy for selector choice without shifting: https://github.com/ethereum/solidity/pull/7597
 - [x] compiler stack: https://github.com/ethereum/solidity/pull/7606/
 - [x] ewasm to text: https://github.com/ethereum/solidity/pull/7601
 - [x] wasm dialect: https://github.com/ethereum/solidity/pull/7602
 - [x] word size transform: https://github.com/ethereum/solidity/pull/7604
 - [x] commandline interface: https://github.com/ethereum/solidity/pull/7606/
 - [x] assembly stack: https://github.com/ethereum/solidity/pull/7606/
