### PR TITLE
resolved grammatical error in tutorial docs

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -71,7 +71,7 @@ Subcurrency Example
 ===================
 
 The following contract implements the simplest form of a
-cryptocurrency. The contract allows only its creator to create new coins (different issuance scheme are possible).
+cryptocurrency. The contract allows only its creator to create new coins (different issuance schemes are possible).
 Anyone can send coins to each other without a need for
 registering with a username and password, all you need is an Ethereum keypair.
 


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

The subcurrency tutorial uses incorrect grammar when referring to token issuance schemes.


### Checklist
- [ x] Code compiles correctly
- [ x] All tests are passing
- [ x] New tests have been created which fail without the change (if possible)
- [ x] README / documentation was extended, if necessary
- [ x] Changelog entry (if change is visible to the user)
- [ x] Used meaningful commit messages
