### PR TITLE
[isoltest] Fix raw bytes output in warning on expectation mismatch

### DIFF
--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -225,7 +225,7 @@ string BytesUtils::formatRawBytes(
 	{
 		bytes byteRange{it, it + static_cast<long>(parameter.abiType.size)};
 
-		os << _linePrefix << formatBytes(byteRange, parameter.abiType);
+		os << _linePrefix << byteRange;
 		if (&parameter != &parameters.back())
 			os << endl;
 


### PR DESCRIPTION
### Description
After https://github.com/ethereum/solidity/pull/8340, the warnings that `isoltest` prints on an expectation mismatch in a semantic test, is wrong. The actual returned bytes are formatted (e.g. `library_function_selectors_struct.sol`):
```
  Expected result:
  // library: L
  // f() -> true, true, 41
  // g() -> true, true, 23

  Obtained result:
  // library: L
  // f() -> true, true, 42
  Warning: The call to "f()" returned 
  true
  true
  42
  // g() -> true, true, 23
```
instead of being printed raw:
```
  Expected result:
  // library: L
  // f() -> true, true, 41
  // g() -> true, true, 23

  Obtained result:
  // library: L
  // f() -> true, true, 42
  Warning: The call to "f()" returned 
  [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]
  [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]
  [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2a]
  // g() -> true, true, 23
```
The raw actual output (divided in 32-bytes chunks) will be printed again with this PR. Having the raw output printed helps debugging semantic tests.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [x] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
