### PR TITLE
Fix wrong construction of ElementaryTypeNameToken

### DIFF
--- a/liblangutil/Token.cpp
+++ b/liblangutil/Token.cpp
@@ -72,6 +72,9 @@ void ElementaryTypeNameToken::assertDetails(Token _baseType, unsigned const& _fi
 			"No elementary type " + string(TokenTraits::toString(_baseType)) + to_string(_first) + "x" + to_string(_second) + "."
 		);
 	}
+	else
+		solAssert(_first == 0 && _second == 0, "Unexpected size arguments");
+
 	m_token = _baseType;
 	m_firstNumber = _first;
 	m_secondNumber = _second;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1678,7 +1678,7 @@ ASTPointer<Expression> Parser::parseLeftHandSideExpression(
 		expectToken(Token::Payable);
 		nodeFactory.markEndPosition();
 		auto expressionType = nodeFactory.createNode<ElementaryTypeName>(
-			ElementaryTypeNameToken(Token::Address, 160, 0),
+			ElementaryTypeNameToken(Token::Address, 0, 0),
 			std::make_optional(StateMutability::Payable)
 		);
 		expression = nodeFactory.createNode<ElementaryTypeNameExpression>(expressionType);


### PR DESCRIPTION
And add an assert to prevent it in the future

Split off #7153.