### PR TITLE
Remove VarNameCleaner from OptimiserSuite step list

### DIFF
--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -308,9 +308,7 @@ void OptimiserSuite::run(
 		if (ast.statements.size() > 1 && std::get<Block>(ast.statements.front()).statements.empty())
 			ast.statements.erase(ast.statements.begin());
 	}
-	suite.runSequence({
-		VarNameCleaner::name
-	}, ast);
+	VarNameCleaner::run(suite.m_context, ast);
 
 	*_object.analysisInfo = AsmAnalyzer::analyzeStrictAssertCorrect(_dialect, _object);
 }
@@ -366,8 +364,14 @@ map<string, unique_ptr<OptimiserStep>> const& OptimiserSuite::allSteps()
 			SSATransform,
 			StructuralSimplifier,
 			UnusedPruner,
-			VarDeclInitializer,
-			VarNameCleaner
+			VarDeclInitializer
+
+			// NOTE: VarNameCleaner implements the same interface but it's not a real optimisation
+			// step (just like disambiguator isn't one) and should not be included here. It currently
+			// does not even guarantee unique names and does not register added names in the name
+			// dispenser so it's not safe to run arbitrary steps after it without disambiguation
+			// and recreating the context.
+			//VarNameCleaner
 		>();
 	return instance;
 }

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -180,6 +180,12 @@ public:
 				break;
 			case 'l':
 				VarNameCleaner::run(context, *m_ast);
+
+				// VarNameCleaner is not a real optimisation step, just like disambiguator is not.
+				// It currently does not even guarantee unique names and does not register added
+				// names in the name dispenser making the context unsafe to use with subsequent
+				// steps. We can easily fix that by rerunning the disambiguator.
+				disambiguated = false;
 				break;
 			case 'x':
 				ExpressionSplitter::run(context, *m_ast);


### PR DESCRIPTION
### Description
Extracted from #8164. See also discussion in https://github.com/ethereum/solidity/pull/8164#discussion_r370912339 and https://github.com/ethereum/solidity/pull/8164#discussion_r371360480.

`VarNameCleaner` has the same interface as the other optimisation steps but can't be arbitrarily mixed with them. This pull request removes it from the list of all steps in `OptimiserSuite` and makes it apply it manually instead.

It also makes `yulopti` rerun disambiguator afterwards to make it safe to use.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
