### PR TITLE
EVMHost: mark precompiles as existing accounts in the constructor 

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -86,6 +86,20 @@ EVMHost::EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm):
 		assertThrow(false, Exception, "Berlin is not supported yet.");
 	else //if (_evmVersion == langutil::EVMVersion::petersburg())
 		m_evmRevision = EVMC_PETERSBURG;
+
+	// Mark all precompiled contracts as existing. Existing here means to have a balance (as per EIP-161).
+	// NOTE: keep this in sync with `EVMHost::call` below.
+	//
+	// A lot of precompile addresses had a balance before they became valid addresses for precompiles.
+	// For example all the precompile addresses allocated in Byzantium had a 1 wei balance sent to them
+	// roughly 22 days before the update went live.
+	for (unsigned precompiledAddress = 1; precompiledAddress <= 8; precompiledAddress++)
+	{
+		evmc::address address{};
+		address.bytes[19] = precompiledAddress;
+		// 1wei
+		m_state.accounts[address].balance.bytes[31] = 1;
+	}
 }
 
 evmc_storage_status EVMHost::set_storage(const evmc::address& _addr, const evmc::bytes32& _key, const evmc::bytes32& _value) noexcept

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -166,15 +166,15 @@ public:
 	evmc::address m_coinbase = convertToEVMC(Address("0x7878787878787878787878787878787878787878"));
 
 private:
-	evmc::result precompileECRecover(evmc_message const& _message) noexcept;
-	evmc::result precompileSha256(evmc_message const& _message) noexcept;
-	evmc::result precompileRipeMD160(evmc_message const& _message) noexcept;
-	evmc::result precompileIdentity(evmc_message const& _message) noexcept;
-	evmc::result precompileModExp(evmc_message const& _message) noexcept;
-	evmc::result precompileALTBN128G1Add(evmc_message const& _message) noexcept;
-	evmc::result precompileALTBN128G1Mul(evmc_message const& _message) noexcept;
-	evmc::result precompileALTBN128PairingProduct(evmc_message const& _message) noexcept;
-	evmc::result precompileGeneric(evmc_message const& _message, std::map<bytes, bytes> const& _inOut) noexcept;
+	static evmc::result precompileECRecover(evmc_message const& _message) noexcept;
+	static evmc::result precompileSha256(evmc_message const& _message) noexcept;
+	static evmc::result precompileRipeMD160(evmc_message const& _message) noexcept;
+	static evmc::result precompileIdentity(evmc_message const& _message) noexcept;
+	static evmc::result precompileModExp(evmc_message const& _message) noexcept;
+	static evmc::result precompileALTBN128G1Add(evmc_message const& _message) noexcept;
+	static evmc::result precompileALTBN128G1Mul(evmc_message const& _message) noexcept;
+	static evmc::result precompileALTBN128PairingProduct(evmc_message const& _message) noexcept;
+	static evmc::result precompileGeneric(evmc_message const& _message, std::map<bytes, bytes> const& _inOut) noexcept;
 	/// @returns a result object with no gas usage and result data taken from @a _data.
 	/// @note The return value is only valid as long as @a _data is alive!
 	static evmc::result resultWithGas(evmc_message const& _message, bytes const& _data) noexcept;

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -70,10 +70,6 @@ public:
 
 	Account* account(evmc::address const& _address)
 	{
-		// Make all precompiled contracts exist.
-		// Be future-proof and consider everything below 1024 as precompiled contract.
-		if (u160(convertFromEVMC(_address)) < 1024)
-			m_state.accounts[_address];
 		auto it = m_state.accounts.find(_address);
 		return it == m_state.accounts.end() ? nullptr : &it->second;
 	}


### PR DESCRIPTION
Inspired by #7848.

Depends on #7868.

See https://github.com/ethereum/solidity/pull/7848#discussion_r352170125 and https://github.com/ethereum/solidity/pull/7848#discussion_r352191012