### PR TITLE
PostTypeChecker: ConstStateVarCircularReferenceChecker on function type state variables.

### DIFF
--- a/libsolidity/analysis/PostTypeChecker.cpp
+++ b/libsolidity/analysis/PostTypeChecker.cpp
@@ -133,9 +133,9 @@ struct ConstStateVarCircularReferenceChecker: public PostTypeChecker::Checker
 
 	bool visit(VariableDeclaration const& _variable) override
 	{
-		solAssert(!m_currentConstVariable, "");
 		if (_variable.isConstant())
 		{
+			solAssert(!m_currentConstVariable, "");
 			m_currentConstVariable = &_variable;
 			m_constVariables.push_back(&_variable);
 		}

--- a/test/libsolidity/syntaxTests/cycle_checker_function_type.sol
+++ b/test/libsolidity/syntaxTests/cycle_checker_function_type.sol
@@ -1,0 +1,6 @@
+// Used to cause ICE.
+contract C {
+        function ( ) internal returns ( bytes [ ] storage , mapping ( bytes => mapping ( bytes => mapping ( uint => mapping ( bytes => mapping ( string => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( string => mapping ( string => mapping ( uint => mapping ( bytes => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( bytes => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( uint => mapping ( string => mapping ( uint => string ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) ) [ ] storage ) constant c = c ;
+}
+// ----
+// TypeError: (43-643): The value of the constant c has a cyclic dependency via c.

--- a/test/libsolidity/syntaxTests/types/constant_of_invalid_function_type.sol
+++ b/test/libsolidity/syntaxTests/types/constant_of_invalid_function_type.sol
@@ -1,0 +1,7 @@
+contract C {
+	// Used to cause internal compiler error.
+	function() returns (x) constant x = x;
+
+}
+// ----
+// TypeError: (77-78): Name has to refer to a struct, enum or contract.


### PR DESCRIPTION
@Marenz @chriseth Was there any reason to build this like this that I'm not aware of? The design made it impossible for the individual checkers to control visiting their subnodes...

Closes https://github.com/ethereum/solidity/issues/8296