### PR TITLE
Ignore empty options to (i)soltest

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -122,6 +122,11 @@ bool CommonOptions::parse(int argc, char const* const* argv)
 	for (auto const& parsedOption: parsedOptions.options)
 		if (parsedOption.position_key >= 0)
 		{
+			if (
+				parsedOption.original_tokens.empty() ||
+				(parsedOption.original_tokens.size() == 1 && parsedOption.original_tokens.front().empty())
+			)
+				continue; // ignore empty options
 			std::stringstream errorMessage;
 			errorMessage << "Unrecognized option: ";
 			for (auto const& token: parsedOption.original_tokens)


### PR DESCRIPTION
Follow-up for https://github.com/ethereum/solidity/pull/8100/

``scripts/tests.sh`` passes ``"$optimize"`` to ``soltest``, which ends up being an empty positional argument in ``boost::program_options`` - and all unrecognized positional arguments were turned into errors in https://github.com/ethereum/solidity/pull/8100/.
This PR makes an exception for empty ones.

[still thinking ``boost::program_options`` is weird ;-)]