### PR TITLE
Fix upgrade tool build on windows.

### DIFF
--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -25,6 +25,15 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/algorithm/string.hpp>
 
+#ifdef _WIN32 // windows
+	#include <io.h>
+	#define isatty _isatty
+	#define fileno _fileno
+#else // unix
+	#include <unistd.h>
+#endif
+
+
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 


### PR DESCRIPTION
The last build just went through - I only just force-pushed to align exactly with what we do in the command line interface.
Ref: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/isatty?view=vs-2019
Ref: https://github.com/ethereum/solidity/blob/a41f5e91f6cd147f451c629a7d7c17e0917cdfa8/solc/CommandLineInterface.cpp#L59