### PR TITLE
Add hour and minute to bytecode repo directory names.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ build_script:
     - msbuild solidity.sln /p:Configuration=%CONFIGURATION% /m:%NUMBER_OF_PROCESSORS% /v:minimal
     - cd %APPVEYOR_BUILD_FOLDER%
     - scripts\release.bat %CONFIGURATION% 2017
-    - ps: $bytecodedir = git show -s --format="%cd-%H" --date=short
+    - ps: $bytecodedir = git show -s --format="%cd-%H" --date="format:%Y-%m-%d-%H-%M"
 
 test_script:
     - cd %APPVEYOR_BUILD_FOLDER%\build\test\%CONFIGURATION%

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -126,7 +126,7 @@ EOF
         git config user.email "chris@ethereum.org"
         git clean -f -d -x
 
-        DIRNAME=$(cd "$REPO_ROOT" && git show -s --format="%cd-%H" --date=short)
+        DIRNAME=$(cd "$REPO_ROOT" && git show -s --format="%cd-%H" --date="format:%Y-%m-%d-%H-%M")
         mkdir -p "$DIRNAME"
         REPORT="$DIRNAME/$ZIP_SUFFIX.txt"
         cp ../report.txt "$REPORT"


### PR DESCRIPTION
This should ensure that the comparison is always run on the latest commit (unless we merge two PRs to develop within one minute :-)).