### PR TITLE
[yul-phaser] Miscellaneous Population tweaks and improvements

### DIFF
--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -67,25 +67,31 @@ BOOST_AUTO_TEST_CASE(constructor_should_convert_from_string_to_optimisation_step
 	BOOST_TEST(Chromosome("ChrOmOsoMe").optimisationSteps() == expectedSteps);
 }
 
-BOOST_AUTO_TEST_CASE(makeRandom_should_create_chromosome_with_random_optimisation_steps)
+BOOST_AUTO_TEST_CASE(makeRandom_should_return_different_chromosome_each_time)
 {
-	constexpr uint32_t numSteps = 1000;
+	SimulationRNG::reset(1);
+	for (size_t i = 0; i < 10; ++i)
+		BOOST_TEST(Chromosome::makeRandom(100) != Chromosome::makeRandom(100));
+}
 
-	auto chromosome1 = Chromosome::makeRandom(numSteps);
-	auto chromosome2 = Chromosome::makeRandom(numSteps);
-	BOOST_CHECK_EQUAL(chromosome1.length(), numSteps);
-	BOOST_CHECK_EQUAL(chromosome2.length(), numSteps);
+BOOST_AUTO_TEST_CASE(makeRandom_should_use_every_possible_step_with_the_same_probability)
+{
+	SimulationRNG::reset(1);
+	constexpr int samplesPerStep = 100;
+	constexpr double relativeTolerance = 0.01;
 
-	multiset<string> steps1;
-	multiset<string> steps2;
-	for (auto const& step: chromosome1.optimisationSteps())
-		steps1.insert(step);
-	for (auto const& step: chromosome2.optimisationSteps())
-		steps2.insert(step);
+	map<string, size_t> stepIndices = enumerateOptmisationSteps();
+	auto chromosome = Chromosome::makeRandom(stepIndices.size() * samplesPerStep);
 
-	// Check if steps are different and also if they're not just a permutation of the same set.
-	// Technically they could be the same and still random but the probability is infinitesimally low.
-	BOOST_TEST(steps1 != steps2);
+	vector<size_t> samples;
+	for (auto& step: chromosome.optimisationSteps())
+		samples.push_back(stepIndices.at(step));
+
+	const double expectedValue = (stepIndices.size() - 1) / 2.0;
+	const double variance = (stepIndices.size() * stepIndices.size() - 1) / 12.0;
+
+	BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
 }
 
 BOOST_AUTO_TEST_CASE(constructor_should_store_optimisation_steps)

--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -21,8 +21,18 @@
 #include <tools/yulPhaser/SimulationRNG.h>
 
 #include <libyul/optimiser/BlockFlattener.h>
-#include <libyul/optimiser/StructuralSimplifier.h>
+#include <libyul/optimiser/ConditionalSimplifier.h>
+#include <libyul/optimiser/ExpressionInliner.h>
+#include <libyul/optimiser/ExpressionSimplifier.h>
+#include <libyul/optimiser/ForLoopConditionOutOfBody.h>
+#include <libyul/optimiser/ForLoopConditionOutOfBody.h>
+#include <libyul/optimiser/ForLoopInitRewriter.h>
+#include <libyul/optimiser/FunctionHoister.h>
+#include <libyul/optimiser/LoopInvariantCodeMotion.h>
+#include <libyul/optimiser/RedundantAssignEliminator.h>
+#include <libyul/optimiser/Rematerialiser.h>
 #include <libyul/optimiser/Suite.h>
+#include <libyul/optimiser/StructuralSimplifier.h>
 #include <libyul/optimiser/UnusedPruner.h>
 
 #include <libsolutil/CommonIO.h>
@@ -38,6 +48,24 @@ namespace solidity::phaser::test
 
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(ChromosomeTest)
+
+BOOST_AUTO_TEST_CASE(constructor_should_convert_from_string_to_optimisation_steps)
+{
+	vector<string> expectedSteps{
+		ConditionalSimplifier::name,
+		FunctionHoister::name,
+		RedundantAssignEliminator::name,
+		ForLoopConditionOutOfBody::name,
+		Rematerialiser::name,
+		ForLoopConditionOutOfBody::name,
+		ExpressionSimplifier::name,
+		ForLoopInitRewriter::name,
+		LoopInvariantCodeMotion::name,
+		ExpressionInliner::name
+	};
+
+	BOOST_TEST(Chromosome("ChrOmOsoMe").optimisationSteps() == expectedSteps);
+}
 
 BOOST_AUTO_TEST_CASE(makeRandom_should_create_chromosome_with_random_optimisation_steps)
 {

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -25,6 +25,15 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 
+vector<size_t> phaser::test::chromosomeLengths(Population const& _population)
+{
+	vector<size_t> lengths;
+	for (auto const& individual: _population.individuals())
+		lengths.push_back(individual.chromosome.length());
+
+	return lengths;
+}
+
 map<string, size_t> phaser::test::enumerateOptmisationSteps()
 {
 	map<string, size_t> stepIndices;

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -19,6 +19,8 @@
 
 #include <libyul/optimiser/Suite.h>
 
+#include <regex>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
@@ -31,4 +33,10 @@ map<string, size_t> phaser::test::enumerateOptmisationSteps()
 		stepIndices.insert({nameAndAbbreviation.first, i++});
 
 	return stepIndices;
+}
+
+string phaser::test::stripWhitespace(string const& input)
+{
+	regex whitespaceRegex("\\s+");
+	return regex_replace(input, whitespaceRegex, "");
 }

--- a/test/yulPhaser/Common.h
+++ b/test/yulPhaser/Common.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <tools/yulPhaser/Population.h>
+
 #include <cassert>
 #include <map>
 #include <string>
@@ -37,6 +39,10 @@ namespace solidity::phaser::test
 {
 
 // CHROMOSOME AND POPULATION HELPERS
+
+/// Returns a vector containing lengths of all chromosomes in the population (in the same order).
+std::vector<size_t> chromosomeLengths(Population const& _population);
+
 /// Assigns indices from 0 to N to all optimisation steps available in the OptimiserSuite.
 /// This is a convenience helper to make it easier to test their distribution with tools made for
 /// integers.

--- a/test/yulPhaser/Common.h
+++ b/test/yulPhaser/Common.h
@@ -42,6 +42,11 @@ namespace solidity::phaser::test
 /// integers.
 std::map<std::string, size_t> enumerateOptmisationSteps();
 
+// STRING UTILITIES
+
+/// Returns the input string with all the whitespace characters (spaces, line endings, etc.) removed.
+std::string stripWhitespace(std::string const& input);
+
 // STATISTICAL UTILITIES
 
 /// Calculates the mean value of a series of samples given in a vector.

--- a/test/yulPhaser/CommonTest.cpp
+++ b/test/yulPhaser/CommonTest.cpp
@@ -51,6 +51,20 @@ BOOST_AUTO_TEST_CASE(enumerateOptimisationSteps_should_assing_indices_to_all_ava
 	}
 }
 
+BOOST_AUTO_TEST_CASE(stripWhitespace_should_remove_all_whitespace_characters_from_a_string)
+{
+	BOOST_TEST(stripWhitespace("") == "");
+	BOOST_TEST(stripWhitespace(" ") == "");
+	BOOST_TEST(stripWhitespace(" \n\t\v ") == "");
+
+	BOOST_TEST(stripWhitespace("abc") == "abc");
+	BOOST_TEST(stripWhitespace(" abc") == "abc");
+	BOOST_TEST(stripWhitespace("abc ") == "abc");
+	BOOST_TEST(stripWhitespace(" a b c ") == "abc");
+	BOOST_TEST(stripWhitespace(" a b\tc\n") == "abc");
+	BOOST_TEST(stripWhitespace("   a   b \n\n  c \n\t\v") == "abc");
+}
+
 BOOST_AUTO_TEST_CASE(mean_should_calculate_statistical_mean)
 {
 	BOOST_TEST(mean<int>({0}) == 0.0);

--- a/test/yulPhaser/CommonTest.cpp
+++ b/test/yulPhaser/CommonTest.cpp
@@ -19,11 +19,14 @@
 
 #include <libyul/optimiser/Suite.h>
 
+#include <liblangutil/CharStream.h>
+
 #include <boost/test/unit_test.hpp>
 
 #include <set>
 
 using namespace std;
+using namespace solidity::langutil;
 using namespace solidity::yul;
 using namespace boost::test_tools;
 
@@ -32,6 +35,18 @@ namespace solidity::phaser::test
 
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(CommonTest)
+
+BOOST_AUTO_TEST_CASE(chromosomeLengths_should_return_lengths_of_all_chromosomes_in_a_population)
+{
+	CharStream sourceStream("{}", "");
+	auto program = Program::load(sourceStream);
+
+	Population population1(program, {Chromosome(), Chromosome("a"), Chromosome("aa"), Chromosome("aaa")});
+	BOOST_TEST((chromosomeLengths(population1) == vector<size_t>{0, 1, 2, 3}));
+
+	Population population2(program);
+	BOOST_TEST((chromosomeLengths(population2) == vector<size_t>{}));
+}
 
 BOOST_AUTO_TEST_CASE(enumerateOptimisationSteps_should_assing_indices_to_all_available_optimisation_steps)
 {

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -104,6 +104,18 @@ BOOST_AUTO_TEST_CASE(isFitter_should_use_fitness_as_the_main_criterion)
 	BOOST_TEST(!isFitter(Individual{Chromosome("aaa"), 10}, Individual{Chromosome("aaaaa"), 5}));
 }
 
+BOOST_AUTO_TEST_CASE(isFitter_should_use_alphabetical_order_when_fitness_is_the_same)
+{
+	BOOST_TEST(isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("c"), 3}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("c"), 3}, Individual{Chromosome("a"), 3}));
+
+	BOOST_TEST(isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("aa"), 3}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("aa"), 3}, Individual{Chromosome("a"), 3}));
+
+	BOOST_TEST(isFitter(Individual{Chromosome("T"), 3}, Individual{Chromosome("a"), 3}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("T"), 3}));
+}
+
 BOOST_AUTO_TEST_CASE(isFitter_should_return_false_for_identical_individuals)
 {
 	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("a"), 3}));

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -92,6 +92,24 @@ protected:
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(PopulationTest)
 
+BOOST_AUTO_TEST_CASE(isFitter_should_use_fitness_as_the_main_criterion)
+{
+	BOOST_TEST(isFitter(Individual{Chromosome("a"), 5}, Individual{Chromosome("a"), 10}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 10}, Individual{Chromosome("a"), 5}));
+
+	BOOST_TEST(isFitter(Individual{Chromosome("aaa"), 5}, Individual{Chromosome("aaaaa"), 10}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("aaaaa"), 10}, Individual{Chromosome("aaa"), 5}));
+
+	BOOST_TEST(isFitter(Individual{Chromosome("aaaaa"), 5}, Individual{Chromosome("aaa"), 10}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("aaa"), 10}, Individual{Chromosome("aaaaa"), 5}));
+}
+
+BOOST_AUTO_TEST_CASE(isFitter_should_return_false_for_identical_individuals)
+{
+	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("a"), 3}));
+	BOOST_TEST(!isFitter(Individual{Chromosome("acT"), 0}, Individual{Chromosome("acT"), 0}));
+}
+
 BOOST_FIXTURE_TEST_CASE(constructor_should_copy_chromosomes_and_not_compute_fitness, PopulationFixture)
 {
 	vector<Chromosome> chromosomes = {

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -142,11 +142,11 @@ BOOST_AUTO_TEST_CASE(run_should_not_make_fitness_of_top_chromosomes_worse)
 	stringstream output;
 	CharStream sourceStream(sampleSourceCode, current_test_case().p_name);
 	vector<Chromosome> chromosomes = {
-		Chromosome({StructuralSimplifier::name}),
-		Chromosome({BlockFlattener::name}),
-		Chromosome({SSAReverser::name}),
-		Chromosome({UnusedPruner::name}),
-		Chromosome({StructuralSimplifier::name, BlockFlattener::name}),
+		Chromosome(vector<string>{StructuralSimplifier::name}),
+		Chromosome(vector<string>{BlockFlattener::name}),
+		Chromosome(vector<string>{SSAReverser::name}),
+		Chromosome(vector<string>{UnusedPruner::name}),
+		Chromosome(vector<string>{StructuralSimplifier::name, BlockFlattener::name}),
 	};
 	auto program = Program::load(sourceStream);
 	Population population(program, chromosomes);

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -261,6 +261,15 @@ BOOST_FIXTURE_TEST_CASE(run_should_not_make_fitness_of_top_chromosomes_worse, Po
 	}
 }
 
+BOOST_FIXTURE_TEST_CASE(plus_operator_should_add_two_populations, PopulationFixture)
+{
+	BOOST_CHECK_EQUAL(
+		Population(m_program, {Chromosome("ac"), Chromosome("cx")}) +
+		Population(m_program, {Chromosome("g"), Chromosome("h"), Chromosome("iI")}),
+		Population(m_program, {Chromosome("ac"), Chromosome("cx"), Chromosome("g"), Chromosome("h"), Chromosome("iI")})
+	);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/yulPhaser/Program.cpp
+++ b/test/yulPhaser/Program.cpp
@@ -15,6 +15,8 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <test/yulPhaser/Common.h>
+
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Program.h>
 
@@ -30,7 +32,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <cassert>
-#include <regex>
 #include <string>
 
 using namespace std;
@@ -50,12 +51,6 @@ namespace
 			return skipRedundantBlocks(get<Block>(_block.statements[0]));
 		else
 			return _block;
-	}
-
-	string stripWhitespace(string const& input)
-	{
-		regex whitespaceRegex("\\s+");
-		return regex_replace(input, whitespaceRegex, "");
 	}
 }
 

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -36,6 +36,12 @@ ostream& operator<<(ostream& _stream, Chromosome const& _chromosome);
 
 }
 
+Chromosome::Chromosome(string const& _optimisationSteps)
+{
+	for (char abbreviation: _optimisationSteps)
+		m_optimisationSteps.push_back(OptimiserSuite::stepAbbreviationToNameMap().at(abbreviation));
+}
+
 Chromosome Chromosome::makeRandom(size_t _length)
 {
 	vector<string> steps;

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -42,6 +42,7 @@ public:
 	Chromosome() = default;
 	explicit Chromosome(std::vector<std::string> _optimisationSteps):
 		m_optimisationSteps(std::move(_optimisationSteps)) {}
+	explicit Chromosome(std::string const& _optimisationSteps);
 	static Chromosome makeRandom(size_t _length);
 
 	size_t length() const { return m_optimisationSteps.size(); }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -125,6 +125,13 @@ Population operator+(Population _a, Population _b)
 	return Population(_a.m_program, move(_a.m_individuals) + move(_b.m_individuals));
 }
 
+bool Population::operator==(Population const& _other) const
+{
+	// TODO: Comparing programs is pretty heavy but it's just a stopgap. It will soon be replaced
+	// by a comparison of fitness metric associated with the population (once metrics are introduced).
+	return m_individuals == _other.m_individuals && toString(m_program) == toString(_other.m_program);
+}
+
 ostream& phaser::operator<<(ostream& _stream, Population const& _population)
 {
 	auto individual = _population.m_individuals.begin();

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -55,13 +55,31 @@ Population::Population(Program _program, vector<Chromosome> const& _chromosomes)
 		m_individuals.push_back({chromosome});
 }
 
-Population Population::makeRandom(Program _program, size_t _size)
+Population Population::makeRandom(
+	Program _program,
+	size_t _size,
+	function<size_t()> _chromosomeLengthGenerator
+)
 {
 	vector<Individual> individuals;
 	for (size_t i = 0; i < _size; ++i)
-		individuals.push_back({Chromosome::makeRandom(randomChromosomeLength())});
+		individuals.push_back({Chromosome::makeRandom(_chromosomeLengthGenerator())});
 
 	return Population(move(_program), individuals);
+}
+
+Population Population::makeRandom(
+	Program _program,
+	size_t _size,
+	size_t _minChromosomeLength,
+	size_t _maxChromosomeLength
+)
+{
+	return makeRandom(
+		move(_program),
+		_size,
+		std::bind(uniformChromosomeLength, _minChromosomeLength, _maxChromosomeLength)
+	);
 }
 
 size_t Population::measureFitness(Chromosome const& _chromosome, Program const& _program)
@@ -130,6 +148,6 @@ void Population::randomizeWorstChromosomes(
 	auto individual = _individuals.begin() + (_individuals.size() - _count);
 	for (; individual != _individuals.end(); ++individual)
 	{
-		*individual = {Chromosome::makeRandom(randomChromosomeLength())};
+		*individual = {Chromosome::makeRandom(binomialChromosomeLength(MaxChromosomeLength))};
 	}
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -48,6 +48,13 @@ ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
 	return _stream;
 }
 
+bool phaser::isFitter(Individual const& a, Individual const& b)
+{
+	assert(a.fitness.has_value() && b.fitness.has_value());
+
+	return a.fitness.value() < b.fitness.value();
+}
+
 Population::Population(Program _program, vector<Chromosome> const& _chromosomes):
 	m_program{move(_program)}
 {
@@ -128,12 +135,7 @@ void Population::doSelection()
 {
 	assert(all_of(m_individuals.begin(), m_individuals.end(), [](auto& i){ return i.fitness.has_value(); }));
 
-	sort(
-		m_individuals.begin(),
-		m_individuals.end(),
-		[](auto const& a, auto const& b){ return a.fitness.value() < b.fitness.value(); }
-	);
-
+	sort(m_individuals.begin(), m_individuals.end(), isFitter);
 	randomizeWorstChromosomes(m_individuals, m_individuals.size() / 2);
 }
 

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -19,6 +19,7 @@
 
 #include <tools/yulPhaser/Program.h>
 
+#include <libsolutil/CommonData.h>
 #include <libsolutil/CommonIO.h>
 
 #include <algorithm>
@@ -115,6 +116,13 @@ void Population::run(optional<size_t> _numRounds, ostream& _outputStream)
 		_outputStream << "---------- ROUND " << round << " ----------" << endl;
 		_outputStream << *this;
 	}
+}
+
+Population operator+(Population _a, Population _b)
+{
+	assert(toString(_a.m_program) == toString(_b.m_program));
+
+	return Population(_a.m_program, move(_a.m_individuals) + move(_b.m_individuals));
 }
 
 ostream& phaser::operator<<(ostream& _stream, Population const& _population)

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <numeric>
 
 using namespace std;

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -19,6 +19,8 @@
 
 #include <tools/yulPhaser/Program.h>
 
+#include <libsolutil/CommonIO.h>
+
 #include <algorithm>
 #include <cassert>
 #include <numeric>
@@ -26,6 +28,7 @@
 using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
+using namespace solidity::util;
 using namespace solidity::phaser;
 
 namespace solidity::phaser
@@ -52,7 +55,11 @@ bool phaser::isFitter(Individual const& a, Individual const& b)
 {
 	assert(a.fitness.has_value() && b.fitness.has_value());
 
-	return a.fitness.value() < b.fitness.value();
+	return (
+		(a.fitness.value() < b.fitness.value()) ||
+		(a.fitness.value() == b.fitness.value() && a.chromosome.length() < b.chromosome.length()) ||
+		(a.fitness.value() == b.fitness.value() && a.chromosome.length() == b.chromosome.length() && toString(a.chromosome) < toString(b.chromosome))
+	);
 }
 
 Population::Population(Program _program, vector<Chromosome> const& _chromosomes):

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -67,7 +67,7 @@ public:
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(Program _program, std::vector<Individual> _individuals = {}):
+	explicit Population(Program _program, std::vector<Individual> _individuals):
 		m_program{std::move(_program)},
 		m_individuals{std::move(_individuals)} {}
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -48,6 +48,9 @@ struct Individual
 	Chromosome chromosome;
 	std::optional<size_t> fitness = std::nullopt;
 
+	bool operator==(Individual const& _other) const { return fitness == _other.fitness && chromosome == _other.chromosome; }
+	bool operator!=(Individual const& _other) const { return !(*this == _other); }
+
 	friend std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
 };
 
@@ -92,6 +95,9 @@ public:
 	static size_t uniformChromosomeLength(size_t _min, size_t _max) { return SimulationRNG::uniformInt(_min, _max); }
 	static size_t binomialChromosomeLength(size_t _max) { return SimulationRNG::binomialInt(_max, 0.5); }
 	static size_t measureFitness(Chromosome const& _chromosome, Program const& _program);
+
+	bool operator==(Population const& _other) const;
+	bool operator!=(Population const& _other) const { return !(*this == _other); }
 
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -40,6 +40,9 @@ struct Individual
 	friend std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
 };
 
+/// Determines which individual is better by comparing fitness values.
+bool isFitter(Individual const& a, Individual const& b);
+
 /**
  * Represents a changing set of individuals undergoing a genetic algorithm.
  * Each round of the algorithm involves mutating existing individuals, evaluating their fitness

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -55,13 +55,25 @@ public:
 	static constexpr size_t MaxChromosomeLength = 30;
 
 	explicit Population(Program _program, std::vector<Chromosome> const& _chromosomes = {});
-	static Population makeRandom(Program _program, size_t _size);
+
+	static Population makeRandom(
+		Program _program,
+		size_t _size,
+		std::function<size_t()> _chromosomeLengthGenerator
+	);
+	static Population makeRandom(
+		Program _program,
+		size_t _size,
+		size_t _minChromosomeLength,
+		size_t _maxChromosomeLength
+	);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
 
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 
-	static size_t randomChromosomeLength() { return SimulationRNG::binomialInt(MaxChromosomeLength, 0.5); }
+	static size_t uniformChromosomeLength(size_t _min, size_t _max) { return SimulationRNG::uniformInt(_min, _max); }
+	static size_t binomialChromosomeLength(size_t _max) { return SimulationRNG::binomialInt(_max, 0.5); }
 	static size_t measureFitness(Chromosome const& _chromosome, Program const& _program);
 
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -28,6 +28,17 @@
 namespace solidity::phaser
 {
 
+class Population;
+
+}
+
+// This operator+ must be declared in the global namespace. Otherwise it would shadow global
+// operator+ overloads from CommonData.h (e.g. the one for vector) in the namespace it was declared in.
+solidity::phaser::Population operator+(solidity::phaser::Population _a, solidity::phaser::Population _b);
+
+namespace solidity::phaser
+{
+
 /**
  * Information describing the state of an individual member of the population during the course
  * of the genetic algorithm.
@@ -74,6 +85,7 @@ public:
 	);
 
 	void run(std::optional<size_t> _numRounds, std::ostream& _outputStream);
+	friend Population (::operator+)(Population _a, Population _b);
 
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -40,7 +40,9 @@ struct Individual
 	friend std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
 };
 
-/// Determines which individual is better by comparing fitness values.
+/// Determines which individual is better by comparing fitness values. If fitness is the same
+/// takes into account all the other properties of the individual to make the comparison
+/// deterministic as long as the individuals are not equal.
 bool isFitter(Individual const& a, Individual const& b);
 
 /**

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -28,6 +28,7 @@
 #include <boost/program_options.hpp>
 
 #include <iostream>
+#include <functional>
 #include <string>
 
 using namespace std;
@@ -70,7 +71,11 @@ CharStream loadSource(string const& _sourcePath)
 void runAlgorithm(string const& _sourcePath)
 {
 	CharStream sourceCode = loadSource(_sourcePath);
-	auto population = Population::makeRandom(Program::load(sourceCode), 10);
+	auto population = Population::makeRandom(
+		Program::load(sourceCode),
+		10,
+		bind(Population::binomialChromosomeLength, Population::MaxChromosomeLength)
+	);
 	population.run(nullopt, cout);
 }
 


### PR DESCRIPTION
### Description
The fourth pull request implementing #7806. Originally a part of #8256 which is now closed. Depends on #8324.

This is a bunch of loosely related changes that are used by later PRs but are not really a part of the "business logic" of the application. Extracted into a separate PR to make the others smaller and easier to review.

1. `Chromosome` can now be constructed from a string with step abbreviations.
2. Operator `+` for `Population`. This will be a core mechanic in the algorithms as the `Population` becomes immutable in one of the next PRs (#8327) but is also very convenient in general.
3. Ability to specify desired chromosome length in `Population::makeRandom()`.
4. Deterministic order of individuals. Now it takes into account the chromosome so that individuals with the same fitness are always ordered the same way (lexicographically). A side-benefit is that the shorter chromosomes are now preferred.
5. Equality operators for `Population` and `Individual`.
6. More helpers added to `test/yulPhaser/Common.h`
7. Fixture that takes the repetitive program construction out of the test cases.
8. Improved tests for `makeRandom()` based on the improvements from the `SimulationRNG` PR (#8324).

Some of the new features (equality operators, `Chromosome` constructor, etc.) are not yet necessary in non-test code but they simplify tests **a lot**. Especially the constructor removes the need for a long list of extra includes. I considered putting them in `Common.h` instead (and in some cases I did - there are some new helpers there) but in my opinion they're not out of place in the normal code and might come in handy later. Being able to easily construct and compare objects does make for a better class API in my opinion.

### Dependencies
This PR is based on #8324. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages