### PR TITLE
abiv2 proto converter: Resize dynamic storage arrays via push

### DIFF
--- a/test/tools/ossfuzz/protoToAbiV2.cpp
+++ b/test/tools/ossfuzz/protoToAbiV2.cpp
@@ -810,13 +810,16 @@ pair<string, string> AssignCheckVisitor::visit(ArrayType const& _type)
 		length = getDynArrayLengthFromFuzz(_type.length(), counter());
 		lengthStr = to_string(length);
 		if (m_stateVar)
-			resizeBuffer = assignAndCheckStringPair(
-				m_varName + ".length",
-				m_paramName + ".length",
-				lengthStr,
-				lengthStr,
-				DataType::VALUE
-				);
+		{
+			// Dynamic storage arrays are resized via the empty push() operation
+			resizeBuffer.first = Whiskers(R"(<indentation>for (uint i = 0; i < <length>; i++) <arrayRef>.push();)")
+				("indentation", indentation())
+				("length", lengthStr)
+				("arrayRef", m_varName)
+				.render() + "\n";
+			// Add a dynamic check on the resized length
+			resizeBuffer.second = checkString(m_paramName + ".length", lengthStr, DataType::VALUE);
+		}
 		else
 		{
 			// Resizing memory arrays via the new operator


### PR DESCRIPTION
Fixes #7960 and #8018 

Earlier we resized dynamic storage arrays by writing to the length field, but now don't do that since the length field of an array is read-only.

~~Note that this is still a draft pull request because I want to make sure that a different crash (see https://github.com/ethereum/evmone/pull/227) is not related to the issue this PR addresses.~~