### PR TITLE
Bumps XCode version for CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ jobs:
 
   b_osx:
     macos:
-      xcode: "10.0.0"
+      xcode: "11.0.0"
     environment:
       TERM: xterm
       CMAKE_BUILD_TYPE: Debug
@@ -445,7 +445,7 @@ jobs:
 
   t_osx_cli:
     macos:
-      xcode: "10.0.0"
+      xcode: "11.0.0"
     environment:
       TERM: xterm
     steps:


### PR DESCRIPTION
MacOS builds are failing as of today. Came up here: https://github.com/ethereum/solidity/pull/7524 and here https://github.com/ethereum/solidity/pull/7541.