### PR TITLE
Use pipeline parameters to store/reference current docker image revision

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -11,7 +11,7 @@ docker build -t ethereum/solidity-buildpack-deps:ubuntu1904-<revision> -f Docker
 docker push ethereum/solidity-buildpack-deps:ubuntu1904-<revision>
 ```
 
-The current revision is `2`.
+The current revision is stored in a [circle ci pipeline parameter](https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/pipeline-parameters.md#pipeline-parameters) called `docker-image-rev`. Please update the value assigned to this parameter at the time of a docker image update. Please verify that the value assigned to the parameter matches the revision part of the docker image tag (`<revision>` in the docker build/push snippet shown above). Otherwise, the docker image used by circle ci and the one actually pushed to docker hub will differ.
 
 Once the docker image has been built and pushed to Dockerhub, you can find it at:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,11 @@
 #     - t: test
 #     - ubu: ubuntu
 #     - ems: Emscripten
-version: 2
+version: 2.1
+parameters:
+  docker-image-rev:
+    type: string
+    default: "2"
 
 defaults:
 
@@ -106,7 +110,7 @@ defaults:
 
   - test_ubuntu1904_clang: &test_ubuntu1904_clang
       docker:
-        - image: ethereum/solidity-buildpack-deps:ubuntu1904-clang-2
+        - image: ethereum/solidity-buildpack-deps:ubuntu1904-clang-<< pipeline.parameters.docker-image-rev >>
       steps:
         - checkout
         - attach_workspace:
@@ -117,7 +121,7 @@ defaults:
 
   - test_ubuntu1904: &test_ubuntu1904
       docker:
-        - image: ethereum/solidity-buildpack-deps:ubuntu1904-2
+        - image: ethereum/solidity-buildpack-deps:ubuntu1904-<< pipeline.parameters.docker-image-rev >>
       steps:
         - checkout
         - attach_workspace:
@@ -287,7 +291,7 @@ jobs:
 
   b_ubu_clang: &build_ubuntu1904_clang
     docker:
-      - image: ethereum/solidity-buildpack-deps:ubuntu1904-clang-2
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904-clang-<< pipeline.parameters.docker-image-rev >>
     environment:
       CC: clang
       CXX: clang++
@@ -299,7 +303,7 @@ jobs:
 
   b_ubu: &build_ubuntu1904
     docker:
-      - image: ethereum/solidity-buildpack-deps:ubuntu1904-2
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904-<< pipeline.parameters.docker-image-rev >>
     steps:
       - checkout
       - run: *run_build
@@ -313,7 +317,7 @@ jobs:
 
   b_ubu18: &build_ubuntu1804
     docker:
-      - image: ethereum/solidity-buildpack-deps:ubuntu1804-2
+      - image: ethereum/solidity-buildpack-deps:ubuntu1804-<< pipeline.parameters.docker-image-rev >>
     environment:
       CMAKE_OPTIONS: -DCMAKE_CXX_FLAGS=-O2
       CMAKE_BUILD_TYPE: RelWithDebugInfo
@@ -519,7 +523,7 @@ jobs:
 
   b_docs:
     docker:
-      - image: ethereum/solidity-buildpack-deps:ubuntu1904-2
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904-<< pipeline.parameters.docker-image-rev >>
     steps:
       - checkout
       - run: *setup_prerelease_commit_hash
@@ -544,7 +548,7 @@ jobs:
 
   t_ubu_cli: &t_ubu_cli
     docker:
-      - image: ethereum/solidity-buildpack-deps:ubuntu1904-2
+      - image: ethereum/solidity-buildpack-deps:ubuntu1904-<< pipeline.parameters.docker-image-rev >>
     environment:
       TERM: xterm
     steps:


### PR DESCRIPTION
Fixes #7736

~~This is WIP as I try to find a fix for #7736 without resorting to pipeline parameters that will force us to upgrade to circle ci configuration version 2.1~~