### PR TITLE
Docs 'breaking changes 5.0' clarifications

### DIFF
--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -63,7 +63,7 @@ This section highlights changes that affect syntax and semantics.
   last one only works for value types).  Change every ``keccak256(a, b, c)`` to
   ``keccak256(abi.encodePacked(a, b, c))``. Even though it is not a breaking
   change, it is suggested that developers change
-  ``x.call(bytes4(keccak256("f(uint256)"), a, b)`` to
+  ``x.call(bytes4(keccak256("f(uint256)")), a, b)`` to
   ``x.call(abi.encodeWithSignature("f(uint256)", a, b))``.
 
 * Functions ``.call()``, ``.delegatecall()`` and ``.staticcall()`` now return

--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -455,7 +455,7 @@ New version:
             uint z = someInteger();
             x += z;
             // Throw is now disallowed.
-            require(x > 100);
+            require(x <= 100);
             int y = -3 >> 1;
             require(y == -2);
             do {


### PR DESCRIPTION
### Description

I noticed two small errors while reading [Solidity v0.5.0 Breaking Changes](https://solidity.readthedocs.io/en/v0.6.2/050-breaking-changes.html). One can misleading the reader so I propose here a tiny fix.

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
