### PR TITLE
Replace void cast by maybe_unused

### DIFF
--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -211,7 +211,7 @@ public:
 	/// Always returns a value greater than zero and throws if the type cannot be encoded in calldata
 	/// (or is dynamically encoded).
 	/// If @a _padded then it is assumed that each element is padded to a multiple of 32 bytes.
-	virtual unsigned calldataEncodedSize(bool _padded) const { (void)_padded; solAssert(false, ""); }
+	virtual unsigned calldataEncodedSize([[maybe_unused]] bool _padded) const { solAssert(false, ""); }
 	/// Convenience version of @see calldataEncodedSize(bool)
 	unsigned calldataEncodedSize() const { return calldataEncodedSize(true); }
 	/// @returns the distance between two elements of this type in a calldata array, tuple or struct.
@@ -1432,7 +1432,7 @@ public:
 	BoolResult isImplicitlyConvertibleTo(Type const&) const override { return false; }
 	BoolResult isExplicitlyConvertibleTo(Type const&) const override { return false; }
 	TypeResult binaryOperatorResult(Token, Type const*) const override { return nullptr; }
-	unsigned calldataEncodedSize(bool _padded) const override { (void)_padded; return 32; }
+	unsigned calldataEncodedSize(bool) const override { return 32; }
 	bool canBeStored() const override { return false; }
 	bool canLiveOutsideStorage() const override { return false; }
 	bool isValueType() const override { return true; }

--- a/libsolidity/formal/SMTPortfolio.cpp
+++ b/libsolidity/formal/SMTPortfolio.cpp
@@ -34,7 +34,7 @@ using namespace solidity::frontend::smt;
 SMTPortfolio::SMTPortfolio(
 	map<h256, string> const& _smtlib2Responses,
 	ReadCallback::Callback const& _smtCallback,
-	SMTSolverChoice _enabledSolvers
+	[[maybe_unused]] SMTSolverChoice _enabledSolvers
 )
 {
 	m_solvers.emplace_back(make_unique<smt::SMTLib2Interface>(_smtlib2Responses, _smtCallback));
@@ -46,7 +46,6 @@ SMTPortfolio::SMTPortfolio(
 	if (_enabledSolvers.cvc4)
 		m_solvers.emplace_back(make_unique<smt::CVC4Interface>());
 #endif
-	(void)_enabledSolvers;
 }
 
 void SMTPortfolio::reset()

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -554,8 +554,7 @@ bool Parser::isValidNumberLiteral(string const& _literal)
 	try
 	{
 		// Try to convert _literal to u256.
-		auto tmp = u256(_literal);
-		(void) tmp;
+		[[maybe_unused]] auto tmp = u256(_literal);
 	}
 	catch (...)
 	{


### PR DESCRIPTION
The upstream version
https://github.com/okdshin/PicoSHA2/blob/b699e6c900be6e00152db5a3d123c1db42ea13d0/picosha2.h#L93
updated the use of `last` which was unused.
Updated that and some other `maybe_unused` cases.