### PR TITLE
libsolidity/codegen: Use calldatacopy to cheaply zero memory..

### DIFF
--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -605,7 +605,7 @@ void CompilerUtils::zeroInitialiseMemoryArray(ArrayType const& _type)
 		Whiskers templ(R"({
 			let size := mul(length, <element_size>)
 			// cheap way of zero-initializing a memory range
-			codecopy(memptr, codesize(), size)
+			calldatacopy(memptr, calldatasize(), size)
 			memptr := add(memptr, size)
 		})");
 		templ("element_size", to_string(_type.memoryStride()));

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -10179,7 +10179,7 @@ BOOST_AUTO_TEST_CASE(create_dynamic_array_with_zero_length)
 
 BOOST_AUTO_TEST_CASE(correctly_initialize_memory_array_in_constructor)
 {
-	// Memory arrays are initialized using codecopy past the size of the code.
+	// Memory arrays are initialized using calldatacopy past the size of the calldata.
 	// This test checks that it also works in the constructor context.
 	char const* sourceCode = R"(
 		contract C {


### PR DESCRIPTION
### Description
 
Use calldatacopy to cheaply zero memory instead of codecopy.

Motiviation:
  Zero'ing memory is commonplace in contracts, but with the upcoming
  Layer-2 EVM translation layers and other on-chain verification
  mechanisms, using `codecopy` becomes a `costly` operation in those
  sandboxes. Using `calldatacopy` achieves the same thing, gas costs
  are also the same as codecopy, and is significantly cheaper in the `sandbox` situation.

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->
<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
