### PR TITLE
Remove overwritten tag in CI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,17 +104,6 @@ defaults:
       name: command line tests
       command: ./test/cmdlineTests.sh
 
-  - test_ubuntu1904: &test_ubuntu1904
-      docker:
-        - image: ethereum/solidity-buildpack-deps:ubuntu1904
-      steps:
-        - checkout
-        - attach_workspace:
-            at: build
-        - run: *run_soltest
-        - store_test_results: *store_test_results
-        - store_artifacts: *artifacts_test_results
-
   - test_ubuntu1904_clang: &test_ubuntu1904_clang
       docker:
         - image: ethereum/solidity-buildpack-deps:ubuntu1904-clang
@@ -126,7 +115,7 @@ defaults:
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
 
-  - test_ubuntu1904_all: &test_ubuntu1904
+  - test_ubuntu1904: &test_ubuntu1904
       docker:
         - image: ethereum/solidity-buildpack-deps:ubuntu1904
       steps:


### PR DESCRIPTION
Came up in https://github.com/ethereum/solidity/pull/7464

If I see this correctly, the tag I now removed was unused and the label it created was overwritten, so cleaner to just remove it - let's see if I was right. Expected result: the ubuntu CI test runs should have run ``soltest_all.sh`` before this PR and should still do it after this PR.