### PR TITLE
Return shared_ptr instead of unique_ptr from Parser::parse()

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -385,7 +385,7 @@ void CompilerContext::appendInlineAssembly(
 	ErrorReporter errorReporter(errors);
 	auto scanner = make_shared<langutil::Scanner>(langutil::CharStream(_assembly, "--CODEGEN--"));
 	yul::EVMDialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(m_evmVersion);
-	auto parserResult = yul::Parser(errorReporter, dialect).parse(scanner, false);
+	shared_ptr<yul::Block> parserResult = yul::Parser(errorReporter, dialect).parse(scanner, false);
 #ifdef SOL_OUTPUT_ASM
 	cout << yul::AsmPrinter()(*parserResult) << endl;
 #endif

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -37,7 +37,7 @@ using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::yul;
 
-shared_ptr<Block> Parser::parse(std::shared_ptr<Scanner> const& _scanner, bool _reuseScanner)
+unique_ptr<Block> Parser::parse(std::shared_ptr<Scanner> const& _scanner, bool _reuseScanner)
 {
 	m_recursionDepth = 0;
 
@@ -47,7 +47,7 @@ shared_ptr<Block> Parser::parse(std::shared_ptr<Scanner> const& _scanner, bool _
 	try
 	{
 		m_scanner = _scanner;
-		auto block = make_shared<Block>(parseBlock());
+		auto block = make_unique<Block>(parseBlock());
 		if (!_reuseScanner)
 			expectToken(Token::EOS);
 		return block;

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -52,7 +52,7 @@ public:
 	/// Parses an inline assembly block starting with `{` and ending with `}`.
 	/// @param _reuseScanner if true, do check for end of input after the `}`.
 	/// @returns an empty shared pointer on error.
-	std::shared_ptr<Block> parse(std::shared_ptr<langutil::Scanner> const& _scanner, bool _reuseScanner);
+	std::unique_ptr<Block> parse(std::shared_ptr<langutil::Scanner> const& _scanner, bool _reuseScanner);
 
 	/// @returns a map of all EVM instructions available to assembly.
 	static std::map<std::string, evmasm::Instruction> const& instructions();


### PR DESCRIPTION
### Description
Extracted from #8164.

From C++ guidelines: [C.50: Use a factory function if you need "virtual behavior" during initialization](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rc-factory)
> The return type of the factory should normally be `unique_ptr` by default; if some uses are shared, the caller can `move` the `unique_ptr` into a `shared_ptr`. However, if the factory author knows that all uses of the returned object will be shared uses, return `shared_ptr` and use `make_shared` in the body to save an allocation.

I changed `yul::Parser.parse()` to return `unique_ptr<Block>`. This way it can be converted to `shared_ptr` if necessary but the caller is not forced to do it.

The reason for this change is that `unique_ptr` is more appropriate in my `Program` class implementaion in #8164 and I don't think the reason for originally choosing `shared_ptr` for this was motivated by any special considerations. If I'm wrong, well, I could just change my implementation.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
