### PR TITLE
Remove unrelated link.

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -204,7 +204,7 @@ The evaluation order of expressions is not specified (more formally, the order
 in which the children of one node in the expression tree are evaluated is not
 specified, but they are of course evaluated before the node itself). It is only
 guaranteed that statements are executed in order and short-circuiting for
-boolean expressions is done. See :ref:`order` for more information.
+boolean expressions is done.
 
 .. index:: ! assignment
 


### PR DESCRIPTION
The link goes to the table describing the parsing precedence of operators, which is a different topic than the evaluation order.