### PR TITLE
Move ContractKind from ContractDefinition to file-scope

### DIFF
--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -208,18 +208,18 @@ void ContractLevelChecker::checkAbstractFunctions(ContractDefinition const& _con
 
 	if (_contract.abstract())
 	{
-		if (_contract.contractKind() == ContractDefinition::ContractKind::Interface)
+		if (_contract.contractKind() == ContractKind::Interface)
 			m_errorReporter.typeError(_contract.location(), "Interfaces do not need the \"abstract\" keyword, they are abstract implicitly.");
-		else if (_contract.contractKind() == ContractDefinition::ContractKind::Library)
+		else if (_contract.contractKind() == ContractKind::Library)
 			m_errorReporter.typeError(_contract.location(), "Libraries cannot be abstract.");
 		else
-			solAssert(_contract.contractKind() == ContractDefinition::ContractKind::Contract, "");
+			solAssert(_contract.contractKind() == ContractKind::Contract, "");
 	}
 
 	// For libraries, we emit errors on function-level, so this is fine as long as we do
 	// not have inheritance for libraries.
 	if (
-		_contract.contractKind() == ContractDefinition::ContractKind::Contract &&
+		_contract.contractKind() == ContractKind::Contract &&
 		!_contract.abstract() &&
 		!_contract.annotation().unimplementedFunctions.empty()
 	)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -326,7 +326,7 @@ bool TypeChecker::visit(StructDefinition const& _struct)
 
 bool TypeChecker::visit(FunctionDefinition const& _function)
 {
-	bool isLibraryFunction = _function.inContractKind() == ContractDefinition::ContractKind::Library;
+	bool isLibraryFunction = _function.inContractKind() == ContractKind::Library;
 
 	if (_function.markedVirtual())
 	{
@@ -425,7 +425,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		if (_function.isConstructor())
 			m_errorReporter.typeError(_function.location(), "Constructor cannot be defined in interfaces.");
 	}
-	else if (m_scope->contractKind() == ContractDefinition::ContractKind::Library)
+	else if (m_scope->contractKind() == ContractKind::Library)
 		if (_function.isConstructor())
 			m_errorReporter.typeError(_function.location(), "Constructor cannot be defined in libraries.");
 	if (_function.isImplemented())
@@ -1733,7 +1733,7 @@ void TypeChecker::typeCheckFallbackFunction(FunctionDefinition const& _function)
 {
 	solAssert(_function.isFallback(), "");
 
-	if (_function.inContractKind() == ContractDefinition::ContractKind::Library)
+	if (_function.inContractKind() == ContractKind::Library)
 		m_errorReporter.typeError(_function.location(), "Libraries cannot have fallback functions.");
 	if (_function.stateMutability() != StateMutability::NonPayable && _function.stateMutability() != StateMutability::Payable)
 		m_errorReporter.typeError(
@@ -1759,7 +1759,7 @@ void TypeChecker::typeCheckReceiveFunction(FunctionDefinition const& _function)
 {
 	solAssert(_function.isReceive(), "");
 
-	if (_function.inContractKind() == ContractDefinition::ContractKind::Library)
+	if (_function.inContractKind() == ContractKind::Library)
 		m_errorReporter.typeError(_function.location(), "Libraries cannot have receive ether functions.");
 
 	if (_function.stateMutability() != StateMutability::Payable)

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -272,7 +272,7 @@ void ViewPureChecker::reportMutability(
 	{
 		// We do not warn for library functions because they cannot be payable anyway.
 		// Also internal functions should be allowed to use `msg.value`.
-		if (m_currentFunction->isPublic() && m_currentFunction->inContractKind() != ContractDefinition::ContractKind::Library)
+		if (m_currentFunction->isPublic() && m_currentFunction->inContractKind() != ContractKind::Library)
 		{
 			if (_nestedLocation)
 				m_errorReporter.typeError(

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -305,7 +305,7 @@ TypeDeclarationAnnotation& EnumDefinition::annotation() const
 	return dynamic_cast<TypeDeclarationAnnotation&>(*m_annotation);
 }
 
-ContractDefinition::ContractKind FunctionDefinition::inContractKind() const
+ContractKind FunctionDefinition::inContractKind() const
 {
 	auto contractDef = dynamic_cast<ContractDefinition const*>(scope());
 	solAssert(contractDef, "Enclosing Scope of FunctionDefinition was not set.");

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -378,8 +378,6 @@ protected:
 class ContractDefinition: public Declaration, public Documented
 {
 public:
-	enum class ContractKind { Interface, Contract, Library };
-
 	ContractDefinition(
 		SourceLocation const& _location,
 		ASTPointer<ASTString> const& _name,
@@ -711,7 +709,7 @@ public:
 	/// @returns the external identifier of this function (the hash of the signature) as a hex string.
 	std::string externalIdentifierHex() const;
 
-	ContractDefinition::ContractKind inContractKind() const;
+	ContractKind inContractKind() const;
 
 	TypePointer type() const override;
 

--- a/libsolidity/ast/ASTEnums.h
+++ b/libsolidity/ast/ASTEnums.h
@@ -69,5 +69,7 @@ struct FuncCallArguments
 	bool hasNamedArguments() const { return !names.empty(); }
 };
 
+enum class ContractKind { Interface, Contract, Library };
+
 }
 }

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -834,15 +834,15 @@ string ASTJsonConverter::location(VariableDeclaration::Location _location)
 	return {};
 }
 
-string ASTJsonConverter::contractKind(ContractDefinition::ContractKind _kind)
+string ASTJsonConverter::contractKind(ContractKind _kind)
 {
 	switch (_kind)
 	{
-	case ContractDefinition::ContractKind::Interface:
+	case ContractKind::Interface:
 		return "interface";
-	case ContractDefinition::ContractKind::Contract:
+	case ContractKind::Contract:
 		return "contract";
-	case ContractDefinition::ContractKind::Library:
+	case ContractKind::Library:
 		return "library";
 	}
 

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -147,7 +147,7 @@ private:
 	}
 	Json::Value inlineAssemblyIdentifierToJson(std::pair<yul::Identifier const* , InlineAssemblyAnnotation::ExternalIdentifierInfo> _info) const;
 	static std::string location(VariableDeclaration::Location _location);
-	static std::string contractKind(ContractDefinition::ContractKind _kind);
+	static std::string contractKind(ContractKind _kind);
 	static std::string functionCallKind(FunctionCallKind _kind);
 	static std::string literalTokenKind(Token _token);
 	static std::string type(Expression const& _expression);

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -245,9 +245,9 @@ ASTPointer<ImportDirective> Parser::parseImportDirective()
 	return nodeFactory.createNode<ImportDirective>(path, unitAlias, move(symbolAliases));
 }
 
-std::pair<ContractDefinition::ContractKind, bool> Parser::parseContractKind()
+std::pair<ContractKind, bool> Parser::parseContractKind()
 {
-	ContractDefinition::ContractKind kind;
+	ContractKind kind;
 	bool abstract = false;
 	if (m_scanner->currentToken() == Token::Abstract)
 	{
@@ -257,13 +257,13 @@ std::pair<ContractDefinition::ContractKind, bool> Parser::parseContractKind()
 	switch (m_scanner->currentToken())
 	{
 	case Token::Interface:
-		kind = ContractDefinition::ContractKind::Interface;
+		kind = ContractKind::Interface;
 		break;
 	case Token::Contract:
-		kind = ContractDefinition::ContractKind::Contract;
+		kind = ContractKind::Contract;
 		break;
 	case Token::Library:
-		kind = ContractDefinition::ContractKind::Library;
+		kind = ContractKind::Library;
 		break;
 	default:
 		solAssert(false, "Invalid contract kind.");
@@ -280,7 +280,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 	ASTPointer<ASTString> docString;
 	vector<ASTPointer<InheritanceSpecifier>> baseContracts;
 	vector<ASTPointer<ASTNode>> subNodes;
-	std::pair<ContractDefinition::ContractKind, bool> contractKind{};
+	std::pair<ContractKind, bool> contractKind{};
 	try
 	{
 		if (m_scanner->currentCommentLiteral() != "")

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -84,9 +84,9 @@ private:
 	void parsePragmaVersion(langutil::SourceLocation const& _location, std::vector<Token> const& _tokens, std::vector<std::string> const& _literals);
 	ASTPointer<PragmaDirective> parsePragmaDirective();
 	ASTPointer<ImportDirective> parseImportDirective();
-	/// @returns an std::pair<ContractDefinition::ContractKind, bool>, where
+	/// @returns an std::pair<ContractKind, bool>, where
 	/// result.second is set to true, if an abstract contract was parsed, false otherwise.
-	std::pair<ContractDefinition::ContractKind, bool> parseContractKind();
+	std::pair<ContractKind, bool> parseContractKind();
 	ASTPointer<ContractDefinition> parseContractDefinition();
 	ASTPointer<InheritanceSpecifier> parseInheritanceSpecifier();
 	Visibility parseVisibilitySpecifier();

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 	TypePointer multiArray = TypeProvider::array(DataLocation::Storage, stringArray);
 	BOOST_CHECK_EQUAL(multiArray->identifier(), "t_array$_t_array$_t_string_storage_$20_storage_$dyn_storage_ptr");
 
-	ContractDefinition c(SourceLocation{}, make_shared<string>("MyContract$"), {}, {}, {}, ContractDefinition::ContractKind::Contract);
+	ContractDefinition c(SourceLocation{}, make_shared<string>("MyContract$"), {}, {}, {}, ContractKind::Contract);
 	BOOST_CHECK_EQUAL(c.type()->identifier(), "t_type$_t_contract$_MyContract$$$_$2_$");
 	BOOST_CHECK_EQUAL(ContractType(c, true).identifier(), "t_super$_MyContract$$$_$2");
 


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

The enum is very simple, so there should be little to no impact on compile times, and unlikely to change much, so there should be no impact on incremental builds.

This allows using `ContractKind` in more places. This need was found during #8091.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
