### PR TITLE
[yul-phaser] GEWEP algorithm

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,6 +145,7 @@ set(yul_phaser_sources
     yulPhaser/Chromosome.cpp
     yulPhaser/FitnessMetrics.cpp
     yulPhaser/GeneticAlgorithms.cpp
+    yulPhaser/Mutations.cpp
     yulPhaser/PairSelections.cpp
     yulPhaser/Population.cpp
     yulPhaser/Program.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,6 +145,7 @@ set(yul_phaser_sources
     yulPhaser/Chromosome.cpp
     yulPhaser/FitnessMetrics.cpp
     yulPhaser/GeneticAlgorithms.cpp
+    yulPhaser/PairSelections.cpp
     yulPhaser/Population.cpp
     yulPhaser/Program.cpp
     yulPhaser/Selections.cpp
@@ -156,6 +157,7 @@ set(yul_phaser_sources
     ../tools/yulPhaser/Chromosome.cpp
     ../tools/yulPhaser/FitnessMetrics.cpp
     ../tools/yulPhaser/GeneticAlgorithms.cpp
+    ../tools/yulPhaser/PairSelections.cpp
     ../tools/yulPhaser/Population.cpp
     ../tools/yulPhaser/Program.cpp
     ../tools/yulPhaser/Selections.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -158,6 +158,7 @@ set(yul_phaser_sources
     ../tools/yulPhaser/Chromosome.cpp
     ../tools/yulPhaser/FitnessMetrics.cpp
     ../tools/yulPhaser/GeneticAlgorithms.cpp
+    ../tools/yulPhaser/Mutations.cpp
     ../tools/yulPhaser/PairSelections.cpp
     ../tools/yulPhaser/Population.cpp
     ../tools/yulPhaser/Program.cpp

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -31,6 +31,18 @@ function<Mutation> phaser::test::wholeChromosomeReplacement(Chromosome _newChrom
 	return [_newChromosome = move(_newChromosome)](Chromosome const&) { return _newChromosome; };
 }
 
+function<Mutation> phaser::test::geneSubstitution(size_t _geneIndex, string _geneValue)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> newGenes = _chromosome.optimisationSteps();
+		assert(_geneIndex < newGenes.size());
+		newGenes[_geneIndex] = _geneValue;
+
+		return Chromosome(newGenes);
+	};
+}
+
 vector<size_t> phaser::test::chromosomeLengths(Population const& _population)
 {
 	vector<size_t> lengths;

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -24,6 +24,12 @@
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
+using namespace solidity::phaser;
+
+function<Mutation> phaser::test::wholeChromosomeReplacement(Chromosome _newChromosome)
+{
+	return [_newChromosome = move(_newChromosome)](Chromosome const&) { return _newChromosome; };
+}
 
 vector<size_t> phaser::test::chromosomeLengths(Population const& _population)
 {
@@ -42,6 +48,15 @@ map<string, size_t> phaser::test::enumerateOptmisationSteps()
 		stepIndices.insert({nameAndAbbreviation.first, i++});
 
 	return stepIndices;
+}
+
+size_t phaser::test::countDifferences(Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+{
+	size_t count = 0;
+	for (size_t i = 0; i < min(_chromosome1.length(), _chromosome2.length()); ++i)
+		count += static_cast<int>(_chromosome1.optimisationSteps()[i] != _chromosome2.optimisationSteps()[i]);
+
+	return count + abs(static_cast<int>(_chromosome1.length() - _chromosome2.length()));
 }
 
 string phaser::test::stripWhitespace(string const& input)

--- a/test/yulPhaser/Common.h
+++ b/test/yulPhaser/Common.h
@@ -30,9 +30,11 @@
 
 #include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/FitnessMetrics.h>
+#include <tools/yulPhaser/Mutations.h>
 #include <tools/yulPhaser/Population.h>
 
 #include <cassert>
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -52,10 +54,20 @@ public:
 	size_t evaluate(Chromosome const& _chromosome) const override { return _chromosome.length(); }
 };
 
+// MUTATIONS
+
+/// Mutation that always replaces the whole chromosome with the one specified in the parameter.
+std::function<Mutation> wholeChromosomeReplacement(Chromosome _newChromosome);
+
 // CHROMOSOME AND POPULATION HELPERS
 
 /// Returns a vector containing lengths of all chromosomes in the population (in the same order).
 std::vector<size_t> chromosomeLengths(Population const& _population);
+
+/// Returns the number of genes that differ between two chromosomes.
+/// If the chromnosomes have different lengths, the positions that are present in only one of them
+/// are counted as mismatches.
+size_t countDifferences(Chromosome const& _chromosome1, Chromosome const& _chromosome2);
 
 /// Assigns indices from 0 to N to all optimisation steps available in the OptimiserSuite.
 /// This is a convenience helper to make it easier to test their distribution with tools made for

--- a/test/yulPhaser/Common.h
+++ b/test/yulPhaser/Common.h
@@ -59,6 +59,11 @@ public:
 /// Mutation that always replaces the whole chromosome with the one specified in the parameter.
 std::function<Mutation> wholeChromosomeReplacement(Chromosome _newChromosome);
 
+/// Mutation that always replaces the optimisation step at position @a _geneIndex with @a _geneValue.
+///
+/// The chromosome must be long enough for this position to exist.
+std::function<Mutation> geneSubstitution(size_t _geneIndex, std::string _geneValue);
+
 // CHROMOSOME AND POPULATION HELPERS
 
 /// Returns a vector containing lengths of all chromosomes in the population (in the same order).

--- a/test/yulPhaser/CommonTest.cpp
+++ b/test/yulPhaser/CommonTest.cpp
@@ -40,6 +40,12 @@ BOOST_AUTO_TEST_CASE(ChromosomeLengthMetric_evaluate_should_return_chromosome_le
 	BOOST_TEST(ChromosomeLengthMetric{}.evaluate(Chromosome("aaaaa")) == 5);
 }
 
+BOOST_AUTO_TEST_CASE(wholeChromosomeReplacement_should_replace_whole_chromosome_with_another)
+{
+	function<Mutation> mutation = wholeChromosomeReplacement(Chromosome("aaa"));
+	BOOST_TEST(mutation(Chromosome("ccc")) == Chromosome("aaa"));
+}
+
 BOOST_AUTO_TEST_CASE(chromosomeLengths_should_return_lengths_of_all_chromosomes_in_a_population)
 {
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ChromosomeLengthMetric>();
@@ -49,6 +55,34 @@ BOOST_AUTO_TEST_CASE(chromosomeLengths_should_return_lengths_of_all_chromosomes_
 
 	Population population2(fitnessMetric);
 	BOOST_TEST((chromosomeLengths(population2) == vector<size_t>{}));
+}
+
+BOOST_AUTO_TEST_CASE(countDifferences_should_return_zero_for_identical_chromosomes)
+{
+	BOOST_TEST(countDifferences(Chromosome(), Chromosome()) == 0);
+	BOOST_TEST(countDifferences(Chromosome("a"), Chromosome("a")) == 0);
+	BOOST_TEST(countDifferences(Chromosome("afxT"), Chromosome("afxT")) == 0);
+}
+
+BOOST_AUTO_TEST_CASE(countDifferences_should_count_mismatched_positions_in_chromosomes_of_the_same_length)
+{
+	BOOST_TEST(countDifferences(Chromosome("a"), Chromosome("f")) == 1);
+	BOOST_TEST(countDifferences(Chromosome("aa"), Chromosome("ac")) == 1);
+	BOOST_TEST(countDifferences(Chromosome("ac"), Chromosome("cc")) == 1);
+	BOOST_TEST(countDifferences(Chromosome("aa"), Chromosome("cc")) == 2);
+	BOOST_TEST(countDifferences(Chromosome("afxT"), Chromosome("Txfa")) == 4);
+}
+
+BOOST_AUTO_TEST_CASE(countDifferences_should_count_missing_characters_as_differences)
+{
+	BOOST_TEST(countDifferences(Chromosome(""), Chromosome("a")) == 1);
+	BOOST_TEST(countDifferences(Chromosome("a"), Chromosome("")) == 1);
+	BOOST_TEST(countDifferences(Chromosome("aa"), Chromosome("")) == 2);
+	BOOST_TEST(countDifferences(Chromosome("aaa"), Chromosome("")) == 3);
+
+	BOOST_TEST(countDifferences(Chromosome("aa"), Chromosome("aaaa")) == 2);
+	BOOST_TEST(countDifferences(Chromosome("aa"), Chromosome("aacc")) == 2);
+	BOOST_TEST(countDifferences(Chromosome("aa"), Chromosome("cccc")) == 4);
 }
 
 BOOST_AUTO_TEST_CASE(enumerateOptimisationSteps_should_assing_indices_to_all_available_optimisation_steps)

--- a/test/yulPhaser/CommonTest.cpp
+++ b/test/yulPhaser/CommonTest.cpp
@@ -46,6 +46,17 @@ BOOST_AUTO_TEST_CASE(wholeChromosomeReplacement_should_replace_whole_chromosome_
 	BOOST_TEST(mutation(Chromosome("ccc")) == Chromosome("aaa"));
 }
 
+BOOST_AUTO_TEST_CASE(geneSubstitution_should_change_a_single_gene_at_a_given_index)
+{
+	Chromosome chromosome("aaccff");
+
+	function<Mutation> mutation1 = geneSubstitution(0, chromosome.optimisationSteps()[5]);
+	BOOST_TEST(mutation1(chromosome) == Chromosome("faccff"));
+
+	function<Mutation> mutation2 = geneSubstitution(5, chromosome.optimisationSteps()[0]);
+	BOOST_TEST(mutation2(chromosome) == Chromosome("aaccfa"));
+}
+
 BOOST_AUTO_TEST_CASE(chromosomeLengths_should_return_lengths_of_all_chromosomes_in_a_population)
 {
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<ChromosomeLengthMetric>();

--- a/test/yulPhaser/Mutations.cpp
+++ b/test/yulPhaser/Mutations.cpp
@@ -1,0 +1,219 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/yulPhaser/Common.h>
+
+#include <tools/yulPhaser/Mutations.h>
+
+#include <tools/yulPhaser/SimulationRNG.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <vector>
+
+using namespace std;
+
+namespace solidity::phaser::test
+{
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(MutationsTest)
+BOOST_AUTO_TEST_SUITE(GeneRandomisationTest)
+
+BOOST_AUTO_TEST_CASE(geneRandomisation_should_iterate_over_genes_and_replace_them_with_random_ones_with_given_probability)
+{
+	Chromosome chromosome("fcCUnDvejs");
+	function<Mutation> mutation01 = geneRandomisation(0.1);
+	function<Mutation> mutation05 = geneRandomisation(0.5);
+	function<Mutation> mutation10 = geneRandomisation(1.0);
+
+	SimulationRNG::reset(1);
+	BOOST_TEST(countDifferences(mutation01(chromosome), chromosome), 2);
+	BOOST_TEST(countDifferences(mutation05(chromosome), chromosome), 5);
+	BOOST_TEST(countDifferences(mutation10(chromosome), chromosome), 7);
+	SimulationRNG::reset(2);
+	BOOST_TEST(countDifferences(mutation01(chromosome), chromosome), 1);
+	BOOST_TEST(countDifferences(mutation05(chromosome), chromosome), 3);
+	BOOST_TEST(countDifferences(mutation10(chromosome), chromosome), 9);
+}
+
+BOOST_AUTO_TEST_CASE(geneRandomisation_should_return_identical_chromosome_if_probability_is_zero)
+{
+	Chromosome chromosome("fcCUnDvejsrmV");
+	function<Mutation> mutation = geneRandomisation(0.0);
+
+	BOOST_TEST(mutation(chromosome) == chromosome);
+}
+
+BOOST_AUTO_TEST_CASE(geneDeletion_should_iterate_over_genes_and_delete_them_with_given_probability)
+{
+	Chromosome chromosome("fcCUnDvejs");
+	function<Mutation> mutation01 = geneDeletion(0.1);
+	function<Mutation> mutation05 = geneDeletion(0.5);
+
+	SimulationRNG::reset(1);
+	//                                                               fcCUnDvejs
+	BOOST_TEST(mutation01(chromosome) == Chromosome(stripWhitespace("fcCU Dvejs")));
+	BOOST_TEST(mutation05(chromosome) == Chromosome(stripWhitespace("     D ejs")));
+	SimulationRNG::reset(2);
+	BOOST_TEST(mutation01(chromosome) == Chromosome(stripWhitespace("fcUnDvejs")));
+	BOOST_TEST(mutation05(chromosome) == Chromosome(stripWhitespace("  Un    s")));
+}
+
+BOOST_AUTO_TEST_CASE(geneDeletion_should_return_identical_chromosome_if_probability_is_zero)
+{
+	Chromosome chromosome("fcCUnDvejsrmV");
+	function<Mutation> mutation = geneDeletion(0.0);
+
+	BOOST_TEST(mutation(chromosome) == chromosome);
+}
+
+BOOST_AUTO_TEST_CASE(geneDeletion_should_delete_all_genes_if_probability_is_one)
+{
+	Chromosome chromosome("fcCUnDvejsrmV");
+	function<Mutation> mutation = geneDeletion(1.0);
+
+	BOOST_TEST(mutation(chromosome) == Chromosome(""));
+}
+
+BOOST_AUTO_TEST_CASE(geneAddition_should_iterate_over_gene_positions_and_insert_new_genes_with_given_probability)
+{
+	Chromosome chromosome("fcCUnDvejs");
+	function<Mutation> mutation01 = geneAddition(0.1);
+	function<Mutation> mutation05 = geneAddition(0.5);
+
+	SimulationRNG::reset(1);
+	//                                                                 f  c  C  U  n  D  v  e  j  s
+	BOOST_TEST(mutation01(chromosome) == Chromosome(stripWhitespace("  f  c  C  UC n  D  v  e  jx s")));  //  20% more
+	BOOST_TEST(mutation05(chromosome) == Chromosome(stripWhitespace("j f  cu C  U  ne D  v  eI j  sf"))); //  50% more
+	SimulationRNG::reset(2);
+	BOOST_TEST(mutation01(chromosome) == Chromosome(stripWhitespace("  f  cu C  U  n  D  v  e  j  s")));  //  10% more
+	BOOST_TEST(mutation05(chromosome) == Chromosome(stripWhitespace("L f  ce Cv U  n  D  v  e  jO s")));  //  40% more
+}
+
+BOOST_AUTO_TEST_CASE(geneAddition_should_be_able_to_insert_before_first_position)
+{
+	SimulationRNG::reset(7);
+	Chromosome chromosome("fcCUnDvejs");
+	function<Mutation> mutation = geneAddition(0.1);
+
+	Chromosome mutatedChromosome = mutation(chromosome);
+	BOOST_TEST(mutatedChromosome.length() > chromosome.length());
+
+	vector<string> suffix(
+		mutatedChromosome.optimisationSteps().end() - chromosome.length(),
+		mutatedChromosome.optimisationSteps().end()
+	);
+	BOOST_TEST(suffix == chromosome.optimisationSteps());
+}
+
+BOOST_AUTO_TEST_CASE(geneAddition_should_be_able_to_insert_after_last_position)
+{
+	SimulationRNG::reset(81);
+	Chromosome chromosome("fcCUnDvejs");
+	function<Mutation> mutation = geneAddition(0.1);
+
+	Chromosome mutatedChromosome = mutation(chromosome);
+	BOOST_TEST(mutatedChromosome.length() > chromosome.length());
+
+	vector<string> prefix(
+		mutatedChromosome.optimisationSteps().begin(),
+		mutatedChromosome.optimisationSteps().begin() + chromosome.length()
+	);
+	BOOST_TEST(prefix == chromosome.optimisationSteps());
+}
+
+BOOST_AUTO_TEST_CASE(geneAddition_should_return_identical_chromosome_if_probability_is_zero)
+{
+	Chromosome chromosome("fcCUnDvejsrmV");
+	function<Mutation> mutation = geneAddition(0.0);
+
+	BOOST_TEST(mutation(chromosome) == chromosome);
+}
+
+BOOST_AUTO_TEST_CASE(geneAddition_should_insert_genes_at_all_positions_if_probability_is_one)
+{
+	Chromosome chromosome("fcCUnDvejsrmV");
+	function<Mutation> mutation = geneAddition(1.0);
+
+	Chromosome mutatedChromosome = mutation(chromosome);
+	BOOST_TEST(mutatedChromosome.length() == chromosome.length() * 2 + 1);
+
+	vector<string> originalGenes;
+	for (size_t i = 0; i < mutatedChromosome.length() - 1; ++i)
+		if (i % 2 == 1)
+			originalGenes.push_back(mutatedChromosome.optimisationSteps()[i]);
+
+	BOOST_TEST(Chromosome(originalGenes) == chromosome);
+}
+
+BOOST_AUTO_TEST_CASE(alternativeMutations_should_choose_between_mutations_with_given_probability)
+{
+	SimulationRNG::reset(1);
+	Chromosome chromosome("a");
+	function<Mutation> mutation = alternativeMutations(
+		0.8,
+		wholeChromosomeReplacement(Chromosome("c")),
+		wholeChromosomeReplacement(Chromosome("f"))
+	);
+
+	size_t cCount = 0;
+	size_t fCount = 0;
+	for (size_t i = 0; i < 10; ++i)
+	{
+		Chromosome mutatedChromosome = mutation(chromosome);
+		cCount += static_cast<int>(mutatedChromosome == Chromosome("c"));
+		fCount += static_cast<int>(mutatedChromosome == Chromosome("f"));
+	}
+
+	// This particular seed results in 7 "c"s out of 10 which looks plausible given the 80% chance.
+	BOOST_TEST(cCount == 7);
+	BOOST_TEST(fCount == 3);
+}
+
+BOOST_AUTO_TEST_CASE(alternativeMutations_should_always_choose_first_mutation_if_probability_is_one)
+{
+	Chromosome chromosome("a");
+	function<Mutation> mutation = alternativeMutations(
+		1.0,
+		wholeChromosomeReplacement(Chromosome("c")),
+		wholeChromosomeReplacement(Chromosome("f"))
+	);
+
+	for (size_t i = 0; i < 10; ++i)
+		BOOST_TEST(mutation(chromosome) == Chromosome("c"));
+}
+
+BOOST_AUTO_TEST_CASE(alternativeMutations_should_always_choose_second_mutation_if_probability_is_zero)
+{
+	Chromosome chromosome("a");
+	function<Mutation> mutation = alternativeMutations(
+		0.0,
+		wholeChromosomeReplacement(Chromosome("c")),
+		wholeChromosomeReplacement(Chromosome("f"))
+	);
+
+	for (size_t i = 0; i < 10; ++i)
+		BOOST_TEST(mutation(chromosome) == Chromosome("f"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/Mutations.cpp
+++ b/test/yulPhaser/Mutations.cpp
@@ -214,11 +214,14 @@ BOOST_AUTO_TEST_CASE(alternativeMutations_should_always_choose_second_mutation_i
 
 BOOST_AUTO_TEST_CASE(randomPointCrossover_should_swap_chromosome_parts_at_random_point)
 {
-	SimulationRNG::reset(1);
 	function<Crossover> crossover = randomPointCrossover();
 
-	auto [result1, result2] = crossover(Chromosome("aaaaaaaaaa"), Chromosome("cccccc"));
+	SimulationRNG::reset(1);
+	Chromosome result1 = crossover(Chromosome("aaaaaaaaaa"), Chromosome("cccccc"));
 	BOOST_TEST(result1 == Chromosome("aaaccc"));
+
+	SimulationRNG::reset(1);
+	Chromosome result2 = crossover(Chromosome("cccccc"), Chromosome("aaaaaaaaaa"));
 	BOOST_TEST(result2 == Chromosome("cccaaaaaaa"));
 }
 
@@ -229,12 +232,19 @@ BOOST_AUTO_TEST_CASE(randomPointCrossover_should_only_consider_points_available_
 
 	for (size_t i = 0; i < 30; ++i)
 	{
-		auto [result1, result2] = crossover(Chromosome("aaa"), Chromosome("TTTTTTTTTTTTTTTTTTTT"));
+		Chromosome result1 = crossover(Chromosome("aaa"), Chromosome("TTTTTTTTTTTTTTTTTTTT"));
+		Chromosome result2 = crossover(Chromosome("TTTTTTTTTTTTTTTTTTTT"), Chromosome("aaa"));
 		BOOST_TEST((
-			(result1 == Chromosome("TTTTTTTTTTTTTTTTTTTT") && result2 == Chromosome("aaa")) ||
-			(result1 == Chromosome("aTTTTTTTTTTTTTTTTTTT") && result2 == Chromosome("Taa")) ||
-			(result1 == Chromosome("aaTTTTTTTTTTTTTTTTTT") && result2 == Chromosome("TTa")) ||
-			(result1 == Chromosome("aaaTTTTTTTTTTTTTTTTT") && result2 == Chromosome("TTT"))
+			result1 == Chromosome("TTTTTTTTTTTTTTTTTTTT") ||
+			result1 == Chromosome("aTTTTTTTTTTTTTTTTTTT") ||
+			result1 == Chromosome("aaTTTTTTTTTTTTTTTTTT") ||
+			result1 == Chromosome("aaaTTTTTTTTTTTTTTTTT")
+		));
+		BOOST_TEST((
+			result2 == Chromosome("aaa") ||
+			result2 == Chromosome("Taa") ||
+			result2 == Chromosome("TTa") ||
+			result2 == Chromosome("TTT")
 		));
 	}
 }
@@ -246,7 +256,8 @@ BOOST_AUTO_TEST_CASE(randomPointCrossover_should_never_split_at_position_zero_if
 
 	for (size_t i = 0; i < 30; ++i)
 	{
-		auto [result1, result2] = crossover(Chromosome("aa"), Chromosome("TTTTTTTTTTTTTTTTTTTT"));
+		Chromosome result1 = crossover(Chromosome("aa"), Chromosome("TTTTTTTTTTTTTTTTTTTT"));
+		Chromosome result2 = crossover(Chromosome("TTTTTTTTTTTTTTTTTTTT"), Chromosome("aa"));
 		BOOST_TEST(result1 != Chromosome("TTTTTTTTTTTTTTTTTTTT"));
 		BOOST_TEST(result2 != Chromosome("aa"));
 	}
@@ -259,7 +270,8 @@ BOOST_AUTO_TEST_CASE(randomPointCrossover_should_never_split_at_position_zero_if
 
 	for (size_t i = 0; i < 30; ++i)
 	{
-		auto [result1, result2] = crossover(Chromosome("a"), Chromosome("T"));
+		Chromosome result1 = crossover(Chromosome("a"), Chromosome("T"));
+		Chromosome result2 = crossover(Chromosome("T"), Chromosome("a"));
 		BOOST_TEST(result1 == Chromosome("a"));
 		BOOST_TEST(result2 == Chromosome("T"));
 	}
@@ -270,8 +282,8 @@ BOOST_AUTO_TEST_CASE(randomPointCrossover_should_work_even_if_one_chromosome_is_
 	function<Crossover> crossover = randomPointCrossover();
 
 	SimulationRNG::reset(1);
-	BOOST_CHECK(crossover(Chromosome("ff"), Chromosome("a")) == ChromosomePair(Chromosome("f"), Chromosome("af")));
-	BOOST_CHECK(crossover(Chromosome("a"), Chromosome("ff")) == ChromosomePair(Chromosome("af"), Chromosome("f")));
+	BOOST_CHECK(crossover(Chromosome("ff"), Chromosome("a")) == Chromosome("f"));
+	BOOST_CHECK(crossover(Chromosome("a"), Chromosome("ff")) == Chromosome("af"));
 }
 
 BOOST_AUTO_TEST_CASE(randomPointCrossover_should_split_at_position_zero_only_if_at_least_one_chromosome_is_empty)
@@ -282,52 +294,59 @@ BOOST_AUTO_TEST_CASE(randomPointCrossover_should_split_at_position_zero_only_if_
 	function<Crossover> crossover = randomPointCrossover();
 
 	SimulationRNG::reset(1);
-	BOOST_CHECK(crossover(empty, empty) == ChromosomePair(empty, empty));
-	BOOST_CHECK(crossover(unsplittable, empty) == ChromosomePair(empty, unsplittable));
-	BOOST_CHECK(crossover(empty, unsplittable) == ChromosomePair(unsplittable, empty));
-	BOOST_CHECK(crossover(splittable, empty) == ChromosomePair(empty, splittable));
-	BOOST_CHECK(crossover(empty, splittable) == ChromosomePair(splittable, empty));
+	BOOST_CHECK(crossover(empty, empty) == empty);
+	BOOST_CHECK(crossover(unsplittable, empty) == empty);
+	BOOST_CHECK(crossover(empty, unsplittable) == unsplittable);
+	BOOST_CHECK(crossover(splittable, empty) == empty);
+	BOOST_CHECK(crossover(empty, splittable) == splittable);
 }
 
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_swap_chromosome_parts_at_given_point)
 {
-	auto [result1, result2] = fixedPointCrossover(0.8)(Chromosome("aaaaaaaaaa"), Chromosome("cccccccccc"));
+	Chromosome result1 = fixedPointCrossover(0.8)(Chromosome("aaaaaaaaaa"), Chromosome("cccccccccc"));
+	Chromosome result2 = fixedPointCrossover(0.8)(Chromosome("cccccccccc"), Chromosome("aaaaaaaaaa"));
 	BOOST_TEST(result1 == Chromosome("aaaaaaaacc"));
 	BOOST_TEST(result2 == Chromosome("ccccccccaa"));
 }
 
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_determine_crossover_point_based_on_length_of_shorter_chromosome)
 {
-	auto [result1, result2] = fixedPointCrossover(0.4)(Chromosome("aaaaa"), Chromosome("cccccccccc"));
+	Chromosome result1 = fixedPointCrossover(0.4)(Chromosome("aaaaa"), Chromosome("cccccccccc"));
+	Chromosome result2 = fixedPointCrossover(0.4)(Chromosome("cccccccccc"), Chromosome("aaaaa"));
 	BOOST_TEST(result1 == Chromosome("aacccccccc"));
 	BOOST_TEST(result2 == Chromosome("ccaaa"));
 }
 
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_round_split_point)
 {
-	auto [result1, result2] = fixedPointCrossover(0.49)(Chromosome("aaaaa"), Chromosome("ccccc"));
+	Chromosome result1 = fixedPointCrossover(0.49)(Chromosome("aaaaa"), Chromosome("ccccc"));
+	Chromosome result2 = fixedPointCrossover(0.49)(Chromosome("ccccc"), Chromosome("aaaaa"));
 	BOOST_TEST(result1 == Chromosome("aaccc"));
 	BOOST_TEST(result2 == Chromosome("ccaaa"));
 
-	auto [result3, result4] = fixedPointCrossover(0.50)(Chromosome("aaaaa"), Chromosome("ccccc"));
+	Chromosome result3 = fixedPointCrossover(0.50)(Chromosome("aaaaa"), Chromosome("ccccc"));
+	Chromosome result4 = fixedPointCrossover(0.50)(Chromosome("ccccc"), Chromosome("aaaaa"));
 	BOOST_TEST(result3 == Chromosome("aaacc"));
 	BOOST_TEST(result4 == Chromosome("cccaa"));
 
-	auto [result5, result6] = fixedPointCrossover(0.51)(Chromosome("aaaaa"), Chromosome("ccccc"));
+	Chromosome result5 = fixedPointCrossover(0.51)(Chromosome("aaaaa"), Chromosome("ccccc"));
+	Chromosome result6 = fixedPointCrossover(0.51)(Chromosome("ccccc"), Chromosome("aaaaa"));
 	BOOST_TEST(result5 == Chromosome("aaacc"));
 	BOOST_TEST(result6 == Chromosome("cccaa"));
 }
 
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_split_at_position_zero_if_explicitly_requested)
 {
-	auto [result1, result2] = fixedPointCrossover(0.0)(Chromosome("aaaaa"), Chromosome("cccccccccc"));
+	Chromosome result1 = fixedPointCrossover(0.0)(Chromosome("aaaaa"), Chromosome("cccccccccc"));
+	Chromosome result2 = fixedPointCrossover(0.0)(Chromosome("cccccccccc"), Chromosome("aaaaa"));
 	BOOST_TEST(result1 == Chromosome("cccccccccc"));
 	BOOST_TEST(result2 == Chromosome("aaaaa"));
 }
 
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_split_at_end_of_shorter_chromosome_if_crossover_point_is_after_last_position)
 {
-	auto [result1, result2] = fixedPointCrossover(1.0)(Chromosome("aaaaa"), Chromosome("cccccccccc"));
+	Chromosome result1 = fixedPointCrossover(1.0)(Chromosome("aaaaa"), Chromosome("cccccccccc"));
+	Chromosome result2 = fixedPointCrossover(1.0)(Chromosome("cccccccccc"), Chromosome("aaaaa"));
 	BOOST_TEST(result1 == Chromosome("aaaaaccccc"));
 	BOOST_TEST(result2 == Chromosome("ccccc"));
 }
@@ -335,16 +354,16 @@ BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_split_at_end_of_shorter_chromoso
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_select_correct_split_point_for_unsplittable_chromosomes)
 {
 	function<Crossover> crossover00 = fixedPointCrossover(0.0);
-	BOOST_CHECK(crossover00(Chromosome("fff"), Chromosome("a")) == ChromosomePair(Chromosome("a"), Chromosome("fff")));
-	BOOST_CHECK(crossover00(Chromosome("a"), Chromosome("fff")) == ChromosomePair(Chromosome("fff"), Chromosome("a")));
+	BOOST_CHECK(crossover00(Chromosome("fff"), Chromosome("a")) == Chromosome("a"));
+	BOOST_CHECK(crossover00(Chromosome("a"), Chromosome("fff")) == Chromosome("fff"));
 
-	BOOST_CHECK(crossover00(Chromosome("f"), Chromosome("a")) == ChromosomePair(Chromosome("a"), Chromosome("f")));
+	BOOST_CHECK(crossover00(Chromosome("f"), Chromosome("a")) == Chromosome("a"));
 
 	function<Crossover> crossover10 = fixedPointCrossover(1.0);
-	BOOST_CHECK(crossover10(Chromosome("fff"), Chromosome("a")) == ChromosomePair(Chromosome("f"), Chromosome("aff")));
-	BOOST_CHECK(crossover10(Chromosome("a"), Chromosome("fff")) == ChromosomePair(Chromosome("aff"), Chromosome("f")));
+	BOOST_CHECK(crossover10(Chromosome("fff"), Chromosome("a")) == Chromosome("f"));
+	BOOST_CHECK(crossover10(Chromosome("a"), Chromosome("fff")) == Chromosome("aff"));
 
-	BOOST_CHECK(crossover10(Chromosome("f"), Chromosome("a")) == ChromosomePair(Chromosome("f"), Chromosome("a")));
+	BOOST_CHECK(crossover10(Chromosome("f"), Chromosome("a")) == Chromosome("f"));
 }
 
 BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_always_use_position_zero_as_split_point_when_chromosome_empty)
@@ -354,18 +373,18 @@ BOOST_AUTO_TEST_CASE(fixedPointCrossover_should_always_use_position_zero_as_spli
 	Chromosome splittable("aaaa");
 
 	function<Crossover> crossover00 = fixedPointCrossover(0.0);
-	BOOST_CHECK(crossover00(empty, empty) == ChromosomePair(empty, empty));
-	BOOST_CHECK(crossover00(unsplittable, empty) == ChromosomePair(empty, unsplittable));
-	BOOST_CHECK(crossover00(empty, unsplittable) == ChromosomePair(unsplittable, empty));
-	BOOST_CHECK(crossover00(splittable, empty) == ChromosomePair(empty, splittable));
-	BOOST_CHECK(crossover00(empty, splittable) == ChromosomePair(splittable, empty));
+	BOOST_CHECK(crossover00(empty, empty) == empty);
+	BOOST_CHECK(crossover00(unsplittable, empty) == empty);
+	BOOST_CHECK(crossover00(empty, unsplittable) == unsplittable);
+	BOOST_CHECK(crossover00(splittable, empty) == empty);
+	BOOST_CHECK(crossover00(empty, splittable) == splittable);
 
 	function<Crossover> crossover10 = fixedPointCrossover(1.0);
-	BOOST_CHECK(crossover10(empty, empty) == ChromosomePair(empty, empty));
-	BOOST_CHECK(crossover10(unsplittable, empty) == ChromosomePair(empty, unsplittable));
-	BOOST_CHECK(crossover10(empty, unsplittable) == ChromosomePair(unsplittable, empty));
-	BOOST_CHECK(crossover10(splittable, empty) == ChromosomePair(empty, splittable));
-	BOOST_CHECK(crossover10(empty, splittable) == ChromosomePair(splittable, empty));
+	BOOST_CHECK(crossover10(empty, empty) == empty);
+	BOOST_CHECK(crossover10(unsplittable, empty) == empty);
+	BOOST_CHECK(crossover10(empty, unsplittable) == unsplittable);
+	BOOST_CHECK(crossover10(splittable, empty) == empty);
+	BOOST_CHECK(crossover10(empty, splittable) == splittable);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/PairSelections.cpp
+++ b/test/yulPhaser/PairSelections.cpp
@@ -1,0 +1,185 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/yulPhaser/Common.h>
+
+#include <tools/yulPhaser/PairSelections.h>
+#include <tools/yulPhaser/SimulationRNG.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <tuple>
+#include <vector>
+
+using namespace std;
+
+namespace solidity::phaser::test
+{
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(PairSelectionsTest)
+BOOST_AUTO_TEST_SUITE(RandomPairSelectionTest)
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_random_values_with_equal_probabilities)
+{
+	constexpr int collectionSize = 10;
+	constexpr int selectionSize = 100;
+	constexpr double relativeTolerance = 0.1;
+	constexpr double expectedValue = (collectionSize - 1) / 2.0;
+	constexpr double variance = (collectionSize * collectionSize - 1) / 12.0;
+
+	SimulationRNG::reset(1);
+	vector<tuple<size_t, size_t>> pairs = RandomPairSelection(selectionSize).materialise(collectionSize);
+	vector<size_t> samples;
+	for (auto& [first, second]: pairs)
+	{
+		samples.push_back(first);
+		samples.push_back(second);
+	}
+
+	BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_only_values_that_can_be_used_as_collection_indices)
+{
+	const size_t collectionSize = 200;
+
+	vector<tuple<size_t, size_t>> pairs = RandomPairSelection(0.5).materialise(collectionSize);
+
+	BOOST_TEST(pairs.size() == 100);
+	BOOST_TEST(all_of(pairs.begin(), pairs.end(), [&](auto const& pair){ return get<0>(pair) <= collectionSize; }));
+	BOOST_TEST(all_of(pairs.begin(), pairs.end(), [&](auto const& pair){ return get<1>(pair) <= collectionSize; }));
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_never_return_a_pair_of_identical_indices)
+{
+	vector<tuple<size_t, size_t>> pairs = RandomPairSelection(0.5).materialise(100);
+
+	BOOST_TEST(pairs.size() == 50);
+	BOOST_TEST(all_of(pairs.begin(), pairs.end(), [](auto const& pair){ return get<0>(pair) != get<1>(pair); }));
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_number_of_pairs_thats_a_fraction_of_collection_size)
+{
+	BOOST_TEST(RandomPairSelection(0.0).materialise(10).size() == 0);
+	BOOST_TEST(RandomPairSelection(0.3).materialise(10).size() == 3);
+	BOOST_TEST(RandomPairSelection(0.5).materialise(10).size() == 5);
+	BOOST_TEST(RandomPairSelection(0.7).materialise(10).size() == 7);
+	BOOST_TEST(RandomPairSelection(1.0).materialise(10).size() == 10);
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_support_number_of_pairs_bigger_than_collection_size)
+{
+	BOOST_TEST(RandomPairSelection(2.0).materialise(5).size() == 10);
+	BOOST_TEST(RandomPairSelection(1.5).materialise(10).size() == 15);
+	BOOST_TEST(RandomPairSelection(10.0).materialise(10).size() == 100);
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_round_the_number_of_pairs_to_the_nearest_integer)
+{
+	BOOST_TEST(RandomPairSelection(0.49).materialise(3).size() == 1);
+	BOOST_TEST(RandomPairSelection(0.50).materialise(3).size() == 2);
+	BOOST_TEST(RandomPairSelection(0.51).materialise(3).size() == 2);
+
+	BOOST_TEST(RandomPairSelection(1.51).materialise(3).size() == 5);
+
+	BOOST_TEST(RandomPairSelection(0.01).materialise(2).size() == 0);
+	BOOST_TEST(RandomPairSelection(0.01).materialise(3).size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_no_pairs_if_collection_is_empty)
+{
+	BOOST_TEST(RandomPairSelection(0).materialise(0).empty());
+	BOOST_TEST(RandomPairSelection(0.5).materialise(0).empty());
+	BOOST_TEST(RandomPairSelection(1.0).materialise(0).empty());
+	BOOST_TEST(RandomPairSelection(2.0).materialise(0).empty());
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_no_pairs_if_collection_has_one_element)
+{
+	BOOST_TEST(RandomPairSelection(0).materialise(1).empty());
+	BOOST_TEST(RandomPairSelection(0.5).materialise(1).empty());
+	BOOST_TEST(RandomPairSelection(1.0).materialise(1).empty());
+	BOOST_TEST(RandomPairSelection(2.0).materialise(1).empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE(PairMosaicSelectionTest)
+
+using IndexPairs = vector<tuple<size_t, size_t>>;
+
+BOOST_AUTO_TEST_CASE(materialise)
+{
+	BOOST_TEST(PairMosaicSelection({{1, 1}}, 0.5).materialise(4) == IndexPairs({{1, 1}, {1, 1}}));
+	BOOST_TEST(PairMosaicSelection({{1, 1}}, 1.0).materialise(4) == IndexPairs({{1, 1}, {1, 1}, {1, 1}, {1, 1}}));
+	BOOST_TEST(PairMosaicSelection({{1, 1}}, 2.0).materialise(4) == IndexPairs({{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}));
+	BOOST_TEST(PairMosaicSelection({{1, 1}}, 1.0).materialise(2) == IndexPairs({{1, 1}, {1, 1}}));
+
+	IndexPairs pairs1{{0, 1}, {1, 0}};
+	BOOST_TEST(PairMosaicSelection(pairs1, 0.5).materialise(4) == IndexPairs({{0, 1}, {1, 0}}));
+	BOOST_TEST(PairMosaicSelection(pairs1, 1.0).materialise(4) == IndexPairs({{0, 1}, {1, 0}, {0, 1}, {1, 0}}));
+	BOOST_TEST(PairMosaicSelection(pairs1, 2.0).materialise(4) == IndexPairs({{0, 1}, {1, 0}, {0, 1}, {1, 0}, {0, 1}, {1, 0}, {0, 1}, {1, 0}}));
+	BOOST_TEST(PairMosaicSelection(pairs1, 1.0).materialise(2) == IndexPairs({{0, 1}, {1, 0}}));
+
+	IndexPairs pairs2{{3, 2}, {2, 3}, {1, 0}, {1, 1}};
+	BOOST_TEST(PairMosaicSelection(pairs2, 0.5).materialise(4) == IndexPairs({{3, 2}, {2, 3}}));
+	BOOST_TEST(PairMosaicSelection(pairs2, 1.0).materialise(4) == IndexPairs({{3, 2}, {2, 3}, {1, 0}, {1, 1}}));
+	BOOST_TEST(PairMosaicSelection(pairs2, 2.0).materialise(4) == IndexPairs({{3, 2}, {2, 3}, {1, 0}, {1, 1}, {3, 2}, {2, 3}, {1, 0}, {1, 1}}));
+
+	IndexPairs pairs3{{1, 0}, {1, 1}, {1, 0}, {1, 1}};
+	BOOST_TEST(PairMosaicSelection(pairs3, 1.0).materialise(2) == IndexPairs({{1, 0}, {1, 1}}));
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_round_indices)
+{
+	IndexPairs pairs{{4, 4}, {3, 3}, {2, 2}, {1, 1}, {0, 0}};
+	BOOST_TEST(PairMosaicSelection(pairs, 0.49).materialise(5) == IndexPairs({{4, 4}, {3, 3}}));
+	BOOST_TEST(PairMosaicSelection(pairs, 0.50).materialise(5) == IndexPairs({{4, 4}, {3, 3}, {2, 2}}));
+	BOOST_TEST(PairMosaicSelection(pairs, 0.51).materialise(5) == IndexPairs({{4, 4}, {3, 3}, {2, 2}}));
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_no_pairs_if_collection_is_empty)
+{
+	BOOST_TEST(PairMosaicSelection({{1, 1}}, 1.0).materialise(0).empty());
+	BOOST_TEST(PairMosaicSelection({{1, 1}, {3, 3}}, 2.0).materialise(0).empty());
+	BOOST_TEST(PairMosaicSelection({{5, 5}, {4, 4}, {3, 3}, {2, 2}}, 0.5).materialise(0).empty());
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_return_no_pairs_if_collection_has_one_element)
+{
+	IndexPairs pairs{{4, 4}, {3, 3}, {2, 2}, {1, 1}, {0, 0}};
+	BOOST_TEST(PairMosaicSelection(pairs, 0.0).materialise(1).empty());
+	BOOST_TEST(PairMosaicSelection(pairs, 0.5).materialise(1).empty());
+	BOOST_TEST(PairMosaicSelection(pairs, 1.0).materialise(1).empty());
+	BOOST_TEST(PairMosaicSelection(pairs, 7.0).materialise(1).empty());
+}
+
+BOOST_AUTO_TEST_CASE(materialise_should_clamp_indices_at_collection_size)
+{
+	IndexPairs pairs{{4, 4}, {3, 3}, {2, 2}, {1, 1}, {0, 0}};
+	BOOST_TEST(PairMosaicSelection(pairs, 1.0).materialise(4) == IndexPairs({{3, 3}, {3, 3}, {2, 2}, {1, 1}}));
+	BOOST_TEST(PairMosaicSelection(pairs, 2.0).materialise(3) == IndexPairs({{2, 2}, {2, 2}, {2, 2}, {1, 1}, {0, 0}, {2, 2}}));
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -18,6 +18,7 @@
 #include <test/yulPhaser/Common.h>
 
 #include <tools/yulPhaser/Chromosome.h>
+#include <tools/yulPhaser/PairSelections.h>
 #include <tools/yulPhaser/Population.h>
 #include <tools/yulPhaser/Program.h>
 #include <tools/yulPhaser/Selections.h>
@@ -31,6 +32,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <cmath>
 #include <optional>
 #include <string>
 #include <sstream>
@@ -224,6 +226,70 @@ BOOST_FIXTURE_TEST_CASE(select_should_return_empty_population_if_selection_is_em
 	assert(selection.materialise(population.individuals().size()).empty());
 
 	BOOST_TEST(population.select(selection).individuals().empty());
+}
+
+BOOST_FIXTURE_TEST_CASE(mutate_should_return_population_containing_individuals_indicated_by_selection_with_mutation_applied, PopulationFixture)
+{
+	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("cc"), Chromosome("gg"), Chromosome("hh")});
+	RangeSelection selection(0.25, 0.75);
+	assert(selection.materialise(population.individuals().size()) == (vector<size_t>{1, 2}));
+
+	Population expectedPopulation(m_fitnessMetric, {Chromosome("fc"), Chromosome("fg")});
+
+	BOOST_TEST(population.mutate(selection, geneSubstitution(0, BlockFlattener::name)) == expectedPopulation);
+}
+
+BOOST_FIXTURE_TEST_CASE(mutate_should_include_duplicates_if_selection_contains_duplicates, PopulationFixture)
+{
+	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("aa")});
+	RangeSelection selection(0.0, 1.0);
+	assert(selection.materialise(population.individuals().size()) == (vector<size_t>{0, 1}));
+
+	BOOST_TEST(
+		population.mutate(selection, geneSubstitution(0, BlockFlattener::name)) ==
+		Population(m_fitnessMetric, {Chromosome("fa"), Chromosome("fa")})
+	);
+}
+
+BOOST_FIXTURE_TEST_CASE(mutate_should_return_empty_population_if_selection_is_empty, PopulationFixture)
+{
+	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("cc")});
+	RangeSelection selection(0.0, 0.0);
+	assert(selection.materialise(population.individuals().size()).empty());
+
+	BOOST_TEST(population.mutate(selection, geneSubstitution(0, BlockFlattener::name)).individuals().empty());
+}
+
+BOOST_FIXTURE_TEST_CASE(crossover_should_return_population_containing_individuals_indicated_by_selection_with_crossover_applied, PopulationFixture)
+{
+	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("cc"), Chromosome("gg"), Chromosome("hh")});
+	PairMosaicSelection selection({{0, 1}, {2, 1}}, 0.5);
+	assert(selection.materialise(population.individuals().size()) == (vector<tuple<size_t, size_t>>{{0, 1}, {2, 1}}));
+
+	Population expectedPopulation(m_fitnessMetric, {Chromosome("ac"), Chromosome("ca"), Chromosome("cg"), Chromosome("gc")});
+
+	BOOST_TEST(population.crossover(selection, fixedPointCrossover(0.5)) == expectedPopulation);
+}
+
+BOOST_FIXTURE_TEST_CASE(crossover_should_include_duplicates_if_selection_contains_duplicates, PopulationFixture)
+{
+	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("aa")});
+	PairMosaicSelection selection({{0, 0}, {1, 1}}, 1.0);
+	assert(selection.materialise(population.individuals().size()) == (vector<tuple<size_t, size_t>>{{0, 0}, {1, 1}}));
+
+	BOOST_TEST(
+		population.crossover(selection, fixedPointCrossover(0.5)) ==
+		Population(m_fitnessMetric, {Chromosome("aa"), Chromosome("aa"), Chromosome("aa"), Chromosome("aa")})
+	);
+}
+
+BOOST_FIXTURE_TEST_CASE(crossover_should_return_empty_population_if_selection_is_empty, PopulationFixture)
+{
+	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("cc")});
+	PairMosaicSelection selection({}, 0.0);
+	assert(selection.materialise(population.individuals().size()).empty());
+
+	BOOST_TEST(population.crossover(selection, fixedPointCrossover(0.5)).individuals().empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -263,10 +263,10 @@ BOOST_FIXTURE_TEST_CASE(mutate_should_return_empty_population_if_selection_is_em
 BOOST_FIXTURE_TEST_CASE(crossover_should_return_population_containing_individuals_indicated_by_selection_with_crossover_applied, PopulationFixture)
 {
 	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("cc"), Chromosome("gg"), Chromosome("hh")});
-	PairMosaicSelection selection({{0, 1}, {2, 1}}, 0.5);
-	assert(selection.materialise(population.individuals().size()) == (vector<tuple<size_t, size_t>>{{0, 1}, {2, 1}}));
+	PairMosaicSelection selection({{0, 1}, {2, 1}}, 1.0);
+	assert(selection.materialise(population.individuals().size()) == (vector<tuple<size_t, size_t>>{{0, 1}, {2, 1}, {0, 1}, {2, 1}}));
 
-	Population expectedPopulation(m_fitnessMetric, {Chromosome("ac"), Chromosome("ca"), Chromosome("cg"), Chromosome("gc")});
+	Population expectedPopulation(m_fitnessMetric, {Chromosome("ac"), Chromosome("ac"), Chromosome("gc"), Chromosome("gc")});
 
 	BOOST_TEST(population.crossover(selection, fixedPointCrossover(0.5)) == expectedPopulation);
 }
@@ -274,8 +274,8 @@ BOOST_FIXTURE_TEST_CASE(crossover_should_return_population_containing_individual
 BOOST_FIXTURE_TEST_CASE(crossover_should_include_duplicates_if_selection_contains_duplicates, PopulationFixture)
 {
 	Population population(m_fitnessMetric, {Chromosome("aa"), Chromosome("aa")});
-	PairMosaicSelection selection({{0, 0}, {1, 1}}, 1.0);
-	assert(selection.materialise(population.individuals().size()) == (vector<tuple<size_t, size_t>>{{0, 0}, {1, 1}}));
+	PairMosaicSelection selection({{0, 0}, {1, 1}}, 2.0);
+	assert(selection.materialise(population.individuals().size()) == (vector<tuple<size_t, size_t>>{{0, 0}, {1, 1}, {0, 0}, {1, 1}}));
 
 	BOOST_TEST(
 		population.crossover(selection, fixedPointCrossover(0.5)) ==

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(yul-phaser
 	yulPhaser/FitnessMetrics.cpp
 	yulPhaser/Chromosome.h
 	yulPhaser/Chromosome.cpp
+	yulPhaser/PairSelections.h
+	yulPhaser/PairSelections.cpp
 	yulPhaser/Selections.h
 	yulPhaser/Selections.cpp
 	yulPhaser/Program.h

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -23,6 +23,8 @@ add_executable(yul-phaser
 	yulPhaser/FitnessMetrics.cpp
 	yulPhaser/Chromosome.h
 	yulPhaser/Chromosome.cpp
+	yulPhaser/Mutations.h
+	yulPhaser/Mutations.cpp
 	yulPhaser/PairSelections.h
 	yulPhaser/PairSelections.cpp
 	yulPhaser/Selections.h

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -71,7 +71,7 @@ void GenerationalElitistWithExclusivePools::runNextRound()
 			)
 		) +
 		m_population.select(elite).crossover(
-			RandomPairSelection(m_options.crossoverPoolSize / elitePoolSize / 2),
+			RandomPairSelection(m_options.crossoverPoolSize / elitePoolSize),
 			randomPointCrossover()
 		);
 }

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -16,7 +16,9 @@
 */
 
 #include <tools/yulPhaser/GeneticAlgorithms.h>
+#include <tools/yulPhaser/Mutations.h>
 #include <tools/yulPhaser/Selections.h>
+#include <tools/yulPhaser/PairSelections.h>
 
 using namespace std;
 using namespace solidity::phaser;
@@ -46,5 +48,30 @@ void RandomAlgorithm::runNextRound()
 			replacementCount,
 			m_options.minChromosomeLength,
 			m_options.maxChromosomeLength
+		);
+}
+
+void GenerationalElitistWithExclusivePools::runNextRound()
+{
+	double elitePoolSize = 1.0 - (m_options.mutationPoolSize + m_options.crossoverPoolSize);
+	RangeSelection elite(0.0, elitePoolSize);
+
+	m_population =
+		m_population.select(elite) +
+		m_population.select(elite).mutate(
+			RandomSelection(m_options.mutationPoolSize / elitePoolSize),
+			alternativeMutations(
+				m_options.randomisationChance,
+				geneRandomisation(m_options.percentGenesToRandomise),
+				alternativeMutations(
+					m_options.deletionVsAdditionChance,
+					geneDeletion(m_options.percentGenesToAddOrDelete),
+					geneAddition(m_options.percentGenesToAddOrDelete)
+				)
+			)
+		) +
+		m_population.select(elite).crossover(
+			RandomPairSelection(m_options.crossoverPoolSize / elitePoolSize / 2),
+			randomPointCrossover()
 		);
 }

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -112,4 +112,57 @@ private:
 	Options m_options;
 };
 
+/**
+ * A generational, elitist genetic algorithm that replaces the population by mutating and crossing
+ * over chromosomes from the elite.
+ *
+ * The elite consists of individuals not included in the crossover and mutation pools.
+ * The crossover operator used is @a randomPointCrossover. The mutation operator is randomly chosen
+ * from three possibilities: @a geneRandomisation, @a geneDeletion or @a geneAddition (with
+ * configurable probabilities). Each mutation also has a parameter determining the chance of a gene
+ * being affected by it.
+ */
+class GenerationalElitistWithExclusivePools: public GeneticAlgorithm
+{
+public:
+	struct Options
+	{
+		double mutationPoolSize;          ///< Percentage of population to regenerate using mutations in each round.
+		double crossoverPoolSize;         ///< Percentage of population to regenerate using crossover in each round.
+		double randomisationChance;       ///< The chance of choosing @a geneRandomisation as the mutation to perform
+		double deletionVsAdditionChance;  ///< The chance of choosing @a geneDeletion as the mutation if randomisation was not chosen.
+		double percentGenesToRandomise;   ///< The chance of any given gene being mutated in gene randomisation.
+		double percentGenesToAddOrDelete; ///< The chance of a gene being added (or deleted) in gene addition (or deletion).
+
+		bool isValid() const
+		{
+			return (
+				0 <= mutationPoolSize && mutationPoolSize <= 1.0 &&
+				0 <= crossoverPoolSize && crossoverPoolSize <= 1.0 &&
+				0 <= randomisationChance && randomisationChance <= 1.0 &&
+				0 <= deletionVsAdditionChance && deletionVsAdditionChance <= 1.0 &&
+				0 <= percentGenesToRandomise && percentGenesToRandomise <= 1.0 &&
+				0 <= percentGenesToAddOrDelete && percentGenesToAddOrDelete <= 1.0 &&
+				mutationPoolSize + crossoverPoolSize <= 1.0
+			);
+		}
+	};
+
+	GenerationalElitistWithExclusivePools(
+		Population _initialPopulation,
+		std::ostream& _outputStream,
+		Options const& _options
+	):
+		GeneticAlgorithm(_initialPopulation, _outputStream),
+		m_options(_options)
+	{
+		assert(_options.isValid());
+	}
+
+	void runNextRound() override;
+
+private:
+	Options m_options;
+};
+
 }

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -1,0 +1,91 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Mutations.h>
+
+#include <tools/yulPhaser/SimulationRNG.h>
+
+#include <string>
+#include <vector>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::phaser;
+
+function<Mutation> phaser::geneRandomisation(double _chance)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> optimisationSteps;
+		for (auto const& step: _chromosome.optimisationSteps())
+			optimisationSteps.push_back(
+				SimulationRNG::bernoulliTrial(_chance) ?
+				Chromosome::randomOptimisationStep() :
+				step
+			);
+
+		return Chromosome(move(optimisationSteps));
+	};
+}
+
+function<Mutation> phaser::geneDeletion(double _chance)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> optimisationSteps;
+		for (auto const& step: _chromosome.optimisationSteps())
+			if (!SimulationRNG::bernoulliTrial(_chance))
+				optimisationSteps.push_back(step);
+
+		return Chromosome(move(optimisationSteps));
+	};
+}
+
+function<Mutation> phaser::geneAddition(double _chance)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		vector<string> optimisationSteps;
+
+		if (SimulationRNG::bernoulliTrial(_chance))
+			optimisationSteps.push_back(Chromosome::randomOptimisationStep());
+
+		for (auto const& step: _chromosome.optimisationSteps())
+		{
+			optimisationSteps.push_back(step);
+			if (SimulationRNG::bernoulliTrial(_chance))
+				optimisationSteps.push_back(Chromosome::randomOptimisationStep());
+		}
+
+		return Chromosome(move(optimisationSteps));
+	};
+}
+
+function<Mutation> phaser::alternativeMutations(
+	double _firstMutationChance,
+	function<Mutation> _mutation1,
+	function<Mutation> _mutation2
+)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		if (SimulationRNG::bernoulliTrial(_firstMutationChance))
+			return _mutation1(_chromosome);
+		else
+			return _mutation2(_chromosome);
+	};
+}

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -98,7 +98,7 @@ function<Mutation> phaser::alternativeMutations(
 namespace
 {
 
-ChromosomePair buildChromosomesBySwappingParts(
+Chromosome buildChromosomesBySwappingParts(
 	Chromosome const& _chromosome1,
 	Chromosome const& _chromosome2,
 	size_t _crossoverPoint
@@ -110,15 +110,9 @@ ChromosomePair buildChromosomesBySwappingParts(
 	auto begin1 = _chromosome1.optimisationSteps().begin();
 	auto begin2 = _chromosome2.optimisationSteps().begin();
 
-	return ChromosomePair(
-		Chromosome(
-			vector<string>(begin1, begin1 + _crossoverPoint) +
-			vector<string>(begin2 + _crossoverPoint, _chromosome2.optimisationSteps().end())
-		),
-		Chromosome(
-			vector<string>(begin2, begin2 + _crossoverPoint) +
-			vector<string>(begin1 + _crossoverPoint, _chromosome1.optimisationSteps().end())
-		)
+	return Chromosome(
+		vector<string>(begin1, begin1 + _crossoverPoint) +
+		vector<string>(begin2 + _crossoverPoint, _chromosome2.optimisationSteps().end())
 	);
 }
 

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -28,10 +28,8 @@
 namespace solidity::phaser
 {
 
-using ChromosomePair = std::tuple<Chromosome, Chromosome>;
-
 using Mutation = Chromosome(Chromosome const&);
-using Crossover = ChromosomePair(Chromosome const&, Chromosome const&);
+using Crossover = Chromosome(Chromosome const&, Chromosome const&);
 
 // MUTATIONS
 
@@ -64,10 +62,9 @@ std::function<Mutation> alternativeMutations(
 std::function<Crossover> randomPointCrossover();
 
 /// Creates a crossover operator that always chooses a point that lies at @a _crossoverPoint
-/// percent of the length of the shorter chromosome. Then creates a pair of chromosomes by
-/// splitting both inputs at the crossover point and stitching the resulting parts. The first
-/// output is created from the first half or first input and the second half of the second input
-/// The second output from the remaining two halves.
+/// percent of the length of the shorter chromosome. Then creates a new chromosome by
+/// splitting both inputs at the crossover point and stitching output from the first half or first
+/// input and the second half of the second input.
 ///
 /// Avoids selecting position 0 (since this just produces a chromosome identical to the second one)
 /// unless there is no other choice (i.e. one of the chromosomes is empty).

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -23,11 +23,15 @@
 #include <tools/yulPhaser/Chromosome.h>
 
 #include <functional>
+#include <tuple>
 
 namespace solidity::phaser
 {
 
+using ChromosomePair = std::tuple<Chromosome, Chromosome>;
+
 using Mutation = Chromosome(Chromosome const&);
+using Crossover = ChromosomePair(Chromosome const&, Chromosome const&);
 
 // MUTATIONS
 
@@ -52,5 +56,21 @@ std::function<Mutation> alternativeMutations(
 	std::function<Mutation> _mutation1,
 	std::function<Mutation> _mutation2
 );
+
+// CROSSOVER
+
+/// Creates a crossover operator that randomly selects a number between 0 and 1 and uses it as the
+/// position at which to perform perform @a fixedPointCrossover.
+std::function<Crossover> randomPointCrossover();
+
+/// Creates a crossover operator that always chooses a point that lies at @a _crossoverPoint
+/// percent of the length of the shorter chromosome. Then creates a pair of chromosomes by
+/// splitting both inputs at the crossover point and stitching the resulting parts. The first
+/// output is created from the first half or first input and the second half of the second input
+/// The second output from the remaining two halves.
+///
+/// Avoids selecting position 0 (since this just produces a chromosome identical to the second one)
+/// unless there is no other choice (i.e. one of the chromosomes is empty).
+std::function<Crossover> fixedPointCrossover(double _crossoverPoint);
 
 }

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -1,0 +1,56 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Mutation and crossover operators for use in genetic algorithms.
+ */
+
+#pragma once
+
+#include <tools/yulPhaser/Chromosome.h>
+
+#include <functional>
+
+namespace solidity::phaser
+{
+
+using Mutation = Chromosome(Chromosome const&);
+
+// MUTATIONS
+
+/// Creates a mutation operator that iterates over all genes in a chromosome and with probability
+/// @a _chance replaces a gene with a random one (which could also be the same as the original).
+std::function<Mutation> geneRandomisation(double _chance);
+
+/// Creates a mutation operator that iterates over all genes in a chromosome and with probability
+/// @a _chance deletes it.
+std::function<Mutation> geneDeletion(double _chance);
+
+/// Creates a mutation operator that iterates over all positions in a chromosome (including spots
+/// at the beginning and at the end of the sequence) and with probability @a _chance insert a new,
+/// randomly chosen gene.
+std::function<Mutation> geneAddition(double _chance);
+
+/// Creates a mutation operator that always applies one of the mutations passed to it.
+/// The probability that the chosen mutation is the first one is @a _firstMutationChance.
+/// randomly chosen gene.
+std::function<Mutation> alternativeMutations(
+	double _firstMutationChance,
+	std::function<Mutation> _mutation1,
+	std::function<Mutation> _mutation2
+);
+
+}

--- a/tools/yulPhaser/PairSelections.cpp
+++ b/tools/yulPhaser/PairSelections.cpp
@@ -1,0 +1,18 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/PairSelections.h>

--- a/tools/yulPhaser/PairSelections.cpp
+++ b/tools/yulPhaser/PairSelections.cpp
@@ -16,3 +16,50 @@
 */
 
 #include <tools/yulPhaser/PairSelections.h>
+
+#include <tools/yulPhaser/SimulationRNG.h>
+
+#include <cmath>
+
+using namespace std;
+using namespace solidity::phaser;
+
+vector<tuple<size_t, size_t>> RandomPairSelection::materialise(size_t _poolSize) const
+{
+	if (_poolSize < 2)
+		return {};
+
+	size_t count = static_cast<size_t>(round(_poolSize * m_selectionSize));
+
+	vector<tuple<size_t, size_t>> selection;
+	for (size_t i = 0; i < count; ++i)
+	{
+		size_t index1 = SimulationRNG::uniformInt(0, _poolSize - 1);
+		size_t index2;
+		do
+		{
+			index2 = SimulationRNG::uniformInt(0, _poolSize - 1);
+		} while (index1 == index2);
+
+		selection.push_back({index1, index2});
+	}
+
+	return selection;
+}
+
+vector<tuple<size_t, size_t>> PairMosaicSelection::materialise(size_t _poolSize) const
+{
+	if (_poolSize < 2)
+		return {};
+
+	size_t count = static_cast<size_t>(round(_poolSize * m_selectionSize));
+
+	vector<tuple<size_t, size_t>> selection;
+	for (size_t i = 0; i < count; ++i)
+	{
+		tuple<size_t, size_t> pair = m_pattern[i % m_pattern.size()];
+		selection.push_back({min(get<0>(pair), _poolSize - 1), min(get<1>(pair), _poolSize - 1)});
+	}
+
+	return selection;
+}

--- a/tools/yulPhaser/PairSelections.h
+++ b/tools/yulPhaser/PairSelections.h
@@ -1,0 +1,53 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Contains an abstract base class representing a selection of pairs of elements from a collection
+ * and its concrete implementations.
+ */
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+
+namespace solidity::phaser
+{
+
+/**
+ * Abstract base class for selections of pairs elements from a collection.
+ *
+ * An instance of this class represents a specific method of selecting a set of pairs of elements
+ * from containers of arbitrary sizes. The selected pairs always point at a subset of the elements
+ * from the container but may indicate the same element more than once. The pairs themselves can
+ * repeat too. The selection may or may not be fixed - it's up to a specific implementation whether
+ * subsequent calls for the same container produce the same indices or not.
+ *
+ * Derived classes are meant to override the @a materialise() method.
+ * This method is expected to produce pairs of selected elements given the size of the collection.
+ */
+class PairSelection
+{
+public:
+	PairSelection() = default;
+	PairSelection(PairSelection const&) = delete;
+	PairSelection& operator=(PairSelection const&) = delete;
+	virtual ~PairSelection() = default;
+
+	virtual std::vector<std::tuple<size_t, size_t>> materialise(size_t _poolSize) const = 0;
+};
+
+}

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/Population.h>
 
+#include <tools/yulPhaser/PairSelections.h>
 #include <tools/yulPhaser/Selections.h>
 
 #include <libsolutil/CommonData.h>
@@ -91,6 +92,31 @@ Population Population::select(Selection const& _selection) const
 		selectedIndividuals.emplace_back(m_individuals[i]);
 
 	return Population(m_fitnessMetric, selectedIndividuals);
+}
+
+Population Population::mutate(Selection const& _selection, function<Mutation> _mutation) const
+{
+	vector<Individual> mutatedIndividuals;
+	for (size_t i: _selection.materialise(m_individuals.size()))
+		mutatedIndividuals.emplace_back(_mutation(m_individuals[i].chromosome), *m_fitnessMetric);
+
+	return Population(m_fitnessMetric, mutatedIndividuals);
+}
+
+Population Population::crossover(PairSelection const& _selection, function<Crossover> _crossover) const
+{
+	vector<Individual> crossedIndividuals;
+	for (auto const& [i, j]: _selection.materialise(m_individuals.size()))
+	{
+		auto [childChromosome1, childChromosome2] = _crossover(
+			m_individuals[i].chromosome,
+			m_individuals[j].chromosome
+		);
+		crossedIndividuals.emplace_back(move(childChromosome1), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(move(childChromosome2), *m_fitnessMetric);
+	}
+
+	return Population(m_fitnessMetric, crossedIndividuals);
 }
 
 Population operator+(Population _a, Population _b)

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -108,12 +108,11 @@ Population Population::crossover(PairSelection const& _selection, function<Cross
 	vector<Individual> crossedIndividuals;
 	for (auto const& [i, j]: _selection.materialise(m_individuals.size()))
 	{
-		auto [childChromosome1, childChromosome2] = _crossover(
+		auto childChromosome = _crossover(
 			m_individuals[i].chromosome,
 			m_individuals[j].chromosome
 		);
-		crossedIndividuals.emplace_back(move(childChromosome1), *m_fitnessMetric);
-		crossedIndividuals.emplace_back(move(childChromosome2), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(move(childChromosome), *m_fitnessMetric);
 	}
 
 	return Population(m_fitnessMetric, crossedIndividuals);

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -19,6 +19,7 @@
 
 #include <tools/yulPhaser/Chromosome.h>
 #include <tools/yulPhaser/FitnessMetrics.h>
+#include <tools/yulPhaser/Mutations.h>
 #include <tools/yulPhaser/SimulationRNG.h>
 
 #include <optional>
@@ -39,6 +40,7 @@ solidity::phaser::Population operator+(solidity::phaser::Population _a, solidity
 namespace solidity::phaser
 {
 
+class PairSelection;
 class Selection;
 
 /**
@@ -104,6 +106,8 @@ public:
 	);
 
 	Population select(Selection const& _selection) const;
+	Population mutate(Selection const& _selection, std::function<Mutation> _mutation) const;
+	Population crossover(PairSelection const& _selection, std::function<Crossover> _crossover) const;
 	friend Population (::operator+)(Population _a, Population _b);
 
 	std::shared_ptr<FitnessMetric const> fitnessMetric() const { return m_fitnessMetric; }

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -143,8 +143,8 @@ void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 					/* crossoverPoolSize = */ 0.25,
 					/* randomisationChance = */ 0.9,
 					/* deletionVsAdditionChance = */ 0.5,
-					/* percentGenesToRandomise = */ 0.1,
-					/* percentGenesToAddOrDelete = */ 0.1,
+					/* percentGenesToRandomise = */ 1.0 / maxChromosomeLength,
+					/* percentGenesToAddOrDelete = */ 1.0 / maxChromosomeLength,
 				}
 			).run();
 

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -49,7 +49,7 @@ struct CommandLineParsingResult
 };
 
 
-void initializeRNG(po::variables_map const& arguments)
+void initialiseRNG(po::variables_map const& arguments)
 {
 	uint32_t seed;
 	if (arguments.count("seed") > 0)
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
 	if (parsingResult.exitCode != 0)
 		return parsingResult.exitCode;
 
-	initializeRNG(parsingResult.arguments);
+	initialiseRNG(parsingResult.arguments);
 
 	try
 	{

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -41,7 +41,8 @@ namespace po = boost::program_options;
 
 enum class Algorithm
 {
-	Random
+	Random,
+	GEWEP
 };
 
 istream& operator>>(istream& inputStream, Algorithm& algorithm)
@@ -51,6 +52,8 @@ istream& operator>>(istream& inputStream, Algorithm& algorithm)
 
 	if (value == "random")
 		algorithm = Algorithm::Random;
+	else if (value == "GEWEP")
+		algorithm = Algorithm::GEWEP;
 	else
 		inputStream.setstate(ios_base::failbit);
 
@@ -61,6 +64,8 @@ ostream& operator<<(ostream& outputStream, Algorithm algorithm)
 {
 	if (algorithm == Algorithm::Random)
 		outputStream << "random";
+	else if (algorithm == Algorithm::GEWEP)
+		outputStream << "GEWEP";
 	else
 		outputStream.setstate(ios_base::failbit);
 
@@ -128,6 +133,23 @@ void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 
 			break;
 		}
+		case Algorithm::GEWEP:
+		{
+			GenerationalElitistWithExclusivePools(
+				population,
+				cout,
+				{
+					/* mutationPoolSize = */ 0.25,
+					/* crossoverPoolSize = */ 0.25,
+					/* randomisationChance = */ 0.9,
+					/* deletionVsAdditionChance = */ 0.5,
+					/* percentGenesToRandomise = */ 0.1,
+					/* percentGenesToAddOrDelete = */ 0.1,
+				}
+			).run();
+
+			break;
+		}
 	}
 }
 
@@ -153,7 +175,7 @@ CommandLineParsingResult parseCommandLine(int argc, char** argv)
 		("seed", po::value<uint32_t>(), "Seed for the random number generator")
 		(
 			"algorithm",
-			po::value<Algorithm>()->default_value(Algorithm::Random),
+			po::value<Algorithm>()->default_value(Algorithm::GEWEP),
 			"Algorithm"
 		)
 	;

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -39,6 +39,34 @@ using namespace solidity::util;
 
 namespace po = boost::program_options;
 
+enum class Algorithm
+{
+	Random
+};
+
+istream& operator>>(istream& inputStream, Algorithm& algorithm)
+{
+	string value;
+	inputStream >> value;
+
+	if (value == "random")
+		algorithm = Algorithm::Random;
+	else
+		inputStream.setstate(ios_base::failbit);
+
+	return inputStream;
+}
+
+ostream& operator<<(ostream& outputStream, Algorithm algorithm)
+{
+	if (algorithm == Algorithm::Random)
+		outputStream << "random";
+	else
+		outputStream.setstate(ios_base::failbit);
+
+	return outputStream;
+}
+
 namespace
 {
 
@@ -69,7 +97,7 @@ CharStream loadSource(string const& _sourcePath)
 	return CharStream(sourceCode, _sourcePath);
 }
 
-void runAlgorithm(string const& _sourcePath)
+void runAlgorithm(string const& _sourcePath, Algorithm _algorithm)
 {
 	constexpr size_t populationSize = 20;
 	constexpr size_t minChromosomeLength = 12;
@@ -83,15 +111,24 @@ void runAlgorithm(string const& _sourcePath)
 		minChromosomeLength,
 		maxChromosomeLength
 	);
-	RandomAlgorithm(
-		population,
-		cout,
+
+	switch (_algorithm)
+	{
+		case Algorithm::Random:
 		{
-			/* elitePoolSize = */ 1.0 / populationSize,
-			/* minChromosomeLength = */ minChromosomeLength,
-			/* maxChromosomeLength = */ maxChromosomeLength,
+			RandomAlgorithm(
+				population,
+				cout,
+				{
+					/* elitePoolSize = */ 1.0 / populationSize,
+					/* minChromosomeLength = */ minChromosomeLength,
+					/* maxChromosomeLength = */ maxChromosomeLength,
+				}
+			).run();
+
+			break;
 		}
-	).run();
+	}
 }
 
 CommandLineParsingResult parseCommandLine(int argc, char** argv)
@@ -114,6 +151,11 @@ CommandLineParsingResult parseCommandLine(int argc, char** argv)
 		("help", "Show help message and exit.")
 		("input-file", po::value<string>()->required(), "Input file")
 		("seed", po::value<uint32_t>(), "Seed for the random number generator")
+		(
+			"algorithm",
+			po::value<Algorithm>()->default_value(Algorithm::Random),
+			"Algorithm"
+		)
 	;
 
 	po::positional_options_description positionalDescription;
@@ -160,7 +202,10 @@ int main(int argc, char** argv)
 
 	try
 	{
-		runAlgorithm(parsingResult.arguments["input-file"].as<string>());
+		runAlgorithm(
+			parsingResult.arguments["input-file"].as<string>(),
+			parsingResult.arguments["algorithm"].as<Algorithm>()
+		);
 	}
 	catch (InvalidProgram const& _exception)
 	{


### PR DESCRIPTION
### Description
The seventh pull request implementing #7806. Originally a part of #8256 which is now closed. Depends on #8327.

This PR introduces mutations and crossover and adds a real genetic algorithm that uses them. The algorithm isn't anything special and I don't think it has any specific name in the literature so I gave it a descriptive name based on its properties: `GenerationalElitistWithExclusivePools` or just GEWEP in short.

Mutations and crossover are implemented as functions that take one or two chromosomes, respectively, as input and produce a new chromosome (this has been changed from two, as requested in https://github.com/ethereum/solidity/pull/8256#issuecomment-582887820). I implemented a few simple ones as needed by the new algorithm. More will come later when I'm experimenting with algorithm tweaks.

Mutations and crossover operators can be used with the new methods added to `Population`: `mutate()` and `crossover()`. To make the crossover work this way I needed to extend the selection mechanism to pairs and so `PairSelection` and its specializations were born.

The application has gained `--algorithm` option which can be used to select between GEWEP and the random algorithm. GEWEP is now the default.

As requested in https://github.com/ethereum/solidity/pull/8256#issuecomment-582909159 I lowered the mutation chance (to 1 / 30). This does seem to make the algorithm converge faster to better sequences. Probably because it has the chance to consider more variations of the best chromosomes.

#### Algorithm
`yul-phaser` now has the algorithm proposed in the initial e-mails with only slight differences:
> - initialize the pool with 20 chromosomes of random length between 12 and 30, their contents fully random from the set of operations (including repetitions).
> - evaluate them by running them in a loop of maybe 5 iterations on the example input set (we should talk about that, too, but probably those in https://github.com/ethereum/solidity/tree/develop/test/libyul/yulOptimizerTests/fullSuite are fine for now)
> - sort by fitness, discard the lower half
> - re-fill one fourth by randomly selecting some chromosomes and exchanging random genes by other genes (mutation)
> - re-fill the last fourth by randomly selecting pairs of chromosomes and exchanging their genes at random cut points (cross-over)

The only difference is that the mutations performed by the current implementation include also random deletion and addition of genes, not just replacement. For each chromosome that undergoes mutation there's a 90% chance that the mutation is a gene replacement, 5% chance that it's a deletion and 5% chance that it's an addition. In each case every gene in the chromosome has a 3.33% chance of being affected by the mutation.

#### Running the program
``` bash
cd build/
make yul-phaser
tools/yul-phaser ../test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul --algorithm GEWEP
```

### Dependencies
This PR is based on #8327. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages