### PR TITLE
Fix re-printing value expectations.

### DIFF
--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -238,23 +238,12 @@ enum class FunctionValueUnit
 };
 
 /// Holds value along with unit it was expressed in originally.
-/// Value should be always converted to wei, no meter on which unit it was originally
+/// @a value is always in wei - it is converted back when stringifying again.
 struct FunctionValue
 {
 	u256 value;
 	FunctionValueUnit unit = FunctionValueUnit::Wei;
 };
-
-inline bool operator==(FunctionValue const& _a, FunctionValue const& _b)
-{
-	return _a.value == _b.value;
-}
-
-inline std::ostream& operator<<(std::ostream& _os, FunctionValue const& _v)
-{
-	_os << _v.value << (_v.unit == FunctionValueUnit::Wei ? " wei" : " ether");
-	return _os;
-}
 
 /**
  * Represents a function call read from an input stream. It contains the signature, the

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -64,7 +64,8 @@ void testFunctionCall(
 	ABI_CHECK(_call.arguments.rawBytes(), _arguments);
 	ABI_CHECK(_call.expectations.rawBytes(), _expectations);
 	BOOST_REQUIRE_EQUAL(_call.displayMode, _mode);
-	BOOST_REQUIRE_EQUAL(_call.value, _value);
+	BOOST_REQUIRE_EQUAL(_call.value.value, _value.value);
+	BOOST_REQUIRE_EQUAL(size_t(_call.value.unit), size_t(_value.unit));
 	BOOST_REQUIRE_EQUAL(_call.arguments.comment, _argumentComment);
 	BOOST_REQUIRE_EQUAL(_call.expectations.comment, _expectationComment);
 

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -52,6 +52,7 @@ string TestFunctionCall::format(
 		string comma = formatToken(Token::Comma);
 		string comment = formatToken(Token::Comment);
 		string ether = formatToken(Token::Ether);
+		string wei = formatToken(Token::Wei);
 		string newline = formatToken(Token::Newline);
 		string failure = formatToken(Token::Failure);
 
@@ -64,7 +65,14 @@ string TestFunctionCall::format(
 		/// Formats the function signature. This is the same independent from the display-mode.
 		stream << _linePrefix << newline << ws << m_call.signature;
 		if (m_call.value.value > u256(0))
-			stream << comma << ws << m_call.value.value << ws << ether;
+		{
+			if (m_call.value.unit == FunctionValueUnit::Ether)
+				stream << comma << ws << (m_call.value.value / exp256(10, 18)) << ws << ether;
+			else if (m_call.value.unit == FunctionValueUnit::Wei)
+				stream << comma << ws << m_call.value.value << ws << wei;
+			else
+				soltestAssert(false, "");
+		}
 		if (!m_call.arguments.rawBytes().empty())
 		{
 			string output = formatRawParameters(m_call.arguments.parameters, _linePrefix);


### PR DESCRIPTION
isoltest did not properly re-scale the value if "ether" was used.