### PR TITLE
Switch to building soljson.js with base64 encoded embedded wasm binary.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,9 @@ Compiler Features:
 Bugfixes:
 
 
+Build System:
+ * Switch to building soljson.js with an embedded base64-encoded wasm binary.
+
 
 ### 0.6.1 (2020-01-02)
 

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -110,9 +110,13 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s STRICT=1")
 			# Export the Emscripten-generated auxiliary methods which are needed by solc-js.
 			# Which methods of libsolc itself are exported is specified in libsolc/CMakeLists.txt.
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s EXTRA_EXPORTED_RUNTIME_METHODS=['cwrap','addFunction','removeFunction','UTF8ToString','lengthBytesUTF8','_malloc','stringToUTF8','setValue']")
-			# Do not build as a WebAssembly target - we need an asm.js output.
-			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s WASM=0")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s EXTRA_EXPORTED_RUNTIME_METHODS=['cwrap','addFunction','removeFunction','UTF8ToString','lengthBytesUTF8','stringToUTF8','setValue']")
+			# Build for webassembly target.
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s WASM=1")
+			# Set webassembly build to synchronous loading.
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s WASM_ASYNC_COMPILATION=0")
+			# Output a single js file with the wasm binary embedded as base64 string.
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s SINGLE_FILE=1")
 
 			# Disable warnings about not being pure asm.js due to memory growth.
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-almost-asm")

--- a/scripts/travis-emscripten/build_emscripten.sh
+++ b/scripts/travis-emscripten/build_emscripten.sh
@@ -54,14 +54,6 @@ fi
 
 WORKSPACE=/root/project
 
-# Increase nodejs stack size
-if ! [ -e /emsdk_portable/node/current/bin/node_orig ]
-then
-  mv /emsdk_portable/node/current/bin/node /emsdk_portable/node/current/bin/node_orig
-  echo -e '#!/bin/sh\nexec /emsdk_portable/node/current/bin/node_orig --stack-size=8192 $@' > /emsdk_portable/node/current/bin/node
-  chmod 755 /emsdk_portable/node/current/bin/node
-fi
-
 # Boost
 echo -en 'travis_fold:start:compiling_boost\\r'
 test -e "$WORKSPACE"/boost_1_70_0_install/include/boost/version.hpp || (


### PR DESCRIPTION
Closes #2090
Depends on #7832

Should build soljson.js and soljson.wasm for synchronous loading.