### PR TITLE
Enum access from inline assembly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Language Features:
  * Allow global enums and structs.
  * Allow underscores as delimiters in hex strings.
  * Allow explicit conversions from ``address`` to ``address payable`` via ``payable(...)``.
+ * Inline Assembly: allow accessing enum values inside inline assembly.
  * Introduce syntax for array slices and implement them for dynamic calldata arrays.
  * Introduce ``push()`` for dynamic storage arrays. It returns a reference to the newly allocated element, if applicable.
  * Modify ``push(element)`` for dynamic storage arrays such that it does not return the new length anymore.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -640,7 +640,13 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 		Declaration const* declaration = ref->second.declaration;
 		solAssert(!!declaration, "");
 		bool requiresStorage = ref->second.isSlot || ref->second.isOffset;
-		if (auto var = dynamic_cast<VariableDeclaration const*>(declaration))
+		if (ref->second.enumValue)
+		{
+			solAssert(dynamic_cast<EnumDefinition const*>(ref->second.declaration) && !requiresStorage, "");
+			ref->second.valueSize = 1;
+			return size_t(1);
+		}
+		else if (auto var = dynamic_cast<VariableDeclaration const*>(declaration))
 		{
 			solAssert(var->type(), "Expected variable type!");
 			if (var->isConstant())

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -642,6 +642,11 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 		bool requiresStorage = ref->second.isSlot || ref->second.isOffset;
 		if (ref->second.enumValue)
 		{
+			if (_context == yul::IdentifierContext::LValue)
+			{
+				m_errorReporter.typeError(_identifier.location, "Enum values cannot be assigned to.");
+				return size_t(-1);
+			}
 			solAssert(dynamic_cast<EnumDefinition const*>(ref->second.declaration) && !requiresStorage, "");
 			ref->second.valueSize = 1;
 			return size_t(1);

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -138,6 +138,7 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 		Declaration const* declaration = nullptr;
 		bool isSlot = false; ///< Whether the storage slot of a variable is queried.
 		bool isOffset = false; ///< Whether the intra-slot offset of a storage variable is queried.
+		std::optional<ASTString> enumValue = {}; ///< The name of the enum value, if one is queried.
 		size_t valueSize = size_t(-1);
 	};
 

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -185,6 +185,8 @@ Json::Value ASTJsonConverter::inlineAssemblyIdentifierToJson(pair<yul::Identifie
 	tuple["isSlot"] = Json::Value(_info.second.isSlot);
 	tuple["isOffset"] = Json::Value(_info.second.isOffset);
 	tuple["valueSize"] = Json::Value(Json::LargestUInt(_info.second.valueSize));
+	if (_info.second.enumValue)
+		tuple["enumValue"] = Json::Value(*_info.second.enumValue);
 	return tuple;
 }
 

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -755,6 +755,15 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 				solAssert(contract->isLibrary(), "");
 				_assembly.appendLinkerSymbol(contract->fullyQualifiedName());
 			}
+			else if (auto enumDefinition = dynamic_cast<EnumDefinition const*>(decl))
+			{
+				solAssert(ref->second.enumValue && !ref->second.isOffset && !ref->second.isSlot, "");
+				TypeType const* typeType = dynamic_cast<TypeType const*>(enumDefinition->type());
+				solAssert(typeType, "");
+				EnumType const* enumType = dynamic_cast<EnumType const*>(typeType->actualType());
+				solAssert(enumType, "");
+				m_context << u256(enumType->memberValue(*ref->second.enumValue));
+			}
 			else
 				solAssert(false, "Invalid declaration type.");
 			solAssert(_assembly.stackHeight() - depositBefore == int(ref->second.valueSize), "");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -61,6 +61,23 @@ struct CopyTranslate: public yul::ASTCopier
 		if (m_references.count(&_identifier))
 		{
 			auto const& reference = m_references.at(&_identifier);
+			if (auto const* enumDecl = dynamic_cast<EnumDefinition const*>(reference.declaration))
+			{
+				solAssert(reference.enumValue && !reference.isSlot && !reference.isOffset, "");
+				solAssert(enumDecl, "");
+				TypeType const* typeType = dynamic_cast<TypeType const*>(enumDecl->type());
+				solAssert(typeType, "");
+				EnumType const* enumType = dynamic_cast<EnumType const*>(typeType->actualType());
+				solAssert(enumType, "");
+
+				return yul::Literal{
+					_identifier.location,
+					yul::LiteralKind::Number,
+					yul::YulString{to_string(enumType->memberValue(*reference.enumValue))},
+					yul::YulString{"uint256"}
+				};
+			}
+			solAssert(!reference.enumValue, "");
 			auto const varDecl = dynamic_cast<VariableDeclaration const*>(reference.declaration);
 			solUnimplementedAssert(varDecl, "");
 

--- a/test/libsolidity/semanticTests/inlineAssembly/enum_access.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/enum_access.sol
@@ -1,0 +1,14 @@
+contract C {
+    enum A { X, Y, Z }
+    function f() public pure returns (uint a, uint b, uint c) {
+        assembly {
+            a := A.X
+            b := A.Y
+            c := A.Z
+        }
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 0, 1, 2

--- a/test/libsolidity/syntaxTests/inlineAssembly/enum_access.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/enum_access.sol
@@ -1,0 +1,19 @@
+contract D {
+    enum B { V }
+}
+contract C {
+	enum A { X, Y, Z }
+	function f() public pure returns (uint a, uint b, uint c, uint d, uint e) {
+		assembly {
+			a := A.X
+			b := C.A.Y
+			c := D.B.V
+			{
+				let A.X := 2
+				d := A.X
+				let A.A := 3
+				e := A.A
+			}
+		}
+	}
+}

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/enum_access.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/enum_access.sol
@@ -1,0 +1,10 @@
+contract C {
+	enum A { X, Y, Z }
+	function f() public pure returns (uint a) {
+		assembly {
+			a := A.A
+		}
+	}
+}
+// ----
+// DeclarationError: (99-102): Identifier not found.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/enum_value_assign.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/enum_value_assign.sol
@@ -1,0 +1,10 @@
+contract C {
+	enum A { X, Y, Z }
+	function f() public pure {
+		assembly {
+			A.X := 2
+		}
+	}
+}
+// ----
+// TypeError: (77-80): Enum values cannot be assigned to.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/enum_value_invalid.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/enum_value_invalid.sol
@@ -1,0 +1,12 @@
+contract C {
+	enum A { X, Y, Z }
+	function f() public pure returns (uint a, uint b, uint c) {
+		assembly {
+			a := A.
+			b := A.U
+		}
+	}
+}
+// ----
+// DeclarationError: (115-117): Identifier not found.
+// DeclarationError: (126-129): Identifier not found.


### PR DESCRIPTION
Fixes #7622.

This works, but it's a bit hacky as it stands.

Also I think we should generally have a look into shadowing inside inline assembly - it seems a bit off for constants as well.