### PR TITLE
Add a new Function Type referring to FunctionDefinition's without calling context and use it to allow selector lookup.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.6.2 (unreleased)
 
 Language Features:
+ * Allow accessing external functions via contract and interface names to obtain their selector.
 
 
 Compiler Features:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1691,6 +1691,16 @@ void TypeChecker::typeCheckFunctionCall(
 	solAssert(!!_functionType, "");
 	solAssert(_functionType->kind() != FunctionType::Kind::ABIDecode, "");
 
+	if (_functionType->kind() == FunctionType::Kind::Declaration)
+	{
+		m_errorReporter.typeError(
+			_functionCall.location(),
+			"Cannot call function via contract name."
+		);
+		return;
+	}
+
+
 	// Check for unsupported use of bare static call
 	if (
 		_functionType->kind() == FunctionType::Kind::BareStaticCall &&

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -203,7 +203,7 @@ vector<pair<util::FixedHash<4>, FunctionTypePointer>> const& ContractDefinition:
 			vector<FunctionTypePointer> functions;
 			for (FunctionDefinition const* f: contract->definedFunctions())
 				if (f->isPartOfExternalInterface())
-					functions.push_back(TypeProvider::function(*f, false));
+					functions.push_back(TypeProvider::function(*f, FunctionType::Kind::External));
 			for (VariableDeclaration const* v: contract->stateVariables())
 				if (v->isPartOfExternalInterface())
 					functions.push_back(TypeProvider::function(*v));
@@ -333,7 +333,7 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 		case Visibility::Private:
 		case Visibility::Internal:
 		case Visibility::Public:
-			return TypeProvider::function(*this, _internal);
+			return TypeProvider::function(*this, FunctionType::Kind::Internal);
 		case Visibility::External:
 			return {};
 		}
@@ -349,7 +349,7 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 			return {};
 		case Visibility::Public:
 		case Visibility::External:
-			return TypeProvider::function(*this, _internal);
+			return TypeProvider::function(*this, FunctionType::Kind::External);
 		}
 	}
 
@@ -360,7 +360,7 @@ FunctionTypePointer FunctionDefinition::functionType(bool _internal) const
 TypePointer FunctionDefinition::type() const
 {
 	solAssert(visibility() != Visibility::External, "");
-	return TypeProvider::function(*this);
+	return TypeProvider::function(*this, FunctionType::Kind::Internal);
 }
 
 string FunctionDefinition::externalSignature() const

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -414,9 +414,9 @@ ReferenceType const* TypeProvider::withLocation(ReferenceType const* _type, Data
 	return static_cast<ReferenceType const*>(instance().m_generalTypes.back().get());
 }
 
-FunctionType const* TypeProvider::function(FunctionDefinition const& _function, bool _isInternal)
+FunctionType const* TypeProvider::function(FunctionDefinition const& _function, FunctionType::Kind _kind)
 {
-	return createAndGet<FunctionType>(_function, _isInternal);
+	return createAndGet<FunctionType>(_function, _kind);
 }
 
 FunctionType const* TypeProvider::function(VariableDeclaration const& _varDecl)

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -120,8 +120,8 @@ public:
 		return _type;
 	}
 
-	/// @returns the internally-facing or externally-facing type of a function.
-	static FunctionType const* function(FunctionDefinition const& _function, bool _isInternal = true);
+	/// @returns the internally-facing or externally-facing type of a function or the type of a function declaration.
+	static FunctionType const* function(FunctionDefinition const& _function, FunctionType::Kind _kind = FunctionType::Kind::Declaration);
 
 	/// @returns the accessor function type of a state variable.
 	static FunctionType const* function(VariableDeclaration const& _varDecl);

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1051,11 +1051,16 @@ public:
 		ABIEncodeWithSignature,
 		ABIDecode,
 		GasLeft, ///< gasleft()
-		MetaType ///< type(...)
+		MetaType, ///< type(...)
+		/// Refers to a function declaration without calling context
+		/// (i.e. when accessed directly via the name of the containing contract).
+		/// Cannot be called.
+		Declaration
 	};
 
 	/// Creates the type of a function.
-	explicit FunctionType(FunctionDefinition const& _function, bool _isInternal = true);
+	/// @arg _kind must be Kind::Internal, Kind::External or Kind::Declaration.
+	explicit FunctionType(FunctionDefinition const& _function, Kind _kind = Kind::Declaration);
 	/// Creates the accessor function type of a state variable.
 	explicit FunctionType(VariableDeclaration const& _varDecl);
 	/// Creates the function type of an event.
@@ -1066,7 +1071,7 @@ public:
 	FunctionType(
 		strings const& _parameterTypes,
 		strings const& _returnParameterTypes,
-		Kind _kind = Kind::Internal,
+		Kind _kind,
 		bool _arbitraryParameters = false,
 		StateMutability _stateMutability = StateMutability::NonPayable
 	): FunctionType(

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -550,6 +550,9 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 			solAssert(function.kind() == FunctionType::Kind::DelegateCall || function.kind() == FunctionType::Kind::Internal, "");
 		switch (function.kind())
 		{
+		case FunctionType::Kind::Declaration:
+			solAssert(false, "Attempted to generate code for calling a function definition.");
+			break;
 		case FunctionType::Kind::Internal:
 		{
 			// Calling convention: Caller pushes return address and arguments
@@ -1289,14 +1292,22 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			_memberAccess.expression().accept(*this);
 		return false;
 	}
-	// Another special case for `this.f.selector` which does not need the address.
-	// There are other uses of `.selector` which do need the address, but we want this
-	// specific use to be a pure expression.
+	// Another special case for `this.f.selector` and for ``C.f.selector`` which do not need the address.
+	// There are other uses of `.selector` which do need the address, but we want these
+	// specific uses to be pure expressions.
 	if (
-		_memberAccess.expression().annotation().type->category() == Type::Category::Function &&
-		member == "selector"
+		auto const* functionType = dynamic_cast<FunctionType const*>(_memberAccess.expression().annotation().type);
+		functionType && member == "selector"
 	)
-		if (auto const* expr = dynamic_cast<MemberAccess const*>(&_memberAccess.expression()))
+	{
+		if (functionType->kind() == FunctionType::Kind::Declaration)
+		{
+			m_context << functionType->externalIdentifier();
+			/// need to store it as bytes4
+			utils().leftShiftNumberOnStack(224);
+			return false;
+		}
+		else if (auto const* expr = dynamic_cast<MemberAccess const*>(&_memberAccess.expression()))
 			if (auto const* exprInt = dynamic_cast<Identifier const*>(&expr->expression()))
 				if (exprInt->name() == "this")
 					if (Declaration const* declaration = expr->annotation().referencedDeclaration)
@@ -1313,6 +1324,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 						utils().leftShiftNumberOnStack(224);
 						return false;
 					}
+	}
 	// Another special case for `address(this).balance`. Post-Istanbul, we can use the selfbalance
 	// opcode.
 	if (

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -75,7 +75,7 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 	}
 	if (_contractDef.constructor())
 	{
-		FunctionType constrType(*_contractDef.constructor(), false);
+		FunctionType constrType(*_contractDef.constructor());
 		FunctionType const* externalFunctionType = constrType.interfaceFunctionType();
 		solAssert(!!externalFunctionType, "");
 		Json::Value method;
@@ -92,7 +92,7 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 	for (auto const* fallbackOrReceive: {_contractDef.fallbackFunction(), _contractDef.receiveFunction()})
 		if (fallbackOrReceive)
 		{
-			FunctionType const* externalFunctionType = FunctionType(*fallbackOrReceive, false).interfaceFunctionType();
+			auto const* externalFunctionType = FunctionType(*fallbackOrReceive).interfaceFunctionType();
 			solAssert(!!externalFunctionType, "");
 			Json::Value method;
 			method["type"] = TokenTraits::toString(fallbackOrReceive->kind());

--- a/test/libsolidity/semanticTests/functionSelector/function_selector_via_contract_name.sol
+++ b/test/libsolidity/semanticTests/functionSelector/function_selector_via_contract_name.sol
@@ -1,0 +1,20 @@
+contract A {
+    function f() external {}
+    function g(uint256) external {}
+}
+contract B {
+    function f() external returns (uint256) {}
+    function g(uint256) external returns (uint256) {}
+}
+contract C {
+    function test1() external returns(bytes4, bytes4, bytes4, bytes4) {
+        return (A.f.selector, A.g.selector, B.f.selector, B.g.selector);
+    }
+    function test2() external returns(bytes4, bytes4, bytes4, bytes4) {
+        A a; B b;
+        return (a.f.selector, a.g.selector, b.f.selector, b.g.selector);
+    }
+}
+// ----
+// test1() -> left(0x26121ff0), left(0xe420264a), left(0x26121ff0), left(0xe420264a)
+// test2() -> left(0x26121ff0), left(0xe420264a), left(0x26121ff0), left(0xe420264a)

--- a/test/libsolidity/syntaxTests/types/function_types/definition/assign_function_via_contract_name_to_var.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/assign_function_via_contract_name_to_var.sol
@@ -1,0 +1,14 @@
+contract A {
+    function f() external {}
+    function g() external pure {}
+}
+
+contract B {
+    function h() external {
+        function() external f = A.f;
+        function() external pure g = A.g;
+    }
+}
+// ----
+// TypeError: (128-155): Type function A.f() is not implicitly convertible to expected type function () external.
+// TypeError: (165-197): Type function A.g() pure is not implicitly convertible to expected type function () pure external.

--- a/test/libsolidity/syntaxTests/types/function_types/definition/call_function_via_contract_name.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/call_function_via_contract_name.sol
@@ -1,0 +1,17 @@
+contract A {
+    function f() external {}
+    function g() external pure {}
+    function h() public pure {}
+}
+
+contract B {
+    function i() external {
+        A.f();
+        A.g();
+        A.h(); // might be allowed in the future
+    }
+}
+// ----
+// TypeError: (160-165): Cannot call function via contract name.
+// TypeError: (175-180): Cannot call function via contract name.
+// TypeError: (190-195): Cannot call function via contract name.

--- a/test/libsolidity/syntaxTests/types/function_types/definition/function_selector_via_contract_name.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/function_selector_via_contract_name.sol
@@ -1,0 +1,9 @@
+contract A {
+    function f() external {}
+}
+
+contract B {
+    function g() external pure {
+        A.f.selector;
+    }
+}

--- a/test/libsolidity/syntaxTests/types/function_types/definition/function_selector_via_interface_name.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/function_selector_via_interface_name.sol
@@ -1,0 +1,9 @@
+interface I {
+    function f() external;
+}
+
+contract B {
+    function g() external pure {
+        I.f.selector;
+    }
+}

--- a/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_internal.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_internal.sol
@@ -1,0 +1,11 @@
+contract A {
+    function f() internal {}
+}
+
+contract B {
+    function g() external {
+        A.f;
+    }
+}
+// ----
+// TypeError: (94-97): Member "f" not found or not visible after argument-dependent lookup in type(contract A).

--- a/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_overloaded.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_overloaded.sol
@@ -1,0 +1,12 @@
+contract A {
+    function f() external {}
+    function f(uint256) external {}
+}
+
+contract B {
+    function g() external {
+        A.f;
+    }
+}
+// ----
+// TypeError: (130-133): Member "f" not unique after argument-dependent lookup in type(contract A).

--- a/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_private.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_private.sol
@@ -1,0 +1,11 @@
+contract A {
+    function f() private {}
+}
+
+contract B {
+    function g() external {
+        A.f;
+    }
+}
+// ----
+// TypeError: (93-96): Member "f" not found or not visible after argument-dependent lookup in type(contract A).

--- a/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_public.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/definition/function_via_contract_name_public.sol
@@ -1,0 +1,9 @@
+contract A {
+    function f() public {}
+}
+
+contract B {
+    function g() external pure {
+        A.f.selector;
+    }
+}


### PR DESCRIPTION
This is probably easiest to review commit by commit.
I first remove the defaulted ``_isInternal`` bool used to construct function types and replace it by an explicit ``kind`` argument, while reproducing the exact same behaviour as before.

Then I add the new ``Definition`` Kind and make it the default instead. So far if function types were needed without an actual calling context, the kind was "Internal" - now it is "Definition", which I'd say makes more sense.

Then finally I added all externally visible functions with kind "definition" as members to the contract TypeType and added appropriate assertions and type checks. Those members themselves for now can only be used for selector lookup with their "selector" members.

This partly fixes https://github.com/ethereum/solidity/issues/3506 and is related to https://github.com/ethereum/solidity/pull/7987.
What is missing is proper handling of base contracts, which is what https://github.com/ethereum/solidity/pull/7987 tried to do, but which will be easier on top of this (as discussed with @Marenz).
