### PR TITLE
Fix str/bytes mismatch crashing prepare_report.py when running storebytecode.sh

### DIFF
--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -6,7 +6,7 @@ import subprocess
 import json
 
 SOLC_BIN = sys.argv[1]
-REPORT_FILE = open("report.txt", "wb")
+REPORT_FILE = open("report.txt", "w")
 
 for optimize in [False, True]:
     for f in sorted(glob.glob("*.sol")):
@@ -26,9 +26,9 @@ for optimize in [False, True]:
         if optimize:
             args += ['--optimize']
         proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (out, err) = proc.communicate(json.dumps(input_json))
+        (out, err) = proc.communicate(json.dumps(input_json).encode('utf-8'))
         try:
-            result = json.loads(out.strip())
+            result = json.loads(out.decode('utf-8').strip())
             for filename in sorted(result['contracts'].keys()):
                 for contractName in sorted(result['contracts'][filename].keys()):
                     contractData = result['contracts'][filename][contractName]


### PR DESCRIPTION
### Description
I found a bug in `prepare_report.py` while investigating CI failures in #8165. The script uses unicode strings when raw byte arrays are expected and vice versa, which results in exceptions:
1) `Popen.communicate()` expects `bytes` (a raw, binary string) if `stdout`/`stderr` are open in binary mode but is given output from `json.loads()` which is str (an abstract unicode string). Encoding the `str` object into `bytes` using UTF-8 encoding fixes that.
2) `REPORT_FILE` gets opened in binary mode which means that functions like `write()` expect `bytes`. We're giving them `str` which results in an error. Changed mode to text solves the problem.

Fixes https://github.com/ethereum/solidity/issues/8156 

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
