### PR TITLE
Implement simple type checking for isoltest

### DIFF
--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -125,6 +125,7 @@ private:
 
 	bool accept(soltest::Token _token, bool const _expect = false);
 	bool expect(soltest::Token _token, bool const _advance = true);
+	void validateType(std::string _type);
 
 	/// Parses a function call signature in the form of `f(uint256, ...)` and
 	/// returns the signature and a flag that indicates if the function name was

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -731,6 +731,46 @@ BOOST_AUTO_TEST_CASE(call_arguments_hex_string_right_align)
 	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
 }
 
+BOOST_AUTO_TEST_CASE(call_no_bitwidth_int)
+{
+	char const* source = R"(
+		// f(int): ->
+	)";
+	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
+BOOST_AUTO_TEST_CASE(call_no_bitwidth_uint)
+{
+	char const* source = R"(
+		// f(uint): ->
+	)";
+	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
+BOOST_AUTO_TEST_CASE(call_invalid_bitwidth_uint)
+{
+	char const* source = R"(
+		// f(uint257): ->
+	)";
+	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
+BOOST_AUTO_TEST_CASE(call_invalid_bitwidth_int)
+{
+	char const* source = R"(
+		// f(int257): ->
+	)";
+	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
+BOOST_AUTO_TEST_CASE(call_invalid_bitwidth_bytes)
+{
+	char const* source = R"(
+		// f(bytes33): ->
+	)";
+	BOOST_REQUIRE_THROW(parse(source), langutil::Error);
+}
+
 BOOST_AUTO_TEST_CASE(call_newline_invalid)
 {
 	char const* source = R"(


### PR DESCRIPTION
Only for the types int, uint and bytes. More can easily be added.