### PR TITLE
Refactor currentlocation

### DIFF
--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -28,14 +28,9 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 
-int ParserBase::position() const
+SourceLocation ParserBase::currentLocation() const
 {
-	return m_scanner->currentLocation().start;
-}
-
-int ParserBase::endPosition() const
-{
-	return m_scanner->currentLocation().end;
+	return m_scanner->currentLocation();
 }
 
 Token ParserBase::currentToken() const
@@ -101,8 +96,8 @@ void ParserBase::expectTokenOrConsumeUntil(Token _value, string const& _currentN
 	Token tok = m_scanner->currentToken();
 	if (tok != _value)
 	{
-		int startPosition = position();
-		SourceLocation errorLoc = SourceLocation{startPosition, endPosition(), source()};
+		SourceLocation errorLoc = currentLocation();
+		int startPosition = errorLoc.start;
 		while (m_scanner->currentToken() != _value && m_scanner->currentToken() != Token::EOS)
 			m_scanner->next();
 
@@ -150,7 +145,7 @@ void ParserBase::decreaseRecursionDepth()
 
 void ParserBase::parserWarning(string const& _description)
 {
-	m_errorReporter.warning(SourceLocation{position(), endPosition(), source()}, _description);
+	m_errorReporter.warning(currentLocation(), _description);
 }
 
 void ParserBase::parserError(SourceLocation const& _location, string const& _description)
@@ -160,12 +155,12 @@ void ParserBase::parserError(SourceLocation const& _location, string const& _des
 
 void ParserBase::parserError(string const& _description)
 {
-	parserError(SourceLocation{position(), endPosition(), source()}, _description);
+	parserError(currentLocation(), _description);
 }
 
 void ParserBase::fatalParserError(string const& _description)
 {
-	fatalParserError(SourceLocation{position(), endPosition(), source()}, _description);
+	fatalParserError(currentLocation(), _description);
 }
 
 void ParserBase::fatalParserError(SourceLocation const& _location, string const& _description)

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -62,10 +62,8 @@ protected:
 		ParserBase& m_parser;
 	};
 
-	/// Start position of the current token
-	int position() const;
-	/// End position of the current token
-	int endPosition() const;
+	/// Location of the current token
+	SourceLocation currentLocation() const;
 
 	///@{
 	///@name Helper functions

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -681,6 +681,7 @@ void Scanner::scanToken()
 	}
 	while (token == Token::Whitespace);
 	m_tokens[NextNext].location.end = sourcePos();
+	m_tokens[NextNext].location.source = m_source;
 	m_tokens[NextNext].token = token;
 	m_tokens[NextNext].extendedTokenInfo = make_tuple(m, n);
 }

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -88,7 +88,7 @@ Block Parser::parseBlock()
 	expectToken(Token::LBrace);
 	while (currentToken() != Token::RBrace)
 		block.statements.emplace_back(parseStatement());
-	block.location.end = endPosition();
+	block.location.end = currentLocation().end;
 	advance();
 	return block;
 }
@@ -151,7 +151,7 @@ Statement Parser::parseStatement()
 		{
 			Statement stmt{createWithLocation<Leave>()};
 			if (!m_insideFunction)
-				m_errorReporter.syntaxError(location(), "Keyword \"leave\" can only be used inside a function.");
+				m_errorReporter.syntaxError(currentLocation(), "Keyword \"leave\" can only be used inside a function.");
 			m_scanner->next();
 			return stmt;
 		}
@@ -328,13 +328,13 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 		YulString literal{currentLiteral()};
 		if (m_dialect.builtin(literal))
 		{
-			Identifier identifier{location(), literal};
+			Identifier identifier{currentLocation(), literal};
 			advance();
 			expectToken(Token::LParen, false);
 			return FunctionCall{identifier.location, identifier, {}};
 		}
 		else
-			ret = Identifier{location(), literal};
+			ret = Identifier{currentLocation(), literal};
 		advance();
 		break;
 	}
@@ -363,7 +363,7 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 		}
 
 		Literal literal{
-			location(),
+			currentLocation(),
 			kind,
 			YulString{currentLiteral()},
 			kind == LiteralKind::Boolean ? m_dialect.boolType : m_dialect.defaultType
@@ -372,7 +372,7 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 		if (currentToken() == Token::Colon)
 		{
 			expectToken(Token::Colon);
-			literal.location.end = endPosition();
+			literal.location.end = currentLocation().end;
 			literal.type = expectAsmIdentifier();
 		}
 
@@ -415,7 +415,7 @@ FunctionDefinition Parser::parseFunctionDefinition()
 
 	if (m_currentForLoopComponent == ForLoopComponent::ForLoopPre)
 		m_errorReporter.syntaxError(
-			location(),
+			currentLocation(),
 			"Functions cannot be defined inside a for-loop init block."
 		);
 
@@ -481,7 +481,7 @@ Expression Parser::parseCall(Parser::ElementaryOperation&& _initialOp)
 			ret.arguments.emplace_back(parseExpression());
 		}
 	}
-	ret.location.end = endPosition();
+	ret.location.end = currentLocation().end;
 	expectToken(Token::RParen);
 	return ret;
 }
@@ -494,7 +494,7 @@ TypedName Parser::parseTypedName()
 	if (currentToken() == Token::Colon)
 	{
 		expectToken(Token::Colon);
-		typedName.location.end = endPosition();
+		typedName.location.end = currentLocation().end;
 		typedName.type = expectAsmIdentifier();
 	}
 	else
@@ -530,13 +530,13 @@ void Parser::checkBreakContinuePosition(string const& _which)
 	switch (m_currentForLoopComponent)
 	{
 	case ForLoopComponent::None:
-		m_errorReporter.syntaxError(location(), "Keyword \"" + _which + "\" needs to be inside a for-loop body.");
+		m_errorReporter.syntaxError(currentLocation(), "Keyword \"" + _which + "\" needs to be inside a for-loop body.");
 		break;
 	case ForLoopComponent::ForLoopPre:
-		m_errorReporter.syntaxError(location(), "Keyword \"" + _which + "\" in for-loop init block is not allowed.");
+		m_errorReporter.syntaxError(currentLocation(), "Keyword \"" + _which + "\" in for-loop init block is not allowed.");
 		break;
 	case ForLoopComponent::ForLoopPost:
-		m_errorReporter.syntaxError(location(), "Keyword \"" + _which + "\" in for-loop post block is not allowed.");
+		m_errorReporter.syntaxError(currentLocation(), "Keyword \"" + _which + "\" in for-loop post block is not allowed.");
 		break;
 	case ForLoopComponent::ForLoopBody:
 		break;

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -206,8 +206,8 @@ Statement Parser::parseStatement()
 			elementary = parseElementaryOperation();
 		}
 
-		Assignment assignment =
-			createWithLocation<Assignment>(std::get<Identifier>(elementary).location);
+		Assignment assignment;
+		assignment.location = std::get<Identifier>(elementary).location;
 		assignment.variableNames = std::move(variableNames);
 
 		expectToken(Token::AssemblyAssign);

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -64,10 +64,9 @@ protected:
 	template <class T> T createWithLocation() const
 	{
 		T r;
-		r.location = location();
+		r.location = currentLocation();
 		return r;
 	}
-	langutil::SourceLocation location() const { return {position(), endPosition(), m_scanner->charStream()}; }
 
 	Block parseBlock();
 	Statement parseStatement();

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -60,18 +60,11 @@ public:
 protected:
 	using ElementaryOperation = std::variant<Literal, Identifier, FunctionCall>;
 
-	/// Creates an inline assembly node with the given source location.
-	template <class T> T createWithLocation(langutil::SourceLocation const& _loc = {}) const
+	/// Creates an inline assembly node with the current source location.
+	template <class T> T createWithLocation() const
 	{
 		T r;
-		r.location = _loc;
-		if (!r.location.hasText())
-		{
-			r.location.start = position();
-			r.location.end = endPosition();
-		}
-		if (!r.location.source)
-			r.location.source = m_scanner->charStream();
+		r.location = location();
 		return r;
 	}
 	langutil::SourceLocation location() const { return {position(), endPosition(), m_scanner->charStream()}; }


### PR DESCRIPTION
Replaced `ParserBase::position()` and `ParserBase::endPosition()` with `ParserBase::currentLocation()`.

It might be simpler to pass `SourceLocation` object instead of splitting it into `start` and `end`, and creating another SourceLocation object using the same `start` and `end` later.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
