### PR TITLE
soltest: Improve handling invalid EVMVersion syntax in test files.

### DIFF
--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -186,7 +186,7 @@ bool EVMVersionRestrictedTestCase::validateSettings(langutil::EVMVersion _evmVer
 	versionString = versionString.substr(versionBegin);
 	std::optional<langutil::EVMVersion> version = langutil::EVMVersion::fromString(versionString);
 	if (!version)
-		throw runtime_error("Invalid EVM version: \"" + versionString + "\"");
+		BOOST_THROW_EXCEPTION(runtime_error{"Invalid EVM version: \"" + versionString + "\""});
 
 	if (comparator == ">")
 		return _evmVersion > version;
@@ -201,6 +201,5 @@ bool EVMVersionRestrictedTestCase::validateSettings(langutil::EVMVersion _evmVer
 	else if (comparator == "!")
 		return !(_evmVersion == version);
 	else
-		throw runtime_error("Invalid EVM comparator: \"" + comparator + "\"");
-	return false; // not reached
+		BOOST_THROW_EXCEPTION(runtime_error{"Invalid EVM comparator: \"" + comparator + "\""});
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7594

Improves handling invalid `EVMVersion` values in .sol test file's metadata section. Before you saw a huge mess of c++ source code when test test failed because of that.

Now you see still an exception, but a much smaller and more descriptive one.