### PR TITLE
Document variable name restrictions for declarations in inline assembly.

### DIFF
--- a/docs/060-breaking-changes.rst
+++ b/docs/060-breaking-changes.rst
@@ -28,6 +28,13 @@ This section lists purely syntactic changes that do not affect the behavior of e
 
 * New reserved keywords: ``virtual``.
 
+* The names of variables declared in inline assembly may no longer end in ``_slot`` or ``_offset``.
+
+* Variable declarations in inline assembly may no longer shadow any declaration outside the inline assembly block.
+  If the name contains a dot, its prefix up to the dot may not conflict with any declaration outside the inline
+  assembly block.
+
+
 Semantic Only Changes
 =====================
 
@@ -71,6 +78,8 @@ This section gives detailed instructions on how to update prior code for every b
   like ``function f() public returns (uint value)`` and a ``@dev`` annotating it, document its return
   parameters like so: ``@return value The return value.``. You can mix named and un-named return parameters
   documentation so long as the notices are in the order they appear in the tuple return type.
+
+* Choose unique identifiers for variable declarations in inline assembly that do not conflict with declartions outside the inline assembly block.
 
 New Features
 ============

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -439,6 +439,12 @@ for the variable and automatically removed again when the end of the block
 is reached. You need to provide an initial value for the variable which can
 be just ``0``, but it can also be a complex functional-style expression.
 
+Since 0.6.0 the name of a declared variable may not end in ``_offset`` or ``_slot``
+and it may not shadow any declaration visible in the scope of the inline assembly block
+(including variable, contract and function declarations). Similarly, if the name of a declared
+variable contains a dot ``.``, the prefix up to the ``.`` may not conflict with any
+declaration visible in the scope of the inline assembly block.
+
 .. code::
 
     pragma solidity >=0.4.16 <0.7.0;


### PR DESCRIPTION
Addresses https://github.com/ethereum/solidity/pull/7648#issuecomment-551061926.

Open to suggestions.