### PR TITLE
test: Use evmc::VM directly

### DIFF
--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -40,9 +40,9 @@ public:
 	/// Tries to dynamically load libevmone. @returns nullptr on failure.
 	/// The path has to be provided for the first successful run and will be ignored
 	/// afterwards.
-	static evmc::VM* getVM(std::string const& _path = {});
+	static evmc::VM& getVM(std::string const& _path = {});
 
-	explicit EVMHost(langutil::EVMVersion _evmVersion, evmc::VM* _vm = getVM());
+	explicit EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm = getVM());
 
 	struct Account
 	{
@@ -179,7 +179,7 @@ private:
 	/// @note The return value is only valid as long as @a _data is alive!
 	static evmc::result resultWithGas(evmc_message const& _message, bytes const& _data) noexcept;
 
-	evmc::VM* m_vm = nullptr;
+	evmc::VM& m_vm;
 	// EVM version requested by the testing tool
 	langutil::EVMVersion m_evmVersion;
 	// EVM version requested from EVMC (matches the above)

--- a/test/tools/ossfuzz/abiV2ProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/abiV2ProtoFuzzer.cpp
@@ -142,7 +142,7 @@ DEFINE_PROTO_FUZZER(Contract const& _input)
 
 	// We target the default EVM which is the latest
 	langutil::EVMVersion version = {};
-	EVMHost hostContext(version, &evmone);
+	EVMHost hostContext(version, evmone);
 
 	// Deploy contract and signal failure if deploy failed
 	evmc::result createResult = deployContract(hostContext, byteCode);


### PR DESCRIPTION
The evmc::VM works as a RAII wrapper similarly to unique_ptr, so there is no point in using additional unique_ptr.

Closes #7802.