### PR TITLE
Switch nightly fuzzer build from ASan (slow) to UBSan (fast)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,6 @@ jobs:
           name: Regression tests
           command: |
             mkdir -p test_results
-            export ASAN_OPTIONS="check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2"
             scripts/regressions.py -o test_results
       - run: *gitter_notify_failure
       - run: *gitter_notify_success
@@ -793,7 +792,7 @@ workflows:
     jobs:
       # OSSFUZZ builds and (regression) tests
       - b_ubu_ossfuzz: *workflow_trigger_on_tags
-#      - t_ubu_ossfuzz: *workflow_ubuntu1904_ossfuzz
+      - t_ubu_ossfuzz: *workflow_ubuntu1904_ossfuzz
 
       # Code Coverage enabled build and tests
       - b_ubu_codecov: *workflow_trigger_on_tags

--- a/cmake/toolchains/libfuzzer.cmake
+++ b/cmake/toolchains/libfuzzer.cmake
@@ -7,5 +7,5 @@ set(USE_CVC4 OFF CACHE BOOL "Disable CVC4" FORCE)
 set(OSSFUZZ ON CACHE BOOL "Enable fuzzer build" FORCE)
 # Use libfuzzer as the fuzzing back-end
 set(LIB_FUZZING_ENGINE "-fsanitize=fuzzer" CACHE STRING "Use libfuzzer back-end" FORCE)
-# clang/libfuzzer specific flags for ASan instrumentation
-set(CMAKE_CXX_FLAGS "-O1 -gline-tables-only -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=fuzzer-no-link -stdlib=libstdc++" CACHE STRING "Custom compilation flags" FORCE)
+# clang/libfuzzer specific flags for UBSan instrumentation
+set(CMAKE_CXX_FLAGS "-O1 -gline-tables-only -fsanitize=undefined -fsanitize=fuzzer-no-link -stdlib=libstdc++" CACHE STRING "Custom compilation flags" FORCE)


### PR DESCRIPTION
Fixes #8219 

Notes:

- Main reason for timeout was run time overhead of Address sanitizer (ASan)
- Since we have ASan CIs already (t_ubu_asan*), this PR switches to undefined sanitizer (UBSan)
- UBSan detects type errors such as integer overflow
- UBSan is a smaller run time overhead than ASan, the hope is that nightly runs complete sooner
- With this switch, we won't detect memory errors in nightly runs but the following error classes
  - Type errors
  - ICE
  - Any uncaught exception in solidity
- Corpus has not been altered, this means each nightly run will run nightly UBSan build against existing fuzzer corpus

@chriseth This PR is still WIP. How do I test it in a nightly environment? Afaiu, only develop builds are picked up for fuzzer nightly? 