### PR TITLE
Yul AST cleanup (part 1)

### DIFF
--- a/libyul/AsmDataForward.h
+++ b/libyul/AsmDataForward.h
@@ -27,7 +27,6 @@
 namespace yul
 {
 
-struct Instruction;
 struct Literal;
 struct Label;
 struct Identifier;
@@ -49,6 +48,6 @@ struct Block;
 struct TypedName;
 
 using Expression = boost::variant<FunctionalInstruction, FunctionCall, Identifier, Literal>;
-using Statement = boost::variant<ExpressionStatement, Instruction, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Leave, Block>;
+using Statement = boost::variant<ExpressionStatement, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Leave, Block>;
 
 }

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -232,8 +232,8 @@ Statement Parser::parseStatement()
 	}
 	else
 	{
-		solAssert(elementary.type() == typeid(Instruction), "Invalid elementary operation.");
-		return boost::get<Instruction>(elementary);
+		solAssert(false, "Invalid elementary operation.");
+		return {};
 	}
 }
 

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -39,13 +39,6 @@ using namespace yul;
 
 //@TODO source locations
 
-string AsmPrinter::operator()(yul::Instruction const& _instruction) const
-{
-	solAssert(!m_yul, "");
-	solAssert(isValidInstruction(_instruction.instruction), "Invalid instruction");
-	return boost::to_lower_copy(instructionInfo(_instruction.instruction).name);
-}
-
 string AsmPrinter::operator()(Literal const& _literal) const
 {
 	switch (_literal.kind)

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -36,7 +36,6 @@ class AsmPrinter: public boost::static_visitor<std::string>
 public:
 	explicit AsmPrinter(bool _yul = false): m_yul(_yul) {}
 
-	std::string operator()(Instruction const& _instruction) const;
 	std::string operator()(Literal const& _literal) const;
 	std::string operator()(Identifier const& _identifier) const;
 	std::string operator()(FunctionalInstruction const& _functionalInstruction) const;

--- a/libyul/AsmScopeFiller.h
+++ b/libyul/AsmScopeFiller.h
@@ -49,7 +49,6 @@ class ScopeFiller: public boost::static_visitor<bool>
 public:
 	ScopeFiller(AsmAnalysisInfo& _info, langutil::ErrorReporter& _errorReporter);
 
-	bool operator()(Instruction const&) { return true; }
 	bool operator()(Literal const&) { return true; }
 	bool operator()(Identifier const&) { return true; }
 	bool operator()(FunctionalInstruction const&) { return true; }

--- a/libyul/backends/wasm/EWasmCodeTransform.cpp
+++ b/libyul/backends/wasm/EWasmCodeTransform.cpp
@@ -171,12 +171,6 @@ wasm::Expression EWasmCodeTransform::operator()(Literal const& _literal)
 	return wasm::Literal{uint64_t(value)};
 }
 
-wasm::Expression EWasmCodeTransform::operator()(yul::Instruction const&)
-{
-	yulAssert(false, "EVM instruction used for Wasm code generation.");
-	return {};
-}
-
 wasm::Expression EWasmCodeTransform::operator()(If const& _if)
 {
 	return wasm::If{visit(*_if.condition), visit(_if.body.statements), {}};

--- a/libyul/backends/wasm/EWasmCodeTransform.h
+++ b/libyul/backends/wasm/EWasmCodeTransform.h
@@ -38,7 +38,6 @@ public:
 	static std::string run(Dialect const& _dialect, yul::Block const& _ast);
 
 public:
-	wasm::Expression operator()(yul::Instruction const& _instruction);
 	wasm::Expression operator()(yul::Literal const& _literal);
 	wasm::Expression operator()(yul::Identifier const& _identifier);
 	wasm::Expression operator()(yul::FunctionalInstruction const& _instr);

--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -30,12 +30,6 @@ using namespace std;
 using namespace dev;
 using namespace yul;
 
-Statement ASTCopier::operator()(Instruction const&)
-{
-	assertThrow(false, OptimizerException, "Invalid operation.");
-	return {};
-}
-
 Statement ASTCopier::operator()(ExpressionStatement const& _statement)
 {
 	return ExpressionStatement{ _statement.location, translate(_statement.expression) };

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -49,7 +49,6 @@ class StatementCopier: public boost::static_visitor<Statement>
 public:
 	virtual ~StatementCopier() = default;
 	virtual Statement operator()(ExpressionStatement const& _statement) = 0;
-	virtual Statement operator()(Instruction const& _instruction) = 0;
 	virtual Statement operator()(Assignment const& _assignment) = 0;
 	virtual Statement operator()(VariableDeclaration const& _varDecl) = 0;
 	virtual Statement operator()(If const& _if) = 0;
@@ -71,7 +70,6 @@ class ASTCopier: public ExpressionCopier, public StatementCopier
 public:
 	virtual ~ASTCopier() = default;
 	Expression operator()(Literal const& _literal) override;
-	Statement operator()(Instruction const& _instruction) override;
 	Expression operator()(Identifier const& _identifier) override;
 	Expression operator()(FunctionalInstruction const& _instr) override;
 	Expression operator()(FunctionCall const&) override;

--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -43,7 +43,6 @@ class ASTWalker: public boost::static_visitor<>
 public:
 	virtual ~ASTWalker() = default;
 	virtual void operator()(Literal const&) {}
-	virtual void operator()(Instruction const&) { assertThrow(false, OptimizerException, ""); }
 	virtual void operator()(Identifier const&) {}
 	virtual void operator()(FunctionalInstruction const& _instr);
 	virtual void operator()(FunctionCall const& _funCall);
@@ -79,7 +78,6 @@ class ASTModifier: public boost::static_visitor<>
 public:
 	virtual ~ASTModifier() = default;
 	virtual void operator()(Literal&) {}
-	virtual void operator()(Instruction&) { assertThrow(false, OptimizerException, ""); }
 	virtual void operator()(Identifier&) {}
 	virtual void operator()(FunctionalInstruction& _instr);
 	virtual void operator()(FunctionCall& _funCall);

--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -33,9 +33,10 @@ void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 {
 	if (m_dialect.booleanNegationFunction() && _forLoop.condition->type() != typeid(Literal))
 	{
-		langutil::SourceLocation loc = locationOf(*_forLoop.condition);
-		_forLoop.body.statements.insert(
-			_forLoop.body.statements.begin(),
+		langutil::SourceLocation const loc = locationOf(*_forLoop.condition);
+
+		_forLoop.body.statements.emplace(
+			begin(_forLoop.body.statements),
 			If {
 				loc,
 				make_unique<Expression>(

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -159,11 +159,6 @@ bool SyntacticallyEqual::statementEqual(ForLoop const& _lhs, ForLoop const& _rhs
 		statementEqual(_lhs.post, _rhs.post);
 }
 
-bool SyntacticallyEqual::statementEqual(Instruction const&, Instruction const&)
-{
-	assertThrow(false, OptimizerException, "");
-}
-
 bool SyntacticallyEqual::statementEqual(Block const& _lhs, Block const& _rhs)
 {
 	return containerEqual(_lhs.statements, _rhs.statements, [this](Statement const& _lhsStmt, Statement const& _rhsStmt) -> bool {

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -60,8 +60,6 @@ public:
 	bool statementEqual(Leave const&, Leave const&) { return true; }
 	bool statementEqual(Block const& _lhs, Block const& _rhs);
 private:
-	bool statementEqual(Instruction const& _lhs, Instruction const& _rhs);
-
 	bool visitDeclaration(TypedName const& _lhs, TypedName const& _rhs);
 
 	template<typename U, typename V>


### PR DESCRIPTION
take 2, part 1.

The second commit is necessary to work around GCC errors that seem to *only* happen on CircleCI for Ubuntu Linux. - On the other hand, I think it's better to prefer emplace() over insert/push operations where possible anyways.