### PR TITLE
Fix error message suggestion for receive

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -680,7 +680,7 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 		fatalParserError(
 			"Expected a state variable declaration. If you intended this as a fallback function "
 			"or a function to handle plain ether transactions, use the \"fallback\" keyword "
-			"or the \"ether\" keyword instead."
+			"or the \"receive\" keyword instead."
 		);
 
 	bool isIndexed = false;

--- a/test/libsolidity/syntaxTests/fallback/old_syntax.sol
+++ b/test/libsolidity/syntaxTests/fallback/old_syntax.sol
@@ -2,4 +2,4 @@ contract C {
     function() external {}
 }
 // ----
-// ParserError: (37-38): Expected a state variable declaration. If you intended this as a fallback function or a function to handle plain ether transactions, use the "fallback" keyword or the "ether" keyword instead.
+// ParserError: (37-38): Expected a state variable declaration. If you intended this as a fallback function or a function to handle plain ether transactions, use the "fallback" keyword or the "receive" keyword instead.

--- a/test/libsolidity/syntaxTests/receiveEther/old_syntax.sol
+++ b/test/libsolidity/syntaxTests/receiveEther/old_syntax.sol
@@ -2,4 +2,4 @@ contract C {
     function() external payable {}
 }
 // ----
-// ParserError: (45-46): Expected a state variable declaration. If you intended this as a fallback function or a function to handle plain ether transactions, use the "fallback" keyword or the "ether" keyword instead.
+// ParserError: (45-46): Expected a state variable declaration. If you intended this as a fallback function or a function to handle plain ether transactions, use the "fallback" keyword or the "receive" keyword instead.


### PR DESCRIPTION
When compiling a contract that has a 0.5.x-style fallback function using 0.6.1, the following error message is displayed:

```
ParserError: Expected a state variable declaration. If you intended this as a fallback function or a function to handle plain ether transactions, use the "fallback" keyword or the "ether" keyword instead.
```

The suggestion should tell the developer to use the `receive` keyword, not `ether` (which as far as I know doesn't exist).