### PR TITLE
Update PPA build scripts.

### DIFF
--- a/.circleci/docker/Dockerfile.clang.ubuntu1904
+++ b/.circleci/docker/Dockerfile.clang.ubuntu1904
@@ -62,7 +62,7 @@ RUN git clone --recursive -b boost-1.69.0 https://github.com/boostorg/boost.git 
     rm -rf /usr/src/boost
 
 # Z3
-RUN git clone --depth 1 -b Z3-4.8.5 https://github.com/Z3Prover/z3.git \
+RUN git clone --depth 1 -b z3-4.8.6 https://github.com/Z3Prover/z3.git \
     /usr/src/z3; \
     cd /usr/src/z3; \
     python scripts/mk_make.py --prefix=/usr ; \

--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -25,9 +25,9 @@ set -ev
 keyid=70D110489D66E2F6
 email=builds@ethereum.org
 packagename=libz3-static-dev
-version=4.8.5
+version=4.8.6
 
-DISTRIBUTIONS="bionic disco"
+DISTRIBUTIONS="bionic disco eoan"
 
 for distribution in $DISTRIBUTIONS
 do
@@ -40,7 +40,7 @@ pparepo=cpp-build-deps
 ppafilesurl=https://launchpad.net/~ethereum/+archive/ubuntu/${pparepo}/+files
 
 # Fetch source
-git clone --depth 1 --branch Z3-${version} https://github.com/Z3Prover/z3.git
+git clone --depth 1 --branch z3-${version} https://github.com/Z3Prover/z3.git
 cd z3
 debversion="$version"
 

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -57,7 +57,7 @@ packagename=solc
 
 static_build_distribution=disco
 
-DISTRIBUTIONS="bionic disco"
+DISTRIBUTIONS="bionic disco eoan"
 
 if is_release
 then


### PR DESCRIPTION
Adds ubuntu "eoan" (19.10) to PPA scripts and updates Z3 to 4.8.6.

This can be pulled out of draft mode once the Z3 builds (https://launchpad.net/~ethereum/+archive/ubuntu/cpp-build-deps/+packages) have finished successfully.

We might also want to trigger a prerelease PPA build to check the new eoan build, but I don't expect any issues with that.