### PR TITLE
[SMTChecker] Do not visit the name of a modifier invocation

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -537,6 +537,15 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 	}
 }
 
+bool SMTEncoder::visit(ModifierInvocation const& _node)
+{
+	if (auto const* args = _node.arguments())
+		for (auto const& arg: *args)
+			if (arg)
+				arg->accept(*this);
+	return false;
+}
+
 void SMTEncoder::initContract(ContractDefinition const& _contract)
 {
 	solAssert(m_currentContract == nullptr, "");
@@ -605,9 +614,7 @@ void SMTEncoder::endVisit(Identifier const& _identifier)
 		defineExpr(_identifier, m_context.thisAddress());
 		m_uninterpretedTerms.insert(&_identifier);
 	}
-	else if (
-		_identifier.annotation().type->category() != Type::Category::Modifier
-	)
+	else
 		createExpr(_identifier);
 }
 

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -82,6 +82,7 @@ protected:
 	bool visit(BinaryOperation const& _node) override;
 	void endVisit(BinaryOperation const& _node) override;
 	void endVisit(FunctionCall const& _node) override;
+	bool visit(ModifierInvocation const& _node) override;
 	void endVisit(Identifier const& _node) override;
 	void endVisit(ElementaryTypeNameExpression const& _node) override;
 	void endVisit(Literal const& _node) override;

--- a/test/libsolidity/smtCheckerTests/functions/constructor_base_basic.sol
+++ b/test/libsolidity/smtCheckerTests/functions/constructor_base_basic.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	constructor() public {
+		x = 2;
+	}
+}
+
+contract B is A {
+	constructor() A() public {
+		x = 3;
+	}
+}
+// ----
+// Warning: (56-90): Assertion checker does not yet support constructors.
+// Warning: (113-151): Assertion checker does not yet support constructors.


### PR DESCRIPTION
Visiting the name doesn't do anything and would only cause annoying warnings like "type type(...) not supported"
Found it when implementing constructors in https://github.com/ethereum/solidity/pull/7490/