### PR TITLE
Prevent windows line endings in bytecode report.

### DIFF
--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -6,7 +6,7 @@ import subprocess
 import json
 
 SOLC_BIN = sys.argv[1]
-REPORT_FILE = open("report.txt", mode="w", encoding='utf8')
+REPORT_FILE = open("report.txt", mode="w", encoding='utf8', newline='\n')
 
 for optimize in [False, True]:
     for f in sorted(glob.glob("*.sol")):


### PR DESCRIPTION
I saw the following in recent appveyor runs on develop:
```
scripts\bytecodecompare\storebytecode.bat : warning: CRLF will be replaced by LF in 2020-02-14-2917cf4bbccad116463e94b5b7ba7e7099af4386/windows.txt.
At line:1 char:71
+ ... D_COMMIT) { scripts\bytecodecompare\storebytecode.bat $Env:CONFIGURAT ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (warning: CRLF w...86/windows.txt.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
The file will have its original line endings in your working directory
```
That should be fixed by forcing the python script to generate LF line endings for the bytecode reports.