### PR TITLE
Disallow dead positional arguments for (i)soltest

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -117,8 +117,19 @@ bool CommonOptions::parse(int argc, char const* const* argv)
 
 	po::command_line_parser cmdLineParser(argc, argv);
 	cmdLineParser.options(options);
-	po::store(cmdLineParser.run(), arguments);
+	auto parsedOptions = cmdLineParser.run();
+	po::store(parsedOptions, arguments);
 	po::notify(arguments);
+
+	for (auto const& parsedOption: parsedOptions.options)
+		if (parsedOption.position_key >= 0)
+		{
+			std::stringstream errorMessage;
+			errorMessage << "Unrecognized option: ";
+			for (auto const& token: parsedOption.original_tokens)
+				errorMessage << token;
+			throw std::runtime_error(errorMessage.str());
+		}
 
 	return true;
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7718

By the way: ``boost::program_options`` is weird :-).