### PR TITLE
Handle empty source strings in SourceReferenceExtractor

### DIFF
--- a/liblangutil/SourceReferenceExtractor.cpp
+++ b/liblangutil/SourceReferenceExtractor.cpp
@@ -46,6 +46,9 @@ SourceReference SourceReferenceExtractor::extract(SourceLocation const* _locatio
 	if (!_location || !_location->source.get()) // Nothing we can extract here
 		return SourceReference::MessageOnly(std::move(message));
 
+	if (_location->source->source().empty()) // No source text, so we can only extract the source name
+		return SourceReference::MessageOnly(std::move(message), _location->source->name());
+
 	shared_ptr<CharStream> const& source = _location->source;
 
 	LineColumn const interest = source->translatePositionToLineColumn(_location->start);

--- a/liblangutil/SourceReferenceExtractor.h
+++ b/liblangutil/SourceReferenceExtractor.h
@@ -49,10 +49,11 @@ struct SourceReference
 	int endColumn = {-1};     ///< Highlighting range-end of text field.
 
 	/// Constructs a SourceReference containing a message only.
-	static SourceReference MessageOnly(std::string _msg)
+	static SourceReference MessageOnly(std::string _msg, std::string _sourceName = {})
 	{
 		SourceReference sref;
 		sref.message = std::move(_msg);
+		sref.sourceName = std::move(_sourceName);
 		return sref;
 	}
 };


### PR DESCRIPTION
This may or may not be needed for proper reporting in https://github.com/ethereum/solidity/pull/7153
But I think it's generally a good idea to have some safe-guards for handling cases like this gracefully.