### PR TITLE
implementing formatAsStringOrNumber

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -27,6 +27,8 @@
 
 #include <boost/optional.hpp>
 
+#include "FixedHash.h"
+
 #include <vector>
 #include <type_traits>
 #include <cstring>
@@ -130,6 +132,17 @@ enum class HexCase
 	Upper = 1,
 	Mixed = 2,
 };
+
+std::string formatAsStringOrNumber(std::string const& _value) {
+	std::string result;
+	for (int i = 0; i < _value.length; i++) {
+		if (!isalpha(_value[i]) {
+			return "0x" + h256(_value, h256::AlignLeft).hex();
+		}
+		result += _value[i];
+	}
+	return "\"" + result + "\"";
+}
 
 /// Convert a series of bytes to the corresponding string of hex duplets.
 /// @param _w specifies the width of the first of the elements. Defaults to two - enough to represent a byte.

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -975,7 +975,7 @@ string ABIFunctions::abiEncodingFunctionStringLiteral(
 			for (size_t i = 0; i < words; ++i)
 			{
 				wordParams[i]["offset"] = to_string(i * 32);
-				wordParams[i]["wordValue"] = "0x" + h256(value.substr(32 * i, 32), h256::AlignLeft).hex();
+				wordParams[i]["wordValue"] = dev::formatAsStringOrNumber(value.substr(32 * i, 32));
 			}
 			templ("word", wordParams);
 			return templ.render();
@@ -990,7 +990,7 @@ string ABIFunctions::abiEncodingFunctionStringLiteral(
 				}
 			)");
 			templ("functionName", functionName);
-			templ("wordValue", "0x" + h256(value, h256::AlignLeft).hex());
+			templ("wordValue", dev::formatAsStringOrNumber(value));
 			return templ.render();
 		}
 	});

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1756,7 +1756,7 @@ string YulUtilFunctions::conversionFunctionSpecial(Type const& _from, Type const
 			for (size_t i = 0; i < words; ++i)
 			{
 				wordParams[i]["offset"] = to_string(32 + i * 32);
-				wordParams[i]["wordValue"] = "0x" + h256(data.substr(32 * i, 32), h256::AlignLeft).hex();
+				wordParams[i]["wordValue"] = dev::formatAsStringOrNumber(data.substr(32 * i, 32));
 			}
 			templ("word", wordParams);
 			return templ.render();


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

Implementing dev::formatAsStringOrNumber and using it on ABIFunctions.cpp:978, ABIFunctions.cpp:993 and YulUtilFunctions.cpp:1759

### Checklist
- [x] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
