### PR TITLE
[yul-phaser] Error handling

### DIFF
--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -36,7 +36,7 @@ class FitnessMetricFixture
 protected:
 	FitnessMetricFixture():
 		m_sourceStream(SampleSourceCode, ""),
-		m_program(Program::load(m_sourceStream)) {}
+		m_program(get<Program>(Program::load(m_sourceStream))) {}
 
 	static constexpr char SampleSourceCode[] =
 		"{\n"

--- a/test/yulPhaser/Program.cpp
+++ b/test/yulPhaser/Program.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(copy_constructor_should_make_deep_copy_of_ast)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	Program programCopy(program);
 
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(load_should_rewind_the_stream)
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
 	sourceStream.setPosition(5);
 
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	BOOST_TEST(CodeSize::codeSize(program.ast()) == 2);
 }
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(load_should_disambiguate)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	// skipRedundantBlocks() makes the test independent of whether load() includes function grouping or not.
 	Block const& parentBlock = skipRedundantBlocks(program.ast());
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(load_should_do_function_grouping_and_hoisting)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	BOOST_TEST(program.ast().statements.size() == 3);
 	BOOST_TEST(holds_alternative<Block>(program.ast().statements[0]));
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(load_should_do_loop_init_rewriting)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	// skipRedundantBlocks() makes the test independent of whether load() includes function grouping or not.
 	Block const& parentBlock = skipRedundantBlocks(program.ast());
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(load_should_throw_InvalidProgram_if_program_cant_be_parsed)
 	string sourceCode("invalid program\n");
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
 
-	BOOST_CHECK_THROW(Program::load(sourceStream), InvalidProgram);
+	BOOST_TEST(holds_alternative<ErrorList>(Program::load(sourceStream)));
 }
 
 BOOST_AUTO_TEST_CASE(load_should_throw_InvalidProgram_if_program_cant_be_analyzed)
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(load_should_throw_InvalidProgram_if_program_cant_be_analyze
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
 
-	BOOST_CHECK_THROW(Program::load(sourceStream), InvalidProgram);
+	BOOST_TEST(holds_alternative<ErrorList>(Program::load(sourceStream)));
 }
 
 BOOST_AUTO_TEST_CASE(optimise)
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(optimise)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	[[maybe_unused]] Block const& parentBlockBefore = skipRedundantBlocks(program.ast());
 	assert(parentBlockBefore.statements.size() == 2);
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(output_operator)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	// NOTE: The snippet above was chosen so that the few optimisations applied automatically by load()
 	// as of now do not change the code significantly. If that changes, you may have to update it.
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(toJson)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	Json::Value parsingResult;
 	string errors;
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(codeSize)
 		"}\n"
 	);
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
-	auto program = Program::load(sourceStream);
+	Program program = get<Program>(Program::load(sourceStream));
 
 	BOOST_TEST(program.codeSize() == CodeSize::codeSizeIncludingFunctions(program.ast()));
 }

--- a/tools/yulPhaser/Exceptions.h
+++ b/tools/yulPhaser/Exceptions.h
@@ -22,6 +22,9 @@
 namespace solidity::phaser
 {
 
-struct InvalidProgram: virtual util::Exception {};
+struct BadInput: virtual util::Exception {};
+struct InvalidProgram: virtual BadInput {};
+struct NoInputFiles: virtual BadInput {};
+struct MissingFile: virtual BadInput {};
 
 }

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -125,7 +125,13 @@ ProgramFactory::Options ProgramFactory::Options::fromCommandLine(po::variables_m
 Program ProgramFactory::build(Options const& _options)
 {
 	CharStream sourceCode = loadSource(_options.inputFile);
-	return Program::load(sourceCode);
+	variant<Program, ErrorList> programOrErrors = Program::load(sourceCode);
+	if (holds_alternative<ErrorList>(programOrErrors))
+	{
+		cerr << get<ErrorList>(programOrErrors) << endl;
+		assertThrow(false, InvalidProgram, "Failed to load program " + _options.inputFile);
+	}
+	return move(get<Program>(programOrErrors));
 }
 
 CharStream ProgramFactory::loadSource(string const& _sourcePath)

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -136,7 +136,7 @@ Program ProgramFactory::build(Options const& _options)
 
 CharStream ProgramFactory::loadSource(string const& _sourcePath)
 {
-	assertThrow(boost::filesystem::exists(_sourcePath), InvalidProgram, "Source file does not exist");
+	assertThrow(boost::filesystem::exists(_sourcePath), MissingFile, "Source file does not exist: " + _sourcePath);
 
 	string sourceCode = readFileAsString(_sourcePath);
 	return CharStream(sourceCode, _sourcePath);
@@ -216,10 +216,7 @@ Phaser::CommandLineParsingResult Phaser::parseCommandLine(int _argc, char** _arg
 	}
 
 	if (arguments.count("input-file") == 0)
-	{
-		cerr << "Missing argument: input-file." << endl;
-		return {1, move(arguments)};
-	}
+		assertThrow(false, NoInputFiles, "Missing argument: input-file.");
 
 	return {0, arguments};
 }

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -212,7 +212,7 @@ Phaser::CommandLineParsingResult Phaser::parseCommandLine(int _argc, char** _arg
 	if (arguments.count("help") > 0)
 	{
 		cout << keywordDescription << endl;
-		return {2, move(arguments)};
+		return {0, move(arguments)};
 	}
 
 	if (arguments.count("input-file") == 0)

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -205,17 +205,9 @@ Phaser::CommandLineParsingResult Phaser::parseCommandLine(int _argc, char** _arg
 	po::variables_map arguments;
 	po::notify(arguments);
 
-	try
-	{
-		po::command_line_parser parser(_argc, _argv);
-		parser.options(keywordDescription).positional(positionalDescription);
-		po::store(parser.run(), arguments);
-	}
-	catch (po::error const & _exception)
-	{
-		cerr << _exception.what() << endl;
-		return {1, move(arguments)};
-	}
+	po::command_line_parser parser(_argc, _argv);
+	parser.options(keywordDescription).positional(positionalDescription);
+	po::store(parser.run(), arguments);
 
 	if (arguments.count("help") > 0)
 	{

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -142,16 +142,15 @@ CharStream ProgramFactory::loadSource(string const& _sourcePath)
 	return CharStream(sourceCode, _sourcePath);
 }
 
-int Phaser::main(int _argc, char** _argv)
+void Phaser::main(int _argc, char** _argv)
 {
-	CommandLineParsingResult parsingResult = parseCommandLine(_argc, _argv);
-	if (parsingResult.exitCode != 0)
-		return parsingResult.exitCode;
+	optional<po::variables_map> arguments = parseCommandLine(_argc, _argv);
+	if (!arguments.has_value())
+		return;
 
-	initialiseRNG(parsingResult.arguments);
+	initialiseRNG(arguments.value());
 
-	runAlgorithm(parsingResult.arguments);
-	return 0;
+	runAlgorithm(arguments.value());
 }
 
 Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
@@ -198,7 +197,7 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	return {keywordDescription, positionalDescription};
 }
 
-Phaser::CommandLineParsingResult Phaser::parseCommandLine(int _argc, char** _argv)
+optional<po::variables_map> Phaser::parseCommandLine(int _argc, char** _argv)
 {
 	auto [keywordDescription, positionalDescription] = buildCommandLineDescription();
 
@@ -212,13 +211,13 @@ Phaser::CommandLineParsingResult Phaser::parseCommandLine(int _argc, char** _arg
 	if (arguments.count("help") > 0)
 	{
 		cout << keywordDescription << endl;
-		return {0, move(arguments)};
+		return nullopt;
 	}
 
 	if (arguments.count("input-file") == 0)
 		assertThrow(false, NoInputFiles, "Missing argument: input-file.");
 
-	return {0, arguments};
+	return arguments;
 }
 
 void Phaser::initialiseRNG(po::variables_map const& _arguments)

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -25,6 +25,7 @@
 
 #include <istream>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -128,7 +129,7 @@ private:
 class Phaser
 {
 public:
-	static int main(int argc, char** argv);
+	static void main(int argc, char** argv);
 
 private:
 	struct CommandLineDescription
@@ -137,14 +138,8 @@ private:
 		boost::program_options::positional_options_description positionalDescription;
 	};
 
-	struct CommandLineParsingResult
-	{
-		int exitCode;
-		boost::program_options::variables_map arguments;
-	};
-
 	static CommandLineDescription buildCommandLineDescription();
-	static CommandLineParsingResult parseCommandLine(int _argc, char** _argv);
+	static std::optional<boost::program_options::variables_map> parseCommandLine(int _argc, char** _argv);
 	static void initialiseRNG(boost::program_options::variables_map const& _arguments);
 
 	static void runAlgorithm(boost::program_options::variables_map const& _arguments);

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -133,7 +133,7 @@ variant<unique_ptr<Block>, ErrorList> Program::parseSource(Dialect const& _diale
 		return errors;
 
 	assert(errorReporter.errors().empty());
-	return ast;
+	return variant<unique_ptr<Block>, ErrorList>(move(ast));
 }
 
 variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect const& _dialect, Block const& _ast)
@@ -148,7 +148,7 @@ variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect cons
 		return errors;
 
 	assert(errorReporter.errors().empty());
-	return analysisInfo;
+	return variant<unique_ptr<AsmAnalysisInfo>, ErrorList>(move(analysisInfo));
 }
 
 unique_ptr<Block> Program::disambiguateAST(

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -22,6 +22,7 @@
 #include <liblangutil/CharStream.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Exceptions.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
@@ -55,6 +56,16 @@ namespace solidity::phaser
 
 ostream& operator<<(ostream& _stream, Program const& _program);
 
+}
+
+ostream& std::operator<<(ostream& _outputStream, ErrorList const& _errors)
+{
+	SourceReferenceFormatter formatter(_outputStream);
+
+	for (auto const& error: _errors)
+		formatter.printErrorInformation(*error);
+
+	return _outputStream;
 }
 
 Program::Program(Program const& program):

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -20,10 +20,13 @@
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/AsmData.h>
 
+#include <liblangutil/Exceptions.h>
+
 #include <optional>
 #include <ostream>
 #include <set>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace solidity::langutil
@@ -72,7 +75,7 @@ public:
 	Program operator=(Program const& program) = delete;
 	Program operator=(Program&& program) = delete;
 
-	static Program load(langutil::CharStream& _sourceCode);
+	static std::variant<Program, langutil::ErrorList> load(langutil::CharStream& _sourceCode);
 	void optimise(std::vector<std::string> const& _optimisationSteps);
 
 	size_t codeSize() const { return computeCodeSize(*m_ast); }
@@ -91,11 +94,11 @@ private:
 		m_nameDispenser(_dialect, *m_ast, {})
 	{}
 
-	static std::unique_ptr<yul::Block> parseSource(
+	static std::variant<std::unique_ptr<yul::Block>, langutil::ErrorList> parseSource(
 		yul::Dialect const& _dialect,
 		langutil::CharStream _source
 	);
-	static std::unique_ptr<yul::AsmAnalysisInfo> analyzeAST(
+	static std::variant<std::unique_ptr<yul::AsmAnalysisInfo>, langutil::ErrorList> analyzeAST(
 		yul::Dialect const& _dialect,
 		yul::Block const& _ast
 	);

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -41,6 +41,13 @@ struct Dialect;
 
 }
 
+namespace std
+{
+
+std::ostream& operator<<(std::ostream& _outputStream, solidity::langutil::ErrorList const& _errors);
+
+}
+
 namespace solidity::phaser
 {
 

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -36,10 +36,10 @@ int main(int argc, char** argv)
 		std::cerr << "ERROR: " << exception.what() << std::endl;
 		return 1;
 	}
-	catch (solidity::phaser::InvalidProgram const& exception)
+	catch (solidity::phaser::BadInput const& exception)
 	{
-		// Error in the input data. One of the provided programs contains errors and could not be loaded.
-		// Handle it and exit.
+		// Bad input data. Syntax errors in the input program, semantic errors in command-line
+		// parameters, etc.
 
 		std::cerr << std::endl;
 		std::cerr << "ERROR: " << exception.what() << std::endl;

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -18,6 +18,8 @@
 #include <tools/yulPhaser/Exceptions.h>
 #include <tools/yulPhaser/Phaser.h>
 
+#include <libsolutil/Exceptions.h>
+
 #include <iostream>
 
 int main(int argc, char** argv)
@@ -28,7 +30,51 @@ int main(int argc, char** argv)
 	}
 	catch (solidity::phaser::InvalidProgram const& exception)
 	{
+		// Error in the input data. One of the provided programs contains errors and could not be loaded.
+		// Handle it and exit.
+
+		std::cerr << std::endl;
 		std::cerr << "ERROR: " << exception.what() << std::endl;
 		return 1;
+	}
+	catch (solidity::util::Exception const& exception)
+	{
+		// Something's seriously wrong. Probably a bug in the program or a missing handler (which
+		// is really also a bug). The exception should have been handled gracefully by this point
+		// if it's something that can happen in normal usage. E.g. an error in the input or a
+		// failure of some part of the system that's outside of control of the application (disk,
+		// network, etc.). The bug should be reported and investigated so our job here is just to
+		// provide as much useful information about it as possible.
+
+		std::cerr << std::endl;
+		std::cerr << "UNCAUGHT EXCEPTION!" << std::endl;
+
+		// We can print some useful diagnostic info for this particular exception type.
+		std::cerr << "Location: " << exception.lineInfo() << std::endl;
+
+		char const* const* function = boost::get_error_info<boost::throw_function>(exception);
+		if (function != nullptr)
+			std::cerr << "Function: " << *function << std::endl;
+
+		// Let it crash. The terminate() will print some more stuff useful for debugging like
+		// what() and the actual exception type.
+		throw;
+	}
+	catch (std::exception const&)
+	{
+		// Again, probably a bug but this time it's just plain std::exception so there's no point
+		// in doing anything special. terminate() will do an adequate job.
+		std::cerr << std::endl;
+		std::cerr << "UNCAUGHT EXCEPTION!" << std::endl;
+		throw;
+	}
+	catch (...)
+	{
+		// Some people don't believe these exist.
+		// I have no idea what this is and it's flying towards me so technically speaking it's an
+		// unidentified flying object.
+		std::cerr << std::endl;
+		std::cerr << "UFO SPOTTED!" << std::endl;
+		throw;
 	}
 }

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -28,6 +28,14 @@ int main(int argc, char** argv)
 	{
 		return solidity::phaser::Phaser::main(argc, argv);
 	}
+	catch (boost::program_options::error const& exception)
+	{
+		// Bad input data. Invalid command-line parameters.
+
+		std::cerr << std::endl;
+		std::cerr << "ERROR: " << exception.what() << std::endl;
+		return 1;
+	}
 	catch (solidity::phaser::InvalidProgram const& exception)
 	{
 		// Error in the input data. One of the provided programs contains errors and could not be loaded.

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -26,7 +26,8 @@ int main(int argc, char** argv)
 {
 	try
 	{
-		return solidity::phaser::Phaser::main(argc, argv);
+		solidity::phaser::Phaser::main(argc, argv);
+		return 0;
 	}
 	catch (boost::program_options::error const& exception)
 	{


### PR DESCRIPTION
### Description
The ninth pull request implementing #7806. Depends on #8421.

This PR changes the way `yul-phaser` reports and handles errors:
- If parsing or analysis fails for a Yul program, the application will now print the list of errors to `stderr`.
- The top-level exception handler now catches all exceptions not handled at lower layers, tries to get some useful debugging information out of them (like code location and function in case of `solidity::util::Exception`) and then rethrows them to make the program fail, as expected in case of a bug. This is just to help debugging since all exceptions that can happen during normal operation should already be handled by that point.
- Added a few more specific exception types and `catch` blocks that handle them.
- `--help` no longer exists with error status.

### Dependencies
This PR is based on #8421. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages