### PR TITLE
Fix ICE in FixedBytes IndexAccess

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Bugfixes:
  * Type Checker: Disallow constructor of the same class to be used as modifier
  * Code Generator: Fixed a faulty assert that would wrongly trigger for array sizes exceeding unsigned integer
  * Type Checker: Treat magic variables as unknown identifiers in inline assembly
+ * SMTChecker: Fix internal error when accessing indices of fixed bytes.
 
 
 

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -766,6 +766,15 @@ void SMTEncoder::endVisit(IndexAccess const& _indexAccess)
 		auto varDecl = identifierToVariable(*id);
 		solAssert(varDecl, "");
 		array = m_context.variable(*varDecl);
+
+		if (varDecl->type()->category() == Type::Category::FixedBytes)
+		{
+			m_errorReporter.warning(
+				_indexAccess.location(),
+				"Assertion checker does not yet support index accessing fixed bytes."
+			);
+			return;
+		}
 	}
 	else if (auto const& innerAccess = dynamic_cast<IndexAccess const*>(&_indexAccess.baseExpression()))
 	{

--- a/test/libsolidity/smtCheckerTests/operators/index_access_for_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/index_access_for_bytes.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract C {
+    bytes20 x;
+    function f(bytes16 b) public view {
+        b[uint8(x[2])];
+    }
+}
+// ----
+// Warning: (116-120): Assertion checker does not yet support index accessing fixed bytes.
+// Warning: (108-122): Assertion checker does not yet support index accessing fixed bytes.


### PR DESCRIPTION
Found via https://github.com/ethereum/solidity/issues/7466

This only makes it not ICE. Full support tracked in https://github.com/ethereum/solidity/issues/7663