### PR TITLE
Add assertion for contract name clash in the resolver in CompilerStack

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -310,12 +310,19 @@ bool CompilerStack::analyze()
 					if (!resolver.resolveNamesAndTypes(*node))
 						return false;
 					if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
+					{
 						// Note that we now reference contracts by their fully qualified names, and
-						// thus contracts can only conflict if declared in the same source file.  This
-						// already causes a double-declaration error elsewhere, so we do not report
-						// an error here and instead silently drop any additional contracts we find.
+						// thus contracts can only conflict if declared in the same source file. This
+						// should already cause a double-declaration error elsewhere.
 						if (m_contracts.find(contract->fullyQualifiedName()) == m_contracts.end())
 							m_contracts[contract->fullyQualifiedName()].contract = contract;
+						else
+							solAssert(
+								m_errorReporter.hasErrors(),
+								"Contract already present (name clash?), but no error was reported."
+							);
+					}
+
 				}
 
 		// Next, we check inheritance, overrides, function collisions and other things at


### PR DESCRIPTION
Oops it seems this was never created as a PR:
![Screenshot 2019-12-07 at 12 44 25](https://user-images.githubusercontent.com/20340/70374847-4f01f480-18ef-11ea-8053-705069326aa7.png)

Tests pass so we likely catch this already. But if we want to be safe, perhaps only merge for 0.6.0 as that could have other bugs (as all new breaking releases do).