### PR TITLE
Github: remove blank issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,0 @@
-blank_issues_enabled: false


### PR DESCRIPTION
Reverts https://github.com/ethereum/solidity/pull/7634 due to https://github.com/ethereum/solidity/pull/7634#issuecomment-549910217