### PR TITLE
Implement language server (LSP) using new tool solls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ include(EthCcache)
 
 # Let's find our dependencies
 include(EthDependencies)
+include(fmtlib)
 include(jsoncpp)
 include(range-v3)
 include_directories(SYSTEM ${JSONCPP_INCLUDE_DIR})

--- a/cmake/fmtlib.cmake
+++ b/cmake/fmtlib.cmake
@@ -1,0 +1,31 @@
+include(ExternalProject)
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+	set(FMTLIB_CMAKE_COMMAND emcmake cmake)
+else()
+	set(FMTLIB_CMAKE_COMMAND ${CMAKE_COMMAND})
+endif()
+
+set(3rdparty_fmtlib_VERSION "7.1.3" CACHE STRING "fmtlib version")
+set(3rdparty_fmtlib_CHECKSUM "SHA256=5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc" CACHE STRING "fmtlib checksum")
+set(3rdparty_fmtlib_URL "https://github.com/fmtlib/fmt/archive/refs/tags/${3rdparty_fmtlib_VERSION}.tar.gz")
+
+include(FetchContent)
+
+FetchContent_Declare(
+	fmtlib
+	PREFIX "${CMAKE_BINARY_DIR}/deps"
+	URL "${3rdparty_fmtlib_URL}"
+	URL_HASH "${3rdparty_fmtlib_CHECKSUM}"
+	DOWNLOAD_NAME "fmtlib-${3rdparty_fmtlib_VERSION}.tar.gz"
+)
+
+if(CMAKE_VERSION VERSION_LESS "3.14.0")
+	FetchContent_GetProperties(fmtlib)
+	if(NOT fmtlib_POPULATED)
+	  FetchContent_Populate(fmtlib)
+	  add_subdirectory(${fmtlib_SOURCE_DIR} ${fmtlib_BINARY_DIR})
+	endif()
+else()
+	FetchContent_MakeAvailable(fmtlib)
+endif()

--- a/liblangutil/CharStream.cpp
+++ b/liblangutil/CharStream.cpp
@@ -118,3 +118,31 @@ tuple<int, int> CharStream::translatePositionToLineColumn(int _position) const
 	}
 	return tuple<int, int>(lineNumber, searchPosition - lineStart);
 }
+
+// @p _line and @p _column should be 1-based, because it's not an index but a line/column number.
+optional<int> CharStream::translateLineColumnToPosition(int _line, int _column) const
+{
+	return translateLineColumnToPosition(m_source, _line, _column);
+}
+
+optional<int> CharStream::translateLineColumnToPosition(std::string const& _text, int _line, int _column)
+{
+	size_t offset = 0;
+
+	while (_line > 0)
+	{
+		if (auto const found = _text.find('\n', offset); found != _text.npos)
+		{
+			offset = found + 1;
+			_line--;
+		}
+		else
+			return nullopt;
+	}
+
+	if (offset + size_t(_column) >= _text.size())
+		return nullopt;
+
+	return int(offset) + _column;
+}
+

--- a/liblangutil/CharStream.h
+++ b/liblangutil/CharStream.h
@@ -53,6 +53,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -95,8 +96,15 @@ public:
 	/// Functions that help pretty-printing parse errors
 	/// Do only use in error cases, they are quite expensive.
 	std::string lineAtPosition(int _position) const;
+
+	/// @returns (1-based) line and column that matches to the byte offset @p _position.
 	std::tuple<int, int> translatePositionToLineColumn(int _position) const;
 	///@}
+
+	/// Translates a line:column to the absolute position.
+	std::optional<int> translateLineColumnToPosition(int _line, int _column) const;
+
+	static std::optional<int> translateLineColumnToPosition(std::string const& _text, int _line, int _column);
 
 	/// Tests whether or not given octet sequence is present at the current position in stream.
 	/// @returns true if the sequence could be found, false otherwise.

--- a/liblangutil/SourceLocation.h
+++ b/liblangutil/SourceLocation.h
@@ -62,6 +62,13 @@ struct SourceLocation
 		return start <= _other.start && _other.end <= end;
 	}
 
+	inline bool contains(int _pos) const
+	{
+		if (!source)
+			return false;
+		return start <= _pos && _pos < end;
+	}
+
 	inline bool intersects(SourceLocation const& _other) const
 	{
 		if (!hasText() || !_other.hasText() || source.get() != _other.source.get())

--- a/liblangutil/SourceReferenceExtractor.h
+++ b/liblangutil/SourceReferenceExtractor.h
@@ -35,6 +35,7 @@ struct LineColumn
 
 	LineColumn() = default;
 	LineColumn(std::tuple<int, int> const& _t): line{std::get<0>(_t)}, column{std::get<1>(_t)} {}
+	LineColumn(int _line, int _column): line{_line}, column{_column} {}
 };
 
 struct SourceReference

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -149,6 +149,12 @@ set(sources
 	interface/StorageLayout.h
 	interface/Version.cpp
 	interface/Version.h
+	lsp/LanguageServer.cpp
+	lsp/LanguageServer.h
+	lsp/ReferenceCollector.cpp
+	lsp/ReferenceCollector.h
+	lsp/Transport.cpp
+	lsp/Transport.h
 	parsing/DocStringParser.cpp
 	parsing/DocStringParser.h
 	parsing/Parser.cpp

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -157,4 +157,4 @@ set(sources
 )
 
 add_library(solidity ${sources})
-target_link_libraries(solidity PUBLIC yul evmasm langutil smtutil solutil Boost::boost)
+target_link_libraries(solidity PUBLIC yul evmasm langutil smtutil solutil Boost::boost fmt::fmt-header-only)

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -241,7 +241,10 @@ public:
 
 	/// @returns the declared name.
 	ASTString const& name() const { return *m_name; }
+
+	/// @returns the location of the declared name itself or empty location if not available or unknown.
 	SourceLocation const& nameLocation() const noexcept { return m_nameLocation; }
+
 	bool noVisibilitySpecified() const { return m_visibility == Visibility::Default; }
 	Visibility visibility() const { return m_visibility == Visibility::Default ? defaultVisibility() : m_visibility; }
 	bool isPublic() const { return visibility() >= Visibility::Public; }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1443,7 +1443,7 @@ CompilerStack::Source const& CompilerStack::source(string const& _sourceName) co
 {
 	auto it = m_sources.find(_sourceName);
 	if (it == m_sources.end())
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Given source file not found."));
+		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Given source file not found. " + _sourceName));
 
 	return it->second;
 }

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -73,7 +73,7 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 			return ReadCallback::Result{false, "File outside of allowed directories."};
 
 		if (!boost::filesystem::exists(canonicalPath))
-			return ReadCallback::Result{false, "File not found."};
+			return ReadCallback::Result{false, "File not found: " + canonicalPath.generic_string()};
 
 		if (!boost::filesystem::is_regular_file(canonicalPath))
 			return ReadCallback::Result{false, "Not a valid file."};

--- a/libsolidity/lsp/LSPTypes.h
+++ b/libsolidity/lsp/LSPTypes.h
@@ -1,0 +1,74 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <liblangutil/SourceLocation.h>
+#include <liblangutil/SourceReferenceExtractor.h> // LineColumn
+
+#include <optional>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace solidity::lsp
+{
+
+struct LineColumnRange
+{
+	langutil::LineColumn start;
+	langutil::LineColumn end;
+};
+
+enum class Trace { Off, Messages, Verbose };
+
+struct DocumentPosition {
+	std::string path;
+	langutil::LineColumn position;
+};
+
+enum class DocumentHighlightKind {
+	Unspecified,
+	Text,           //!< a textual occurrence
+	Read,           //!< read access to a variable
+	Write,          //!< write access to a variable
+};
+
+// Represents a symbol / AST node that is to be highlighted, with some context associated.
+struct DocumentHighlight {
+	langutil::SourceLocation location;
+	// std::string sourceName;
+	// LineColumnRange range;
+	DocumentHighlightKind kind = DocumentHighlightKind::Unspecified;
+};
+
+enum class DiagnosticSeverity {
+	Error = 1,
+	Warning = 2,
+	Information = 3,
+	Hint = 4,
+};
+
+/// Represents a related message and source code location for a diagnostic. This should be
+/// used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+/// a symbol in a scope.
+struct DiagnosticRelatedInformation {
+	langutil::SourceLocation location;   // The location of this related diagnostic information.
+	std::string message; // The message of this related diagnostic information.
+};
+
+}

--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -1,0 +1,956 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/interface/ReadFile.h>
+#include <libsolidity/lsp/LanguageServer.h>
+#include <libsolidity/lsp/ReferenceCollector.h>
+
+#include <liblangutil/SourceReferenceExtractor.h>
+#include <liblangutil/CharStream.h>
+
+#include <libsolutil/Visitor.h>
+#include <libsolutil/JSON.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <ostream>
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace std::placeholders;
+
+using namespace solidity::langutil;
+using namespace solidity::frontend;
+
+namespace solidity::lsp {
+
+namespace // {{{ helpers
+{
+
+string toFileURI(std::string const& _path)
+{
+	return "file://" + _path;
+}
+
+class ASTNodeLocator: public ASTConstVisitor
+{
+public:
+	static ASTNode const* locate(int _pos, SourceUnit const& _sourceUnit)
+	{
+		ASTNodeLocator locator{_pos};
+		_sourceUnit.accept(locator);
+		return locator.m_closestMatch;
+	}
+
+	bool visitNode(ASTNode const& _node) override
+	{
+		if (_node.location().contains(m_pos))
+		{
+			m_closestMatch = &_node;
+			return true;
+		}
+		return false;
+	}
+
+private:
+	explicit ASTNodeLocator(int _pos): m_pos{_pos}, m_closestMatch{nullptr} {}
+
+	int m_pos;
+	ASTNode const* m_closestMatch;
+};
+
+optional<string> extractPathFromFileURI(std::string const& _uri)
+{
+	if (!boost::starts_with(_uri, "file://"))
+		return nullopt;
+
+	return _uri.substr(7);
+}
+
+DocumentPosition extractDocumentPosition(Json::Value const& _json)
+{
+	DocumentPosition dpos{};
+	dpos.path = extractPathFromFileURI(_json["textDocument"]["uri"].asString()).value();
+	dpos.position.line = _json["position"]["line"].asInt();
+	dpos.position.column = _json["position"]["character"].asInt();
+	return dpos;
+}
+
+Json::Value toJson(LineColumn _pos)
+{
+	Json::Value json = Json::objectValue;
+	json["line"] = max(_pos.line, 0);
+	json["character"] = max(_pos.column, 0);
+
+	return json;
+}
+
+Json::Value toJsonRange(int _startLine, int _startColumn, int _endLine, int _endColumn)
+{
+	Json::Value json;
+	json["start"] = toJson({_startLine, _startColumn});
+	json["end"] = toJson({_endLine, _endColumn});
+	return json;
+}
+
+Json::Value toJsonRange(SourceLocation const& _location)
+{
+	solAssert(_location.source, "");
+	auto const [startLine, startColumn] = _location.source->translatePositionToLineColumn(_location.start);
+	auto const [endLine, endColumn] = _location.source->translatePositionToLineColumn(_location.end);
+	return toJsonRange(startLine, startColumn, endLine, endColumn);
+}
+
+Json::Value toJson(boost::filesystem::path const& _basePath, SourceLocation const& _location)
+{
+	solAssert(_location.source.get() != nullptr, "");
+	Json::Value item = Json::objectValue;
+	if (_location.source->name().front() == '/')
+		item["uri"] = toFileURI(_location.source->name());
+	else
+		item["uri"] = toFileURI((_basePath / boost::filesystem::path(_location.source->name())).generic_string());
+	item["range"] = toJsonRange(_location);
+	return item;
+}
+
+std::pair<size_t, size_t> offsetsOf(std::string const& _text, LineColumnRange _range) noexcept
+{
+	auto const start = CharStream::translateLineColumnToPosition(_text, _range.start.line, _range.start.column);
+	auto const end = CharStream::translateLineColumnToPosition(_text, _range.end.line, _range.end.column);
+	solAssert(start.has_value(), "");
+	solAssert(end.has_value(), "");
+	return std::pair{ size_t(start.value()), size_t(end.value()) };
+}
+
+} // }}} end helpers
+
+LanguageServer::LanguageServer(Logger _logger, istream& _in, ostream& _out):
+	m_client{make_unique<JSONTransport>(_in, _out, _logger)},
+	m_handlers{
+		{"cancelRequest", [](auto, auto) {/*don't do anything for now, as we're synchronous*/}},
+		{"$/cancelRequest", [](auto, auto) {/*don't do anything for now, as we're synchronous*/}},
+		{"initialize", bind(&LanguageServer::handle_initialize, this, _1, _2)},
+		{"initialized", {} },
+		{"shutdown", [this](auto, auto) { m_shutdownRequested = true; }},
+		{"workspace/didChangeConfiguration", bind(&LanguageServer::handle_workspace_didChangeConfiguration, this, _1, _2)},
+		{"textDocument/didOpen", bind(&LanguageServer::handle_textDocument_didOpen, this, _1, _2)},
+		{"textDocument/didChange", bind(&LanguageServer::handle_textDocument_didChange, this, _1, _2)},
+		{"textDocument/didClose", [](auto, auto) {/*nothing for now*/}},
+		{"textDocument/definition", bind(&LanguageServer::handle_textDocument_definition, this, _1, _2)},
+		{"textDocument/documentHighlight", bind(&LanguageServer::handle_textDocument_highlight, this, _1, _2)},
+		{"textDocument/hover", bind(&LanguageServer::handle_textDocument_hover, this, _1, _2)},
+		{"textDocument/references", bind(&LanguageServer::handle_textDocument_references, this, _1, _2)},
+	},
+	m_logger{std::move(_logger)}
+{
+}
+
+void LanguageServer::changeConfiguration(Json::Value const& _settings)
+{
+	if (_settings["evm"].isString())
+		if (auto const evmVersionOpt = EVMVersion::fromString(_settings["evm"].asString()); evmVersionOpt.has_value())
+			m_evmVersion = evmVersionOpt.value();
+
+	if (_settings["remapping"].isArray())
+	{
+		for (auto const& element: _settings["remapping"])
+		{
+			if (element.isString())
+			{
+				if (auto remappingOpt = FileRemapper::parseRemapping(element.asString()); remappingOpt.has_value())
+					m_remappings.emplace_back(move(remappingOpt.value()));
+				else
+					trace("Failed to parse remapping: '"s + element.asString() + "'");
+			}
+		}
+	}
+}
+
+void LanguageServer::documentContentUpdated(string const& _path, LineColumnRange _range, string const& _replacementText)
+{
+	// TODO: all this info is actually unrelated to solidity/lsp specifically except knowing that
+	// the file has updated, so we can  abstract that away and only do the re-validation here.
+	auto file = m_fileReader->sourceCodes().find(_path);
+	if (file == m_fileReader->sourceCodes().end())
+	{
+		log("LanguageServer: File to be modified not opened \"" + _path + "\"");
+		return;
+	}
+
+	string buffer = file->second;
+
+	auto const [start, end] = offsetsOf(buffer, _range);
+	buffer.replace(start, end - start, _replacementText);
+
+	m_fileReader->setSource(_path, buffer);
+}
+
+void LanguageServer::documentContentUpdated(string const& _path, string const& _replacementText)
+{
+	auto file = m_fileReader->sourceCodes().find(_path);
+	if (file == m_fileReader->sourceCodes().end())
+	{
+		log("LanguageServer: File to be modified not opened \"" + _path + "\"");
+		return;
+	}
+
+	m_fileReader->setSource(_path, _replacementText);
+
+	compileSource(_path);
+}
+
+frontend::ReadCallback::Result LanguageServer::readFile(string const& _kind, string const& _path)
+{
+	return m_fileReader->readFile(_kind, _path);
+}
+
+constexpr DiagnosticSeverity toDiagnosticSeverity(Error::Type _errorType)
+{
+	using Type = Error::Type;
+	using Severity = DiagnosticSeverity;
+	switch (_errorType)
+	{
+		case Type::CodeGenerationError:
+		case Type::DeclarationError:
+		case Type::DocstringParsingError:
+		case Type::ParserError:
+		case Type::SyntaxError:
+		case Type::TypeError:
+			return Severity::Error;
+		case Type::Warning:
+			return Severity::Warning;
+	}
+	// Should never be reached.
+	return Severity::Error;
+}
+
+bool LanguageServer::compile(std::string const& _path)
+{
+	// TODO: optimize! do not recompile if nothing has changed (file(s) not flagged dirty).
+
+	auto const i = m_fileReader->sourceCodes().find(_path);
+	if (i == m_fileReader->sourceCodes().end())
+		return false;
+
+	m_compilerStack.reset();
+	m_compilerStack = make_unique<CompilerStack>(bind(&FileReader::readFile, ref(*m_fileReader), _1, _2));
+
+	// TODO: configure all compiler flags like in CommandLineInterface (TODO: refactor to share logic!)
+	OptimiserSettings settings = OptimiserSettings::standard(); // TODO: get from config
+	m_compilerStack->setOptimiserSettings(settings);
+	m_compilerStack->setParserErrorRecovery(false);
+	m_compilerStack->setRevertStringBehaviour(RevertStrings::Default); // TODO get from config
+	m_compilerStack->setSources(m_fileReader->sourceCodes());
+	m_compilerStack->setRemappings(m_remappings);
+
+	m_compilerStack->setEVMVersion(m_evmVersion);
+
+	trace("compile: using EVM "s + m_evmVersion.name());
+
+	m_compilerStack->compile(CompilerStack::State::AnalysisPerformed);
+	return true;
+}
+
+void LanguageServer::compileSource(std::string const& _path)
+{
+	compile(_path);
+
+	Json::Value params;
+	params["uri"] = toFileURI(_path);
+
+	params["diagnostics"] = Json::arrayValue;
+	for (shared_ptr<Error const> const& error: m_compilerStack->errors())
+	{
+		SourceReferenceExtractor::Message const message = SourceReferenceExtractor::extract(*error);
+
+		Json::Value jsonDiag;
+		jsonDiag["source"] = "solc";
+		jsonDiag["severity"] = int(toDiagnosticSeverity(error->type()));
+		jsonDiag["message"] = message.primary.message;
+
+		if (message.errorId.has_value())
+			jsonDiag["code"] = Json::UInt64{message.errorId.value().error};
+
+		jsonDiag["range"] = toJsonRange(
+			message.primary.position.line, message.primary.startColumn,
+			message.primary.position.line, message.primary.endColumn
+		);
+
+		for (SourceReference const& secondary: message.secondary)
+		{
+			Json::Value jsonRelated;
+			jsonRelated["message"] = secondary.message;
+			jsonRelated["location"]["uri"] = toFileURI((m_basePath / boost::filesystem::path(secondary.sourceName)).generic_string());
+			jsonRelated["location"]["range"] = toJsonRange(
+				secondary.position.line, secondary.startColumn,
+				secondary.position.line, secondary.endColumn
+			);
+			jsonDiag["relatedInformation"].append(jsonRelated);
+		}
+
+		params["diagnostics"].append(jsonDiag);
+	}
+
+	m_client->notify("textDocument/publishDiagnostics", params);
+}
+
+frontend::ASTNode const* LanguageServer::findASTNode(LineColumn _position, std::string const& _fileName)
+{
+	if (!m_compilerStack)
+		return nullptr;
+
+	// TODO: calling ast(...) throws if no AST is present (build failed),
+	// so catch this in at least document updates, so errors can be sent out properly
+	frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(_fileName);
+	trace("findASTNode: "s + to_string(_position.line) + ":" + to_string(_position.column));
+	auto const sourcePos = sourceUnit.location().source->translateLineColumnToPosition(_position.line, _position.column);
+
+	if (!sourcePos.has_value())
+	{
+		trace(
+			"findASTNode: could not locate offset for "s +
+			to_string(_position.line) + ":" +
+			to_string(_position.column)
+		);
+		return nullptr;
+	}
+
+	ASTNode const* closestMatch = ASTNodeLocator::locate(sourcePos.value(), sourceUnit);
+
+	if (!closestMatch)
+		trace(
+			"findASTNode not found for "s +
+			to_string(sourcePos.value()) + ":" +
+			to_string(_position.line) + ":" +
+			to_string(_position.column)
+		);
+	else
+		trace(
+			"findASTNode found for "s +
+			to_string(sourcePos.value()) + ":" +
+			to_string(_position.line) + ":" +
+			to_string(_position.column) + ": " +
+			closestMatch->location().text() + " (" +
+			typeid(*closestMatch).name() +
+			")"s
+		);
+
+
+	return closestMatch;
+}
+
+optional<SourceLocation> LanguageServer::declarationPosition(frontend::Declaration const* _declaration)
+{
+	if (!_declaration)
+		return nullopt;
+
+	if (_declaration->nameLocation().isValid())
+		return _declaration->nameLocation();
+
+	if (_declaration->location().isValid())
+		return _declaration->location();
+
+	return nullopt;
+}
+
+std::vector<SourceLocation> LanguageServer::findAllReferences(
+	frontend::Declaration const* _declaration,
+	string const& _sourceIdentifierName,
+	frontend::SourceUnit const& _sourceUnit
+)
+{
+	std::vector<SourceLocation> output;
+	for (DocumentHighlight& highlight: ReferenceCollector::collect(_declaration, _sourceUnit, _sourceIdentifierName))
+		output.emplace_back(move(highlight.location));
+	return output;
+}
+
+void LanguageServer::findAllReferences(
+	frontend::Declaration const* _declaration,
+	string const& _sourceIdentifierName,
+	frontend::SourceUnit const& _sourceUnit,
+	std::vector<SourceLocation>& _output
+)
+{
+	for (DocumentHighlight& highlight: ReferenceCollector::collect(_declaration, _sourceUnit, _sourceIdentifierName))
+		_output.emplace_back(move(highlight.location));
+}
+
+vector<SourceLocation> LanguageServer::references(DocumentPosition _documentPosition)
+{
+	auto const file = m_fileReader->sourceCodes().find(_documentPosition.path);
+	if (file == m_fileReader->sourceCodes().end())
+	{
+		trace("File does not exist. " + _documentPosition.path);
+		return {};
+	}
+
+	if (!m_compilerStack)
+		compile(_documentPosition.path);
+
+	solAssert(m_compilerStack.get() != nullptr, "");
+
+	string const& sourceName = _documentPosition.path;
+
+	ASTNode const* sourceNode = findASTNode(_documentPosition.position, sourceName);
+	if (!sourceNode)
+	{
+		trace("AST node not found");
+		return {};
+	}
+
+	if (auto const sourceIdentifier = dynamic_cast<Identifier const*>(sourceNode))
+	{
+		string const& sourceName = _documentPosition.path;
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(sourceName);
+
+		vector<SourceLocation> output;
+		if (auto decl = sourceIdentifier->annotation().referencedDeclaration)
+			output += findAllReferences(decl, decl->name(), sourceUnit);
+
+		for (auto const decl: sourceIdentifier->annotation().candidateDeclarations)
+			output += findAllReferences(decl, decl->name(), sourceUnit);
+		return output;
+	}
+	else if (auto const decl = dynamic_cast<VariableDeclaration const*>(sourceNode))
+	{
+		auto const sourceName = _documentPosition.path;
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(sourceName);
+		return findAllReferences(decl, decl->name(), sourceUnit);
+	}
+	else if (auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(sourceName);
+		return findAllReferences(functionDefinition, functionDefinition->name(), sourceUnit);
+	}
+	else if (auto const* enumDef = dynamic_cast<EnumDefinition const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(sourceName);
+		return findAllReferences(enumDef, enumDef->name(), sourceUnit);
+	}
+	else if (auto const memberAccess = dynamic_cast<MemberAccess const*>(sourceNode))
+	{
+		if (Declaration const* decl = memberAccess->annotation().referencedDeclaration)
+		{
+			auto const sourceName = _documentPosition.path;
+			frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(sourceName);
+			return findAllReferences(decl, memberAccess->memberName(), sourceUnit);
+		}
+		return {};
+	}
+	else if (auto const* importDef = dynamic_cast<ImportDirective const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(sourceName);
+		return findAllReferences(importDef, importDef->name(), sourceUnit);
+	}
+
+	trace("references: not an identifier: "s + typeid(*sourceNode).name());
+	return {};
+}
+
+vector<DocumentHighlight> LanguageServer::semanticHighlight(DocumentPosition _documentPosition)
+{
+	solAssert(m_compilerStack.get() != nullptr, "");
+
+	frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(_documentPosition.path);
+	ASTNode const* sourceNode = findASTNode(_documentPosition.position, _documentPosition.path);
+	if (!sourceNode)
+	{
+		trace("semanticHighlight: AST node not found");
+		return {};
+	}
+
+	trace(
+		"semanticHighlight: Source Node("s + typeid(*sourceNode).name() + "): " +
+		sourceNode->location().text()
+	);
+
+	// TODO: ImportDirective: hovering a symbol of an import directive should highlight all uses of that symbol.
+	if (auto const* sourceIdentifier = dynamic_cast<Identifier const*>(sourceNode))
+	{
+		vector<DocumentHighlight> output;
+		if (sourceIdentifier->annotation().referencedDeclaration)
+			output += ReferenceCollector::collect(sourceIdentifier->annotation().referencedDeclaration, sourceUnit, sourceIdentifier->name());
+
+		for (Declaration const* declaration: sourceIdentifier->annotation().candidateDeclarations)
+			output += ReferenceCollector::collect(declaration, sourceUnit, sourceIdentifier->name());
+
+		for (Declaration const* declaration: sourceIdentifier->annotation().overloadedDeclarations)
+			output += ReferenceCollector::collect(declaration, sourceUnit, sourceIdentifier->name());
+		return output;
+	}
+	else if (auto const* varDecl = dynamic_cast<VariableDeclaration const*>(sourceNode))
+		return ReferenceCollector::collect(varDecl, sourceUnit, varDecl->name());
+	else if (auto const* structDef = dynamic_cast<StructDefinition const*>(sourceNode))
+		return ReferenceCollector::collect(structDef, sourceUnit, structDef->name());
+	else if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(sourceNode))
+	{
+		Type const* type = memberAccess->expression().annotation().type;
+		if (auto const ttype = dynamic_cast<TypeType const*>(type))
+		{
+			auto const memberName = memberAccess->memberName();
+
+			if (auto const* enumType = dynamic_cast<EnumType const*>(ttype->actualType()))
+			{
+				// find the definition
+				vector<DocumentHighlight> output;
+				for (auto const& enumMember: enumType->enumDefinition().members())
+					if (enumMember->name() == memberName)
+						output += ReferenceCollector::collect(enumMember.get(), sourceUnit, enumMember->name());
+
+				// TODO: find uses of the enum value
+				return output;
+			}
+		}
+		else
+		{
+			// TODO: StructType, ...
+			trace("semanticHighlight: member type is: "s + (type ? typeid(*type).name() : "NULL"));
+		}
+
+		// TODO: If the cursor os positioned on top of a type name, then all other symbols matching
+		// this type should be highlighted (clangd does so, too).
+		//
+		// if (auto const tt = dynamic_cast<TypeType const*>(type))
+		// {
+		// 	output = findAllReferences(declaration, sourceUnit);
+		// }
+	}
+	else if (auto const* identifierPath = dynamic_cast<IdentifierPath const*>(sourceNode))
+	{
+		solAssert(!identifierPath->path().empty(), "");
+		return ReferenceCollector::collect(identifierPath->annotation().referencedDeclaration, sourceUnit, identifierPath->path().back());
+	}
+	else if (auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(sourceNode))
+		return ReferenceCollector::collect(functionDefinition, sourceUnit, functionDefinition->name());
+	else if (auto const* enumDef = dynamic_cast<EnumDefinition const*>(sourceNode))
+		return ReferenceCollector::collect(enumDef, sourceUnit, enumDef->name());
+	else if (auto const* importDef = dynamic_cast<ImportDirective const*>(sourceNode))
+		return ReferenceCollector::collect(importDef, sourceUnit, importDef->name());
+	else
+		trace("semanticHighlight: not an identifier. "s + typeid(*sourceNode).name());
+
+	return {};
+}
+
+// {{{ LSP internals
+bool LanguageServer::run()
+{
+	while (!m_exitRequested && !m_client->closed())
+	{
+		optional<Json::Value> const jsonMessage = m_client->receive();
+		if (!jsonMessage.has_value())
+		{
+			m_client->error(Json::nullValue, ErrorCode::InvalidRequest, "Could not parse request.");
+			continue;
+		}
+
+		try
+		{
+			handleMessage(*jsonMessage);
+		}
+		catch (std::exception const& e)
+		{
+			log("Unhandled exception caught when handling message. "s + e.what());
+		}
+	}
+
+	if (m_shutdownRequested)
+		return true;
+	else
+		return false;
+}
+
+#define MYDEBUG 0
+void LanguageServer::handle_initialize(MessageId _id, Json::Value const& _args)
+{
+	string rootPath;
+	if (Json::Value uri = _args["rootUri"])
+		rootPath = extractPathFromFileURI(uri.asString()).value();
+	else if (Json::Value rootPath = _args["rootPath"]; rootPath)
+		rootPath = rootPath.asString();
+
+	trace("initialize: root path: '"s + rootPath + "'");
+
+	if (Json::Value value = _args["trace"]; value)
+	{
+		string const name = value.asString();
+		if (name == "messages")
+			m_trace = Trace::Messages;
+		else if (name == "verbose")
+			m_trace = Trace::Verbose;
+		else if (name == "off")
+			m_trace = Trace::Off;
+	}
+
+#if MYDEBUG // Currently not used.
+	// At least VScode supports more than one workspace.
+	// This is the list of initial configured workspace folders
+	struct WorkspaceFolder { std::string name; std::string path; };
+	std::vector<WorkspaceFolder> workspaceFolders;
+	if (Json::Value folders = _args["workspaceFolders"]; folders)
+	{
+		for (Json::Value folder: folders)
+		{
+			WorkspaceFolder wsFolder{};
+			wsFolder.name = folder["name"].asString();
+			wsFolder.path = extractPathFromFileURI(folder["uri"].asString()).value();
+			workspaceFolders.emplace_back(move(wsFolder));
+		}
+	}
+#endif
+
+	auto const fspath = boost::filesystem::path(rootPath);
+
+	m_basePath = fspath;
+	m_fileReader = make_unique<FileReader>(m_basePath, FileReader::FileSystemPathSet{fspath});
+
+	if (_args["initializationOptions"].isObject())
+		changeConfiguration(_args["initializationOptions"]);
+
+	// {{{ encoding
+	Json::Value replyArgs;
+
+	replyArgs["serverInfo"]["name"] = "solc";
+	replyArgs["serverInfo"]["version"] = string(solidity::frontend::VersionNumber);
+	replyArgs["hoverProvider"] = true;
+	replyArgs["capabilities"]["hoverProvider"] = true;
+	replyArgs["capabilities"]["textDocumentSync"]["openClose"] = true;
+	replyArgs["capabilities"]["textDocumentSync"]["change"] = 2; // 0=none, 1=full, 2=incremental
+	replyArgs["capabilities"]["definitionProvider"] = true;
+	replyArgs["capabilities"]["documentHighlightProvider"] = true;
+	replyArgs["capabilities"]["referencesProvider"] = true;
+
+	m_client->reply(_id, replyArgs);
+	// }}}
+}
+
+void LanguageServer::handle_workspace_didChangeConfiguration(MessageId, Json::Value const& _args)
+{
+	if (_args["settings"].isObject())
+		changeConfiguration(_args["settings"]);
+}
+
+void LanguageServer::handle_exit(MessageId _id, Json::Value const& /*_args*/)
+{
+	m_exitRequested = true;
+	auto const exitCode = m_shutdownRequested ? 0 : 1;
+
+	Json::Value replyArgs = Json::intValue;
+	replyArgs = exitCode;
+
+	m_client->reply(_id, replyArgs);
+}
+
+void LanguageServer::handle_textDocument_didOpen(MessageId /*_id*/, Json::Value const& _args)
+{
+	// decoding
+	if (!_args["textDocument"])
+		return;
+
+	auto const path = extractPathFromFileURI(_args["textDocument"]["uri"].asString()).value();
+	auto const text = _args["textDocument"]["text"].asString();
+	// auto const version = _args["textDocument"]["version"].asInt();
+	// auto const languageId = _args["textDocument"]["languageId"].asString();
+
+	log("LanguageServer: Opening document: " + path);
+
+	//m_vfs[path] = text;
+	m_fileReader->setSource(path, nullopt, text);
+
+	compileSource(path);
+
+	// no encoding
+}
+
+void LanguageServer::handle_textDocument_didChange(MessageId /*_id*/, Json::Value const& _args)
+{
+	//auto const version = _args["textDocument"]["version"].asInt();
+	auto const path = extractPathFromFileURI(_args["textDocument"]["uri"].asString()).value();
+
+	// TODO: in the longer run, I'd like to try moving the VFS handling into Server class, so
+	// the specific Solidity LSP implementation doesn't need to care about that.
+
+	auto const contentChanges = _args["contentChanges"];
+	for (Json::Value jsonContentChange: contentChanges)
+	{
+		if (!jsonContentChange.isObject())
+			// Protocol error, will only happen on broken clients, so silently ignore it.
+			continue;
+
+		auto const text = jsonContentChange["text"].asString();
+
+		if (jsonContentChange["range"].isObject())
+		{
+			Json::Value jsonRange = jsonContentChange["range"];
+			LineColumnRange range{};
+			range.start.line = jsonRange["start"]["line"].asInt();
+			range.start.column = jsonRange["start"]["character"].asInt();
+			range.end.line = jsonRange["end"]["line"].asInt();
+			range.end.column = jsonRange["end"]["character"].asInt();
+
+			documentContentUpdated(path, range, text);
+		}
+		else
+		{
+			// full content update
+			documentContentUpdated(path, text);
+		}
+	}
+
+	if (!contentChanges.empty())
+		compileSource(path);
+}
+
+void LanguageServer::handle_textDocument_definition(MessageId _id, Json::Value const& _args)
+{
+	DocumentPosition const dpos = extractDocumentPosition(_args);
+
+	// source should be compiled already
+	solAssert(m_compilerStack.get() != nullptr, "");
+
+	auto const file = m_fileReader->sourceCodes().find(dpos.path);
+	if (file == m_fileReader->sourceCodes().end())
+	{
+		Json::Value emptyResponse = Json::arrayValue;
+		m_client->reply(_id, emptyResponse);
+		return;
+	}
+
+	auto const sourceNode = findASTNode(dpos.position, dpos.path);
+	if (!sourceNode)
+	{
+		trace("gotoDefinition: AST node not found for "s + to_string(dpos.position.line) + ":" + to_string(dpos.position.column));
+		// Could not infer AST node from given source location.
+		Json::Value emptyResponse = Json::arrayValue;
+		m_client->reply(_id, emptyResponse);
+		return;
+	}
+
+	vector<SourceLocation> locations;
+	if (auto const importDirective = dynamic_cast<ImportDirective const*>(sourceNode))
+	{
+		// When cursor is on an import directive, then we want to jump to the actual file that
+		// is being imported.
+		auto const fpm = m_fileReader->pathMappings().find(importDirective->path());
+		if (fpm != m_fileReader->pathMappings().end())
+			locations.emplace_back(SourceLocation{0, 0, make_shared<CharStream>("", fpm->second.generic_string())});
+		else
+			trace("gotoDefinition: (importDirective) full path mapping not found\n");
+	}
+	else if (auto const n = dynamic_cast<frontend::MemberAccess const*>(sourceNode))
+	{
+		// For scope members, jump to the naming symbol of the referencing declaration of this member.
+		auto const declaration = n->annotation().referencedDeclaration;
+		auto const location = declarationPosition(declaration);
+		if (location.has_value())
+			locations.emplace_back(location.value());
+		else
+			trace("gotoDefinition: declaration not found.");
+	}
+	else if (auto const sourceIdentifier = dynamic_cast<Identifier const*>(sourceNode))
+	{
+		// For identifiers, jump to the naming symbol of the definition of this identifier.
+		if (Declaration const* decl = sourceIdentifier->annotation().referencedDeclaration)
+			if (auto location = declarationPosition(decl); location.has_value())
+				locations.emplace_back(move(location.value()));
+		// if (auto location = declarationPosition(sourceIdentifier->annotation().referencedDeclaration); location.has_value())
+		// 	locations.emplace_back(move(location.value()));
+
+		for (auto const declaration: sourceIdentifier->annotation().candidateDeclarations)
+			if (auto location = declarationPosition(declaration); location.has_value())
+				locations.emplace_back(move(location.value()));
+	}
+	else
+		trace("gotoDefinition: Symbol is not an identifier. "s + typeid(*sourceNode).name());
+
+	Json::Value reply = Json::arrayValue;
+	for (SourceLocation const& location: locations)
+		reply.append(toJson(m_basePath, location));
+	m_client->reply(_id, reply);
+}
+
+void LanguageServer::handle_textDocument_hover(MessageId _id, Json::Value const& _args)
+{
+	auto const dpos = extractDocumentPosition(_args);
+
+	auto const sourceNode = findASTNode(dpos.position, dpos.path);
+	if (!sourceNode)
+	{
+		Json::Value emptyResponse = Json::arrayValue;
+		m_client->reply(_id, emptyResponse); // reply with "No references".
+		return;
+	}
+
+	Json::Value reply = Json::objectValue;
+
+	reply["range"] = toJsonRange(sourceNode->location());
+	reply["contents"]["kind"] = "markdown";
+	reply["contents"]["value"] = ""; // Will be the Natspec documentation (converted to markdown) later.
+
+	m_client->reply(_id, reply);
+}
+
+void LanguageServer::handle_textDocument_highlight(MessageId _id, Json::Value const& _args)
+{
+	auto const dpos = extractDocumentPosition(_args);
+
+	Json::Value jsonReply = Json::arrayValue;
+	for (DocumentHighlight const& highlight: semanticHighlight(dpos))
+	{
+		Json::Value item = Json::objectValue;
+		item["range"] = toJsonRange(highlight.location);
+		if (highlight.kind != DocumentHighlightKind::Unspecified)
+			item["kind"] = static_cast<int>(highlight.kind);
+
+		jsonReply.append(item);
+	}
+	m_client->reply(_id, jsonReply);
+}
+
+void LanguageServer::handle_textDocument_references(MessageId _id, Json::Value const& _args)
+{
+	auto const dpos = extractDocumentPosition(_args);
+
+	trace(
+		"find all references: " +
+		dpos.path + ":" +
+		to_string(dpos.position.line) + ":" +
+		to_string(dpos.position.column)
+	);
+
+	auto file = m_fileReader->sourceCodes().find(dpos.path);
+	if (file == m_fileReader->sourceCodes().end())
+	{
+		Json::Value emptyResponse = Json::arrayValue;
+		m_client->reply(_id, emptyResponse); // reply with "No references".
+		return;
+	}
+
+	if (!m_compilerStack)
+		compile(dpos.path);
+	solAssert(m_compilerStack.get() != nullptr, "");
+
+	auto const sourceNode = findASTNode(dpos.position, dpos.path);
+	if (!sourceNode)
+	{
+		Json::Value emptyResponse = Json::arrayValue;
+		m_client->reply(_id, emptyResponse); // reply with "No references".
+		return;
+	}
+
+	auto locations = vector<SourceLocation>{};
+	if (auto const sourceIdentifier = dynamic_cast<Identifier const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(dpos.path);
+
+		if (auto decl = sourceIdentifier->annotation().referencedDeclaration)
+			findAllReferences(decl, decl->name(), sourceUnit, locations);
+
+		for (auto const decl: sourceIdentifier->annotation().candidateDeclarations)
+			findAllReferences(decl, decl->name(), sourceUnit, locations);
+	}
+	else if (auto const decl = dynamic_cast<VariableDeclaration const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(dpos.path);
+		findAllReferences(decl, decl->name(), sourceUnit, locations);
+	}
+	else if (auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(dpos.path);
+		findAllReferences(functionDefinition, functionDefinition->name(), sourceUnit, locations);
+	}
+	else if (auto const* enumDef = dynamic_cast<EnumDefinition const*>(sourceNode))
+	{
+		frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(dpos.path);
+		findAllReferences(enumDef, enumDef->name(), sourceUnit, locations);
+	}
+	else if (auto const memberAccess = dynamic_cast<MemberAccess const*>(sourceNode))
+	{
+		if (Declaration const* decl = memberAccess->annotation().referencedDeclaration)
+		{
+			frontend::SourceUnit const& sourceUnit = m_compilerStack->ast(dpos.path);
+			findAllReferences(decl, memberAccess->memberName(), sourceUnit, locations);
+		}
+	}
+	else
+		trace("references: not an identifier: "s + typeid(*sourceNode).name());
+
+	Json::Value jsonReply = Json::arrayValue;
+	for (SourceLocation const& location: locations)
+		jsonReply.append(toJson(m_basePath, location));
+
+	m_client->reply(_id, jsonReply);
+}
+
+void LanguageServer::log(string const& _message)
+{
+	if (m_trace < Trace::Messages)
+		return;
+
+	Json::Value json = Json::objectValue;
+	json["type"] = static_cast<int>(Trace::Messages);
+	json["message"] = _message;
+
+	m_client->notify("window/logMessage", json);
+
+	if (m_logger)
+		m_logger(_message);
+}
+
+void LanguageServer::trace(string const& _message)
+{
+	if (m_trace < Trace::Verbose)
+		return;
+
+	Json::Value json = Json::objectValue;
+	json["type"] = static_cast<int>(Trace::Verbose);
+	json["message"] = _message;
+
+	m_client->notify("window/logMessage", json);
+
+	if (m_logger)
+		m_logger(_message);
+}
+
+void LanguageServer::handleMessage(Json::Value const& _jsonMessage)
+{
+	string const methodName = _jsonMessage["method"].asString();
+
+	MessageId const id = _jsonMessage["id"].isInt()
+		? MessageId{to_string(_jsonMessage["id"].asInt())}
+		: _jsonMessage["id"].isString()
+			? MessageId{_jsonMessage["id"].asString()}
+			: MessageId{};
+
+	auto const handler = m_handlers.find(methodName);
+	if (handler == m_handlers.end())
+		m_client->error(id, ErrorCode::MethodNotFound, "Unknown method " + methodName);
+	else if (handler->second)
+	{
+		Json::Value const& jsonArgs = _jsonMessage["params"];
+		handler->second(id, jsonArgs);
+	}
+}
+// }}}
+
+} // namespace solidity

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -1,0 +1,174 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <libsolidity/interface/CompilerStack.h>
+#include <libsolidity/interface/FileReader.h>
+#include <libsolidity/interface/FileRemapper.h>
+#include <libsolidity/lsp/LSPTypes.h>
+#include <libsolidity/lsp/ReferenceCollector.h>
+#include <libsolidity/lsp/Transport.h>
+
+#include <libsolidity/ast/AST.h>
+
+#include <liblangutil/SourceReferenceExtractor.h>
+
+#include <json/value.h>
+
+#include <boost/filesystem/path.hpp>
+
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace solidity::frontend {
+	class Declaration;
+}
+
+namespace solidity::lsp {
+
+enum class ErrorCode;
+
+/// Solidity Language Server, managing one LSP client.
+///
+/// This implements a subset of LSP version 3.16 that can be found at:
+///     https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/
+class LanguageServer
+{
+public:
+	using Logger = std::function<void(std::string_view)>;
+
+	/// @param _logger special logger used for debugging the LSP.
+	LanguageServer(Logger _logger, std::istream& _in, std::ostream& _out);
+	explicit LanguageServer(Logger _logger): LanguageServer(std::move(_logger), std::cin, std::cout) {}
+
+	/// Compiles the source behind path @p _file and updates the diagnostics pushed to the client.
+	///
+	/// update diagnostics and also pushes any updates to the client.
+	void compileSource(std::string const& _file);
+
+	/// Loops over incoming messages via the transport layer until shutdown condition is met.
+	///
+	/// The standard shutdown condition is when the maximum number of consecutive failures
+	/// has been exceeded.
+	///
+	/// @return boolean indicating normal or abnormal termination.
+	bool run();
+
+	/// Handles a single JSON-RPC message in string form.
+	void handleMessage(std::string const& _message);
+
+	/// Handles a single JSON-RPC message.
+	void handleMessage(Json::Value const& _jsonMessage);
+
+protected:
+	void handle_initialize(MessageId _id, Json::Value const& _args);
+	void handle_exit(MessageId _id, Json::Value const& _args);
+	void handle_workspace_didChangeConfiguration(MessageId _id, Json::Value const& _args);
+	void handle_textDocument_didOpen(MessageId _id, Json::Value const& _args);
+	void handle_textDocument_didChange(MessageId _id, Json::Value const& _args);
+	void handle_textDocument_definition(MessageId _id, Json::Value const& _args);
+	void handle_textDocument_hover(MessageId _id, Json::Value const& _args);
+	void handle_textDocument_highlight(MessageId _id, Json::Value const& _args);
+	void handle_textDocument_references(MessageId _id, Json::Value const& _args);
+
+	// {{{ Client-to-Server messages
+	/// Invoked when the server user-supplied configuration changes (initiated by the client).
+	void changeConfiguration(Json::Value const&);
+	void documentContentUpdated(std::string const& _path, std::string const& _fullContentChange);
+	void documentContentUpdated(std::string const& _path, LineColumnRange _range, std::string const& _text);
+
+	/// Find all semantically equivalent occurrences of the symbol the current cursor is located at.
+	///
+	/// @returns a list of ranges to highlight as well as their use kind (read fraom, written to, other text).
+	std::vector<DocumentHighlight> semanticHighlight(DocumentPosition _documentPosition);
+
+	/// Finds all references of the current symbol at the given document position.
+	///
+	/// @returns all references as document ranges as well as their use kind (read fraom, written to, other text).
+	std::vector<langutil::SourceLocation> references(DocumentPosition _documentPosition);
+	// }}}
+
+	/// Logs a message (should be used for logging messages that are informationally useful to the client).
+	void log(std::string const& _message);
+
+	/// Logs a verbose trace message (should used for logging messages that are helpful to the client).
+	void trace(std::string const& _message);
+
+	frontend::ReadCallback::Result readFile(std::string const&, std::string const&);
+
+	bool compile(std::string const& _path);
+
+	frontend::ASTNode const* findASTNode(langutil::LineColumn _position, std::string const& _fileName);
+
+	std::optional<langutil::SourceLocation> declarationPosition(frontend::Declaration const* _declaration);
+
+	std::vector<langutil::SourceLocation> findAllReferences(
+		frontend::Declaration const* _declaration,
+		std::string const& _sourceIdentifierName,
+		frontend::SourceUnit const& _sourceUnit
+	);
+
+	void findAllReferences(
+		frontend::Declaration const* _declaration,
+		std::string const& _sourceIdentifierName,
+		frontend::SourceUnit const& _sourceUnit,
+		std::vector<langutil::SourceLocation>& _output
+	);
+
+	// {{{ LSP related member fields
+	using Handler = std::function<void(MessageId, Json::Value const&)>;
+	using HandlerMap = std::unordered_map<std::string, Handler>;
+
+	std::unique_ptr<JSONTransport> m_client;
+	HandlerMap m_handlers;
+	bool m_shutdownRequested = false;
+	bool m_exitRequested = false;
+	Trace m_trace = Trace::Off;
+	std::function<void(std::string_view)> m_logger;
+	// }}}
+
+	/// FileReader is used for reading files during comilation phase but is also used as VFS for the LSP.
+	std::unique_ptr<FileReader> m_fileReader;
+
+	/// Workspace root directory
+	boost::filesystem::path m_basePath;
+
+	/// map of input files to source code strings
+	///
+	/// The key must be a fully qualified path to the file.
+	// TODO (dead) std::map<std::string, std::string> m_sourceCodes;
+
+	std::unique_ptr<frontend::CompilerStack> m_compilerStack;
+	std::vector<FileRemapper::Remapping> m_remappings;
+
+	/// Configured EVM version that is being used in compilations.
+	langutil::EVMVersion m_evmVersion = langutil::EVMVersion::berlin();
+};
+
+} // namespace solidity
+

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -19,7 +19,7 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/FileReader.h>
-#include <libsolidity/interface/FileRemapper.h>
+#include <libsolidity/interface/ImportRemapper.h>
 #include <libsolidity/lsp/LSPTypes.h>
 #include <libsolidity/lsp/ReferenceCollector.h>
 #include <libsolidity/lsp/Transport.h>
@@ -153,7 +153,7 @@ protected:
 	// }}}
 
 	/// FileReader is used for reading files during comilation phase but is also used as VFS for the LSP.
-	std::unique_ptr<FileReader> m_fileReader;
+	std::unique_ptr<frontend::FileReader> m_fileReader;
 
 	/// Workspace root directory
 	boost::filesystem::path m_basePath;
@@ -164,10 +164,13 @@ protected:
 	// TODO (dead) std::map<std::string, std::string> m_sourceCodes;
 
 	std::unique_ptr<frontend::CompilerStack> m_compilerStack;
-	std::vector<FileRemapper::Remapping> m_remappings;
+	std::vector<frontend::ImportRemapper::Remapping> m_remappings;
 
 	/// Configured EVM version that is being used in compilations.
 	langutil::EVMVersion m_evmVersion = langutil::EVMVersion::berlin();
+
+	/// Maps source paths names to fully qualified local path names.
+	std::map<std::string, std::string> m_pathMappings;
 };
 
 } // namespace solidity

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -171,19 +171,11 @@ protected:
 	/// Workspace root directory
 	boost::filesystem::path m_basePath;
 
-	/// map of input files to source code strings
-	///
-	/// The key must be a fully qualified path to the file.
-	// TODO (dead) std::map<std::string, std::string> m_sourceCodes;
-
 	std::unique_ptr<frontend::CompilerStack> m_compilerStack;
 	std::vector<frontend::ImportRemapper::Remapping> m_remappings;
 
 	/// Configured EVM version that is being used in compilations.
 	langutil::EVMVersion m_evmVersion = langutil::EVMVersion::berlin();
-
-	/// Maps source paths names to fully qualified local path names.
-	std::map<std::string, std::string> m_pathMappings;
 };
 
 } // namespace solidity

--- a/libsolidity/lsp/ReferenceCollector.cpp
+++ b/libsolidity/lsp/ReferenceCollector.cpp
@@ -1,0 +1,118 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/lsp/ReferenceCollector.h>
+
+#include <libsolidity/ast/AST.h>
+#include <libsolidity/lsp/LanguageServer.h>
+
+using std::move;
+using std::vector;
+using std::string;
+
+using namespace std::string_literals;
+using namespace solidity::frontend;
+
+namespace solidity::lsp
+{
+
+ReferenceCollector::ReferenceCollector(
+	frontend::Declaration const& _declaration,
+	std::string const& _sourceIdentifierName
+):
+	m_declaration{_declaration},
+	m_sourceIdentifierName{_sourceIdentifierName.empty() ? _declaration.name() : _sourceIdentifierName}
+{
+}
+
+std::vector<DocumentHighlight> ReferenceCollector::collect(
+	frontend::Declaration const* _declaration,
+	frontend::ASTNode const& _ast,
+	std::string const& _sourceIdentifierName
+)
+{
+	if (!_declaration)
+		return {};
+
+	// TODO if vardecl, just use decl's scope (for lower overhead).
+	auto collector = ReferenceCollector(*_declaration, _sourceIdentifierName);
+	_ast.accept(collector);
+	return move(collector.m_result);
+}
+
+void ReferenceCollector::endVisit(frontend::ImportDirective const& _import)
+{
+	for (auto const& symbolAlias: _import.symbolAliases())
+		if (m_sourceIdentifierName == *symbolAlias.alias)
+		{
+			addReference(symbolAlias.location);
+			break;
+		}
+}
+
+bool ReferenceCollector::tryAddReference(frontend::Declaration const* _declaration, solidity::langutil::SourceLocation const& _location)
+{
+	if (&m_declaration != _declaration)
+		return false;
+
+	addReference(_location);
+	return true;
+}
+
+void ReferenceCollector::endVisit(frontend::Identifier const& _identifier)
+{
+	if (auto const* declaration = _identifier.annotation().referencedDeclaration)
+		tryAddReference(declaration, _identifier.location());
+
+	for (auto const* declaration: _identifier.annotation().candidateDeclarations)
+		tryAddReference(declaration, _identifier.location());
+
+	for (auto const* declaration: _identifier.annotation().overloadedDeclarations)
+		tryAddReference(declaration, _identifier.location());
+}
+
+void ReferenceCollector::endVisit(frontend::IdentifierPath  const& _identifierPath)
+{
+	tryAddReference(_identifierPath.annotation().referencedDeclaration, _identifierPath.location());
+}
+
+void ReferenceCollector::endVisit(frontend::MemberAccess const& _memberAccess)
+{
+	if (_memberAccess.annotation().referencedDeclaration == &m_declaration)
+		addReference(_memberAccess.location());
+}
+
+bool ReferenceCollector::visitNode(frontend::ASTNode const& _node)
+{
+	if (&_node == &m_declaration)
+	{
+		if (auto const* decl = dynamic_cast<Declaration const*>(&_node))
+			addReference(decl->nameLocation());
+		else
+			addReference(_node.location());
+	}
+
+	return true;
+}
+
+void ReferenceCollector::addReference(solidity::langutil::SourceLocation const& _location)
+{
+	// TODO: kill this function & inline the one-liner?
+	m_result.emplace_back(DocumentHighlight{_location, DocumentHighlightKind::Text});
+}
+
+}

--- a/libsolidity/lsp/ReferenceCollector.h
+++ b/libsolidity/lsp/ReferenceCollector.h
@@ -1,0 +1,54 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <libsolidity/ast/ASTForward.h>
+#include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/lsp/LSPTypes.h>
+
+namespace solidity::lsp
+{
+
+class ReferenceCollector: public frontend::ASTConstVisitor
+{
+public:
+	ReferenceCollector(frontend::Declaration const& _declaration, std::string const& _sourceIdentifierName);
+
+	static std::vector<DocumentHighlight> collect(
+		frontend::Declaration const* _declaration,
+		frontend::ASTNode const& _ast,
+		std::string const& _sourceIdentifierName = {}
+	);
+
+	void endVisit(frontend::ImportDirective const& _import) override;
+	void endVisit(frontend::Identifier const& _identifier) override;
+	void endVisit(frontend::IdentifierPath  const& _identifierPath) override;
+	void endVisit(frontend::MemberAccess const& _memberAccess) override;
+	bool visitNode(frontend::ASTNode const& _node) override;
+
+private:
+	bool tryAddReference(frontend::Declaration const* _declaration, solidity::langutil::SourceLocation const& _location);
+	void addReference(solidity::langutil::SourceLocation const& _location);
+
+private:
+	frontend::Declaration const& m_declaration;
+	std::string const& m_sourceIdentifierName;
+	std::vector<DocumentHighlight> m_result;
+};
+
+} // end namespace

--- a/libsolidity/lsp/Transport.cpp
+++ b/libsolidity/lsp/Transport.cpp
@@ -1,0 +1,166 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/lsp/Transport.h>
+
+#include <libsolutil/JSON.h>
+#include <libsolutil/Visitor.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include <iostream>
+#include <sstream>
+
+using std::cin;
+using std::cout;
+using std::function;
+using std::istream;
+using std::nullopt;
+using std::optional;
+using std::ostream;
+using std::string;
+using std::string_view;
+using std::stringstream;
+
+namespace solidity::lsp {
+
+JSONTransport::JSONTransport(istream& _in, ostream& _out, function<void(string_view)> _trace):
+	m_input{_in},
+	m_output{_out},
+	m_trace{std::move(_trace)}
+{
+}
+
+JSONTransport::JSONTransport(function<void(string_view)> _trace):
+	JSONTransport(cin, cout, std::move(_trace))
+{
+}
+
+bool JSONTransport::closed() const noexcept
+{
+	return m_input.eof();
+}
+
+optional<Json::Value> JSONTransport::receive()
+{
+	auto const headers = parseHeaders();
+	if (!headers)
+		return nullopt;
+
+	if (!headers->count("content-length"))
+		return nullopt;
+
+	string const data = readBytes(stoi(headers->at("content-length")));
+
+	Json::Value jsonMessage;
+	string errs;
+	solidity::util::jsonParseStrict(data, jsonMessage, &errs);
+	if (!errs.empty())
+		return nullopt; // JsonParseError
+
+	traceMessage(jsonMessage, "Request");
+
+	return {jsonMessage};
+}
+
+void JSONTransport::notify(string const& _method, Json::Value const& _message)
+{
+	Json::Value json;
+	json["method"] = _method;
+	json["params"] = _message;
+	send(json);
+}
+
+void JSONTransport::reply(MessageId const& _id, Json::Value const& _message)
+{
+	Json::Value json;
+	json["result"] = _message;
+	send(json, _id);
+}
+
+void JSONTransport::error(MessageId _id, ErrorCode _code, string const& _message)
+{
+	Json::Value json;
+	json["error"]["code"] = static_cast<int>(_code);
+	json["error"]["message"] = _message;
+	send(json, _id);
+}
+
+void JSONTransport::send(Json::Value _json, MessageId _id)
+{
+	_json["jsonrpc"] = "2.0";
+	if (!_id.isNull())
+		_json["id"] = _id;
+
+	string const jsonString = solidity::util::jsonCompactPrint(_json);
+
+	m_output << "Content-Length: " << jsonString.size() << "\r\n";
+	m_output << "\r\n";
+	m_output << jsonString;
+
+	m_output.flush();
+	traceMessage(_json, "Response");
+}
+
+void JSONTransport::traceMessage(Json::Value const& _message, string_view _title)
+{
+	if (m_trace)
+		m_trace(string(_title) + ": " + solidity::util::jsonPrettyPrint(_message));
+}
+
+string JSONTransport::readLine()
+{
+	string line;
+
+	getline(m_input, line);
+
+	// Calling getline() trims the LF already, but if a CRLF is passed, the CR needs to be trimmed off, too.
+	if (!line.empty() && line.back() == '\r')
+		line.resize(line.size() - 1);
+
+	return line;
+}
+
+optional<JSONTransport::HeaderMap> JSONTransport::parseHeaders()
+{
+	HeaderMap headers;
+
+	for (string line = readLine(); !line.empty(); line = readLine())
+	{
+		auto const delimiterPos = line.find(':');
+		if (delimiterPos == string::npos)
+			return nullopt;
+
+		auto const name = boost::to_lower_copy(line.substr(0, delimiterPos));
+		auto const value = boost::trim_copy(line.substr(delimiterPos + 1));
+		headers[move(name)] = value;
+	}
+	return {move(headers)};
+}
+
+string JSONTransport::readBytes(int _n)
+{
+	if (_n < 0)
+		return {};
+
+	string data;
+	data.resize(static_cast<string::size_type>(_n));
+	m_input.read(data.data(), _n);
+	return data;
+}
+
+} // end namespace

--- a/libsolidity/lsp/Transport.cpp
+++ b/libsolidity/lsp/Transport.cpp
@@ -85,14 +85,14 @@ void JSONTransport::notify(string const& _method, Json::Value const& _message)
 	send(json);
 }
 
-void JSONTransport::reply(MessageId const& _id, Json::Value const& _message)
+void JSONTransport::reply(MessageID _id, Json::Value const& _message)
 {
 	Json::Value json;
 	json["result"] = _message;
 	send(json, _id);
 }
 
-void JSONTransport::error(MessageId _id, ErrorCode _code, string const& _message)
+void JSONTransport::error(MessageID _id, ErrorCode _code, string const& _message)
 {
 	Json::Value json;
 	json["error"]["code"] = static_cast<int>(_code);
@@ -100,7 +100,7 @@ void JSONTransport::error(MessageId _id, ErrorCode _code, string const& _message
 	send(json, _id);
 }
 
-void JSONTransport::send(Json::Value _json, MessageId _id)
+void JSONTransport::send(Json::Value _json, MessageID _id)
 {
 	_json["jsonrpc"] = "2.0";
 	if (!_id.isNull())

--- a/libsolidity/lsp/Transport.h
+++ b/libsolidity/lsp/Transport.h
@@ -1,0 +1,101 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <json/value.h>
+
+#include <functional>
+#include <iosfwd>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace solidity::lsp {
+
+using MessageId = Json::Value;
+
+enum class ErrorCode
+{
+	// Defined by JSON RPC
+	ParseError = -32700,
+	InvalidRequest = -32600,
+	MethodNotFound = -32601,
+	InvalidParams = -32602,
+	InternalError = -32603,
+	serverErrorStart = -32099,
+	serverErrorEnd = -32000,
+	ServerNotInitialized = -32002,
+	UnknownErrorCode = -32001,
+
+	// Defined by the protocol.
+	RequestCancelled = -32800,
+	ContentModified = -32801,
+};
+
+/// Transport layer API
+///
+/// The transport layer API is abstracted so it users become more testable as well as
+/// this way it could be possible to support other transports (HTTP for example) easily.
+class JSONTransport
+{
+public:
+	/// Constructs a standard stream transport layer.
+	///
+	/// @param _in for example std::cin (stdin)
+	/// @param _out for example std::cout (stdout)
+	/// @param _trace special logger used for debugging the LSP messages.
+	JSONTransport(std::istream& _in, std::ostream& _out, std::function<void(std::string_view)> _trace);
+
+	// Constructs a JSON transport using standard I/O streams.
+	explicit JSONTransport(std::function<void(std::string_view)> _trace);
+
+	bool closed() const noexcept;
+	std::optional<Json::Value> receive();
+	void notify(std::string const& _method, Json::Value const& _params);
+	void reply(MessageId const& _id, Json::Value const& _result);
+	void error(MessageId _id, ErrorCode _code, std::string const& _message);
+
+protected:
+	using HeaderMap = std::map<std::string, std::string>;
+
+	/// Reads given number of bytes from the client.
+	virtual std::string readBytes(int _n);
+
+	/// Sends an arbitrary raw message to the client.
+	///
+	/// Used by the notify/reply/error function family.
+	virtual void send(Json::Value _message, MessageId _id = Json::nullValue);
+
+	/// Parses a single text line from the client ending with CRLF (or just LF).
+	std::string readLine();
+
+	/// Parses header section from the client including message-delimiting empty line.
+	std::optional<HeaderMap> parseHeaders();
+
+	/// Appends given JSON message to the trace log.
+	void traceMessage(Json::Value const& _message, std::string_view _title);
+
+private:
+	std::istream& m_input;
+	std::ostream& m_output;
+	std::function<void(std::string_view)> m_trace;
+};
+
+} // end namespace

--- a/solc/CMakeLists.txt
+++ b/solc/CMakeLists.txt
@@ -4,8 +4,21 @@ set(
 	main.cpp
 )
 
+if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+	# Since we do not want to depend on networking code on production binaries,
+	# this feature is only available when creating a debug build.
+	# the LSP's TCP listener is exclusively used more convenient debugging.
+	option(SOLC_LSP_TCP "Solidity LSP: Enables TCP listener support (should only be eanbled for debugging purposes)." OFF)
+	if(SOLC_LSP_TCP)
+		set(SOLC_DEFINITIONS SOLC_LSP_TCP=1)
+		list(APPEND sources LSPTCPTransport.cpp LSPTCPTransport.h)
+		set(SOLC_LSP_LIBS pthread)
+	endif()
+endif()
+
 add_executable(solc ${sources})
-target_link_libraries(solc PRIVATE solidity Boost::boost Boost::program_options)
+target_link_libraries(solc PRIVATE solidity Boost::boost Boost::program_options ${SOLC_LSP_LIBS})
+target_compile_definitions(solc PRIVATE ${SOLC_DEFINITIONS})
 
 include(GNUInstallDirs)
 install(TARGETS solc DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1794,7 +1794,8 @@ bool CommandLineInterface::serveLSP()
 			*traceLog << _msg << endl;
 	};
 
-	lsp::LanguageServer languageServer(traceLogger);
+	std::unique_ptr<lsp::Transport> transport = make_unique<lsp::JSONTransport>(traceLogger);
+	lsp::LanguageServer languageServer(traceLogger, move(transport));
 	return languageServer.run();
 }
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -38,6 +38,8 @@
 #include <libsolidity/interface/DebugSettings.h>
 #include <libsolidity/interface/ImportRemapper.h>
 #include <libsolidity/interface/StorageLayout.h>
+#include <libsolidity/lsp/LanguageServer.h>
+#include <libsolidity/lsp/Transport.h>
 
 #include <libyul/AssemblyStack.h>
 #include <libyul/optimiser/Suite.h>
@@ -55,6 +57,8 @@
 #include <libsolutil/CommonData.h>
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/JSON.h>
+
+#include <range/v3/all.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -925,6 +929,16 @@ General Information)").c_str(),
 			"Supported Inputs is the output of the --" + g_argStandardJSON + " or the one produced by "
 			"--" + g_argCombinedJson + " " + g_strAst + "," + g_strCompactJSON).c_str()
 		)
+		(
+			"lsp",
+			"Enables Language Server (LSP) mode. "
+			"This won't compile input but serves as language server to to clients."
+		)
+		(
+			"lsp-trace",
+			po::value<string>()->value_name("path"),
+			"Writes a trace log file when running in LSP mode. Only useful when debugging solc LSP."
+		)
 	;
 	desc.add(alternativeInputModes);
 
@@ -1107,6 +1121,26 @@ General Information)").c_str(),
 	if (!checkMutuallyExclusive(m_args, g_argColor, g_argNoColor))
 		return false;
 
+	static vector<string> const allowedWithLSP{
+		// LSP related arguments.
+		"lsp",
+		"lsp-trace",
+		// Defaulted arguments must be listed.
+		g_argModelCheckerEngine,
+		g_argModelCheckerTargets,
+		g_argOptimizeRuns
+	};
+
+	if (m_args.count("lsp"))
+		for (auto const& arg: m_args)
+		{
+			if (ranges::none_of(allowedWithLSP, [&](auto const& a) -> bool { return a == arg.first; }))
+			{
+				serr() << "Option " << arg.first << " and " << "lsp" << " are mutually exclusive." << endl;
+				return false;
+			}
+		}
+
 	static vector<string> const conflictingWithStopAfter{
 		g_argBinary,
 		g_argIR,
@@ -1178,6 +1212,10 @@ General Information)").c_str(),
 
 bool CommandLineInterface::processInput()
 {
+	if (m_args.count("lsp"))
+		// Input is coming in interactively in LSP mode.
+		return true;
+
 	if (m_args.count(g_argBasePath))
 	{
 		boost::filesystem::path const fspath{m_args[g_argBasePath].as<string>()};
@@ -1742,8 +1780,28 @@ void CommandLineInterface::handleAst()
 	}
 }
 
+bool CommandLineInterface::serveLSP()
+{
+	std::unique_ptr<ofstream> traceLog;
+	if (m_args.count("lsp-trace"))
+		traceLog = make_unique<ofstream>(m_args.at("lsp-trace").as<string>(), std::ios::app);
+	else
+		traceLog = make_unique<ofstream>("/tmp/solc.lsp.log", std::ios::app);
+
+	auto const traceLogger = [&traceLog](string_view _msg)
+	{
+		if (traceLog)
+			*traceLog << _msg << endl;
+	};
+
+	lsp::LanguageServer languageServer(traceLogger);
+	return languageServer.run();
+}
+
 bool CommandLineInterface::actOnInput()
 {
+	if (m_args.count("lsp"))
+		serveLSP();
 	if (m_args.count(g_argStandardJSON) || m_onlyAssemble)
 		// Already done in "processInput" phase.
 		return true;

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -52,6 +52,8 @@ public:
 	bool actOnInput();
 
 private:
+	bool serveLSP();
+
 	bool link();
 	void writeLinkedFiles();
 	/// @returns the ``// <identifier> -> name`` hint for library placeholders.

--- a/solc/LSPTCPTransport.cpp
+++ b/solc/LSPTCPTransport.cpp
@@ -1,0 +1,99 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include "LSPTCPTransport.h"
+
+#include <optional>
+#include <string>
+#include <iostream>
+
+using namespace solidity::lsp;
+
+namespace solidity::frontend {
+
+using std::nullopt;
+using std::optional;
+using std::to_string;
+
+using namespace std::string_literals;
+
+LSPTCPTransport::LSPTCPTransport(unsigned short _port, std::function<void(std::string_view)> _trace):
+	m_io_service(),
+	m_endpoint(boost::asio::ip::make_address("127.0.0.1"), _port),
+	m_acceptor(m_io_service),
+	m_stream(),
+	m_jsonTransport(),
+	m_trace(std::move(_trace))
+{
+	m_acceptor.open(m_endpoint.protocol());
+	m_acceptor.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+	m_acceptor.bind(m_endpoint);
+	m_acceptor.listen();
+	m_trace("Listening on tcp://127.0.0.1:"s + to_string(_port));
+}
+
+bool LSPTCPTransport::closed() const noexcept
+{
+	return !m_acceptor.is_open();
+}
+
+optional<Json::Value> LSPTCPTransport::receive()
+{
+	auto const clientClosed = [&]() { return !m_stream || !m_stream.value().good() || m_stream.value().eof(); };
+
+	if (clientClosed())
+	{
+		m_stream.emplace(m_acceptor.accept());
+		if (clientClosed())
+			return nullopt;
+
+		auto const remoteAddr = m_stream.value().socket().remote_endpoint().address().to_string();
+		auto const remotePort = m_stream.value().socket().remote_endpoint().port();
+		m_trace("New client connected from "s + remoteAddr + ":" + to_string(remotePort) + ".");
+		m_jsonTransport.emplace(m_stream.value(), m_stream.value(), [this](auto msg) { if (m_trace) m_trace(msg); });
+	}
+	if (auto value = m_jsonTransport.value().receive(); value.has_value())
+		return value;
+
+	if (clientClosed())
+	{
+		m_trace("Client disconnected.");
+		m_jsonTransport.reset();
+		m_stream.reset();
+	}
+	return nullopt;
+}
+
+void LSPTCPTransport::notify(std::string const& _method, Json::Value const& _params)
+{
+	if (m_jsonTransport.has_value())
+		m_jsonTransport.value().notify(_method, _params);
+}
+
+void LSPTCPTransport::reply(MessageID _id, Json::Value const& _result)
+{
+	if (m_jsonTransport.has_value())
+		m_jsonTransport.value().reply(_id, _result);
+}
+
+void LSPTCPTransport::error(MessageID _id, ErrorCode _code, std::string const& _message)
+{
+	if (m_jsonTransport.has_value())
+		m_jsonTransport.value().error(_id, _code, _message);
+}
+
+}

--- a/solc/LSPTCPTransport.h
+++ b/solc/LSPTCPTransport.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <libsolidity/lsp/Transport.h>
+
+#include <boost/asio.hpp>
+#include <optional>
+
+namespace solidity::frontend {
+
+class LSPTCPTransport: public lsp::Transport {
+public:
+	explicit LSPTCPTransport(unsigned short _port, std::function<void(std::string_view)> = {});
+
+	bool closed() const noexcept override;
+	std::optional<Json::Value> receive() override;
+	void notify(std::string const& _method, Json::Value const& _params) override;
+	void reply(lsp::MessageID _id, Json::Value const& _result) override;
+	void error(lsp::MessageID _id, lsp::ErrorCode _code, std::string const& _message) override;
+
+private:
+	boost::asio::io_service m_io_service;
+	boost::asio::ip::tcp::endpoint m_endpoint;
+	boost::asio::ip::tcp::acceptor m_acceptor;
+	std::optional<boost::asio::ip::tcp::iostream> m_stream;
+	std::optional<lsp::JSONTransport> m_jsonTransport;
+	std::function<void(std::string_view)> m_trace;
+};
+
+} // end namespace


### PR DESCRIPTION
## Dependencies

- [x] PR: #10833 (commitS currently included here, too, for easier development)
- [x] PR: #10880

## Status
- [x] basic client/server communication working (tested in vim/neovim and its [coc.nvim](https://github.com/neoclide/coc.nvim)) LSP plugin.
* [x] compilation errors are published to the client
* [x] Goto definition
* [x] Semantic highlighting
* [x] Find all references
* [x] REFACTOR: remove some of the abstractions in liblsp/solls in order to simplify the code / reduce the SLoC's
* [x] Merge into`solc` executable with CLI argument `--lsp` to enable LSP mode.
* [x] properly handle remapping
* [x] add some sort of configurability via JSON settings object (EVM version, ...)

### Thoughts

I think basicaly all standard LSP features that a user would expect look implementable except auto completion. Here I would suggest having a look at what clangd is doing.

My current take on this is:
1. parse as usual (fatal parser errors should be okay); if the parser has to parse an expression, such as `expression.` without the right hand side filled, a placeholder could be added to the AST node, denoting that there is an expression that looks incomplete (in case it is allowed to be filled)
2. the analyzer can take this into account and if auto completion position matches that, it'll fill the response with all the members of `expression`.

Also, I'd distinguish here between general error recovery that was once attempted an this kind of artificially generated syntax errors. The scope of auto completion generated syntax errors should limit the cases the parser has to deal with.