### PR TITLE
Fix Wasm transform.

### DIFF
--- a/libyul/backends/wasm/EVMToEWasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEWasmTranslator.cpp
@@ -29,6 +29,7 @@
 #include <libyul/optimiser/Disambiguator.h>
 #include <libyul/optimiser/NameDisplacer.h>
 #include <libyul/optimiser/OptimiserStep.h>
+#include <libyul/optimiser/ForLoopConditionIntoBody.h>
 
 #include <libyul/AsmParser.h>
 #include <libyul/AsmAnalysis.h>
@@ -702,6 +703,7 @@ Object EVMToEWasmTranslator::run(Object const& _object)
 	FunctionHoister::run(context, ast);
 	FunctionGrouper::run(context, ast);
 	MainFunction{}(ast);
+	ForLoopConditionIntoBody::run(context, ast);
 	ExpressionSplitter::run(context, ast);
 	WordSizeTransform::run(m_dialect, ast, nameDispenser);
 

--- a/libyul/backends/wasm/WordSizeTransform.h
+++ b/libyul/backends/wasm/WordSizeTransform.h
@@ -55,7 +55,7 @@ namespace yul
  * takes four u64 parameters and is supposed to return the logical disjunction
  * of them as a u64 value. If this name is already used somewhere, it is renamed.
  *
- * Prerequisite: Disambiguator, ExpressionSplitter
+ * Prerequisite: Disambiguator, ForLoopConditionIntoBody, ExpressionSplitter
  */
 class WordSizeTransform: public ASTModifier
 {


### PR DESCRIPTION
If we don't do this, then the word size transform cannot really work.