### PR TITLE
Updates fixed version pragma in ext. truffle tests.

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -224,6 +224,8 @@ function truffle_run_test
     local compile_fn="$1"
     local test_fn="$2"
 
+    replace_version_pragmas
+
     force_solc "$CONFIG" "$DIR" "$SOLJSON"
 
     printLog "Checking optimizer level..."


### PR DESCRIPTION
Since solc-js tests are running as part of our external testing framework, we need to replace the fixed version pragma before every compilation (solc-js and external tests are handle differently by the script).