### PR TITLE
Use evmc::MockedHost moar

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -100,6 +100,15 @@ EVMHost::EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm):
 		// 1wei
 		m_state.accounts[address].balance.bytes[31] = 1;
 	}
+
+	// TODO: support short literals in EVMC and use them here
+	tx_context.block_difficulty = convertToEVMC(u256("200000000"));
+	tx_context.block_gas_limit = 20000000;
+	tx_context.block_coinbase = 0x7878787878787878787878787878787878787878_address;
+	tx_context.tx_gas_price = convertToEVMC(u256("3000000000"));
+	tx_context.tx_origin = 0x9292929292929292929292929292929292929292_address;
+	// Mainnet according to EIP-155
+	tx_context.chain_id = convertToEVMC(u256(1));
 }
 
 evmc_storage_status EVMHost::set_storage(const evmc::address& _addr, const evmc::bytes32& _key, const evmc::bytes32& _value) noexcept
@@ -227,22 +236,6 @@ evmc::result EVMHost::call(evmc_message const& _message) noexcept
 		m_state = stateBackup;
 
 	return result;
-}
-
-evmc_tx_context EVMHost::get_tx_context() const noexcept
-{
-	evmc_tx_context ctx = {};
-	ctx.block_timestamp = m_state.timestamp;
-	ctx.block_number = m_state.blockNumber;
-	ctx.block_coinbase = m_coinbase;
-	// TODO: support short literals in EVMC and use them here
-	ctx.block_difficulty = convertToEVMC(u256("200000000"));
-	ctx.block_gas_limit = 20000000;
-	ctx.tx_gas_price = convertToEVMC(u256("3000000000"));
-	ctx.tx_origin = 0x9292929292929292929292929292929292929292_address;
-	// Mainnet according to EIP-155
-	ctx.chain_id = convertToEVMC(u256(1));
-	return ctx;
 }
 
 evmc::bytes32 EVMHost::get_block_hash(int64_t _number) const noexcept

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -111,23 +111,6 @@ EVMHost::EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm):
 	tx_context.chain_id = convertToEVMC(u256(1));
 }
 
-evmc_storage_status EVMHost::set_storage(const evmc::address& _addr, const evmc::bytes32& _key, const evmc::bytes32& _value) noexcept
-{
-	evmc::bytes32 previousValue = accounts[_addr].storage[_key].value;
-	accounts[_addr].storage[_key].value = _value;
-
-	// TODO EVMC_STORAGE_MODIFIED_AGAIN should be also used
-	if (previousValue == _value)
-		return EVMC_STORAGE_UNCHANGED;
-	else if (previousValue == evmc::bytes32{})
-		return EVMC_STORAGE_ADDED;
-	else if (_value == evmc::bytes32{})
-		return EVMC_STORAGE_DELETED;
-	else
-		return EVMC_STORAGE_MODIFIED;
-
-}
-
 void EVMHost::selfdestruct(const evmc::address& _addr, const evmc::address& _beneficiary) noexcept
 {
 	// TODO actual selfdestruct is even more complicated.

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -250,23 +250,6 @@ evmc::bytes32 EVMHost::get_block_hash(int64_t _number) const noexcept
 	return convertToEVMC(u256("0x3737373737373737373737373737373737373737373737373737373737373737") + _number);
 }
 
-void EVMHost::emit_log(
-	evmc::address const& _addr,
-	uint8_t const* _data,
-	size_t _dataSize,
-	evmc::bytes32 const _topics[],
-	size_t _topicsCount
-) noexcept
-{
-	LogEntry entry;
-	entry.address = convertFromEVMC(_addr);
-	for (size_t i = 0; i < _topicsCount; ++i)
-		entry.topics.emplace_back(convertFromEVMC(_topics[i]));
-	entry.data = bytes(_data, _data + _dataSize);
-	m_state.logs.emplace_back(std::move(entry));
-}
-
-
 Address EVMHost::convertFromEVMC(evmc::address const& _addr)
 {
 	return Address(bytes(begin(_addr.bytes), end(_addr.bytes)));

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <test/evmc/mocked_host.hpp>
 #include <test/evmc/evmc.hpp>
 #include <test/evmc/evmc.h>
 
@@ -34,7 +35,7 @@ namespace test
 {
 using Address = h160;
 
-class EVMHost: public evmc::Host
+class EVMHost: public evmc::MockedHost
 {
 public:
 	/// Tries to dynamically load libevmone. @returns nullptr on failure.

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -133,10 +133,9 @@ public:
 	static h256 convertFromEVMC(evmc::bytes32 const& _data);
 	static evmc::bytes32 convertToEVMC(h256 const& _data);
 
-
+private:
 	evmc::address m_currentAddress = {};
 
-private:
 	static evmc::result precompileECRecover(evmc_message const& _message) noexcept;
 	static evmc::result precompileSha256(evmc_message const& _message) noexcept;
 	static evmc::result precompileRipeMD160(evmc_message const& _message) noexcept;

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -85,7 +85,7 @@ public:
 		evmc::address const& _addr,
 		evmc::bytes32 const& _key,
 		evmc::bytes32 const& _value
-	) noexcept;
+	) noexcept final;
 
 	evmc::uint256be get_balance(evmc::address const& _addr) const noexcept final
 	{
@@ -122,11 +122,11 @@ public:
 		return i;
 	}
 
-	void selfdestruct(evmc::address const& _addr, evmc::address const& _beneficiary) noexcept;
+	void selfdestruct(evmc::address const& _addr, evmc::address const& _beneficiary) noexcept final;
 
-	evmc::result call(evmc_message const& _message) noexcept;
+	evmc::result call(evmc_message const& _message) noexcept final;
 
-	evmc::bytes32 get_block_hash(int64_t number) const noexcept;
+	evmc::bytes32 get_block_hash(int64_t number) const noexcept final;
 
 	static Address convertFromEVMC(evmc::address const& _addr);
 	static evmc::address convertToEVMC(Address const& _addr);

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -56,8 +56,6 @@ public:
 
 	struct State
 	{
-		size_t blockNumber;
-		uint64_t timestamp;
 		std::map<evmc::address, Account> accounts;
 	};
 
@@ -76,8 +74,8 @@ public:
 	void reset() { m_state = State{}; m_currentAddress = {}; }
 	void newBlock()
 	{
-		m_state.blockNumber++;
-		m_state.timestamp += 15;
+		tx_context.block_number++;
+		tx_context.block_timestamp += 15;
 		recorded_logs.clear();
 	}
 
@@ -142,8 +140,6 @@ public:
 
 	evmc::result call(evmc_message const& _message) noexcept;
 
-	evmc_tx_context get_tx_context() const noexcept;
-
 	evmc::bytes32 get_block_hash(int64_t number) const noexcept;
 
 	static Address convertFromEVMC(evmc::address const& _addr);
@@ -154,7 +150,6 @@ public:
 
 	State m_state;
 	evmc::address m_currentAddress = {};
-	evmc::address m_coinbase = convertToEVMC(Address("0x7878787878787878787878787878787878787878"));
 
 private:
 	static evmc::result precompileECRecover(evmc_message const& _message) noexcept;

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -45,24 +45,19 @@ public:
 
 	explicit EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm = getVM());
 
-	struct State
-	{
-		std::map<evmc::address, evmc::MockedAccount> accounts;
-	};
-
 	evmc::MockedAccount const* account(evmc::address const& _address) const
 	{
-		auto it = m_state.accounts.find(_address);
-		return it == m_state.accounts.end() ? nullptr : &it->second;
+		auto it = accounts.find(_address);
+		return it == accounts.end() ? nullptr : &it->second;
 	}
 
 	evmc::MockedAccount* account(evmc::address const& _address)
 	{
-		auto it = m_state.accounts.find(_address);
-		return it == m_state.accounts.end() ? nullptr : &it->second;
+		auto it = accounts.find(_address);
+		return it == accounts.end() ? nullptr : &it->second;
 	}
 
-	void reset() { m_state = State{}; m_currentAddress = {}; }
+	void reset() { accounts.clear(); m_currentAddress = {}; }
 	void newBlock()
 	{
 		tx_context.block_number++;
@@ -139,7 +134,6 @@ public:
 	static evmc::bytes32 convertToEVMC(h256 const& _data);
 
 
-	State m_state;
 	evmc::address m_currentAddress = {};
 
 private:

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -54,19 +54,11 @@ public:
 		std::map<evmc::bytes32, evmc::bytes32> storage;
 	};
 
-	struct LogEntry
-	{
-		Address address;
-		std::vector<h256> topics;
-		bytes data;
-	};
-
 	struct State
 	{
 		size_t blockNumber;
 		uint64_t timestamp;
 		std::map<evmc::address, Account> accounts;
-		std::vector<LogEntry> logs;
 	};
 
 	Account const* account(evmc::address const& _address) const
@@ -86,7 +78,7 @@ public:
 	{
 		m_state.blockNumber++;
 		m_state.timestamp += 15;
-		m_state.logs.clear();
+		recorded_logs.clear();
 	}
 
 	bool account_exists(evmc::address const& _addr) const noexcept final
@@ -153,14 +145,6 @@ public:
 	evmc_tx_context get_tx_context() const noexcept;
 
 	evmc::bytes32 get_block_hash(int64_t number) const noexcept;
-
-	void emit_log(
-		evmc::address const& _addr,
-		uint8_t const* _data,
-		size_t _dataSize,
-		evmc::bytes32 const _topics[],
-		size_t _topicsCount
-	) noexcept;
 
 	static Address convertFromEVMC(evmc::address const& _addr);
 	static evmc::address convertToEVMC(Address const& _addr);

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -25,7 +25,6 @@
 #include <test/EVMHost.h>
 
 #include <test/evmc/evmc.hpp>
-#include <test/evmc/loader.h>
 
 #include <libdevcore/CommonIO.h>
 
@@ -56,7 +55,7 @@ ExecutionFramework::ExecutionFramework(langutil::EVMVersion _evmVersion):
 	m_evmHost->reset();
 
 	for (size_t i = 0; i < 10; i++)
-		m_evmHost->m_state.accounts[EVMHost::convertToEVMC(account(i))].balance =
+		m_evmHost->accounts[EVMHost::convertToEVMC(account(i))].balance =
 			EVMHost::convertToEVMC(u256(1) << 100);
 
 }

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -234,10 +234,10 @@ u256 ExecutionFramework::balanceAt(Address const& _addr)
 
 bool ExecutionFramework::storageEmpty(Address const& _addr)
 {
-	if (EVMHost::Account const* acc = m_evmHost->account(EVMHost::convertToEVMC(_addr)))
+	if (auto const* acc = m_evmHost->account(EVMHost::convertToEVMC(_addr)))
 	{
 		for (auto const& entry: acc->storage)
-			if (!(entry.second == evmc::bytes32{}))
+			if (!(entry.second.value == evmc::bytes32{}))
 				return false;
 	}
 	return true;

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -89,12 +89,12 @@ std::pair<bool, string> ExecutionFramework::compareAndCreateMessage(
 
 u256 ExecutionFramework::gasLimit() const
 {
-	return {m_evmHost->get_tx_context().block_gas_limit};
+	return {m_evmHost->tx_context.block_gas_limit};
 }
 
 u256 ExecutionFramework::gasPrice() const
 {
-	return {EVMHost::convertFromEVMC(m_evmHost->get_tx_context().tx_gas_price)};
+	return {EVMHost::convertFromEVMC(m_evmHost->tx_context.tx_gas_price)};
 }
 
 u256 ExecutionFramework::blockHash(u256 const& _number) const
@@ -104,7 +104,7 @@ u256 ExecutionFramework::blockHash(u256 const& _number) const
 
 u256 ExecutionFramework::blockNumber() const
 {
-	return m_evmHost->m_state.blockNumber;
+	return m_evmHost->tx_context.block_number;
 }
 
 void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 const& _value)
@@ -178,7 +178,7 @@ void ExecutionFramework::sendEther(Address const& _addr, u256 const& _amount)
 
 size_t ExecutionFramework::currentTimestamp()
 {
-	return m_evmHost->get_tx_context().block_timestamp;
+	return m_evmHost->tx_context.block_timestamp;
 }
 
 size_t ExecutionFramework::blockTimestamp(u256 _block)

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -201,27 +201,30 @@ bool ExecutionFramework::addressHasCode(Address const& _addr)
 
 size_t ExecutionFramework::numLogs() const
 {
-	return m_evmHost->m_state.logs.size();
+	return m_evmHost->recorded_logs.size();
 }
 
 size_t ExecutionFramework::numLogTopics(size_t _logIdx) const
 {
-	return m_evmHost->m_state.logs.at(_logIdx).topics.size();
+	return m_evmHost->recorded_logs.at(_logIdx).topics.size();
 }
 
 h256 ExecutionFramework::logTopic(size_t _logIdx, size_t _topicIdx) const
 {
-	return m_evmHost->m_state.logs.at(_logIdx).topics.at(_topicIdx);
+	return EVMHost::convertFromEVMC(m_evmHost->recorded_logs.at(_logIdx).topics.at(_topicIdx));
 }
 
 Address ExecutionFramework::logAddress(size_t _logIdx) const
 {
-	return m_evmHost->m_state.logs.at(_logIdx).address;
+	return EVMHost::convertFromEVMC(m_evmHost->recorded_logs.at(_logIdx).creator);
 }
 
-bytes const& ExecutionFramework::logData(size_t _logIdx) const
+bytes ExecutionFramework::logData(size_t _logIdx) const
 {
-	return m_evmHost->m_state.logs.at(_logIdx).data;
+	const auto& data = m_evmHost->recorded_logs.at(_logIdx).data;
+	// TODO: Return a copy of log data, because this is expected from REQUIRE_LOG_DATA(),
+	//       but reference type like string_view would be preferable.
+	return {data.begin(), data.end()};
 }
 
 u256 ExecutionFramework::balanceAt(Address const& _addr)

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -233,9 +233,10 @@ u256 ExecutionFramework::balanceAt(Address const& _addr)
 
 bool ExecutionFramework::storageEmpty(Address const& _addr)
 {
-	if (auto const* acc = m_evmHost->account(EVMHost::convertToEVMC(_addr)))
+	const auto it = m_evmHost->accounts.find(EVMHost::convertToEVMC(_addr));
+	if (it != m_evmHost->accounts.end())
 	{
-		for (auto const& entry: acc->storage)
+		for (auto const& entry: it->second.storage)
 			if (!(entry.second.value == evmc::bytes32{}))
 				return false;
 	}

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -266,7 +266,7 @@ protected:
 	size_t numLogTopics(size_t _logIdx) const;
 	h256 logTopic(size_t _logIdx, size_t _topicIdx) const;
 	Address logAddress(size_t _logIdx) const;
-	bytes const& logData(size_t _logIdx) const;
+	bytes logData(size_t _logIdx) const;
 
 	langutil::EVMVersion m_evmVersion;
 	solidity::OptimiserSettings m_optimiserSettings = solidity::OptimiserSettings::minimal();

--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -27,7 +27,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <string>
-#include <tuple>
 
 using namespace std;
 using namespace dev::test;
@@ -280,8 +279,7 @@ protected:
 		}
 	};
 
-	size_t const m_biddingTime = size_t(7 * 24 * 3600);
-	size_t const m_renewalInterval = size_t(365 * 24 * 3600);
+	int64_t const m_biddingTime = 7 * 24 * 3600;
 };
 
 }
@@ -417,7 +415,7 @@ BOOST_AUTO_TEST_CASE(auction_simple)
 	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
 	// "wait" until auction end
 
-	m_evmHost->m_state.timestamp += m_biddingTime + 10;
+	m_evmHost->tx_context.block_timestamp += m_biddingTime + 10;
 	// trigger auction again
 	registrar.reserve(name);
 	BOOST_CHECK_EQUAL(registrar.owner(name), m_sender);
@@ -429,7 +427,7 @@ BOOST_AUTO_TEST_CASE(auction_bidding)
 	string name = "x";
 
 	unsigned startTime = 0x776347e2;
-	m_evmHost->m_state.timestamp = startTime;
+	m_evmHost->tx_context.block_timestamp = startTime;
 
 	RegistrarInterface registrar(*this);
 	// initiate auction
@@ -437,19 +435,19 @@ BOOST_AUTO_TEST_CASE(auction_bidding)
 	registrar.reserve(name);
 	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
 	// overbid self
-	m_evmHost->m_state.timestamp = startTime + m_biddingTime - 10;
+	m_evmHost->tx_context.block_timestamp = startTime + m_biddingTime - 10;
 	registrar.setNextValue(12);
 	registrar.reserve(name);
 	// another bid by someone else
 	sendEther(account(1), 10 * ether);
 	m_sender = account(1);
-	m_evmHost->m_state.timestamp = startTime + 2 * m_biddingTime - 50;
+	m_evmHost->tx_context.block_timestamp = startTime + 2 * m_biddingTime - 50;
 	registrar.setNextValue(13);
 	registrar.reserve(name);
 	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
 	// end auction by first bidder (which is not highest) trying to overbid again (too late)
 	m_sender = account(0);
-	m_evmHost->m_state.timestamp = startTime + 4 * m_biddingTime;
+	m_evmHost->tx_context.block_timestamp = startTime + 4 * m_biddingTime;
 	registrar.setNextValue(20);
 	registrar.reserve(name);
 	BOOST_CHECK_EQUAL(registrar.owner(name), account(1));

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -1135,7 +1135,7 @@ BOOST_AUTO_TEST_CASE(blockchain)
 			}
 		}
 	)";
-	m_evmHost->m_coinbase = EVMHost::convertToEVMC(Address("0x1212121212121212121212121212121212121212"));
+	m_evmHost->tx_context.block_coinbase = EVMHost::convertToEVMC(Address("0x1212121212121212121212121212121212121212"));
 	m_evmHost->newBlock();
 	m_evmHost->newBlock();
 	m_evmHost->newBlock();


### PR DESCRIPTION
This reuses some data structs and features already defined in `evmc::MockedHost` in `EVMHost` implementation. It is up to discussion if this should be continued and if the direction is right in general.

Depends on #7848.