### PR TITLE
Colorized GCC output in CMake

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -54,6 +54,9 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			message(FATAL_ERROR "${PROJECT_NAME} requires g++ 5.0 or greater.")
 		endif ()
 
+		# Use fancy colors in the compiler diagnostics
+		add_compile_options(-fdiagnostics-color)
+
 	# Additional Clang-specific compiler settings.
 	elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")


### PR DESCRIPTION
### Description
Errors and warnings from GCC are not colorized when running the makefiles. GCC uses colors when it detects that it's connected to an interactive terminal which not the case when CMake runs it (see [CMake syntax highlighting on stderr from c++ compiler](https://gitlab.kitware.com/cmake/cmake/issues/16851)).

We already have `-fcolor-diagnostics` flag in `EthCompilerSettings.cmake` to enable colors for clang. This pull request adds a similar flag for GCC (`-fdiagnostics-color`).

~**Submitting as a draft for now to see if it passes CI checks on all systems.** Works on my machine but the comments in the file about not wanting some clang flags on Linux make me suspect that it'll  need some tweaking.~ Looks like it passed CI checks just fine.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
