### PR TITLE
Treat super as an unknown identifier in inline assembly #4575

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 Bugfixes:
  * Type Checker: Disallow constructor of the same class to be used as modifier
  * Code Generator: Fixed a faulty assert that would wrongly trigger for array sizes exceeding unsigned integer
+ * Type Checker: Treat magic variables as unknown identifiers in inline assembly
 
 
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -702,6 +702,9 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 		}
 		else if (_context == yul::IdentifierContext::LValue)
 		{
+			if (dynamic_cast<MagicVariableDeclaration const*>(declaration))
+				return size_t(-1);
+
 			m_errorReporter.typeError(_identifier.location, "Only local variables can be assigned to in inline assembly.");
 			return size_t(-1);
 		}

--- a/test/libsolidity/syntaxTests/inlineAssembly/assignment_to_special.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/assignment_to_special.sol
@@ -2,12 +2,18 @@ contract C {
   function f() public {
     assembly {
       super := 1
+      this := 1
+      msg := 1
+      block := 1
       f := 1
       C := 1
     }
   }
 }
 // ----
-// TypeError: (58-63): Only local variables can be assigned to in inline assembly.
-// TypeError: (75-76): Only local variables can be assigned to in inline assembly.
-// TypeError: (88-89): Only local variables can be assigned to in inline assembly.
+// DeclarationError: (58-63): Variable not found or variable not lvalue.
+// DeclarationError: (75-79): Variable not found or variable not lvalue.
+// DeclarationError: (91-94): Variable not found or variable not lvalue.
+// DeclarationError: (106-111): Variable not found or variable not lvalue.
+// TypeError: (123-124): Only local variables can be assigned to in inline assembly.
+// TypeError: (136-137): Only local variables can be assigned to in inline assembly.


### PR DESCRIPTION
## Description

This fixes #4575. For keywords such as 'super' and 'this', will be
treated as unknown identifiers.

For example, if we use `assembly { super := 1 }`, the error message will be
"Variable not found or variable not lvalue.", which is identical to the error
message of `assembly { unknown_identifier := 1 }`.

### Checklist
- [X] Code compiles correctly
- [X] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [X] Used meaningful commit messages
