### PR TITLE
Remove `yul::Instruction`.

### DIFF
--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -43,10 +43,6 @@ public:
 		m_dialect(_dialect),
 		m_reportMutability(_reportMutability) {}
 
-	void operator()(yul::Instruction const& _instruction)
-	{
-		checkInstruction(_instruction.location, _instruction.instruction);
-	}
 	void operator()(yul::Literal const&) {}
 	void operator()(yul::Identifier const&) {}
 	void operator()(yul::ExpressionStatement const& _expr)

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -86,16 +86,6 @@ AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Dialect const& _dialect,
 	return analysisInfo;
 }
 
-bool AsmAnalyzer::operator()(yul::Instruction const& _instruction)
-{
-	yulAssert(false, "The use of non-functional instructions is disallowed. Please use functional notation instead.");
-	auto const& info = instructionInfo(_instruction.instruction);
-	m_stackHeight += info.ret - info.args;
-	m_info.stackHeightInfo[&_instruction] = m_stackHeight;
-	warnOnInstructions(_instruction.instruction, _instruction.location);
-	return true;
-}
-
 bool AsmAnalyzer::operator()(Literal const& _literal)
 {
 	expectValidType(_literal.type.str(), _literal.location);

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -77,7 +77,6 @@ public:
 	/// Asserts on failure.
 	static AsmAnalysisInfo analyzeStrictAssertCorrect(Dialect const& _dialect, Object const& _object);
 
-	bool operator()(Instruction const&);
 	bool operator()(Literal const& _literal);
 	bool operator()(Identifier const&);
 	bool operator()(ExpressionStatement const&);

--- a/libyul/AsmData.h
+++ b/libyul/AsmData.h
@@ -25,12 +25,8 @@
 #include <libyul/AsmDataForward.h>
 #include <libyul/YulString.h>
 
-#include <libevmasm/Instruction.h>
 #include <liblangutil/SourceLocation.h>
 
-#include <boost/noncopyable.hpp>
-
-#include <map>
 #include <memory>
 
 namespace yul
@@ -41,8 +37,6 @@ using Type = YulString;
 struct TypedName { langutil::SourceLocation location; YulString name; Type type; };
 using TypedNameList = std::vector<TypedName>;
 
-/// Direct EVM instruction (except PUSHi and JUMPDEST)
-struct Instruction { langutil::SourceLocation location; dev::eth::Instruction instruction; };
 /// Literal number or string (up to 32 bytes)
 enum class LiteralKind { Number, Boolean, String };
 struct Literal { langutil::SourceLocation location; LiteralKind kind; YulString value; Type type; };

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -29,6 +29,8 @@
 #include <liblangutil/Scanner.h>
 #include <liblangutil/ParserBase.h>
 
+#include <libevmasm/Instruction.h>
+
 #include <memory>
 #include <variant>
 #include <vector>
@@ -56,7 +58,7 @@ public:
 	static std::map<std::string, dev::eth::Instruction> const& instructions();
 
 protected:
-	using ElementaryOperation = std::variant<Instruction, Literal, Identifier, FunctionCall>;
+	using ElementaryOperation = std::variant<Literal, Identifier, FunctionCall>;
 
 	/// Creates an inline assembly node with the given source location.
 	template <class T> T createWithLocation(langutil::SourceLocation const& _loc = {}) const

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -43,7 +43,6 @@ enum class Instruction: uint8_t;
 
 namespace yul
 {
-struct Instruction;
 struct Identifier;
 
 ///

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -350,16 +350,6 @@ void CodeTransform::operator()(Literal const& _literal)
 	checkStackHeight(&_literal);
 }
 
-void CodeTransform::operator()(yul::Instruction const& _instruction)
-{
-	yulAssert(!m_allowStackOpt, "");
-	yulAssert(!m_evm15 || _instruction.instruction != dev::eth::Instruction::JUMP, "Bare JUMP instruction used for EVM1.5");
-	yulAssert(!m_evm15 || _instruction.instruction != dev::eth::Instruction::JUMPI, "Bare JUMPI instruction used for EVM1.5");
-	m_assembly.setSourceLocation(_instruction.location);
-	m_assembly.appendInstruction(_instruction.instruction);
-	checkStackHeight(&_instruction);
-}
-
 void CodeTransform::operator()(If const& _if)
 {
 	visitExpression(*_if.condition);

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -170,7 +170,6 @@ protected:
 	void deleteVariable(Scope::Variable const& _var);
 
 public:
-	void operator()(Instruction const& _instruction);
 	void operator()(Literal const& _literal);
 	void operator()(Identifier const& _identifier);
 	void operator()(FunctionCall const&);


### PR DESCRIPTION
This was a leftover from removing loose assembly.