### PR TITLE
Avoided trailing '\r' in CharStream::lineAtPosition().

### DIFF
--- a/liblangutil/CharStream.cpp
+++ b/liblangutil/CharStream.cpp
@@ -93,10 +93,13 @@ string CharStream::lineAtPosition(int _position) const
 		lineStart = 0;
 	else
 		lineStart++;
-	return m_source.substr(
+	string line = m_source.substr(
 		lineStart,
 		min(m_source.find('\n', lineStart), m_source.size()) - lineStart
 	);
+	if (!line.empty() && line.back() == '\r')
+		line.pop_back();
+	return line;
 }
 
 tuple<int, int> CharStream::translatePositionToLineColumn(int _position) const


### PR DESCRIPTION
While making **cmdlineTests.sh** work on Wndows, I noticed that a couple of tests produce slightly different results.


#### test/cmdlineTests/too_long_line_multiline/err
Expected:
```
2 |     function f() returns (byte _b, byte ... _b7, bytes22 _b22, bytes32 _b32)  {
```
Got (missing `_` in front of `b7`):
```
2 |     function f() returns (byte _b, byte ... b7, bytes22 _b22, bytes32 _b32)  {
```

#### test/cmdlineTests/too_long_line_edge_in/err
Expected:
```
2 |    function ffffffffffffffffffffff(announcementTypeTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT Ty, string A) onlyOwner external {
```
Got (`...` at the end):
```
2 |    function ffffffffffffffffffffff(announcementTypeTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT Ty, string A) onlyOwner external { ...
```

The cause seems to be that `CharStream::lineAtPosition` did not remove trailing `\r` (from `\r\n` line ending).

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
