### PR TITLE
Move states from the TypeChecker to the PostTypeChecker

### DIFF
--- a/libsolidity/analysis/PostTypeChecker.h
+++ b/libsolidity/analysis/PostTypeChecker.h
@@ -36,6 +36,7 @@ namespace solidity::frontend
  * This module performs analyses on the AST that are done after type checking and assignments of types:
  *  - whether there are circular references in constant state variables
  *  - whether override specifiers are actually contracts
+ *  - whether a modifier is in a function header
  *
  *  When adding a new checker, make sure a visitor that forwards calls that your
  *  checker uses exists in PostTypeChecker. Add missing ones.
@@ -68,6 +69,9 @@ private:
 	void endVisit(VariableDeclaration const& _variable) override;
 
 	bool visit(Identifier const& _identifier) override;
+
+	bool visit(ModifierInvocation const& _modifierInvocation) override;
+	void endVisit(ModifierInvocation const& _modifierInvocation) override;
 
 	template <class T>
 	bool callVisit(T const& _node)

--- a/libsolidity/analysis/PostTypeChecker.h
+++ b/libsolidity/analysis/PostTypeChecker.h
@@ -38,6 +38,7 @@ namespace solidity::frontend
  *  - whether override specifiers are actually contracts
  *  - whether a modifier is in a function header
  *  - whether an event is used outside of an emit statement
+ *  - whether a variable is declared in a interface
  *
  *  When adding a new checker, make sure a visitor that forwards calls that your
  *  checker uses exists in PostTypeChecker. Add missing ones.
@@ -75,6 +76,9 @@ private:
 	bool visit(FunctionCall const& _functionCall) override;
 
 	bool visit(Identifier const& _identifier) override;
+
+	bool visit(StructDefinition const& _struct) override;
+	void endVisit(StructDefinition const& _struct) override;
 
 	bool visit(ModifierInvocation const& _modifierInvocation) override;
 	void endVisit(ModifierInvocation const& _modifierInvocation) override;

--- a/libsolidity/analysis/PostTypeChecker.h
+++ b/libsolidity/analysis/PostTypeChecker.h
@@ -37,6 +37,7 @@ namespace solidity::frontend
  *  - whether there are circular references in constant state variables
  *  - whether override specifiers are actually contracts
  *  - whether a modifier is in a function header
+ *  - whether an event is used outside of an emit statement
  *
  *  When adding a new checker, make sure a visitor that forwards calls that your
  *  checker uses exists in PostTypeChecker. Add missing ones.
@@ -67,6 +68,11 @@ private:
 
 	bool visit(VariableDeclaration const& _variable) override;
 	void endVisit(VariableDeclaration const& _variable) override;
+
+	bool visit(EmitStatement const& _emit) override;
+	void endVisit(EmitStatement const& _emit) override;
+
+	bool visit(FunctionCall const& _functionCall) override;
 
 	bool visit(Identifier const& _identifier) override;
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -547,11 +547,7 @@ void TypeChecker::visitManually(
 	for (ASTPointer<Expression> const& argument: arguments)
 		argument->accept(*this);
 
-	{
-		m_insideModifierInvocation = true;
-		ScopeGuard resetFlag{[&] () { m_insideModifierInvocation = false; }};
-		_modifier.name()->accept(*this);
-	}
+	_modifier.name()->accept(*this);
 
 	auto const* declaration = &dereference(*_modifier.name());
 	vector<ASTPointer<VariableDeclaration>> emptyParameterList;
@@ -2703,15 +2699,6 @@ bool TypeChecker::visit(Identifier const& _identifier)
 				"\"suicide\" has been deprecated in favour of \"selfdestruct\"."
 			);
 	}
-
-	if (!m_insideModifierInvocation)
-		if (ModifierType const* type = dynamic_cast<decltype(type)>(_identifier.annotation().type))
-		{
-			m_errorReporter.typeError(
-				_identifier.location(),
-				"Modifier can only be referenced in function headers."
-			);
-		}
 
 	return false;
 }

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -981,7 +981,6 @@ void TypeChecker::endVisit(EmitStatement const& _emit)
 		dynamic_cast<FunctionType const&>(*type(_emit.eventCall().expression())).kind() != FunctionType::Kind::Event
 	)
 		m_errorReporter.typeError(_emit.eventCall().expression().location(), "Expression has to be an event invocation.");
-	m_insideEmitStatement = false;
 }
 
 namespace
@@ -1713,13 +1712,6 @@ void TypeChecker::typeCheckFunctionCall(
 		m_errorReporter.typeError(
 			_functionCall.location(),
 			"\"staticcall\" is not supported by the VM version."
-		);
-
-	// Check for event outside of emit statement
-	if (!m_insideEmitStatement && _functionType->kind() == FunctionType::Kind::Event)
-		m_errorReporter.typeError(
-			_functionCall.location(),
-			"Event invocations have to be prefixed by \"emit\"."
 		);
 
 	// Perform standard function call type checking

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -317,10 +317,7 @@ bool TypeChecker::visit(StructDefinition const& _struct)
 	if (CycleDetector<StructDefinition>(visitor).run(_struct) != nullptr)
 		m_errorReporter.fatalTypeError(_struct.location(), "Recursive struct definition.");
 
-	bool insideStruct = true;
-	swap(insideStruct, m_insideStruct);
 	ASTNode::listAccept(_struct.members(), *this);
-	m_insideStruct = insideStruct;
 
 	return false;
 }
@@ -451,16 +448,6 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 
 bool TypeChecker::visit(VariableDeclaration const& _variable)
 {
-	// Forbid any variable declarations inside interfaces unless they are part of
-	// * a function's input/output parameters,
-	// * or inside of a struct definition.
-	if (
-		m_scope->isInterface()
-		&& !_variable.isCallableOrCatchParameter()
-		&& !m_insideStruct
-	)
-		m_errorReporter.typeError(_variable.location(), "Variables cannot be declared in interfaces.");
-
 	if (_variable.typeName())
 		_variable.typeName()->accept(*this);
 

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -126,7 +126,6 @@ private:
 	bool visit(WhileStatement const& _whileStatement) override;
 	bool visit(ForStatement const& _forStatement) override;
 	void endVisit(Return const& _return) override;
-	bool visit(EmitStatement const&) override { m_insideEmitStatement = true; return true; }
 	void endVisit(EmitStatement const& _emit) override;
 	bool visit(VariableDeclarationStatement const& _variable) override;
 	void endVisit(ExpressionStatement const& _statement) override;
@@ -163,9 +162,6 @@ private:
 	ContractDefinition const* m_scope = nullptr;
 
 	langutil::EVMVersion m_evmVersion;
-
-	/// Flag indicating whether we are currently inside an EmitStatement.
-	bool m_insideEmitStatement = false;
 
 	/// Flag indicating whether we are currently inside a StructDefinition.
 	bool m_insideStruct = false;

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -170,9 +170,6 @@ private:
 	/// Flag indicating whether we are currently inside a StructDefinition.
 	bool m_insideStruct = false;
 
-	/// Flag indicating whether we are currently inside the invocation of a modifier
-	bool m_insideModifierInvocation = false;
-
 	langutil::ErrorReporter& m_errorReporter;
 };
 

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -163,9 +163,6 @@ private:
 
 	langutil::EVMVersion m_evmVersion;
 
-	/// Flag indicating whether we are currently inside a StructDefinition.
-	bool m_insideStruct = false;
-
 	langutil::ErrorReporter& m_errorReporter;
 };
 


### PR DESCRIPTION
closes #7566
based on #8038

This PR moves all states from the TypeChecker except the `m_scope` into the PostTypechecker.
I am not sure if we can and should remove `m_scope` as it seems rather heavily used in the class to do all kinds of analytics
