### PR TITLE
Add symlinks to solc-bin/wasm for releases.

### DIFF
--- a/scripts/travis-emscripten/publish_binary.sh
+++ b/scripts/travis-emscripten/publish_binary.sh
@@ -36,9 +36,6 @@ VER="v$VER"
 COMMIT=$(git rev-parse --short=8 HEAD)
 DATE=$(date --date="$(git log -1 --date=iso --format=%ad HEAD)" --utc +%Y.%-m.%-d)
 
-# remove leading zeros in components - they are not semver-compatible
-COMMIT=$(echo "$COMMIT" | sed -e 's/^0*//')
-
 ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
 ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
 ENCRYPTED_KEY=${!ENCRYPTED_KEY_VAR}

--- a/scripts/travis-emscripten/publish_binary.sh
+++ b/scripts/travis-emscripten/publish_binary.sh
@@ -81,18 +81,22 @@ else
 fi
 
 
-NEWFILE=./bin/"soljson-$FULLVERSION.js"
+NEWFILE="soljson-$FULLVERSION.js"
 
 # Prepare for update script
 npm install
 
 # This file is assumed to be the product of the build_emscripten.sh script.
-cp ../soljson.js "$NEWFILE"
+cp ../soljson.js ./bin/"$NEWFILE"
+
+# For releases, add a symlink to the wasm directory.
+[ "$TRAVIS_BRANCH" = release ] && ln -sf ../bin/"$NEWFILE" ./wasm/"$NEWFILE"
 
 # Run update script
 npm run update
 
 # Publish updates
-git add "$NEWFILE"
+git add ./bin/"$NEWFILE"
+[ "$TRAVIS_BRANCH" = release ] && git add ./wasm/"$NEWFILE"
 git commit -a -m "Added compiler version $FULLVERSION"
 git push origin gh-pages


### PR DESCRIPTION
Unfortunately, I'm not sure there's a good way to actually test this... we might just have to keep in mind having an eye on this for the next release.

I also partially addressed https://github.com/ethereum/solidity/issues/8127 in a separate commit here, since I was touching the file anyways, but I can move that to a separate PR, if you prefer. We still need to decide how we want to deal with the leading zeros in commit hashes of past releases in any case.