### PR TITLE
WIP: Debug information for local variable->stack slot

### DIFF
--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <libsolidity/ast/ASTForward.h>
+
 #include <libevmasm/Instruction.h>
 #include <liblangutil/SourceLocation.h>
 #include <libevmasm/AssemblyItem.h>
@@ -181,6 +183,8 @@ protected:
 	int m_deposit = 0;
 
 	langutil::SourceLocation m_currentSourceLocation;
+	std::map<solidity::Declaration const*, unsigned> m_localVariables;
+
 public:
 	size_t m_currentModifierDepth = 0;
 };

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -142,6 +142,15 @@ bool AssemblyItem::canBeFunctional() const
 	return false;
 }
 
+void AssemblyItem::setLocalVariables(std::map<solidity::Declaration const*, std::vector<unsigned>> localVariables) {
+	m_localVariables = std::map<solidity::Declaration const*, unsigned>();
+	for (auto mapping : localVariables) {
+		if (!mapping.second.empty()) {
+			m_localVariables[mapping.first] = mapping.second.back();
+		}
+	}
+}
+
 string AssemblyItem::getJumpTypeAsString() const
 {
 	switch (m_jumpType)

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -142,15 +142,6 @@ bool AssemblyItem::canBeFunctional() const
 	return false;
 }
 
-void AssemblyItem::setLocalVariables(std::map<solidity::Declaration const*, std::vector<unsigned>> localVariables) {
-	m_localVariables = std::map<solidity::Declaration const*, unsigned>();
-	for (auto mapping : localVariables) {
-		if (!mapping.second.empty()) {
-			m_localVariables[mapping.first] = mapping.second.back();
-		}
-	}
-}
-
 string AssemblyItem::getJumpTypeAsString() const
 {
 	switch (m_jumpType)

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -146,8 +146,6 @@ public:
 	void setLocation(langutil::SourceLocation const& _location) { m_location = _location; }
 	langutil::SourceLocation const& location() const { return m_location; }
 
-	void setLocalVariables(std::map<solidity::Declaration const*, std::vector<unsigned>> localVariables);
-
 	std::map<solidity::Declaration const*, unsigned> localVariables() const { return m_localVariables; }
 
 	void setJumpType(JumpType _jumpType) { m_jumpType = _jumpType; }

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -53,7 +53,7 @@ enum AssemblyItemType {
 
 class Assembly;
 
-using VariableMapping = std::map<solidity::Declaration const*, std::vector<unsigned>>;
+using VariableMapping = std::map<solidity::Declaration const*, unsigned>;
 
 class AssemblyItem
 {
@@ -67,16 +67,15 @@ public:
 				 VariableMapping _localVariables = VariableMapping()):
 		m_type(Operation),
 		m_instruction(_i),
-		m_location(std::move(_location))
-	{
-		setLocalVariables(_localVariables);
-	}
+		m_location(std::move(_location)),
+		m_localVariables(_localVariables)
+	{}
 	AssemblyItem(AssemblyItemType _type, u256 _data = 0, langutil::SourceLocation _location = langutil::SourceLocation(),
 				 VariableMapping _localVariables = VariableMapping()):
 		m_type(_type),
-		m_location(std::move(_location))
+		m_location(std::move(_location)),
+		m_localVariables(_localVariables)
 	{
-		setLocalVariables(_localVariables);
 		if (m_type == Operation)
 			m_instruction = Instruction(uint8_t(_data));
 		else

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -508,6 +508,20 @@ eth::Assembly::OptimiserSettings CompilerContext::translateOptimiserSettings(Opt
 	return asmSettings;
 }
 
+std::map<Declaration const*, unsigned> CompilerContext::localsCurrentOffsets() {
+	std::map<Declaration const*, unsigned> localOffsets = std::map<solidity::Declaration const*, unsigned>();
+	for (auto mapping : m_localVariables) {
+		if (!mapping.second.empty()) {
+			unsigned baseOffset = baseStackOffsetOfVariable(*mapping.first);
+			if (baseOffset < stackHeight()) {
+				signed currentOffset = baseToCurrentStackOffset(baseOffset);
+				localOffsets[mapping.first] = currentOffset;
+			}
+		}
+	}
+	return localOffsets;
+}
+
 eth::AssemblyItem CompilerContext::FunctionCompilationQueue::entryLabel(
 	Declaration const& _declaration,
 	CompilerContext& _context

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -203,8 +203,8 @@ public:
 
 	/// Append elements to the current instruction list and adjust @a m_stackOffset.
 	CompilerContext& operator<<(eth::AssemblyItem const& _item) { m_asm->append(_item); return *this; }
-	CompilerContext& operator<<(dev::eth::Instruction _instruction) { m_asm->append(eth::AssemblyItem(_instruction, langutil::SourceLocation(), m_localVariables)); return *this; }
-	CompilerContext& operator<<(u256 const& _value) { m_asm->append(eth::AssemblyItem(_value, langutil::SourceLocation(), m_localVariables)); return *this; }
+	CompilerContext& operator<<(dev::eth::Instruction _instruction) { m_asm->append(eth::AssemblyItem(_instruction, langutil::SourceLocation(), localsCurrentOffsets())); return *this; }
+	CompilerContext& operator<<(u256 const& _value) { m_asm->append(eth::AssemblyItem(_value, langutil::SourceLocation(), localsCurrentOffsets())); return *this; }
 	CompilerContext& operator<<(bytes const& _data) { m_asm->append(_data); return *this; }
 
 	/// Appends inline assembly (strict mode).
@@ -277,6 +277,8 @@ private:
 	void updateSourceLocation();
 
 	eth::Assembly::OptimiserSettings translateOptimiserSettings(OptimiserSettings const& _settings);
+
+	std::map<Declaration const*, unsigned> localsCurrentOffsets();
 
 	/**
 	 * Helper class that manages function labels and ensures that referenced functions are

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -203,8 +203,8 @@ public:
 
 	/// Append elements to the current instruction list and adjust @a m_stackOffset.
 	CompilerContext& operator<<(eth::AssemblyItem const& _item) { m_asm->append(_item); return *this; }
-	CompilerContext& operator<<(dev::eth::Instruction _instruction) { m_asm->append(_instruction); return *this; }
-	CompilerContext& operator<<(u256 const& _value) { m_asm->append(_value); return *this; }
+	CompilerContext& operator<<(dev::eth::Instruction _instruction) { m_asm->append(eth::AssemblyItem(_instruction, langutil::SourceLocation(), m_localVariables)); return *this; }
+	CompilerContext& operator<<(u256 const& _value) { m_asm->append(eth::AssemblyItem(_value, langutil::SourceLocation(), m_localVariables)); return *this; }
 	CompilerContext& operator<<(bytes const& _data) { m_asm->append(_data); return *this; }
 
 	/// Appends inline assembly (strict mode).

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1463,10 +1463,14 @@ string CompilerStack::computeLocalVariables(eth::AssemblyItems const& _items) co
 
 	string ret;
 
+	bool first = true;
 	for (auto const& item: _items)
 	{
-		if (!ret.empty())
+		if (first) {
+			first = false;
+		} else {
 			ret += ";";
+		}
 
 		std::map<solidity::Declaration const*, unsigned> mappings = item.localVariables();
 		bool first = true;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -277,6 +277,10 @@ public:
 	/// if the contract does not (yet) have bytecode.
 	std::string const* runtimeSourceMapping(std::string const& _contractName) const;
 
+	std::string const* localVariables(std::string const& _contractName) const;
+
+	std::string const* localVariablesRuntime(std::string const& _contractName) const;
+
 	/// @return a verbose text representation of the assembly.
 	/// @arg _sourceCodes is the map of input files to source code strings
 	/// Prerequisite: Successful compilation.
@@ -347,6 +351,7 @@ private:
 		mutable std::unique_ptr<Json::Value const> devDocumentation;
 		mutable std::unique_ptr<std::string const> sourceMapping;
 		mutable std::unique_ptr<std::string const> runtimeSourceMapping;
+		mutable std::unique_ptr<std::string const> localVariables;
 	};
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback
@@ -401,6 +406,8 @@ private:
 
 	/// @returns the computer source mapping string.
 	std::string computeSourceMapping(eth::AssemblyItems const& _items) const;
+
+	std::string computeLocalVariables(eth::AssemblyItems const& _items) const;
 
 	/// @returns the contract ABI as a JSON object.
 	/// This will generate the JSON object and store it in the Contract object if it is not present yet.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -159,6 +159,8 @@ static string const g_strSources = "sources";
 static string const g_strSourceList = "sourceList";
 static string const g_strSrcMap = "srcmap";
 static string const g_strSrcMapRuntime = "srcmap-runtime";
+static string const g_strLocalVariables = "local-mappings";
+static string const g_strLocalVariablesRuntime = "local-mappings-runtime";
 static string const g_strStandardJSON = "standard-json";
 static string const g_strStrictAssembly = "strict-assembly";
 static string const g_strSwarm = "swarm";
@@ -226,7 +228,9 @@ static set<string> const g_combinedJsonArgs
 	g_strOpcodes,
 	g_strSignatureHashes,
 	g_strSrcMap,
-	g_strSrcMapRuntime
+	g_strSrcMapRuntime,
+	g_strLocalVariables,
+	g_strLocalVariablesRuntime
 };
 
 /// Possible arguments to for --machine
@@ -1191,6 +1195,16 @@ void CommandLineInterface::handleCombinedJSON()
 		{
 			auto map = m_compiler->runtimeSourceMapping(contractName);
 			contractData[g_strSrcMapRuntime] = map ? *map : "";
+		}
+		if (requests.count(g_strLocalVariables) && m_compiler->compilationSuccessful())
+		{
+			auto map = m_compiler->localVariables(contractName);
+			contractData[g_strLocalVariables] = map ? *map : "";
+		}
+		if (requests.count(g_strLocalVariablesRuntime) && m_compiler->compilationSuccessful())
+		{
+			auto map = m_compiler->localVariablesRuntime(contractName);
+			contractData[g_strLocalVariables] = map ? *map : "";
 		}
 		if (requests.count(g_strSignatureHashes))
 			contractData[g_strSignatureHashes] = m_compiler->methodIdentifiers(contractName);


### PR DESCRIPTION
### Description

This PR adds a combined-json option to output a per-instruction map from solidity variable names to EVM stack offsets. This information helps downstream static analysis tools translate high level program annotations to the bytecode level. The output format is similar to the format used for source mappings.

### Discussion

This PR is intended as a proof-of-concept. As implemented, this feature has already been useful for Certora's verification tool. However, it is probably not ready to be merged as-is. We would like to start a design discussion around supporting this kind of debugging information in Solidity. Once we have converged on a design, we'll be happy to polish up this PR per the contribution guidelines.

### Unresolved Design Issues

- is it better to use --combined-json or --standard-json?
- is there some way to unify this with `storageLayout`s?
- what would the best output format be?

cc:
@shellygr @wilcoxjay