### PR TITLE
CMake: Renaming devcore static library to solutil (to match source code paths)

### DIFF
--- a/libevmasm/CMakeLists.txt
+++ b/libevmasm/CMakeLists.txt
@@ -36,4 +36,4 @@ set(sources
 )
 
 add_library(evmasm ${sources})
-target_link_libraries(evmasm PUBLIC devcore)
+target_link_libraries(evmasm PUBLIC solutil)

--- a/liblangutil/CMakeLists.txt
+++ b/liblangutil/CMakeLists.txt
@@ -28,4 +28,4 @@ set(sources
 )
 
 add_library(langutil ${sources})
-target_link_libraries(langutil PUBLIC devcore)
+target_link_libraries(langutil PUBLIC solutil)

--- a/liblll/CMakeLists.txt
+++ b/liblll/CMakeLists.txt
@@ -11,4 +11,4 @@ set(sources
 )
 
 add_library(lll ${sources})
-target_link_libraries(lll PUBLIC evmasm devcore)
+target_link_libraries(lll PUBLIC evmasm solutil)

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -151,7 +151,7 @@ if (NOT (${Z3_FOUND} OR ${CVC4_FOUND}))
 endif()
 
 add_library(solidity ${sources} ${z3_SRCS} ${cvc4_SRCS})
-target_link_libraries(solidity PUBLIC yul evmasm langutil devcore Boost::boost Boost::filesystem Boost::system)
+target_link_libraries(solidity PUBLIC yul evmasm langutil solutil Boost::boost Boost::filesystem Boost::system)
 
 if (${Z3_FOUND})
   target_link_libraries(solidity PUBLIC z3::libz3)

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -33,11 +33,11 @@ set(sources
 	Whiskers.h
 )
 
-add_library(devcore ${sources})
-target_link_libraries(devcore PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system)
-target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
-add_dependencies(devcore solidity_BuildInfo.h)
+add_library(solutil ${sources})
+target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system)
+target_include_directories(solutil PUBLIC "${CMAKE_SOURCE_DIR}")
+add_dependencies(solutil solidity_BuildInfo.h)
 
 if(SOLC_LINK_STATIC)
-	target_link_libraries(devcore PUBLIC Threads::Threads)
+	target_link_libraries(solutil PUBLIC Threads::Threads)
 endif()

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -158,4 +158,4 @@ add_library(yul
 	optimiser/VarNameCleaner.cpp
 	optimiser/VarNameCleaner.h
 )
-target_link_libraries(yul PUBLIC evmasm devcore langutil)
+target_link_libraries(yul PUBLIC evmasm solutil langutil)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -159,7 +159,7 @@ add_executable(soltest ${sources}
     ${libsolidity_sources}
     ${libsolidity_util_sources}
 )
-target_link_libraries(soltest PRIVATE libsolc yul solidity yulInterpreter evmasm devcore Boost::boost Boost::program_options Boost::unit_test_framework evmc)
+target_link_libraries(soltest PRIVATE libsolc yul solidity yulInterpreter evmasm solutil Boost::boost Boost::program_options Boost::unit_test_framework evmc)
 
 
 # Special compilation flag for Visual Studio (version 2019 at least affected)

--- a/test/tools/yulInterpreter/CMakeLists.txt
+++ b/test/tools/yulInterpreter/CMakeLists.txt
@@ -8,4 +8,4 @@ set(sources
 )
 
 add_library(yulInterpreter ${sources})
-target_link_libraries(yulInterpreter PUBLIC yul solidity devcore)
+target_link_libraries(yulInterpreter PUBLIC yul solidity solutil)


### PR DESCRIPTION
I apparently forgot to rename the CMake target for the solutil library, so doint it now.