### PR TITLE
[docs] Compile examples with minimal compiler version

### DIFF
--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -1,0 +1,67 @@
+# ------------------------------------------------------------------------------
+# vim:ts=4:et
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2019 solidity contributors.
+# ------------------------------------------------------------------------------
+
+FULLARGS="--optimize --ignore-missing --combined-json abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
+
+function compileFull()
+{
+    local expected_exit_code=0
+    local expect_output=0
+    if [[ $1 = '-e' ]]
+    then
+        expected_exit_code=1
+        expect_output=1
+        shift;
+    fi
+    if [[ $1 = '-w' ]]
+    then
+        expect_output=1
+        shift;
+    fi
+
+    local files="$*"
+    local output
+
+    local stderr_path=$(mktemp)
+
+    set +e
+    "$SOLC" $FULLARGS $files >/dev/null 2>"$stderr_path"
+    local exit_code=$?
+    local errors=$(grep -v -E 'Warning: This is a pre-release compiler version|Warning: Experimental features are turned on|pragma experimental ABIEncoderV2|^ +--> |^ +\||^[0-9]+ +\|' < "$stderr_path")
+    set -e
+    rm "$stderr_path"
+
+    if [[ \
+        "$exit_code" -ne "$expected_exit_code" || \
+            ( $expect_output -eq 0 && -n "$errors" ) || \
+            ( $expect_output -ne 0 && -z "$errors" ) \
+    ]]
+    then
+        printError "Unexpected compilation result:"
+        printError "Expected failure: $expected_exit_code - Expected warning / error output: $expect_output"
+        printError "Was failure: $exit_code"
+        echo "$errors"
+        printError "While calling:"
+        echo "\"$SOLC\" $FULLARGS $files"
+        printError "Inside directory:"
+        pwd
+        false
+    fi
+}

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016 solidity contributors.
+#------------------------------------------------------------------------------
+
+set -e
+
+## GLOBAL VARIABLES
+
+REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
+source "${REPO_ROOT}/scripts/common.sh"
+source "${REPO_ROOT}/scripts/common_cmdline.sh"
+
+printTask "Compiling all examples from the documentation..."
+SOLTMPDIR=$(mktemp -d)
+(
+    set -e
+    cd "$SOLTMPDIR"
+    "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/ docs
+
+    for f in *.sol
+    do
+        # The contributors guide uses syntax tests, but we cannot
+        # really handle them here.
+        if grep -E 'DeclarationError:|// ----' "$f" >/dev/null
+        then
+            continue
+        fi
+        echo "$f"
+
+        opts=''
+        # We expect errors if explicitly stated, or if imports
+        # are used (in the style guide)
+        if grep -E "This will not compile|import \"" "$f" >/dev/null
+        then
+            opts="-e"
+        fi
+        if grep -E "This will report a warning|pragma experimental SMTChecker" "$f" >/dev/null
+        then
+            opts="$opts -w"
+        fi
+
+        grep -Po "/pragma/folk" "$f"
+
+        if grep -E "(pragma solidity >=)" "$f"
+        then
+            echo "pragma solidity >="
+        fi
+
+        if grep -E "pragma solidity >" "$f"
+        then
+            echo "pragma solidity >"
+        fi
+
+        # Get minimum compiler version defined by pragma
+        version="0.6.2"
+        solc_bin="solc-$version"
+        if [[ ! -f "$solc_bin" ]]; then
+            # wget https://github.com/ethereum/solidity/releases/download/v$version/solc-static-linux
+            mv solc-static-linux $solc_bin
+        fi
+
+
+        ln -sf "$solc_bin" "solc"
+        chmod a+x solc
+
+        SOLC="$SOLTMPDIR/solc"
+        compileFull $opts "$SOLTMPDIR/$f"
+    done
+)
+rm -rf "$SOLTMPDIR"
+echo "Done."

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -33,14 +33,13 @@ set -e
 REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
 SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
 source "${REPO_ROOT}/scripts/common.sh"
+source "${REPO_ROOT}/scripts/common_cmdline.sh"
 SOLC="$REPO_ROOT/${SOLIDITY_BUILD_DIR}/solc/solc"
 INTERACTIVE=true
 if ! tty -s || [ "$CI" ]
 then
     INTERACTIVE=""
 fi
-
-FULLARGS="--optimize --ignore-missing --combined-json abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
 
 # extend stack size in case we run via ASAN
 if [[ -n "${CIRCLECI}" ]] || [[ -n "$CI" ]]; then
@@ -49,52 +48,6 @@ if [[ -n "${CIRCLECI}" ]] || [[ -n "$CI" ]]; then
 fi
 
 ## FUNCTIONS
-
-function compileFull()
-{
-    local expected_exit_code=0
-    local expect_output=0
-    if [[ $1 = '-e' ]]
-    then
-        expected_exit_code=1
-        expect_output=1
-        shift;
-    fi
-    if [[ $1 = '-w' ]]
-    then
-        expect_output=1
-        shift;
-    fi
-
-    local files="$*"
-    local output
-
-    local stderr_path=$(mktemp)
-
-    set +e
-    "$SOLC" $FULLARGS $files >/dev/null 2>"$stderr_path"
-    local exit_code=$?
-    local errors=$(grep -v -E 'Warning: This is a pre-release compiler version|Warning: Experimental features are turned on|pragma experimental ABIEncoderV2|^ +--> |^ +\||^[0-9]+ +\|' < "$stderr_path")
-    set -e
-    rm "$stderr_path"
-
-    if [[ \
-        "$exit_code" -ne "$expected_exit_code" || \
-            ( $expect_output -eq 0 && -n "$errors" ) || \
-            ( $expect_output -ne 0 && -z "$errors" ) \
-    ]]
-    then
-        printError "Unexpected compilation result:"
-        printError "Expected failure: $expected_exit_code - Expected warning / error output: $expect_output"
-        printError "Was failure: $exit_code"
-        echo "$errors"
-        printError "While calling:"
-        echo "\"$SOLC\" $FULLARGS $files"
-        printError "Inside directory:"
-        pwd
-        false
-    fi
-}
 
 function ask_expectation_update()
 {


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8099.

Adds `scripts/docs_version_pragma_check.sh `, which aims to extract the minimal version from the pragma in documentation examples. This extracted version is then used to download that specific static linux binary from the release page and to compile the example.

Could be run as part of our nightly pipeline.

It shares some code with example extraction in place, and these changes are also included.

#### TODO
- [x] Change script, such that it extracts the minimal compiler version from each example
- [ ] Change all documentation examples which do not compile. These will be at least the ones mentioned in https://github.com/ethereum/solidity/issues/8099