### PR TITLE
Fix AST JSON test on MacOS

### DIFF
--- a/scripts/ASTImportTest.sh
+++ b/scripts/ASTImportTest.sh
@@ -79,7 +79,7 @@ for solfile in $(find $SYNTAXTESTS_DIR -name *.sol)
 do
     echo -n "."
     # create a temporary sub-directory
-    FILETMP=$(mktemp -d -p $WORKINGDIR)
+    FILETMP=$(mktemp -d)
     cd $FILETMP
 
     OUTPUT=$($SPLITSOURCES $solfile)


### PR DESCRIPTION
CLI tests on MacOS do report the illegal usage of `-p` (e.g. https://circleci.com/gh/ethereum/solidity/258312?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
```
.mktemp: illegal option -- p
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix 
```