### PR TITLE
[circleci] Splits out compilation only job for external tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,12 +758,6 @@ workflows:
                 - develop_060
 
     jobs:
-      # Emscripten builds and external tests
-      - b_ems: *workflow_trigger_on_tags
-      - t_ems_test_ext_zeppelin: *workflow_emscripten
-      - t_ems_test_ext_gnosis: *workflow_emscripten
-      - t_ems_test_ext_colony: *workflow_emscripten
-
       # OSSFUZZ builds and (regression) tests
       - b_ubu_ossfuzz: *workflow_trigger_on_tags
       - t_ubu_ossfuzz: *workflow_ubuntu1904_ossfuzz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,22 @@ jobs:
             npm --version
             test/solcjsTests.sh /tmp/workspace/soljson.js $(cat /tmp/workspace/version.txt)
 
-  t_ems_external_gnosis:
+  t_ems_compile_ext_gnosis:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: External GnosisSafe compilation
+          command: |
+            export COMPILE_ONLY=1
+            test/externalTests/gnosis.sh /tmp/workspace/soljson.js || test/externalTests/gnosis.sh /tmp/workspace/soljson.js
+
+  t_ems_test_ext_gnosis:
     docker:
       - image: circleci/node:10
     environment:
@@ -613,7 +628,22 @@ jobs:
       - run: *gitter_notify_failure
       - run: *gitter_notify_success
 
-  t_ems_external_zeppelin:
+  t_ems_compile_ext_zeppelin:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: External Zeppelin compilation
+          command: |
+            export COMPILE_ONLY=1
+            test/externalTests/zeppelin.sh /tmp/workspace/soljson.js || test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
+
+  t_ems_test_ext_zeppelin:
     docker:
       - image: circleci/node:10
     environment:
@@ -629,7 +659,26 @@ jobs:
       - run: *gitter_notify_failure
       - run: *gitter_notify_success
 
-  t_ems_external_colony:
+  t_ems_compile_ext_colony:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Install test dependencies
+          command: |
+            sudo apt-get -qy install lsof
+      - run:
+          name: External ColonyNetworks compilation
+          command: |
+            export COMPILE_ONLY=1
+            test/externalTests/colony.sh /tmp/workspace/soljson.js || test/externalTests/colony.sh /tmp/workspace/soljson.js
+
+  t_ems_test_ext_colony:
     docker:
       - image: circleci/node:10
     environment:
@@ -693,6 +742,9 @@ workflows:
       # Emscripten build and selected tests
       - b_ems: *workflow_trigger_on_tags
       - t_ems_solcjs: *workflow_emscripten
+      - t_ems_compile_ext_colony: *workflow_emscripten
+      - t_ems_compile_ext_gnosis: *workflow_emscripten
+      - t_ems_compile_ext_zeppelin: *workflow_emscripten
 
   nightly:
 
@@ -708,9 +760,9 @@ workflows:
     jobs:
       # Emscripten builds and external tests
       - b_ems: *workflow_trigger_on_tags
-      - t_ems_external_zeppelin: *workflow_emscripten
-      - t_ems_external_gnosis: *workflow_emscripten
-      - t_ems_external_colony: *workflow_emscripten
+      - t_ems_test_ext_zeppelin: *workflow_emscripten
+      - t_ems_test_ext_gnosis: *workflow_emscripten
+      - t_ems_test_ext_colony: *workflow_emscripten
 
       # OSSFUZZ builds and (regression) tests
       - b_ubu_ossfuzz: *workflow_trigger_on_tags

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -216,8 +216,13 @@ function run_test
         printLog "Running compile function..."
         $compile_fn
         verify_compiler_version "$SOLCVERSION"
-        printLog "Running test function..."
-        $test_fn
+
+        if [[ "$COMPILE_ONLY" == 1 ]]; then
+            printLog "Skipping test function..."
+        else
+            printLog "Running test function..."
+            $test_fn
+        fi
     done
 }
 


### PR DESCRIPTION
This PR adds a successful compilation of external projects (currently 3) to the list of checks in Circle.

It's mainly meant to target 0.6.0, since there it will force us to update ext. contracts as part of (breaking) feature development again.

All ext. tests are still fully run on a nightly basis. Only those nightly runs do report to Gitter.