### PR TITLE
added note about gas counting and its effect on staticall.gas(gasLimi…

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -301,6 +301,11 @@ The ``gas`` option is available on all three methods, while the ``value`` option
 supported for ``delegatecall``.
 
 .. note::
+    It is best to avoid relying on hardcoded gas values in your smart contract code,
+    regardless of whether state is read from or written to, as this can have many pitfalls.
+    Also, access to gas might change in the future.
+
+.. note::
     All contracts can be converted to ``address`` type, so it is possible to query the balance of the
     current contract using ``address(this).balance``.
 


### PR DESCRIPTION
### Description

I made a tiny change to the solidity docs. I added a note about limiting gas stipends in `staticcalls` (`staticcall.gas(gasLimit)`). I think the docs should mention "gas counting" here and how it can affect reading state from `view functions` that make use of `staticcall.gas(gasLimit)`, even if you only call that read-only function from a Javascript API.

I myself was not fully aware of this until I found this to be the case when testing my own code. Some other solidity developers I talked to also were not aware of the importance of `gas counting` when reading state from Ethereum from a Javascript API. The more common misconceived oversimplification seems to be that gas does not matter for state reads because they do not cost gas.