### PR TITLE
 Fix CompilerStack::loadMissingSources()

### DIFF
--- a/test/libsolidity/syntaxTests/more_than_256_importerrors.sol
+++ b/test/libsolidity/syntaxTests/more_than_256_importerrors.sol
@@ -1,0 +1,521 @@
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+import "a.sol";
+
+contract C {
+  function f() public {
+  }
+}
+// ----
+// ParserError: (0-15): Source "a.sol" not found: File not supplied initially.
+// ParserError: (16-31): Source "a.sol" not found: File not supplied initially.
+// ParserError: (32-47): Source "a.sol" not found: File not supplied initially.
+// ParserError: (48-63): Source "a.sol" not found: File not supplied initially.
+// ParserError: (64-79): Source "a.sol" not found: File not supplied initially.
+// ParserError: (80-95): Source "a.sol" not found: File not supplied initially.
+// ParserError: (96-111): Source "a.sol" not found: File not supplied initially.
+// ParserError: (112-127): Source "a.sol" not found: File not supplied initially.
+// ParserError: (128-143): Source "a.sol" not found: File not supplied initially.
+// ParserError: (144-159): Source "a.sol" not found: File not supplied initially.
+// ParserError: (160-175): Source "a.sol" not found: File not supplied initially.
+// ParserError: (176-191): Source "a.sol" not found: File not supplied initially.
+// ParserError: (192-207): Source "a.sol" not found: File not supplied initially.
+// ParserError: (208-223): Source "a.sol" not found: File not supplied initially.
+// ParserError: (224-239): Source "a.sol" not found: File not supplied initially.
+// ParserError: (240-255): Source "a.sol" not found: File not supplied initially.
+// ParserError: (256-271): Source "a.sol" not found: File not supplied initially.
+// ParserError: (272-287): Source "a.sol" not found: File not supplied initially.
+// ParserError: (288-303): Source "a.sol" not found: File not supplied initially.
+// ParserError: (304-319): Source "a.sol" not found: File not supplied initially.
+// ParserError: (320-335): Source "a.sol" not found: File not supplied initially.
+// ParserError: (336-351): Source "a.sol" not found: File not supplied initially.
+// ParserError: (352-367): Source "a.sol" not found: File not supplied initially.
+// ParserError: (368-383): Source "a.sol" not found: File not supplied initially.
+// ParserError: (384-399): Source "a.sol" not found: File not supplied initially.
+// ParserError: (400-415): Source "a.sol" not found: File not supplied initially.
+// ParserError: (416-431): Source "a.sol" not found: File not supplied initially.
+// ParserError: (432-447): Source "a.sol" not found: File not supplied initially.
+// ParserError: (448-463): Source "a.sol" not found: File not supplied initially.
+// ParserError: (464-479): Source "a.sol" not found: File not supplied initially.
+// ParserError: (480-495): Source "a.sol" not found: File not supplied initially.
+// ParserError: (496-511): Source "a.sol" not found: File not supplied initially.
+// ParserError: (512-527): Source "a.sol" not found: File not supplied initially.
+// ParserError: (528-543): Source "a.sol" not found: File not supplied initially.
+// ParserError: (544-559): Source "a.sol" not found: File not supplied initially.
+// ParserError: (560-575): Source "a.sol" not found: File not supplied initially.
+// ParserError: (576-591): Source "a.sol" not found: File not supplied initially.
+// ParserError: (592-607): Source "a.sol" not found: File not supplied initially.
+// ParserError: (608-623): Source "a.sol" not found: File not supplied initially.
+// ParserError: (624-639): Source "a.sol" not found: File not supplied initially.
+// ParserError: (640-655): Source "a.sol" not found: File not supplied initially.
+// ParserError: (656-671): Source "a.sol" not found: File not supplied initially.
+// ParserError: (672-687): Source "a.sol" not found: File not supplied initially.
+// ParserError: (688-703): Source "a.sol" not found: File not supplied initially.
+// ParserError: (704-719): Source "a.sol" not found: File not supplied initially.
+// ParserError: (720-735): Source "a.sol" not found: File not supplied initially.
+// ParserError: (736-751): Source "a.sol" not found: File not supplied initially.
+// ParserError: (752-767): Source "a.sol" not found: File not supplied initially.
+// ParserError: (768-783): Source "a.sol" not found: File not supplied initially.
+// ParserError: (784-799): Source "a.sol" not found: File not supplied initially.
+// ParserError: (800-815): Source "a.sol" not found: File not supplied initially.
+// ParserError: (816-831): Source "a.sol" not found: File not supplied initially.
+// ParserError: (832-847): Source "a.sol" not found: File not supplied initially.
+// ParserError: (848-863): Source "a.sol" not found: File not supplied initially.
+// ParserError: (864-879): Source "a.sol" not found: File not supplied initially.
+// ParserError: (880-895): Source "a.sol" not found: File not supplied initially.
+// ParserError: (896-911): Source "a.sol" not found: File not supplied initially.
+// ParserError: (912-927): Source "a.sol" not found: File not supplied initially.
+// ParserError: (928-943): Source "a.sol" not found: File not supplied initially.
+// ParserError: (944-959): Source "a.sol" not found: File not supplied initially.
+// ParserError: (960-975): Source "a.sol" not found: File not supplied initially.
+// ParserError: (976-991): Source "a.sol" not found: File not supplied initially.
+// ParserError: (992-1007): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1008-1023): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1024-1039): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1040-1055): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1056-1071): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1072-1087): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1088-1103): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1104-1119): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1120-1135): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1136-1151): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1152-1167): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1168-1183): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1184-1199): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1200-1215): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1216-1231): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1232-1247): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1248-1263): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1264-1279): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1280-1295): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1296-1311): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1312-1327): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1328-1343): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1344-1359): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1360-1375): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1376-1391): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1392-1407): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1408-1423): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1424-1439): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1440-1455): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1456-1471): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1472-1487): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1488-1503): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1504-1519): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1520-1535): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1536-1551): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1552-1567): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1568-1583): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1584-1599): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1600-1615): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1616-1631): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1632-1647): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1648-1663): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1664-1679): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1680-1695): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1696-1711): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1712-1727): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1728-1743): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1744-1759): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1760-1775): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1776-1791): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1792-1807): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1808-1823): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1824-1839): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1840-1855): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1856-1871): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1872-1887): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1888-1903): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1904-1919): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1920-1935): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1936-1951): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1952-1967): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1968-1983): Source "a.sol" not found: File not supplied initially.
+// ParserError: (1984-1999): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2000-2015): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2016-2031): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2032-2047): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2048-2063): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2064-2079): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2080-2095): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2096-2111): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2112-2127): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2128-2143): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2144-2159): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2160-2175): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2176-2191): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2192-2207): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2208-2223): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2224-2239): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2240-2255): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2256-2271): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2272-2287): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2288-2303): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2304-2319): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2320-2335): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2336-2351): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2352-2367): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2368-2383): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2384-2399): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2400-2415): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2416-2431): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2432-2447): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2448-2463): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2464-2479): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2480-2495): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2496-2511): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2512-2527): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2528-2543): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2544-2559): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2560-2575): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2576-2591): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2592-2607): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2608-2623): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2624-2639): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2640-2655): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2656-2671): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2672-2687): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2688-2703): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2704-2719): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2720-2735): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2736-2751): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2752-2767): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2768-2783): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2784-2799): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2800-2815): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2816-2831): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2832-2847): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2848-2863): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2864-2879): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2880-2895): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2896-2911): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2912-2927): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2928-2943): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2944-2959): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2960-2975): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2976-2991): Source "a.sol" not found: File not supplied initially.
+// ParserError: (2992-3007): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3008-3023): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3024-3039): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3040-3055): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3056-3071): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3072-3087): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3088-3103): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3104-3119): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3120-3135): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3136-3151): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3152-3167): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3168-3183): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3184-3199): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3200-3215): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3216-3231): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3232-3247): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3248-3263): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3264-3279): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3280-3295): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3296-3311): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3312-3327): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3328-3343): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3344-3359): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3360-3375): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3376-3391): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3392-3407): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3408-3423): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3424-3439): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3440-3455): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3456-3471): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3472-3487): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3488-3503): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3504-3519): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3520-3535): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3536-3551): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3552-3567): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3568-3583): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3584-3599): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3600-3615): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3616-3631): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3632-3647): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3648-3663): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3664-3679): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3680-3695): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3696-3711): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3712-3727): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3728-3743): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3744-3759): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3760-3775): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3776-3791): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3792-3807): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3808-3823): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3824-3839): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3840-3855): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3856-3871): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3872-3887): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3888-3903): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3904-3919): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3920-3935): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3936-3951): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3952-3967): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3968-3983): Source "a.sol" not found: File not supplied initially.
+// ParserError: (3984-3999): Source "a.sol" not found: File not supplied initially.
+// ParserError: (4000-4015): Source "a.sol" not found: File not supplied initially.
+// ParserError: (4016-4031): Source "a.sol" not found: File not supplied initially.
+// ParserError: (4032-4047): Source "a.sol" not found: File not supplied initially.
+// ParserError: (4048-4063): Source "a.sol" not found: File not supplied initially.
+// ParserError: (4064-4079): Source "a.sol" not found: File not supplied initially.
+// ParserError: (4080-4095): Source "a.sol" not found: File not supplied initially.
+// Warning: There are more than 256 errors. Aborting.


### PR DESCRIPTION
An exception was not caught within `CompilerStack::loadMissingSources()`, if more than 256 errors where detected. 

The main problem related to #8102 was that the used standard-json tried to import a lot of additional `*.sol` files that where not present. These errors exceeded the 256 error count limit and finally ended up with an `FatalError` exception. I added an additional test `test/libsolidity/syntaxTests/more_than_256_importerrors.sol` to cover those kind of errors. 