### PR TITLE
[WIP][yul-phaser] Genetic algorithm

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,6 +148,7 @@ set(yul_phaser_sources
     # My current workaround is just to include its source files here but this introduces
     # unnecessary duplication. Create a library or find a way to reuse the list in both places.
     ../tools/yulPhaser/Chromosome.cpp
+    ../tools/yulPhaser/FitnessMetrics.cpp
     ../tools/yulPhaser/Population.cpp
     ../tools/yulPhaser/Program.cpp
     ../tools/yulPhaser/Random.cpp

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/Population.h>
+#include <tools/yulPhaser/Program.h>
 
 #include <libyul/optimiser/BlockFlattener.h>
 #include <libyul/optimiser/SSAReverser.h>
@@ -85,7 +86,7 @@ BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness
 		Chromosome::makeRandom(5),
 		Chromosome::makeRandom(10),
 	};
-	Population population(sourceStream, chromosomes);
+	Population population(Program::load(sourceStream), chromosomes);
 
 	BOOST_TEST(population.individuals().size() == 2);
 	BOOST_TEST(population.individuals()[0].chromosome == chromosomes[0]);
@@ -98,8 +99,9 @@ BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness
 BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	auto population1 = Population::makeRandom(sourceStream, 100);
-	auto population2 = Population::makeRandom(sourceStream, 100);
+	auto program = Program::load(sourceStream);
+	auto population1 = Population::makeRandom(program, 100);
+	auto population2 = Population::makeRandom(program, 100);
 
 	BOOST_TEST(population1.individuals().size() == 100);
 	BOOST_TEST(population2.individuals().size() == 100);
@@ -118,7 +120,7 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes
 BOOST_AUTO_TEST_CASE(makeRandom_should_not_compute_fitness)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	auto population = Population::makeRandom(sourceStream, 5);
+	auto population = Population::makeRandom(Program::load(sourceStream), 5);
 
 	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
 }
@@ -127,7 +129,7 @@ BOOST_AUTO_TEST_CASE(run_should_evaluate_fitness)
 {
 	stringstream output;
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	auto population = Population::makeRandom(sourceStream, 5);
+	auto population = Population::makeRandom(Program::load(sourceStream), 5);
 	assert(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
 
 	population.run(1, output);
@@ -146,11 +148,12 @@ BOOST_AUTO_TEST_CASE(run_should_not_make_fitness_of_top_chromosomes_worse)
 		Chromosome({UnusedPruner::name}),
 		Chromosome({StructuralSimplifier::name, BlockFlattener::name}),
 	};
-	Population population(sourceStream, chromosomes);
+	auto program = Program::load(sourceStream);
+	Population population(program, chromosomes);
 
 	size_t initialTopFitness[2] = {
-		Population::measureFitness(chromosomes[0], sourceStream),
-		Population::measureFitness(chromosomes[1], sourceStream),
+		Population::measureFitness(chromosomes[0], program),
+		Population::measureFitness(chromosomes[1], program),
 	};
 
 	for (int i = 0; i < 6; ++i)

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -86,7 +86,8 @@ BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness
 		Chromosome::makeRandom(5),
 		Chromosome::makeRandom(10),
 	};
-	Population population(Program::load(sourceStream), chromosomes);
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
+	Population population(fitnessMetric, chromosomes);
 
 	BOOST_TEST(population.individuals().size() == 2);
 	BOOST_TEST(population.individuals()[0].chromosome == chromosomes[0]);
@@ -99,9 +100,9 @@ BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness
 BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
-	auto population1 = Population::makeRandom(program, 100);
-	auto population2 = Population::makeRandom(program, 100);
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
+	auto population1 = Population::makeRandom(fitnessMetric, 100);
+	auto population2 = Population::makeRandom(fitnessMetric, 100);
 
 	BOOST_TEST(population1.individuals().size() == 100);
 	BOOST_TEST(population2.individuals().size() == 100);
@@ -120,7 +121,8 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes
 BOOST_AUTO_TEST_CASE(makeRandom_should_not_compute_fitness)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	auto population = Population::makeRandom(Program::load(sourceStream), 5);
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
+	auto population = Population::makeRandom(fitnessMetric, 5);
 
 	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
 }

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -40,19 +40,6 @@ using namespace boost::unit_test::framework;
 namespace solidity::phaser::test
 {
 
-namespace
-{
-	bool fitnessNotSet(Individual const& individual)
-	{
-		return !individual.fitness.has_value();
-	}
-
-	bool fitnessSet(Individual const& individual)
-	{
-		return individual.fitness.has_value();
-	}
-}
-
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(PopulationTest)
 
@@ -79,7 +66,7 @@ string const& sampleSourceCode =
 	"    if 0 { let y := 2 }\n"
 	"}\n";
 
-BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness)
+BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_compute_fitness)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
 	vector<Chromosome> chromosomes = {
@@ -93,8 +80,8 @@ BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness
 	BOOST_TEST(population.individuals()[0].chromosome == chromosomes[0]);
 	BOOST_TEST(population.individuals()[1].chromosome == chromosomes[1]);
 
-	auto fitnessNotSet = [](auto const& individual){ return !individual.fitness.has_value(); };
-	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
+	BOOST_TEST(population.individuals()[0].fitness == fitnessMetric->evaluate(population.individuals()[0].chromosome));
+	BOOST_TEST(population.individuals()[1].fitness == fitnessMetric->evaluate(population.individuals()[1].chromosome));
 }
 
 BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes)
@@ -118,13 +105,15 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes
 	BOOST_TEST(numMatchingPositions < 10);
 }
 
-BOOST_AUTO_TEST_CASE(makeRandom_should_not_compute_fitness)
+BOOST_AUTO_TEST_CASE(makeRandom_should_compute_fitness)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
-	auto population = Population::makeRandom(fitnessMetric, 5);
+	auto population = Population::makeRandom(fitnessMetric, 3);
 
-	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
+	BOOST_TEST(population.individuals()[0].fitness == fitnessMetric->evaluate(population.individuals()[0].chromosome));
+	BOOST_TEST(population.individuals()[1].fitness == fitnessMetric->evaluate(population.individuals()[1].chromosome));
+	BOOST_TEST(population.individuals()[2].fitness == fitnessMetric->evaluate(population.individuals()[2].chromosome));
 }
 
 BOOST_AUTO_TEST_CASE(run_should_evaluate_fitness)

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -76,12 +76,31 @@ BOOST_AUTO_TEST_CASE(constructor_should_copy_chromosomes_and_compute_fitness)
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
 	Population population(fitnessMetric, chromosomes);
 
-	BOOST_TEST(population.individuals().size() == 2);
-	BOOST_TEST(population.individuals()[0].chromosome == chromosomes[0]);
-	BOOST_TEST(population.individuals()[1].chromosome == chromosomes[1]);
+	vector<Individual> const& individuals = population.individuals();
 
-	BOOST_TEST(population.individuals()[0].fitness == fitnessMetric->evaluate(population.individuals()[0].chromosome));
-	BOOST_TEST(population.individuals()[1].fitness == fitnessMetric->evaluate(population.individuals()[1].chromosome));
+	BOOST_TEST(individuals.size() == 2);
+	BOOST_TEST(individuals[0].fitness == fitnessMetric->evaluate(individuals[0].chromosome));
+	BOOST_TEST(individuals[1].fitness == fitnessMetric->evaluate(individuals[1].chromosome));
+	BOOST_TEST(individuals[0].fitness <= individuals[0].fitness);
+
+	size_t fitness[2] = {
+		fitnessMetric->evaluate(chromosomes[0]),
+		fitnessMetric->evaluate(chromosomes[1])
+	};
+	BOOST_TEST((
+		// The order depends on fitness. We're getting random chromosomes so we have to be prepared
+		// for either one being first.
+		(
+			individuals[0].chromosome == chromosomes[0] &&
+			individuals[1].chromosome == chromosomes[1] &&
+			fitness[0] <= fitness[1]
+		) ||
+		(
+			individuals[0].chromosome == chromosomes[1] &&
+			individuals[1].chromosome == chromosomes[0] &&
+			fitness[0] >= fitness[1]
+		)
+	));
 }
 
 BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes)

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -135,54 +135,6 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_compute_fitness)
 	BOOST_TEST(population.individuals()[2].fitness == fitnessMetric->evaluate(population.individuals()[2].chromosome));
 }
 
-BOOST_AUTO_TEST_CASE(run_should_evaluate_fitness)
-{
-	stringstream output;
-	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	auto population = Population::makeRandom(Program::load(sourceStream), 5);
-	assert(all_of(population.individuals().begin(), population.individuals().end(), fitnessNotSet));
-
-	population.run(1, output);
-
-	BOOST_TEST(all_of(population.individuals().begin(), population.individuals().end(), fitnessSet));
-}
-
-BOOST_AUTO_TEST_CASE(run_should_not_make_fitness_of_top_chromosomes_worse)
-{
-	stringstream output;
-	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
-	vector<Chromosome> chromosomes = {
-		Chromosome({StructuralSimplifier::name}),
-		Chromosome({BlockFlattener::name}),
-		Chromosome({SSAReverser::name}),
-		Chromosome({UnusedPruner::name}),
-		Chromosome({StructuralSimplifier::name, BlockFlattener::name}),
-	};
-	auto program = Program::load(sourceStream);
-	Population population(program, chromosomes);
-
-	size_t initialTopFitness[2] = {
-		Population::measureFitness(chromosomes[0], program),
-		Population::measureFitness(chromosomes[1], program),
-	};
-
-	for (int i = 0; i < 6; ++i)
-	{
-		population.run(1, output);
-		BOOST_TEST(population.individuals().size() == 5);
-		BOOST_TEST(fitnessSet(population.individuals()[0]));
-		BOOST_TEST(fitnessSet(population.individuals()[1]));
-
-		size_t currentTopFitness[2] = {
-			population.individuals()[0].fitness.value(),
-			population.individuals()[1].fitness.value(),
-		};
-		BOOST_TEST(currentTopFitness[0] <= initialTopFitness[0]);
-		BOOST_TEST(currentTopFitness[1] <= initialTopFitness[1]);
-		BOOST_TEST(currentTopFitness[0] <= currentTopFitness[1]);
-	}
-}
-
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -107,8 +107,8 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_return_population_with_random_chromosomes
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
-	auto population1 = Population::makeRandom(fitnessMetric, 100);
-	auto population2 = Population::makeRandom(fitnessMetric, 100);
+	auto population1 = Population::makeRandom(fitnessMetric, 100, []{ return 30; });
+	auto population2 = Population::makeRandom(fitnessMetric, 100, []{ return 30; });
 
 	BOOST_TEST(population1.individuals().size() == 100);
 	BOOST_TEST(population2.individuals().size() == 100);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_compute_fitness)
 {
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceStream));
-	auto population = Population::makeRandom(fitnessMetric, 3);
+	auto population = Population::makeRandom(fitnessMetric, 3, []{ return 10; });
 
 	BOOST_TEST(population.individuals()[0].fitness == fitnessMetric->evaluate(population.individuals()[0].chromosome));
 	BOOST_TEST(population.individuals()[1].fitness == fitnessMetric->evaluate(population.individuals()[1].chromosome));

--- a/test/yulPhaser/Program.cpp
+++ b/test/yulPhaser/Program.cpp
@@ -65,6 +65,26 @@ namespace solidity::phaser::test
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(ProgramTest)
 
+BOOST_AUTO_TEST_CASE(copy_constructor_should_make_deep_copy_of_ast)
+{
+	string sourceCode(
+		"{\n"
+		"    let x := 1\n"
+		"}\n"
+	);
+	CharStream sourceStream(sourceCode, current_test_case().p_name);
+	auto program = Program::load(sourceStream);
+
+	Program programCopy(program);
+
+	BOOST_TEST(&programCopy.ast() != &program.ast());
+
+	// There might be a more direct way to compare ASTs but converting to JSON should be good enough
+	// as long as the conversion is deterministic. A very nice side effect of doing it this way is
+	// that BOOST_TEST will print the complete AST structure of both programs in case of a mismatch.
+	BOOST_TEST(programCopy.toJson() == program.toJson());
+}
+
 BOOST_AUTO_TEST_CASE(load_should_rewind_the_stream)
 {
 	string sourceCode(

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(yul-phaser
 	yulPhaser/FitnessMetrics.cpp
 	yulPhaser/Chromosome.h
 	yulPhaser/Chromosome.cpp
+	yulPhaser/Mutations.h
+	yulPhaser/Mutations.cpp
 	yulPhaser/PairSelections.h
 	yulPhaser/PairSelections.cpp
 	yulPhaser/Selections.h

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,10 +15,18 @@ install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 add_executable(yul-phaser
 	yulPhaser/main.cpp
+	yulPhaser/GeneticAlgorithms.h
+	yulPhaser/GeneticAlgorithms.cpp
 	yulPhaser/Population.h
 	yulPhaser/Population.cpp
+	yulPhaser/FitnessMetrics.h
+	yulPhaser/FitnessMetrics.cpp
 	yulPhaser/Chromosome.h
 	yulPhaser/Chromosome.cpp
+	yulPhaser/PairSelections.h
+	yulPhaser/PairSelections.cpp
+	yulPhaser/Selections.h
+	yulPhaser/Selections.cpp
 	yulPhaser/Program.h
 	yulPhaser/Program.cpp
 	yulPhaser/Random.h

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -52,9 +52,10 @@ public:
 	bool operator==(Chromosome const& _other) const { return m_optimisationSteps == _other.m_optimisationSteps; }
 	bool operator!=(Chromosome const& _other) const { return !(*this == _other); }
 
+	static std::string const& randomOptimisationStep();
+
 private:
 	static std::vector<std::string> allStepNames();
-	static std::string const& randomOptimisationStep();
 
 	std::vector<std::string> m_optimisationSteps;
 };

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -16,3 +16,13 @@
 */
 
 #include <tools/yulPhaser/FitnessMetrics.h>
+
+using namespace std;
+using namespace solidity::phaser;
+
+size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
+{
+	Program programCopy = m_program;
+	programCopy.optimise(_chromosome.optimisationSteps());
+	return programCopy.codeSize();
+}

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -1,0 +1,18 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/FitnessMetrics.h>

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -23,6 +23,8 @@ using namespace solidity::phaser;
 size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
 {
 	Program programCopy = m_program;
-	programCopy.optimise(_chromosome.optimisationSteps());
+	for (size_t i = 0; i < m_repetitionCount; ++i)
+		programCopy.optimise(_chromosome.optimisationSteps());
+
 	return programCopy.codeSize();
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/Program.h>
 
 #include <cstddef>
 
@@ -33,6 +34,17 @@ public:
 	virtual ~FitnessMetric() = default;
 
 	virtual size_t evaluate(Chromosome const& _chromosome) const = 0;
+};
+
+class ProgramSize: public FitnessMetric
+{
+public:
+	ProgramSize(Program _program): m_program(std::move(_program)) {}
+
+	size_t evaluate(Chromosome const& _chromosome) const override;
+
+private:
+	Program m_program;
 };
 
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <tools/yulPhaser/Chromosome.h>
+
+#include <cstddef>
+
+namespace solidity::phaser
+{
+
+class FitnessMetric
+{
+public:
+	FitnessMetric() = default;
+	FitnessMetric(FitnessMetric const&) = delete;
+	FitnessMetric& operator=(FitnessMetric const&) = delete;
+	virtual ~FitnessMetric() = default;
+
+	virtual size_t evaluate(Chromosome const& _chromosome) const = 0;
+};
+
+}

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -39,12 +39,15 @@ public:
 class ProgramSize: public FitnessMetric
 {
 public:
-	ProgramSize(Program _program): m_program(std::move(_program)) {}
+	explicit ProgramSize(Program _program, size_t _repetitionCount = 1):
+		m_program(std::move(_program)),
+		m_repetitionCount(_repetitionCount) {}
 
 	size_t evaluate(Chromosome const& _chromosome) const override;
 
 private:
 	Program m_program;
+	size_t m_repetitionCount;
 };
 
 }

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -1,0 +1,32 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/GeneticAlgorithms.h>
+
+using namespace std;
+using namespace solidity::phaser;
+
+void GeneticAlgorithm::run(optional<size_t> _numRounds)
+{
+	for (size_t round = 0; !_numRounds.has_value() || round < _numRounds.value(); ++round)
+	{
+		runNextRound();
+
+		m_outputStream << "---------- ROUND " << round << " ----------" << endl;
+		m_outputStream << m_population;
+	}
+}

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <tools/yulPhaser/GeneticAlgorithms.h>
+#include <tools/yulPhaser/Selections.h>
 
 using namespace std;
 using namespace solidity::phaser;
@@ -29,4 +30,17 @@ void GeneticAlgorithm::run(optional<size_t> _numRounds)
 		m_outputStream << "---------- ROUND " << round << " ----------" << endl;
 		m_outputStream << m_population;
 	}
+}
+
+void RandomAlgorithm::runNextRound()
+{
+	RangeSelection elite(0.0, m_options.elitePoolSize);
+
+	Population elitePopulation = m_population.select(elite);
+	size_t replacementCount = m_population.individuals().size() - elitePopulation.individuals().size();
+
+	m_population = (
+		move(elitePopulation) +
+		Population::makeRandom(m_population.fitnessMetric(), replacementCount)
+	);
 }

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -16,7 +16,9 @@
 */
 
 #include <tools/yulPhaser/GeneticAlgorithms.h>
+#include <tools/yulPhaser/Mutations.h>
 #include <tools/yulPhaser/Selections.h>
+#include <tools/yulPhaser/PairSelections.h>
 
 using namespace std;
 using namespace solidity::phaser;
@@ -42,5 +44,31 @@ void RandomAlgorithm::runNextRound()
 	m_population = (
 		move(elitePopulation) +
 		Population::makeRandom(m_population.fitnessMetric(), replacementCount)
+	);
+}
+
+void GenerationalElitistWithExclusivePools::runNextRound()
+{
+	double elitePoolSize = m_options.mutationPoolSize + m_options.crossoverPoolSize;
+	RangeSelection elite(0.0, elitePoolSize);
+
+	m_population = (
+		m_population.select(elite) +
+		m_population.select(elite).mutate(
+			RandomSelection(0.5),
+			alternativeMutations(
+				m_options.randomizationChance,
+				geneRandomization(m_options.percentGenesToRandomize),
+				alternativeMutations(
+					m_options.deletionVsAdditionChance,
+					geneDeletion(m_options.percentGenesToAddOrDelete),
+					geneAddition(m_options.percentGenesToAddOrDelete)
+				)
+			)
+		) +
+		m_population.select(elite).crossover(
+			RandomPairSelection(0.25),
+			singlePointCrossover()
+		)
 	);
 }

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -43,7 +43,12 @@ void RandomAlgorithm::runNextRound()
 
 	m_population = (
 		move(elitePopulation) +
-		Population::makeRandom(m_population.fitnessMetric(), replacementCount)
+		Population::makeRandom(
+			m_population.fitnessMetric(),
+			replacementCount,
+			m_options.minChromosomeLength,
+			m_options.maxChromosomeLength
+		)
 	);
 }
 

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -50,11 +50,14 @@ public:
 	struct Options
 	{
 		double elitePoolSize;
+		size_t minChromosomeLength;
+		size_t maxChromosomeLength;
 
 		bool isValid() const
 		{
 			return (
-				0 <= elitePoolSize && elitePoolSize <= 1.0
+				0 <= elitePoolSize && elitePoolSize <= 1.0 &&
+				minChromosomeLength <= maxChromosomeLength
 			);
 		}
 	};

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <tools/yulPhaser/Population.h>
+
+#include <optional>
+#include <ostream>
+
+namespace solidity::phaser
+{
+
+class GeneticAlgorithm
+{
+public:
+	GeneticAlgorithm(Population _initialPopulation, std::ostream& _outputStream):
+		m_population(std::move(_initialPopulation)),
+		m_outputStream(_outputStream) {}
+
+	GeneticAlgorithm(PairSelection const&) = delete;
+	GeneticAlgorithm& operator=(GeneticAlgorithm const&) = delete;
+	virtual ~GeneticAlgorithm() = default;
+
+	void run(std::optional<size_t> _numRounds = std::nullopt);
+	virtual void runNextRound() = 0;
+
+protected:
+	Population m_population;
+	std::ostream& m_outputStream;
+};
+
+}

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -76,4 +76,47 @@ private:
 	Options m_options;
 };
 
+class GenerationalElitistWithExclusivePools: public GeneticAlgorithm
+{
+public:
+	struct Options
+	{
+		double mutationPoolSize;
+		double crossoverPoolSize;
+		double randomizationChance;
+		double deletionVsAdditionChance;
+		double percentGenesToRandomize;
+		double percentGenesToAddOrDelete;
+
+		bool isValid() const
+		{
+			return (
+				0 <= mutationPoolSize && mutationPoolSize <= 1.0 &&
+				0 <= crossoverPoolSize && crossoverPoolSize <= 1.0 &&
+				0 <= randomizationChance && randomizationChance <= 1.0 &&
+				0 <= deletionVsAdditionChance && deletionVsAdditionChance <= 1.0 &&
+				0 <= percentGenesToRandomize && percentGenesToRandomize <= 1.0 &&
+				0 <= percentGenesToAddOrDelete && percentGenesToAddOrDelete <= 1.0 &&
+				mutationPoolSize + crossoverPoolSize <= 1.0
+			);
+		}
+	};
+
+	GenerationalElitistWithExclusivePools(
+		Population _initialPopulation,
+		std::ostream& _outputStream,
+		Options const& _options
+	):
+		GeneticAlgorithm(_initialPopulation, _outputStream),
+		m_options(_options)
+	{
+		assert(_options.isValid());
+	}
+
+	void runNextRound() override;
+
+private:
+	Options m_options;
+};
+
 }

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -44,4 +44,36 @@ protected:
 	std::ostream& m_outputStream;
 };
 
+class RandomAlgorithm: public GeneticAlgorithm
+{
+public:
+	struct Options
+	{
+		double elitePoolSize;
+
+		bool isValid() const
+		{
+			return (
+				0 <= elitePoolSize && elitePoolSize <= 1.0
+			);
+		}
+	};
+
+	explicit RandomAlgorithm(
+		Population _initialPopulation,
+		std::ostream& _outputStream,
+		Options const& _options
+	):
+		GeneticAlgorithm(_initialPopulation, _outputStream),
+		m_options(_options)
+	{
+		assert(_options.isValid());
+	}
+
+	void runNextRound() override;
+
+private:
+	Options m_options;
+};
+
 }

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -1,0 +1,87 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Mutations.h>
+
+#include <tools/yulPhaser/Random.h>
+
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::phaser;
+
+function<Mutation> phaser::geneRandomization(double _chance)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> optimisationSteps;
+		for (auto const& step: _chromosome.optimisationSteps())
+			optimisationSteps.push_back(
+				bernoulliTrial(_chance) ?
+				Chromosome::randomOptimisationStep() :
+				step
+			);
+
+		return Chromosome(move(optimisationSteps));
+	};
+}
+
+function<Mutation> phaser::geneDeletion(double _chance)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> optimisationSteps;
+		for (auto const& step: _chromosome.optimisationSteps())
+			if (!bernoulliTrial(_chance))
+				optimisationSteps.push_back(step);
+
+		return Chromosome(move(optimisationSteps));
+	};
+}
+
+function<Mutation> phaser::geneAddition(double _chance)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> optimisationSteps;
+		for (auto const& step: _chromosome.optimisationSteps())
+		{
+			optimisationSteps.push_back(step);
+			if (bernoulliTrial(_chance))
+				optimisationSteps.push_back(Chromosome::randomOptimisationStep());
+		}
+
+		return Chromosome(move(optimisationSteps));
+	};
+}
+
+function<Mutation> phaser::alternativeMutations(
+	double _firstMutationChance,
+	function<Mutation> _mutation1,
+	function<Mutation> _mutation2
+)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		if (bernoulliTrial(_firstMutationChance))
+			return _mutation1(_chromosome);
+		else
+			return _mutation2(_chromosome);
+	};
+}

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -19,6 +19,9 @@
 
 #include <tools/yulPhaser/Random.h>
 
+#include <libsolutil/CommonData.h>
+
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -83,5 +86,31 @@ function<Mutation> phaser::alternativeMutations(
 			return _mutation1(_chromosome);
 		else
 			return _mutation2(_chromosome);
+	};
+}
+
+function<Crossover> phaser::singlePointCrossover()
+{
+	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+	{
+		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+		if (minLength <= 1)
+			return ChromsomePair(_chromosome2, _chromosome1);
+
+		size_t crossoverPoint = uniformRandomInt(1, minLength - 1);
+
+		auto begin1 = _chromosome1.optimisationSteps().begin();
+		auto begin2 = _chromosome2.optimisationSteps().begin();
+
+		return ChromsomePair(
+			Chromosome(
+				vector<string>(begin1, begin1 + crossoverPoint) +
+				vector<string>(begin2 + crossoverPoint, _chromosome2.optimisationSteps().end())
+			),
+			Chromosome(
+				vector<string>(begin2, begin2 + crossoverPoint) +
+				vector<string>(begin1 + crossoverPoint, _chromosome1.optimisationSteps().end())
+			)
+		);
 	};
 }

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <tools/yulPhaser/Chromosome.h>
+
+#include <functional>
+
+namespace solidity::phaser
+{
+
+using Mutation = Chromosome(Chromosome const&);
+
+std::function<Mutation> geneRandomization(double _chance);
+std::function<Mutation> geneDeletion(double _chance);
+std::function<Mutation> geneAddition(double _chance);
+std::function<Mutation> alternativeMutations(
+	double _firstMutationChance,
+	std::function<Mutation> _mutation1,
+	std::function<Mutation> _mutation2
+);
+
+}

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -20,11 +20,15 @@
 #include <tools/yulPhaser/Chromosome.h>
 
 #include <functional>
+#include <tuple>
 
 namespace solidity::phaser
 {
 
+using ChromsomePair = std::tuple<Chromosome, Chromosome>;
+
 using Mutation = Chromosome(Chromosome const&);
+using Crossover = ChromsomePair(Chromosome const&, Chromosome const&);
 
 std::function<Mutation> geneRandomization(double _chance);
 std::function<Mutation> geneDeletion(double _chance);
@@ -34,5 +38,7 @@ std::function<Mutation> alternativeMutations(
 	std::function<Mutation> _mutation1,
 	std::function<Mutation> _mutation2
 );
+
+std::function<Crossover> singlePointCrossover();
 
 }

--- a/tools/yulPhaser/PairSelections.cpp
+++ b/tools/yulPhaser/PairSelections.cpp
@@ -1,0 +1,18 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/PairSelections.h>

--- a/tools/yulPhaser/PairSelections.cpp
+++ b/tools/yulPhaser/PairSelections.cpp
@@ -16,3 +16,33 @@
 */
 
 #include <tools/yulPhaser/PairSelections.h>
+
+#include <tools/yulPhaser/Random.h>
+
+#include <cmath>
+
+using namespace std;
+using namespace solidity::phaser;
+
+vector<tuple<size_t, size_t>> RandomPairSelection::materialize(size_t _poolSize) const
+{
+	if (_poolSize < 2)
+		return {};
+
+	size_t count = static_cast<size_t>(round(_poolSize * m_selectionSize));
+
+	vector<tuple<size_t, size_t>> selection;
+	for (size_t i = 0; i < count; ++i)
+	{
+		size_t index1 = uniformRandomInt(0, _poolSize - 1);
+		size_t index2;
+		do
+		{
+			index2 = uniformRandomInt(0, _poolSize - 1);
+		} while (index1 == index2);
+
+		selection.push_back({index1, index2});
+	}
+
+	return selection;
+}

--- a/tools/yulPhaser/PairSelections.h
+++ b/tools/yulPhaser/PairSelections.h
@@ -34,4 +34,16 @@ public:
 	virtual std::vector<std::tuple<size_t, size_t>> materialize(size_t _poolSize) const = 0;
 };
 
+class RandomPairSelection: public PairSelection
+{
+public:
+	explicit RandomPairSelection(double _selectionSize):
+		m_selectionSize(_selectionSize) {}
+
+	std::vector<std::tuple<size_t, size_t>> materialize(size_t _poolSize) const override;
+
+private:
+	double m_selectionSize;
+};
+
 }

--- a/tools/yulPhaser/PairSelections.h
+++ b/tools/yulPhaser/PairSelections.h
@@ -1,0 +1,37 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+
+namespace solidity::phaser
+{
+
+class PairSelection
+{
+public:
+	PairSelection() = default;
+	PairSelection(PairSelection const&) = delete;
+	PairSelection& operator=(PairSelection const&) = delete;
+	virtual ~PairSelection() = default;
+
+	virtual std::vector<std::tuple<size_t, size_t>> materialize(size_t _poolSize) const = 0;
+};
+
+}

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -49,27 +49,27 @@ ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
 	return _stream;
 }
 
-Population::Population(CharStream _sourceCode, vector<Chromosome> const& _chromosomes):
-	m_sourceCode{move(_sourceCode)}
+Population::Population(Program _program, vector<Chromosome> const& _chromosomes):
+	m_program{move(_program)}
 {
 	for (auto const& chromosome: _chromosomes)
 		m_individuals.push_back({chromosome});
 }
 
-Population Population::makeRandom(CharStream _sourceCode, size_t _size)
+Population Population::makeRandom(Program _program, size_t _size)
 {
 	vector<Individual> individuals;
 	for (size_t i = 0; i < _size; ++i)
 		individuals.push_back({Chromosome::makeRandom(randomChromosomeLength())});
 
-	return Population(move(_sourceCode), individuals);
+	return Population(move(_program), individuals);
 }
 
-size_t Population::measureFitness(Chromosome const& _chromosome, CharStream& _sourceCode)
+size_t Population::measureFitness(Chromosome const& _chromosome, Program const& _program)
 {
-	auto program = Program::load(_sourceCode);
-	program.optimise(_chromosome.optimisationSteps());
-	return program.codeSize();
+	Program programCopy = _program;
+	programCopy.optimise(_chromosome.optimisationSteps());
+	return programCopy.codeSize();
 }
 
 void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
@@ -88,8 +88,6 @@ void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
 
 ostream& phaser::operator<<(ostream& _stream, Population const& _population)
 {
-	_stream << "Stream name: " << _population.m_sourceCode.name() << endl;
-
 	auto individual = _population.m_individuals.begin();
 	for (; individual != _population.m_individuals.end(); ++individual)
 		_stream << *individual << endl;
@@ -106,7 +104,7 @@ void Population::doEvaluation()
 {
 	for (auto& individual: m_individuals)
 		if (!individual.fitness.has_value())
-			individual.fitness = measureFitness(individual.chromosome, m_sourceCode);
+			individual.fitness = measureFitness(individual.chromosome, m_program);
 }
 
 void Population::doSelection()

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <numeric>
 
 using namespace std;

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -53,18 +53,6 @@ Population Population::makeRandom(shared_ptr<FitnessMetric const> _fitnessMetric
 	return Population(move(_fitnessMetric), move(chromosomes));
 }
 
-void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
-{
-	for (size_t round = 0; !_numRounds.has_value() || round < _numRounds.value(); ++round)
-	{
-		doMutation();
-		doSelection();
-
-		_outputStream << "---------- ROUND " << round << " ----------" << endl;
-		_outputStream << *this;
-	}
-}
-
 Population Population::select(Selection const& _selection) const
 {
 	vector<Individual> selectedIndividuals;
@@ -115,35 +103,6 @@ ostream& phaser::operator<<(ostream& _stream, Population const& _population)
 		_stream << *individual << endl;
 
 	return _stream;
-}
-
-void Population::doMutation()
-{
-	// TODO: Implement mutation and crossover
-}
-
-void Population::doSelection()
-{
-	randomizeWorstChromosomes(*m_fitnessMetric, m_individuals, m_individuals.size() / 2);
-	m_individuals = sortIndividuals(move(m_individuals));
-}
-
-void Population::randomizeWorstChromosomes(
-	FitnessMetric const& _fitnessMetric,
-	vector<Individual>& _individuals,
-	size_t _count
-)
-{
-	assert(_individuals.size() >= _count);
-	// ASSUMPTION: _individuals is sorted in ascending order
-
-	auto individual = _individuals.begin() + (_individuals.size() - _count);
-	for (; individual != _individuals.end(); ++individual)
-	{
-		auto chromosome = Chromosome::makeRandom(randomChromosomeLength());
-		size_t fitness = _fitnessMetric.evaluate(chromosome);
-		*individual = {move(chromosome), fitness};
-	}
 }
 
 vector<Individual> Population::chromosomesToIndividuals(

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -48,13 +48,6 @@ ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
 	return _stream;
 }
 
-Population::Population(Program _program, vector<Chromosome> const& _chromosomes):
-	m_program{move(_program)}
-{
-	for (auto const& chromosome: _chromosomes)
-		m_individuals.push_back({chromosome});
-}
-
 Population Population::makeRandom(Program _program, size_t _size)
 {
 	vector<Individual> individuals;
@@ -132,4 +125,15 @@ void Population::randomizeWorstChromosomes(
 	{
 		*individual = {Chromosome::makeRandom(randomChromosomeLength())};
 	}
+}
+
+vector<Individual> Population::chromosomesToIndividuals(
+	vector<Chromosome> _chromosomes
+)
+{
+	vector<Individual> individuals;
+	for (auto& chromosome: _chromosomes)
+		individuals.push_back({move(chromosome)});
+
+	return individuals;
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -65,6 +65,40 @@ void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
 	}
 }
 
+Population Population::select(Selection const& _selection) const
+{
+	vector<Individual> selectedIndividuals;
+	for (size_t i: _selection.materialize(m_individuals.size()))
+		selectedIndividuals.emplace_back(m_individuals[i]);
+
+	return Population(m_fitnessMetric, selectedIndividuals);
+}
+
+Population Population::mutate(Selection const& _selection, function<Mutation> _mutation) const
+{
+	vector<Individual> mutatedIndividuals;
+	for (size_t i: _selection.materialize(m_individuals.size()))
+		mutatedIndividuals.emplace_back(_mutation(m_individuals[i].chromosome), *m_fitnessMetric);
+
+	return Population(m_fitnessMetric, mutatedIndividuals);
+}
+
+Population Population::crossover(PairSelection const& _selection, function<Crossover> _crossover) const
+{
+	vector<Individual> crossedIndividuals;
+	for (auto const& [i, j]: _selection.materialize(m_individuals.size()))
+	{
+		auto [childChromosome1, childChromosome2] = _crossover(
+			m_individuals[i].chromosome,
+			m_individuals[j].chromosome
+		);
+		crossedIndividuals.emplace_back(move(childChromosome1), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(move(childChromosome2), *m_fitnessMetric);
+	}
+
+	return Population(m_fitnessMetric, crossedIndividuals);
+}
+
 Population operator+(Population _a, Population _b)
 {
 	// This operator is meant to be used only with populations sharing the same metric (and, to make

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/Population.h>
 
+#include <libsolutil/CommonData.h>
 
 #include <algorithm>
 #include <cassert>
@@ -62,6 +63,15 @@ void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
 		_outputStream << "---------- ROUND " << round << " ----------" << endl;
 		_outputStream << *this;
 	}
+}
+
+Population operator+(Population _a, Population _b)
+{
+	// This operator is meant to be used only with populations sharing the same metric (and, to make
+	// things simple, "the same" here means the same exact object in memory).
+	assert(_a.m_fitnessMetric == _b.m_fitnessMetric);
+
+	return Population(_a.m_fitnessMetric, move(_a.m_individuals) + move(_b.m_individuals));
 }
 
 ostream& phaser::operator<<(ostream& _stream, Population const& _population)

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -109,10 +109,7 @@ vector<Individual> Population::chromosomesToIndividuals(
 {
 	vector<Individual> individuals;
 	for (auto& chromosome: _chromosomes)
-	{
-		size_t fitness = _fitnessMetric.evaluate(chromosome);
-		individuals.push_back({move(chromosome), fitness});
-	}
+		individuals.emplace_back(move(chromosome), _fitnessMetric);
 
 	return individuals;
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -17,7 +17,6 @@
 
 #include <tools/yulPhaser/Population.h>
 
-#include <tools/yulPhaser/Program.h>
 
 #include <algorithm>
 #include <cassert>
@@ -48,20 +47,13 @@ ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
 	return _stream;
 }
 
-Population Population::makeRandom(Program _program, size_t _size)
+Population Population::makeRandom(shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size)
 {
 	vector<Individual> individuals;
 	for (size_t i = 0; i < _size; ++i)
 		individuals.push_back({Chromosome::makeRandom(randomChromosomeLength())});
 
-	return Population(move(_program), individuals);
-}
-
-size_t Population::measureFitness(Chromosome const& _chromosome, Program const& _program)
-{
-	Program programCopy = _program;
-	programCopy.optimise(_chromosome.optimisationSteps());
-	return programCopy.codeSize();
+	return Population(move(_fitnessMetric), move(individuals));
 }
 
 void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
@@ -96,7 +88,7 @@ void Population::doEvaluation()
 {
 	for (auto& individual: m_individuals)
 		if (!individual.fitness.has_value())
-			individual.fitness = measureFitness(individual.chromosome, m_program);
+			individual.fitness = m_fitnessMetric->evaluate(individual.chromosome);
 }
 
 void Population::doSelection()

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -101,14 +101,7 @@ void Population::doEvaluation()
 
 void Population::doSelection()
 {
-	assert(all_of(m_individuals.begin(), m_individuals.end(), [](auto& i){ return i.fitness.has_value(); }));
-
-	sort(
-		m_individuals.begin(),
-		m_individuals.end(),
-		[](auto const& a, auto const& b){ return a.fitness.value() < b.fitness.value(); }
-	);
-
+	m_individuals = sortIndividuals(move(m_individuals));
 	randomizeWorstChromosomes(m_individuals, m_individuals.size() / 2);
 }
 
@@ -136,4 +129,17 @@ vector<Individual> Population::chromosomesToIndividuals(
 		individuals.push_back({move(chromosome)});
 
 	return individuals;
+}
+
+vector<Individual> Population::sortIndividuals(vector<Individual> _individuals)
+{
+	assert(all_of(_individuals.begin(), _individuals.end(), [](auto& i){ return i.fitness.has_value(); }));
+
+	sort(
+		_individuals.begin(),
+		_individuals.end(),
+		[](auto const& a, auto const& b){ return a.fitness.value() < b.fitness.value(); }
+	);
+
+	return _individuals;
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -44,13 +44,30 @@ ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
 	return _stream;
 }
 
-Population Population::makeRandom(shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size)
+Population Population::makeRandom(
+	shared_ptr<FitnessMetric const> _fitnessMetric,
+	size_t _size,
+	function<int()> _chromosomeLengthGenerator
+)
 {
 	vector<Chromosome> chromosomes;
 	for (size_t i = 0; i < _size; ++i)
-		chromosomes.push_back(Chromosome::makeRandom(randomChromosomeLength()));
+		chromosomes.push_back(Chromosome::makeRandom(_chromosomeLengthGenerator()));
 
 	return Population(move(_fitnessMetric), move(chromosomes));
+}
+
+Population Population::makeRandom(
+	std::shared_ptr<FitnessMetric const> _fitnessMetric,
+	size_t _size,
+	size_t _minChromosomeLength,
+	size_t _maxChromosomeLength
+)
+{
+	return makeRandom(
+		_fitnessMetric,
+		_size, std::bind(uniformChromosomeLength, _minChromosomeLength, _maxChromosomeLength)
+	);
 }
 
 Population Population::select(Selection const& _selection) const

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -80,8 +80,8 @@ void Population::doMutation()
 
 void Population::doSelection()
 {
-	m_individuals = sortIndividuals(move(m_individuals));
 	randomizeWorstChromosomes(*m_fitnessMetric, m_individuals, m_individuals.size() / 2);
+	m_individuals = sortIndividuals(move(m_individuals));
 }
 
 void Population::randomizeWorstChromosomes(

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -18,9 +18,8 @@
 #pragma once
 
 #include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/Program.h>
 #include <tools/yulPhaser/Random.h>
-
-#include <liblangutil/CharStream.h>
 
 #include <optional>
 #include <ostream>
@@ -47,7 +46,7 @@ struct Individual
  * and selecting the best ones for the next round.
  *
  * An individual is a sequence of optimiser steps represented by a @a Chromosome instance. The whole
- * population is associated with a fixed Yul program. By loading the source code into a @a Program
+ * population is associated with a fixed Yul program. By applying the steps to the @a Program
  * instance the class can compute fitness of the individual.
  */
 class Population
@@ -55,21 +54,21 @@ class Population
 public:
 	static constexpr size_t MaxChromosomeLength = 30;
 
-	explicit Population(langutil::CharStream _sourceCode, std::vector<Chromosome> const& _chromosomes = {});
-	static Population makeRandom(langutil::CharStream _sourceCode, size_t _size);
+	explicit Population(Program _program, std::vector<Chromosome> const& _chromosomes = {});
+	static Population makeRandom(Program _program, size_t _size);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
 
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 
 	static size_t randomChromosomeLength() { return binomialRandomInt(MaxChromosomeLength, 0.5); }
-	static size_t measureFitness(Chromosome const& _chromosome, langutil::CharStream& _sourceCode);
+	static size_t measureFitness(Chromosome const& _chromosome, Program const& _program);
 
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(langutil::CharStream _sourceCode, std::vector<Individual> _individuals = {}):
-		m_sourceCode{std::move(_sourceCode)},
+	explicit Population(Program _program, std::vector<Individual> _individuals = {}):
+		m_program{std::move(_program)},
 		m_individuals{std::move(_individuals)} {}
 
 	void doMutation();
@@ -81,8 +80,7 @@ private:
 		size_t _count
 	);
 
-	langutil::CharStream m_sourceCode;
-
+	Program m_program;
 	std::vector<Individual> m_individuals;
 };
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -67,7 +67,7 @@ public:
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(Program _program, std::vector<Individual> _individuals = {}):
+	explicit Population(Program _program, std::vector<Individual> _individuals):
 		m_program{std::move(_program)},
 		m_individuals{std::move(_individuals)} {}
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <tools/yulPhaser/Chromosome.h>
-#include <tools/yulPhaser/Program.h>
+#include <tools/yulPhaser/FitnessMetrics.h>
 #include <tools/yulPhaser/Random.h>
 
 #include <optional>
@@ -54,25 +54,28 @@ class Population
 public:
 	static constexpr size_t MaxChromosomeLength = 30;
 
-	explicit Population(Program _program, std::vector<Chromosome> _chromosomes = {}):
+	explicit Population(
+		std::shared_ptr<FitnessMetric const> _fitnessMetric,
+		std::vector<Chromosome> _chromosomes = {}
+	):
 		Population(
-			std::move(_program),
+			std::move(_fitnessMetric),
 			chromosomesToIndividuals(std::move(_chromosomes))
 		) {}
-	static Population makeRandom(Program _program, size_t _size);
+	static Population makeRandom(std::shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
 
+	std::shared_ptr<FitnessMetric const> fitnessMetric() const { return m_fitnessMetric; }
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 
 	static size_t randomChromosomeLength() { return binomialRandomInt(MaxChromosomeLength, 0.5); }
-	static size_t measureFitness(Chromosome const& _chromosome, Program const& _program);
 
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(Program _program, std::vector<Individual> _individuals):
-		m_program{std::move(_program)},
+	explicit Population(std::shared_ptr<FitnessMetric const> _fitnessMetric, std::vector<Individual> _individuals):
+		m_fitnessMetric(std::move(_fitnessMetric)),
 		m_individuals{std::move(_individuals)} {}
 
 	void doMutation();
@@ -88,7 +91,7 @@ private:
 	);
 	std::vector<Individual> sortIndividuals(std::vector<Individual> _individuals);
 
-	Program m_program;
+	std::shared_ptr<FitnessMetric const> m_fitnessMetric;
 	std::vector<Individual> m_individuals;
 };
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -35,7 +35,7 @@ namespace solidity::phaser
 struct Individual
 {
 	Chromosome chromosome;
-	std::optional<size_t> fitness = std::nullopt;
+	size_t fitness;
 
 	friend std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
 };
@@ -60,7 +60,7 @@ public:
 	):
 		Population(
 			std::move(_fitnessMetric),
-			chromosomesToIndividuals(std::move(_chromosomes))
+			chromosomesToIndividuals(*_fitnessMetric, std::move(_chromosomes))
 		) {}
 	static Population makeRandom(std::shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size);
 
@@ -79,14 +79,15 @@ private:
 		m_individuals{std::move(_individuals)} {}
 
 	void doMutation();
-	void doEvaluation();
 	void doSelection();
 
 	static void randomizeWorstChromosomes(
+		FitnessMetric const& _fitnessMetric,
 		std::vector<Individual>& _individuals,
 		size_t _count
 	);
 	std::vector<Individual> chromosomesToIndividuals(
+		FitnessMetric const& _fitnessMetric,
 		std::vector<Chromosome> _chromosomes
 	);
 	std::vector<Individual> sortIndividuals(std::vector<Individual> _individuals);

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -85,7 +85,6 @@ public:
 		) {}
 	static Population makeRandom(std::shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size);
 
-	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
 	Population select(Selection const& _selection) const;
 	Population mutate(Selection const& _selection, std::function<Mutation> _mutation) const;
 	Population crossover(PairSelection const& _selection, std::function<Crossover> _crossover) const;
@@ -103,14 +102,6 @@ private:
 		m_fitnessMetric(std::move(_fitnessMetric)),
 		m_individuals{sortIndividuals(std::move(_individuals))} {}
 
-	void doMutation();
-	void doSelection();
-
-	static void randomizeWorstChromosomes(
-		FitnessMetric const& _fitnessMetric,
-		std::vector<Individual>& _individuals,
-		size_t _count
-	);
 	std::vector<Individual> chromosomesToIndividuals(
 		FitnessMetric const& _fitnessMetric,
 		std::vector<Chromosome> _chromosomes

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -86,6 +86,7 @@ private:
 	std::vector<Individual> chromosomesToIndividuals(
 		std::vector<Chromosome> _chromosomes
 	);
+	std::vector<Individual> sortIndividuals(std::vector<Individual> _individuals);
 
 	Program m_program;
 	std::vector<Individual> m_individuals;

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -19,7 +19,10 @@
 
 #include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/FitnessMetrics.h>
+#include <tools/yulPhaser/Mutations.h>
+#include <tools/yulPhaser/PairSelections.h>
 #include <tools/yulPhaser/Random.h>
+#include <tools/yulPhaser/Selections.h>
 
 #include <optional>
 #include <ostream>
@@ -83,6 +86,9 @@ public:
 	static Population makeRandom(std::shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
+	Population select(Selection const& _selection) const;
+	Population mutate(Selection const& _selection, std::function<Mutation> _mutation) const;
+	Population crossover(PairSelection const& _selection, std::function<Crossover> _crossover) const;
 	friend Population (::operator+)(Population _a, Population _b);
 
 	std::shared_ptr<FitnessMetric const> fitnessMetric() const { return m_fitnessMetric; }

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -54,7 +54,11 @@ class Population
 public:
 	static constexpr size_t MaxChromosomeLength = 30;
 
-	explicit Population(Program _program, std::vector<Chromosome> const& _chromosomes = {});
+	explicit Population(Program _program, std::vector<Chromosome> _chromosomes = {}):
+		Population(
+			std::move(_program),
+			chromosomesToIndividuals(std::move(_chromosomes))
+		) {}
 	static Population makeRandom(Program _program, size_t _size);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
@@ -78,6 +82,9 @@ private:
 	static void randomizeWorstChromosomes(
 		std::vector<Individual>& _individuals,
 		size_t _count
+	);
+	std::vector<Individual> chromosomesToIndividuals(
+		std::vector<Chromosome> _chromosomes
 	);
 
 	Program m_program;

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -76,7 +76,7 @@ public:
 private:
 	explicit Population(std::shared_ptr<FitnessMetric const> _fitnessMetric, std::vector<Individual> _individuals):
 		m_fitnessMetric(std::move(_fitnessMetric)),
-		m_individuals{std::move(_individuals)} {}
+		m_individuals{sortIndividuals(std::move(_individuals))} {}
 
 	void doMutation();
 	void doSelection();

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -37,6 +37,13 @@ struct Individual
 	Chromosome chromosome;
 	size_t fitness;
 
+	Individual(Chromosome _chromosome, size_t _fitness):
+		chromosome(std::move(_chromosome)),
+		fitness(_fitness) {}
+	Individual(Chromosome _chromosome, FitnessMetric const& _fitnessMetric):
+		chromosome(std::move(_chromosome)),
+		fitness(_fitnessMetric.evaluate(chromosome)) {}
+
 	friend std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
 };
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -73,8 +73,6 @@ struct Individual
 class Population
 {
 public:
-	static constexpr size_t MaxChromosomeLength = 30;
-
 	explicit Population(
 		std::shared_ptr<FitnessMetric const> _fitnessMetric,
 		std::vector<Chromosome> _chromosomes = {}
@@ -83,7 +81,18 @@ public:
 			std::move(_fitnessMetric),
 			chromosomesToIndividuals(*_fitnessMetric, std::move(_chromosomes))
 		) {}
-	static Population makeRandom(std::shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size);
+
+	static Population makeRandom(
+		std::shared_ptr<FitnessMetric const> _fitnessMetric,
+		size_t _size,
+		std::function<int()> _chromosomeLengthGenerator
+	);
+	static Population makeRandom(
+		std::shared_ptr<FitnessMetric const> _fitnessMetric,
+		size_t _size,
+		size_t _minChromosomeLength,
+		size_t _maxChromosomeLength
+	);
 
 	Population select(Selection const& _selection) const;
 	Population mutate(Selection const& _selection, std::function<Mutation> _mutation) const;
@@ -93,7 +102,8 @@ public:
 	std::shared_ptr<FitnessMetric const> fitnessMetric() const { return m_fitnessMetric; }
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 
-	static size_t randomChromosomeLength() { return binomialRandomInt(MaxChromosomeLength, 0.5); }
+	static size_t uniformChromosomeLength(size_t _min, size_t _max) { return uniformRandomInt(_min, _max); }
+	static size_t binomialChromosomeLength(size_t _max) { return binomialRandomInt(_max, 0.5); }
 
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -28,6 +28,17 @@
 namespace solidity::phaser
 {
 
+class Population;
+
+}
+
+// This operator+ must be declared in the global namespace. Otherwise it would shadow global
+// operator+ overloads from CommonData.h (e.g. the one for vector) in the namespace it was declared in.
+solidity::phaser::Population operator+(solidity::phaser::Population _a, solidity::phaser::Population _b);
+
+namespace solidity::phaser
+{
+
 /**
  * Information describing the state of an individual member of the population during the course
  * of the genetic algorithm.
@@ -72,6 +83,7 @@ public:
 	static Population makeRandom(std::shared_ptr<FitnessMetric const> _fitnessMetric, size_t _size);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
+	friend Population (::operator+)(Population _a, Population _b);
 
 	std::shared_ptr<FitnessMetric const> fitnessMetric() const { return m_fitnessMetric; }
 	std::vector<Individual> const& individuals() const { return m_individuals; }

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -57,6 +57,13 @@ ostream& operator<<(ostream& _stream, Program const& _program);
 
 }
 
+Program::Program(Program const& program):
+	m_ast(make_unique<Block>(get<Block>(ASTCopier{}(*program.m_ast)))),
+	m_dialect{program.m_dialect},
+	m_nameDispenser(program.m_nameDispenser)
+{
+}
+
 Program Program::load(CharStream& _sourceCode)
 {
 	// ASSUMPTION: parseSource() rewinds the stream on its own

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -79,7 +79,7 @@ Program Program::load(CharStream& _sourceCode)
 
 void Program::optimise(vector<string> const& _optimisationSteps)
 {
-	applyOptimisationSteps(m_dialect, m_nameDispenser, *m_ast, _optimisationSteps);
+	m_ast = applyOptimisationSteps(m_dialect, m_nameDispenser, move(m_ast), _optimisationSteps);
 }
 
 ostream& phaser::operator<<(ostream& _stream, Program const& _program)
@@ -133,10 +133,10 @@ unique_ptr<Block> Program::disambiguateAST(
 	return make_unique<Block>(get<Block>(disambiguator(_ast)));
 }
 
-void Program::applyOptimisationSteps(
+unique_ptr<Block> Program::applyOptimisationSteps(
 	Dialect const& _dialect,
 	NameDispenser& _nameDispenser,
-	Block& _ast,
+	unique_ptr<Block> _ast,
 	vector<string> const& _optimisationSteps
 )
 {
@@ -146,7 +146,9 @@ void Program::applyOptimisationSteps(
 	OptimiserStepContext context{_dialect, _nameDispenser, externallyUsedIdentifiers};
 
 	for (string const& step: _optimisationSteps)
-		OptimiserSuite::allSteps().at(step)->run(context, _ast);
+		OptimiserSuite::allSteps().at(step)->run(context, *_ast);
+
+	return _ast;
 }
 
 size_t Program::computeCodeSize(Block const& _ast)

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -20,8 +20,6 @@
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/AsmData.h>
 
-#include <boost/noncopyable.hpp>
-
 #include <optional>
 #include <ostream>
 #include <set>
@@ -55,14 +53,16 @@ namespace solidity::phaser
  * The class allows the user to apply extra optimisations and obtain metrics and general
  * information about the resulting syntax tree.
  */
-class Program: private boost::noncopyable
+class Program
 {
 public:
+	Program(Program const& program);
 	Program(Program&& program):
 		m_ast(std::move(program.m_ast)),
 		m_dialect{program.m_dialect},
 		m_nameDispenser(std::move(program.m_nameDispenser))
 	{}
+	Program operator=(Program const& program) = delete;
 	Program operator=(Program&& program) = delete;
 
 	static Program load(langutil::CharStream& _sourceCode);

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -97,10 +97,10 @@ private:
 		yul::Block const& _ast,
 		yul::AsmAnalysisInfo const& _analysisInfo
 	);
-	static void applyOptimisationSteps(
+	static std::unique_ptr<yul::Block> applyOptimisationSteps(
 		yul::Dialect const& _dialect,
 		yul::NameDispenser& _nameDispenser,
-		yul::Block& _ast,
+		std::unique_ptr<yul::Block> _ast,
 		std::vector<std::string> const& _optimisationSteps
 	);
 	static size_t computeCodeSize(yul::Block const& _ast);

--- a/tools/yulPhaser/Random.cpp
+++ b/tools/yulPhaser/Random.cpp
@@ -17,13 +17,23 @@
 
 #include <tools/yulPhaser/Random.h>
 
+#include <boost/random/bernoulli_distribution.hpp>
+#include <boost/random/binomial_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
-#include <boost/random/binomial_distribution.hpp>
 
 #include <ctime>
 
 using namespace solidity;
+
+
+bool phaser::bernoulliTrial(double _successProbability)
+{
+	static boost::random::mt19937 generator(time(0));
+	boost::random::bernoulli_distribution<> distribution(_successProbability);
+
+	return static_cast<bool>(distribution(generator));
+}
 
 uint32_t phaser::uniformRandomInt(uint32_t _min, uint32_t _max)
 {

--- a/tools/yulPhaser/Random.h
+++ b/tools/yulPhaser/Random.h
@@ -22,6 +22,7 @@
 namespace solidity::phaser
 {
 
+bool bernoulliTrial(double _successProbability);
 uint32_t uniformRandomInt(uint32_t _min, uint32_t _max);
 uint32_t binomialRandomInt(uint32_t _numTrials, double _successProbability);
 

--- a/tools/yulPhaser/Selections.cpp
+++ b/tools/yulPhaser/Selections.cpp
@@ -1,0 +1,18 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Selections.h>

--- a/tools/yulPhaser/Selections.cpp
+++ b/tools/yulPhaser/Selections.cpp
@@ -16,3 +16,33 @@
 */
 
 #include <tools/yulPhaser/Selections.h>
+
+#include <tools/yulPhaser/Random.h>
+
+#include <cmath>
+
+using namespace std;
+using namespace solidity::phaser;
+
+vector<size_t> RangeSelection::materialize(size_t _poolSize) const
+{
+	size_t beginIndex = static_cast<size_t>(round(_poolSize * m_startPercent));
+	size_t endIndex = static_cast<size_t>(round(_poolSize * m_endPercent));
+	vector<size_t> selection;
+
+	for (size_t i = beginIndex; i < endIndex; ++i)
+		selection.push_back(i);
+
+	return selection;
+}
+
+vector<size_t> RandomSelection::materialize(size_t _poolSize) const
+{
+	size_t count = static_cast<size_t>(round(_poolSize * m_selectionSize));
+
+	vector<size_t> selection;
+	for (size_t i = 0; i < count; ++i)
+		selection.push_back(uniformRandomInt(0, _poolSize - 1));
+
+	return selection;
+}

--- a/tools/yulPhaser/Selections.h
+++ b/tools/yulPhaser/Selections.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <vector>
 
 namespace solidity::phaser
@@ -31,6 +32,38 @@ public:
 	virtual ~Selection() = default;
 
 	virtual std::vector<size_t> materialize(size_t _poolSize) const = 0;
+};
+
+class RangeSelection: public Selection
+{
+public:
+	explicit RangeSelection(double _startPercent = 0.0, double _endPercent = 1.0):
+		m_startPercent(_startPercent),
+		m_endPercent(_endPercent)
+	{
+		assert(0 <= m_startPercent && m_startPercent <= m_endPercent && m_endPercent <= 1.0);
+	}
+
+	std::vector<size_t> materialize(size_t _poolSize) const override;
+
+private:
+	double m_startPercent;
+	double m_endPercent;
+};
+
+class RandomSelection: public Selection
+{
+public:
+	explicit RandomSelection(double _selectionSize):
+		m_selectionSize(_selectionSize)
+	{
+		assert(_selectionSize >= 0);
+	}
+
+	std::vector<size_t> materialize(size_t _poolSize) const override;
+
+private:
+	double m_selectionSize;
 };
 
 }

--- a/tools/yulPhaser/Selections.h
+++ b/tools/yulPhaser/Selections.h
@@ -1,0 +1,36 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <vector>
+
+namespace solidity::phaser
+{
+
+class Selection
+{
+public:
+	Selection() = default;
+	Selection(Selection const&) = delete;
+	Selection& operator=(Selection const&) = delete;
+	virtual ~Selection() = default;
+
+	virtual std::vector<size_t> materialize(size_t _poolSize) const = 0;
+};
+
+}

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Population.h>
+#include <tools/yulPhaser/Program.h>
 
 #include <libsolutil/Assertions.h>
 #include <libsolutil/CommonIO.h>
@@ -54,7 +55,8 @@ CharStream loadSource(string const& _sourcePath)
 
 void runAlgorithm(string const& _sourcePath)
 {
-	auto population = Population::makeRandom(loadSource(_sourcePath), 10);
+	CharStream sourceCode = loadSource(_sourcePath);
+	auto population = Population::makeRandom(Program::load(sourceCode), 10);
 	population.run(nullopt, cout);
 }
 

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -89,12 +89,12 @@ CharStream loadSource(string const& _sourcePath)
 
 void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 {
-	constexpr size_t populationSize = 10;
+	constexpr size_t populationSize = 20;
 	constexpr size_t minChromosomeLength = 12;
 	constexpr size_t maxChromosomeLength = 30;
 
 	CharStream sourceCode = loadSource(_sourcePath);
-	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode));
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode), 5);
 	auto population = Population::makeRandom(
 		fitnessMetric,
 		populationSize,
@@ -110,7 +110,7 @@ void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 				population,
 				cout,
 				{
-					/* elitePoolSize = */ 0.5,
+					/* _elitePoolSize = */ 1.0 / populationSize,
 					/* minChromosomeLength = */ minChromosomeLength,
 					/* maxChromosomeLength = */ maxChromosomeLength
 				}
@@ -159,7 +159,7 @@ CommandLineParsingResult parseCommandLine(int argc, char** argv)
 		("input-file", po::value<string>()->required(), "Input file")
 		(
 			"algorithm",
-			po::value<Algorithm>()->default_value(Algorithm::Random),
+			po::value<Algorithm>()->default_value(Algorithm::GEWEP),
 			"Algorithm"
 		)
 	;

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -16,8 +16,8 @@
 */
 
 #include <tools/yulPhaser/Exceptions.h>
-#include <tools/yulPhaser/Population.h>
 #include <tools/yulPhaser/FitnessMetrics.h>
+#include <tools/yulPhaser/GeneticAlgorithms.h>
 #include <tools/yulPhaser/Program.h>
 
 #include <libsolutil/Assertions.h>
@@ -39,7 +39,8 @@ namespace po = boost::program_options;
 
 enum class Algorithm
 {
-	Random
+	Random,
+	GEWEP
 };
 
 istream& operator>>(istream& inputStream, Algorithm& algorithm)
@@ -49,6 +50,8 @@ istream& operator>>(istream& inputStream, Algorithm& algorithm)
 
 	if (value == "random")
 		algorithm = Algorithm::Random;
+	else if (value == "GEWEP")
+		algorithm = Algorithm::GEWEP;
 	else
 		inputStream.setstate(ios_base::failbit);
 
@@ -59,6 +62,8 @@ ostream& operator<<(ostream& outputStream, Algorithm algorithm)
 {
 	if (algorithm == Algorithm::Random)
 		outputStream << "random";
+	else if (algorithm == Algorithm::GEWEP)
+		outputStream << "GEWEP";
 	else
 		outputStream.setstate(ios_base::failbit);
 
@@ -93,7 +98,31 @@ void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 	{
 		case Algorithm::Random:
 		{
-			population.run(nullopt, cout);
+			RandomAlgorithm(
+				population,
+				cout,
+				{
+					/* elitePoolSize = */ 0.5
+				}
+			).run();
+
+			break;
+		}
+		case Algorithm::GEWEP:
+		{
+			GenerationalElitistWithExclusivePools(
+				population,
+				cout,
+				{
+					/* mutationPoolSize = */ 0.25,
+					/* crossoverPoolSize = */ 0.25,
+					/* randomizationChance = */ 0.9,
+					/* deletionVsAdditionChance = */ 0.5,
+					/* percentGenesToRandomize = */ 0.1,
+					/* percentGenesToAddOrDelete = */ 0.1
+				}
+			).run();
+
 			break;
 		}
 	}

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Population.h>
+#include <tools/yulPhaser/FitnessMetrics.h>
 #include <tools/yulPhaser/Program.h>
 
 #include <libsolutil/Assertions.h>
@@ -56,7 +57,8 @@ CharStream loadSource(string const& _sourcePath)
 void runAlgorithm(string const& _sourcePath)
 {
 	CharStream sourceCode = loadSource(_sourcePath);
-	auto population = Population::makeRandom(Program::load(sourceCode), 10);
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode));
+	auto population = Population::makeRandom(fitnessMetric, 10);
 	population.run(nullopt, cout);
 }
 

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -90,10 +90,18 @@ CharStream loadSource(string const& _sourcePath)
 void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 {
 	constexpr size_t populationSize = 10;
+	constexpr size_t minChromosomeLength = 12;
+	constexpr size_t maxChromosomeLength = 30;
 
 	CharStream sourceCode = loadSource(_sourcePath);
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode));
-	auto population = Population::makeRandom(fitnessMetric, populationSize);
+	auto population = Population::makeRandom(
+		fitnessMetric,
+		populationSize,
+		minChromosomeLength,
+		maxChromosomeLength
+	);
+
 	switch (_algorithm)
 	{
 		case Algorithm::Random:
@@ -102,7 +110,9 @@ void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 				population,
 				cout,
 				{
-					/* elitePoolSize = */ 0.5
+					/* elitePoolSize = */ 0.5,
+					/* minChromosomeLength = */ minChromosomeLength,
+					/* maxChromosomeLength = */ maxChromosomeLength
 				}
 			).run();
 


### PR DESCRIPTION
### Description
The third pull request implementing #7806. This PR depends on #8223.

#### Algorithm
This pull request adds an actual genetic algorithm to `yul-phaser`. It's the algorithm proposed in the initial e-mails with only slight differences:
> - initialize the pool with 20 chromosomes of random length between 12 and 30, their contents fully random from the set of operations (including repetitions).
> - evaluate them by running them in a loop of maybe 5 iterations on the example input set (we should talk about that, too, but probably those in https://github.com/ethereum/solidity/tree/develop/test/libyul/yulOptimizerTests/fullSuite are fine for now)
> - sort by fitness, discard the lower half
> - re-fill one fourth by randomly selecting some chromosomes and exchanging random genes by other genes (mutation)
> - re-fill the last fourth by randomly selecting pairs of chromosomes and exchanging their genes at random cut points (cross-over)

The only difference is that the mutations performed by the current implementation include also random deletion and addition of genes, not just replacement. For each chromosome that undergoes mutation there's a 90% chance that the mutation is a gene replacement, 5% chance that it's a deletion and 5% chance that it's an addition. In each case every gene in the chromosome has a 10% chance of being affected by the mutation.

#### Implementation details
1. `GeneticAlgorithm` is a base class for concrete algorithm implementations. There are currently two: 
    - `RandomAlgorithm` (the same random algorithm that was used until now)
    - `GenerationalElitistWithExclusivePools` (the new algorithm).
    
    They can be selected on the command line using the `--algorithm` option. Valid values are: `random` and `GEWEP` (default).
2. There are a few new building blocks meant to make it easy to put together custom algorithms:
    - **Fitness metrics** - classes derived from `FitnessMetric`. For example `ProgramSize` metric stores a `Program` instance and computes the final size given a chromosome.
    - **Mutation and crossover operators** - functors that accept and return, a chromosome or a pair of chromosomes. They can be applied to a selection of chromosomes from a given population. Multiple simpler operators can be joined into more complex mutations using `alternativeMutations()` and in the future probably other combining operators.
    - **Selections and pair selections**: classes derived from `Selection` and `PairSelection`. They generate a set of indices (or pairs of indices) of population members according to specific rules. 
        - `RandomSelection` can choose a specific proportion of individuals at random. 
        - `RandomPairSelection` selects pairs of different chromosomes at random.
        - `RangeSelection` can select a sequence of individuals from a sorted population (e.g. invididuals classified between top 10% and bottom 20% of the population).
    - **Populations**: instances of the `Population` class. The class is now an immutable container for chromosomes associated with a particular fitness metrics. It no longer provides methods for running rounds of the algorithm (it's now `GeneticAlgorithm`'s job). Instead it has methods for generating new populations matching a selection and (optionally) modified by a mutation or crossover operator.
        - Populations are now always kept ordered by fitness. Fitness is no longer an optional part of `Individual` and is computed as soon as a chromosome is inserted.
    - **Chromosomes**: instances of `Chromosome` representing sequences of optimisation steps. This one did not change much in this PR.

#### Additional features
- `ProgramSize` metric can apply an optimisation sequence repeatedly specified number of times. The number is hard-coded to 5 right now.
- The random algorithm now preserves only the single best chromosome in each round.

#### Running the program
``` bash
cd build/
make yul-phaser
tools/yul-phaser ../test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul --algorithm GEWEP
```

### PR status
This PR still needs some polishing but is ready for an initial round of review. Please just keep in mind that some stuff might not yet be as polished as it should be and can still change a bit. The algorithm is already functional and just needs some tweaking.

Stuff remaining before I can change it from draft to a final PR:
- [ ] Add tests for all the new code (for now I just updated the existing ones).
- [ ] Add/update class docstrings.
- [ ] Clean up the `[TMP]` commits.
- [ ] Some small tweaks here and there.

Stuff that'll probably be done in separate PRs:
- [ ] Make mutations more aggressive or tweak some other parameters to prevent a bunch of duplicates ending up at the top. Right now there are often multiple copies of the same chromosome because the set of candidates for crossover is pretty small.
- [ ] Selections that can be iterated to generate numbers on the fly instead of storing them in a vector.
- [ ] Make selections work as `Population` iterators. Currently they only know population size and generate indices based on that. Having them associated with a specific population would allow doing stuff like skipping duplicates.
- [ ] Add command-line options for some of the algorithm parameters that are currently hard-coded in `main.cpp`.
- [ ] Change internal representation of `Chromosome` from a vector of strings to a string of step abbreviations.
- [ ] Templated metrics that could return values other than `size_t`. For example returning a tuple containing program size and size of the chromosome would allow us prioritize shorter chromosomes that give the same results.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages