### PR TITLE
Fix external zeppelin tests on develop

### DIFF
--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -35,8 +35,6 @@ function zeppelin_test
     run_install install_fn
 
     CONFIG="truffle-config.js"
-    replace_libsolc_call
-
     run_test compile_fn test_fn
 }
 


### PR DESCRIPTION
After https://github.com/OpenZeppelin/openzeppelin-contracts/commit/5f92adc2e76fe92d7ab952710ff3fb6d76066a35
we no longer need the workaround (and having it in fact breaks the tests).