### PR TITLE
[yul-phaser] Minimal application

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,6 +141,7 @@ detect_stray_source_files("${libyul_sources}" "libyul/")
 set(yul_phaser_sources
     yulPhaser/Chromosome.cpp
     yulPhaser/Program.cpp
+    yulPhaser/Random.cpp
 
     # FIXME: yul-phaser is not a library so I can't just add it to target_link_libraries().
     # My current workaround is just to include its source files here but this introduces

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,11 +140,13 @@ detect_stray_source_files("${libyul_sources}" "libyul/")
 
 set(yul_phaser_sources
     yulPhaser/Chromosome.cpp
+    yulPhaser/Program.cpp
 
     # FIXME: yul-phaser is not a library so I can't just add it to target_link_libraries().
     # My current workaround is just to include its source files here but this introduces
     # unnecessary duplication. Create a library or find a way to reuse the list in both places.
     ../tools/yulPhaser/Chromosome.cpp
+    ../tools/yulPhaser/Program.cpp
     ../tools/yulPhaser/Random.cpp
 )
 detect_stray_source_files("${yul_phaser_sources}" "yulPhaser/")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,7 @@ detect_stray_source_files("${libyul_sources}" "libyul/")
 
 set(yul_phaser_sources
     yulPhaser/Chromosome.cpp
+    yulPhaser/Population.cpp
     yulPhaser/Program.cpp
     yulPhaser/Random.cpp
 
@@ -147,6 +148,7 @@ set(yul_phaser_sources
     # My current workaround is just to include its source files here but this introduces
     # unnecessary duplication. Create a library or find a way to reuse the list in both places.
     ../tools/yulPhaser/Chromosome.cpp
+    ../tools/yulPhaser/Population.cpp
     ../tools/yulPhaser/Program.cpp
     ../tools/yulPhaser/Random.cpp
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,12 @@ detect_stray_source_files("${libyul_sources}" "libyul/")
 
 set(yul_phaser_sources
     yulPhaser/Chromosome.cpp
+
+    # FIXME: yul-phaser is not a library so I can't just add it to target_link_libraries().
+    # My current workaround is just to include its source files here but this introduces
+    # unnecessary duplication. Create a library or find a way to reuse the list in both places.
+    ../tools/yulPhaser/Chromosome.cpp
+    ../tools/yulPhaser/Random.cpp
 )
 detect_stray_source_files("${yul_phaser_sources}" "yulPhaser/")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,6 +138,11 @@ set(libyul_sources
 )
 detect_stray_source_files("${libyul_sources}" "libyul/")
 
+set(yul_phaser_sources
+    yulPhaser/Chromosome.cpp
+)
+detect_stray_source_files("${yul_phaser_sources}" "yulPhaser/")
+
 add_executable(soltest ${sources}
     ${contracts_sources}
     ${libsolutil_sources}
@@ -146,6 +151,7 @@ add_executable(soltest ${sources}
     ${libyul_sources}
     ${libsolidity_sources}
     ${libsolidity_util_sources}
+    ${yul_phaser_sources}
 )
 target_link_libraries(soltest PRIVATE libsolc yul solidity yulInterpreter evmasm solutil Boost::boost Boost::program_options Boost::unit_test_framework evmc)
 

--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -1,0 +1,26 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <boost/test/unit_test.hpp>
+
+namespace solidity::phaser::test
+{
+
+BOOST_AUTO_TEST_SUITE(ChromosomeTest)
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -15,12 +15,87 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <tools/yulPhaser/Chromosome.h>
+
+#include <libyul/optimiser/BlockFlattener.h>
+#include <libyul/optimiser/StructuralSimplifier.h>
+#include <libyul/optimiser/Suite.h>
+#include <libyul/optimiser/UnusedPruner.h>
+
+#include <libsolutil/CommonIO.h>
+
 #include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace solidity::yul;
+using namespace solidity::util;
 
 namespace solidity::phaser::test
 {
 
+BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(ChromosomeTest)
+
+BOOST_AUTO_TEST_CASE(makeRandom_should_create_chromosome_with_random_optimisation_steps)
+{
+	constexpr uint32_t numSteps = 1000;
+
+	auto chromosome1 = Chromosome::makeRandom(numSteps);
+	auto chromosome2 = Chromosome::makeRandom(numSteps);
+	BOOST_CHECK_EQUAL(chromosome1.length(), numSteps);
+	BOOST_CHECK_EQUAL(chromosome2.length(), numSteps);
+
+	multiset<string> steps1;
+	multiset<string> steps2;
+	for (auto const& step: chromosome1.optimisationSteps())
+		steps1.insert(step);
+	for (auto const& step: chromosome2.optimisationSteps())
+		steps2.insert(step);
+
+	// Check if steps are different and also if they're not just a permutation of the same set.
+	// Technically they could be the same and still random but the probability is infinitesimally low.
+	BOOST_TEST(steps1 != steps2);
+}
+
+BOOST_AUTO_TEST_CASE(constructor_should_store_optimisation_steps)
+{
+	vector<string> steps = {
+		StructuralSimplifier::name,
+		BlockFlattener::name,
+		UnusedPruner::name,
+	};
+	Chromosome chromosome(steps);
+
+	BOOST_TEST(steps == chromosome.optimisationSteps());
+}
+
+BOOST_AUTO_TEST_CASE(constructor_should_allow_duplicate_steps)
+{
+	vector<string> steps = {
+		StructuralSimplifier::name,
+		StructuralSimplifier::name,
+		BlockFlattener::name,
+		UnusedPruner::name,
+		BlockFlattener::name,
+	};
+	Chromosome chromosome(steps);
+
+	BOOST_TEST(steps == chromosome.optimisationSteps());
+}
+
+BOOST_AUTO_TEST_CASE(output_operator_should_create_concise_and_unambiguous_string_representation)
+{
+	vector<string> allSteps;
+	for (auto const& step: OptimiserSuite::allSteps())
+		allSteps.push_back(step.first);
+	Chromosome chromosome(allSteps);
+
+	BOOST_TEST(chromosome.length() == allSteps.size());
+	BOOST_TEST(chromosome.optimisationSteps() == allSteps);
+	BOOST_TEST(toString(chromosome) == "fcCUnDvejsxIOoighTLMrmVatud");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -1,0 +1,176 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/Population.h>
+
+#include <libyul/optimiser/BlockFlattener.h>
+#include <libyul/optimiser/SSAReverser.h>
+#include <libyul/optimiser/StructuralSimplifier.h>
+#include <libyul/optimiser/UnusedPruner.h>
+
+#include <liblangutil/CharStream.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <optional>
+#include <string>
+#include <sstream>
+
+using namespace std;
+using namespace solidity::langutil;
+using namespace solidity::yul;
+using namespace boost::unit_test::framework;
+
+namespace solidity::phaser::test
+{
+
+namespace
+{
+	bool fitnessNotSet(Individual const& individual)
+	{
+		return !individual.fitness.has_value();
+	}
+
+	bool fitnessSet(Individual const& individual)
+	{
+		return individual.fitness.has_value();
+	}
+}
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(PopulationTest)
+
+string const& sampleSourceCode =
+	"{\n"
+	"    let factor := 13\n"
+	"    {\n"
+	"        if factor\n"
+	"        {\n"
+	"            let variable := add(1, 2)\n"
+	"        }\n"
+	"        let result := factor\n"
+	"    }\n"
+	"    let something := 6\n"
+	"    {\n"
+	"        {\n"
+	"            {\n"
+	"                let value := 15\n"
+	"            }\n"
+	"        }\n"
+	"    }\n"
+	"    let something_else := mul(mul(something, 1), add(factor, 0))\n"
+	"    if 1 { let x := 1 }\n"
+	"    if 0 { let y := 2 }\n"
+	"}\n";
+
+BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness)
+{
+	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
+	vector<Chromosome> chromosomes = {
+		Chromosome::makeRandom(5),
+		Chromosome::makeRandom(10),
+	};
+	Population population(sourceStream, chromosomes);
+
+	BOOST_TEST(population.individuals().size() == 2);
+	BOOST_TEST(population.individuals()[0].chromosome == chromosomes[0]);
+	BOOST_TEST(population.individuals()[1].chromosome == chromosomes[1]);
+
+	auto fitnessNotSet = [](auto const& individual){ return !individual.fitness.has_value(); };
+	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
+}
+
+BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes)
+{
+	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
+	auto population1 = Population::makeRandom(sourceStream, 100);
+	auto population2 = Population::makeRandom(sourceStream, 100);
+
+	BOOST_TEST(population1.individuals().size() == 100);
+	BOOST_TEST(population2.individuals().size() == 100);
+
+	int numMatchingPositions = 0;
+	for (size_t i = 0; i < 100; ++i)
+		if (population1.individuals()[i].chromosome == population2.individuals()[i].chromosome)
+			++numMatchingPositions;
+
+	// Assume that the results are random if there are no more than 10 identical chromosomes on the
+	// same positions. One duplicate is very unlikely but still possible after billions of runs
+	// (especially for short chromosomes). For ten the probability is so small that we can ignore it.
+	BOOST_TEST(numMatchingPositions < 10);
+}
+
+BOOST_AUTO_TEST_CASE(makeRandom_should_not_compute_fitness)
+{
+	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
+	auto population = Population::makeRandom(sourceStream, 5);
+
+	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
+}
+
+BOOST_AUTO_TEST_CASE(run_should_evaluate_fitness)
+{
+	stringstream output;
+	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
+	auto population = Population::makeRandom(sourceStream, 5);
+	assert(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
+
+	population.run(1, output);
+
+	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessSet));
+}
+
+BOOST_AUTO_TEST_CASE(run_should_not_make_fitness_of_top_chromosomes_worse)
+{
+	stringstream output;
+	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
+	vector<Chromosome> chromosomes = {
+		Chromosome({StructuralSimplifier::name}),
+		Chromosome({BlockFlattener::name}),
+		Chromosome({SSAReverser::name}),
+		Chromosome({UnusedPruner::name}),
+		Chromosome({StructuralSimplifier::name, BlockFlattener::name}),
+	};
+	Population population(sourceStream, chromosomes);
+
+	size_t initialTopFitness[2] = {
+		Population::measureFitness(chromosomes[0], sourceStream),
+		Population::measureFitness(chromosomes[1], sourceStream),
+	};
+
+	for (int i = 0; i < 6; ++i)
+	{
+		population.run(1, output);
+		BOOST_TEST(population.individuals().size() == 5);
+		BOOST_TEST(fitnessSet(population.individuals()[0]));
+		BOOST_TEST(fitnessSet(population.individuals()[1]));
+
+		size_t currentTopFitness[2] = {
+			population.individuals()[0].fitness.value(),
+			population.individuals()[1].fitness.value(),
+		};
+		BOOST_TEST(currentTopFitness[0] <= initialTopFitness[0]);
+		BOOST_TEST(currentTopFitness[1] <= initialTopFitness[1]);
+		BOOST_TEST(currentTopFitness[0] <= currentTopFitness[1]);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/Program.cpp
+++ b/test/yulPhaser/Program.cpp
@@ -1,0 +1,266 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Exceptions.h>
+#include <tools/yulPhaser/Program.h>
+
+#include <libyul/optimiser/BlockFlattener.h>
+#include <libyul/optimiser/Metrics.h>
+#include <libyul/optimiser/StructuralSimplifier.h>
+#include <libyul/AsmData.h>
+
+#include <libsolutil/CommonIO.h>
+#include <libsolutil/JSON.h>
+#include <liblangutil/CharStream.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cassert>
+#include <regex>
+#include <string>
+
+using namespace std;
+using namespace solidity::langutil;
+using namespace solidity::util;
+using namespace solidity::yul;
+using namespace boost::unit_test::framework;
+
+namespace
+{
+	/// If the specified block is redundant (i.e. the only thing it contains is another block)
+	/// the function recurses into it and returns the first non-redundant one it finds.
+	/// If the block isn't redundant it just returns it immediately.
+	Block const& skipRedundantBlocks(Block const& _block)
+	{
+		if (_block.statements.size() == 1 && holds_alternative<Block>(_block.statements[0]))
+			return skipRedundantBlocks(get<Block>(_block.statements[0]));
+		else
+			return _block;
+	}
+
+	string stripWhitespace(string const& input)
+	{
+		regex whitespaceRegex("\\s+");
+		return regex_replace(input, whitespaceRegex, "");
+	}
+}
+
+namespace solidity::phaser::test
+{
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(ProgramTest)
+
+BOOST_AUTO_TEST_CASE(load_should_rewind_the_stream)
+{
+	string sourceCode(
+		"{\n"
+		"    let x := 1\n"
+		"    let y := 2\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	sourceStream.setPosition(5);
+
+	auto program = Program::load(sourceStream);
+
+	BOOST_TEST(CodeSize::codeSize(program.ast()) == 2);
+}
+
+BOOST_AUTO_TEST_CASE(load_should_disambiguate)
+{
+	string sourceCode(
+		"{\n"
+		"    {\n"
+		"        let x := 1\n"
+		"    }\n"
+		"    {\n"
+		"        let x := 2\n"
+		"    }\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	// skipRedundantBlocks() makes the test independent of whether load() includes function grouping or not.
+	Block const& parentBlock = skipRedundantBlocks(program.ast());
+	BOOST_TEST(parentBlock.statements.size() == 2);
+
+	Block const& innerBlock1 = get<Block>(parentBlock.statements[0]);
+	Block const& innerBlock2 = get<Block>(parentBlock.statements[1]);
+	VariableDeclaration const& declaration1 = get<VariableDeclaration>(innerBlock1.statements[0]);
+	VariableDeclaration const& declaration2 = get<VariableDeclaration>(innerBlock2.statements[0]);
+
+	BOOST_TEST(declaration1.variables[0].name.str() == "x");
+	BOOST_TEST(declaration2.variables[0].name.str() != "x");
+}
+
+BOOST_AUTO_TEST_CASE(load_should_do_function_grouping_and_hoisting)
+{
+	string sourceCode(
+		"{\n"
+		"    function foo() -> result\n"
+		"    {\n"
+		"        result := 1\n"
+		"    }\n"
+		"    let x := 1\n"
+		"    function bar(a) -> result\n"
+		"    {\n"
+		"        result := 2\n"
+		"    }\n"
+		"    let y := 2\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	BOOST_TEST(program.ast().statements.size() == 3);
+	BOOST_TEST(holds_alternative<Block>(program.ast().statements[0]));
+	BOOST_TEST(holds_alternative<FunctionDefinition>(program.ast().statements[1]));
+	BOOST_TEST(holds_alternative<FunctionDefinition>(program.ast().statements[2]));
+}
+
+BOOST_AUTO_TEST_CASE(load_should_do_loop_init_rewriting)
+{
+	string sourceCode(
+		"{\n"
+		"    for { let i := 0 } true {}\n"
+		"    {\n"
+		"    }\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	// skipRedundantBlocks() makes the test independent of whether load() includes function grouping or not.
+	Block const& parentBlock = skipRedundantBlocks(program.ast());
+	BOOST_TEST(holds_alternative<VariableDeclaration>(parentBlock.statements[0]));
+	BOOST_TEST(holds_alternative<ForLoop>(parentBlock.statements[1]));
+}
+
+BOOST_AUTO_TEST_CASE(load_should_throw_InvalidProgram_if_program_cant_be_parsed)
+{
+	string sourceCode("invalid program\n");
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+
+	BOOST_CHECK_THROW(Program::load(sourceStream), InvalidProgram);
+}
+
+BOOST_AUTO_TEST_CASE(load_should_throw_InvalidProgram_if_program_cant_be_analyzed)
+{
+	// This should be parsed just fine but fail the analysis with:
+	//     Error: Variable not found or variable not lvalue.
+	string sourceCode(
+		"{\n"
+		"    x := 1\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+
+	BOOST_CHECK_THROW(Program::load(sourceStream), InvalidProgram);
+}
+
+BOOST_AUTO_TEST_CASE(optimise)
+{
+	string sourceCode(
+		"{\n"
+		"    {\n"
+		"        if 1 { let x := 1 }\n"
+		"        if 0 { let y := 2 }\n"
+		"    }\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	[[maybe_unused]] Block const& parentBlockBefore = skipRedundantBlocks(program.ast());
+	assert(parentBlockBefore.statements.size() == 2);
+	assert(holds_alternative<If>(parentBlockBefore.statements[0]));
+	assert(holds_alternative<If>(parentBlockBefore.statements[1]));
+
+	program.optimise({StructuralSimplifier::name, BlockFlattener::name});
+
+	Block const& parentBlockAfter = program.ast();
+	BOOST_TEST(parentBlockAfter.statements.size() == 1);
+	BOOST_TEST(holds_alternative<VariableDeclaration>(parentBlockAfter.statements[0]));
+}
+
+BOOST_AUTO_TEST_CASE(output_operator)
+{
+	string sourceCode(
+		"{\n"
+		"    let factor := 13\n"
+		"    {\n"
+		"        if factor\n"
+		"        {\n"
+		"            let variable := add(1, 2)\n"
+		"        }\n"
+		"        let result := factor\n"
+		"    }\n"
+		"    let something := 6\n"
+		"    let something_else := mul(something, factor)\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	// NOTE: The snippet above was chosen so that the few optimisations applied automatically by load()
+	// as of now do not change the code significantly. If that changes, you may have to update it.
+	BOOST_TEST(stripWhitespace(toString(program)) == stripWhitespace("{" + sourceCode + "}"));
+}
+
+BOOST_AUTO_TEST_CASE(toJson)
+{
+	string sourceCode(
+		"{\n"
+		"    let a := 3\n"
+		"    if a\n"
+		"    {\n"
+		"        let abc := add(1, 2)\n"
+		"    }\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	Json::Value parsingResult;
+	string errors;
+	BOOST_TEST(jsonParseStrict(program.toJson(), parsingResult, &errors));
+	BOOST_TEST(errors.empty());
+}
+
+BOOST_AUTO_TEST_CASE(codeSize)
+{
+	string sourceCode(
+		"{\n"
+		"    function foo() -> result\n"
+		"    {\n"
+		"        result := 15\n"
+		"    }\n"
+		"    let a := 1\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	BOOST_TEST(program.codeSize() == CodeSize::codeSizeIncludingFunctions(program.ast()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/Random.cpp
+++ b/test/yulPhaser/Random.cpp
@@ -1,0 +1,95 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Random.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cassert>
+
+using namespace std;
+
+namespace solidity::phaser::test
+{
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(RandomTest)
+
+BOOST_AUTO_TEST_CASE(uniformRandomInt_returns_different_values_when_called_multiple_times)
+{
+	constexpr uint32_t numSamples = 1000;
+	constexpr uint32_t numOutcomes = 100;
+
+	vector<uint32_t> samples1;
+	vector<uint32_t> samples2;
+	for (uint32_t i = 0; i < numSamples; ++i)
+	{
+		samples1.push_back(uniformRandomInt(0, numOutcomes - 1));
+		samples2.push_back(uniformRandomInt(0, numOutcomes - 1));
+	}
+
+	vector<uint32_t> counts1(numSamples, 0);
+	vector<uint32_t> counts2(numSamples, 0);
+	for (uint32_t i = 0; i < numSamples; ++i)
+	{
+		++counts1[samples1[i]];
+		++counts2[samples2[i]];
+	}
+
+	// This test rules out not only the possibility that the two sequences are the same but also
+	// that they're just different permutations of the same values. The test is probabilistic so
+	// it's technically possible for it to fail even if generator is good but the probability is
+	// so low that it would happen on average once very 10^125 billion years if you repeated it
+	// every second. The chance is much lower than 1 in 1000^100 / 100!.
+	//
+	// This does not really guarantee that the generated numbers have the right distribution or
+	// or that they don't come in long, repeating sequences but the implementation is very simple
+	// (it just calls a generator from boost) so our goal here is just to make sure it's used
+	// properly and we're not getting something totally non-random, e.g. the same number every time.
+	BOOST_TEST(counts1 != counts2);
+}
+
+BOOST_AUTO_TEST_CASE(binomialRandomInt_returns_different_values_when_called_multiple_times)
+{
+	constexpr uint32_t numSamples = 1000;
+	constexpr uint32_t numTrials = 100;
+	constexpr double successProbability = 0.6;
+
+	vector<uint32_t> samples1;
+	vector<uint32_t> samples2;
+	for (uint32_t i = 0; i < numSamples; ++i)
+	{
+		samples1.push_back(binomialRandomInt(numTrials, successProbability));
+		samples2.push_back(binomialRandomInt(numTrials, successProbability));
+	}
+
+	vector<uint32_t> counts1(numSamples, 0);
+	vector<uint32_t> counts2(numSamples, 0);
+	for (uint32_t i = 0; i < numSamples; ++i)
+	{
+		++counts1[samples1[i]];
+		++counts2[samples2[i]];
+	}
+
+	// See remark for uniformRandomInt() above. Same applies here.
+	BOOST_TEST(counts1 != counts2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,5 +16,6 @@ install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
 add_executable(yul-phaser
 	yulPhaser/main.cpp
 )
+target_link_libraries(yul-phaser PRIVATE Boost::program_options)
 
 install(TARGETS yul-phaser DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(yul-phaser
 	yulPhaser/main.cpp
 	yulPhaser/Program.h
 	yulPhaser/Program.cpp
+	yulPhaser/Random.h
+	yulPhaser/Random.cpp
 )
 target_link_libraries(yul-phaser PRIVATE solidity Boost::program_options)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,3 +12,9 @@ target_link_libraries(solidity-upgrade PRIVATE solidity Boost::boost Boost::prog
 
 include(GNUInstallDirs)
 install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+add_executable(yul-phaser
+	yulPhaser/main.cpp
+)
+
+install(TARGETS yul-phaser DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,7 +15,9 @@ install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 add_executable(yul-phaser
 	yulPhaser/main.cpp
+	yulPhaser/Program.h
+	yulPhaser/Program.cpp
 )
-target_link_libraries(yul-phaser PRIVATE Boost::program_options)
+target_link_libraries(yul-phaser PRIVATE solidity Boost::program_options)
 
 install(TARGETS yul-phaser DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,6 +15,8 @@ install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 add_executable(yul-phaser
 	yulPhaser/main.cpp
+	yulPhaser/Population.h
+	yulPhaser/Population.cpp
 	yulPhaser/Chromosome.h
 	yulPhaser/Chromosome.cpp
 	yulPhaser/Program.h

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,6 +15,8 @@ install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 add_executable(yul-phaser
 	yulPhaser/main.cpp
+	yulPhaser/Chromosome.h
+	yulPhaser/Chromosome.cpp
 	yulPhaser/Program.h
 	yulPhaser/Program.cpp
 	yulPhaser/Random.h

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -26,7 +26,6 @@
 
 using namespace std;
 using namespace solidity;
-using namespace solidity::util;
 using namespace solidity::yul;
 using namespace solidity::phaser;
 
@@ -63,50 +62,9 @@ vector<string> Chromosome::allStepNames()
 	return stepNames;
 }
 
-vector<string> Chromosome::allStepNamesExcept(vector<string> const& _excludedStepNames)
-{
-	// This is not very efficient but vectors are small and the caller will cache the results anyway.
-	// What matters a bit more is that using vector rather than a set gives us O(1) access to
-	// random elements in other functions.
-	return convertContainer<vector<string>>(
-		convertContainer<set<string>>(allStepNames()) -
-		convertContainer<set<string>>(_excludedStepNames)
-	);
-}
-
 string const& Chromosome::randomOptimisationStep()
 {
-	static vector<string> stepNames = allStepNamesExcept({
-		// All possible steps, listed and commented-out for easy tweaking.
-		// The uncommented ones are not used (possibly because they fail).
-		//{BlockFlattener::name},
-		//{CommonSubexpressionEliminator::name},
-		//{ConditionalSimplifier::name},
-		//{ConditionalUnsimplifier::name},
-		//{ControlFlowSimplifier::name},
-		//{DeadCodeEliminator::name},
-		//{EquivalentFunctionCombiner::name},
-		//{ExpressionInliner::name},
-		//{ExpressionJoiner::name},
-		//{ExpressionSimplifier::name},
-		//{ExpressionSplitter::name},
-		//{ForLoopConditionIntoBody::name},
-		//{ForLoopConditionOutOfBody::name},
-		//{ForLoopInitRewriter::name},
-		//{FullInliner::name},
-		//{FunctionGrouper::name},
-		//{FunctionHoister::name},
-		//{LiteralRematerialiser::name},
-		//{LoadResolver::name},
-		//{LoopInvariantCodeMotion::name},
-		//{RedundantAssignEliminator::name},
-		//{Rematerialiser::name},
-		//{SSAReverser::name},
-		//{SSATransform::name},
-		//{StructuralSimplifier::name},
-		//{UnusedPruner::name},
-		//{VarDeclInitializer::name},
-	});
+	static vector<string> stepNames = allStepNames();
 
 	return stepNames[uniformRandomInt(0, stepNames.size() - 1)];
 }

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -1,0 +1,112 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Chromosome.h>
+
+#include <tools/yulPhaser/Random.h>
+
+#include <libyul/optimiser/Suite.h>
+#include <libsolutil/CommonData.h>
+
+#include <sstream>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::yul;
+using namespace solidity::phaser;
+
+namespace solidity::phaser
+{
+
+ostream& operator<<(ostream& _stream, Chromosome const& _chromosome);
+
+}
+
+Chromosome Chromosome::makeRandom(size_t _length)
+{
+	vector<string> steps;
+	for (size_t i = 0; i < _length; ++i)
+		steps.push_back(randomOptimisationStep());
+
+	return Chromosome(move(steps));
+}
+
+ostream& phaser::operator<<(ostream& _stream, Chromosome const& _chromosome)
+{
+	for (auto const& stepName: _chromosome.m_optimisationSteps)
+		_stream << OptimiserSuite::stepNameToAbbreviationMap().at(stepName);
+
+	return _stream;
+}
+
+vector<string> Chromosome::allStepNames()
+{
+	vector<string> stepNames;
+	for (auto const& step: OptimiserSuite::allSteps())
+		stepNames.push_back(step.first);
+
+	return stepNames;
+}
+
+vector<string> Chromosome::allStepNamesExcept(vector<string> const& _excludedStepNames)
+{
+	// This is not very efficient but vectors are small and the caller will cache the results anyway.
+	// What matters a bit more is that using vector rather than a set gives us O(1) access to
+	// random elements in other functions.
+	return convertContainer<vector<string>>(
+		convertContainer<set<string>>(allStepNames()) -
+		convertContainer<set<string>>(_excludedStepNames)
+	);
+}
+
+string const& Chromosome::randomOptimisationStep()
+{
+	static vector<string> stepNames = allStepNamesExcept({
+		// All possible steps, listed and commented-out for easy tweaking.
+		// The uncommented ones are not used (possibly because they fail).
+		//{BlockFlattener::name},
+		//{CommonSubexpressionEliminator::name},
+		//{ConditionalSimplifier::name},
+		//{ConditionalUnsimplifier::name},
+		//{ControlFlowSimplifier::name},
+		//{DeadCodeEliminator::name},
+		//{EquivalentFunctionCombiner::name},
+		//{ExpressionInliner::name},
+		//{ExpressionJoiner::name},
+		//{ExpressionSimplifier::name},
+		//{ExpressionSplitter::name},
+		//{ForLoopConditionIntoBody::name},
+		//{ForLoopConditionOutOfBody::name},
+		//{ForLoopInitRewriter::name},
+		//{FullInliner::name},
+		//{FunctionGrouper::name},
+		//{FunctionHoister::name},
+		//{LiteralRematerialiser::name},
+		//{LoadResolver::name},
+		//{LoopInvariantCodeMotion::name},
+		//{RedundantAssignEliminator::name},
+		//{Rematerialiser::name},
+		//{SSAReverser::name},
+		//{SSATransform::name},
+		//{StructuralSimplifier::name},
+		//{UnusedPruner::name},
+		//{VarDeclInitializer::name},
+	});
+
+	return stepNames[uniformRandomInt(0, stepNames.size() - 1)];
+}

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -1,0 +1,65 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace solidity::phaser
+{
+
+/**
+ * An object that represents a sequence of optimiser steps that can be applied to a program.
+ * Such sequences are used in our genetic algorithm to represent individual members of the
+ * population.
+ *
+ * To calculate the fitness of an individual one must apply its sequence to a specific program.
+ * This class does not provide any means to do so. It just stores information.
+ *
+ * Once created a sequence cannot be changed. The only way to mutate it is to generate a new
+ * chromosome based on the old one.
+ */
+class Chromosome
+{
+public:
+	Chromosome() = default;
+	explicit Chromosome(std::vector<std::string> _optimisationSteps):
+		m_optimisationSteps(std::move(_optimisationSteps)) {}
+	static Chromosome makeRandom(size_t _length);
+
+	size_t length() const { return m_optimisationSteps.size(); }
+	std::vector<std::string> const& optimisationSteps() const { return m_optimisationSteps; }
+
+	friend std::ostream& operator<<(std::ostream& _stream, Chromosome const& _chromosome);
+
+	bool operator==(Chromosome const& _other) const { return m_optimisationSteps == _other.m_optimisationSteps; }
+	bool operator!=(Chromosome const& _other) const { return !(*this == _other); }
+
+private:
+	static std::vector<std::string> allStepNames();
+	static std::vector<std::string> allStepNamesExcept(
+		std::vector<std::string> const& _excludedStepNames
+	);
+	static std::string const& randomOptimisationStep();
+
+	std::vector<std::string> m_optimisationSteps;
+};
+
+}

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -54,9 +54,6 @@ public:
 
 private:
 	static std::vector<std::string> allStepNames();
-	static std::vector<std::string> allStepNamesExcept(
-		std::vector<std::string> const& _excludedStepNames
-	);
 	static std::string const& randomOptimisationStep();
 
 	std::vector<std::string> m_optimisationSteps;

--- a/tools/yulPhaser/Exceptions.h
+++ b/tools/yulPhaser/Exceptions.h
@@ -1,0 +1,27 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolutil/Exceptions.h>
+
+namespace solidity::phaser
+{
+
+struct InvalidProgram: virtual util::Exception {};
+
+}

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -1,0 +1,137 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Population.h>
+
+#include <tools/yulPhaser/Program.h>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <numeric>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::phaser;
+
+namespace solidity::phaser
+{
+
+ostream& operator<<(ostream& _stream, Individual const& _individual);
+ostream& operator<<(ostream& _stream, Population const& _population);
+
+}
+
+ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
+{
+	_stream << "Fitness: ";
+	if (_individual.fitness.has_value())
+		_stream << _individual.fitness.value();
+	else
+		_stream << "<NONE>";
+	_stream << ", optimisations: " << _individual.chromosome;
+
+	return _stream;
+}
+
+Population::Population(string const& _sourcePath, vector<Chromosome> const& _chromosomes):
+	m_sourcePath{_sourcePath}
+{
+	for (auto const& chromosome: _chromosomes)
+		m_individuals.push_back({chromosome});
+}
+
+Population Population::makeRandom(string const& _sourcePath, size_t _size)
+{
+	vector<Individual> individuals;
+	for (size_t i = 0; i < _size; ++i)
+		individuals.push_back({Chromosome::makeRandom(randomChromosomeLength())});
+
+	return Population(_sourcePath, individuals);
+}
+
+size_t Population::measureFitness(Chromosome const& _chromosome, string const& _sourcePath)
+{
+	auto program = Program::load(_sourcePath);
+	program.optimise(_chromosome.optimisationSteps());
+	return program.codeSize();
+}
+
+void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
+{
+	doEvaluation();
+	for (size_t round = 0; !_numRounds.has_value() || round < _numRounds.value(); ++round)
+	{
+		doMutation();
+		doSelection();
+		doEvaluation();
+
+		_outputStream << "---------- ROUND " << round << " ----------" << endl;
+		_outputStream << *this;
+	}
+}
+
+ostream& phaser::operator<<(ostream& _stream, Population const& _population)
+{
+	_stream << "Source: " << _population.m_sourcePath << endl;
+
+	auto individual = _population.m_individuals.begin();
+	for (; individual != _population.m_individuals.end(); ++individual)
+		_stream << *individual << endl;
+
+	return _stream;
+}
+
+void Population::doMutation()
+{
+	// TODO: Implement mutation and crossover
+}
+
+void Population::doEvaluation()
+{
+	for (auto& individual: m_individuals)
+		if (!individual.fitness.has_value())
+			individual.fitness = measureFitness(individual.chromosome, m_sourcePath);
+}
+
+void Population::doSelection()
+{
+	assert(all_of(m_individuals.begin(), m_individuals.end(), [](auto& i){ return i.fitness.has_value(); }));
+
+	sort(
+		m_individuals.begin(),
+		m_individuals.end(),
+		[](auto const& a, auto const& b){ return a.fitness.value() < b.fitness.value(); }
+	);
+
+	randomizeWorstChromosomes(m_individuals, m_individuals.size() / 2);
+}
+
+void Population::randomizeWorstChromosomes(
+	vector<Individual>& _individuals,
+	size_t _count
+)
+{
+	assert(_individuals.size() >= _count);
+	// ASSUMPTION: _individuals is sorted in ascending order
+
+	auto individual = _individuals.begin() + (_individuals.size() - _count);
+	for (; individual != _individuals.end(); ++individual)
+	{
+		*individual = {Chromosome::makeRandom(randomChromosomeLength())};
+	}
+}

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -20,6 +20,8 @@
 #include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/Random.h>
 
+#include <liblangutil/CharStream.h>
+
 #include <optional>
 #include <ostream>
 #include <vector>
@@ -53,21 +55,21 @@ class Population
 public:
 	static constexpr size_t MaxChromosomeLength = 30;
 
-	explicit Population(std::string const& _sourcePath, std::vector<Chromosome> const& _chromosomes = {});
-	static Population makeRandom(std::string const& _sourcePath, size_t _size);
+	explicit Population(langutil::CharStream _sourceCode, std::vector<Chromosome> const& _chromosomes = {});
+	static Population makeRandom(langutil::CharStream _sourceCode, size_t _size);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
 
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 
 	static size_t randomChromosomeLength() { return binomialRandomInt(MaxChromosomeLength, 0.5); }
-	static size_t measureFitness(Chromosome const& _chromosome, std::string const& _sourcePath);
+	static size_t measureFitness(Chromosome const& _chromosome, langutil::CharStream& _sourceCode);
 
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(std::string const& _sourcePath, std::vector<Individual> _individuals = {}):
-		m_sourcePath{_sourcePath},
+	explicit Population(langutil::CharStream _sourceCode, std::vector<Individual> _individuals = {}):
+		m_sourceCode{std::move(_sourceCode)},
 		m_individuals{std::move(_individuals)} {}
 
 	void doMutation();
@@ -79,7 +81,7 @@ private:
 		size_t _count
 	);
 
-	std::string m_sourcePath;
+	langutil::CharStream m_sourceCode;
 
 	std::vector<Individual> m_individuals;
 };

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -1,0 +1,87 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/Random.h>
+
+#include <optional>
+#include <ostream>
+#include <vector>
+
+namespace solidity::phaser
+{
+
+/**
+ * Information describing the state of an individual member of the population during the course
+ * of the genetic algorithm.
+ */
+struct Individual
+{
+	Chromosome chromosome;
+	std::optional<size_t> fitness = std::nullopt;
+
+	friend std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
+};
+
+/**
+ * Represents a changing set of individuals undergoing a genetic algorithm.
+ * Each round of the algorithm involves mutating existing individuals, evaluating their fitness
+ * and selecting the best ones for the next round.
+ *
+ * An individual is a sequence of optimiser steps represented by a @a Chromosome instance. The whole
+ * population is associated with a fixed Yul program. By loading the source code into a @a Program
+ * instance the class can compute fitness of the individual.
+ */
+class Population
+{
+public:
+	static constexpr size_t MaxChromosomeLength = 30;
+
+	explicit Population(std::string const& _sourcePath, std::vector<Chromosome> const& _chromosomes = {});
+	static Population makeRandom(std::string const& _sourcePath, size_t _size);
+
+	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
+
+	std::vector<Individual> const& individuals() const { return m_individuals; }
+
+	static size_t randomChromosomeLength() { return binomialRandomInt(MaxChromosomeLength, 0.5); }
+	static size_t measureFitness(Chromosome const& _chromosome, std::string const& _sourcePath);
+
+	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
+
+private:
+	explicit Population(std::string const& _sourcePath, std::vector<Individual> _individuals = {}):
+		m_sourcePath{_sourcePath},
+		m_individuals{std::move(_individuals)} {}
+
+	void doMutation();
+	void doEvaluation();
+	void doSelection();
+
+	static void randomizeWorstChromosomes(
+		std::vector<Individual>& _individuals,
+		size_t _count
+	);
+
+	std::string m_sourcePath;
+
+	std::vector<Individual> m_individuals;
+};
+
+}

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -25,7 +25,6 @@
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/AsmData.h>
 #include <libyul/AsmParser.h>
 #include <libyul/YulString.h>
 #include <libyul/backends/evm/EVMDialect.h>
@@ -56,7 +55,7 @@ set<YulString> const Program::s_externallyUsedIdentifiers = {};
 Program Program::load(string const& _sourcePath)
 {
 	Dialect const& dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion{});
-	shared_ptr<Block> ast = parseSource(dialect, loadSource(_sourcePath));
+	unique_ptr<Block> ast = parseSource(dialect, loadSource(_sourcePath));
 	unique_ptr<AsmAnalysisInfo> analysisInfo = analyzeAST(dialect, *ast);
 
 	Program program(
@@ -85,14 +84,14 @@ CharStream Program::loadSource(string const& _sourcePath)
 	return CharStream(sourceCode, _sourcePath);
 }
 
-shared_ptr<Block> Program::parseSource(Dialect const& _dialect, CharStream _source)
+unique_ptr<Block> Program::parseSource(Dialect const& _dialect, CharStream _source)
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
 	auto scanner = make_shared<Scanner>(move(_source));
 	Parser parser(errorReporter, _dialect);
 
-	shared_ptr<Block> ast = parser.parse(scanner, false);
+	unique_ptr<Block> ast = parser.parse(scanner, false);
 	assertThrow(ast != nullptr, InvalidProgram, "Error parsing source");
 	assert(errorReporter.errors().empty());
 

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -25,7 +25,9 @@
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AsmJsonConverter.h>
 #include <libyul/AsmParser.h>
+#include <libyul/AsmPrinter.h>
 #include <libyul/YulString.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/Disambiguator.h>
@@ -33,10 +35,10 @@
 #include <libyul/optimiser/FunctionGrouper.h>
 #include <libyul/optimiser/FunctionHoister.h>
 #include <libyul/optimiser/Metrics.h>
-
 #include <libyul/optimiser/Suite.h>
 
 #include <libsolutil/CommonIO.h>
+#include <libsolutil/JSON.h>
 
 #include <boost/filesystem.hpp>
 
@@ -49,6 +51,13 @@ using namespace solidity::langutil;
 using namespace solidity::yul;
 using namespace solidity::util;
 using namespace solidity::phaser;
+
+namespace solidity::phaser
+{
+
+ostream& operator<<(ostream& _stream, Program const& _program);
+
+}
 
 set<YulString> const Program::s_externallyUsedIdentifiers = {};
 
@@ -74,6 +83,17 @@ Program Program::load(string const& _sourcePath)
 void Program::optimise(vector<string> const& _optimisationSteps)
 {
 	applyOptimisationSteps(m_optimiserStepContext, *m_ast, _optimisationSteps);
+}
+
+ostream& phaser::operator<<(ostream& _stream, Program const& _program)
+{
+	return _stream << AsmPrinter()(*_program.m_ast);
+}
+
+string Program::toJson() const
+{
+	Json::Value serializedAst = AsmJsonConverter(0)(*m_ast);
+	return jsonPrettyPrint(serializedAst);
 }
 
 CharStream Program::loadSource(string const& _sourcePath)

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -1,0 +1,140 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Program.h>
+
+#include <tools/yulPhaser/Exceptions.h>
+
+#include <liblangutil/CharStream.h>
+#include <liblangutil/ErrorReporter.h>
+#include <liblangutil/Exceptions.h>
+
+#include <libyul/AsmAnalysis.h>
+#include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AsmData.h>
+#include <libyul/AsmParser.h>
+#include <libyul/YulString.h>
+#include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/optimiser/Disambiguator.h>
+#include <libyul/optimiser/ForLoopInitRewriter.h>
+#include <libyul/optimiser/FunctionGrouper.h>
+#include <libyul/optimiser/FunctionHoister.h>
+#include <libyul/optimiser/Metrics.h>
+
+#include <libyul/optimiser/Suite.h>
+
+#include <libsolutil/CommonIO.h>
+
+#include <boost/filesystem.hpp>
+
+#include <cassert>
+#include <memory>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::langutil;
+using namespace solidity::yul;
+using namespace solidity::util;
+using namespace solidity::phaser;
+
+set<YulString> const Program::s_externallyUsedIdentifiers = {};
+
+Program Program::load(string const& _sourcePath)
+{
+	Dialect const& dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion{});
+	shared_ptr<Block> ast = parseSource(dialect, loadSource(_sourcePath));
+	unique_ptr<AsmAnalysisInfo> analysisInfo = analyzeAST(dialect, *ast);
+
+	Program program(
+		dialect,
+		disambiguateAST(dialect, *ast, *analysisInfo)
+	);
+	program.optimise({
+		FunctionHoister::name,
+		FunctionGrouper::name,
+		ForLoopInitRewriter::name,
+	});
+
+	return program;
+}
+
+void Program::optimise(vector<string> const& _optimisationSteps)
+{
+	applyOptimisationSteps(m_optimiserStepContext, *m_ast, _optimisationSteps);
+}
+
+CharStream Program::loadSource(string const& _sourcePath)
+{
+	assertThrow(boost::filesystem::exists(_sourcePath), InvalidProgram, "Source file does not exist");
+
+	string sourceCode = readFileAsString(_sourcePath);
+	return CharStream(sourceCode, _sourcePath);
+}
+
+shared_ptr<Block> Program::parseSource(Dialect const& _dialect, CharStream _source)
+{
+	ErrorList errors;
+	ErrorReporter errorReporter(errors);
+	auto scanner = make_shared<Scanner>(move(_source));
+	Parser parser(errorReporter, _dialect);
+
+	shared_ptr<Block> ast = parser.parse(scanner, false);
+	assertThrow(ast != nullptr, InvalidProgram, "Error parsing source");
+	assert(errorReporter.errors().empty());
+
+	return ast;
+}
+
+unique_ptr<AsmAnalysisInfo> Program::analyzeAST(Dialect const& _dialect, Block const& _ast)
+{
+	ErrorList errors;
+	ErrorReporter errorReporter(errors);
+	auto analysisInfo = make_unique<AsmAnalysisInfo>();
+	AsmAnalyzer analyzer(*analysisInfo, errorReporter, _dialect);
+
+	bool analysisSuccessful = analyzer.analyze(_ast);
+	assertThrow(analysisSuccessful, InvalidProgram, "Error analyzing source");
+	assert(errorReporter.errors().empty());
+
+	return analysisInfo;
+}
+
+unique_ptr<Block> Program::disambiguateAST(
+	Dialect const& _dialect,
+	Block const& _ast,
+	AsmAnalysisInfo const& _analysisInfo
+)
+{
+	Disambiguator disambiguator(_dialect, _analysisInfo, s_externallyUsedIdentifiers);
+
+	return make_unique<Block>(get<Block>(disambiguator(_ast)));
+}
+
+void Program::applyOptimisationSteps(
+	OptimiserStepContext& _context,
+	Block& _ast,
+	vector<string> const& _optimisationSteps
+)
+{
+	for (string const& step: _optimisationSteps)
+		OptimiserSuite::allSteps().at(step)->run(_context, _ast);
+}
+
+size_t Program::computeCodeSize(Block const& _ast)
+{
+	return CodeSize::codeSizeIncludingFunctions(_ast);
+}

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -21,6 +21,8 @@
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/AsmData.h>
 
+#include <boost/noncopyable.hpp>
+
 #include <optional>
 #include <set>
 #include <string>
@@ -54,9 +56,17 @@ namespace solidity::phaser
  * The class allows the user to apply extra optimisations and obtain metrics and general
  * information about the resulting syntax tree.
  */
-class Program
+class Program: private boost::noncopyable
 {
 public:
+	Program(Program&& program):
+		m_ast(std::move(program.m_ast)),
+		m_nameDispenser(std::move(program.m_nameDispenser)),
+		// Creating a new instance because a copied one would have a dangling reference to the old dispenser
+		m_optimiserStepContext{program.m_optimiserStepContext.dialect, m_nameDispenser, s_externallyUsedIdentifiers}
+	{}
+	Program operator=(Program&& program) = delete;
+
 	static Program load(std::string const& _sourcePath);
 	void optimise(std::vector<std::string> const& _optimisationSteps);
 

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -1,0 +1,108 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libyul/optimiser/OptimiserStep.h>
+#include <libyul/optimiser/NameDispenser.h>
+
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace solidity::langutil
+{
+
+class CharStream;
+
+}
+
+namespace solidity::yul
+{
+
+struct AsmAnalysisInfo;
+struct Block;
+struct Dialect;
+class YulString;
+
+}
+
+namespace solidity::phaser
+{
+
+/**
+ * Class representing parsed and analysed Yul program that we can apply optimisations to.
+ * The program is already disambiguated and has several prerequisite optimiser steps applied to it
+ * so that the requirements of any possible step that could be later applied by the user are
+ * already satisfied.
+ *
+ * The class allows the user to apply extra optimisations and obtain metrics and general
+ * information about the resulting syntax tree.
+ */
+class Program
+{
+public:
+	static Program load(std::string const& _sourcePath);
+	void optimise(std::vector<std::string> const& _optimisationSteps);
+
+	size_t codeSize() const { return computeCodeSize(*m_ast); }
+	yul::Block const& ast() const { return *m_ast; }
+
+private:
+	Program(
+		yul::Dialect const& _dialect,
+		std::shared_ptr<yul::Block> _ast
+	):
+		m_ast(_ast),
+		m_nameDispenser(_dialect, *_ast, s_externallyUsedIdentifiers),
+		m_optimiserStepContext{_dialect, m_nameDispenser, s_externallyUsedIdentifiers}
+	{}
+
+	static langutil::CharStream loadSource(std::string const& _sourcePath);
+	static std::shared_ptr<yul::Block> parseSource(
+		yul::Dialect const& _dialect,
+		langutil::CharStream _source
+	);
+	static std::unique_ptr<yul::AsmAnalysisInfo> analyzeAST(
+		yul::Dialect const& _dialect,
+		yul::Block const& _ast
+	);
+	static std::unique_ptr<yul::Block> disambiguateAST(
+		yul::Dialect const& _dialect,
+		yul::Block const& _ast,
+		yul::AsmAnalysisInfo const& _analysisInfo
+	);
+	static void applyOptimisationSteps(
+		yul::OptimiserStepContext& _context,
+		yul::Block& _ast,
+		std::vector<std::string> const& _optimisationSteps
+	);
+	static size_t computeCodeSize(yul::Block const& _ast);
+
+	std::shared_ptr<yul::Block> m_ast;
+	yul::NameDispenser m_nameDispenser;
+	yul::OptimiserStepContext m_optimiserStepContext;
+
+	// Always empty set of reserved identifiers. It could be a constructor parameter but I don't
+	// think it would be useful in this tool. Other tools (like yulopti) have it empty too.
+	// We need it to live as long as m_optimiserStepContext because it stores a reference
+	// but since it's empty and read-only we can just have all objects share one static instance.
+	static std::set<yul::YulString> const s_externallyUsedIdentifiers;
+};
+
+}

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -65,7 +65,7 @@ public:
 	{}
 	Program operator=(Program&& program) = delete;
 
-	static Program load(std::string const& _sourcePath);
+	static Program load(langutil::CharStream& _sourceCode);
 	void optimise(std::vector<std::string> const& _optimisationSteps);
 
 	size_t codeSize() const { return computeCodeSize(*m_ast); }
@@ -84,7 +84,6 @@ private:
 		m_nameDispenser(_dialect, *m_ast, {})
 	{}
 
-	static langutil::CharStream loadSource(std::string const& _sourcePath);
 	static std::unique_ptr<yul::Block> parseSource(
 		yul::Dialect const& _dialect,
 		langutil::CharStream _source

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -19,6 +19,7 @@
 
 #include <libyul/optimiser/OptimiserStep.h>
 #include <libyul/optimiser/NameDispenser.h>
+#include <libyul/AsmData.h>
 
 #include <optional>
 #include <set>
@@ -36,7 +37,6 @@ namespace solidity::yul
 {
 
 struct AsmAnalysisInfo;
-struct Block;
 struct Dialect;
 class YulString;
 
@@ -66,15 +66,15 @@ public:
 private:
 	Program(
 		yul::Dialect const& _dialect,
-		std::shared_ptr<yul::Block> _ast
+		std::unique_ptr<yul::Block> _ast
 	):
-		m_ast(_ast),
-		m_nameDispenser(_dialect, *_ast, s_externallyUsedIdentifiers),
+		m_ast(std::move(_ast)),
+		m_nameDispenser(_dialect, *m_ast, s_externallyUsedIdentifiers),
 		m_optimiserStepContext{_dialect, m_nameDispenser, s_externallyUsedIdentifiers}
 	{}
 
 	static langutil::CharStream loadSource(std::string const& _sourcePath);
-	static std::shared_ptr<yul::Block> parseSource(
+	static std::unique_ptr<yul::Block> parseSource(
 		yul::Dialect const& _dialect,
 		langutil::CharStream _source
 	);
@@ -94,7 +94,7 @@ private:
 	);
 	static size_t computeCodeSize(yul::Block const& _ast);
 
-	std::shared_ptr<yul::Block> m_ast;
+	std::unique_ptr<yul::Block> m_ast;
 	yul::NameDispenser m_nameDispenser;
 	yul::OptimiserStepContext m_optimiserStepContext;
 

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -24,6 +24,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <optional>
+#include <ostream>
 #include <set>
 #include <string>
 #include <vector>
@@ -72,6 +73,9 @@ public:
 
 	size_t codeSize() const { return computeCodeSize(*m_ast); }
 	yul::Block const& ast() const { return *m_ast; }
+
+	friend std::ostream& operator<<(std::ostream& _stream, Program const& _program);
+	std::string toJson() const;
 
 private:
 	Program(

--- a/tools/yulPhaser/Random.cpp
+++ b/tools/yulPhaser/Random.cpp
@@ -1,0 +1,44 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Random.h>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/binomial_distribution.hpp>
+
+#include <ctime>
+
+using namespace solidity;
+
+uint32_t phaser::uniformRandomInt(uint32_t _min, uint32_t _max)
+{
+	// TODO: Seed must be configurable
+	static boost::random::mt19937 generator(time(0));
+	boost::random::uniform_int_distribution<> distribution(_min, _max);
+
+	return distribution(generator);
+}
+
+uint32_t phaser::binomialRandomInt(uint32_t _numTrials, double _successProbability)
+{
+	// TODO: Seed must be configurable
+	static boost::random::mt19937 generator(time(0));
+	boost::random::binomial_distribution<> distribution(_numTrials, _successProbability);
+
+	return distribution(generator);
+}

--- a/tools/yulPhaser/Random.h
+++ b/tools/yulPhaser/Random.h
@@ -1,0 +1,28 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace solidity::phaser
+{
+
+uint32_t uniformRandomInt(uint32_t _min, uint32_t _max);
+uint32_t binomialRandomInt(uint32_t _numTrials, double _successProbability);
+
+}

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -1,0 +1,21 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+	return 0;
+}

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -18,13 +18,20 @@
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Population.h>
 
+#include <libsolutil/Assertions.h>
+#include <libsolutil/CommonIO.h>
+#include <liblangutil/CharStream.h>
+
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <iostream>
 #include <string>
 
 using namespace std;
+using namespace solidity::langutil;
 using namespace solidity::phaser;
+using namespace solidity::util;
 
 namespace po = boost::program_options;
 
@@ -37,9 +44,17 @@ struct CommandLineParsingResult
 	po::variables_map arguments;
 };
 
+CharStream loadSource(string const& _sourcePath)
+{
+	assertThrow(boost::filesystem::exists(_sourcePath), InvalidProgram, "Source file does not exist");
+
+	string sourceCode = readFileAsString(_sourcePath);
+	return CharStream(sourceCode, _sourcePath);
+}
+
 void runAlgorithm(string const& _sourcePath)
 {
-	auto population = Population::makeRandom(_sourcePath, 10);
+	auto population = Population::makeRandom(loadSource(_sourcePath), 10);
 	population.run(nullopt, cout);
 }
 

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -15,9 +15,8 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/Exceptions.h>
-#include <tools/yulPhaser/Program.h>
+#include <tools/yulPhaser/Population.h>
 
 #include <boost/program_options.hpp>
 
@@ -40,8 +39,8 @@ struct CommandLineParsingResult
 
 void runAlgorithm(string const& _sourcePath)
 {
-	Program::load(_sourcePath).optimize(Chromosome::makeRandom(15).asSequence());
-	cout << "Program load and optimization successful." << endl;
+	auto population = Population::makeRandom(_sourcePath, 10);
+	population.run(nullopt, cout);
 }
 
 CommandLineParsingResult parseCommandLine(int argc, char** argv)

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -15,6 +15,7 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Program.h>
 
@@ -39,8 +40,8 @@ struct CommandLineParsingResult
 
 void runAlgorithm(string const& _sourcePath)
 {
-	Program::load(_sourcePath);
-	cout << "Program load successful." << endl;
+	Program::load(_sourcePath).optimize(Chromosome::makeRandom(15).asSequence());
+	cout << "Program load and optimization successful." << endl;
 }
 
 CommandLineParsingResult parseCommandLine(int argc, char** argv)

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -15,6 +15,8 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <tools/yulPhaser/Exceptions.h>
+#include <tools/yulPhaser/Program.h>
 
 #include <boost/program_options.hpp>
 
@@ -22,6 +24,8 @@
 #include <string>
 
 using namespace std;
+using namespace solidity::phaser;
+
 namespace po = boost::program_options;
 
 namespace
@@ -35,7 +39,8 @@ struct CommandLineParsingResult
 
 void runAlgorithm(string const& _sourcePath)
 {
-	cout << "Input: " << _sourcePath << endl;
+	Program::load(_sourcePath);
+	cout << "Program load successful." << endl;
 }
 
 CommandLineParsingResult parseCommandLine(int argc, char** argv)
@@ -99,7 +104,15 @@ int main(int argc, char** argv)
 	if (parsingResult.exitCode != 0)
 		return parsingResult.exitCode;
 
-	runAlgorithm(parsingResult.arguments["input-file"].as<string>());
+	try
+	{
+		runAlgorithm(parsingResult.arguments["input-file"].as<string>());
+	}
+	catch (InvalidProgram const& _exception)
+	{
+		cerr << "ERROR: " << _exception.what() << endl;
+		return 1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
### Description
This is the initial part of the implementation of #7806.

It provides a command-line application (`tools/yul-phaser`) which can already load `.yul` source code, apply optimizations and rank the resulting programs by their size. It runs a trivial (completely randomized) genetic algorithm and prints the result of each round to the console. ~The pull request includes a few unit tests but the coverage is still minimal.~

~This is still work in progress.~ The PR is ready.

#### Structure
- `Program` class encapsulates all the details of source code parsing, analysis and application of optimizations. An instance represents a syntax tree after a few hard-coded transformations (disambiguation, grouping, hoisting, etc.) and ready for arbitrary optimizations.
- `Chromosome` class defines a sequence of optimization steps. Provides methods for generating, changing and accessing its sequence. It does not know about `Program` and does not interact with it directly.
- `Population` class runs the genetic algorithm. It stores a set of chromosomes and refines it in subsequent algorithm rounds. It's mostly concerned with controlling the flow of the algorithm and does not itself do anything complicated. It uses `Chromosome` and `Program` to evaluate fitness of sequences.

#### Not yet implemented
1. No mutation or crossover yet. The algorithm just drops the worse half of the population in each round and refills it with randomized chromosomes.
2. No way to specify the seed for the random number generator yet.
3. ~Needs more unit tests. For now I have tests only for `Chromosome`.~
4. No saving and reloading of algorithm state. When interrupted, the state is lost.
5. A sequence is applied to the program only once. It's supposed to be applied a few times in a loop.
6. `Program` is loaded from file and parsed each time it's being evaluated. I should keep one initialized instance and make a copy when I need to apply optimizations to it.
7. Lots of stuff is still hard-coded. The program is not flexible enough for experimenting yet.

EDIT: All of the above will be implemented in subsequent PRs.

#### Known issues
1. ~`VarNameCleaner` is disabled for now because it throws `Source needs to be disambiguated` even though it is already disambiguated. `FullInliner` used to fail for me in the same way. `SSATransform` too but on `yulAssert()` instead. Both went away when I changed how I pass AST and other objects around (by value vs smart pointers/references). It's likely that I'm using it wrong or copying something that should not really be copied. I need to take a closer look at this.~

#### Questions
1. Should I worry about moving vectors of `std::string`s around? I realized that I could make almost all of them `char const*` and save some dynamic allocations because step names are just `constexpr`s but I'm not sure it's worth the time. It won't be a bottleneck anyway.
2. Is it OK to use plain `assert()` for sanity checks? `solAssert()` looks more like a normal check to me. It throws exceptions and does not get removed in release builds so I'm a bit reluctant to use it for heavier checks for invariants, preconditions and generally stuff that should not happen unless there is actually a bug in the code.
3. Since `yul-phaser` is not a library, I had to list all the necessary `.cpp` files again in `test/CMakeLists.txt` to have `soltest` link properly. This does not seem like a very good solution. Should I store those paths in some cmake variable? Or maybe try to create a library out of the classes I want to test?
4. Tests for `tools/yul_phaser/` seem like they should go into a subdirectory in `test/tools/` but that directory already exists and contains extra tools for testing so. It did not seem right to me to mix them with test cases so I put them in `tests/yul_phaser/` instead. Is that OK?

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
