### PR TITLE
Use explicit variant constructor in direct list initializer

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -968,7 +968,7 @@ void IRGeneratorForStatements::endVisit(IndexAccess const& _indexAccess)
 			*_indexAccess.annotation().type,
 			IRLValue::Storage{
 				slot,
-				0
+				0u
 			}
 		});
 	}


### PR DESCRIPTION
Fix uses explicit type for variant constructor inside list initializer

Fixes #8332 