### PR TITLE
CompilerStack lock.

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -87,7 +87,7 @@ CompilerStack::CompilerStack(ReadCallback::Callback const& _readFile):
 {
 	// Because TypeProvider is currently a singleton API, we must ensure that
 	// no more than one entity is actually using it at a time.
-	solAssert(g_compilerStackCounts == 0, "You shall not have another CompilerStack aside me.");
+	while(g_compilerStackCounts != 0);
 	++g_compilerStackCounts;
 }
 


### PR DESCRIPTION
I'm having an issue running some Rust tests that make use of [solidity_compile](https://github.com/ethereum/solidity/blob/develop/libsolc/libsolc.cpp#L131) via [solc-rust](https://github.com/axic/solc-rust). It gives me the error `You shall not have another CompilerStack aside me.` This is because my tests run in parallel by default. I've replaced the `solAssert` statement with a while lock, which makes it possible to run `solidity_compile` from separate threads without failure.

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages
