### PR TITLE
Sol-to-Yul codegen for try-catch statement

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -75,6 +75,8 @@ set(sources
 	codegen/LValue.h
 	codegen/MultiUseYulFunctionCollector.h
 	codegen/MultiUseYulFunctionCollector.cpp
+	codegen/ReturnInfo.h
+	codegen/ReturnInfo.cpp
 	codegen/YulUtilFunctions.h
 	codegen/YulUtilFunctions.cpp
 	codegen/ir/IRGenerator.cpp

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -756,3 +756,25 @@ string Literal::getChecksummedAddress() const
 	address.insert(address.begin(), 40 - address.size(), '0');
 	return util::getChecksummedAddress(address);
 }
+
+TryCatchClause const* TryStatement::successClause() const
+{
+	solAssert(m_clauses.size() > 0, "");
+	return m_clauses[0].get();
+}
+
+TryCatchClause const* TryStatement::structuredClause() const
+{
+	for (size_t i = 1; i < m_clauses.size(); ++i)
+		if (m_clauses[i]->errorName() == "Error")
+			return m_clauses[i].get();
+	return nullptr;
+}
+
+TryCatchClause const* TryStatement::fallbackClause() const
+{
+	for (size_t i = 1; i < m_clauses.size(); ++i)
+		if (m_clauses[i]->errorName().empty())
+			return m_clauses[i].get();
+	return nullptr;
+}

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1451,6 +1451,10 @@ public:
 	Expression const& externalCall() const { return *m_externalCall; }
 	std::vector<ASTPointer<TryCatchClause>> const& clauses() const { return m_clauses; }
 
+	TryCatchClause const* successClause() const;
+	TryCatchClause const* structuredClause() const;
+	TryCatchClause const* fallbackClause() const;
+
 private:
 	ASTPointer<Expression> m_externalCall;
 	std::vector<ASTPointer<TryCatchClause>> m_clauses;

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -949,43 +949,7 @@ void ContractCompiler::handleCatch(vector<ASTPointer<TryCatchClause>> const& _ca
 
 		// Try to decode the error message.
 		// If this fails, leaves 0 on the stack, otherwise the pointer to the data string.
-		m_context << u256(0);
-		m_context.appendInlineAssembly(
-			util::Whiskers(R"({
-				data := mload(0x40)
-				mstore(data, 0)
-				for {} 1 {} {
-					if lt(returndatasize(), 0x44) { data := 0 break }
-					returndatacopy(0, 0, 4)
-					let sig := <getSig>
-					if iszero(eq(sig, 0x<ErrorSignature>)) { data := 0 break }
-					returndatacopy(data, 4, sub(returndatasize(), 4))
-					let offset := mload(data)
-					if or(
-						gt(offset, 0xffffffffffffffff),
-						gt(add(offset, 0x24), returndatasize())
-					) {
-						data := 0
-						break
-					}
-					let msg := add(data, offset)
-					let length := mload(msg)
-					if gt(length, 0xffffffffffffffff) { data := 0 break }
-					let end := add(add(msg, 0x20), length)
-					if gt(end, add(data, returndatasize())) { data := 0 break }
-					mstore(0x40, and(add(end, 0x1f), not(0x1f)))
-					data := msg
-					break
-				}
-			})")
-			("ErrorSignature", errorHash)
-			("getSig",
-				m_context.evmVersion().hasBitwiseShifting() ?
-				"shr(224, mload(0))" :
-				"div(mload(0), " + (u256(1) << 224).str() + ")"
-			).render(),
-			{"data"}
-		);
+		m_context.callYulFunction(m_context.utilFunctions().tryDecodeErrorMessageFunction(), 0, 1);
 		m_context << Instruction::DUP1;
 		AssemblyItem decodeSuccessTag = m_context.appendConditionalJump();
 		m_context << Instruction::POP;

--- a/libsolidity/codegen/ReturnInfo.cpp
+++ b/libsolidity/codegen/ReturnInfo.cpp
@@ -1,0 +1,55 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/codegen/ReturnInfo.h>
+
+#include <libsolidity/ast/Types.h>
+#include <libsolidity/ast/AST.h>
+
+using namespace solidity::frontend;
+using namespace solidity::langutil;
+
+ReturnInfo::ReturnInfo(EVMVersion const& _evmVersion, FunctionType const& _functionType)
+{
+	FunctionType::Kind const funKind = _functionType.kind();
+	bool const haveReturndatacopy = _evmVersion.supportsReturndata();
+	bool const returnSuccessConditionAndReturndata =
+		funKind == FunctionType::Kind::BareCall ||
+		funKind == FunctionType::Kind::BareDelegateCall ||
+		funKind == FunctionType::Kind::BareStaticCall;
+
+	if (!returnSuccessConditionAndReturndata)
+	{
+		if (haveReturndatacopy)
+			returnTypes = _functionType.returnParameterTypes();
+		else
+			returnTypes = _functionType.returnParameterTypesWithoutDynamicTypes();
+
+		for (auto const& retType: returnTypes)
+			if (retType->isDynamicallyEncoded())
+			{
+				solAssert(haveReturndatacopy, "");
+				dynamicReturnSize = true;
+				estimatedReturnSize = 0;
+				break;
+			}
+			else if (retType->decodingType())
+				estimatedReturnSize += retType->decodingType()->calldataEncodedSize();
+			else
+				estimatedReturnSize += retType->calldataEncodedSize();
+	}
+}

--- a/libsolidity/codegen/ReturnInfo.h
+++ b/libsolidity/codegen/ReturnInfo.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Component that computes information relevant during decoding an external function
+ * call's return values.
+ */
+#pragma once
+
+#include <liblangutil/EVMVersion.h>
+#include <libsolidity/ast/Types.h>
+
+namespace solidity::frontend
+{
+
+/**
+ * Computes and holds information relevant during decoding an external function
+ * call's return values.
+ */
+struct ReturnInfo
+{
+	ReturnInfo(langutil::EVMVersion const& _evmVersion, FunctionType const& _functionType);
+
+	/// Vector of TypePointer, for each return variable. Dynamic types are already replaced if required.
+	TypePointers returnTypes = {};
+
+	/// Boolean, indicating whether or not return size is only known at runtime.
+	bool dynamicReturnSize = false;
+
+	/// Contains the at compile time estimated return size.
+	unsigned estimatedReturnSize = 0;
+};
+
+}

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2252,3 +2252,84 @@ string YulUtilFunctions::revertReasonIfDebug(string const& _message)
 {
 	return revertReasonIfDebug(m_revertStrings, _message);
 }
+
+string YulUtilFunctions::tryDecodeErrorMessageFunction()
+{
+	string const functionName = "try_decode_error_message";
+
+	return m_functionCollector.createFunction(functionName, [&]() {
+		return util::Whiskers(R"(
+			function <functionName>() -> ret {
+				if lt(returndatasize(), 0x44) { leave }
+
+				returndatacopy(0, 0, 4)
+				let sig := <shr224>(mload(0))
+				if iszero(eq(sig, 0x<ErrorSignature>)) { leave }
+
+				let data := mload(<freeMemoryPointer>)
+				returndatacopy(data, 4, sub(returndatasize(), 4))
+
+				let offset := mload(data)
+				if or(
+					gt(offset, 0xffffffffffffffff),
+					gt(add(offset, 0x24), returndatasize())
+				) {
+					leave
+				}
+
+				let msg := add(data, offset)
+				let length := mload(msg)
+				if gt(length, 0xffffffffffffffff) { leave }
+
+				let end := add(add(msg, 0x20), length)
+				if gt(end, add(data, returndatasize())) { leave }
+
+				mstore(<freeMemoryPointer>, add(add(msg, 0x20), <roundUp>(length)))
+				ret := msg
+			}
+		)")
+		("functionName", functionName)
+		("shr224", shiftRightFunction(224))
+		("ErrorSignature", FixedHash<4>(util::keccak256("Error(string)")).hex())
+		("freeMemoryPointer", to_string(CompilerUtils::freeMemoryPointer))
+		("roundUp", roundUpFunction())
+		.render();
+	});
+}
+
+string YulUtilFunctions::extractReturndataFunction()
+{
+	string const functionName = "extract_returndata";
+
+	return m_functionCollector.createFunction(functionName, [&]() {
+		return util::Whiskers(R"(
+			function <functionName>() -> data {
+				<?supportsReturndata>
+					switch returndatasize()
+					case 0 {
+						data := <emptyArray>()
+					}
+					default {
+						// allocate some memory into data of size returndatasize() + PADDING
+						data := <allocate>(<roundUp>(add(returndatasize(), 0x20)))
+
+						// store array length into the front
+						mstore(data, returndatasize())
+
+						// append to data
+						returndatacopy(add(data, 0x20), 0, returndatasize())
+					}
+				<!supportsReturndata>
+					data := <emptyArray>()
+				</supportsReturndata>
+			}
+		)")
+		("functionName", functionName)
+		("supportsReturndata", m_evmVersion.supportsReturndata())
+		("allocate", allocationFunction())
+		("roundUp", roundUpFunction())
+		("emptyArray", zeroValueFunction(*TypeProvider::bytesMemory()))
+		.render();
+	});
+}
+

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -22,6 +22,7 @@
 
 #include <liblangutil/EVMVersion.h>
 
+#include <libsolidity/ast/Types.h>
 #include <libsolidity/codegen/MultiUseYulFunctionCollector.h>
 
 #include <libsolidity/interface/DebugSettings.h>
@@ -322,6 +323,20 @@ public:
 	static std::string revertReasonIfDebug(RevertStrings revertStrings, std::string const& _message = "");
 
 	std::string revertReasonIfDebug(std::string const& _message = "");
+
+	/// Returns the name of a function that decodes an error message.
+	/// signature: () -> arrayPtr
+	///
+	/// Returns a newly allocated `bytes memory` array containing the decoded error message
+	/// or 0 on failure.
+	std::string tryDecodeErrorMessageFunction();
+
+
+	/// Returns a function name that returns a newly allocated `bytes` array that contains the return data.
+	///
+	/// If returndatacopy() is not supported by the underlying target, a empty array will be returned instead.
+	std::string extractReturndataFunction();
+
 private:
 	/// Special case of conversionFunction - handles everything that does not
 	/// use exactly one variable to hold the value.

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -87,6 +87,17 @@ string IRGenerationContext::newYulVariable()
 	return "_" + to_string(++m_varCounter);
 }
 
+string IRGenerationContext::trySuccessConditionVariable(Expression const& _expression) const
+{
+	// NB: The TypeChecker already ensured that the Expression is of type FunctionCall.
+	solAssert(
+		static_cast<FunctionCallAnnotation const&>(_expression.annotation()).tryCall,
+		"Parameter must be a FunctionCall with tryCall-annotation set."
+	);
+
+	return "trySuccessCondition_" + to_string(_expression.id());
+}
+
 string IRGenerationContext::internalDispatch(size_t _in, size_t _out)
 {
 	string funName = "dispatch_internal_in_" + to_string(_in) + "_out_" + to_string(_out);
@@ -141,3 +152,4 @@ std::string IRGenerationContext::revertReasonIfDebug(std::string const& _message
 {
 	return YulUtilFunctions::revertReasonIfDebug(m_revertStrings, _message);
 }
+

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -99,6 +99,10 @@ public:
 
 	RevertStrings revertStrings() const { return m_revertStrings; }
 
+	/// @returns the variable name that can be used to inspect the success or failure of an external
+	/// function call that was invoked as part of the try statement.
+	std::string trySuccessConditionVariable(Expression const& _expression) const;
+
 private:
 	langutil::EVMVersion m_evmVersion;
 	RevertStrings m_revertStrings;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -24,6 +24,8 @@
 #include <libsolidity/codegen/ir/IRLValue.h>
 #include <libsolidity/codegen/ir/IRVariable.h>
 
+#include <functional>
+
 namespace solidity::frontend
 {
 
@@ -70,7 +72,21 @@ public:
 	void endVisit(Identifier const& _identifier) override;
 	bool visit(Literal const& _literal) override;
 
+	bool visit(TryStatement const& _tryStatement) override;
+	bool visit(TryCatchClause const& _tryCatchClause) override;
+
 private:
+	/// Handles all catch cases of a try statement, except the success-case.
+	void handleCatch(TryStatement const& _tryStatement);
+	void handleCatchStructuredAndFallback(
+		TryCatchClause const& _structured,
+		TryCatchClause const* _fallback
+	);
+	void handleCatchFallback(TryCatchClause const& _fallback);
+
+	/// Generates code to rethrow an exception.
+	void rethrow();
+
 	/// Appends code to call an external function with the given arguments.
 	/// All involved expressions have already been visited.
 	void appendExternalFunctionCall(

--- a/test/libsolidity/semanticTests/tryCatch/lowLevel.sol
+++ b/test/libsolidity/semanticTests/tryCatch/lowLevel.sol
@@ -12,6 +12,7 @@ contract C {
     }
 }
 // ====
+// compileViaYul: also
 // EVMVersion: >=byzantium
 // ----
 // f(bool): true -> 1, 2, 96, 0

--- a/test/libsolidity/semanticTests/tryCatch/nested.sol
+++ b/test/libsolidity/semanticTests/tryCatch/nested.sol
@@ -26,6 +26,7 @@ contract C {
 }
 // ====
 // EVMVersion: >=byzantium
+// compileViaYul: also
 // ----
 // f(bool,bool): true, true -> 1, 2, 96, 7, "success"
 // f(bool,bool): true, false -> 12, 0, 96, 7, "failure"

--- a/test/libsolidity/semanticTests/tryCatch/return_function.sol
+++ b/test/libsolidity/semanticTests/tryCatch/return_function.sol
@@ -13,5 +13,7 @@ contract C {
     }
     function fun() public pure {}
 }
+// ====
+// compileViaYul: also
 // ----
 // f() -> 0x1, 0xfdd67305928fcac8d213d1e47bfa6165cd0b87b946644cd0000000000000000, 9

--- a/test/libsolidity/semanticTests/tryCatch/simple.sol
+++ b/test/libsolidity/semanticTests/tryCatch/simple.sol
@@ -1,10 +1,10 @@
 contract C {
-    function g(bool b) public pure returns (uint, uint) {
+    function g(bool b) public pure returns (uint x, uint y) {
         require(b);
         return (1, 2);
     }
-    function f(bool b) public returns (uint x, uint y) {
-        try this.g(b) returns (uint a, uint b) {
+    function f(bool flag) public view returns (uint x, uint y) {
+        try this.g(flag) returns (uint a, uint b) {
             (x, y) = (a, b);
         } catch {
             (x, y) = (9, 10);
@@ -13,6 +13,7 @@ contract C {
 }
 // ====
 // EVMVersion: >=byzantium
+// compileViaYul: also
 // ----
 // f(bool): true -> 1, 2
 // f(bool): false -> 9, 10

--- a/test/libsolidity/semanticTests/tryCatch/simple_notuple.sol
+++ b/test/libsolidity/semanticTests/tryCatch/simple_notuple.sol
@@ -1,0 +1,19 @@
+contract C {
+    function g(bool b) public pure returns (uint x) {
+        require(b);
+        return 13;
+    }
+    function f(bool flag) public view returns (uint x) {
+        try this.g(flag) returns (uint a) {
+            x = a;
+        } catch {
+            x = 9;
+        }
+    }
+}
+// ====
+// EVMVersion: >=byzantium
+// compileViaYul: also
+// ----
+// f(bool): true -> 13
+// f(bool): false -> 9

--- a/test/libsolidity/semanticTests/tryCatch/structured.sol
+++ b/test/libsolidity/semanticTests/tryCatch/structured.sol
@@ -14,6 +14,7 @@ contract C {
 }
 // ====
 // EVMVersion: >=byzantium
+// compileViaYul: also
 // ----
 // f(bool): true -> 1, 2, 0x60, 7, "success"
 // f(bool): false -> 0, 0, 0x60, 7, "message"

--- a/test/libsolidity/semanticTests/tryCatch/structuredAndLowLevel.sol
+++ b/test/libsolidity/semanticTests/tryCatch/structuredAndLowLevel.sol
@@ -18,6 +18,7 @@ contract C {
 }
 // ====
 // EVMVersion: >=byzantium
+// compileViaYul: also
 // ----
 // f(bool): true -> 1, 2, 96, 7, "success"
 // f(bool): false -> 99, 0, 96, 82, "message longer than 32 bytes 32 ", "bytes 32 bytes 32 bytes 32 bytes", " 32 bytes 32 bytes"

--- a/test/libsolidity/semanticTests/tryCatch/super_trivial.sol
+++ b/test/libsolidity/semanticTests/tryCatch/super_trivial.sol
@@ -1,0 +1,18 @@
+contract C {
+    function g(bool x) external pure {
+        require(x);
+    }
+    function f(bool x) public returns (uint) {
+        try this.g(x) {
+            return 1;
+        } catch {
+            return 2;
+        }
+    }
+}
+// ====
+// EVMVersion: >=byzantium
+// compileViaYul: also
+// ----
+// f(bool): true -> 1
+// f(bool): false -> 2


### PR DESCRIPTION
~~I *think* I'm done.~~

## Checklist:
* [x] simple try/catch statements
* [x] return data handling
* [x] `nested.sol` FIX
* [x] `structured.sol`: FIX internal compiler error "Invalid variable kind"
* [x] `structuredAndLowLevel.sol`: same as `structured.sol`
* [x] `returns_function.sol`
* [x] `assert.sol`
* [x] `trivial.sol`

## Tests that cannot be enabled:
* [ ] `create.sol`: requires constructors with parameters (Ticket: #8350)
* [ ] `invalid_error_encoding.sol`: some other bug?

## Tasks that can possibly be factored out into own PRs:
* [x] Move `IRGeneratorForStatements::verifyTrySuccessClause` logic into TypeChecker (so old codegen benefits from it, too)
