### PR TITLE
Fix ICE when calling unimplemented base/super function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -45,6 +45,10 @@ Compiler Features:
  * ABIEncoderV2: Do not warn about enabled ABIEncoderV2 anymore (the pragma is still needed, though).
 
 
+Bugfixes:
+ * Fix compiler error when calling the base function from the derived function when base is missing an implementation.
+
+
 ### 0.5.14 (2019-12-09)
 
 Language Features:

--- a/libsolidity/analysis/OverrideChecker.h
+++ b/libsolidity/analysis/OverrideChecker.h
@@ -44,7 +44,7 @@ class ModifierType;
 
 /**
  * Class that represents a function, public state variable or modifier
- * and helps with overload checking.
+ * and helps with override checking.
  * Regular comparison is performed based on AST node, while CompareBySignature
  * results in two elements being equal when they can override each
  * other.

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -164,6 +164,9 @@ private:
 
 	ContractDefinition const* m_scope = nullptr;
 
+	/// Pointer to the function we're currently in
+	FunctionDefinition const* m_scopeFunction = nullptr;
+
 	langutil::EVMVersion m_evmVersion;
 
 	/// Flag indicating whether we are currently inside an EmitStatement.

--- a/test/libsolidity/syntaxTests/unimplemented_base_function.sol
+++ b/test/libsolidity/syntaxTests/unimplemented_base_function.sol
@@ -1,0 +1,8 @@
+abstract contract a {
+    function f() virtual public;
+}
+contract b is a {
+    function f() public override { a.f(); }
+}
+// ----
+// TypeError: (110-113): Referencing unimplemented function "a.f".

--- a/test/libsolidity/syntaxTests/unimplemented_base_function_derived.sol
+++ b/test/libsolidity/syntaxTests/unimplemented_base_function_derived.sol
@@ -1,0 +1,12 @@
+abstract contract a {
+    function f() virtual public;
+}
+contract b is a {
+    function f() public virtual override { a.f(); }
+}
+contract c is a,b {
+    function f() public override(a, b) { a.f(); }
+}
+// ----
+// TypeError: (118-121): Referencing unimplemented function "a.f".
+// TypeError: (190-193): Referencing unimplemented function "a.f".

--- a/test/libsolidity/syntaxTests/unimplemented_base_function_indirect.sol
+++ b/test/libsolidity/syntaxTests/unimplemented_base_function_indirect.sol
@@ -1,0 +1,11 @@
+abstract contract a {
+    function f() virtual public;
+}
+contract b is a {
+    function f() public override virtual {  }
+}
+contract c is b {
+    function f() public override { a.f(); }
+}
+// ----
+// TypeError: (176-179): Referencing unimplemented function "a.f".

--- a/test/libsolidity/syntaxTests/unimplemented_base_function_referencing.sol
+++ b/test/libsolidity/syntaxTests/unimplemented_base_function_referencing.sol
@@ -1,0 +1,11 @@
+abstract contract a {
+    function f() virtual internal;
+}
+contract b is a {
+    function f() internal override
+	{
+		function() internal x = a.f;
+	}
+}
+// ----
+// TypeError: (141-144): Referencing unimplemented function "a.f".


### PR DESCRIPTION
fixes #7314

I need to use the `resolveDirectBaseContracts` function from the override checker. I am currently not sure what the best way to do that is. I could pull it out into a different or extra file.. I could move my check into the override checker.. or something else?