### PR TITLE
yulopti: Add missing ConditionalUnsimplifier step

### DIFF
--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -35,6 +35,7 @@
 #include <libyul/optimiser/CallGraphGenerator.h>
 #include <libyul/optimiser/CommonSubexpressionEliminator.h>
 #include <libyul/optimiser/ConditionalSimplifier.h>
+#include <libyul/optimiser/ConditionalUnsimplifier.h>
 #include <libyul/optimiser/ControlFlowSimplifier.h>
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/EquivalentFunctionCombiner.h>
@@ -143,7 +144,7 @@ public:
 			cout << "  (r)edundant assign elim./re(m)aterializer/f(o)r-loop-init-rewriter/for-loop-condition-(I)nto-body/" << endl;
 			cout << "  for-loop-condition-(O)ut-of-body/s(t)ructural simplifier/equi(v)alent function combiner/ssa re(V)erser/" << endl;
 			cout << "  co(n)trol flow simplifier/stack com(p)ressor/(D)ead code eliminator/(L)oad resolver/" << endl;
-			cout << "  (C)onditional simplifier/loop-invariant code (M)otion?" << endl;
+			cout << "  (C)onditional simplifier/conditional (U)nsimplifier/loop-invariant code (M)otion?" << endl;
 			cout.flush();
 			int option = readStandardInputChar();
 			cout << ' ' << char(option) << endl;
@@ -170,6 +171,9 @@ public:
 				break;
 			case 'C':
 				ConditionalSimplifier::run(context, *m_ast);
+				break;
+			case 'U':
+				ConditionalUnsimplifier::run(context, *m_ast);
 				break;
 			case 'd':
 				VarDeclInitializer::run(context, *m_ast);

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -139,7 +139,7 @@ public:
 				m_nameDispenser = make_shared<NameDispenser>(m_dialect, *m_ast, reservedIdentifiers);
 				disambiguated = true;
 			}
-			cout << "(q)quit/(f)latten/(c)se/initialize var(d)ecls/(x)plit/(j)oin/(g)rouper/(h)oister/" << endl;
+			cout << "(q)uit/(f)latten/(c)se/initialize var(d)ecls/(x)plit/(j)oin/(g)rouper/(h)oister/" << endl;
 			cout << "  (e)xpr inline/(i)nline/(s)implify/varname c(l)eaner/(u)nusedprune/ss(a) transform/" << endl;
 			cout << "  (r)edundant assign elim./re(m)aterializer/f(o)r-loop-init-rewriter/for-loop-condition-(I)nto-body/" << endl;
 			cout << "  for-loop-condition-(O)ut-of-body/s(t)ructural simplifier/equi(v)alent function combiner/ssa re(V)erser/" << endl;

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -138,7 +138,7 @@ public:
 				m_nameDispenser = make_shared<NameDispenser>(m_dialect, *m_ast, reservedIdentifiers);
 				disambiguated = true;
 			}
-			cout << "(q)quit/(f)flatten/(c)se/initialize var(d)ecls/(x)plit/(j)oin/(g)rouper/(h)oister/" << endl;
+			cout << "(q)quit/(f)latten/(c)se/initialize var(d)ecls/(x)plit/(j)oin/(g)rouper/(h)oister/" << endl;
 			cout << "  (e)xpr inline/(i)nline/(s)implify/varname c(l)eaner/(u)nusedprune/ss(a) transform/" << endl;
 			cout << "  (r)edundant assign elim./re(m)aterializer/f(o)r-loop-init-rewriter/for-loop-condition-(I)nto-body/" << endl;
 			cout << "  for-loop-condition-(O)ut-of-body/s(t)ructural simplifier/equi(v)alent function combiner/ssa re(V)erser/" << endl;


### PR DESCRIPTION
### Description
While working on #8164 I noticed two minor issues in `yulopti`:
- `ConditionalUnsimplifier` step was not available in the tool but present in `OptimiserSuite::allSteps()`. I suspect it might have been added later and nobody remembered to add it to the tool.
- A typo: repeated `f` in `(f)flatten`.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

I'm not sure it this change requires anything in README or Changelog. As for tests, the tool is just a single `.cpp` file and therefore does not have any as far as I can tell. Please let me know if any of these should be added after all.
