### PR TITLE
Move scope of Scopable into new ScopableAnnotation

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -639,7 +639,7 @@ void DeclarationRegistrationHelper::endVisit(FunctionDefinition&)
 
 bool DeclarationRegistrationHelper::visit(TryCatchClause& _tryCatchClause)
 {
-	_tryCatchClause.setScope(m_currentScope);
+	_tryCatchClause.annotation().scope = m_currentScope;
 	enterNewSubScope(_tryCatchClause);
 	return true;
 }
@@ -675,7 +675,7 @@ void DeclarationRegistrationHelper::endVisit(FunctionTypeName&)
 
 bool DeclarationRegistrationHelper::visit(Block& _block)
 {
-	_block.setScope(m_currentScope);
+	_block.annotation().scope = m_currentScope;
 	enterNewSubScope(_block);
 	return true;
 }
@@ -687,7 +687,7 @@ void DeclarationRegistrationHelper::endVisit(Block&)
 
 bool DeclarationRegistrationHelper::visit(ForStatement& _for)
 {
-	_for.setScope(m_currentScope);
+	_for.annotation().scope = m_currentScope;
 	enterNewSubScope(_for);
 	return true;
 }
@@ -761,7 +761,7 @@ void DeclarationRegistrationHelper::registerDeclaration(Declaration& _declaratio
 
 	registerDeclaration(*m_scopes[m_currentScope], _declaration, nullptr, nullptr, warnAboutShadowing, inactive, m_errorReporter);
 
-	_declaration.setScope(m_currentScope);
+	_declaration.annotation().scope = m_currentScope;
 	if (_opensScope)
 		enterNewSubScope(_declaration);
 }

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -660,6 +660,27 @@ InlineAssemblyAnnotation& InlineAssembly::annotation() const
 	return dynamic_cast<InlineAssemblyAnnotation&>(*m_annotation);
 }
 
+BlockAnnotation& Block::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = make_unique<BlockAnnotation>();
+	return dynamic_cast<BlockAnnotation&>(*m_annotation);
+}
+
+TryCatchClauseAnnotation& TryCatchClause::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = make_unique<TryCatchClauseAnnotation>();
+	return dynamic_cast<TryCatchClauseAnnotation&>(*m_annotation);
+}
+
+ForStatementAnnotation& ForStatement::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = make_unique<ForStatementAnnotation>();
+	return dynamic_cast<ForStatementAnnotation&>(*m_annotation);
+}
+
 ReturnAnnotation& Return::annotation() const
 {
 	if (!m_annotation)

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -449,6 +449,13 @@ string Scopable::sourceUnitName() const
 	return sourceUnit().annotation().path;
 }
 
+DeclarationAnnotation& Declaration::annotation() const
+{
+	if (!m_annotation)
+		m_annotation = make_unique<DeclarationAnnotation>();
+	return dynamic_cast<DeclarationAnnotation&>(*m_annotation);
+}
+
 bool VariableDeclaration::isLValue() const
 {
 	// Constant declared variables are Read-Only

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1171,6 +1171,8 @@ public:
 
 	std::vector<ASTPointer<Statement>> const& statements() const { return m_statements; }
 
+	BlockAnnotation& annotation() const override;
+
 private:
 	std::vector<ASTPointer<Statement>> m_statements;
 };
@@ -1249,6 +1251,8 @@ public:
 	ASTString const& errorName() const { return *m_errorName; }
 	ParameterList const* parameters() const { return m_parameters.get(); }
 	Block const& block() const { return *m_block; }
+
+	TryCatchClauseAnnotation& annotation() const override;
 
 private:
 	ASTPointer<ASTString> m_errorName;
@@ -1358,6 +1362,8 @@ public:
 	Expression const* condition() const { return m_condExpression.get(); }
 	ExpressionStatement const* loopExpression() const { return m_loopExpression.get(); }
 	Statement const& body() const { return *m_body; }
+
+	ForStatementAnnotation& annotation() const override;
 
 private:
 	/// For statement's initialization expression. for (XXX; ; ). Can be empty

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -159,8 +159,7 @@ public:
 	virtual ~Scopable() = default;
 	/// @returns the scope this declaration resides in. Can be nullptr if it is the global scope.
 	/// Available only after name and type resolution step.
-	ASTNode const* scope() const { return m_scope; }
-	void setScope(ASTNode const* _scope) { m_scope = _scope; }
+	ASTNode const* scope() const { return annotation().scope; }
 
 	/// @returns the source unit this scopable is present in.
 	SourceUnit const& sourceUnit() const;
@@ -172,8 +171,7 @@ public:
 	/// Can be combined with annotation().canonicalName (if present) to form a globally unique name.
 	std::string sourceUnitName() const;
 
-protected:
-	ASTNode const* m_scope = nullptr;
+	virtual ScopableAnnotation& annotation() const = 0;
 };
 
 /**

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -231,6 +231,8 @@ public:
 	/// @returns null when it is not accessible as a function.
 	virtual FunctionTypePointer functionType(bool /*_internal*/) const { return {}; }
 
+	DeclarationAnnotation& annotation() const override;
+
 protected:
 	virtual Visibility defaultVisibility() const { return Visibility::Public; }
 

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -86,7 +86,7 @@ struct DeclarationAnnotation: ASTAnnotation, ScopableAnnotation
 {
 };
 
-struct ImportAnnotation: ASTAnnotation
+struct ImportAnnotation: DeclarationAnnotation
 {
 	/// The absolute path of the source unit to import.
 	std::string absolutePath;
@@ -94,7 +94,7 @@ struct ImportAnnotation: ASTAnnotation
 	SourceUnit const* sourceUnit = nullptr;
 };
 
-struct TypeDeclarationAnnotation: ASTAnnotation
+struct TypeDeclarationAnnotation: DeclarationAnnotation
 {
 	/// The name of this type, prefixed by proper namespaces if globally accessible.
 	std::string canonicalName;
@@ -115,7 +115,7 @@ struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, DocumentedAnnota
 	std::map<FunctionDefinition const*, ASTNode const*> baseConstructorArguments;
 };
 
-struct CallableDeclarationAnnotation: ASTAnnotation
+struct CallableDeclarationAnnotation: DeclarationAnnotation
 {
 	/// The set of functions/modifiers/events this callable overrides.
 	std::set<CallableDeclaration const*> baseFunctions;
@@ -135,7 +135,7 @@ struct ModifierDefinitionAnnotation: CallableDeclarationAnnotation, DocumentedAn
 {
 };
 
-struct VariableDeclarationAnnotation: ASTAnnotation
+struct VariableDeclarationAnnotation: DeclarationAnnotation
 {
 	/// Type of variable (type of identifier referencing this variable).
 	TypePointer type = nullptr;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -75,6 +75,13 @@ struct SourceUnitAnnotation: ASTAnnotation
 	std::set<ExperimentalFeature> experimentalFeatures;
 };
 
+struct ScopableAnnotation
+{
+	/// The scope this declaration resides in. Can be nullptr if it is the global scope.
+	/// Available only after name and type resolution step.
+	ASTNode const* scope = nullptr;
+};
+
 struct ImportAnnotation: ASTAnnotation
 {
 	/// The absolute path of the source unit to import.

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -163,6 +163,18 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 	std::shared_ptr<yul::AsmAnalysisInfo> analysisInfo;
 };
 
+struct BlockAnnotation: StatementAnnotation, ScopableAnnotation
+{
+};
+
+struct TryCatchClauseAnnotation: ASTAnnotation, ScopableAnnotation
+{
+};
+
+struct ForStatementAnnotation: StatementAnnotation, ScopableAnnotation
+{
+};
+
 struct ReturnAnnotation: StatementAnnotation
 {
 	/// Reference to the return parameters of the function.

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -82,6 +82,10 @@ struct ScopableAnnotation
 	ASTNode const* scope = nullptr;
 };
 
+struct DeclarationAnnotation: ASTAnnotation, ScopableAnnotation
+{
+};
+
 struct ImportAnnotation: ASTAnnotation
 {
 	/// The absolute path of the source unit to import.


### PR DESCRIPTION
### Description

Move scope field from Scopable to annotation. This makes `Scopable` a truly constant class and follows the practice of having mutable state of ASTNodes in the annotations.

This should not change any semantics for consumers that only use `Scopable::scope`.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] ~New tests have been created which fail without the change (if possible)~ N/A
- [x] ~README / documentation was extended, if necessary~ N/A
- [x] ~Changelog entry (if change is visible to the user)~ N/A
- [x] Used meaningful commit messages
