### PR TITLE
Fixes#7578: Updated/added quotes within error messages

### DIFF
--- a/liblll/Parser.cpp
+++ b/liblll/Parser.cpp
@@ -144,7 +144,7 @@ void dev::lll::parseTreeLLL(string const& _s, sp::utree& o_out)
 	{
 		std::string fragment(e.first, e.last);
 		std::string loc = to_string(std::distance(s.cbegin(), e.first) - 1);
-		std::string reason("Lexer failure at " + loc + ": '" + fragment + "'");
+		std::string reason("Lexer failure at " + loc + ": \"" + fragment + "\"");
 		BOOST_THROW_EXCEPTION(ParserException() << errinfo_comment(reason));
 	}
 	for (auto i = ret; i != s.cend(); ++i)

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -47,12 +47,13 @@ void ConstantEvaluator::endVisit(BinaryOperation const& _operation)
 		if (!commonType)
 			m_errorReporter.fatalTypeError(
 				_operation.location(),
-				"Operator " +
+				"Operator \"" +
 				string(TokenTraits::toString(_operation.getOperator())) +
-				" not compatible with types " +
+				"\" not compatible with types \"" +
 				left->toString() +
-				" and " +
-				right->toString()
+				"\" and \"" +
+				right->toString() +
+				"\""
 			);
 		setType(
 			_operation,

--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -445,7 +445,7 @@ void ContractLevelChecker::checkHashCollisions(ContractDefinition const& _contra
 		if (hashes.count(hash))
 			m_errorReporter.typeError(
 				_contract.location(),
-				string("Function signature hash collision for ") + it.second->externalSignature()
+				string("Function signature hash collision for \"") + it.second->externalSignature() + "\""
 			);
 		hashes.insert(hash);
 	}

--- a/libsolidity/analysis/PostTypeChecker.cpp
+++ b/libsolidity/analysis/PostTypeChecker.cpp
@@ -52,8 +52,8 @@ void PostTypeChecker::endVisit(ContractDefinition const&)
 		if (auto identifier = findCycle(*declaration))
 			m_errorReporter.typeError(
 				declaration->location(),
-				"The value of the constant " + declaration->name() +
-				" has a cyclic dependency via " + identifier->name() + "."
+				"The value of the constant \"" + declaration->name() +
+				"\" has a cyclic dependency via \"" + identifier->name() + "\"."
 			);
 
 	m_constVariables.clear();

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -211,7 +211,7 @@ bool StaticAnalyzer::visit(MemberAccess const& _memberAccess)
 				m_errorReporter.warning(
 					_memberAccess.location(),
 					"The constructor of the contract (or its base) uses inline assembly. "
-					"Because of that, it might be that the deployed bytecode is different from type(...).runtimeCode."
+					"Because of that, it might be that the deployed bytecode is different from \"type(...).runtimeCode\"."
 				);
 		}
 	}

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -121,8 +121,8 @@ bool SyntaxChecker::visit(PragmaDirective const& _pragma)
 		if (!matchExpression.matches(currentVersion))
 			m_errorReporter.syntaxError(
 				_pragma.location(),
-				"Source file requires different compiler version (current compiler is " +
-				string(VersionString) + " - note that nightly builds are considered to be "
+				"Source file requires different compiler version (current compiler is \"" +
+				string(VersionString) + "\" - note that nightly builds are considered to be "
 				"strictly less than the released version"
 			);
 		m_versionPragmaFound = true;
@@ -141,7 +141,7 @@ bool SyntaxChecker::visit(ModifierDefinition const&)
 void SyntaxChecker::endVisit(ModifierDefinition const& _modifier)
 {
 	if (!m_placeholderFound)
-		m_errorReporter.syntaxError(_modifier.body().location(), "Modifier body does not contain '_'.");
+		m_errorReporter.syntaxError(_modifier.body().location(), "Modifier body does not contain \"_\".");
 	m_placeholderFound = false;
 }
 
@@ -252,7 +252,7 @@ bool SyntaxChecker::visit(Literal const& _literal)
 bool SyntaxChecker::visit(UnaryOperation const& _operation)
 {
 	if (_operation.getOperator() == Token::Add)
-		m_errorReporter.syntaxError(_operation.location(), "Use of unary + is disallowed.");
+		m_errorReporter.syntaxError(_operation.location(), "Use of unary \"+\" is disallowed.");
 
 	return true;
 }
@@ -265,8 +265,8 @@ bool SyntaxChecker::visit(InlineAssembly const& _inlineAssembly)
 	if (yul::MSizeFinder::containsMSize(_inlineAssembly.dialect(), _inlineAssembly.operations()))
 		m_errorReporter.syntaxError(
 			_inlineAssembly.location(),
-			"The msize instruction cannot be used when the Yul optimizer is activated because "
-			"it can change its semantics. Either disable the Yul optimizer or do not use the instruction."
+			"The \"msize\" instruction cannot be used when the \"Yul\" optimizer is activated because "
+			"it can change its semantics. Either disable the \"Yul\" optimizer or do not use the instruction."
 		);
 	return false;
 }

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -144,9 +144,9 @@ TypePointers TypeChecker::typeCheckABIDecodeAndRetrieveReturnType(FunctionCall c
 			m_errorReporter.typeErrorConcatenateDescriptions(
 				arguments.front()->location(),
 				"Invalid type for argument in function call. "
-				"Invalid implicit conversion from " +
+				"Invalid implicit conversion from \"" +
 				type(*arguments.front())->toString() +
-				" to bytes memory requested.",
+				"\" to bytes memory requested.",
 				result.message()
 			);
 	}
@@ -189,7 +189,7 @@ TypePointers TypeChecker::typeCheckABIDecodeAndRetrieveReturnType(FunctionCall c
 			if (!actualType->fullEncodingType(false, _abiEncoderV2, false))
 				m_errorReporter.typeError(
 					typeArgument->location(),
-					"Decoding type " + actualType->toString(false) + " not supported."
+					"Decoding type \"" + actualType->toString(false) + "\" not supported."
 				);
 			components.push_back(actualType);
 		}
@@ -224,9 +224,9 @@ TypePointers TypeChecker::typeCheckMetaTypeFunctionAndRetrieveReturnType(Functio
 		m_errorReporter.typeError(
 			arguments.front()->location(),
 			"Invalid type for argument in function call. "
-			"Contract type required, but " +
+			"Contract type required, but \"" +
 			type(*arguments.front())->toString(true) +
-			" provided."
+			"\" provided."
 		);
 		return {};
 	}
@@ -271,11 +271,11 @@ void TypeChecker::endVisit(InheritanceSpecifier const& _inheritance)
 				m_errorReporter.typeErrorConcatenateDescriptions(
 					(*arguments)[i]->location(),
 					"Invalid type for argument in constructor call. "
-					"Invalid implicit conversion from " +
+					"Invalid implicit conversion from \"" +
 					type(*(*arguments)[i])->toString() +
-					" to " +
+					"\" to \"" +
 					parameterTypes[i]->toString() +
-					" requested.",
+					"\" requested.",
 					result.message()
 				);
 		}
@@ -479,7 +479,7 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 	{
 		if (varType->dataStoredIn(DataLocation::Memory) || varType->dataStoredIn(DataLocation::CallData))
 			if (!varType->canLiveOutsideStorage())
-				m_errorReporter.typeError(_variable.location(), "Type " + varType->toString() + " is only valid in storage.");
+				m_errorReporter.typeError(_variable.location(), "Type \"" + varType->toString() + "\" is only valid in storage.");
 	}
 	else if (_variable.visibility() >= VariableDeclaration::Visibility::Public)
 	{
@@ -492,9 +492,9 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 					unsupportedTypes.emplace_back(param->toString());
 			if (!unsupportedTypes.empty())
 				m_errorReporter.typeError(_variable.location(),
-					"The following types are only supported for getters in the new experimental ABI encoder: " +
+					"The following types are only supported for getters in the new experimental ABI encoder: \"" +
 					joinHumanReadable(unsupportedTypes) +
-					". Either remove \"public\" or use \"pragma experimental ABIEncoderV2;\" to enable the feature."
+					"\". Either remove \"public\" or use \"pragma experimental ABIEncoderV2;\" to enable the feature."
 				);
 		}
 		if (!getter.interfaceFunctionType())
@@ -575,11 +575,11 @@ void TypeChecker::visitManually(
 			m_errorReporter.typeErrorConcatenateDescriptions(
 				arguments[i]->location(),
 				"Invalid type for argument in modifier invocation. "
-				"Invalid implicit conversion from " +
+				"Invalid implicit conversion from \"" +
 				type(*arguments[i])->toString() +
-				" to " +
+				"\" to \"" +
 				type(*(*parameters)[i])->toString() +
-				" requested.",
+				"\" requested.",
 				result.message()
 			);
 	}
@@ -664,7 +664,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 				}
 				else if (requiresStorage)
 				{
-					m_errorReporter.typeError(_identifier.location, "The suffixes _offset and _slot can only be used on non-constant storage variables.");
+					m_errorReporter.typeError(_identifier.location, "The \"suffixes _offset\" and \"_slot\" can only be used on non-constant storage variables.");
 					return size_t(-1);
 				}
 			}
@@ -673,7 +673,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			{
 				if (!var->isStateVariable() && !var->type()->dataStoredIn(DataLocation::Storage))
 				{
-					m_errorReporter.typeError(_identifier.location, "The suffixes _offset and _slot can only be used on storage variables.");
+					m_errorReporter.typeError(_identifier.location, "The \"suffixes _offset\" and \"_slot\" can only be used on storage variables.");
 					return size_t(-1);
 				}
 				else if (_context != yul::IdentifierContext::RValue)
@@ -684,12 +684,12 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			}
 			else if (!var->isConstant() && var->isStateVariable())
 			{
-				m_errorReporter.typeError(_identifier.location, "Only local variables are supported. To access storage variables, use the _slot and _offset suffixes.");
+				m_errorReporter.typeError(_identifier.location, "Only local variables are supported. To access storage variables, use the \"_slot\" and \"_offset\" suffixes.");
 				return size_t(-1);
 			}
 			else if (var->type()->dataStoredIn(DataLocation::Storage))
 			{
-				m_errorReporter.typeError(_identifier.location, "You have to use the _slot or _offset suffix to access storage reference variables.");
+				m_errorReporter.typeError(_identifier.location, "You have to use the \"_slot\" or \"_offset\" suffix to access storage reference variables.");
 				return size_t(-1);
 			}
 			else if (var->type()->sizeOnStack() != 1)
@@ -703,7 +703,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 		}
 		else if (requiresStorage)
 		{
-			m_errorReporter.typeError(_identifier.location, "The suffixes _offset and _slot can only be used on storage variables.");
+			m_errorReporter.typeError(_identifier.location, "The suffixes \"_offset\" and \"_slot\" can only be used on storage variables.");
 			return size_t(-1);
 		}
 		else if (_context == yul::IdentifierContext::LValue)
@@ -807,10 +807,10 @@ void TypeChecker::endVisit(Return const& _return)
 			if (!result)
 				m_errorReporter.typeErrorConcatenateDescriptions(
 					_return.expression()->location(),
-					"Return argument type " +
+					"Return argument type \"" +
 					type(*_return.expression())->toString() +
-					" is not implicitly convertible to expected type " +
-					TupleType(returnTypes).toString(false) + ".",
+					"\" is not implicitly convertible to expected type \"" +
+					TupleType(returnTypes).toString(false) + "\".",
 					result.message()
 				);
 		}
@@ -824,10 +824,10 @@ void TypeChecker::endVisit(Return const& _return)
 		if (!result)
 			m_errorReporter.typeErrorConcatenateDescriptions(
 				_return.expression()->location(),
-				"Return argument type " +
+				"Return argument type \"" +
 				type(*_return.expression())->toString() +
-				" is not implicitly convertible to expected type (type of first return variable) " +
-				expected->toString() + ".",
+				"\" is not implicitly convertible to expected type (type of first return variable) \"" +
+				expected->toString() + "\".",
 				result.message()
 			);
 	}
@@ -981,9 +981,9 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 				if (valueComponentType->category() == Type::Category::RationalNumber)
 					m_errorReporter.fatalTypeError(
 						_statement.initialValue()->location(),
-						"Invalid rational " +
+						"Invalid rational \"" +
 						valueComponentType->toString() +
-						" (absolute value too large or division by zero)."
+						"\" (absolute value too large or division by zero)."
 					);
 				else
 					solAssert(false, "");
@@ -1042,9 +1042,9 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 						m_errorReporter.typeError(
 							_statement.location(),
 							errorMsg +
-							". Try converting to type " +
+							". Try converting to type \"" +
 							valueComponentType->mobileType()->toString() +
-							" or use an explicit conversion."
+							"\" or use an explicit conversion."
 						);
 				}
 				else
@@ -1077,7 +1077,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 			m_errorReporter.syntaxError(
 				_statement.location(),
 				"Use of the \"var\" keyword is disallowed. "
-				"Use explicit declaration `" + createTupleDecl(variables) + " = ...´ instead."
+				"Use explicit declaration \"" + createTupleDecl(variables) + " = ...\" instead."
 			);
 	}
 
@@ -1103,7 +1103,7 @@ void TypeChecker::endVisit(ExpressionStatement const& _statement)
 			)
 				m_errorReporter.warning(_statement.location(), "Return value of low-level calls not used.");
 			else if (kind == FunctionType::Kind::Send)
-				m_errorReporter.warning(_statement.location(), "Failure condition of 'send' ignored. Consider using 'transfer' instead.");
+				m_errorReporter.warning(_statement.location(), "Failure condition of \"send\" ignored. Consider using \"transfer\" instead.");
 		}
 	}
 }
@@ -1121,12 +1121,12 @@ bool TypeChecker::visit(Conditional const& _conditional)
 	TypePointer commonType = nullptr;
 
 	if (!trueType)
-		m_errorReporter.typeError(_conditional.trueExpression().location(), "Invalid mobile type in true expression.");
+		m_errorReporter.typeError(_conditional.trueExpression().location(), "Invalid mobile type in \"true\" expression.");
 	else
 		commonType = trueType;
 
 	if (!falseType)
-		m_errorReporter.typeError(_conditional.falseExpression().location(), "Invalid mobile type in false expression.");
+		m_errorReporter.typeError(_conditional.falseExpression().location(), "Invalid mobile type in \"false\" expression.");
 	else
 		commonType = falseType;
 
@@ -1140,11 +1140,11 @@ bool TypeChecker::visit(Conditional const& _conditional)
 		{
 			m_errorReporter.typeError(
 					_conditional.location(),
-					"True expression's type " +
+					"True expression's type \"" +
 					trueType->toString() +
-					" doesn't match false expression's type " +
+					"\" doesn't match false expression's type \"" +
 					falseType->toString() +
-					"."
+					"\"."
 					);
 			// even we can't find a common type, we have to set a type here,
 			// otherwise the upper statement will not be able to check the type.
@@ -1235,12 +1235,13 @@ bool TypeChecker::visit(Assignment const& _assignment)
 		if (!resultType || *resultType != *t)
 			m_errorReporter.typeError(
 				_assignment.location(),
-				"Operator " +
+				"Operator \"" +
 				string(TokenTraits::toString(_assignment.assignmentOperator())) +
-				" not compatible with types " +
+				"\" not compatible with types \"" +
 				t->toString() +
-				" and " +
-				type(_assignment.rightHandSide())->toString()
+				"\" and \"" +
+				type(_assignment.rightHandSide())->toString() +
+				"\"."
 			);
 	}
 	return false;
@@ -1321,7 +1322,7 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 			if (!inlineArrayType)
 				m_errorReporter.fatalTypeError(_tuple.location(), "Unable to deduce common type for array elements.");
 			else if (!inlineArrayType->canLiveOutsideStorage())
-				m_errorReporter.fatalTypeError(_tuple.location(), "Type " + inlineArrayType->toString() + " is only valid in storage.");
+				m_errorReporter.fatalTypeError(_tuple.location(), "Type \"" + inlineArrayType->toString() + "\" is only valid in storage.");
 
 			_tuple.annotation().type = TypeProvider::array(DataLocation::Memory, inlineArrayType, types.size());
 		}
@@ -1352,10 +1353,11 @@ bool TypeChecker::visit(UnaryOperation const& _operation)
 	{
 		m_errorReporter.typeError(
 			_operation.location(),
-			"Unary operator " +
+			"Unary operator \"" +
 			string(TokenTraits::toString(op)) +
-			" cannot be applied to type " +
-			subExprType->toString()
+			"\" cannot be applied to type \"" +
+			subExprType->toString() +
+			"\"."
 		);
 		t = subExprType;
 	}
@@ -1374,13 +1376,13 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 	{
 		m_errorReporter.typeError(
 			_operation.location(),
-			"Operator " +
+			"Operator \"" +
 			string(TokenTraits::toString(_operation.getOperator())) +
-			" not compatible with types " +
+			"\" not compatible with types \"" +
 			leftType->toString() +
-			" and " +
+			"\" and \"" +
 			rightType->toString() +
-			(!result.message().empty() ? ". " + result.message() : "")
+			(!result.message().empty() ? "\". " + result.message() : "\".")
 		);
 		commonType = leftType;
 	}
@@ -1409,7 +1411,7 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 			))
 				m_errorReporter.warning(
 					_operation.location(),
-					"Result of " + operation + " has type " + commonType->toString() + " and thus "
+					"Result of \"" + operation + "\" has type \"" + commonType->toString() + "\" and thus "
 					"might overflow. Silence this warning by converting the literal to the "
 					"expected type."
 				);
@@ -1722,7 +1724,7 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 				msg +=
 					" This function requires a single bytes argument."
 					" If all your arguments are value types, you can use"
-					" abi.encode(...) to properly generate it.";
+					" \"abi.encode(...)\" to properly generate it.";
 		}
 		else if (
 			_functionType->kind() == FunctionType::Kind::KECCAK256 ||
@@ -1731,8 +1733,8 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 		)
 			msg +=
 				" This function requires a single bytes argument."
-				" Use abi.encodePacked(...) to obtain the pre-0.5.0"
-				" behaviour or abi.encode(...) to use ABI encoding.";
+				" Use \"abi.encodePacked(...)\" to obtain the pre-0.5.0"
+				" behaviour or \"abi.encode(...)\" to use ABI encoding.";
 		m_errorReporter.typeError(_functionCall.location(), msg);
 		return;
 	}
@@ -1823,7 +1825,7 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 				msg +=
 					" This function requires a single bytes argument."
 					" If all your arguments are value types, you can"
-					" use abi.encode(...) to properly generate it.";
+					" use \"abi.encode(...)\" to properly generate it.";
 			else if (
 				_functionType->kind() == FunctionType::Kind::KECCAK256 ||
 				_functionType->kind() == FunctionType::Kind::SHA256 ||
@@ -1831,8 +1833,8 @@ void TypeChecker::typeCheckFunctionGeneralChecks(
 			)
 				msg +=
 					" This function requires a single bytes argument."
-					" Use abi.encodePacked(...) to obtain the pre-0.5.0"
-					" behaviour or abi.encode(...) to use ABI encoding.";
+					" Use \"abi.encodePacked(...)\" to obtain the pre-0.5.0"
+					" behaviour or \"abi.encode(...)\" to use ABI encoding.";
 			m_errorReporter.typeError(paramArgMap[i]->location(), msg);
 		}
 	}
@@ -2087,13 +2089,13 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 			if (!storageType->members(m_scope).membersByName(memberName).empty())
 				m_errorReporter.fatalTypeError(
 					_memberAccess.location(),
-					"Member \"" + memberName + "\" is not available in " +
+					"Member \"" + memberName + "\" is not available in \"" +
 					exprType->toString() +
-					" outside of storage."
+					"\" outside of storage."
 				);
 		}
 		string errorMsg = "Member \"" + memberName + "\" not found or not visible "
-				"after argument-dependent lookup in " + exprType->toString() + ".";
+				"after argument-dependent lookup in \"" + exprType->toString() + "\".";
 
 		if (auto const& funType = dynamic_cast<FunctionType const*>(exprType))
 		{
@@ -2102,7 +2104,7 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 			if (memberName == "value")
 			{
 				if (funType->kind() == FunctionType::Kind::Creation)
-					errorMsg = "Constructor for " + t.front()->toString() + " must be payable for member \"value\" to be available.";
+					errorMsg = "Constructor for \"" + t.front()->toString() + "\" must be payable for member \"value\" to be available.";
 				else if (
 					funType->kind() == FunctionType::Kind::DelegateCall ||
 					funType->kind() == FunctionType::Kind::BareDelegateCall
@@ -2309,7 +2311,7 @@ bool TypeChecker::visit(IndexAccess const& _access)
 	default:
 		m_errorReporter.fatalTypeError(
 			_access.baseExpression().location(),
-			"Indexed expression has to be a type, mapping or array (is " + baseType->toString() + ")"
+			"Indexed expression has to be a type, mapping or array (is \"" + baseType->toString() + "\")"
 		);
 	}
 	_access.annotation().type = resultType;
@@ -2462,7 +2464,7 @@ void TypeChecker::endVisit(Literal const& _literal)
 			m_errorReporter.syntaxError(
 				_literal.location(),
 				msg +
-				" If this is not used as an address, please prepend '00'. " +
+				" If this is not used as an address, please prepend \"00\". " +
 				"For more information please see https://solidity.readthedocs.io/en/develop/types.html#address-literals"
 			);
 	}
@@ -2541,9 +2543,9 @@ bool TypeChecker::expectType(Expression const& _expression, Type const& _expecte
 				m_errorReporter.typeError(
 					_expression.location(),
 					errorMsg +
-					". Try converting to type " +
+					". Try converting to type \"" +
 					type(_expression)->mobileType()->toString() +
-					" or use an explicit conversion."
+					"\" or use an explicit conversion."
 				);
 		}
 		else

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -179,7 +179,7 @@ void ViewPureChecker::endVisit(FunctionDefinition const& _funDef)
 	)
 		m_errorReporter.warning(
 			_funDef.location(),
-			"Function state mutability can be restricted to " + stateMutabilityToString(m_bestMutabilityAndLocation.mutability)
+			"Function state mutability can be restricted to \"" + stateMutabilityToString(m_bestMutabilityAndLocation.mutability) + "\"."
 		);
 	m_currentFunction = nullptr;
 }
@@ -269,10 +269,10 @@ void ViewPureChecker::reportMutability(
 	{
 		m_errorReporter.typeError(
 			_location,
-			"Function declared as " +
+			"Function declared as \"" +
 			stateMutabilityToString(m_currentFunction->stateMutability()) +
-			", but this expression (potentially) modifies the state and thus "
-			"requires non-payable (the default) or payable."
+			"\", but this expression (potentially) modifies the state and thus "
+			"requires \"non-payable\" (the default) or \"payable\"."
 		);
 		m_errors = true;
 	}

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -370,7 +370,7 @@ void CompilerContext::appendInlineAssembly(
 			BOOST_THROW_EXCEPTION(
 				CompilerError() <<
 				errinfo_sourceLocation(_identifier.location) <<
-				errinfo_comment("Stack too deep (" + to_string(stackDiff) + "), try removing local variables.")
+				errinfo_comment("Stack too deep (\"" + to_string(stackDiff) + "\"), try removing local variables.")
 			);
 		if (_context == yul::IdentifierContext::RValue)
 			_assembly.appendInstruction(dupInstruction(stackDiff));

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -743,7 +743,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 				BOOST_THROW_EXCEPTION(
 					CompilerError() <<
 					errinfo_sourceLocation(_inlineAssembly.location()) <<
-					errinfo_comment("Stack too deep(" + to_string(stackDiff) + "), try removing local variables.")
+					errinfo_comment("Stack too deep(\"" + to_string(stackDiff) + "\"), try removing local variables.")
 				);
 			_assembly.appendInstruction(swapInstruction(stackDiff));
 			_assembly.appendInstruction(Instruction::POP);

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -434,7 +434,7 @@ void BMC::inlineFunctionCall(FunctionCall const& _funCall)
 		m_errorReporter.warning(
 			_funCall.location(),
 			"Assertion checker does not support recursive function calls.",
-			SecondarySourceLocation().append("Starting from function:", funDef->location())
+			SecondarySourceLocation().append("Starting from function: ", funDef->location())
 		);
 	}
 	else

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -782,9 +782,9 @@ void SMTEncoder::endVisit(Literal const& _literal)
 	{
 		m_errorReporter.warning(
 			_literal.location(),
-			"Assertion checker does not yet support the type of this literal (" +
+			"Assertion checker does not yet support the type of this literal (\"" +
 			_literal.annotation().type->toString() +
-			")."
+			"\")."
 		);
 	}
 }
@@ -1065,7 +1065,7 @@ void SMTEncoder::arithmeticOperation(BinaryOperation const& _op)
 	else
 		m_errorReporter.warning(
 			_op.location(),
-			"Assertion checker does not yet implement this operator for type " + type->richIdentifier() + "."
+			"Assertion checker does not yet implement this operator for type \"" + type->richIdentifier() + "\"."
 		);
 }
 
@@ -1156,7 +1156,7 @@ void SMTEncoder::compareOperation(BinaryOperation const& _op)
 	else
 		m_errorReporter.warning(
 			_op.location(),
-			"Assertion checker does not yet implement the type " + _op.annotation().commonType->toString() + " for comparisons"
+			"Assertion checker does not yet implement the type \"" + _op.annotation().commonType->toString() + "\" for comparisons"
 		);
 }
 
@@ -1184,7 +1184,7 @@ void SMTEncoder::booleanOperation(BinaryOperation const& _op)
 	else
 		m_errorReporter.warning(
 			_op.location(),
-			"Assertion checker does not yet implement the type " + _op.annotation().commonType->toString() + " for boolean operations"
+			"Assertion checker does not yet implement the type \"" + _op.annotation().commonType->toString() + "\" for boolean operations"
 		);
 }
 
@@ -1216,7 +1216,7 @@ void SMTEncoder::assignment(
 
 		m_errorReporter.warning(
 			_location,
-			"Assertion checker does not yet implement type " + _type->toString()
+			"Assertion checker does not yet implement type \"" + _type->toString() + "\"."
 		);
 	}
 	else if (auto varDecl = identifierToVariable(_left))
@@ -1477,7 +1477,7 @@ void SMTEncoder::createExpr(Expression const& _e)
 	if (abstract)
 		m_errorReporter.warning(
 			_e.location(),
-			"Assertion checker does not yet implement type " + _e.annotation().type->toString()
+			"Assertion checker does not yet implement type \"" + _e.annotation().type->toString() + "\"."
 		);
 }
 

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -206,7 +206,7 @@ void CompilerStack::setSources(StringMap _sources)
 bool CompilerStack::parse()
 {
 	if (m_stackState != SourcesSet)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must call parse only after the SourcesSet state."));
+		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must call parse only after the \"SourcesSet\" state."));
 	m_errorReporter.clear();
 	ASTNode::resetID();
 
@@ -215,7 +215,7 @@ bool CompilerStack::parse()
 
 	if (m_optimiserSettings.runYulOptimiser)
 		m_errorReporter.warning(
-			"The Yul optimiser is still experimental. "
+			"The \"Yul\" optimiser is still experimental. "
 			"Do not use it in production unless correctness of generated code is verified with extensive tests."
 		);
 
@@ -229,7 +229,7 @@ bool CompilerStack::parse()
 		source.scanner->reset();
 		source.ast = Parser(m_errorReporter, m_evmVersion, m_parserErrorRecovery).parse(source.scanner);
 		if (!source.ast)
-			solAssert(!Error::containsOnlyWarnings(m_errorReporter.errors()), "Parser returned null but did not report error.");
+			solAssert(!Error::containsOnlyWarnings(m_errorReporter.errors()), "Parser returned \"null\" but did not report error.");
 		else
 		{
 			source.ast->annotation().path = path;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -123,8 +123,8 @@ void Parser::parsePragmaVersion(SourceLocation const& _location, vector<Token> c
 		if (!m_parserErrorRecovery)
 			m_errorReporter.fatalParserError(
 				_location,
-				"Source file requires different compiler version (current compiler is " +
-				string(VersionString) + " - note that nightly builds are considered to be "
+				"Source file requires different compiler version (current compiler is \"" +
+				string(VersionString) + "\" - note that nightly builds are considered to be "
 				"strictly less than the released version"
 			);
 }

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -120,7 +120,7 @@ bool AsmAnalyzer::operator()(Literal const& _literal)
 	{
 		m_errorReporter.typeError(
 			_literal.location,
-			"String literal too long (" + to_string(_literal.value.str().size()) + " > 32)"
+			"String literal too long (\"" + to_string(_literal.value.str().size()) + "\" > 32)"
 		);
 		return false;
 	}
@@ -153,7 +153,7 @@ bool AsmAnalyzer::operator()(Identifier const& _identifier)
 			{
 				m_errorReporter.declarationError(
 					_identifier.location,
-					"Variable " + _identifier.name.str() + " used before it was declared."
+					"Variable \"" + _identifier.name.str() + "\" used before it was declared."
 				);
 				success = false;
 			}
@@ -167,7 +167,7 @@ bool AsmAnalyzer::operator()(Identifier const& _identifier)
 		{
 			m_errorReporter.typeError(
 				_identifier.location,
-				"Function " + _identifier.name.str() + " used without being called."
+				"Function \"" + _identifier.name.str() + "\" used without being called."
 			);
 			success = false;
 		}
@@ -223,7 +223,7 @@ bool AsmAnalyzer::operator()(ExpressionStatement const& _statement)
 			to_string(m_stackHeight - initialStackHeight) +
 			" value" +
 			(m_stackHeight - initialStackHeight == 1 ? "" : "s") +
-			"). Use ``pop()`` or assign them.";
+			"). Use \"pop()\" or assign them.";
 		m_errorReporter.error(errorType, _statement.location, msg);
 		if (errorType != Error::Type::Warning)
 			success = false;
@@ -254,11 +254,11 @@ bool AsmAnalyzer::operator()(Assignment const& _assignment)
 	{
 		m_errorReporter.declarationError(
 			_assignment.location,
-			"Variable count does not match number of values (" +
+			"Variable count does not match number of values (\"" +
 			to_string(expectedItems) +
-			" vs. " +
+			"\" vs. \"" +
 			to_string(m_stackHeight - stackHeight) +
-			")"
+			"\")."
 		);
 		return false;
 	}
@@ -625,7 +625,7 @@ bool AsmAnalyzer::checkAssignment(Identifier const& _variable, size_t _valueSize
 		{
 			m_errorReporter.declarationError(
 				_variable.location,
-				"Variable " + _variable.name.str() + " used before it was declared."
+				"Variable \"" + _variable.name.str() + "\" used before it was declared."
 			);
 			success = false;
 		}

--- a/libyul/AsmScopeFiller.cpp
+++ b/libyul/AsmScopeFiller.cpp
@@ -57,7 +57,7 @@ bool ScopeFiller::operator()(Label const& _item)
 		//@TODO secondary location
 		m_errorReporter.declarationError(
 			_item.location,
-			"Label name " + _item.name.str() + " already taken in this scope."
+			"Label name \"" + _item.name.str() + "\" already taken in this scope."
 		);
 		return false;
 	}
@@ -155,7 +155,7 @@ bool ScopeFiller::registerVariable(TypedName const& _name, SourceLocation const&
 		//@TODO secondary location
 		m_errorReporter.declarationError(
 			_location,
-			"Variable name " + _name.name.str() + " already taken in this scope."
+			"Variable name \"" + _name.name.str() + "\" already taken in this scope."
 		);
 		return false;
 	}
@@ -175,7 +175,7 @@ bool ScopeFiller::registerFunction(FunctionDefinition const& _funDef)
 		//@TODO secondary location
 		m_errorReporter.declarationError(
 			_funDef.location,
-			"Function name " + _funDef.name.str() + " already taken in this scope."
+			"Function name \"" + _funDef.name.str() + "\" already taken in this scope."
 		);
 		return false;
 	}

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -560,9 +560,9 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 		{
 			StackTooDeepError error(_function.name, YulString{}, stackLayout.size() - 17);
 			error << errinfo_comment(
-				"The function " +
+				"The function \"" +
 				_function.name.str() +
-				" has " +
+				"\" has " +
 				to_string(stackLayout.size() - 17) +
 				" parameters or return variables too many to fit the stack size."
 			);
@@ -817,9 +817,9 @@ int CodeTransform::variableHeightDiff(Scope::Variable const& _var, YulString _va
 	{
 		m_stackErrors.emplace_back(_varName, heightDiff - limit);
 		m_stackErrors.back() << errinfo_comment(
-			"Variable " +
+			"Variable \"" +
 			_varName.str() +
-			" is " +
+			"\" is " +
 			to_string(heightDiff - limit) +
 			" slot(s) too deep inside the stack."
 		);

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -617,7 +617,7 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 	ofstream outFile(pathName);
 	outFile << _data;
 	if (!outFile)
-		BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: " + pathName));
+		BOOST_THROW_EXCEPTION(FileError() << errinfo_comment("Could not write to file: \"" + pathName + "\"."));
 }
 
 void CommandLineInterface::createJson(string const& _fileName, string const& _json)

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/010_type_conversion_for_comparison.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/010_type_conversion_for_comparison.sol
@@ -3,4 +3,4 @@ contract test {
 }
 // ----
 // Warning: (42-63): Statement has no effect.
-// Warning: (20-66): Function state mutability can be restricted to pure
+// Warning: (20-66): Function state mutability can be restricted to "pure"

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/011_type_conversion_for_comparison_invalid.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/011_type_conversion_for_comparison_invalid.sol
@@ -2,4 +2,4 @@ contract test {
     function f() public { int32(2) == uint64(2); }
 }
 // ----
-// TypeError: (42-63): Operator == not compatible with types int32 and uint64
+// TypeError: (42-63): Operator == not compatible with types "int32" and "uint64"

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/013_large_string_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/013_large_string_literal.sol
@@ -3,4 +3,4 @@ contract test {
 }
 // ----
 // Warning: (42-57): Unused local variable.
-// Warning: (20-98): Function state mutability can be restricted to pure
+// Warning: (20-98): Function state mutability can be restricted to "pure"


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description
Fixes #7578 

Updated existing quotes within error messages to double quotes, added new double quotes around user-defined variables.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
