### PR TITLE
[yul-phaser] Fitness metrics

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,6 +143,7 @@ set(yul_phaser_sources
     yulPhaser/Common.cpp
     yulPhaser/CommonTest.cpp
     yulPhaser/Chromosome.cpp
+    yulPhaser/FitnessMetrics.cpp
     yulPhaser/Population.cpp
     yulPhaser/Program.cpp
     yulPhaser/SimulationRNG.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,6 +151,7 @@ set(yul_phaser_sources
     # My current workaround is just to include its source files here but this introduces
     # unnecessary duplication. Create a library or find a way to reuse the list in both places.
     ../tools/yulPhaser/Chromosome.cpp
+    ../tools/yulPhaser/FitnessMetrics.cpp
     ../tools/yulPhaser/Population.cpp
     ../tools/yulPhaser/Program.cpp
     ../tools/yulPhaser/SimulationRNG.cpp

--- a/test/yulPhaser/Common.h
+++ b/test/yulPhaser/Common.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/FitnessMetrics.h>
 #include <tools/yulPhaser/Population.h>
 
 #include <cassert>
@@ -37,6 +39,18 @@
 
 namespace solidity::phaser::test
 {
+
+/**
+ * Fitness metric that only takes into account the number of optimisation steps in the chromosome.
+ * Recommended for use in tests because it's much faster than ProgramSize metric and it's very
+ * easy to guess the result at a glance.
+ */
+class ChromosomeLengthMetric: public FitnessMetric
+{
+public:
+	using FitnessMetric::FitnessMetric;
+	size_t evaluate(Chromosome const& _chromosome) const override { return _chromosome.length(); }
+};
 
 // CHROMOSOME AND POPULATION HELPERS
 

--- a/test/yulPhaser/CommonTest.cpp
+++ b/test/yulPhaser/CommonTest.cpp
@@ -19,14 +19,11 @@
 
 #include <libyul/optimiser/Suite.h>
 
-#include <liblangutil/CharStream.h>
-
 #include <boost/test/unit_test.hpp>
 
 #include <set>
 
 using namespace std;
-using namespace solidity::langutil;
 using namespace solidity::yul;
 using namespace boost::test_tools;
 
@@ -36,15 +33,21 @@ namespace solidity::phaser::test
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(CommonTest)
 
+BOOST_AUTO_TEST_CASE(ChromosomeLengthMetric_evaluate_should_return_chromosome_length)
+{
+	BOOST_TEST(ChromosomeLengthMetric{}.evaluate(Chromosome()) == 0);
+	BOOST_TEST(ChromosomeLengthMetric{}.evaluate(Chromosome("a")) == 1);
+	BOOST_TEST(ChromosomeLengthMetric{}.evaluate(Chromosome("aaaaa")) == 5);
+}
+
 BOOST_AUTO_TEST_CASE(chromosomeLengths_should_return_lengths_of_all_chromosomes_in_a_population)
 {
-	CharStream sourceStream("{}", "");
-	auto program = Program::load(sourceStream);
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ChromosomeLengthMetric>();
 
-	Population population1(program, {Chromosome(), Chromosome("a"), Chromosome("aa"), Chromosome("aaa")});
+	Population population1(fitnessMetric, {Chromosome(), Chromosome("a"), Chromosome("aa"), Chromosome("aaa")});
 	BOOST_TEST((chromosomeLengths(population1) == vector<size_t>{0, 1, 2, 3}));
 
-	Population population2(program);
+	Population population2(fitnessMetric);
 	BOOST_TEST((chromosomeLengths(population2) == vector<size_t>{}));
 }
 

--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -72,6 +72,39 @@ BOOST_FIXTURE_TEST_CASE(evaluate_should_compute_size_of_the_optimised_program, F
 	BOOST_TEST(ProgramSize(m_program).evaluate(chromosome) == optimisedProgram.codeSize());
 }
 
+BOOST_FIXTURE_TEST_CASE(evaluate_should_repeat_the_optimisation_specified_number_of_times, FitnessMetricFixture)
+{
+	Chromosome chromosome(vector<string>{UnusedPruner::name, EquivalentFunctionCombiner::name});
+
+	Program programOptimisedOnce = m_program;
+	programOptimisedOnce.optimise(chromosome.optimisationSteps());
+	Program programOptimisedTwice = programOptimisedOnce;
+	programOptimisedTwice.optimise(chromosome.optimisationSteps());
+	assert(m_program.codeSize() != programOptimisedOnce.codeSize());
+	assert(m_program.codeSize() != programOptimisedTwice.codeSize());
+	assert(programOptimisedOnce.codeSize() != programOptimisedTwice.codeSize());
+
+	ProgramSize metric(m_program, 2);
+
+	BOOST_TEST(metric.evaluate(chromosome) != m_program.codeSize());
+	BOOST_TEST(metric.evaluate(chromosome) != programOptimisedOnce.codeSize());
+	BOOST_TEST(metric.evaluate(chromosome) == programOptimisedTwice.codeSize());
+}
+
+BOOST_FIXTURE_TEST_CASE(evaluate_should_not_optimise_if_number_of_repetitions_is_zero, FitnessMetricFixture)
+{
+	Chromosome chromosome(vector<string>{UnusedPruner::name, EquivalentFunctionCombiner::name});
+
+	Program optimisedProgram = m_program;
+	optimisedProgram.optimise(chromosome.optimisationSteps());
+	assert(m_program.codeSize() != optimisedProgram.codeSize());
+
+	ProgramSize metric(m_program, 0);
+
+	BOOST_TEST(metric.evaluate(chromosome) == m_program.codeSize());
+	BOOST_TEST(metric.evaluate(chromosome) != optimisedProgram.codeSize());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -1,0 +1,80 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/FitnessMetrics.h>
+
+#include <libyul/optimiser/EquivalentFunctionCombiner.h>
+#include <libyul/optimiser/UnusedPruner.h>
+
+#include <liblangutil/CharStream.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace solidity::langutil;
+using namespace solidity::yul;
+
+namespace solidity::phaser::test
+{
+
+class FitnessMetricFixture
+{
+protected:
+	FitnessMetricFixture():
+		m_sourceStream(SampleSourceCode, ""),
+		m_program(Program::load(m_sourceStream)) {}
+
+	static constexpr char SampleSourceCode[] =
+		"{\n"
+		"    function foo() -> result\n"
+		"    {\n"
+		"        let x := 1\n"
+		"        result := 15\n"
+		"    }\n"
+		"    function bar() -> result\n"
+		"    {\n"
+		"        result := 15\n"
+		"    }\n"
+		"    mstore(foo(), bar())\n"
+		"}\n";
+
+	CharStream m_sourceStream;
+	Program m_program;
+};
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(FitnessMetricsTest)
+BOOST_AUTO_TEST_SUITE(ProgramSizeTest)
+
+BOOST_FIXTURE_TEST_CASE(evaluate_should_compute_size_of_the_optimised_program, FitnessMetricFixture)
+{
+	Chromosome chromosome(vector<string>{UnusedPruner::name, EquivalentFunctionCombiner::name});
+
+	Program optimisedProgram = m_program;
+	optimisedProgram.optimise(chromosome.optimisationSteps());
+	assert(m_program.codeSize() != optimisedProgram.codeSize());
+
+	BOOST_TEST(ProgramSize(m_program).evaluate(chromosome) != m_program.codeSize());
+	BOOST_TEST(ProgramSize(m_program).evaluate(chromosome) == optimisedProgram.codeSize());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}
+

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -53,32 +53,32 @@ BOOST_AUTO_TEST_SUITE(PopulationTest)
 
 BOOST_AUTO_TEST_CASE(isFitter_should_use_fitness_as_the_main_criterion)
 {
-	BOOST_TEST(isFitter(Individual{Chromosome("a"), 5}, Individual{Chromosome("a"), 10}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 10}, Individual{Chromosome("a"), 5}));
+	BOOST_TEST(isFitter(Individual(Chromosome("a"), 5), Individual(Chromosome("a"), 10)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("a"), 10), Individual(Chromosome("a"), 5)));
 
-	BOOST_TEST(isFitter(Individual{Chromosome("aaa"), 5}, Individual{Chromosome("aaaaa"), 10}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("aaaaa"), 10}, Individual{Chromosome("aaa"), 5}));
+	BOOST_TEST(isFitter(Individual(Chromosome("aaa"), 5), Individual(Chromosome("aaaaa"), 10)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("aaaaa"), 10), Individual(Chromosome("aaa"), 5)));
 
-	BOOST_TEST(isFitter(Individual{Chromosome("aaaaa"), 5}, Individual{Chromosome("aaa"), 10}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("aaa"), 10}, Individual{Chromosome("aaaaa"), 5}));
+	BOOST_TEST(isFitter(Individual(Chromosome("aaaaa"), 5), Individual(Chromosome("aaa"), 10)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("aaa"), 10), Individual(Chromosome("aaaaa"), 5)));
 }
 
 BOOST_AUTO_TEST_CASE(isFitter_should_use_alphabetical_order_when_fitness_is_the_same)
 {
-	BOOST_TEST(isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("c"), 3}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("c"), 3}, Individual{Chromosome("a"), 3}));
+	BOOST_TEST(isFitter(Individual(Chromosome("a"), 3), Individual(Chromosome("c"), 3)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("c"), 3), Individual(Chromosome("a"), 3)));
 
-	BOOST_TEST(isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("aa"), 3}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("aa"), 3}, Individual{Chromosome("a"), 3}));
+	BOOST_TEST(isFitter(Individual(Chromosome("a"), 3), Individual(Chromosome("aa"), 3)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("aa"), 3), Individual(Chromosome("a"), 3)));
 
-	BOOST_TEST(isFitter(Individual{Chromosome("T"), 3}, Individual{Chromosome("a"), 3}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("T"), 3}));
+	BOOST_TEST(isFitter(Individual(Chromosome("T"), 3), Individual(Chromosome("a"), 3)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("a"), 3), Individual(Chromosome("T"), 3)));
 }
 
 BOOST_AUTO_TEST_CASE(isFitter_should_return_false_for_identical_individuals)
 {
-	BOOST_TEST(!isFitter(Individual{Chromosome("a"), 3}, Individual{Chromosome("a"), 3}));
-	BOOST_TEST(!isFitter(Individual{Chromosome("acT"), 0}, Individual{Chromosome("acT"), 0}));
+	BOOST_TEST(!isFitter(Individual(Chromosome("a"), 3), Individual(Chromosome("a"), 3)));
+	BOOST_TEST(!isFitter(Individual(Chromosome("acT"), 0), Individual(Chromosome("acT"), 0)));
 }
 
 BOOST_FIXTURE_TEST_CASE(constructor_should_copy_chromosomes_compute_fitness_and_sort_chromosomes, PopulationFixture)

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -81,20 +81,24 @@ BOOST_AUTO_TEST_CASE(isFitter_should_return_false_for_identical_individuals)
 	BOOST_TEST(!isFitter(Individual{Chromosome("acT"), 0}, Individual{Chromosome("acT"), 0}));
 }
 
-BOOST_FIXTURE_TEST_CASE(constructor_should_copy_chromosomes_and_compute_fitness, PopulationFixture)
+BOOST_FIXTURE_TEST_CASE(constructor_should_copy_chromosomes_compute_fitness_and_sort_chromosomes, PopulationFixture)
 {
 	vector<Chromosome> chromosomes = {
 		Chromosome::makeRandom(5),
+		Chromosome::makeRandom(15),
 		Chromosome::makeRandom(10),
 	};
 	Population population(m_fitnessMetric, chromosomes);
 
-	BOOST_TEST(population.individuals().size() == 2);
-	BOOST_TEST(population.individuals()[0].chromosome == chromosomes[0]);
-	BOOST_TEST(population.individuals()[1].chromosome == chromosomes[1]);
+	vector<Individual> const& individuals = population.individuals();
 
-	BOOST_TEST(population.individuals()[0].fitness == m_fitnessMetric->evaluate(population.individuals()[0].chromosome));
-	BOOST_TEST(population.individuals()[1].fitness == m_fitnessMetric->evaluate(population.individuals()[1].chromosome));
+	BOOST_TEST(individuals.size() == 3);
+	BOOST_TEST(individuals[0].fitness == 5);
+	BOOST_TEST(individuals[1].fitness == 10);
+	BOOST_TEST(individuals[2].fitness == 15);
+	BOOST_TEST(individuals[0].chromosome == chromosomes[0]);
+	BOOST_TEST(individuals[1].chromosome == chromosomes[2]);
+	BOOST_TEST(individuals[2].chromosome == chromosomes[1]);
 }
 
 BOOST_FIXTURE_TEST_CASE(makeRandom_should_get_chromosome_lengths_from_specified_generator, PopulationFixture)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(yul-phaser
 	yulPhaser/main.cpp
 	yulPhaser/Population.h
 	yulPhaser/Population.cpp
+	yulPhaser/FitnessMetrics.h
+	yulPhaser/FitnessMetrics.cpp
 	yulPhaser/Chromosome.h
 	yulPhaser/Chromosome.cpp
 	yulPhaser/Program.h

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -16,3 +16,13 @@
 */
 
 #include <tools/yulPhaser/FitnessMetrics.h>
+
+using namespace std;
+using namespace solidity::phaser;
+
+size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
+{
+	Program programCopy = m_program;
+	programCopy.optimise(_chromosome.optimisationSteps());
+	return programCopy.codeSize();
+}

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -1,0 +1,18 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/FitnessMetrics.h>

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -23,6 +23,8 @@ using namespace solidity::phaser;
 size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
 {
 	Program programCopy = m_program;
-	programCopy.optimise(_chromosome.optimisationSteps());
+	for (size_t i = 0; i < m_repetitionCount; ++i)
+		programCopy.optimise(_chromosome.optimisationSteps());
+
 	return programCopy.codeSize();
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/Program.h>
 
 #include <cstddef>
 
@@ -43,6 +44,21 @@ public:
 	virtual ~FitnessMetric() = default;
 
 	virtual size_t evaluate(Chromosome const& _chromosome) const = 0;
+};
+
+/**
+ * Fitness metric based on the size of a specific program after applying the optimisations from the
+ * chromosome to it.
+ */
+class ProgramSize: public FitnessMetric
+{
+public:
+	ProgramSize(Program _program): m_program(std::move(_program)) {}
+
+	size_t evaluate(Chromosome const& _chromosome) const override;
+
+private:
+	Program m_program;
 };
 
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -53,12 +53,15 @@ public:
 class ProgramSize: public FitnessMetric
 {
 public:
-	ProgramSize(Program _program): m_program(std::move(_program)) {}
+	explicit ProgramSize(Program _program, size_t _repetitionCount = 1):
+		m_program(std::move(_program)),
+		m_repetitionCount(_repetitionCount) {}
 
 	size_t evaluate(Chromosome const& _chromosome) const override;
 
 private:
 	Program m_program;
+	size_t m_repetitionCount;
 };
 
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -1,0 +1,48 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Contains an abstract base class representing a fitness metric and its concrete implementations.
+ */
+
+#pragma once
+
+#include <tools/yulPhaser/Chromosome.h>
+
+#include <cstddef>
+
+namespace solidity::phaser
+{
+
+/**
+ * Abstract base class for fitness metrics.
+ *
+ * The main feature is the @a evaluate() method that can tell how good a given chromosome is.
+ * The lower the value, the better the fitness is. The result should be deterministic and depend
+ * only on the chromosome and metric's state (which is constant).
+ */
+class FitnessMetric
+{
+public:
+	FitnessMetric() = default;
+	FitnessMetric(FitnessMetric const&) = delete;
+	FitnessMetric& operator=(FitnessMetric const&) = delete;
+	virtual ~FitnessMetric() = default;
+
+	virtual size_t evaluate(Chromosome const& _chromosome) const = 0;
+};
+
+}

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -128,8 +128,8 @@ void Population::doMutation()
 
 void Population::doSelection()
 {
-	m_individuals = sortedIndividuals(move(m_individuals));
 	randomizeWorstChromosomes(*m_fitnessMetric, m_individuals, m_individuals.size() / 2);
+	m_individuals = sortedIndividuals(move(m_individuals));
 }
 
 void Population::randomizeWorstChromosomes(

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -148,9 +148,7 @@ void Population::doEvaluation()
 
 void Population::doSelection()
 {
-	assert(all_of(m_individuals.begin(), m_individuals.end(), [](auto& i){ return i.fitness.has_value(); }));
-
-	sort(m_individuals.begin(), m_individuals.end(), isFitter);
+	m_individuals = sortedIndividuals(move(m_individuals));
 	randomizeWorstChromosomes(m_individuals, m_individuals.size() / 2);
 }
 
@@ -178,4 +176,12 @@ vector<Individual> Population::chromosomesToIndividuals(
 		individuals.push_back({move(chromosome)});
 
 	return individuals;
+}
+
+vector<Individual> Population::sortedIndividuals(vector<Individual> _individuals)
+{
+	assert(all_of(_individuals.begin(), _individuals.end(), [](auto& i){ return i.fitness.has_value(); }));
+
+	sort(_individuals.begin(), _individuals.end(), isFitter);
+	return _individuals;
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -63,13 +63,6 @@ bool phaser::isFitter(Individual const& a, Individual const& b)
 	);
 }
 
-Population::Population(Program _program, vector<Chromosome> const& _chromosomes):
-	m_program{move(_program)}
-{
-	for (auto const& chromosome: _chromosomes)
-		m_individuals.push_back({chromosome});
-}
-
 Population Population::makeRandom(
 	Program _program,
 	size_t _size,
@@ -174,4 +167,15 @@ void Population::randomizeWorstChromosomes(
 	{
 		*individual = {Chromosome::makeRandom(binomialChromosomeLength(MaxChromosomeLength))};
 	}
+}
+
+vector<Individual> Population::chromosomesToIndividuals(
+	vector<Chromosome> _chromosomes
+)
+{
+	vector<Individual> individuals;
+	for (auto& chromosome: _chromosomes)
+		individuals.push_back({move(chromosome)});
+
+	return individuals;
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -157,10 +157,7 @@ vector<Individual> Population::chromosomesToIndividuals(
 {
 	vector<Individual> individuals;
 	for (auto& chromosome: _chromosomes)
-	{
-		size_t fitness = _fitnessMetric.evaluate(chromosome);
-		individuals.push_back({move(chromosome), fitness});
-	}
+		individuals.emplace_back(move(chromosome), _fitnessMetric);
 
 	return individuals;
 }

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -73,7 +73,11 @@ class Population
 public:
 	static constexpr size_t MaxChromosomeLength = 30;
 
-	explicit Population(Program _program, std::vector<Chromosome> const& _chromosomes = {});
+	explicit Population(Program _program, std::vector<Chromosome> _chromosomes = {}):
+		Population(
+			std::move(_program),
+			chromosomesToIndividuals(std::move(_chromosomes))
+		) {}
 
 	static Population makeRandom(
 		Program _program,
@@ -113,6 +117,9 @@ private:
 	static void randomizeWorstChromosomes(
 		std::vector<Individual>& _individuals,
 		size_t _count
+	);
+	static std::vector<Individual> chromosomesToIndividuals(
+		std::vector<Chromosome> _chromosomes
 	);
 
 	Program m_program;

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -46,7 +46,7 @@ namespace solidity::phaser
 struct Individual
 {
 	Chromosome chromosome;
-	std::optional<size_t> fitness = std::nullopt;
+	size_t fitness;
 
 	bool operator==(Individual const& _other) const { return fitness == _other.fitness && chromosome == _other.chromosome; }
 	bool operator!=(Individual const& _other) const { return !(*this == _other); }
@@ -67,6 +67,7 @@ bool isFitter(Individual const& a, Individual const& b);
  * An individual is a sequence of optimiser steps represented by a @a Chromosome instance.
  * Individuals are stored together with a fitness value that can be computed by the fitness metric
  * associated with the population.
+ * The fitness is computed using the metric as soon as an individual is inserted into the population.
  */
 class Population
 {
@@ -78,8 +79,8 @@ public:
 		std::vector<Chromosome> _chromosomes = {}
 	):
 		Population(
-			std::move(_fitnessMetric),
-			chromosomesToIndividuals(std::move(_chromosomes))
+			_fitnessMetric,
+			chromosomesToIndividuals(*_fitnessMetric, std::move(_chromosomes))
 		) {}
 
 	static Population makeRandom(
@@ -114,14 +115,15 @@ private:
 		m_individuals{std::move(_individuals)} {}
 
 	void doMutation();
-	void doEvaluation();
 	void doSelection();
 
 	static void randomizeWorstChromosomes(
+		FitnessMetric const& _fitnessMetric,
 		std::vector<Individual>& _individuals,
 		size_t _count
 	);
 	static std::vector<Individual> chromosomesToIndividuals(
+		FitnessMetric const& _fitnessMetric,
 		std::vector<Chromosome> _chromosomes
 	);
 	static std::vector<Individual> sortedIndividuals(std::vector<Individual> _individuals);

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -65,8 +65,7 @@ bool isFitter(Individual const& a, Individual const& b);
  * and selecting the best ones for the next round.
  *
  * An individual is a sequence of optimiser steps represented by a @a Chromosome instance.
- * Individuals are stored together with a fitness value that can be computed by the fitness metric
- * associated with the population.
+ * Individuals are always ordered by their fitness (based on @_fitnessMetric and @a isFitter()).
  * The fitness is computed using the metric as soon as an individual is inserted into the population.
  */
 class Population
@@ -112,7 +111,7 @@ public:
 private:
 	explicit Population(std::shared_ptr<FitnessMetric const> _fitnessMetric, std::vector<Individual> _individuals):
 		m_fitnessMetric(std::move(_fitnessMetric)),
-		m_individuals{std::move(_individuals)} {}
+		m_individuals{sortedIndividuals(std::move(_individuals))} {}
 
 	void doMutation();
 	void doSelection();

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -121,6 +121,7 @@ private:
 	static std::vector<Individual> chromosomesToIndividuals(
 		std::vector<Chromosome> _chromosomes
 	);
+	static std::vector<Individual> sortedIndividuals(std::vector<Individual> _individuals);
 
 	Program m_program;
 	std::vector<Individual> m_individuals;

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -48,6 +48,13 @@ struct Individual
 	Chromosome chromosome;
 	size_t fitness;
 
+	Individual(Chromosome _chromosome, size_t _fitness):
+		chromosome(std::move(_chromosome)),
+		fitness(_fitness) {}
+	Individual(Chromosome _chromosome, FitnessMetric const& _fitnessMetric):
+		chromosome(std::move(_chromosome)),
+		fitness(_fitnessMetric.evaluate(chromosome)) {}
+
 	bool operator==(Individual const& _other) const { return fitness == _other.fitness && chromosome == _other.chromosome; }
 	bool operator!=(Individual const& _other) const { return !(*this == _other); }
 

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Population.h>
+#include <tools/yulPhaser/FitnessMetrics.h>
 #include <tools/yulPhaser/Program.h>
 #include <tools/yulPhaser/SimulationRNG.h>
 
@@ -71,8 +72,9 @@ CharStream loadSource(string const& _sourcePath)
 void runAlgorithm(string const& _sourcePath)
 {
 	CharStream sourceCode = loadSource(_sourcePath);
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode));
 	auto population = Population::makeRandom(
-		Program::load(sourceCode),
+		fitnessMetric,
 		10,
 		bind(Population::binomialChromosomeLength, Population::MaxChromosomeLength)
 	);

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -72,7 +72,7 @@ CharStream loadSource(string const& _sourcePath)
 void runAlgorithm(string const& _sourcePath)
 {
 	CharStream sourceCode = loadSource(_sourcePath);
-	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode));
+	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ProgramSize>(Program::load(sourceCode), 5);
 	auto population = Population::makeRandom(
 		fitnessMetric,
 		10,


### PR DESCRIPTION
### Description
The fifth pull request implementing #7806. Originally a part of #8256 which is now closed. Depends on #8325.

This PR introduces the `FitnessMetric` class and makes `Population` independent of the `Program` (it can now work with any metric). A specific metric called `ProgramSize` now takes over the task of calculating the resulting program size.

`Population` now evaluates chromosomes as soon as they are added/produced and keeps them sorted at all times.

`ProgramSize` metric can apply the optimisations from a `Chromosome` multiple times. The application now applies them 5 times.

### Dependencies
This PR is based on #8325. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages