### PR TITLE
[SMTChecker] Fix ICE in CHC when function used as argument

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ Bugfixes:
  * Code Generator: Fixed a faulty assert that would wrongly trigger for array sizes exceeding unsigned integer
  * Type Checker: Treat magic variables as unknown identifiers in inline assembly
  * SMTChecker: Fix internal error when accessing indices of fixed bytes.
+ * SMTChecker: Fix internal error when using function pointers as arguments.
 
 
 

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -154,15 +154,15 @@ private:
 	//@{
 	/// Constructor predicate.
 	/// Default constructor sets state vars to 0.
-	std::unique_ptr<smt::SymbolicVariable> m_constructorPredicate;
+	std::unique_ptr<smt::SymbolicFunctionVariable> m_constructorPredicate;
 
 	/// Artificial Interface predicate.
 	/// Single entry block for all functions.
-	std::unique_ptr<smt::SymbolicVariable> m_interfacePredicate;
+	std::unique_ptr<smt::SymbolicFunctionVariable> m_interfacePredicate;
 
 	/// Artificial Error predicate.
 	/// Single error block for all assertions.
-	std::unique_ptr<smt::SymbolicVariable> m_errorPredicate;
+	std::unique_ptr<smt::SymbolicFunctionVariable> m_errorPredicate;
 	//@}
 
 	/// Variables.

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -594,10 +594,10 @@ void SMTEncoder::endVisit(Identifier const& _identifier)
 	{
 		// Will be translated as part of the node that requested the lvalue.
 	}
-	else if (_identifier.annotation().type->category() == Type::Category::Function)
-		visitFunctionIdentifier(_identifier);
 	else if (auto decl = identifierToVariable(_identifier))
 		defineExpr(_identifier, currentValue(*decl));
+	else if (_identifier.annotation().type->category() == Type::Category::Function)
+		visitFunctionIdentifier(_identifier);
 	else if (_identifier.name() == "now")
 		defineGlobalVariable(_identifier.name(), _identifier);
 	else if (_identifier.name() == "this")
@@ -1343,7 +1343,7 @@ void SMTEncoder::createExpr(Expression const& _e)
 void SMTEncoder::defineExpr(Expression const& _e, smt::Expression _value)
 {
 	createExpr(_e);
-	solAssert(smt::smtKind(_e.annotation().type->category()) != smt::Kind::Function, "Equality operator applied to type that is not fully supported");
+	solAssert(_value.sort->kind != smt::Kind::Function, "Equality operator applied to type that is not fully supported");
 	m_context.addAssertion(expr(_e) == _value);
 }
 

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -19,7 +19,6 @@
 
 #include <libsolidity/formal/SymbolicTypes.h>
 #include <libsolidity/ast/AST.h>
-#include <libsolidity/ast/TypeProvider.h>
 
 using namespace std;
 using namespace dev;
@@ -153,21 +152,48 @@ SymbolicFunctionVariable::SymbolicFunctionVariable(
 	solAssert(m_sort->kind == Kind::Function, "");
 }
 
-void SymbolicFunctionVariable::resetDeclaration()
+Expression SymbolicFunctionVariable::currentValue(solidity::TypePointer const& _targetType) const
 {
-	m_declaration = m_context.newVariable(currentName(), m_sort);
+	return m_abstract.currentValue(_targetType);
+}
+
+Expression SymbolicFunctionVariable::currentFunctionValue() const
+{
+	return m_declaration;
+}
+
+Expression SymbolicFunctionVariable::valueAtIndex(int _index) const
+{
+	return m_abstract.valueAtIndex(_index);
+}
+
+Expression SymbolicFunctionVariable::functionValueAtIndex(int _index) const
+{
+	return SymbolicVariable::valueAtIndex(_index);
+}
+
+Expression SymbolicFunctionVariable::resetIndex()
+{
+	SymbolicVariable::resetIndex();
+	return m_abstract.resetIndex();
 }
 
 Expression SymbolicFunctionVariable::increaseIndex()
 {
 	++(*m_ssa);
 	resetDeclaration();
-	return currentValue();
+	m_abstract.increaseIndex();
+	return m_abstract.currentValue();
 }
 
 Expression SymbolicFunctionVariable::operator()(vector<Expression> _arguments) const
 {
 	return m_declaration(_arguments);
+}
+
+void SymbolicFunctionVariable::resetDeclaration()
+{
+	m_declaration = m_context.newVariable(currentName(), m_sort);
 }
 
 SymbolicMappingVariable::SymbolicMappingVariable(

--- a/test/libsolidity/smtCheckerTests/typecast/function_type_to_address.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/function_type_to_address.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(address a, function(uint) external g) internal pure {
+		address b = address(g);
+		assert(a == b);
+    }
+}
+// ----
+// Warning: (128-138): Type conversion is not yet fully supported and might yield false positives.
+// Warning: (142-156): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/typecast/function_type_to_function_type_external.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/function_type_to_function_type_external.sol
@@ -1,0 +1,8 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(function(uint) external returns (uint) g, function(uint) external returns (uint) h) public {
+		assert(g(2) == h(2));
+    }
+}
+// ----
+// Warning: (155-175): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/typecast/function_type_to_function_type_internal.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/function_type_to_function_type_internal.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(function(uint) returns (uint) g, function(uint) returns (uint) h) internal {
+		assert(g(2) == h(2));
+		assert(g == h);
+    }
+}
+// ----
+// Warning: (146-150): Assertion checker does not yet implement this type of function call.
+// Warning: (154-158): Assertion checker does not yet implement this type of function call.
+// Warning: (170-176): Assertion checker does not yet implement the type function (uint256) returns (uint256) for comparisons
+// Warning: (139-159): Assertion violation happens here
+// Warning: (163-177): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/function_type_as_argument.sol
+++ b/test/libsolidity/smtCheckerTests/types/function_type_as_argument.sol
@@ -1,0 +1,5 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(function(uint) external g) public {
+    }
+}

--- a/test/libsolidity/smtCheckerTests/types/function_type_call.sol
+++ b/test/libsolidity/smtCheckerTests/types/function_type_call.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+contract C {
+	function(uint) m_g;
+    function f(function(uint) internal g) internal {
+		g(2);
+    }
+	function h() public {
+		f(m_g);
+	}
+}
+// ----
+// Warning: (121-125): Assertion checker does not yet implement this type of function call.
+// Warning: (121-125): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/types/function_type_members.sol
+++ b/test/libsolidity/smtCheckerTests/types/function_type_members.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+contract C {
+    function f(function(uint) external payable g) internal {
+		g.selector;
+		g.gas(2).value(3)(4);
+    }
+}
+// ----
+// Warning: (108-118): Assertion checker does not yet support this expression.
+// Warning: (122-130): Assertion checker does not yet implement this type of function call.
+// Warning: (122-139): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/types/function_type_nested.sol
+++ b/test/libsolidity/smtCheckerTests/types/function_type_nested.sol
@@ -1,0 +1,22 @@
+pragma experimental SMTChecker;
+contract C {
+	function(uint) m_g;
+    function f1(function(uint) internal g1) internal {
+		g1(2);
+    }
+    function f2(function(function(uint) internal) internal g2) internal {
+		g2(m_g);
+    }
+	function h() public {
+		f2(f1);
+	}
+}
+// ----
+// Warning: (123-128): Assertion checker does not yet implement this type of function call.
+// Warning: (152-197): Assertion checker does not yet support the type of this variable.
+// Warning: (212-214): Assertion checker does not yet implement type function (function (uint256))
+// Warning: (212-219): Assertion checker does not yet implement this type of function call.
+// Warning: (255-257): Internal error: Expression undefined for SMT solver.
+// Warning: (255-257): Assertion checker does not yet implement type function (function (uint256))
+// Warning: (212-214): Assertion checker does not yet implement type function (function (uint256))
+// Warning: (212-219): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/types/function_type_nested_return.sol
+++ b/test/libsolidity/smtCheckerTests/types/function_type_nested_return.sol
@@ -1,0 +1,27 @@
+pragma experimental SMTChecker;
+contract C {
+	function(uint) m_g;
+	function r() internal view returns (function(uint)) {
+		return m_g;
+	}
+    function f1(function(uint) internal g1) internal {
+		g1(2);
+    }
+    function f2(function(function(uint) internal) internal g2) internal {
+		g2(r());
+    }
+	function h() public {
+		f2(f1);
+	}
+}
+// ----
+// Warning: (195-200): Assertion checker does not yet implement this type of function call.
+// Warning: (224-269): Assertion checker does not yet support the type of this variable.
+// Warning: (284-286): Assertion checker does not yet implement type function (function (uint256))
+// Warning: (287-288): Assertion checker does not yet support this global variable.
+// Warning: (284-291): Assertion checker does not yet implement this type of function call.
+// Warning: (327-329): Internal error: Expression undefined for SMT solver.
+// Warning: (327-329): Assertion checker does not yet implement type function (function (uint256))
+// Warning: (284-286): Assertion checker does not yet implement type function (function (uint256))
+// Warning: (287-288): Assertion checker does not yet support this global variable.
+// Warning: (284-291): Assertion checker does not yet implement this type of function call.


### PR DESCRIPTION
Found via https://github.com/ethereum/solidity/issues/7466

When used as arguments, function pointers are abstracted as integers.

`SymbolicFunctionVariable` is modified to contain a `SymbolicIntVariable` and use it by default when its symbolic value is required, except for `operator()` applications, where it uses the actual function. New extra function functions were added for the CHC case.