### PR TITLE
Add support for external libraries to extracted semantics tests.

### DIFF
--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -60,7 +60,7 @@ public:
 
 	/// Compiles and deploys currently held source.
 	/// Returns true if deployment was successful, false otherwise.
-	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments);
+	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments, std::map<std::string, dev::test::Address> const& _libraries = {});
 
 private:
 	std::string m_source;

--- a/test/libsolidity/semanticTests/libraries/stub.sol
+++ b/test/libsolidity/semanticTests/libraries/stub.sol
@@ -1,0 +1,13 @@
+library L {
+    function f(uint256 v) external returns (uint256) { return v*v; }
+}
+contract C {
+    function g(uint256 v) external returns (uint256) {
+        return L.f(v);
+    }
+}
+// ----
+// library: L
+// g(uint256): 1 -> 1
+// g(uint256): 2 -> 4
+// g(uint256): 4 -> 16

--- a/test/libsolidity/semanticTests/libraries/stub_internal.sol
+++ b/test/libsolidity/semanticTests/libraries/stub_internal.sol
@@ -1,0 +1,12 @@
+library L {
+    function f(uint256 v) internal returns (uint256) { return v*v; }
+}
+contract C {
+    function g(uint256 v) external returns (uint256) {
+        return L.f(v);
+    }
+}
+// ----
+// g(uint256): 1 -> 1
+// g(uint256): 2 -> 4
+// g(uint256): 4 -> 16

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -58,6 +58,7 @@ namespace test
 	K(Boolean, "boolean", 0)       \
 	/* special keywords */         \
 	K(Left, "left", 0)             \
+	K(Library, "library", 0)       \
 	K(Right, "right", 0)           \
 	K(Failure, "FAILURE", 0)       \
 
@@ -268,6 +269,8 @@ struct FunctionCall
 	/// Marks this function call as "short-handed", meaning
 	/// no `->` declared.
 	bool omitsArrow = true;
+	/// Marks a library deployment call.
+	bool isLibrary = false;
 };
 
 }

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -57,7 +57,9 @@ void testFunctionCall(
 		u256 _value = 0,
 		string _argumentComment = "",
 		string _expectationComment = "",
-		vector<string> _rawArguments = vector<string>{}
+		vector<string> _rawArguments = vector<string>{},
+		bool _isConstructor = false,
+		bool _isLibrary = false
 )
 {
 	BOOST_REQUIRE_EQUAL(_call.expectations.failure, _failure);
@@ -79,6 +81,9 @@ void testFunctionCall(
 			++index;
 		}
 	}
+
+	BOOST_REQUIRE_EQUAL(_call.isConstructor, _isConstructor);
+	BOOST_REQUIRE_EQUAL(_call.isLibrary, _isLibrary);
 }
 
 BOOST_AUTO_TEST_SUITE(TestFileParserTest)
@@ -881,6 +886,51 @@ BOOST_AUTO_TEST_CASE(call_unexpected_character)
 		// f() -> ??
 	)";
 	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
+BOOST_AUTO_TEST_CASE(constructor)
+{
+	char const* source = R"(
+		// constructor()
+	)";
+	auto const calls = parse(source);
+	BOOST_REQUIRE_EQUAL(calls.size(), 1);
+	testFunctionCall(
+		calls.at(0),
+		Mode::SingleLine,
+		"constructor()",
+		false,
+		{},
+		{},
+		0,
+		"",
+		"",
+		{},
+		true
+	);
+}
+
+BOOST_AUTO_TEST_CASE(library)
+{
+	char const* source = R"(
+		// library: L
+	)";
+	auto const calls = parse(source);
+	BOOST_REQUIRE_EQUAL(calls.size(), 1);
+	testFunctionCall(
+		calls.at(0),
+		Mode::SingleLine,
+		"L",
+		false,
+		{},
+		{},
+		0,
+		"",
+		"",
+		{},
+		false,
+		true
+	);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -55,6 +55,12 @@ string TestFunctionCall::format(
 		string newline = formatToken(Token::Newline);
 		string failure = formatToken(Token::Failure);
 
+		if (m_call.isLibrary)
+		{
+			stream << _linePrefix << newline << ws << "library:" << ws << m_call.signature;
+			return;
+		}
+
 		/// Formats the function signature. This is the same independent from the display-mode.
 		stream << _linePrefix << newline << ws << m_call.signature;
 		if (m_call.value > u256(0))


### PR DESCRIPTION
Prerequisite for properly testing https://github.com/ethereum/solidity/issues/6420 in extracted tests.

We can change the syntax later, if anybody is unhappy with it...