### PR TITLE
Add support for reading standard-json from file

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -750,7 +750,7 @@ Allowed options)",
 		(
 			g_argStandardJSON.c_str(),
 			"Switch to Standard JSON input / output mode, ignoring all options. "
-			"It reads from standard input and provides the result on the standard output."
+			"It reads from standard input, if no input file was given, otherwise it reads from the provided input file. The result will be written to standard output."
 		)
 		(
 			g_argImportAst.c_str(),
@@ -965,7 +965,22 @@ bool CommandLineInterface::processInput()
 
 	if (m_args.count(g_argStandardJSON))
 	{
-		string input = readStandardInput();
+		vector<string> inputFiles;
+		string jsonFile;
+		if (m_args.count(g_argInputFile))
+			inputFiles = m_args[g_argInputFile].as<vector<string>>();
+		if (inputFiles.size() == 1)
+			jsonFile = inputFiles[0];
+		else if (inputFiles.size() > 1)
+		{
+			serr() << "If --" << g_argStandardJSON << " is used, only zero or one input files are supported." << endl;
+			return false;
+		}
+		string input;
+		if (jsonFile.empty())
+			input = readStandardInput();
+		else
+			input = readFileAsString(jsonFile);
 		StandardCompiler compiler(fileReader);
 		sout() << compiler.compile(std::move(input)) << endl;
 		return true;


### PR DESCRIPTION
Currently `--standard-json` only supports reading input from `stdin`, reading input from a specified file may simplify debugging.