### PR TITLE
Change solcjs branch back to master

### DIFF
--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -35,7 +35,7 @@ function solcjs_test
     SOLCJS_INPUT_DIR="$TEST_DIR"/test/externalTests/solc-js
 
     # set up solc-js on the branch specified
-    setup master_060
+    setup master
 
     printLog "Updating index.js file..."
     echo "require('./determinism.js');" >> test/index.js


### PR DESCRIPTION
Since all the changes in solc-js are actually being merged to `master` and using version guards when applicable, we can go back to using `master` directly.