### PR TITLE
Use only conforming identifiers

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -69,8 +69,8 @@ public:
 	/// Feeds AssemblyItems into the eliminator and @returns the iterator pointing at the first
 	/// item that must be fed into a new instance of the eliminator.
 	/// @param _msizeImportant if false, do not consider modification of MSIZE a side-effect
-	template <class _AssemblyItemIterator>
-	_AssemblyItemIterator feedItems(_AssemblyItemIterator _iterator, _AssemblyItemIterator _end, bool _msizeImportant);
+	template <class AssemblyItemIterator>
+	AssemblyItemIterator feedItems(AssemblyItemIterator _iterator, AssemblyItemIterator _end, bool _msizeImportant);
 
 	/// @returns the resulting items after optimization.
 	AssemblyItems getOptimizedItems();
@@ -169,10 +169,10 @@ private:
 	std::map<int, Id> m_targetStack;
 };
 
-template <class _AssemblyItemIterator>
-_AssemblyItemIterator CommonSubexpressionEliminator::feedItems(
-	_AssemblyItemIterator _iterator,
-	_AssemblyItemIterator _end,
+template <class AssemblyItemIterator>
+AssemblyItemIterator CommonSubexpressionEliminator::feedItems(
+	AssemblyItemIterator _iterator,
+	AssemblyItemIterator _end,
 	bool _msizeImportant
 )
 {

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -179,7 +179,7 @@ KnownState::StoreOperation KnownState::feedItem(AssemblyItem const& _item, bool 
 
 /// Helper function for KnownState::reduceToCommonKnowledge, removes everything from
 /// _this which is not in or not equal to the value in _other.
-template <class _Mapping> void intersect(_Mapping& _this, _Mapping const& _other)
+template <class Mapping> void intersect(Mapping& _this, Mapping const& _other)
 {
 	for (auto it = _this.begin(); it != _this.end();)
 		if (_other.count(it->first) && _other.at(it->first) == it->second)

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -405,13 +405,13 @@ void NameAndTypeResolver::linearizeBaseContracts(ContractDefinition& _contract)
 	_contract.annotation().contractDependencies.insert(result.begin() + 1, result.end());
 }
 
-template <class _T>
-vector<_T const*> NameAndTypeResolver::cThreeMerge(list<list<_T const*>>& _toMerge)
+template <class T>
+vector<T const*> NameAndTypeResolver::cThreeMerge(list<list<T const*>>& _toMerge)
 {
 	// returns true iff _candidate appears only as last element of the lists
-	auto appearsOnlyAtHead = [&](_T const* _candidate) -> bool
+	auto appearsOnlyAtHead = [&](T const* _candidate) -> bool
 	{
-		for (list<_T const*> const& bases: _toMerge)
+		for (list<T const*> const& bases: _toMerge)
 		{
 			solAssert(!bases.empty(), "");
 			if (find(++bases.begin(), bases.end(), _candidate) != bases.end())
@@ -420,9 +420,9 @@ vector<_T const*> NameAndTypeResolver::cThreeMerge(list<list<_T const*>>& _toMer
 		return true;
 	};
 	// returns the next candidate to append to the linearized list or nullptr on failure
-	auto nextCandidate = [&]() -> _T const*
+	auto nextCandidate = [&]() -> T const*
 	{
-		for (list<_T const*> const& bases: _toMerge)
+		for (list<T const*> const& bases: _toMerge)
 		{
 			solAssert(!bases.empty(), "");
 			if (appearsOnlyAtHead(bases.front()))
@@ -431,7 +431,7 @@ vector<_T const*> NameAndTypeResolver::cThreeMerge(list<list<_T const*>>& _toMer
 		return nullptr;
 	};
 	// removes the given contract from all lists
-	auto removeCandidate = [&](_T const* _candidate)
+	auto removeCandidate = [&](T const* _candidate)
 	{
 		for (auto it = _toMerge.begin(); it != _toMerge.end();)
 		{
@@ -443,13 +443,13 @@ vector<_T const*> NameAndTypeResolver::cThreeMerge(list<list<_T const*>>& _toMer
 		}
 	};
 
-	_toMerge.remove_if([](list<_T const*> const& _bases) { return _bases.empty(); });
-	vector<_T const*> result;
+	_toMerge.remove_if([](list<T const*> const& _bases) { return _bases.empty(); });
+	vector<T const*> result;
 	while (!_toMerge.empty())
 	{
-		_T const* candidate = nextCandidate();
+		T const* candidate = nextCandidate();
 		if (!candidate)
-			return vector<_T const*>();
+			return vector<T const*>();
 		result.push_back(candidate);
 		removeCandidate(candidate);
 	}

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -122,8 +122,8 @@ private:
 	void linearizeBaseContracts(ContractDefinition& _contract);
 	/// Computes the C3-merge of the given list of lists of bases.
 	/// @returns the linearized vector or an empty vector if linearization is not possible.
-	template <class _T>
-	static std::vector<_T const*> cThreeMerge(std::list<std::list<_T const*>>& _toMerge);
+	template <class T>
+	static std::vector<T const*> cThreeMerge(std::list<std::list<T const*>>& _toMerge);
 
 	/// Maps nodes declaring a scope to scopes, i.e. ContractDefinition and FunctionDeclaration,
 	/// where nullptr denotes the global scope. Note that structs are not scope since they do

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -88,8 +88,8 @@ public:
 	}
 
 	/// @returns a copy of the vector containing only the nodes which derive from T.
-	template <class _T>
-	static std::vector<_T const*> filteredNodes(std::vector<ASTPointer<ASTNode>> const& _nodes);
+	template <class T>
+	static std::vector<T const*> filteredNodes(std::vector<ASTPointer<ASTNode>> const& _nodes);
 
 	/// Returns the source code location of this node.
 	SourceLocation const& location() const { return m_location; }
@@ -121,12 +121,12 @@ private:
 	SourceLocation m_location;
 };
 
-template <class _T>
-std::vector<_T const*> ASTNode::filteredNodes(std::vector<ASTPointer<ASTNode>> const& _nodes)
+template <class T>
+std::vector<T const*> ASTNode::filteredNodes(std::vector<ASTPointer<ASTNode>> const& _nodes)
 {
-	std::vector<_T const*> ret;
+	std::vector<T const*> ret;
 	for (auto const& n: _nodes)
-		if (auto const* nt = dynamic_cast<_T const*>(n.get()))
+		if (auto const* nt = dynamic_cast<T const*>(n.get()))
 			ret.push_back(nt);
 	return ret;
 }

--- a/libsolidity/codegen/ABIFunctions.h
+++ b/libsolidity/codegen/ABIFunctions.h
@@ -204,7 +204,7 @@ private:
 	/// @param _fromMemory if decoding from memory instead of from calldata
 	/// @param _forUseOnStack if the decoded value is stored on stack or in memory.
 	std::string abiDecodingFunction(
-		Type const& _Type,
+		Type const& _type,
 		bool _fromMemory,
 		bool _forUseOnStack
 	);

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -125,8 +125,8 @@ private:
 	void setLValueToStorageItem(Expression const& _expression);
 	/// Sets the current LValue to a new LValue constructed from the arguments.
 	/// Also retrieves the value if it was not requested by @a _expression.
-	template <class _LValueType, class... _Arguments>
-	void setLValue(Expression const& _expression, _Arguments const&... _arguments);
+	template <class LValueType, class... Arguments>
+	void setLValue(Expression const& _expression, Arguments const&... _arguments);
 
 	/// @returns true if the operator applied to the given type requires a cleanup prior to the
 	/// operation.
@@ -143,11 +143,11 @@ private:
 
 };
 
-template <class _LValueType, class... _Arguments>
-void ExpressionCompiler::setLValue(Expression const& _expression, _Arguments const&... _arguments)
+template <class LValueType, class... Arguments>
+void ExpressionCompiler::setLValue(Expression const& _expression, Arguments const&... _arguments)
 {
 	solAssert(!m_currentLValue, "Current LValue not reset before trying to set new one.");
-	std::unique_ptr<_LValueType> lvalue = std::make_unique<_LValueType>(m_context, _arguments...);
+	std::unique_ptr<LValueType> lvalue = std::make_unique<LValueType>(m_context, _arguments...);
 	if (_expression.annotation().lValueRequested)
 		m_currentLValue = move(lvalue);
 	else

--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -40,12 +40,12 @@ namespace solidity::util
 /// Assertion that throws an exception containing the given description if it is not met.
 /// Use it as assertThrow(1 == 1, ExceptionType, "Mathematics is wrong.");
 /// Do NOT supply an exception object as the second parameter.
-#define assertThrow(_condition, _ExceptionType, _description) \
+#define assertThrow(_condition, _exceptionType, _description) \
 	do \
 	{ \
 		if (!(_condition)) \
 			::boost::throw_exception( \
-				_ExceptionType() << \
+				_exceptionType() << \
 				::solidity::util::errinfo_comment(_description) << \
 				::boost::throw_function(ETH_FUNC) << \
 				::boost::throw_file(__FILE__) << \

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -249,14 +249,14 @@ inline void toBigEndian(T _val, Out& o_out)
 }
 
 /// Converts a big-endian byte-stream represented on a templated collection to a templated integer value.
-/// @a _In will typically be either std::string or bytes.
+/// @a In will typically be either std::string or bytes.
 /// @a T will typically by unsigned, u160, u256 or bigint.
-template <class T, class _In>
-inline T fromBigEndian(_In const& _bytes)
+template <class T, class In>
+inline T fromBigEndian(In const& _bytes)
 {
 	T ret = (T)0;
 	for (auto i: _bytes)
-		ret = (T)((ret << 8) | (uint8_t)(typename std::make_unsigned<typename _In::value_type>::type)i);
+		ret = (T)((ret << 8) | (uint8_t)(typename std::make_unsigned<typename In::value_type>::type)i);
 	return ret;
 }
 inline bytes toBigEndian(u256 _val) { bytes ret(32); toBigEndian(_val, ret); return ret; }

--- a/libsolutil/CommonIO.cpp
+++ b/libsolutil/CommonIO.cpp
@@ -40,11 +40,11 @@ using namespace solidity::util;
 namespace
 {
 
-template <typename _T>
-inline _T readFile(std::string const& _file)
+template <typename T>
+inline T readFile(std::string const& _file)
 {
-	_T ret;
-	size_t const c_elementSize = sizeof(typename _T::value_type);
+	T ret;
+	size_t const c_elementSize = sizeof(typename T::value_type);
 	std::ifstream is(_file, std::ifstream::binary);
 	if (!is)
 		return ret;

--- a/libsolutil/CommonIO.h
+++ b/libsolutil/CommonIO.h
@@ -42,8 +42,8 @@ std::string readStandardInput();
 int readStandardInputChar();
 
 /// Converts arbitrary value to string representation using std::stringstream.
-template <class _T>
-std::string toString(_T const& _t)
+template <class T>
+std::string toString(T const& _t)
 {
 	std::ostringstream o;
 	o << _t;

--- a/libsolutil/vector_ref.h
+++ b/libsolutil/vector_ref.h
@@ -16,63 +16,63 @@ namespace solidity::util
 /**
  * A modifiable reference to an existing object or vector in memory.
  */
-template <class _T>
+template <class T>
 class vector_ref
 {
 public:
-	using value_type = _T;
-	using element_type = _T;
-	using mutable_value_type = typename std::conditional<std::is_const<_T>::value, typename std::remove_const<_T>::type, _T>::type;
-	using string_type = typename std::conditional<std::is_const<_T>::value, std::string const, std::string>::type;
-	using vector_type = typename std::conditional<std::is_const<_T>::value, std::vector<typename std::remove_const<_T>::type> const, std::vector<_T>>::type;
-	using iterator = _T*;
-	using const_iterator = _T const*;
+	using value_type = T;
+	using element_type = T;
+	using mutable_value_type = typename std::conditional<std::is_const<T>::value, typename std::remove_const<T>::type, T>::type;
+	using string_type = typename std::conditional<std::is_const<T>::value, std::string const, std::string>::type;
+	using vector_type = typename std::conditional<std::is_const<T>::value, std::vector<typename std::remove_const<T>::type> const, std::vector<T>>::type;
+	using iterator = T*;
+	using const_iterator = T const*;
 
 	static_assert(std::is_pod<value_type>::value, "vector_ref can only be used with PODs due to its low-level treatment of data.");
 
 	vector_ref(): m_data(nullptr), m_count(0) {}
 	/// Creates a new vector_ref to point to @a _count elements starting at @a _data.
-	vector_ref(_T* _data, size_t _count): m_data(_data), m_count(_count) {}
+	vector_ref(T* _data, size_t _count): m_data(_data), m_count(_count) {}
 	/// Creates a new vector_ref pointing to the data part of a string (given as pointer).
-	vector_ref(string_type* _data): m_data(reinterpret_cast<_T*>(_data->data())), m_count(_data->size() / sizeof(_T)) {}
+	vector_ref(string_type* _data): m_data(reinterpret_cast<T*>(_data->data())), m_count(_data->size() / sizeof(T)) {}
 	/// Creates a new vector_ref pointing to the data part of a string (given as reference).
 	vector_ref(string_type& _data): vector_ref(&_data) {}
 	/// Creates a new vector_ref pointing to the data part of a vector (given as pointer).
 	vector_ref(vector_type* _data): m_data(_data->data()), m_count(_data->size()) {}
 	explicit operator bool() const { return m_data && m_count; }
 
-	std::vector<unsigned char> toBytes() const { return std::vector<unsigned char>(reinterpret_cast<unsigned char const*>(m_data), reinterpret_cast<unsigned char const*>(m_data) + m_count * sizeof(_T)); }
-	std::string toString() const { return std::string((char const*)m_data, ((char const*)m_data) + m_count * sizeof(_T)); }
+	std::vector<unsigned char> toBytes() const { return std::vector<unsigned char>(reinterpret_cast<unsigned char const*>(m_data), reinterpret_cast<unsigned char const*>(m_data) + m_count * sizeof(T)); }
+	std::string toString() const { return std::string((char const*)m_data, ((char const*)m_data) + m_count * sizeof(T)); }
 
-	template <class _T2> explicit operator vector_ref<_T2>() const { assert(m_count * sizeof(_T) / sizeof(_T2) * sizeof(_T2) / sizeof(_T) == m_count); return vector_ref<_T2>(reinterpret_cast<_T2*>(m_data), m_count * sizeof(_T) / sizeof(_T2)); }
-	operator vector_ref<_T const>() const { return vector_ref<_T const>(m_data, m_count); }
+	template <class T2> explicit operator vector_ref<T2>() const { assert(m_count * sizeof(T) / sizeof(T2) * sizeof(T2) / sizeof(T) == m_count); return vector_ref<T2>(reinterpret_cast<T2*>(m_data), m_count * sizeof(T) / sizeof(T2)); }
+	operator vector_ref<T const>() const { return vector_ref<T const>(m_data, m_count); }
 
-	_T* data() const { return m_data; }
+	T* data() const { return m_data; }
 	/// @returns the number of elements referenced (not necessarily number of bytes).
 	size_t size() const { return m_count; }
 	bool empty() const { return !m_count; }
 	/// @returns a new vector_ref which is a shifted and shortened view of the original data.
 	/// If this goes out of bounds in any way, returns an empty vector_ref.
 	/// If @a _count is ~size_t(0), extends the view to the end of the data.
-	vector_ref<_T> cropped(size_t _begin, size_t _count) const { if (m_data && _begin <= m_count && _count <= m_count && _begin + _count <= m_count) return vector_ref<_T>(m_data + _begin, _count == ~size_t(0) ? m_count - _begin : _count); else return vector_ref<_T>(); }
+	vector_ref<T> cropped(size_t _begin, size_t _count) const { if (m_data && _begin <= m_count && _count <= m_count && _begin + _count <= m_count) return vector_ref<T>(m_data + _begin, _count == ~size_t(0) ? m_count - _begin : _count); else return vector_ref<T>(); }
 	/// @returns a new vector_ref which is a shifted view of the original data (not going beyond it).
-	vector_ref<_T> cropped(size_t _begin) const { if (m_data && _begin <= m_count) return vector_ref<_T>(m_data + _begin, m_count - _begin); else return vector_ref<_T>(); }
+	vector_ref<T> cropped(size_t _begin) const { if (m_data && _begin <= m_count) return vector_ref<T>(m_data + _begin, m_count - _begin); else return vector_ref<T>(); }
 
-	_T* begin() { return m_data; }
-	_T* end() { return m_data + m_count; }
-	_T const* begin() const { return m_data; }
-	_T const* end() const { return m_data + m_count; }
+	T* begin() { return m_data; }
+	T* end() { return m_data + m_count; }
+	T const* begin() const { return m_data; }
+	T const* end() const { return m_data + m_count; }
 
-	_T& operator[](size_t _i) { assert(m_data); assert(_i < m_count); return m_data[_i]; }
-	_T const& operator[](size_t _i) const { assert(m_data); assert(_i < m_count); return m_data[_i]; }
+	T& operator[](size_t _i) { assert(m_data); assert(_i < m_count); return m_data[_i]; }
+	T const& operator[](size_t _i) const { assert(m_data); assert(_i < m_count); return m_data[_i]; }
 
-	bool operator==(vector_ref<_T> const& _cmp) const { return m_data == _cmp.m_data && m_count == _cmp.m_count; }
-	bool operator!=(vector_ref<_T> const& _cmp) const { return !operator==(_cmp); }
+	bool operator==(vector_ref<T> const& _cmp) const { return m_data == _cmp.m_data && m_count == _cmp.m_count; }
+	bool operator!=(vector_ref<T> const& _cmp) const { return !operator==(_cmp); }
 
 	void reset() { m_data = nullptr; m_count = 0; }
 
 private:
-	_T* m_data = nullptr;
+	T* m_data = nullptr;
 	size_t m_count = 0;
 };
 

--- a/libyul/optimiser/BlockHasher.cpp
+++ b/libyul/optimiser/BlockHasher.cpp
@@ -30,9 +30,9 @@ using namespace solidity::util;
 
 namespace
 {
-static constexpr uint64_t compileTimeLiteralHash(char const* _literal, size_t _N)
+static constexpr uint64_t compileTimeLiteralHash(char const* _literal, size_t _n)
 {
-	return (_N == 0) ? BlockHasher::fnvEmptyHash : (static_cast<uint64_t>(_literal[0]) * BlockHasher::fnvPrime) ^ compileTimeLiteralHash(_literal + 1, _N - 1);
+	return (_n == 0) ? BlockHasher::fnvEmptyHash : (static_cast<uint64_t>(_literal[0]) * BlockHasher::fnvPrime) ^ compileTimeLiteralHash(_literal + 1, _n - 1);
 }
 
 template<size_t N>

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -179,8 +179,8 @@ public:
 		return _padLeft ? padding + _value : _value + padding;
 	}
 	static bytes encode(std::string const& _value) { return encode(util::asBytes(_value), false); }
-	template <class _T>
-	static bytes encode(std::vector<_T> const& _value)
+	template <class T>
+	static bytes encode(std::vector<T> const& _value)
 	{
 		bytes ret;
 		for (auto const& v: _value)


### PR DESCRIPTION
# Description

According to the [C++ Standard](http://eel.is/c++draft/lex.name#3.1), identifiers that begin with an undercase followed by an uppercase letter are reserved to the implementation. Using them in program code makes the program ill-formed, no diagnostic required (which is effectively undefined behavior).

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] ~New tests have been created which fail without the change (if possible)~ N/A
- [x] ~README / documentation was extended, if necessary~ N/A
- [x] ~Changelog entry (if change is visible to the user)~ N/A
- [x] Used meaningful commit messages
