### PR TITLE
Fix the latest byte of metadata hash encoding in the docs

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -142,7 +142,7 @@ to the end of the deployed bytecode::
     0xa2
     0x64 'i' 'p' 'f' 's' 0x58 0x22 <34 bytes IPFS hash>
     0x64 's' 'o' 'l' 'c' 0x43 <3 byte version encoding>
-    0x00 0x32
+    0x00 0x33
 
 So in order to retrieve the data, the end of the deployed bytecode can be checked
 to match that pattern and use the IPFS hash to retrieve the file.


### PR DESCRIPTION
### Description

The last byte of MetaData hash is incorrect in the docs for `0.6.x` version of the Solidity compiler. It is stated there:
>The current version of the Solidity compiler usually adds the following to the end of the deployed bytecode:

>0xa2
0x64 'i' 'p' 'f' 's' 0x58 0x22 <34 bytes IPFS hash>
0x64 's' 'o' 'l' 'c' 0x43 <3 byte version encoding>
0x00 0x32 

But the deployment of a simple contract:
```
pragma solidity 0.6.0;

contract SimpleStorage {
    uint8 storedData;

    function set(uint8 x) public {
        storedData = x;
    }

    function get() public view returns (uint8) {
        return storedData;
    }

}
```

returns me this deployed bytecode:

0x6080604052348015600f57600080fd5b506004361060325760003560e01c806324b8ba5f1460375780636d4ce63c146056575b600080fd5b605460048036036020811015604b57600080fd5b503560ff166072565b005b605c6088565b6040805160ff9092168252519081900360200190f35b6000805460ff191660ff92909216919091179055565b60005460ff169056fea26469706673582212203042d9b6ee864c1aecc6ad4dd5b68b5fe1db7b1eb51d83cff0ac688a11197cad64736f6c634300060000**33**

https://blockscout.com/eth/kovan/address/0x42ff93e2597289a103150f4d5ef6bd398389141f/contracts
https://kovan.etherscan.io/address/0x42Ff93e2597289a103150f4D5ef6Bd398389141F#code

I assume, that it should be changed from 32 -> 33 in the docs.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
