### PR TITLE
Fix yul calldata tail access functions and reuse them for old codegen.

### DIFF
--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -121,56 +121,12 @@ void CompilerUtils::returnDataToArray()
 
 void CompilerUtils::accessCalldataTail(Type const& _type)
 {
-	solAssert(_type.dataStoredIn(DataLocation::CallData), "");
-	solAssert(_type.isDynamicallyEncoded(), "");
-
-	unsigned int tailSize = _type.calldataEncodedTailSize();
-	solAssert(tailSize > 1, "");
-
-	// returns the absolute offset of the tail in "base_ref"
-	m_context.appendInlineAssembly(Whiskers(R"({
-		let rel_offset_of_tail := calldataload(ptr_to_tail)
-		if iszero(slt(rel_offset_of_tail, sub(sub(calldatasize(), base_ref), sub(<neededLength>, 1)))) { <revertString> }
-		base_ref := add(base_ref, rel_offset_of_tail)
-	})")
-	("neededLength", toCompactHexWithPrefix(tailSize))
-	("revertString", m_context.revertReasonIfDebug("Invalid calldata tail offset"))
-	.render(), {"base_ref", "ptr_to_tail"});
-	// stack layout: <absolute_offset_of_tail> <garbage>
-
-	if (!_type.isDynamicallySized())
-	{
-		m_context << Instruction::POP;
-		// stack layout: <absolute_offset_of_tail>
-		solAssert(
-			_type.category() == Type::Category::Struct ||
-			_type.category() == Type::Category::Array,
-			"Invalid dynamically encoded base type on tail access."
-		);
-	}
-	else
-	{
-		auto const* arrayType = dynamic_cast<ArrayType const*>(&_type);
-		solAssert(!!arrayType, "Invalid dynamically sized type.");
-		unsigned int calldataStride = arrayType->calldataStride();
-		solAssert(calldataStride > 0, "");
-
-		// returns the absolute offset of the tail in "base_ref"
-		// and the length of the tail in "length"
-		m_context.appendInlineAssembly(
-			Whiskers(R"({
-				length := calldataload(base_ref)
-				base_ref := add(base_ref, 0x20)
-				if gt(length, 0xffffffffffffffff) { <revertString> }
-				if sgt(base_ref, sub(calldatasize(), mul(length, <calldataStride>))) { revert(0, 0) }
-			})")
-			("calldataStride", toCompactHexWithPrefix(calldataStride))
-			("revertString", m_context.revertReasonIfDebug("Invalid calldata tail length"))
-			.render(),
-			{"base_ref", "length"}
-		);
-		// stack layout: <absolute_offset_of_tail> <length>
-	}
+	m_context << Instruction::SWAP1;
+	m_context.callYulFunction(
+		m_context.utilFunctions().accessCalldataTailFunction(_type),
+		2,
+		_type.isDynamicallySized() ? 2 : 1
+	);
 }
 
 unsigned CompilerUtils::loadFromMemory(

--- a/test/libsolidity/semanticTests/revertStrings/calldata_tail_short.sol
+++ b/test/libsolidity/semanticTests/revertStrings/calldata_tail_short.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+contract C {
+    function f(uint256[][] calldata x) external { x[0]; }
+}
+// ====
+// EVMVersion: >=byzantium
+// revertStrings: debug
+// ----
+// f(uint256[][]): 0x20, 1, 0x20, 2, 0x42 -> FAILURE, hex"08c379a0", 0x20, 23, "Calldata tail too short"


### PR DESCRIPTION
~~Originally part of https://github.com/ethereum/solidity/pull/8408, but now extracted.
Depends on https://github.com/ethereum/solidity/pull/8408~~ [merged]

The increased test coverage in fact revealed a minor bug in the yul util function for call data tail access that I fixed here as well (see comment).

I also ported the revert strings from the old codegen to the yul util function version and added another revert string for the last revert lacking one together with a test case for it.
