### PR TITLE
Switches to Colony fork temporarily

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -32,7 +32,7 @@ function colony_test
 {
     OPTIMIZER_LEVEL=3
     FORCE_ABIv2=false
-    truffle_setup https://github.com/JoinColony/colonyNetwork.git develop
+    truffle_setup https://github.com/erak/colonyNetwork.git develop_060
     run_install install_fn
 
     CONFIG=$(find_truffle_config)


### PR DESCRIPTION
This switches the Colony repository to a fork which contains the changes needed for 0.6.0. 

I'm in contact with the people from Colony and they seem to be interested in having a separate development branch for 0.6.0. 

Here's the PR which contains mainly fixed version pragma updates and some changes needed to conform to strict inline assembly: https://github.com/JoinColony/colonyNetwork/pull/732