### PR TITLE
Override for modifiers

### DIFF
--- a/docs/contracts/inheritance.rst
+++ b/docs/contracts/inheritance.rst
@@ -305,8 +305,9 @@ Modifier Overriding
 ===================
 
 Function modifiers can override each other. This works in the same way as
-function overriding (except that there is no overloading for modifiers). The
-``override`` keyword must be used in the overriding contract:
+`function overriding <function-overriding>`_ (except that there is no overloading for modifiers). The
+``virtual`` keyword must be used on the overridden modifier
+and the ``override`` keyword must be used in the overriding modifier:
 
 ::
 
@@ -314,7 +315,7 @@ function overriding (except that there is no overloading for modifiers). The
 
     contract Base
     {
-        modifier foo() {_;}
+        modifier foo() virtual {_;}
     }
 
     contract Inherited is Base
@@ -332,12 +333,12 @@ explicitly:
 
     contract Base1
     {
-        modifier foo() {_;}
+        modifier foo() virtual {_;}
     }
 
     contract Base2
     {
-        modifier foo() {_;}
+        modifier foo() virtual {_;}
     }
 
     contract Inherited is Base1, Base2

--- a/libsolidity/analysis/ContractLevelChecker.h
+++ b/libsolidity/analysis/ContractLevelChecker.h
@@ -22,7 +22,9 @@
 #pragma once
 
 #include <libsolidity/ast/ASTForward.h>
+#include <liblangutil/SourceLocation.h>
 #include <map>
+#include <functional>
 #include <set>
 
 namespace langutil
@@ -115,6 +117,10 @@ private:
 	/// Checks for functions in different base contracts which conflict with each
 	/// other and thus need to be overridden explicitly.
 	void checkAmbiguousOverrides(ContractDefinition const& _contract) const;
+	void checkAmbiguousOverridesInternal(std::set<
+		CallableDeclaration const*,
+		std::function<bool(CallableDeclaration const*, CallableDeclaration const*)>
+	> _baseCallables, langutil::SourceLocation const& _location) const;
 	/// Resolves an override list of UserDefinedTypeNames to a list of contracts.
 	std::set<ContractDefinition const*, LessFunction> resolveOverrideList(OverrideSpecifier const& _overrides) const;
 

--- a/libsolidity/analysis/ContractLevelChecker.h
+++ b/libsolidity/analysis/ContractLevelChecker.h
@@ -53,6 +53,12 @@ public:
 	bool check(ContractDefinition const& _contract);
 
 private:
+	/**
+	 * Comparator that compares
+	 *  - functions such that equality means that the functions override each other
+	 *  - modifiers by name
+	 *  - contracts by AST id.
+	 */
 	struct LessFunction
 	{
 		bool operator()(ModifierDefinition const* _a, ModifierDefinition const* _b) const;
@@ -70,13 +76,24 @@ private:
 	template <class T>
 	void findDuplicateDefinitions(std::map<std::string, std::vector<T>> const& _definitions, std::string _message);
 	void checkIllegalOverrides(ContractDefinition const& _contract);
-	/// Performs various checks related to @a _function overriding @a _super like
+	/// Performs various checks related to @a _overriding overriding @a _super like
 	/// different return type, invalid visibility change, etc.
+	/// Works on functions, modifiers and public state variables.
 	/// Also stores @a _super as a base function of @a _function in its AST annotations.
-	template<class T>
-	void checkFunctionOverride(T const& _overriding, FunctionDefinition const& _super);
-	void overrideListError(FunctionDefinition const& function, std::set<ContractDefinition const*, LessFunction> _secondary, std::string const& _message1, std::string const& _message2);
-	void overrideError(Declaration const& _overriding, Declaration const& _super, std::string _message, std::string _secondaryMsg = "Overridden function is here:");
+	template<class T, class U>
+	void checkOverride(T const& _overriding, U const& _super);
+	void overrideListError(
+		CallableDeclaration const& _callable,
+		std::set<ContractDefinition const*, LessFunction> _secondary,
+		std::string const& _message1,
+		std::string const& _message2
+	);
+	void overrideError(
+		Declaration const& _overriding,
+		Declaration const& _super,
+		std::string _message,
+		std::string _secondaryMsg = "Overridden function is here:"
+	);
 	void checkAbstractFunctions(ContractDefinition const& _contract);
 	/// Checks that the base constructor arguments are properly provided.
 	/// Fills the list of unimplemented functions in _contract's annotations.
@@ -101,8 +118,11 @@ private:
 	/// Resolves an override list of UserDefinedTypeNames to a list of contracts.
 	std::set<ContractDefinition const*, LessFunction> resolveOverrideList(OverrideSpecifier const& _overrides) const;
 
-	void checkModifierOverrides(FunctionMultiSet const& _funcSet, ModifierMultiSet const& _modSet, std::vector<ModifierDefinition const*> _modifiers);
-	void checkOverrideList(FunctionMultiSet const& _funcSet, FunctionDefinition const& _function);
+	template <class T>
+	void checkOverrideList(
+		std::multiset<T const*, LessFunction> const& _funcSet,
+		T const& _function
+	);
 
 	/// Returns all functions of bases that have not yet been overwritten.
 	/// May contain the same function multiple times when used with shared bases.

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -312,6 +312,16 @@ ContractDefinition::ContractKind FunctionDefinition::inContractKind() const
 	return contractDef->contractKind();
 }
 
+CallableDeclarationAnnotation& CallableDeclaration::annotation() const
+{
+	solAssert(
+		m_annotation,
+		"CallableDeclarationAnnotation is an abstract base, need to call annotation on the concrete class first."
+	);
+	return dynamic_cast<CallableDeclarationAnnotation&>(*m_annotation);
+}
+
+
 FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 {
 	if (_internal)

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -624,6 +624,8 @@ public:
 	bool markedVirtual() const { return m_isVirtual; }
 	virtual bool virtualSemantics() const { return markedVirtual(); }
 
+	CallableDeclarationAnnotation& annotation() const override;
+
 protected:
 	ASTPointer<ParameterList> m_parameters;
 	ASTPointer<OverrideSpecifier> m_overrides;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -104,19 +104,23 @@ struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, DocumentedAnnota
 	std::map<FunctionDefinition const*, ASTNode const*> baseConstructorArguments;
 };
 
-struct FunctionDefinitionAnnotation: ASTAnnotation, DocumentedAnnotation
+struct CallableDeclarationAnnotation: ASTAnnotation
 {
-	/// The set of functions this function overrides.
-	std::set<FunctionDefinition const*> baseFunctions;
+	/// The set of functions/modifiers/events this callable overrides.
+	std::set<CallableDeclaration const*> baseFunctions;
+};
+
+struct FunctionDefinitionAnnotation: CallableDeclarationAnnotation, DocumentedAnnotation
+{
 	/// Pointer to the contract this function is defined in
 	ContractDefinition const* contract = nullptr;
 };
 
-struct EventDefinitionAnnotation: ASTAnnotation, DocumentedAnnotation
+struct EventDefinitionAnnotation: CallableDeclarationAnnotation, DocumentedAnnotation
 {
 };
 
-struct ModifierDefinitionAnnotation: ASTAnnotation, DocumentedAnnotation
+struct ModifierDefinitionAnnotation: CallableDeclarationAnnotation, DocumentedAnnotation
 {
 };
 

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -392,7 +392,7 @@ bool ASTJsonConverter::visit(VariableDeclaration const& _node)
 
 bool ASTJsonConverter::visit(ModifierDefinition const& _node)
 {
-	setJsonNode(_node, "ModifierDefinition", {
+	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("name", _node.name()),
 		make_pair("documentation", _node.documentation() ? Json::Value(*_node.documentation()) : Json::nullValue),
 		make_pair("visibility", Declaration::visibilityToString(_node.visibility())),
@@ -400,7 +400,10 @@ bool ASTJsonConverter::visit(ModifierDefinition const& _node)
 		make_pair("virtual", _node.markedVirtual()),
 		make_pair("overrides", _node.overrides() ? toJson(*_node.overrides()) : Json::nullValue),
 		make_pair("body", toJson(_node.body()))
-	});
+	};
+	if (!_node.annotation().baseFunctions.empty())
+		attributes.emplace_back(make_pair("baseModifiers", getContainerIds(_node.annotation().baseFunctions, true)));
+	setJsonNode(_node, "ModifierDefinition", std::move(attributes));
 	return false;
 }
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2313,7 +2313,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_overriding)
 	char const* sourceCode = R"(
 		contract A {
 			function f() mod public returns (bool r) { return true; }
-			modifier mod { _; }
+			modifier mod virtual { _; }
 		}
 		contract C is A {
 			modifier mod override { if (false) _; }
@@ -2352,7 +2352,7 @@ BOOST_AUTO_TEST_CASE(function_modifier_for_constructor)
 		contract A {
 			uint data;
 			constructor() mod1 public { data |= 2; }
-			modifier mod1 { data |= 1; _; }
+			modifier mod1 virtual { data |= 1; _; }
 			function getData() public returns (uint r) { return data; }
 		}
 		contract C is A {

--- a/test/libsolidity/syntaxTests/inheritance/override/ambiguous_base_and_unique_implementation.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/ambiguous_base_and_unique_implementation.sol
@@ -16,5 +16,5 @@ abstract contract B is I {
 contract C is A, B {
 }
 // ----
-// TypeError: (342-364): Derived contract must override function "f". Function with the same name and parameter types defined in two or more base classes.
-// TypeError: (342-364): Derived contract must override function "g". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (342-364): Derived contract must override function "f". Two or more base classes define function with same name and parameter types.
+// TypeError: (342-364): Derived contract must override function "g". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/ambiguous_base_and_unique_mention.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/ambiguous_base_and_unique_mention.sol
@@ -14,4 +14,4 @@ abstract contract B is I {
 contract C is A, B {
 }
 // ----
-// TypeError: (254-276): Derived contract must override function "f". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (254-276): Derived contract must override function "f". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/common_base_and_unique_implementation.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/common_base_and_unique_implementation.sol
@@ -13,5 +13,5 @@ abstract contract B is I {
 contract C is A, B {
 }
 // ----
-// TypeError: (292-314): Derived contract must override function "f". Function with the same name and parameter types defined in two or more base classes.
-// TypeError: (292-314): Derived contract must override function "g". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (292-314): Derived contract must override function "f". Two or more base classes define function with same name and parameter types.
+// TypeError: (292-314): Derived contract must override function "g". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/internal_external_inheritance.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/internal_external_inheritance.sol
@@ -6,4 +6,4 @@ contract B {
 }
 contract C is A, B {}
 // ----
-// TypeError: (126-147): Derived contract must override function "f". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (126-147): Derived contract must override function "f". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous.sol
@@ -1,0 +1,9 @@
+contract A {
+    modifier f() virtual { _; }
+}
+contract B {
+    modifier f() virtual { _; }
+}
+contract C is A, B {
+    modifier f() override(A,B) { _; }
+}

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous_fail.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous_fail.sol
@@ -1,0 +1,10 @@
+contract A {
+    modifier f() virtual { _; }
+}
+contract B {
+    modifier f() virtual { _; }
+}
+contract C is A, B {
+}
+// ----
+// THIS NEEDS TO BE AN ERROR

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous_fail.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous_fail.sol
@@ -7,4 +7,4 @@ contract B {
 contract C is A, B {
 }
 // ----
-// THIS NEEDS TO BE AN ERROR
+// TypeError: (94-116): Derived contract must override modifier "f". Two or more base classes define modifier with same name.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature.sol
@@ -1,0 +1,10 @@
+contract A {
+    modifier f(uint a) virtual { _; }
+}
+contract B {
+    modifier f() virtual { _; }
+}
+contract C is A, B {
+}
+// ----
+// TypeError: (100-122): Derived contract must override modifier "f". Two or more base classes define modifier with same name.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature_override.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature_override.sol
@@ -1,0 +1,11 @@
+contract A {
+    modifier f(uint a) virtual { _; }
+}
+contract B {
+    modifier f() virtual { _; }
+}
+contract C is A, B {
+    modifier f() virtual override(A, B) { _; }
+}
+// ----
+// TypeError: (125-167): Override changes modifier signature.

--- a/test/libsolidity/syntaxTests/inheritance/override/no_common_base_and_unique_implementation.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/no_common_base_and_unique_implementation.sol
@@ -9,5 +9,5 @@ abstract contract B {
 contract C is A, B {
 }
 // ----
-// TypeError: (176-198): Derived contract must override function "f". Function with the same name and parameter types defined in two or more base classes.
-// TypeError: (176-198): Derived contract must override function "g". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (176-198): Derived contract must override function "f". Two or more base classes define function with same name and parameter types.
+// TypeError: (176-198): Derived contract must override function "g". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
@@ -1,8 +1,8 @@
 contract I {
-	modifier f() { _; }
+	modifier f() virtual { _; }
 }
 contract J {
-	modifier f() { _; }
+	modifier f() virtual { _; }
 }
 contract IJ is I, J {
 	modifier f() virtual override (I, J) { _; }
@@ -16,5 +16,4 @@ contract B is IJ
 }
 contract C is A, B {}
 // ----
-// TypeError: (14-33): Trying to override non-virtual modifier. Did you forget to add "virtual"?
-// TypeError: (50-69): Trying to override non-virtual modifier. Did you forget to add "virtual"?
+// TypeError: (229-250): Derived contract must override modifier "f". Two or more base classes define modifier with same name.

--- a/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
@@ -15,3 +15,6 @@ contract B is IJ
 {
 }
 contract C is A, B {}
+// ----
+// TypeError: (14-33): Trying to override non-virtual modifier. Did you forget to add "virtual"?
+// TypeError: (50-69): Trying to override non-virtual modifier. Did you forget to add "virtual"?

--- a/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
@@ -1,0 +1,17 @@
+contract I {
+	modifier f() { _; }
+}
+contract J {
+	modifier f() { _; }
+}
+contract IJ is I, J {
+	modifier f() virtual override (I, J) { _; }
+}
+contract A is IJ
+{
+	modifier f() override { _; }
+}
+contract B is IJ
+{
+}
+contract C is A, B {}

--- a/test/libsolidity/syntaxTests/inheritance/override/override_ambiguous.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_ambiguous.sol
@@ -9,4 +9,4 @@ abstract contract X is A, B {
 	function test() internal override returns (uint256) {}
 }
 // ----
-// TypeError: (205-292): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (205-292): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/override_modifier_no_override.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_modifier_no_override.sol
@@ -1,0 +1,7 @@
+abstract contract A {
+}
+abstract contract X is A {
+	modifier f() override { _; }
+}
+// ----
+// TypeError: (65-73): Modifier has override specified but does not override anything.

--- a/test/libsolidity/syntaxTests/inheritance/override/override_multiple_no_virtual2.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_multiple_no_virtual2.sol
@@ -10,4 +10,4 @@ contract C is A, B
 {
 }
 // ----
-// TypeError: (94-116): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (94-116): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/override_return_mismatch.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_return_mismatch.sol
@@ -9,4 +9,4 @@ abstract contract X is A, B {
 	function test() internal override virtual returns (uint256);
 }
 // ----
-// TypeError: (203-296): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (203-296): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple.sol
@@ -8,4 +8,4 @@ contract X is A, B {
 	uint public override foo;
 }
 // ----
-// TypeError: (162-211): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (162-211): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond.sol
@@ -11,4 +11,4 @@ contract X is B, C {
 	uint public override foo;
 }
 // ----
-// TypeError: (271-320): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (271-320): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond1.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond1.sol
@@ -12,4 +12,4 @@ contract X is B, C {
 }
 // ----
 // DeclarationError: (245-269): Identifier already declared.
-// TypeError: (223-272): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (223-272): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_explicit_override.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_explicit_override.sol
@@ -8,4 +8,4 @@ contract X is A, B {
 	uint public override(A, B) foo;
 }
 // ----
-// TypeError: (162-217): Derived contract must override function "foo". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (162-217): Derived contract must override function "foo". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/inheritance/override/triangle_impl.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/triangle_impl.sol
@@ -3,4 +3,4 @@ contract B is A { function f() public pure virtual override {} }
 contract C is A, B { }
 contract D is A, B { function f() public pure override(A, B) {} }
 // ----
-// TypeError: (116-138): Derived contract must override function "f". Function with the same name and parameter types defined in two or more base classes.
+// TypeError: (116-138): Derived contract must override function "f". Two or more base classes define function with same name and parameter types.

--- a/test/libsolidity/syntaxTests/modifiers/illegal_modifier_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/illegal_modifier_override.sol
@@ -1,5 +1,6 @@
 contract A { modifier mod(uint a) { _; } }
 contract B is A { modifier mod(uint8 a) { _; } }
 // ----
-// TypeError: (61-89): Overriding modifier is missing 'override' specifier.
 // TypeError: (61-89): Override changes modifier signature.
+// TypeError: (61-89): Overriding modifier is missing 'override' specifier.
+// TypeError: (13-40): Trying to override non-virtual modifier. Did you forget to add "virtual"?

--- a/test/libsolidity/syntaxTests/modifiers/legal_modifier_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/legal_modifier_override.sol
@@ -1,2 +1,2 @@
-contract A { modifier mod(uint a) { _; } }
+contract A { modifier mod(uint a) virtual { _; } }
 contract B is A { modifier mod(uint a) override { _; } }

--- a/test/libsolidity/syntaxTests/modifiers/non-virtual_modifier_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/non-virtual_modifier_override.sol
@@ -1,0 +1,4 @@
+contract A { modifier mod(uint a) { _; } }
+contract B is A { modifier mod(uint a) override { _; } }
+// ----
+// TypeError: (13-40): Trying to override non-virtual modifier. Did you forget to add "virtual"?


### PR DESCRIPTION
Depends on #7878 

TODO:
 - [x] specialize error messages to use "function" / "modifier" correctly
 - [x] implement 'ambigous overrides' for modifiers