### PR TITLE
Reserve from and unsafe as keywords

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ Breaking changes:
  * Commandline Interface: Add option to disable or choose hash method between IPFS and Swarm for the bytecode metadata.
  * General: Disallow explicit conversions from external function types to ``address`` and add a member called ``address`` to them as replacement.
  * General: Enable Yul optimizer as part of standard optimization.
- * General: New reserved keywords: ``override``, ``receive``, and ``virtual``.
+ * General: New reserved keywords: ``from``, ``override``, ``receive``, ``virtual``, and ``unsafe``.
  * General: ``private`` cannot be used together with ``virtual``.
  * General: Split unnamed fallback functions into two cases defined using ``fallback()`` and ``receive()``.
  * Inheritance: State variable shadowing is now disallowed.

--- a/docs/060-breaking-changes.rst
+++ b/docs/060-breaking-changes.rst
@@ -30,7 +30,7 @@ This section lists purely syntactic changes that do not affect the behavior of e
   longer possible to resize storage arrays assigning a new value to their length. Use ``push()``,
   ``push(value)`` or ``pop()`` instead, or assign a full array, which will of course overwrite existing content.
 
-* New reserved keywords: ``override``, ``receive``, and ``virtual``.
+* New reserved keywords: ``from``, ``override``, ``receive``, ``virtual``, and ``unsafe``.
 
 * The names of variables declared in inline assembly may no longer end in ``_slot`` or ``_offset``.
 

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -718,10 +718,10 @@ Reserved Keywords
 These keywords are reserved in Solidity. They might become part of the syntax in the future:
 
 ``abstract``, ``after``, ``alias``, ``apply``, ``auto``, ``case``, ``catch``, ``copyof``, ``default``,
-``define``, ``final``, ``immutable``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
+``define``, ``final``, ``from``, ``immutable``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
 ``mutable``, ``null``, ``of``, ``partial``, ``promise``, ``reference``, ``relocatable``,
 ``sealed``, ``sizeof``, ``static``, ``supports``, ``switch``, ``try``, ``typedef``, ``typeof``,
-``unchecked``.
+``unchecked``, ``unsafe``.
 
 Language Grammar
 ================

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -243,6 +243,7 @@ namespace langutil
 	K(Default, "default", 0)                                           \
 	K(Define, "define", 0)                                             \
 	K(Final, "final", 0)                                               \
+	K(From, "from", 0)                                                 \
 	K(Immutable, "immutable", 0)                                       \
 	K(Implements, "implements", 0)                                     \
 	K(In, "in", 0)                                                     \
@@ -266,6 +267,7 @@ namespace langutil
 	K(Typedef, "typedef", 0)                                           \
 	K(TypeOf, "typeof", 0)                                             \
 	K(Unchecked, "unchecked", 0)                                       \
+	K(Unsafe, "unsafe", 0)                                             \
 	\
 	/* Illegal token - not able to scan. */                            \
 	T(Illegal, "ILLEGAL", 0)                                           \


### PR DESCRIPTION
And also update documentation/chanelog with all the new keywords.

- `from` is #1687 
- `unsafe` is from #796
- `copy` #6040
