### PR TITLE
Rewrite GenericVisitor

### DIFF
--- a/libdevcore/Visitor.h
+++ b/libdevcore/Visitor.h
@@ -20,109 +20,41 @@
 
 #pragma once
 
-#include <functional>
-#include <boost/variant/static_visitor.hpp>
-
 namespace dev
 {
 
-/// Generic visitor used as follows:
-/// std::visit(GenericVisitor<Class1, Class2>(
-///     [](Class1& _c) { _c.f(); },
-///     [](Class2& _c) { _c.g(); }
-/// ), variant);
-/// This one does not have a fallback and will fail at
-/// compile-time if you do not specify all variants.
+/**
+ * Generic visitor used as follows:
+ * std::visit(GenericVisitor{
+ *     [](Class1& _c) { _c.f(); },
+ *     [](Class2& _c) { _c.g(); }
+ * }, variant);
+ * This one does not have a fallback and will fail at
+ * compile-time if you do not specify all variants.
+ *
+ * Fallback with no return:
+ * std::visit(GenericVisitor{
+ *     VisitorFallback<>{},
+ *     [](Class1& _c) { _c.f(); },
+ *     [](Class2& _c) { _c.g(); }
+ * }, variant);
+ *
+ * Fallback with return type R:
+ * std::visit(GenericVisitor{
+ *     VisitorFallback<R>{},
+ *     [](Class1& _c) { _c.f(); },
+ *     [](Class2& _c) { _c.g(); }
+ * }, variant);
+ */
 
-template <class...>
-struct GenericVisitor{};
+template <typename...> struct VisitorFallback;
 
-template <class Visitable, class... Others>
-struct GenericVisitor<Visitable, Others...>: public GenericVisitor<Others...>
-{
-	using GenericVisitor<Others...>::operator ();
-	explicit GenericVisitor(
-		std::function<void(Visitable&)> _visitor,
-		std::function<void(Others&)>... _otherVisitors
-	):
-		GenericVisitor<Others...>(std::move(_otherVisitors)...),
-		m_visitor(std::move(_visitor))
-	{}
+template <typename R>
+struct VisitorFallback<R> { template<typename T> R operator()(T&&) const { return {}; } };
 
-	void operator()(Visitable& _v) const { m_visitor(_v); }
+template<>
+struct VisitorFallback<> { template<typename T> void operator()(T&&) const {} };
 
-	std::function<void(Visitable&)> m_visitor;
-};
-template <>
-struct GenericVisitor<>: public boost::static_visitor<> {
-	void operator()() const {}
-};
-
-/// Generic visitor with fallback:
-/// std::visit(GenericFallbackVisitor<Class1, Class2>(
-///     [](Class1& _c) { _c.f(); },
-///     [](Class2& _c) { _c.g(); }
-/// ), variant);
-/// This one DOES have a fallback and will NOT fail at
-/// compile-time if you do not specify all variants.
-
-template <class...>
-struct GenericFallbackVisitor{};
-
-template <class Visitable, class... Others>
-struct GenericFallbackVisitor<Visitable, Others...>: public GenericFallbackVisitor<Others...>
-{
-	explicit GenericFallbackVisitor(
-		std::function<void(Visitable&)> _visitor,
-		std::function<void(Others&)>... _otherVisitors
-	):
-		GenericFallbackVisitor<Others...>(std::move(_otherVisitors)...),
-		m_visitor(std::move(_visitor))
-	{}
-
-	using GenericFallbackVisitor<Others...>::operator ();
-	void operator()(Visitable& _v) const { m_visitor(_v); }
-
-	std::function<void(Visitable&)> m_visitor;
-};
-template <>
-struct GenericFallbackVisitor<>: public boost::static_visitor<> {
-	template <class T>
-	void operator()(T&) const { }
-};
-
-/// Generic visitor with fallback that can return a value:
-/// std::visit(GenericFallbackReturnsVisitor<ReturnType, Class1, Class2>(
-///     [](Class1& _c) { return _c.f(); },
-///     [](Class2& _c) { return _c.g(); }
-/// ), variant);
-/// This one DOES have a fallback and will NOT fail at
-/// compile-time if you do not specify all variants.
-/// The fallback {}-constructs the return value.
-
-template <class R, class...>
-struct GenericFallbackReturnsVisitor{};
-
-template <class R, class Visitable, class... Others>
-struct GenericFallbackReturnsVisitor<R, Visitable, Others...>: public GenericFallbackReturnsVisitor<R, Others...>
-{
-	explicit GenericFallbackReturnsVisitor(
-		std::function<R(Visitable&)> _visitor,
-		std::function<R(Others&)>... _otherVisitors
-	):
-		GenericFallbackReturnsVisitor<R, Others...>(std::move(_otherVisitors)...),
-		m_visitor(std::move(_visitor))
-	{}
-
-	using GenericFallbackReturnsVisitor<R, Others...>::operator ();
-	R operator()(Visitable& _v) const { return m_visitor(_v); }
-
-	std::function<R(Visitable&)> m_visitor;
-};
-template <class R>
-struct GenericFallbackReturnsVisitor<R>: public boost::static_visitor<R> {
-	template <class T>
-	R operator()(T&) const { return {}; }
-};
-
+template <typename... Visitors> struct GenericVisitor: Visitors... { using Visitors::operator()...; };
+template <typename... Visitors> GenericVisitor(Visitors...) -> GenericVisitor<Visitors...>;
 }

--- a/libdevcore/Visitor.h
+++ b/libdevcore/Visitor.h
@@ -32,14 +32,14 @@ namespace dev
  * This one does not have a fallback and will fail at
  * compile-time if you do not specify all variants.
  *
- * Fallback with no return:
+ * Fallback with no return (it will not fail if you do not specify all variants):
  * std::visit(GenericVisitor{
  *     VisitorFallback<>{},
  *     [](Class1& _c) { _c.f(); },
  *     [](Class2& _c) { _c.g(); }
  * }, variant);
  *
- * Fallback with return type R:
+ * Fallback with return type R (the fallback returns `R{}`:
  * std::visit(GenericVisitor{
  *     VisitorFallback<R>{},
  *     [](Class1& _c) { _c.f(); },

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -146,7 +146,7 @@ bool AsmAnalyzer::operator()(Identifier const& _identifier)
 	solAssert(!_identifier.name.empty(), "");
 	size_t numErrorsBefore = m_errorReporter.errors().size();
 	bool success = true;
-	if (m_currentScope->lookup(_identifier.name, Scope::Visitor(
+	if (m_currentScope->lookup(_identifier.name, GenericVisitor{
 		[&](Scope::Variable const& _var)
 		{
 			if (!m_activeVariables.count(&_var))
@@ -171,7 +171,7 @@ bool AsmAnalyzer::operator()(Identifier const& _identifier)
 			);
 			success = false;
 		}
-	)))
+	}))
 	{
 	}
 	else
@@ -341,7 +341,7 @@ bool AsmAnalyzer::operator()(FunctionCall const& _funCall)
 		if (f->literalArguments)
 			needsLiteralArguments = true;
 	}
-	else if (!m_currentScope->lookup(_funCall.functionName.name, Scope::Visitor(
+	else if (!m_currentScope->lookup(_funCall.functionName.name, GenericVisitor{
 		[&](Scope::Variable const&)
 		{
 			m_errorReporter.typeError(
@@ -364,7 +364,7 @@ bool AsmAnalyzer::operator()(FunctionCall const& _funCall)
 			parameters = _fun.arguments.size();
 			returns = _fun.returns.size();
 		}
-	)))
+	}))
 	{
 		m_errorReporter.declarationError(_funCall.functionName.location, "Function not found.");
 		success = false;

--- a/libyul/AsmScope.h
+++ b/libyul/AsmScope.h
@@ -48,8 +48,6 @@ struct Scope
 	};
 
 	using Identifier = std::variant<Variable, Label, Function>;
-	using Visitor = dev::GenericVisitor<Variable const, Label const, Function const>;
-	using NonconstVisitor = dev::GenericVisitor<Variable, Label, Function>;
 
 	bool registerVariable(YulString _name, YulType const& _type);
 	bool registerLabel(YulString _name);

--- a/libyul/optimiser/ControlFlowSimplifier.cpp
+++ b/libyul/optimiser/ControlFlowSimplifier.cpp
@@ -180,7 +180,8 @@ void ControlFlowSimplifier::visit(Statement& _st)
 
 void ControlFlowSimplifier::simplify(std::vector<yul::Statement>& _statements)
 {
-	GenericFallbackReturnsVisitor<OptionalStatements, If, Switch> const visitor(
+	GenericVisitor visitor{
+		VisitorFallback<OptionalStatements>{},
 		[&](If& _ifStmt) -> OptionalStatements {
 			if (_ifStmt.body.statements.empty() && m_dialect.discardFunction())
 			{
@@ -205,8 +206,7 @@ void ControlFlowSimplifier::simplify(std::vector<yul::Statement>& _statements)
 
 			return {};
 		}
-	);
-
+	};
 	iterateReplacing(
 		_statements,
 		[&](Statement& _stmt) -> OptionalStatements

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -157,17 +157,19 @@ void InlineModifier::operator()(Block& _block)
 std::optional<vector<Statement>> InlineModifier::tryInlineStatement(Statement& _statement)
 {
 	// Only inline for expression statements, assignments and variable declarations.
-	Expression* e = std::visit(GenericFallbackReturnsVisitor<Expression*, ExpressionStatement, Assignment, VariableDeclaration>(
+	Expression* e = std::visit(GenericVisitor{
+		VisitorFallback<Expression*>{},
 		[](ExpressionStatement& _s) { return &_s.expression; },
 		[](Assignment& _s) { return _s.value.get(); },
 		[](VariableDeclaration& _s) { return _s.value.get(); }
-	), _statement);
+	}, _statement);
 	if (e)
 	{
 		// Only inline direct function calls.
-		FunctionCall* funCall = std::visit(GenericFallbackReturnsVisitor<FunctionCall*, FunctionCall&>(
+		FunctionCall* funCall = std::visit(GenericVisitor{
+			VisitorFallback<FunctionCall*>{},
 			[](FunctionCall& _e) { return &_e; }
-		), *e);
+		}, *e);
 		if (funCall && m_driver.shallInline(*funCall, m_currentFunction))
 			return performInline(_statement, *funCall);
 	}
@@ -205,7 +207,8 @@ vector<Statement> InlineModifier::performInline(Statement& _statement, FunctionC
 	Statement newBody = BodyCopier(m_nameDispenser, variableReplacements)(function->body);
 	newStatements += std::move(std::get<Block>(newBody).statements);
 
-	std::visit(GenericFallbackVisitor<Assignment, VariableDeclaration>{
+	std::visit(GenericVisitor{
+		VisitorFallback<>{},
 		[&](Assignment& _assignment)
 		{
 			for (size_t i = 0; i < _assignment.variableNames.size(); ++i)

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -71,7 +71,8 @@ void StructuralSimplifier::operator()(Block& _block)
 
 void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 {
-	GenericFallbackReturnsVisitor<OptionalStatements, If, Switch, ForLoop> const visitor(
+	GenericVisitor visitor{
+		VisitorFallback<OptionalStatements>{},
 		[&](If& _ifStmt) -> OptionalStatements {
 			if (expressionAlwaysTrue(*_ifStmt.condition))
 				return {std::move(_ifStmt.body.statements)};
@@ -89,7 +90,7 @@ void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 				return {std::move(_forLoop.pre.statements)};
 			return {};
 		}
-	);
+	};
 
 	iterateReplacing(
 		_statements,

--- a/libyul/optimiser/VarDeclInitializer.cpp
+++ b/libyul/optimiser/VarDeclInitializer.cpp
@@ -30,7 +30,8 @@ void VarDeclInitializer::operator()(Block& _block)
 	ASTModifier::operator()(_block);
 
 	using OptionalStatements = std::optional<vector<Statement>>;
-	GenericFallbackReturnsVisitor<OptionalStatements, VariableDeclaration> visitor{
+	GenericVisitor visitor{
+		VisitorFallback<OptionalStatements>{},
 		[](VariableDeclaration& _varDecl) -> OptionalStatements
 		{
 			if (_varDecl.value)
@@ -51,5 +52,6 @@ void VarDeclInitializer::operator()(Block& _block)
 			}
 		}
 	};
+
 	iterateReplacing(_block.statements, [&](auto&& _statement) { return std::visit(visitor, _statement); });
 }


### PR DESCRIPTION
Started this with @christianparpart , want to start a discussion now.

C++17's `std::visit` allows us to write visitors such as the ones in this PR.

- `GenericVisitor` forces all `variant` alternatives to be implemented, and is suggested in https://en.cppreference.com/w/cpp/utility/variant/visit.
- `GenericFallbackVisitor` has an extra function that is enabled if the visited `variant` alternative does not have an overloaded visitor and does nothing.
- `GenericFallbackReturnsVisitor` changes that function to have a return type that is the same as the overloaded visitors and returns `{}`.

To discuss:
- It might be possible to merge `GenericFallbackVisitor` and `GenericFallbackReturnsVisitor` by enabling `return {}` only if the return type is not `void`.
- This implementation of `GenericFallbackReturnsVisitor` fails if a visitor such as `auto (auto&& arg) { return arg; }` is given, because it can't infer the common type of the visitors' return types.