### PR TITLE
Reenable ossfuzz builds (but not tests)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ workflows:
       - b_docs: *workflow_trigger_on_tags
       - b_archlinux: *workflow_trigger_on_tags
       - b_ubu_cxx20: *workflow_trigger_on_tags
-#      - b_ubu_ossfuzz: *workflow_trigger_on_tags
+      - b_ubu_ossfuzz: *workflow_trigger_on_tags
 
       # OS/X build and tests
       - b_osx: *workflow_trigger_on_tags
@@ -768,7 +768,7 @@ workflows:
 
     jobs:
       # OSSFUZZ builds and (regression) tests
-#      - b_ubu_ossfuzz: *workflow_trigger_on_tags
+      - b_ubu_ossfuzz: *workflow_trigger_on_tags
 #      - t_ubu_ossfuzz: *workflow_ubuntu1904_ossfuzz
 
       # Code Coverage enabled build and tests


### PR DESCRIPTION
following @bshastry 's recommendation to keep the builds enabled and only disable the tests
refs #8208