### PR TITLE
Update version pragma replacement in external tests

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -66,15 +66,14 @@ function setup
 
     setup_solcjs "$DIR" "$SOLJSON"
     download_project "$repo" "$branch" "$DIR"
-
-    replace_version_pragmas
 }
 
 function replace_version_pragmas
 {
-    # Replace fixed-version pragmas in Gnosis (part of Consensys best practice)
+    # Replace fixed-version pragmas (part of Consensys best practice).
+    # Include all directories to also cover node dependencies.
     printLog "Replacing fixed-version pragmas..."
-    find contracts test -name '*.sol' -type f -print0 | xargs -0 sed -i -e 's/pragma solidity [\^0-9\.]*/pragma solidity >=0.0/'
+    find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -e 's/pragma solidity [\^0-9\.]*/pragma solidity >=0.0/'
 }
 
 function replace_libsolc_call
@@ -187,6 +186,7 @@ function run_test
     local compile_fn="$1"
     local test_fn="$2"
 
+    replace_version_pragmas
     force_solc "$CONFIG" "$DIR" "$SOLJSON"
 
     printLog "Checking optimizer level..."


### PR DESCRIPTION
## Description

Fixes compilation failures (on `develop_060`) during external test runs on Gnosis and Colony contracts, by applying the fixed version pragma replacement after `npm install` in order to cover dependencies, and by including all directories instead of `contracts` only.

Since this change is version independent, it could be just merged into `develop`.

Part of https://github.com/ethereum/solidity/issues/7460.

