### PR TITLE
Remove macOS flag for SMT tests

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -36,11 +36,6 @@ source "${REPO_ROOT}/scripts/common.sh"
 WORKDIR=`mktemp -d`
 CMDLINE_PID=
 
-if [[ "$OSTYPE" == "darwin"* ]]
-then
-    SMT_FLAGS="--no-smt"
-fi
-
 cleanup() {
     # ensure failing commands don't cause termination during cleanup (especially within safe_kill)
     set +e


### PR DESCRIPTION
### Description

As part of https://github.com/ethereum/solidity/pull/7632 I came across this line disabling SMT tests under macOS, but they mostly run for me, so I wondered why it was there. In related, I was wondering if it made sense to add a parameter to the `tests.sh` script so people can disable SMT checks at will, passing the `--no-smt` flag to `soltest.sh`?

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
