### PR TITLE
Remove solc-js DAO tests replacement

### DIFF
--- a/test/solcjsTests.sh
+++ b/test/solcjsTests.sh
@@ -53,11 +53,6 @@ DIR=$(mktemp -d)
     rm -f soljson.js
     cp "$SOLJSON" soljson.js
 
-    # ensure to use always 0.5.0 sources
-    # FIXME: should be removed once the version bump in this repo is done
-    rm -rf test/DAO040
-    cp -R test/DAO test/DAO040
-
     # Update version (needed for some tests)
     echo "Updating package.json to version $VERSION"
     npm version --allow-same-version --no-git-tag-version $VERSION


### PR DESCRIPTION
These were removed from `solc-js` and are tested by Solidity in `develop_060`.