### PR TITLE
Move mapping key checks to ReferencesResolver and make errors fatal.

### DIFF
--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -81,7 +81,7 @@ private:
 	void endVisit(ModifierDefinition const& _modifierDefinition) override;
 	void endVisit(UserDefinedTypeName const& _typeName) override;
 	void endVisit(FunctionTypeName const& _typeName) override;
-	void endVisit(Mapping const& _typeName) override;
+	void endVisit(Mapping const& _mapping) override;
 	void endVisit(ArrayTypeName const& _typeName) override;
 	bool visit(InlineAssembly const& _inlineAssembly) override;
 	bool visit(Return const& _return) override;

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2876,30 +2876,6 @@ void TypeChecker::endVisit(Literal const& _literal)
 	_literal.annotation().isPure = true;
 }
 
-bool TypeChecker::visit(Mapping const& _mapping)
-{
-	if (auto const* keyType = dynamic_cast<UserDefinedTypeName const*>(&_mapping.keyType()))
-	{
-		if (auto const* contractType = dynamic_cast<ContractType const*>(keyType->annotation().type))
-		{
-			if (contractType->contractDefinition().isLibrary())
-				m_errorReporter.typeError(
-					keyType->location(),
-					"Library types cannot be used as mapping keys."
-				);
-		}
-		else if (keyType->annotation().type->category() != Type::Category::Enum)
-			m_errorReporter.typeError(
-				keyType->location(),
-				"Only elementary types, contract types or enums are allowed as mapping keys."
-			);
-	}
-	else
-		solAssert(dynamic_cast<ElementaryTypeName const*>(&_mapping.keyType()), "");
-	return true;
-}
-
-
 bool TypeChecker::contractDependenciesAreCyclic(
 	ContractDefinition const& _contract,
 	std::set<ContractDefinition const*> const& _seenContracts

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -143,7 +143,6 @@ private:
 	bool visit(Identifier const& _identifier) override;
 	void endVisit(ElementaryTypeNameExpression const& _expr) override;
 	void endVisit(Literal const& _literal) override;
-	bool visit(Mapping const& _mapping) override;
 
 	bool contractDependenciesAreCyclic(
 		ContractDefinition const& _contract,

--- a/test/libsolidity/syntaxTests/types/struct_mapping_recursion.sol
+++ b/test/libsolidity/syntaxTests/types/struct_mapping_recursion.sol
@@ -1,0 +1,9 @@
+// Used to segfault.
+contract C {
+	struct S {
+		mapping(S => uint) a;
+	}
+	function g (S calldata) external view {}
+ }
+// ----
+// TypeError: (56-57): Only elementary types, contract types or enums are allowed as mapping keys.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8266