### PR TITLE
Replace boost::variant by std::variant in libyul

### DIFF
--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -21,7 +21,9 @@
 #include <libyul/backends/evm/EVMDialect.h>
 #include <liblangutil/ErrorReporter.h>
 #include <libevmasm/SemanticInformation.h>
+
 #include <functional>
+#include <variant>
 
 using namespace std;
 using namespace dev;
@@ -31,7 +33,7 @@ using namespace dev::solidity;
 namespace
 {
 
-class AssemblyViewPureChecker: public boost::static_visitor<void>
+class AssemblyViewPureChecker
 {
 public:
 	explicit AssemblyViewPureChecker(
@@ -52,21 +54,21 @@ public:
 	{
 		checkInstruction(_instr.location, _instr.instruction);
 		for (auto const& arg: _instr.arguments)
-			boost::apply_visitor(*this, arg);
+			std::visit(*this, arg);
 	}
 	void operator()(yul::ExpressionStatement const& _expr)
 	{
-		boost::apply_visitor(*this, _expr.expression);
+		std::visit(*this, _expr.expression);
 	}
 	void operator()(yul::StackAssignment const&) {}
 	void operator()(yul::Assignment const& _assignment)
 	{
-		boost::apply_visitor(*this, *_assignment.value);
+		std::visit(*this, *_assignment.value);
 	}
 	void operator()(yul::VariableDeclaration const& _varDecl)
 	{
 		if (_varDecl.value)
-			boost::apply_visitor(*this, *_varDecl.value);
+			std::visit(*this, *_varDecl.value);
 	}
 	void operator()(yul::FunctionDefinition const& _funDef)
 	{
@@ -80,16 +82,16 @@ public:
 					checkInstruction(_funCall.location, *fun->instruction);
 
 		for (auto const& arg: _funCall.arguments)
-			boost::apply_visitor(*this, arg);
+			std::visit(*this, arg);
 	}
 	void operator()(yul::If const& _if)
 	{
-		boost::apply_visitor(*this, *_if.condition);
+		std::visit(*this, *_if.condition);
 		(*this)(_if.body);
 	}
 	void operator()(yul::Switch const& _switch)
 	{
-		boost::apply_visitor(*this, *_switch.expression);
+		std::visit(*this, *_switch.expression);
 		for (auto const& _case: _switch.cases)
 		{
 			if (_case.value)
@@ -100,7 +102,7 @@ public:
 	void operator()(yul::ForLoop const& _for)
 	{
 		(*this)(_for.pre);
-		boost::apply_visitor(*this, *_for.condition);
+		std::visit(*this, *_for.condition);
 		(*this)(_for.body);
 		(*this)(_for.post);
 	}
@@ -113,7 +115,7 @@ public:
 	void operator()(yul::Block const& _block)
 	{
 		for (auto const& s: _block.statements)
-			boost::apply_visitor(*this, s);
+			std::visit(*this, s);
 	}
 
 private:

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -833,9 +833,9 @@ bool IRGeneratorForStatements::visit(InlineAssembly const& _inlineAsm)
 
 	yul::Statement modified = bodyCopier(_inlineAsm.operations());
 
-	solAssert(modified.type() == typeid(yul::Block), "");
+	solAssert(holds_alternative<yul::Block>(modified), "");
 
-	m_code << yul::AsmPrinter()(boost::get<yul::Block>(std::move(modified))) << "\n";
+	m_code << yul::AsmPrinter()(std::get<yul::Block>(std::move(modified))) << "\n";
 	return false;
 }
 

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -214,7 +214,7 @@ bool AsmAnalyzer::operator()(FunctionalInstruction const& _instr)
 bool AsmAnalyzer::operator()(ExpressionStatement const& _statement)
 {
 	int initialStackHeight = m_stackHeight;
-	bool success = boost::apply_visitor(*this, _statement.expression);
+	bool success = std::visit(*this, _statement.expression);
 	if (m_stackHeight != initialStackHeight && (m_dialect.flavour != AsmFlavour::Loose || m_errorTypeForLoose))
 	{
 		Error::Type errorType = m_dialect.flavour == AsmFlavour::Loose ? *m_errorTypeForLoose : Error::Type::TypeError;
@@ -249,7 +249,7 @@ bool AsmAnalyzer::operator()(Assignment const& _assignment)
 	int const expectedItems = _assignment.variableNames.size();
 	solAssert(expectedItems >= 1, "");
 	int const stackHeight = m_stackHeight;
-	bool success = boost::apply_visitor(*this, *_assignment.value);
+	bool success = std::visit(*this, *_assignment.value);
 	if ((m_stackHeight - stackHeight) != expectedItems)
 	{
 		m_errorReporter.declarationError(
@@ -276,7 +276,7 @@ bool AsmAnalyzer::operator()(VariableDeclaration const& _varDecl)
 	if (_varDecl.value)
 	{
 		int const stackHeight = m_stackHeight;
-		success = boost::apply_visitor(*this, *_varDecl.value);
+		success = std::visit(*this, *_varDecl.value);
 		int numValues = m_stackHeight - stackHeight;
 		if (numValues != numVariables)
 		{
@@ -298,7 +298,7 @@ bool AsmAnalyzer::operator()(VariableDeclaration const& _varDecl)
 	for (auto const& variable: _varDecl.variables)
 	{
 		expectValidType(variable.type.str(), variable.location);
-		m_activeVariables.insert(&boost::get<Scope::Variable>(m_currentScope->identifiers.at(variable.name)));
+		m_activeVariables.insert(&std::get<Scope::Variable>(m_currentScope->identifiers.at(variable.name)));
 	}
 	m_info.stackHeightInfo[&_varDecl] = m_stackHeight;
 	return success;
@@ -313,7 +313,7 @@ bool AsmAnalyzer::operator()(FunctionDefinition const& _funDef)
 	for (auto const& var: _funDef.parameters + _funDef.returnVariables)
 	{
 		expectValidType(var.type.str(), var.location);
-		m_activeVariables.insert(&boost::get<Scope::Variable>(varScope.identifiers.at(var.name)));
+		m_activeVariables.insert(&std::get<Scope::Variable>(varScope.identifiers.at(var.name)));
 	}
 
 	int const stackHeight = m_stackHeight;
@@ -388,15 +388,15 @@ bool AsmAnalyzer::operator()(FunctionCall const& _funCall)
 			success = false;
 		else if (needsLiteralArguments)
 		{
-			if (arg.type() != typeid(Literal))
+			if (!holds_alternative<Literal>(arg))
 				m_errorReporter.typeError(
 					_funCall.functionName.location,
 					"Function expects direct literals as arguments."
 				);
-			else if (!m_dataNames.count(boost::get<Literal>(arg).value))
+			else if (!m_dataNames.count(std::get<Literal>(arg).value))
 				m_errorReporter.typeError(
 					_funCall.functionName.location,
-					"Unknown data object \"" + boost::get<Literal>(arg).value.str() + "\"."
+					"Unknown data object \"" + std::get<Literal>(arg).value.str() + "\"."
 				);
 		}
 	}
@@ -556,7 +556,7 @@ bool AsmAnalyzer::operator()(Block const& _block)
 	int const initialStackHeight = m_stackHeight;
 
 	for (auto const& s: _block.statements)
-		if (!boost::apply_visitor(*this, s))
+		if (!std::visit(*this, s))
 			success = false;
 
 	m_stackHeight -= scope(&_block).numberOfVariables();
@@ -585,7 +585,7 @@ bool AsmAnalyzer::expectExpression(Expression const& _expr)
 {
 	bool success = true;
 	int const initialHeight = m_stackHeight;
-	if (!boost::apply_visitor(*this, _expr))
+	if (!std::visit(*this, _expr))
 		success = false;
 	if (!expectDeposit(1, initialHeight, locationOf(_expr)))
 		success = false;
@@ -616,12 +616,12 @@ bool AsmAnalyzer::checkAssignment(Identifier const& _variable, size_t _valueSize
 	if (Scope::Identifier const* var = m_currentScope->lookup(_variable.name))
 	{
 		// Check that it is a variable
-		if (var->type() != typeid(Scope::Variable))
+		if (!holds_alternative<Scope::Variable>(*var))
 		{
 			m_errorReporter.typeError(_variable.location, "Assignment requires variable.");
 			success = false;
 		}
-		else if (!m_activeVariables.count(&boost::get<Scope::Variable>(*var)))
+		else if (!m_activeVariables.count(&std::get<Scope::Variable>(*var)))
 		{
 			m_errorReporter.declarationError(
 				_variable.location,

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -30,8 +30,6 @@
 #include <libyul/backends/evm/AbstractAssembly.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
-#include <boost/variant.hpp>
-
 #include <functional>
 #include <list>
 #include <memory>
@@ -53,7 +51,7 @@ struct AsmAnalysisInfo;
  * references and performs other checks.
  * If all these checks pass, code generation should not throw errors.
  */
-class AsmAnalyzer: public boost::static_visitor<bool>
+class AsmAnalyzer
 {
 public:
 	explicit AsmAnalyzer(

--- a/libyul/AsmData.h
+++ b/libyul/AsmData.h
@@ -28,7 +28,6 @@
 #include <libevmasm/Instruction.h>
 #include <liblangutil/SourceLocation.h>
 
-#include <boost/variant.hpp>
 #include <boost/noncopyable.hpp>
 
 #include <map>
@@ -83,7 +82,7 @@ struct Break { langutil::SourceLocation location; };
 /// Continue statement (valid within for loop)
 struct Continue { langutil::SourceLocation location; };
 
-struct LocationExtractor: boost::static_visitor<langutil::SourceLocation>
+struct LocationExtractor
 {
 	template <class T> langutil::SourceLocation operator()(T const& _node) const
 	{
@@ -94,7 +93,7 @@ struct LocationExtractor: boost::static_visitor<langutil::SourceLocation>
 /// Extracts the source location from an inline assembly node.
 template <class T> inline langutil::SourceLocation locationOf(T const& _node)
 {
-	return boost::apply_visitor(LocationExtractor(), _node);
+	return std::visit(LocationExtractor(), _node);
 }
 
 }

--- a/libyul/AsmDataForward.h
+++ b/libyul/AsmDataForward.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace yul
 {
@@ -48,7 +48,7 @@ struct Block;
 
 struct TypedName;
 
-using Expression = boost::variant<FunctionalInstruction, FunctionCall, Identifier, Literal>;
-using Statement = boost::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Block>;
+using Expression = std::variant<FunctionalInstruction, FunctionCall, Identifier, Literal>;
+using Statement = std::variant<ExpressionStatement, Instruction, Label, StackAssignment, Assignment, VariableDeclaration, FunctionDefinition, If, Switch, ForLoop, Break, Continue, Block>;
 
 }

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -30,8 +30,8 @@
 #include <liblangutil/ParserBase.h>
 
 #include <memory>
+#include <variant>
 #include <vector>
-
 
 namespace yul
 {
@@ -56,7 +56,7 @@ public:
 	static std::map<std::string, dev::eth::Instruction> const& instructions();
 
 protected:
-	using ElementaryOperation = boost::variant<Instruction, Literal, Identifier, FunctionCall>;
+	using ElementaryOperation = std::variant<Instruction, Literal, Identifier, FunctionCall>;
 
 	/// Creates an inline assembly node with the given source location.
 	template <class T> T createWithLocation(langutil::SourceLocation const& _loc = {}) const

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -103,14 +103,15 @@ string AsmPrinter::operator()(FunctionalInstruction const& _functionalInstructio
 		boost::to_lower_copy(instructionInfo(_functionalInstruction.instruction).name) +
 		"(" +
 		boost::algorithm::join(
-			_functionalInstruction.arguments | boost::adaptors::transformed(boost::apply_visitor(*this)),
-			", ") +
+			_functionalInstruction.arguments | boost::adaptors::transformed([&](auto&& _node) { return std::visit(*this, _node); }),
+			", "
+		) +
 		")";
 }
 
 string AsmPrinter::operator()(ExpressionStatement const& _statement) const
 {
-	return boost::apply_visitor(*this, _statement.expression);
+	return std::visit(*this, _statement.expression);
 }
 
 string AsmPrinter::operator()(Label const& _label) const
@@ -133,7 +134,7 @@ string AsmPrinter::operator()(Assignment const& _assignment) const
 	string variables = (*this)(_assignment.variableNames.front());
 	for (size_t i = 1; i < _assignment.variableNames.size(); ++i)
 		variables += ", " + (*this)(_assignment.variableNames[i]);
-	return variables + " := " + boost::apply_visitor(*this, *_assignment.value);
+	return variables + " := " + std::visit(*this, *_assignment.value);
 }
 
 string AsmPrinter::operator()(VariableDeclaration const& _variableDeclaration) const
@@ -148,7 +149,7 @@ string AsmPrinter::operator()(VariableDeclaration const& _variableDeclaration) c
 	if (_variableDeclaration.value)
 	{
 		out += " := ";
-		out += boost::apply_visitor(*this, *_variableDeclaration.value);
+		out += std::visit(*this, *_variableDeclaration.value);
 	}
 	return out;
 }
@@ -183,7 +184,7 @@ string AsmPrinter::operator()(FunctionCall const& _functionCall) const
 	return
 		(*this)(_functionCall.functionName) + "(" +
 		boost::algorithm::join(
-			_functionCall.arguments | boost::adaptors::transformed(boost::apply_visitor(*this)),
+			_functionCall.arguments | boost::adaptors::transformed([&](auto&& _node) { return std::visit(*this, _node); }),
 			", " ) +
 		")";
 }
@@ -195,13 +196,13 @@ string AsmPrinter::operator()(If const& _if) const
 	char delim = '\n';
 	if (body.find('\n') == string::npos)
 		delim = ' ';
-	return "if " + boost::apply_visitor(*this, *_if.condition) + delim + (*this)(_if.body);
+	return "if " + std::visit(*this, *_if.condition) + delim + (*this)(_if.body);
 }
 
 string AsmPrinter::operator()(Switch const& _switch) const
 {
 	solAssert(_switch.expression, "Invalid expression pointer.");
-	string out = "switch " + boost::apply_visitor(*this, *_switch.expression);
+	string out = "switch " + std::visit(*this, *_switch.expression);
 	for (auto const& _case: _switch.cases)
 	{
 		if (!_case.value)
@@ -217,7 +218,7 @@ string AsmPrinter::operator()(ForLoop const& _forLoop) const
 {
 	solAssert(_forLoop.condition, "Invalid for loop condition.");
 	string pre = (*this)(_forLoop.pre);
-	string condition = boost::apply_visitor(*this, *_forLoop.condition);
+	string condition = std::visit(*this, *_forLoop.condition);
 	string post = (*this)(_forLoop.post);
 	char delim = '\n';
 	if (
@@ -246,7 +247,7 @@ string AsmPrinter::operator()(Block const& _block) const
 	if (_block.statements.empty())
 		return "{ }";
 	string body = boost::algorithm::join(
-		_block.statements | boost::adaptors::transformed(boost::apply_visitor(*this)),
+		_block.statements | boost::adaptors::transformed([&](auto&& _node) { return std::visit(*this, _node); }),
 		"\n"
 	);
 	if (body.size() < 30 && body.find('\n') == string::npos)

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -26,12 +26,10 @@
 
 #include <libyul/YulString.h>
 
-#include <boost/variant.hpp>
-
 namespace yul
 {
 
-class AsmPrinter: public boost::static_visitor<std::string>
+class AsmPrinter
 {
 public:
 	explicit AsmPrinter(bool _yul = false): m_yul(_yul) {}

--- a/libyul/AsmScope.cpp
+++ b/libyul/AsmScope.cpp
@@ -58,7 +58,7 @@ Scope::Identifier* Scope::lookup(YulString _name)
 		auto id = s->identifiers.find(_name);
 		if (id != s->identifiers.end())
 		{
-			if (crossedFunctionBoundary && id->second.type() == typeid(Scope::Variable))
+			if (crossedFunctionBoundary && holds_alternative<Scope::Variable>(id->second))
 				return nullptr;
 			else
 				return &id->second;
@@ -84,7 +84,7 @@ size_t Scope::numberOfVariables() const
 {
 	size_t count = 0;
 	for (auto const& identifier: identifiers)
-		if (identifier.second.type() == typeid(Scope::Variable))
+		if (holds_alternative<Scope::Variable>(identifier.second))
 			count++;
 	return count;
 }

--- a/libyul/AsmScope.h
+++ b/libyul/AsmScope.h
@@ -26,11 +26,10 @@
 
 #include <libdevcore/Visitor.h>
 
-#include <boost/variant.hpp>
-
 #include <functional>
 #include <memory>
 #include <optional>
+#include <variant>
 
 namespace yul
 {
@@ -48,7 +47,7 @@ struct Scope
 		std::vector<YulType> returns;
 	};
 
-	using Identifier = boost::variant<Variable, Label, Function>;
+	using Identifier = std::variant<Variable, Label, Function>;
 	using Visitor = dev::GenericVisitor<Variable const, Label const, Function const>;
 	using NonconstVisitor = dev::GenericVisitor<Variable, Label, Function>;
 
@@ -74,7 +73,7 @@ struct Scope
 	{
 		if (Identifier* id = lookup(_name))
 		{
-			boost::apply_visitor(_visitor, *id);
+			std::visit(_visitor, *id);
 			return true;
 		}
 		else

--- a/libyul/AsmScopeFiller.cpp
+++ b/libyul/AsmScopeFiller.cpp
@@ -47,7 +47,7 @@ ScopeFiller::ScopeFiller(AsmAnalysisInfo& _info, ErrorReporter& _errorReporter):
 
 bool ScopeFiller::operator()(ExpressionStatement const& _expr)
 {
-	return boost::apply_visitor(*this, _expr.expression);
+	return std::visit(*this, _expr.expression);
 }
 
 bool ScopeFiller::operator()(Label const& _item)
@@ -116,7 +116,7 @@ bool ScopeFiller::operator()(ForLoop const& _forLoop)
 	if (!(*this)(_forLoop.pre))
 		success = false;
 	m_currentScope = &scope(&_forLoop.pre);
-	if (!boost::apply_visitor(*this, *_forLoop.condition))
+	if (!std::visit(*this, *_forLoop.condition))
 		success = false;
 	if (!(*this)(_forLoop.body))
 		success = false;
@@ -137,11 +137,11 @@ bool ScopeFiller::operator()(Block const& _block)
 	// First visit all functions to make them create
 	// an entry in the scope according to their visibility.
 	for (auto const& s: _block.statements)
-		if (s.type() == typeid(FunctionDefinition))
-			if (!registerFunction(boost::get<FunctionDefinition>(s)))
+		if (holds_alternative<FunctionDefinition>(s))
+			if (!registerFunction(std::get<FunctionDefinition>(s)))
 				success = false;
 	for (auto const& s: _block.statements)
-		if (!boost::apply_visitor(*this, s))
+		if (!std::visit(*this, s))
 			success = false;
 
 	m_currentScope = m_currentScope->superScope;

--- a/libyul/AsmScopeFiller.h
+++ b/libyul/AsmScopeFiller.h
@@ -22,8 +22,6 @@
 
 #include <libyul/AsmDataForward.h>
 
-#include <boost/variant.hpp>
-
 #include <functional>
 #include <memory>
 
@@ -44,7 +42,7 @@ struct AsmAnalysisInfo;
  * Fills scopes with identifiers and checks for name clashes.
  * Does not resolve references.
  */
-class ScopeFiller: public boost::static_visitor<bool>
+class ScopeFiller
 {
 public:
 	ScopeFiller(AsmAnalysisInfo& _info, langutil::ErrorReporter& _errorReporter);

--- a/libyul/backends/evm/ConstantOptimiser.cpp
+++ b/libyul/backends/evm/ConstantOptimiser.cpp
@@ -27,6 +27,8 @@
 
 #include <libdevcore/CommonData.h>
 
+#include <variant>
+
 using namespace std;
 using namespace dev;
 using namespace yul;
@@ -35,13 +37,13 @@ using Representation = ConstantOptimiser::Representation;
 
 namespace
 {
-struct MiniEVMInterpreter: boost::static_visitor<u256>
+struct MiniEVMInterpreter
 {
 	explicit MiniEVMInterpreter(EVMDialect const& _dialect): m_dialect(_dialect) {}
 
 	u256 eval(Expression const& _expr)
 	{
-		return boost::apply_visitor(*this, _expr);
+		return std::visit(*this, _expr);
 	}
 
 	u256 eval(dev::eth::Instruction _instr, vector<Expression> const& _arguments)
@@ -92,9 +94,9 @@ struct MiniEVMInterpreter: boost::static_visitor<u256>
 
 void ConstantOptimiser::visit(Expression& _e)
 {
-	if (_e.type() == typeid(Literal))
+	if (holds_alternative<Literal>(_e))
 	{
-		Literal const& literal = boost::get<Literal>(_e);
+		Literal const& literal = std::get<Literal>(_e);
 		if (literal.kind != LiteralKind::Number)
 			return;
 
@@ -115,7 +117,7 @@ Expression const* RepresentationFinder::tryFindRepresentation(dev::u256 const& _
 		return nullptr;
 
 	Representation const& repr = findRepresentation(_value);
-	if (repr.expression->type() == typeid(Literal))
+	if (holds_alternative<Literal>(*repr.expression))
 		return nullptr;
 	else
 		return repr.expression.get();

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -29,6 +29,8 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include <variant>
+
 using namespace std;
 using namespace dev;
 using namespace yul;
@@ -146,9 +148,9 @@ void CodeTransform::freeUnusedVariables()
 		return;
 
 	for (auto const& identifier: m_scope->identifiers)
-		if (identifier.second.type() == typeid(Scope::Variable))
+		if (holds_alternative<Scope::Variable>(identifier.second))
 		{
-			Scope::Variable const& var = boost::get<Scope::Variable>(identifier.second);
+			Scope::Variable const& var = std::get<Scope::Variable>(identifier.second);
 			if (m_variablesScheduledForDeletion.count(&var))
 				deleteVariable(var);
 		}
@@ -179,7 +181,7 @@ void CodeTransform::operator()(VariableDeclaration const& _varDecl)
 	int height = m_assembly.stackHeight();
 	if (_varDecl.value)
 	{
-		boost::apply_visitor(*this, *_varDecl.value);
+		std::visit(*this, *_varDecl.value);
 		expectDeposit(numVariables, height);
 	}
 	else
@@ -193,7 +195,7 @@ void CodeTransform::operator()(VariableDeclaration const& _varDecl)
 	for (int varIndex = numVariables - 1; varIndex >= 0; --varIndex)
 	{
 		YulString varName = _varDecl.variables[varIndex].name;
-		auto& var = boost::get<Scope::Variable>(m_scope->identifiers.at(varName));
+		auto& var = std::get<Scope::Variable>(m_scope->identifiers.at(varName));
 		m_context->variableStackHeights[&var] = height + varIndex;
 		if (!m_allowStackOpt)
 			continue;
@@ -242,7 +244,7 @@ void CodeTransform::stackError(StackTooDeepError _error, int _targetStackHeight)
 void CodeTransform::operator()(Assignment const& _assignment)
 {
 	int height = m_assembly.stackHeight();
-	boost::apply_visitor(*this, *_assignment.value);
+	std::visit(*this, *_assignment.value);
 	expectDeposit(_assignment.variableNames.size(), height);
 
 	m_assembly.setSourceLocation(_assignment.location);
@@ -261,7 +263,7 @@ void CodeTransform::operator()(StackAssignment const& _assignment)
 void CodeTransform::operator()(ExpressionStatement const& _statement)
 {
 	m_assembly.setSourceLocation(_statement.location);
-	boost::apply_visitor(*this, _statement.expression);
+	std::visit(*this, _statement.expression);
 	checkStackHeight(&_statement);
 }
 
@@ -271,7 +273,7 @@ void CodeTransform::operator()(Label const& _label)
 	m_assembly.setSourceLocation(_label.location);
 	solAssert(m_scope, "");
 	solAssert(m_scope->identifiers.count(_label.name), "");
-	Scope::Label& label = boost::get<Scope::Label>(m_scope->identifiers.at(_label.name));
+	Scope::Label& label = std::get<Scope::Label>(m_scope->identifiers.at(_label.name));
 	m_assembly.appendLabel(labelID(label));
 	checkStackHeight(&_label);
 }
@@ -340,7 +342,7 @@ void CodeTransform::operator()(FunctionalInstruction const& _instruction)
 			solAssert(_instruction.arguments.size() == 1, "");
 		}
 		m_assembly.setSourceLocation(_instruction.location);
-		auto label = labelFromIdentifier(boost::get<Identifier>(_instruction.arguments.at(0)));
+		auto label = labelFromIdentifier(std::get<Identifier>(_instruction.arguments.at(0)));
 		if (isJumpI)
 			m_assembly.appendJumpToIf(label);
 		else
@@ -476,7 +478,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 {
 	solAssert(m_scope, "");
 	solAssert(m_scope->identifiers.count(_function.name), "");
-	Scope::Function& function = boost::get<Scope::Function>(m_scope->identifiers.at(_function.name));
+	Scope::Function& function = std::get<Scope::Function>(m_scope->identifiers.at(_function.name));
 
 	int const localStackAdjustment = m_evm15 ? 0 : 1;
 	int height = localStackAdjustment;
@@ -485,7 +487,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 	solAssert(varScope, "");
 	for (auto const& v: _function.parameters | boost::adaptors::reversed)
 	{
-		auto& var = boost::get<Scope::Variable>(varScope->identifiers.at(v.name));
+		auto& var = std::get<Scope::Variable>(varScope->identifiers.at(v.name));
 		m_context->variableStackHeights[&var] = height++;
 	}
 
@@ -503,7 +505,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 
 	for (auto const& v: _function.returnVariables)
 	{
-		auto& var = boost::get<Scope::Variable>(varScope->identifiers.at(v.name));
+		auto& var = std::get<Scope::Variable>(varScope->identifiers.at(v.name));
 		m_context->variableStackHeights[&var] = height++;
 		// Preset stack slots for return variables to zero.
 		m_assembly.appendConstant(u256(0));
@@ -717,7 +719,7 @@ AbstractAssembly::LabelID CodeTransform::functionEntryID(YulString _name, Scope:
 void CodeTransform::visitExpression(Expression const& _expression)
 {
 	int height = m_assembly.stackHeight();
-	boost::apply_visitor(*this, _expression);
+	std::visit(*this, _expression);
 	expectDeposit(1, height);
 }
 
@@ -728,7 +730,7 @@ void CodeTransform::visitStatements(vector<Statement> const& _statements)
 	for (auto const& statement: _statements)
 	{
 		freeUnusedVariables();
-		auto const* functionDefinition = boost::get<FunctionDefinition>(&statement);
+		auto const* functionDefinition = std::get_if<FunctionDefinition>(&statement);
 		if (functionDefinition && !jumpTarget)
 		{
 			m_assembly.setSourceLocation(locationOf(statement));
@@ -741,7 +743,7 @@ void CodeTransform::visitStatements(vector<Statement> const& _statements)
 			jumpTarget = std::nullopt;
 		}
 
-		boost::apply_visitor(*this, statement);
+		std::visit(*this, statement);
 	}
 	// we may have a leftover jumpTarget
 	if (jumpTarget)
@@ -759,9 +761,9 @@ void CodeTransform::finalizeBlock(Block const& _block, int blockStartStackHeight
 	// pop variables
 	solAssert(m_info.scopes.at(&_block).get() == m_scope, "");
 	for (auto const& id: m_scope->identifiers)
-		if (id.second.type() == typeid(Scope::Variable))
+		if (holds_alternative<Scope::Variable>(id.second))
 		{
-			Scope::Variable const& var = boost::get<Scope::Variable>(id.second);
+			Scope::Variable const& var = std::get<Scope::Variable>(id.second);
 			if (m_allowStackOpt)
 			{
 				solAssert(!m_context->variableStackHeights.count(&var), "");
@@ -789,7 +791,7 @@ void CodeTransform::generateAssignment(Identifier const& _variableName)
 	solAssert(m_scope, "");
 	if (auto var = m_scope->lookup(_variableName.name))
 	{
-		Scope::Variable const& _var = boost::get<Scope::Variable>(*var);
+		Scope::Variable const& _var = std::get<Scope::Variable>(*var);
 		if (int heightDiff = variableHeightDiff(_var, _variableName.name, true))
 			m_assembly.appendInstruction(dev::eth::swapInstruction(heightDiff - 1));
 		m_assembly.appendInstruction(dev::eth::Instruction::POP);

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -27,8 +27,6 @@
 #include <libyul/AsmDataForward.h>
 #include <libyul/AsmScope.h>
 
-#include <boost/variant.hpp>
-
 #include <optional>
 #include <stack>
 
@@ -107,7 +105,7 @@ private:
 	Scope* m_scope = nullptr;
 };
 
-class CodeTransform: public boost::static_visitor<>
+class CodeTransform
 {
 public:
 	/// Create the code transformer.

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -113,7 +113,7 @@ map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVe
 			yulAssert(_context.currentObject, "No object available.");
 			yulAssert(_call.arguments.size() == 1, "");
 			Expression const& arg = _call.arguments.front();
-			YulString dataName = boost::get<Literal>(arg).value;
+			YulString dataName = std::get<Literal>(arg).value;
 			if (_context.currentObject->name == dataName)
 				_assembly.appendAssemblySize();
 			else
@@ -134,7 +134,7 @@ map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVe
 			yulAssert(_context.currentObject, "No object available.");
 			yulAssert(_call.arguments.size() == 1, "");
 			Expression const& arg = _call.arguments.front();
-			YulString dataName = boost::get<Literal>(arg).value;
+			YulString dataName = std::get<Literal>(arg).value;
 			if (_context.currentObject->name == dataName)
 				_assembly.appendConstant(0);
 			else

--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -298,12 +298,12 @@ bytes BinaryTransform::operator()(BuiltinCall const& _call)
 	// they are references to object names that should not end up in the code.
 	if (_call.functionName == "dataoffset")
 	{
-		string name = boost::get<StringLiteral>(_call.arguments.at(0)).value;
+		string name = std::get<StringLiteral>(_call.arguments.at(0)).value;
 		return toBytes(Opcode::I64Const) + lebEncodeSigned(m_subModulePosAndSize.at(name).first);
 	}
 	else if (_call.functionName == "datasize")
 	{
-		string name = boost::get<StringLiteral>(_call.arguments.at(0)).value;
+		string name = std::get<StringLiteral>(_call.arguments.at(0)).value;
 		return toBytes(Opcode::I64Const) + lebEncodeSigned(m_subModulePosAndSize.at(name).second);
 	}
 
@@ -333,7 +333,7 @@ bytes BinaryTransform::operator()(FunctionCall const& _call)
 bytes BinaryTransform::operator()(LocalAssignment const& _assignment)
 {
 	return
-		boost::apply_visitor(*this, *_assignment.value) +
+		std::visit(*this, *_assignment.value) +
 		toBytes(Opcode::LocalSet) +
 		lebEncode(m_locals.at(_assignment.variableName));
 }
@@ -341,7 +341,7 @@ bytes BinaryTransform::operator()(LocalAssignment const& _assignment)
 bytes BinaryTransform::operator()(GlobalAssignment const& _assignment)
 {
 	return
-		boost::apply_visitor(*this, *_assignment.value) +
+		std::visit(*this, *_assignment.value) +
 		toBytes(Opcode::GlobalSet) +
 		lebEncode(m_globals.at(_assignment.variableName));
 }
@@ -349,7 +349,7 @@ bytes BinaryTransform::operator()(GlobalAssignment const& _assignment)
 bytes BinaryTransform::operator()(If const& _if)
 {
 	bytes result =
-		boost::apply_visitor(*this, *_if.condition) +
+		std::visit(*this, *_if.condition) +
 		toBytes(Opcode::If) +
 		toBytes(ValueType::Void);
 
@@ -559,7 +559,7 @@ bytes BinaryTransform::visit(vector<Expression> const& _expressions)
 {
 	bytes result;
 	for (auto const& expr: _expressions)
-		result += boost::apply_visitor(*this, expr);
+		result += std::visit(*this, expr);
 	return result;
 }
 
@@ -567,7 +567,7 @@ bytes BinaryTransform::visitReversed(vector<Expression> const& _expressions)
 {
 	bytes result;
 	for (auto const& expr: _expressions | boost::adaptors::reversed)
-		result += boost::apply_visitor(*this, expr);
+		result += std::visit(*this, expr);
 	return result;
 }
 

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -35,7 +35,7 @@ namespace wasm
 /**
  * Web assembly to binary transform.
  */
-class BinaryTransform: public boost::static_visitor<dev::bytes>
+class BinaryTransform
 {
 public:
 	static dev::bytes run(Module const& _module);

--- a/libyul/backends/wasm/EVMToEWasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEWasmTranslator.cpp
@@ -694,7 +694,7 @@ Object EVMToEWasmTranslator::run(Object const& _object)
 	if (!m_polyfill)
 		parsePolyfill();
 
-	Block ast = boost::get<Block>(Disambiguator(m_dialect, *_object.analysisInfo)(*_object.code));
+	Block ast = std::get<Block>(Disambiguator(m_dialect, *_object.analysisInfo)(*_object.code));
 	set<YulString> reservedIdentifiers;
 	NameDispenser nameDispenser{m_dialect, ast, reservedIdentifiers};
 	OptimiserStepContext context{m_dialect, nameDispenser, reservedIdentifiers};
@@ -752,6 +752,6 @@ void EVMToEWasmTranslator::parsePolyfill()
 
 	m_polyfillFunctions.clear();
 	for (auto const& statement: m_polyfill->statements)
-		m_polyfillFunctions.insert(boost::get<FunctionDefinition>(statement).name);
+		m_polyfillFunctions.insert(std::get<FunctionDefinition>(statement).name);
 }
 

--- a/libyul/backends/wasm/EWasmAST.h
+++ b/libyul/backends/wasm/EWasmAST.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <boost/variant.hpp>
+#include <variant>
 #include <string>
 #include <vector>
 #include <map>
@@ -44,7 +44,7 @@ struct If;
 struct Loop;
 struct Break;
 struct BreakIf;
-using Expression = boost::variant<
+using Expression = std::variant<
 	Literal, StringLiteral, LocalVariable, GlobalVariable,
 	FunctionCall, BuiltinCall, LocalAssignment, GlobalAssignment,
 	Block, If, Loop, Break, BreakIf

--- a/libyul/backends/wasm/EWasmCodeTransform.cpp
+++ b/libyul/backends/wasm/EWasmCodeTransform.cpp
@@ -45,11 +45,11 @@ wasm::Module EWasmCodeTransform::run(Dialect const& _dialect, yul::Block const& 
 	for (auto const& statement: _ast.statements)
 	{
 		yulAssert(
-			statement.type() == typeid(yul::FunctionDefinition),
+			holds_alternative<yul::FunctionDefinition>(statement),
 			"Expected only function definitions at the highest level."
 		);
-		if (statement.type() == typeid(yul::FunctionDefinition))
-			module.functions.emplace_back(transform.translateFunction(boost::get<yul::FunctionDefinition>(statement)));
+		if (holds_alternative<yul::FunctionDefinition>(statement))
+			module.functions.emplace_back(transform.translateFunction(std::get<yul::FunctionDefinition>(statement)));
 	}
 
 	for (auto& imp: transform.m_functionsToImport)
@@ -157,7 +157,7 @@ wasm::Expression EWasmCodeTransform::operator()(FunctionCall const& _call)
 		{
 			vector<wasm::Expression> literals;
 			for (auto const& arg: _call.arguments)
-				literals.emplace_back(wasm::StringLiteral{boost::get<Literal>(arg).value.str()});
+				literals.emplace_back(wasm::StringLiteral{std::get<Literal>(arg).value.str()});
 			return wasm::BuiltinCall{_call.functionName.name.str(), std::move(literals)};
 		}
 		else
@@ -303,12 +303,12 @@ wasm::Expression EWasmCodeTransform::operator()(Block const& _block)
 
 unique_ptr<wasm::Expression> EWasmCodeTransform::visit(yul::Expression const& _expression)
 {
-	return make_unique<wasm::Expression>(boost::apply_visitor(*this, _expression));
+	return make_unique<wasm::Expression>(std::visit(*this, _expression));
 }
 
 wasm::Expression EWasmCodeTransform::visitReturnByValue(yul::Expression const& _expression)
 {
-	return boost::apply_visitor(*this, _expression);
+	return std::visit(*this, _expression);
 }
 
 vector<wasm::Expression> EWasmCodeTransform::visit(vector<yul::Expression> const& _expressions)
@@ -321,7 +321,7 @@ vector<wasm::Expression> EWasmCodeTransform::visit(vector<yul::Expression> const
 
 wasm::Expression EWasmCodeTransform::visit(yul::Statement const& _statement)
 {
-	return boost::apply_visitor(*this, _statement);
+	return std::visit(*this, _statement);
 }
 
 vector<wasm::Expression> EWasmCodeTransform::visit(vector<yul::Statement> const& _statements)

--- a/libyul/backends/wasm/EWasmCodeTransform.h
+++ b/libyul/backends/wasm/EWasmCodeTransform.h
@@ -32,7 +32,7 @@ namespace yul
 {
 struct AsmAnalysisInfo;
 
-class EWasmCodeTransform: public boost::static_visitor<wasm::Expression>
+class EWasmCodeTransform
 {
 public:
 	static wasm::Module run(Dialect const& _dialect, yul::Block const& _ast);

--- a/libyul/backends/wasm/EWasmToText.cpp
+++ b/libyul/backends/wasm/EWasmToText.cpp
@@ -171,7 +171,7 @@ string EWasmToText::transform(wasm::FunctionDefinition const& _function)
 
 string EWasmToText::visit(wasm::Expression const& _expression)
 {
-	return boost::apply_visitor(*this, _expression);
+	return std::visit(*this, _expression);
 }
 
 string EWasmToText::joinTransformed(vector<wasm::Expression> const& _expressions, char _separator)

--- a/libyul/backends/wasm/EWasmToText.h
+++ b/libyul/backends/wasm/EWasmToText.h
@@ -28,7 +28,7 @@ namespace yul
 {
 struct AsmAnalysisInfo;
 
-class EWasmToText: public boost::static_visitor<std::string>
+class EWasmToText
 {
 public:
 	std::string run(wasm::Module const& _module);

--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -155,12 +155,12 @@ Statement ASTCopier::operator ()(Block const& _block)
 
 Expression ASTCopier::translate(Expression const& _expression)
 {
-	return _expression.apply_visitor(static_cast<ExpressionCopier&>(*this));
+	return std::visit(static_cast<ExpressionCopier&>(*this), _expression);
 }
 
 Statement ASTCopier::translate(Statement const& _statement)
 {
-	return _statement.apply_visitor(static_cast<StatementCopier&>(*this));
+	return std::visit(static_cast<StatementCopier&>(*this), _statement);
 }
 
 Block ASTCopier::translate(Block const& _block)

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -24,8 +24,6 @@
 
 #include <libyul/YulString.h>
 
-#include <boost/variant.hpp>
-
 #include <memory>
 #include <optional>
 #include <set>
@@ -34,7 +32,7 @@
 namespace yul
 {
 
-class ExpressionCopier: public boost::static_visitor<Expression>
+class ExpressionCopier
 {
 public:
 	virtual ~ExpressionCopier() = default;
@@ -44,7 +42,7 @@ public:
 	virtual Expression operator()(FunctionCall const&) = 0;
 };
 
-class StatementCopier: public boost::static_visitor<Statement>
+class StatementCopier
 {
 public:
 	virtual ~StatementCopier() = default;

--- a/libyul/optimiser/ASTWalker.cpp
+++ b/libyul/optimiser/ASTWalker.cpp
@@ -94,12 +94,12 @@ void ASTWalker::operator()(Block const& _block)
 
 void ASTWalker::visit(Statement const& _st)
 {
-	boost::apply_visitor(*this, _st);
+	std::visit(*this, _st);
 }
 
 void ASTWalker::visit(Expression const& _e)
 {
-	boost::apply_visitor(*this, _e);
+	std::visit(*this, _e);
 }
 
 void ASTModifier::operator()(FunctionalInstruction& _instr)
@@ -176,10 +176,10 @@ void ASTModifier::operator()(Block& _block)
 
 void ASTModifier::visit(Statement& _st)
 {
-	boost::apply_visitor(*this, _st);
+	std::visit(*this, _st);
 }
 
 void ASTModifier::visit(Expression& _e)
 {
-	boost::apply_visitor(*this, _e);
+	std::visit(*this, _e);
 }

--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -25,8 +25,6 @@
 #include <libyul/Exceptions.h>
 #include <libyul/YulString.h>
 
-#include <boost/variant.hpp>
-
 #include <map>
 #include <optional>
 #include <set>
@@ -38,7 +36,7 @@ namespace yul
 /**
  * Generic AST walker.
  */
-class ASTWalker: public boost::static_visitor<>
+class ASTWalker
 {
 public:
 	virtual ~ASTWalker() = default;
@@ -75,7 +73,7 @@ protected:
 /**
  * Generic AST modifier (i.e. non-const version of ASTWalker).
  */
-class ASTModifier: public boost::static_visitor<>
+class ASTModifier
 {
 public:
 	virtual ~ASTModifier() = default;

--- a/libyul/optimiser/BlockFlattener.cpp
+++ b/libyul/optimiser/BlockFlattener.cpp
@@ -32,8 +32,8 @@ void BlockFlattener::operator()(Block& _block)
 		_block.statements,
 		[](Statement& _s) -> std::optional<vector<Statement>>
 		{
-			if (_s.type() == typeid(Block))
-				return std::move(boost::get<Block>(_s).statements);
+			if (holds_alternative<Block>(_s))
+				return std::move(std::get<Block>(_s).statements);
 			else
 				return {};
 		}

--- a/libyul/optimiser/CommonSubexpressionEliminator.cpp
+++ b/libyul/optimiser/CommonSubexpressionEliminator.cpp
@@ -56,8 +56,8 @@ void CommonSubexpressionEliminator::visit(Expression& _e)
 	bool descend = true;
 	// If this is a function call to a function that requires literal arguments,
 	// do not try to simplify there.
-	if (_e.type() == typeid(FunctionCall))
-		if (BuiltinFunction const* builtin = m_dialect.builtin(boost::get<FunctionCall>(_e).functionName.name))
+	if (holds_alternative<FunctionCall>(_e))
+		if (BuiltinFunction const* builtin = m_dialect.builtin(std::get<FunctionCall>(_e).functionName.name))
 			if (builtin->literalArguments)
 				// We should not modify function arguments that have to be literals
 				// Note that replacing the function call entirely is fine,
@@ -72,16 +72,16 @@ void CommonSubexpressionEliminator::visit(Expression& _e)
 	if (descend)
 		DataFlowAnalyzer::visit(_e);
 
-	if (_e.type() == typeid(Identifier))
+	if (holds_alternative<Identifier>(_e))
 	{
-		Identifier& identifier = boost::get<Identifier>(_e);
+		Identifier& identifier = std::get<Identifier>(_e);
 		YulString name = identifier.name;
 		if (m_value.count(name))
 		{
 			assertThrow(m_value.at(name), OptimizerException, "");
-			if (m_value.at(name)->type() == typeid(Identifier))
+			if (holds_alternative<Identifier>(*m_value.at(name)))
 			{
-				YulString value = boost::get<Identifier>(*m_value.at(name)).name;
+				YulString value = std::get<Identifier>(*m_value.at(name)).name;
 				assertThrow(inScope(value), OptimizerException, "");
 				_e = Identifier{locationOf(_e), value};
 			}

--- a/libyul/optimiser/ConditionalUnsimplifier.cpp
+++ b/libyul/optimiser/ConditionalUnsimplifier.cpp
@@ -29,12 +29,12 @@ using namespace yul;
 void ConditionalUnsimplifier::operator()(Switch& _switch)
 {
 	visit(*_switch.expression);
-	if (_switch.expression->type() != typeid(Identifier))
+	if (!holds_alternative<Identifier>(*_switch.expression))
 	{
 		ASTModifier::operator()(_switch);
 		return;
 	}
-	YulString expr = boost::get<Identifier>(*_switch.expression).name;
+	YulString expr = std::get<Identifier>(*_switch.expression).name;
 	for (auto& _case: _switch.cases)
 	{
 		if (_case.value)
@@ -42,15 +42,15 @@ void ConditionalUnsimplifier::operator()(Switch& _switch)
 			(*this)(*_case.value);
 			if (
 				!_case.body.statements.empty() &&
-				_case.body.statements.front().type() == typeid(Assignment)
+				holds_alternative<Assignment>(_case.body.statements.front())
 			)
 			{
-				Assignment const& assignment = boost::get<Assignment>(_case.body.statements.front());
+				Assignment const& assignment = std::get<Assignment>(_case.body.statements.front());
 				if (
 					assignment.variableNames.size() == 1 &&
 					assignment.variableNames.front().name == expr &&
-					assignment.value->type() == typeid(Literal) &&
-					valueOfLiteral(boost::get<Literal>(*assignment.value)) == valueOfLiteral(*_case.value)
+					holds_alternative<Literal>(*assignment.value) &&
+					valueOfLiteral(std::get<Literal>(*assignment.value)) == valueOfLiteral(*_case.value)
 				)
 					_case.body.statements.erase(_case.body.statements.begin());
 			}
@@ -66,27 +66,27 @@ void ConditionalUnsimplifier::operator()(Block& _block)
 		_block.statements,
 		[&](Statement& _stmt1, Statement& _stmt2) -> std::optional<vector<Statement>>
 		{
-			if (_stmt1.type() == typeid(If))
+			if (holds_alternative<If>(_stmt1))
 			{
-				If& _if = boost::get<If>(_stmt1);
+				If& _if = std::get<If>(_stmt1);
 				if (
-					_if.condition->type() == typeid(Identifier) &&
+					holds_alternative<Identifier>(*_if.condition) &&
 					!_if.body.statements.empty()
 				)
 				{
-					YulString condition = boost::get<Identifier>(*_if.condition).name;
+					YulString condition = std::get<Identifier>(*_if.condition).name;
 					if (
-						_stmt2.type() == typeid(Assignment) &&
+						holds_alternative<Assignment>(_stmt2) &&
 						TerminationFinder(m_dialect).controlFlowKind(_if.body.statements.back()) !=
 							TerminationFinder::ControlFlow::FlowOut
 					)
 					{
-						Assignment const& assignment = boost::get<Assignment>(_stmt2);
+						Assignment const& assignment = std::get<Assignment>(_stmt2);
 						if (
 							assignment.variableNames.size() == 1 &&
 							assignment.variableNames.front().name == condition &&
-							assignment.value->type() == typeid(Literal) &&
-							valueOfLiteral(boost::get<Literal>(*assignment.value)) == 0
+							holds_alternative<Literal>(*assignment.value) &&
+							valueOfLiteral(std::get<Literal>(*assignment.value)) == 0
 						)
 							return {make_vector<Statement>(std::move(_stmt1))};
 					}

--- a/libyul/optimiser/ControlFlowSimplifier.cpp
+++ b/libyul/optimiser/ControlFlowSimplifier.cpp
@@ -138,9 +138,9 @@ void ControlFlowSimplifier::operator()(Block& _block)
 
 void ControlFlowSimplifier::visit(Statement& _st)
 {
-	if (_st.type() == typeid(ForLoop))
+	if (holds_alternative<ForLoop>(_st))
 	{
-		ForLoop& forLoop = boost::get<ForLoop>(_st);
+		ForLoop& forLoop = std::get<ForLoop>(_st);
 		yulAssert(forLoop.pre.statements.empty(), "");
 
 		size_t outerBreak = m_numBreakStatements;
@@ -211,7 +211,7 @@ void ControlFlowSimplifier::simplify(std::vector<yul::Statement>& _statements)
 		_statements,
 		[&](Statement& _stmt) -> OptionalStatements
 		{
-			OptionalStatements result = boost::apply_visitor(visitor, _stmt);
+			OptionalStatements result = std::visit(visitor, _stmt);
 			if (result)
 				simplify(*result);
 			else

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -32,6 +32,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
+#include <variant>
 
 using namespace std;
 using namespace dev;
@@ -364,19 +365,19 @@ std::optional<pair<YulString, YulString>> DataFlowAnalyzer::isSimpleStore(
 		_store == dev::eth::Instruction::SSTORE,
 		""
 	);
-	if (_statement.expression.type() == typeid(FunctionCall))
+	if (holds_alternative<FunctionCall>(_statement.expression))
 	{
-		FunctionCall const& funCall = boost::get<FunctionCall>(_statement.expression);
+		FunctionCall const& funCall = std::get<FunctionCall>(_statement.expression);
 		if (EVMDialect const* dialect = dynamic_cast<EVMDialect const*>(&m_dialect))
 			if (auto const* builtin = dialect->builtin(funCall.functionName.name))
 				if (builtin->instruction == _store)
 					if (
-						funCall.arguments.at(0).type() == typeid(Identifier) &&
-						funCall.arguments.at(1).type() == typeid(Identifier)
+						holds_alternative<Identifier>(funCall.arguments.at(0)) &&
+						holds_alternative<Identifier>(funCall.arguments.at(1))
 					)
 					{
-						YulString key = boost::get<Identifier>(funCall.arguments.at(0)).name;
-						YulString value = boost::get<Identifier>(funCall.arguments.at(1)).name;
+						YulString key = std::get<Identifier>(funCall.arguments.at(0)).name;
+						YulString value = std::get<Identifier>(funCall.arguments.at(1)).name;
 						return make_pair(key, value);
 					}
 	}

--- a/libyul/optimiser/DeadCodeEliminator.cpp
+++ b/libyul/optimiser/DeadCodeEliminator.cpp
@@ -56,7 +56,7 @@ void DeadCodeEliminator::operator()(Block& _block)
 			remove_if(
 				_block.statements.begin() + index + 1,
 				_block.statements.end(),
-				[] (Statement const& _s) { return _s.type() != typeid(yul::FunctionDefinition); }
+				[] (Statement const& _s) { return !holds_alternative<yul::FunctionDefinition>(_s); }
 			),
 			_block.statements.end()
 		);

--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -25,8 +25,6 @@
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/optimiser/NameDispenser.h>
 
-#include <boost/variant.hpp>
-
 #include <optional>
 #include <set>
 

--- a/libyul/optimiser/ExpressionInliner.cpp
+++ b/libyul/optimiser/ExpressionInliner.cpp
@@ -49,9 +49,9 @@ void ExpressionInliner::operator()(FunctionDefinition& _fun)
 void ExpressionInliner::visit(Expression& _expression)
 {
 	ASTModifier::visit(_expression);
-	if (_expression.type() == typeid(FunctionCall))
+	if (holds_alternative<FunctionCall>(_expression))
 	{
-		FunctionCall& funCall = boost::get<FunctionCall>(_expression);
+		FunctionCall& funCall = std::get<FunctionCall>(_expression);
 		if (!m_inlinableFunctions.count(funCall.functionName.name))
 			return;
 		FunctionDefinition const& fun = *m_inlinableFunctions.at(funCall.functionName.name);
@@ -74,6 +74,6 @@ void ExpressionInliner::visit(Expression& _expression)
 			substitutions[paraName] = &arg;
 		}
 
-		_expression = Substitution(substitutions).translate(*boost::get<Assignment>(fun.body.statements.front()).value);
+		_expression = Substitution(substitutions).translate(*std::get<Assignment>(fun.body.statements.front()).value);
 	}
 }

--- a/libyul/optimiser/ExpressionInliner.h
+++ b/libyul/optimiser/ExpressionInliner.h
@@ -22,9 +22,7 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/AsmDataForward.h>
 
-#include <boost/variant.hpp>
 #include <optional>
-
 #include <set>
 
 namespace yul

--- a/libyul/optimiser/ExpressionSplitter.cpp
+++ b/libyul/optimiser/ExpressionSplitter.cpp
@@ -101,7 +101,7 @@ void ExpressionSplitter::operator()(Block& _block)
 
 void ExpressionSplitter::outlineExpression(Expression& _expr)
 {
-	if (_expr.type() == typeid(Identifier))
+	if (holds_alternative<Identifier>(_expr))
 		return;
 
 	visit(_expr);

--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -33,8 +33,8 @@ void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 {
 	if (
 		m_dialect.booleanNegationFunction() &&
-		_forLoop.condition->type() != typeid(Literal) &&
-		_forLoop.condition->type() != typeid(Identifier)
+		!holds_alternative<Literal>(*_forLoop.condition) &&
+		!holds_alternative<Identifier>(*_forLoop.condition)
 	)
 	{
 		langutil::SourceLocation loc = locationOf(*_forLoop.condition);

--- a/libyul/optimiser/ForLoopInitRewriter.cpp
+++ b/libyul/optimiser/ForLoopInitRewriter.cpp
@@ -29,9 +29,9 @@ void ForLoopInitRewriter::operator()(Block& _block)
 		_block.statements,
 		[&](Statement& _stmt) -> std::optional<vector<Statement>>
 		{
-			if (_stmt.type() == typeid(ForLoop))
+			if (holds_alternative<ForLoop>(_stmt))
 			{
-				auto& forLoop = boost::get<ForLoop>(_stmt);
+				auto& forLoop = std::get<ForLoop>(_stmt);
 				(*this)(forLoop.pre);
 				(*this)(forLoop.body);
 				(*this)(forLoop.post);

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -50,7 +50,7 @@ FullInliner::FullInliner(Block& _ast, NameDispenser& _dispenser):
 	SSAValueTracker tracker;
 	tracker(m_ast);
 	for (auto const& ssaValue: tracker.values())
-		if (ssaValue.second && ssaValue.second->type() == typeid(Literal))
+		if (ssaValue.second && holds_alternative<Literal>(*ssaValue.second))
 			m_constants.emplace(ssaValue.first);
 
 	// Store size of global statements.
@@ -58,9 +58,9 @@ FullInliner::FullInliner(Block& _ast, NameDispenser& _dispenser):
 	map<YulString, size_t> references = ReferencesCounter::countReferences(m_ast);
 	for (auto& statement: m_ast.statements)
 	{
-		if (statement.type() != typeid(FunctionDefinition))
+		if (!holds_alternative<FunctionDefinition>(statement))
 			continue;
-		FunctionDefinition& fun = boost::get<FunctionDefinition>(statement);
+		FunctionDefinition& fun = std::get<FunctionDefinition>(statement);
 		m_functions[fun.name] = &fun;
 		// Always inline functions that are only called once.
 		if (references[fun.name] == 1)
@@ -72,8 +72,8 @@ FullInliner::FullInliner(Block& _ast, NameDispenser& _dispenser):
 void FullInliner::run()
 {
 	for (auto& statement: m_ast.statements)
-		if (statement.type() == typeid(Block))
-			handleBlock({}, boost::get<Block>(statement));
+		if (holds_alternative<Block>(statement))
+			handleBlock({}, std::get<Block>(statement));
 
 	// TODO it might be good to determine a visiting order:
 	// first handle functions that are called from many places.
@@ -112,9 +112,9 @@ bool FullInliner::shallInline(FunctionCall const& _funCall, YulString _callSite)
 	// Constant arguments might provide a means for further optimization, so they cause a bonus.
 	bool constantArg = false;
 	for (auto const& argument: _funCall.arguments)
-		if (argument.type() == typeid(Literal) || (
-			argument.type() == typeid(Identifier) &&
-			m_constants.count(boost::get<Identifier>(argument).name)
+		if (holds_alternative<Literal>(argument) || (
+			holds_alternative<Identifier>(argument) &&
+			m_constants.count(std::get<Identifier>(argument).name)
 		))
 		{
 			constantArg = true;
@@ -157,7 +157,7 @@ void InlineModifier::operator()(Block& _block)
 std::optional<vector<Statement>> InlineModifier::tryInlineStatement(Statement& _statement)
 {
 	// Only inline for expression statements, assignments and variable declarations.
-	Expression* e = boost::apply_visitor(GenericFallbackReturnsVisitor<Expression*, ExpressionStatement, Assignment, VariableDeclaration>(
+	Expression* e = std::visit(GenericFallbackReturnsVisitor<Expression*, ExpressionStatement, Assignment, VariableDeclaration>(
 		[](ExpressionStatement& _s) { return &_s.expression; },
 		[](Assignment& _s) { return _s.value.get(); },
 		[](VariableDeclaration& _s) { return _s.value.get(); }
@@ -165,7 +165,7 @@ std::optional<vector<Statement>> InlineModifier::tryInlineStatement(Statement& _
 	if (e)
 	{
 		// Only inline direct function calls.
-		FunctionCall* funCall = boost::apply_visitor(GenericFallbackReturnsVisitor<FunctionCall*, FunctionCall&>(
+		FunctionCall* funCall = std::visit(GenericFallbackReturnsVisitor<FunctionCall*, FunctionCall&>(
 			[](FunctionCall& _e) { return &_e; }
 		), *e);
 		if (funCall && m_driver.shallInline(*funCall, m_currentFunction))
@@ -203,9 +203,9 @@ vector<Statement> InlineModifier::performInline(Statement& _statement, FunctionC
 		newVariable(var, nullptr);
 
 	Statement newBody = BodyCopier(m_nameDispenser, variableReplacements)(function->body);
-	newStatements += std::move(boost::get<Block>(newBody).statements);
+	newStatements += std::move(std::get<Block>(newBody).statements);
 
-	boost::apply_visitor(GenericFallbackVisitor<Assignment, VariableDeclaration>{
+	std::visit(GenericFallbackVisitor<Assignment, VariableDeclaration>{
 		[&](Assignment& _assignment)
 		{
 			for (size_t i = 0; i < _assignment.variableNames.size(); ++i)

--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -29,8 +29,6 @@
 
 #include <liblangutil/SourceLocation.h>
 
-#include <boost/variant.hpp>
-
 #include <optional>
 #include <set>
 

--- a/libyul/optimiser/FunctionGrouper.cpp
+++ b/libyul/optimiser/FunctionGrouper.cpp
@@ -40,10 +40,10 @@ void FunctionGrouper::operator()(Block& _block)
 
 	for (auto&& statement: _block.statements)
 	{
-		if (statement.type() == typeid(FunctionDefinition))
+		if (holds_alternative<FunctionDefinition>(statement))
 			reordered.emplace_back(std::move(statement));
 		else
-			boost::get<Block>(reordered.front()).statements.emplace_back(std::move(statement));
+			std::get<Block>(reordered.front()).statements.emplace_back(std::move(statement));
 	}
 	_block.statements = std::move(reordered);
 }
@@ -52,10 +52,10 @@ bool FunctionGrouper::alreadyGrouped(Block const& _block)
 {
 	if (_block.statements.empty())
 		return false;
-	if (_block.statements.front().type() != typeid(Block))
+	if (!holds_alternative<Block>(_block.statements.front()))
 		return false;
 	for (size_t i = 1; i < _block.statements.size(); ++i)
-		if (_block.statements.at(i).type() != typeid(FunctionDefinition))
+		if (!holds_alternative<FunctionDefinition>(_block.statements.at(i)))
 			return false;
 	return true;
 }

--- a/libyul/optimiser/FunctionHoister.cpp
+++ b/libyul/optimiser/FunctionHoister.cpp
@@ -36,8 +36,8 @@ void FunctionHoister::operator()(Block& _block)
 	m_isTopLevel = false;
 	for (auto&& statement: _block.statements)
 	{
-		boost::apply_visitor(*this, statement);
-		if (statement.type() == typeid(FunctionDefinition))
+		std::visit(*this, statement);
+		if (holds_alternative<FunctionDefinition>(statement))
 		{
 			m_functions.emplace_back(std::move(statement));
 			statement = Block{_block.location, {}};

--- a/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
+++ b/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
@@ -45,9 +45,9 @@ void InlinableExpressionFunctionFinder::operator()(FunctionDefinition const& _fu
 	{
 		YulString retVariable = _function.returnVariables.front().name;
 		Statement const& bodyStatement = _function.body.statements.front();
-		if (bodyStatement.type() == typeid(Assignment))
+		if (holds_alternative<Assignment>(bodyStatement))
 		{
-			Assignment const& assignment = boost::get<Assignment>(bodyStatement);
+			Assignment const& assignment = std::get<Assignment>(bodyStatement);
 			if (assignment.variableNames.size() == 1 && assignment.variableNames.front().name == retVariable)
 			{
 				// TODO: use code size metric here
@@ -57,7 +57,7 @@ void InlinableExpressionFunctionFinder::operator()(FunctionDefinition const& _fu
 				// function body.
 				assertThrow(m_disallowedIdentifiers.empty() && !m_foundDisallowedIdentifier, OptimizerException, "");
 				m_disallowedIdentifiers = set<YulString>{retVariable, _function.name};
-				boost::apply_visitor(*this, *assignment.value);
+				std::visit(*this, *assignment.value);
 				if (!m_foundDisallowedIdentifier)
 					m_inlinableFunctions[_function.name] = &_function;
 				m_disallowedIdentifiers.clear();

--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -48,16 +48,16 @@ void LoadResolver::visit(Expression& _e)
 	if (!dynamic_cast<EVMDialect const*>(&m_dialect))
 		return;
 
-	if (_e.type() == typeid(FunctionCall))
+	if (holds_alternative<FunctionCall>(_e))
 	{
-		FunctionCall const& funCall = boost::get<FunctionCall>(_e);
+		FunctionCall const& funCall = std::get<FunctionCall>(_e);
 		if (auto const* builtin = dynamic_cast<EVMDialect const&>(m_dialect).builtin(funCall.functionName.name))
 			if (builtin->instruction)
 				tryResolve(_e, *builtin->instruction, funCall.arguments);
 	}
-	else if (_e.type() == typeid(FunctionalInstruction))
+	else if (holds_alternative<FunctionalInstruction>(_e))
 	{
-		FunctionalInstruction const& instruction = boost::get<FunctionalInstruction>(_e);
+		FunctionalInstruction const& instruction = std::get<FunctionalInstruction>(_e);
 		tryResolve(_e, instruction.instruction, instruction.arguments);
 	}
 }
@@ -68,10 +68,10 @@ void LoadResolver::tryResolve(
 	vector<Expression> const& _arguments
 )
 {
-	if (_arguments.empty() || _arguments.at(0).type() != typeid(Identifier))
+	if (_arguments.empty() || !holds_alternative<Identifier>(_arguments.at(0)))
 		return;
 
-	YulString key = boost::get<Identifier>(_arguments.at(0)).name;
+	YulString key = std::get<Identifier>(_arguments.at(0)).name;
 	if (
 		_instruction == dev::eth::Instruction::SLOAD &&
 		m_storage.values.count(key)

--- a/libyul/optimiser/MainFunction.cpp
+++ b/libyul/optimiser/MainFunction.cpp
@@ -35,13 +35,13 @@ using namespace yul;
 void MainFunction::operator()(Block& _block)
 {
 	assertThrow(_block.statements.size() >= 1, OptimizerException, "");
-	assertThrow(_block.statements[0].type() == typeid(Block), OptimizerException, "");
+	assertThrow(holds_alternative<Block>(_block.statements[0]), OptimizerException, "");
 	for (size_t i = 1; i < _block.statements.size(); ++i)
-		assertThrow(_block.statements.at(i).type() == typeid(FunctionDefinition), OptimizerException, "");
+		assertThrow(holds_alternative<FunctionDefinition>(_block.statements.at(i)), OptimizerException, "");
 	/// @todo this should handle scopes properly and instead of an assertion it should rename the conflicting function
 	assertThrow(NameCollector(_block).names().count("main"_yulstring) == 0, OptimizerException, "");
 
-	Block& block = boost::get<Block>(_block.statements[0]);
+	Block& block = std::get<Block>(_block.statements[0]);
 	FunctionDefinition main{
 		block.location,
 		"main"_yulstring,

--- a/libyul/optimiser/Metrics.cpp
+++ b/libyul/optimiser/Metrics.cpp
@@ -65,23 +65,23 @@ size_t CodeSize::codeSizeIncludingFunctions(Block const& _block)
 
 void CodeSize::visit(Statement const& _statement)
 {
-	if (_statement.type() == typeid(FunctionDefinition) && m_ignoreFunctions)
+	if (holds_alternative<FunctionDefinition>(_statement) && m_ignoreFunctions)
 		return;
 	else if (
-		_statement.type() == typeid(If) ||
-		_statement.type() == typeid(Break) ||
-		_statement.type() == typeid(Continue)
+		holds_alternative<If>(_statement) ||
+		holds_alternative<Break>(_statement) ||
+		holds_alternative<Continue>(_statement)
 	)
 		m_size += 2;
-	else if (_statement.type() == typeid(ForLoop))
+	else if (holds_alternative<ForLoop>(_statement))
 		m_size += 3;
-	else if (_statement.type() == typeid(Switch))
-		m_size += 1 + 2 * boost::get<Switch>(_statement).cases.size();
+	else if (holds_alternative<Switch>(_statement))
+		m_size += 1 + 2 * std::get<Switch>(_statement).cases.size();
 	else if (!(
-		_statement.type() == typeid(Block) ||
-		_statement.type() == typeid(ExpressionStatement) ||
-		_statement.type() == typeid(Assignment) ||
-		_statement.type() == typeid(VariableDeclaration)
+		holds_alternative<Block>(_statement) ||
+		holds_alternative<ExpressionStatement>(_statement) ||
+		holds_alternative<Assignment>(_statement) ||
+		holds_alternative<VariableDeclaration>(_statement)
 	))
 		++m_size;
 
@@ -90,7 +90,7 @@ void CodeSize::visit(Statement const& _statement)
 
 void CodeSize::visit(Expression const& _expression)
 {
-	if (_expression.type() != typeid(Identifier))
+	if (!holds_alternative<Identifier>(_expression))
 		++m_size;
 	ASTWalker::visit(_expression);
 }

--- a/libyul/optimiser/NameDisplacer.cpp
+++ b/libyul/optimiser/NameDisplacer.cpp
@@ -64,8 +64,8 @@ void NameDisplacer::operator()(Block& _block)
 	// First replace all the names of function definitions
 	// because of scoping.
 	for (auto& st: _block.statements)
-		if (st.type() == typeid(FunctionDefinition))
-			checkAndReplaceNew(boost::get<FunctionDefinition>(st).name);
+		if (holds_alternative<FunctionDefinition>(st))
+			checkAndReplaceNew(std::get<FunctionDefinition>(st).name);
 
 	ASTModifier::operator()(_block);
 }

--- a/libyul/optimiser/OptimizerUtilities.cpp
+++ b/libyul/optimiser/OptimizerUtilities.cpp
@@ -33,7 +33,7 @@ using namespace yul;
 void yul::removeEmptyBlocks(Block& _block)
 {
 	auto isEmptyBlock = [](Statement const& _st) -> bool {
-		return _st.type() == typeid(Block) && boost::get<Block>(_st).statements.empty();
+		return holds_alternative<Block>(_st) && std::get<Block>(_st).statements.empty();
 	};
 	boost::range::remove_erase_if(_block.statements, isEmptyBlock);
 }

--- a/libyul/optimiser/RedundantAssignEliminator.cpp
+++ b/libyul/optimiser/RedundantAssignEliminator.cpp
@@ -296,7 +296,7 @@ void RedundantAssignEliminator::finalize(
 void AssignmentRemover::operator()(Block& _block)
 {
 	boost::range::remove_erase_if(_block.statements, [=](Statement const& _statement) -> bool {
-		return _statement.type() == typeid(Assignment) && m_toRemove.count(&boost::get<Assignment>(_statement));
+		return holds_alternative<Assignment>(_statement) && m_toRemove.count(&std::get<Assignment>(_statement));
 	});
 
 	ASTModifier::operator()(_block);

--- a/libyul/optimiser/Rematerialiser.cpp
+++ b/libyul/optimiser/Rematerialiser.cpp
@@ -68,9 +68,9 @@ Rematerialiser::Rematerialiser(
 
 void Rematerialiser::visit(Expression& _e)
 {
-	if (_e.type() == typeid(Identifier))
+	if (holds_alternative<Identifier>(_e))
 	{
-		Identifier& identifier = boost::get<Identifier>(_e);
+		Identifier& identifier = std::get<Identifier>(_e);
 		YulString name = identifier.name;
 		if (m_value.count(name))
 		{
@@ -96,15 +96,15 @@ void Rematerialiser::visit(Expression& _e)
 
 void LiteralRematerialiser::visit(Expression& _e)
 {
-	if (_e.type() == typeid(Identifier))
+	if (holds_alternative<Identifier>(_e))
 	{
-		Identifier& identifier = boost::get<Identifier>(_e);
+		Identifier& identifier = std::get<Identifier>(_e);
 		YulString name = identifier.name;
 		if (m_value.count(name))
 		{
 			Expression const* value = m_value.at(name);
 			assertThrow(value, OptimizerException, "");
-			if (value->type() == typeid(Literal))
+			if (holds_alternative<Literal>(*value))
 				_e = *value;
 		}
 	}

--- a/libyul/optimiser/SSAReverser.cpp
+++ b/libyul/optimiser/SSAReverser.cpp
@@ -19,6 +19,8 @@
 #include <libyul/AsmData.h>
 #include <libdevcore/CommonData.h>
 
+#include <variant>
+
 using namespace std;
 using namespace dev;
 using namespace yul;
@@ -37,7 +39,7 @@ void SSAReverser::operator()(Block& _block)
 		_block.statements,
 		[&](Statement& _stmt1, Statement& _stmt2) -> std::optional<vector<Statement>>
 		{
-			auto* varDecl = boost::get<VariableDeclaration>(&_stmt1);
+			auto* varDecl = std::get_if<VariableDeclaration>(&_stmt1);
 
 			if (!varDecl || varDecl->variables.size() != 1 || !varDecl->value)
 				return {};
@@ -48,9 +50,9 @@ void SSAReverser::operator()(Block& _block)
 			// with
 			//   a := E
 			//   let a_1 := a
-			if (auto* assignment = boost::get<Assignment>(&_stmt2))
+			if (auto* assignment = std::get_if<Assignment>(&_stmt2))
 			{
-				auto* identifier = boost::get<Identifier>(assignment->value.get());
+				auto* identifier = std::get_if<Identifier>(assignment->value.get());
 				if (
 					assignment->variableNames.size() == 1 &&
 					identifier &&
@@ -81,9 +83,9 @@ void SSAReverser::operator()(Block& _block)
 			// with
 			//   let a := E
 			//   let a_1 := a
-			else if (auto* varDecl2 = boost::get<VariableDeclaration>(&_stmt2))
+			else if (auto* varDecl2 = std::get_if<VariableDeclaration>(&_stmt2))
 			{
-				auto* identifier = boost::get<Identifier>(varDecl2->value.get());
+				auto* identifier = std::get_if<Identifier>(varDecl2->value.get());
 				if (
 					varDecl2->variables.size() == 1 &&
 					identifier &&

--- a/libyul/optimiser/Semantics.cpp
+++ b/libyul/optimiser/Semantics.cpp
@@ -165,13 +165,13 @@ pair<TerminationFinder::ControlFlow, size_t> TerminationFinder::firstUncondition
 TerminationFinder::ControlFlow TerminationFinder::controlFlowKind(Statement const& _statement)
 {
 	if (
-		_statement.type() == typeid(ExpressionStatement) &&
-		isTerminatingBuiltin(boost::get<ExpressionStatement>(_statement))
+		holds_alternative<ExpressionStatement>(_statement) &&
+		isTerminatingBuiltin(std::get<ExpressionStatement>(_statement))
 	)
 		return ControlFlow::Terminate;
-	else if (_statement.type() == typeid(Break))
+	else if (holds_alternative<Break>(_statement))
 		return ControlFlow::Break;
-	else if (_statement.type() == typeid(Continue))
+	else if (holds_alternative<Continue>(_statement))
 		return ControlFlow::Continue;
 	else
 		return ControlFlow::FlowOut;
@@ -179,13 +179,13 @@ TerminationFinder::ControlFlow TerminationFinder::controlFlowKind(Statement cons
 
 bool TerminationFinder::isTerminatingBuiltin(ExpressionStatement const& _exprStmnt)
 {
-	if (_exprStmnt.expression.type() == typeid(FunctionalInstruction))
+	if (holds_alternative<FunctionalInstruction>(_exprStmnt.expression))
 		return eth::SemanticInformation::terminatesControlFlow(
-			boost::get<FunctionalInstruction>(_exprStmnt.expression).instruction
+			std::get<FunctionalInstruction>(_exprStmnt.expression).instruction
 		);
-	else if (_exprStmnt.expression.type() == typeid(FunctionCall))
+	else if (holds_alternative<FunctionCall>(_exprStmnt.expression))
 		if (auto const* dialect = dynamic_cast<EVMDialect const*>(&m_dialect))
-			if (auto const* builtin = dialect->builtin(boost::get<FunctionCall>(_exprStmnt.expression).functionName.name))
+			if (auto const* builtin = dialect->builtin(std::get<FunctionCall>(_exprStmnt.expression).functionName.name))
 				if (builtin->instruction)
 					return eth::SemanticInformation::terminatesControlFlow(*builtin->instruction);
 	return false;

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -85,9 +85,9 @@ public:
 	// get called on left-hand-sides of assignments.
 	void visit(Expression& _e) override
 	{
-		if (_e.type() == typeid(Identifier))
+		if (holds_alternative<Identifier>(_e))
 		{
-			YulString name = boost::get<Identifier>(_e).name;
+			YulString name = std::get<Identifier>(_e).name;
 			if (m_expressionCodeCost.count(name))
 			{
 				if (!m_value.count(name))
@@ -162,7 +162,7 @@ bool StackCompressor::run(
 {
 	yulAssert(
 		_object.code &&
-		_object.code->statements.size() > 0 && _object.code->statements.at(0).type() == typeid(Block),
+		_object.code->statements.size() > 0 && holds_alternative<Block>(_object.code->statements.at(0)),
 		"Need to run the function grouper before the stack compressor."
 	);
 	bool allowMSizeOptimzation = !MSizeFinder::containsMSize(_dialect, *_object.code);
@@ -177,7 +177,7 @@ bool StackCompressor::run(
 			yulAssert(stackSurplus.at({}) > 0, "Invalid surplus value.");
 			eliminateVariables(
 				_dialect,
-				boost::get<Block>(_object.code->statements.at(0)),
+				std::get<Block>(_object.code->statements.at(0)),
 				stackSurplus.at({}),
 				allowMSizeOptimzation
 			);
@@ -185,7 +185,7 @@ bool StackCompressor::run(
 
 		for (size_t i = 1; i < _object.code->statements.size(); ++i)
 		{
-			FunctionDefinition& fun = boost::get<FunctionDefinition>(_object.code->statements[i]);
+			FunctionDefinition& fun = std::get<FunctionDefinition>(_object.code->statements[i]);
 			if (!stackSurplus.count(fun.name))
 				continue;
 

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -95,7 +95,7 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 		_statements,
 		[&](Statement& _stmt) -> OptionalStatements
 		{
-			OptionalStatements result = boost::apply_visitor(visitor, _stmt);
+			OptionalStatements result = std::visit(visitor, _stmt);
 			if (result)
 				simplify(*result);
 			else
@@ -123,8 +123,8 @@ bool StructuralSimplifier::expressionAlwaysFalse(Expression const& _expression)
 
 std::optional<dev::u256> StructuralSimplifier::hasLiteralValue(Expression const& _expression) const
 {
-	if (_expression.type() == typeid(Literal))
-		return valueOfLiteral(boost::get<Literal>(_expression));
+	if (holds_alternative<Literal>(_expression))
+		return valueOfLiteral(std::get<Literal>(_expression));
 	else
 		return std::optional<u256>();
 }

--- a/libyul/optimiser/Substitution.cpp
+++ b/libyul/optimiser/Substitution.cpp
@@ -28,9 +28,9 @@ using namespace yul;
 
 Expression Substitution::translate(Expression const& _expression)
 {
-	if (_expression.type() == typeid(Identifier))
+	if (holds_alternative<Identifier>(_expression))
 	{
-		YulString name = boost::get<Identifier>(_expression).name;
+		YulString name = std::get<Identifier>(_expression).name;
 		if (m_substitutions.count(name))
 			// No recursive substitution
 			return ASTCopier().translate(*m_substitutions.at(name));

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -80,7 +80,7 @@ void OptimiserSuite::run(
 	set<YulString> reservedIdentifiers = _externallyUsedIdentifiers;
 	reservedIdentifiers += _dialect.fixedFunctionNames();
 
-	*_object.code = boost::get<Block>(Disambiguator(
+	*_object.code = std::get<Block>(Disambiguator(
 		_dialect,
 		*_object.analysisInfo,
 		reservedIdentifiers
@@ -291,7 +291,7 @@ void OptimiserSuite::run(
 	{
 		// If the first statement is an empty block, remove it.
 		// We should only have function definitions after that.
-		if (ast.statements.size() > 1 && boost::get<Block>(ast.statements.front()).statements.empty())
+		if (ast.statements.size() > 1 && std::get<Block>(ast.statements.front()).statements.empty())
 			ast.statements.erase(ast.statements.begin());
 	}
 	suite.runSequence({
@@ -361,7 +361,7 @@ void OptimiserSuite::runSequence(std::vector<string> const& _steps, Block& _ast)
 {
 	unique_ptr<Block> copy;
 	if (m_debug == Debug::PrintChanges)
-		copy = make_unique<Block>(boost::get<Block>(ASTCopier{}(_ast)));
+		copy = make_unique<Block>(std::get<Block>(ASTCopier{}(_ast)));
 	for (string const& step: _steps)
 	{
 		if (m_debug == Debug::PrintStep)
@@ -376,7 +376,7 @@ void OptimiserSuite::runSequence(std::vector<string> const& _steps, Block& _ast)
 			{
 				cout << "== Running " << step << " changed the AST." << endl;
 				cout << AsmPrinter{}(_ast) << endl;
-				copy = make_unique<Block>(boost::get<Block>(ASTCopier{}(_ast)));
+				copy = make_unique<Block>(std::get<Block>(ASTCopier{}(_ast)));
 			}
 		}
 	}

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -32,7 +32,7 @@ using namespace yul;
 
 bool SyntacticallyEqual::operator()(Expression const& _lhs, Expression const& _rhs)
 {
-	return boost::apply_visitor([this](auto&& _lhsExpr, auto&& _rhsExpr) -> bool {
+	return std::visit([this](auto&& _lhsExpr, auto&& _rhsExpr) -> bool {
 		// ``this->`` is redundant, but required to work around a bug present in gcc 6.x.
 		return this->expressionEqual(_lhsExpr, _rhsExpr);
 	}, _lhs, _rhs);
@@ -40,7 +40,7 @@ bool SyntacticallyEqual::operator()(Expression const& _lhs, Expression const& _r
 
 bool SyntacticallyEqual::operator()(Statement const& _lhs, Statement const& _rhs)
 {
-	return boost::apply_visitor([this](auto&& _lhsStmt, auto&& _rhsStmt) -> bool {
+	return std::visit([this](auto&& _lhsStmt, auto&& _rhsStmt) -> bool {
 		// ``this->`` is redundant, but required to work around a bug present in gcc 6.x.
 		return this->statementEqual(_lhsStmt, _rhsStmt);
 	}, _lhs, _rhs);

--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -68,18 +68,18 @@ UnusedPruner::UnusedPruner(
 void UnusedPruner::operator()(Block& _block)
 {
 	for (auto&& statement: _block.statements)
-		if (statement.type() == typeid(FunctionDefinition))
+		if (holds_alternative<FunctionDefinition>(statement))
 		{
-			FunctionDefinition& funDef = boost::get<FunctionDefinition>(statement);
+			FunctionDefinition& funDef = std::get<FunctionDefinition>(statement);
 			if (!used(funDef.name))
 			{
 				subtractReferences(ReferencesCounter::countReferences(funDef.body));
 				statement = Block{std::move(funDef.location), {}};
 			}
 		}
-		else if (statement.type() == typeid(VariableDeclaration))
+		else if (holds_alternative<VariableDeclaration>(statement))
 		{
-			VariableDeclaration& varDecl = boost::get<VariableDeclaration>(statement);
+			VariableDeclaration& varDecl = std::get<VariableDeclaration>(statement);
 			// Multi-variable declarations are special. We can only remove it
 			// if all variables are unused and the right-hand-side is either
 			// movable or it returns a single value. In the latter case, we
@@ -108,9 +108,9 @@ void UnusedPruner::operator()(Block& _block)
 					}};
 			}
 		}
-		else if (statement.type() == typeid(ExpressionStatement))
+		else if (holds_alternative<ExpressionStatement>(statement))
 		{
-			ExpressionStatement& exprStmt = boost::get<ExpressionStatement>(statement);
+			ExpressionStatement& exprStmt = std::get<ExpressionStatement>(statement);
 			if (
 				SideEffectsCollector(m_dialect, exprStmt.expression, m_functionSideEffects).
 				sideEffectFree(m_allowMSizeOptimization)

--- a/libyul/optimiser/VarDeclInitializer.cpp
+++ b/libyul/optimiser/VarDeclInitializer.cpp
@@ -51,5 +51,5 @@ void VarDeclInitializer::operator()(Block& _block)
 			}
 		}
 	};
-	iterateReplacing(_block.statements, boost::apply_visitor(visitor));
+	iterateReplacing(_block.statements, [&](auto&& _statement) { return std::visit(visitor, _statement); });
 }

--- a/libyul/optimiser/VarNameCleaner.cpp
+++ b/libyul/optimiser/VarNameCleaner.cpp
@@ -40,8 +40,8 @@ VarNameCleaner::VarNameCleaner(
 	m_translatedNames{}
 {
 	for (auto const& statement: _ast.statements)
-		if (statement.type() == typeid(FunctionDefinition))
-			m_blacklist.insert(boost::get<FunctionDefinition>(statement).name);
+		if (holds_alternative<FunctionDefinition>(statement))
+			m_blacklist.insert(std::get<FunctionDefinition>(statement).name);
 	m_usedNames = m_blacklist;
 }
 

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -37,6 +37,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <variant>
+
 using namespace std;
 using namespace langutil;
 using namespace yul;
@@ -75,7 +77,7 @@ pair<shared_ptr<Block>, shared_ptr<yul::AsmAnalysisInfo>> yul::test::parse(strin
 yul::Block yul::test::disambiguate(string const& _source, bool _yul)
 {
 	auto result = parse(_source, _yul);
-	return boost::get<Block>(Disambiguator(defaultDialect(_yul), *result.second, {})(*result.first));
+	return std::get<Block>(Disambiguator(defaultDialect(_yul), *result.second, {})(*result.first));
 }
 
 string yul::test::format(string const& _source, bool _yul)

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -74,6 +74,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <fstream>
+#include <variant>
 
 using namespace dev;
 using namespace langutil;
@@ -415,7 +416,7 @@ bool YulOptimizerTest::parse(ostream& _stream, string const& _linePrefix, bool c
 
 void YulOptimizerTest::disambiguate()
 {
-	*m_ast = boost::get<Block>(Disambiguator(*m_dialect, *m_analysisInfo)(*m_ast));
+	*m_ast = std::get<Block>(Disambiguator(*m_dialect, *m_analysisInfo)(*m_ast));
 	m_analysisInfo.reset();
 	updateContext();
 }

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -35,6 +35,7 @@
 #include <boost/algorithm/cxx11/all_of.hpp>
 
 #include <ostream>
+#include <variant>
 
 using namespace std;
 using namespace dev;
@@ -161,9 +162,9 @@ void Interpreter::operator()(Block const& _block)
 	openScope();
 	// Register functions.
 	for (auto const& statement: _block.statements)
-		if (statement.type() == typeid(FunctionDefinition))
+		if (holds_alternative<FunctionDefinition>(statement))
 		{
-			FunctionDefinition const& funDef = boost::get<FunctionDefinition>(statement);
+			FunctionDefinition const& funDef = std::get<FunctionDefinition>(statement);
 			solAssert(!m_scopes.back().count(funDef.name), "");
 			m_scopes.back().emplace(funDef.name, &funDef);
 		}

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -72,6 +72,7 @@
 #include <string>
 #include <sstream>
 #include <iostream>
+#include <variant>
 
 using namespace std;
 using namespace dev;
@@ -131,7 +132,7 @@ public:
 			set<YulString> reservedIdentifiers;
 			if (!disambiguated)
 			{
-				*m_ast = boost::get<yul::Block>(Disambiguator(m_dialect, *m_analysisInfo)(*m_ast));
+				*m_ast = std::get<yul::Block>(Disambiguator(m_dialect, *m_analysisInfo)(*m_ast));
 				m_analysisInfo.reset();
 				m_nameDispenser = make_shared<NameDispenser>(m_dialect, *m_ast, reservedIdentifiers);
 				disambiguated = true;


### PR DESCRIPTION
In C++17 we get the similar functions
- `boost::get` -> `std::get` or `std::get_if`
- `boost::apply_visitor` -> `std::visit`
- `boost_variant.type() == typeid(Block)` -> `std::holds_alternative<Block>(std_variant)`

Besides, the compiler can deduce that the visitor is Callable (https://en.cppreference.com/w/cpp/named_req/Callable) *AND* the visitor return type `R`, so it's not necessary to derive from `boost::static_visitor<R>` anymore.

Part of #7259.