### PR TITLE
[yul-phaser] Population and algorithm options

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -149,6 +149,7 @@ set(yul_phaser_sources
     yulPhaser/GeneticAlgorithms.cpp
     yulPhaser/Mutations.cpp
     yulPhaser/PairSelections.cpp
+    yulPhaser/Phaser.cpp
     yulPhaser/Population.cpp
     yulPhaser/Program.cpp
     yulPhaser/Selections.cpp
@@ -164,6 +165,7 @@ set(yul_phaser_sources
     ../tools/yulPhaser/GeneticAlgorithms.cpp
     ../tools/yulPhaser/Mutations.cpp
     ../tools/yulPhaser/PairSelections.cpp
+    ../tools/yulPhaser/Phaser.cpp
     ../tools/yulPhaser/Population.cpp
     ../tools/yulPhaser/Program.cpp
     ../tools/yulPhaser/Selections.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -158,6 +158,7 @@ set(yul_phaser_sources
     # My current workaround is just to include its source files here but this introduces
     # unnecessary duplication. Create a library or find a way to reuse the list in both places.
     ../tools/yulPhaser/AlgorithmRunner.cpp
+    ../tools/yulPhaser/Common.cpp
     ../tools/yulPhaser/Chromosome.cpp
     ../tools/yulPhaser/FitnessMetrics.cpp
     ../tools/yulPhaser/GeneticAlgorithms.cpp

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -18,9 +18,11 @@
 #include <test/yulPhaser/TestHelpers.h>
 
 #include <tools/yulPhaser/AlgorithmRunner.h>
+#include <tools/yulPhaser/Common.h>
 
 #include <libsolutil/CommonIO.h>
 
+#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/output_test_stream.hpp>
 
@@ -29,10 +31,12 @@ using namespace boost::unit_test::framework;
 using namespace boost::test_tools;
 using namespace solidity::util;
 
+namespace fs = boost::filesystem;
+
 namespace solidity::phaser::test
 {
 
-class DummyAlgorithm: public GeneticAlgorithm
+class CountingAlgorithm: public GeneticAlgorithm
 {
 public:
 	using GeneticAlgorithm::GeneticAlgorithm;
@@ -45,12 +49,41 @@ public:
 	size_t m_currentRound = 0;
 };
 
+class RandomisingAlgorithm: public GeneticAlgorithm
+{
+public:
+	using GeneticAlgorithm::GeneticAlgorithm;
+	Population runNextRound(Population _population) override
+	{
+		return Population::makeRandom(_population.fitnessMetric(), _population.individuals().size(), 10, 20);
+	}
+};
+
 class AlgorithmRunnerFixture
 {
 protected:
 	shared_ptr<FitnessMetric> m_fitnessMetric = make_shared<ChromosomeLengthMetric>();
 	output_test_stream m_output;
 	AlgorithmRunner::Options m_options;
+};
+
+class AlgorithmRunnerAutosaveFixture: public AlgorithmRunnerFixture
+{
+public:
+	static vector<string> chromosomeStrings(Population const& _population)
+	{
+		vector<string> lines;
+		for (auto const& individual: _population.individuals())
+			lines.push_back(toString(individual.chromosome));
+
+		return lines;
+	}
+
+protected:
+	TemporaryDirectory m_tempDir;
+	string const m_autosavePath = m_tempDir.memberPath("population-autosave.txt");
+	Population const m_population = Population::makeRandom(m_fitnessMetric, 5, 0, 20);
+	RandomisingAlgorithm m_algorithm;
 };
 
 BOOST_AUTO_TEST_SUITE(Phaser)
@@ -60,7 +93,8 @@ BOOST_FIXTURE_TEST_CASE(run_should_call_runNextRound_once_per_round, AlgorithmRu
 {
 	m_options.maxRounds = 5;
 	AlgorithmRunner runner(Population(m_fitnessMetric), m_options, m_output);
-	DummyAlgorithm algorithm;
+
+	CountingAlgorithm algorithm;
 
 	BOOST_TEST(algorithm.m_currentRound == 0);
 	runner.run(algorithm);
@@ -82,7 +116,7 @@ BOOST_FIXTURE_TEST_CASE(run_should_print_the_top_chromosome, AlgorithmRunnerFixt
 		m_output
 	);
 
-	DummyAlgorithm algorithm;
+	CountingAlgorithm algorithm;
 
 	BOOST_TEST(m_output.is_empty());
 	runner.run(algorithm);
@@ -91,6 +125,67 @@ BOOST_FIXTURE_TEST_CASE(run_should_print_the_top_chromosome, AlgorithmRunnerFixt
 	runner.run(algorithm);
 	runner.run(algorithm);
 	BOOST_TEST(countSubstringOccurrences(m_output.str(), toString(runner.population().individuals()[0].chromosome)) == 4);
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_save_initial_population_to_file_if_autosave_file_specified, AlgorithmRunnerAutosaveFixture)
+{
+	m_options.maxRounds = 0;
+	m_options.populationAutosaveFile = m_autosavePath;
+	AlgorithmRunner runner(m_population, m_options, m_output);
+	assert(!fs::exists(m_autosavePath));
+
+	runner.run(m_algorithm);
+	assert(runner.population() == m_population);
+
+	BOOST_TEST(fs::is_regular_file(m_autosavePath));
+	BOOST_TEST(readLinesFromFile(m_autosavePath) == chromosomeStrings(runner.population()));
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_save_population_to_file_if_autosave_file_specified, AlgorithmRunnerAutosaveFixture)
+{
+	m_options.maxRounds = 1;
+	m_options.populationAutosaveFile = m_autosavePath;
+	AlgorithmRunner runner(m_population, m_options, m_output);
+	assert(!fs::exists(m_autosavePath));
+
+	runner.run(m_algorithm);
+	assert(runner.population() != m_population);
+
+	BOOST_TEST(fs::is_regular_file(m_autosavePath));
+	BOOST_TEST(readLinesFromFile(m_autosavePath) == chromosomeStrings(runner.population()));
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_overwrite_existing_file_if_autosave_file_specified, AlgorithmRunnerAutosaveFixture)
+{
+	m_options.maxRounds = 5;
+	m_options.populationAutosaveFile = m_autosavePath;
+	AlgorithmRunner runner(m_population, m_options, m_output);
+	assert(!fs::exists(m_autosavePath));
+
+	vector<string> originalContent = {"Original content"};
+	{
+		ofstream tmpFile(m_autosavePath);
+		tmpFile << originalContent[0] << endl;
+	}
+	assert(fs::exists(m_autosavePath));
+	assert(readLinesFromFile(m_autosavePath) == originalContent);
+
+	runner.run(m_algorithm);
+
+	BOOST_TEST(fs::is_regular_file(m_autosavePath));
+	BOOST_TEST(readLinesFromFile(m_autosavePath) != originalContent);
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_not_save_population_to_file_if_autosave_file_not_specified, AlgorithmRunnerAutosaveFixture)
+{
+	m_options.maxRounds = 5;
+	m_options.populationAutosaveFile = nullopt;
+	AlgorithmRunner runner(m_population, m_options, m_output);
+	assert(!fs::exists(m_autosavePath));
+
+	runner.run(m_algorithm);
+
+	BOOST_TEST(!fs::exists(m_autosavePath));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -188,6 +188,55 @@ BOOST_FIXTURE_TEST_CASE(run_should_not_save_population_to_file_if_autosave_file_
 	BOOST_TEST(!fs::exists(m_autosavePath));
 }
 
+BOOST_FIXTURE_TEST_CASE(run_should_randomise_duplicate_chromosomes_if_requested, AlgorithmRunnerFixture)
+{
+	Chromosome duplicate("afc");
+	Population population(m_fitnessMetric, {duplicate, duplicate, duplicate});
+	CountingAlgorithm algorithm;
+
+	m_options.maxRounds = 1;
+	m_options.randomiseDuplicates = true;
+	m_options.minChromosomeLength = 50;
+	m_options.maxChromosomeLength = 50;
+	AlgorithmRunner runner(population, m_options, m_output);
+
+	runner.run(algorithm);
+
+	auto const& newIndividuals = runner.population().individuals();
+
+	BOOST_TEST(newIndividuals.size() == 3);
+	BOOST_TEST((
+		newIndividuals[0].chromosome == duplicate ||
+		newIndividuals[1].chromosome == duplicate ||
+		newIndividuals[2].chromosome == duplicate
+	));
+	BOOST_TEST(newIndividuals[0] != newIndividuals[1]);
+	BOOST_TEST(newIndividuals[0] != newIndividuals[2]);
+	BOOST_TEST(newIndividuals[1] != newIndividuals[2]);
+
+	BOOST_TEST((newIndividuals[0].chromosome.length() == 50 || newIndividuals[0].chromosome == duplicate));
+	BOOST_TEST((newIndividuals[1].chromosome.length() == 50 || newIndividuals[1].chromosome == duplicate));
+	BOOST_TEST((newIndividuals[2].chromosome.length() == 50 || newIndividuals[2].chromosome == duplicate));
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_not_randomise_duplicate_chromosomes_if_not_requested, AlgorithmRunnerFixture)
+{
+	Chromosome duplicate("afc");
+	Population population(m_fitnessMetric, {duplicate, duplicate, duplicate});
+	CountingAlgorithm algorithm;
+
+	m_options.maxRounds = 1;
+	m_options.randomiseDuplicates = false;
+	AlgorithmRunner runner(population, m_options, m_output);
+
+	runner.run(algorithm);
+
+	BOOST_TEST(runner.population().individuals().size() == 3);
+	BOOST_TEST(runner.population().individuals()[0].chromosome == duplicate);
+	BOOST_TEST(runner.population().individuals()[1].chromosome == duplicate);
+	BOOST_TEST(runner.population().individuals()[2].chromosome == duplicate);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -15,6 +15,8 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <test/yulPhaser/TestHelpers.h>
+
 #include <tools/yulPhaser/Common.h>
 
 #include <libsolutil/CommonData.h>
@@ -22,6 +24,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/output_test_stream.hpp>
 
+#include <fstream>
 #include <sstream>
 #include <string>
 
@@ -31,6 +34,12 @@ using namespace solidity::util;
 
 namespace solidity::phaser::test
 {
+
+class ReadLinesFromFileFixture
+{
+protected:
+	TemporaryDirectory m_tempDir;
+};
 
 namespace
 {
@@ -59,6 +68,17 @@ map<string, TestEnum> const StringToTestEnumMap = invertMap(TestEnumToStringMap)
 
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(CommonTest)
+
+BOOST_FIXTURE_TEST_CASE(readLinesFromFile_should_return_all_lines_from_a_text_file_as_strings_without_newlines, ReadLinesFromFileFixture)
+{
+	{
+		ofstream tmpFile(m_tempDir.memberPath("test-file.txt"));
+		tmpFile << endl << "Line 1" << endl << endl << endl << "Line 2" << endl << "#" << endl << endl;
+	}
+
+	vector<string> lines = readLinesFromFile(m_tempDir.memberPath("test-file.txt"));
+	BOOST_TEST((lines == vector<string>{"", "Line 1", "", "", "Line 2", "#", ""}));
+}
 
 BOOST_AUTO_TEST_CASE(deserializeChoice_should_convert_string_to_enum)
 {

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -1,0 +1,290 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/yulPhaser/TestHelpers.h>
+
+#include <tools/yulPhaser/Exceptions.h>
+#include <tools/yulPhaser/Phaser.h>
+
+#include <liblangutil/CharStream.h>
+
+#include <libsolutil/CommonIO.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+
+using namespace std;
+using namespace solidity::util;
+using namespace solidity::langutil;
+
+namespace fs = boost::filesystem;
+
+namespace solidity::phaser::test
+{
+
+class GeneticAlgorithmFactoryFixture
+{
+protected:
+	GeneticAlgorithmFactory::Options m_options = {
+		/* algorithm = */ Algorithm::Random,
+		/* minChromosomeLength = */ 50,
+		/* maxChromosomeLength = */ 100,
+		/* randomElitePoolSize = */ 0.5,
+		/* gewepMutationPoolSize = */ 0.1,
+		/* gewepCrossoverPoolSize = */ 0.1,
+		/* gewepRandomisationChance = */ 0.6,
+		/* gewepDeletionVsAdditionChance = */ 0.3,
+		/* gewepGenesToRandomise = */ 0.4,
+		/* gewepGenesToAddOrDelete = */ 0.2,
+	};
+};
+
+class FitnessMetricFactoryFixture
+{
+protected:
+	CharStream m_sourceStream = CharStream("{}", "");
+	Program m_program = get<Program>(Program::load(m_sourceStream));
+	FitnessMetricFactory::Options m_options = {
+		/* chromosomeRepetitions = */ 1,
+	};
+};
+
+class PoulationFactoryFixture
+{
+protected:
+	shared_ptr<FitnessMetric> m_fitnessMetric = make_shared<ChromosomeLengthMetric>();
+	PopulationFactory::Options m_options = {
+		/* minChromosomeLength = */ 0,
+		/* maxChromosomeLength = */ 0,
+		/* population = */ {},
+		/* randomPopulation = */ {},
+		/* populationFromFile = */ {},
+	};
+};
+
+BOOST_AUTO_TEST_SUITE(Phaser)
+BOOST_AUTO_TEST_SUITE(PhaserTest)
+BOOST_AUTO_TEST_SUITE(GeneticAlgorithmFactoryTest)
+
+BOOST_FIXTURE_TEST_CASE(build_should_select_the_right_algorithm_and_pass_the_options_to_it, GeneticAlgorithmFactoryFixture)
+{
+	m_options.algorithm = Algorithm::Random;
+	unique_ptr<GeneticAlgorithm> algorithm1 = GeneticAlgorithmFactory::build(m_options, 100);
+	BOOST_REQUIRE(algorithm1 != nullptr);
+
+	auto randomAlgorithm = dynamic_cast<RandomAlgorithm*>(algorithm1.get());
+	BOOST_REQUIRE(randomAlgorithm != nullptr);
+	BOOST_TEST(randomAlgorithm->options().elitePoolSize == m_options.randomElitePoolSize.value());
+	BOOST_TEST(randomAlgorithm->options().minChromosomeLength == m_options.minChromosomeLength);
+	BOOST_TEST(randomAlgorithm->options().maxChromosomeLength == m_options.maxChromosomeLength);
+
+	m_options.algorithm = Algorithm::GEWEP;
+	unique_ptr<GeneticAlgorithm> algorithm2 = GeneticAlgorithmFactory::build(m_options, 100);
+	BOOST_REQUIRE(algorithm2 != nullptr);
+
+	auto gewepAlgorithm = dynamic_cast<GenerationalElitistWithExclusivePools*>(algorithm2.get());
+	BOOST_REQUIRE(gewepAlgorithm != nullptr);
+	BOOST_TEST(gewepAlgorithm->options().mutationPoolSize == m_options.gewepMutationPoolSize);
+	BOOST_TEST(gewepAlgorithm->options().crossoverPoolSize == m_options.gewepCrossoverPoolSize);
+	BOOST_TEST(gewepAlgorithm->options().randomisationChance == m_options.gewepRandomisationChance);
+	BOOST_TEST(gewepAlgorithm->options().deletionVsAdditionChance == m_options.gewepDeletionVsAdditionChance);
+	BOOST_TEST(gewepAlgorithm->options().percentGenesToRandomise == m_options.gewepGenesToRandomise.value());
+	BOOST_TEST(gewepAlgorithm->options().percentGenesToAddOrDelete == m_options.gewepGenesToAddOrDelete.value());
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_set_random_algorithm_elite_pool_size_based_on_population_size_if_not_specified, GeneticAlgorithmFactoryFixture)
+{
+	m_options.algorithm = Algorithm::Random;
+	m_options.randomElitePoolSize = nullopt;
+	unique_ptr<GeneticAlgorithm> algorithm = GeneticAlgorithmFactory::build(m_options, 100);
+	BOOST_REQUIRE(algorithm != nullptr);
+
+	auto randomAlgorithm = dynamic_cast<RandomAlgorithm*>(algorithm.get());
+	BOOST_REQUIRE(randomAlgorithm != nullptr);
+	BOOST_TEST(randomAlgorithm->options().elitePoolSize == 1.0 / 100.0);
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_set_gewep_mutation_percentages_based_on_maximum_chromosome_length_if_not_specified, GeneticAlgorithmFactoryFixture)
+{
+	m_options.algorithm = Algorithm::GEWEP;
+	m_options.gewepGenesToRandomise = nullopt;
+	m_options.gewepGenesToAddOrDelete = nullopt;
+	m_options.maxChromosomeLength = 125;
+
+	unique_ptr<GeneticAlgorithm> algorithm = GeneticAlgorithmFactory::build(m_options, 100);
+	BOOST_REQUIRE(algorithm != nullptr);
+
+	auto gewepAlgorithm = dynamic_cast<GenerationalElitistWithExclusivePools*>(algorithm.get());
+	BOOST_REQUIRE(gewepAlgorithm != nullptr);
+	BOOST_TEST(gewepAlgorithm->options().percentGenesToRandomise == 1.0 / 125.0);
+	BOOST_TEST(gewepAlgorithm->options().percentGenesToAddOrDelete == 1.0 / 125.0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE(FitnessMetricFactoryTest)
+
+BOOST_FIXTURE_TEST_CASE(build_should_create_metric_of_the_right_type, FitnessMetricFactoryFixture)
+{
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_program);
+	BOOST_REQUIRE(metric != nullptr);
+
+	auto programSizeMetric = dynamic_cast<ProgramSize*>(metric.get());
+	BOOST_REQUIRE(programSizeMetric != nullptr);
+	BOOST_TEST(toString(programSizeMetric->program()) == toString(m_program));
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_respect_chromosome_repetitions_option, FitnessMetricFactoryFixture)
+{
+	m_options.chromosomeRepetitions = 5;
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_program);
+	BOOST_REQUIRE(metric != nullptr);
+
+	auto programSizeMetric = dynamic_cast<ProgramSize*>(metric.get());
+	BOOST_REQUIRE(programSizeMetric != nullptr);
+	BOOST_TEST(programSizeMetric->repetitionCount() == m_options.chromosomeRepetitions);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE(PopulationFactoryTest)
+
+BOOST_FIXTURE_TEST_CASE(build_should_create_an_empty_population_if_no_specific_options_given, PoulationFactoryFixture)
+{
+	m_options.population = {};
+	m_options.randomPopulation = {};
+	m_options.populationFromFile = {};
+	BOOST_TEST(
+		PopulationFactory::build(m_options, m_fitnessMetric) ==
+		Population(m_fitnessMetric, vector<Chromosome>{})
+	);
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_respect_population_option, PoulationFactoryFixture)
+{
+	m_options.population = {"a", "afc", "xadd"};
+	BOOST_TEST(
+		PopulationFactory::build(m_options, m_fitnessMetric) ==
+		Population(m_fitnessMetric, {Chromosome("a"), Chromosome("afc"), Chromosome("xadd")})
+	);
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_respect_random_population_option, PoulationFactoryFixture)
+{
+	m_options.randomPopulation = {5, 3, 2};
+	m_options.minChromosomeLength = 5;
+	m_options.maxChromosomeLength = 10;
+
+	auto population = PopulationFactory::build(m_options, m_fitnessMetric);
+
+	BOOST_TEST(population.individuals().size() == 10);
+	BOOST_TEST(all_of(
+		population.individuals().begin(),
+		population.individuals().end(),
+		[](auto const& individual){ return 5 <= individual.chromosome.length() && individual.chromosome.length() <= 10; }
+	));
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_respect_population_from_file_option, PoulationFactoryFixture)
+{
+	map<string, vector<string>> fileContent = {
+		{"a.txt", {"a", "fff", "", "jxccLTa"}},
+		{"b.txt", {}},
+		{"c.txt", {""}},
+		{"d.txt", {"c", "T"}},
+	};
+
+	TemporaryDirectory tempDir;
+	for (auto const& [fileName, chromosomes]: fileContent)
+	{
+		ofstream tmpFile(tempDir.memberPath(fileName));
+		for (auto const& chromosome: chromosomes)
+			tmpFile << chromosome << endl;
+
+		m_options.populationFromFile.push_back(tempDir.memberPath(fileName));
+	}
+
+	BOOST_TEST(
+		PopulationFactory::build(m_options, m_fitnessMetric) ==
+		Population(m_fitnessMetric, {
+			Chromosome("a"),
+			Chromosome("fff"),
+			Chromosome(""),
+			Chromosome("jxccLTa"),
+			Chromosome(""),
+			Chromosome("c"),
+			Chromosome("T"),
+		})
+	);
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_throw_FileOpenError_if_population_file_does_not_exist, PoulationFactoryFixture)
+{
+	m_options.populationFromFile = {"a-file-that-does-not-exist.abcdefgh"};
+	assert(!fs::exists(m_options.populationFromFile[0]));
+
+	BOOST_CHECK_THROW(PopulationFactory::build(m_options, m_fitnessMetric), FileOpenError);
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_combine_populations_from_all_sources, PoulationFactoryFixture)
+{
+	TemporaryDirectory tempDir;
+	{
+		ofstream tmpFile(tempDir.memberPath("population.txt"));
+		tmpFile << "axc" << endl << "fcL" << endl;
+	}
+
+	m_options.population = {"axc", "fcL"};
+	m_options.randomPopulation = {2};
+	m_options.populationFromFile = {tempDir.memberPath("population.txt")};
+	m_options.minChromosomeLength = 3;
+	m_options.maxChromosomeLength = 3;
+
+	auto population = PopulationFactory::build(m_options, m_fitnessMetric);
+
+	auto begin = population.individuals().begin();
+	auto end = population.individuals().end();
+	BOOST_TEST(population.individuals().size() == 6);
+	BOOST_TEST(all_of(begin, end, [](auto const& individual){ return individual.chromosome.length() == 3; }));
+	BOOST_TEST(count(begin, end, Individual(Chromosome("axc"), *m_fitnessMetric)) >= 2);
+	BOOST_TEST(count(begin, end, Individual(Chromosome("fcL"), *m_fitnessMetric)) >= 2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE(ProgramFactoryTest)
+
+BOOST_AUTO_TEST_CASE(build_should_load_program_from_file)
+{
+	TemporaryDirectory tempDir;
+	{
+		ofstream tmpFile(tempDir.memberPath("program.yul"));
+		tmpFile << "{}" << endl;
+	}
+
+	ProgramFactory::Options options{/* inputFile = */ tempDir.memberPath("program.yul")};
+	CharStream expectedProgramSource("{}", "");
+
+	auto program = ProgramFactory::build(options);
+
+	BOOST_TEST(toString(program) == toString(get<Program>(Program::load(expectedProgramSource))));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/TestHelpers.cpp
+++ b/test/yulPhaser/TestHelpers.cpp
@@ -19,12 +19,18 @@
 
 #include <libyul/optimiser/Suite.h>
 
+#include <boost/filesystem.hpp>
+
 #include <regex>
+#include <iostream>
 
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::phaser;
+using namespace solidity::phaser::test;
+
+namespace fs = boost::filesystem;
 
 function<Mutation> phaser::test::wholeChromosomeReplacement(Chromosome _newChromosome)
 {
@@ -69,6 +75,40 @@ size_t phaser::test::countDifferences(Chromosome const& _chromosome1, Chromosome
 		count += static_cast<int>(_chromosome1.optimisationSteps()[i] != _chromosome2.optimisationSteps()[i]);
 
 	return count + abs(static_cast<int>(_chromosome1.length() - _chromosome2.length()));
+}
+
+TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
+	m_path((fs::temp_directory_path() / fs::unique_path(_prefix + "%%%%-%%%%-%%%%-%%%%")).string())
+{
+	// Prefix should just be a file name and not contain anything that would make us step out of /tmp.
+	assert(fs::path(_prefix) == fs::path(_prefix).stem());
+
+	fs::create_directory(m_path);
+}
+
+TemporaryDirectory::~TemporaryDirectory()
+{
+	// A few paranoid sanity checks just to be extra sure we're not deleting someone's homework.
+	assert(m_path.find(fs::temp_directory_path().string()) == 0);
+	assert(fs::path(m_path) != fs::temp_directory_path());
+	assert(fs::path(m_path) != fs::path(m_path).root_path());
+	assert(!fs::path(m_path).empty());
+
+	boost::system::error_code errorCode;
+	uintmax_t numRemoved = fs::remove_all(m_path, errorCode);
+	if (errorCode.value() != boost::system::errc::success)
+	{
+		cerr << "Failed to completely remove temporary directory '" << m_path << "'. ";
+		cerr << "Only " << numRemoved << " files were actually removed." << endl;
+		cerr << "Reason: " << errorCode.message() << endl;
+	}
+}
+
+string TemporaryDirectory::memberPath(string const& _relativePath) const
+{
+	assert(fs::path(_relativePath).is_relative());
+
+	return (fs::path(m_path) / _relativePath).string();
 }
 
 string phaser::test::stripWhitespace(string const& input)

--- a/test/yulPhaser/TestHelpers.h
+++ b/test/yulPhaser/TestHelpers.h
@@ -79,6 +79,31 @@ size_t countDifferences(Chromosome const& _chromosome1, Chromosome const& _chrom
 /// integers.
 std::map<std::string, size_t> enumerateOptmisationSteps();
 
+// FILESYSTEM UTILITIES
+
+/**
+ * An object that creates a unique temporary directory and automatically deletes it and its
+ * content upon being destroyed.
+ *
+ * The directory is guaranteed to be newly created and empty. Directory names are generated
+ * randomly. If a directory with the same name already exists (very unlikely but possible) the
+ * object won't reuse it and will fail with an exception instead.
+ */
+class TemporaryDirectory
+{
+public:
+	TemporaryDirectory(std::string const& _prefix = "yul-phaser-test-");
+	~TemporaryDirectory();
+
+	std::string const& path() const { return m_path; }
+
+	/// Converts a path relative to the directory held by the object into an absolute one.
+	std::string memberPath(std::string const& _relativePath) const;
+
+private:
+	std::string m_path;
+};
+
 // STRING UTILITIES
 
 /// Returns the input string with all the whitespace characters (spaces, line endings, etc.) removed.

--- a/test/yulPhaser/TestHelpersTest.cpp
+++ b/test/yulPhaser/TestHelpersTest.cpp
@@ -19,13 +19,17 @@
 
 #include <libyul/optimiser/Suite.h>
 
+#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <fstream>
 #include <set>
 
 using namespace std;
 using namespace solidity::yul;
 using namespace boost::test_tools;
+
+namespace fs = boost::filesystem;
 
 namespace solidity::phaser::test
 {
@@ -112,6 +116,63 @@ BOOST_AUTO_TEST_CASE(enumerateOptimisationSteps_should_assing_indices_to_all_ava
 
 		stepsSoFar.insert(name);
 	}
+}
+
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_create_and_delete_a_unique_and_empty_directory)
+{
+	fs::path dirPath;
+	{
+		TemporaryDirectory tempDir("temporary-directory-test-");
+		dirPath = tempDir.path();
+
+		BOOST_TEST(dirPath.stem().string().find("temporary-directory-test-") == 0);
+		BOOST_TEST(fs::equivalent(dirPath.parent_path(), fs::temp_directory_path()));
+		BOOST_TEST(fs::is_directory(dirPath));
+		BOOST_TEST(fs::is_empty(dirPath));
+	}
+	BOOST_TEST(!fs::exists(dirPath));
+}
+
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_empty)
+{
+	fs::path dirPath;
+	{
+		TemporaryDirectory tempDir("temporary-directory-test-");
+		dirPath = tempDir.path();
+
+		BOOST_TEST(fs::is_directory(dirPath));
+
+		{
+			ofstream tmpFile((dirPath / "test-file.txt").string());
+			tmpFile << "Delete me!" << endl;
+		}
+		assert(fs::is_regular_file(dirPath / "test-file.txt"));
+	}
+	BOOST_TEST(!fs::exists(dirPath / "test-file.txt"));
+}
+
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_memberPath_should_construct_paths_relative_to_the_temporary_directory)
+{
+	TemporaryDirectory tempDir("temporary-directory-test-");
+
+	BOOST_TEST(fs::equivalent(tempDir.memberPath(""), tempDir.path()));
+	BOOST_TEST(fs::equivalent(tempDir.memberPath("."), tempDir.path() / fs::path(".")));
+	BOOST_TEST(fs::equivalent(tempDir.memberPath(".."), tempDir.path() / fs::path("..")));
+
+	// NOTE: fs::equivalent() only works with paths that actually exist
+	{
+		ofstream file;
+		file.open(tempDir.memberPath("file.txt"), ios::out);
+	}
+	BOOST_TEST(fs::equivalent(tempDir.memberPath("file.txt"), tempDir.path() / fs::path("file.txt")));
+
+	{
+		fs::create_directories(tempDir.memberPath("a/b/"));
+
+		ofstream file;
+		file.open(tempDir.memberPath("a/b/file.txt"), ios::out);
+	}
+	BOOST_TEST(fs::equivalent(tempDir.memberPath("a/b/file.txt"), tempDir.path() / fs::path("a") / fs::path("b") / fs::path("file.txt")));
 }
 
 BOOST_AUTO_TEST_CASE(stripWhitespace_should_remove_all_whitespace_characters_from_a_string)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,6 +16,7 @@ install(TARGETS solidity-upgrade DESTINATION "${CMAKE_INSTALL_BINDIR}")
 add_executable(yul-phaser
 	yulPhaser/main.cpp
 	yulPhaser/Common.h
+	yulPhaser/Common.cpp
 	yulPhaser/AlgorithmRunner.h
 	yulPhaser/AlgorithmRunner.cpp
 	yulPhaser/Phaser.h

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -35,6 +35,7 @@ void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 	for (size_t round = 0; !m_options.maxRounds.has_value() || round < m_options.maxRounds.value(); ++round)
 	{
 		m_population = _algorithm.runNextRound(m_population);
+		randomiseDuplicates();
 
 		m_outputStream << "---------- ROUND " << round + 1 << " ----------" << endl;
 		m_outputStream << m_population;
@@ -62,5 +63,43 @@ void AlgorithmRunner::populationAutosave() const
 		!outputStream.bad(),
 		FileWriteError,
 		"Error while writing to file '" + m_options.populationAutosaveFile.value() + "': " + strerror(errno)
+	);
+}
+
+void AlgorithmRunner::randomiseDuplicates()
+{
+	if (m_options.randomiseDuplicates)
+	{
+		assert(m_options.minChromosomeLength.has_value());
+		assert(m_options.maxChromosomeLength.has_value());
+
+		m_population = randomiseDuplicates(
+			m_population,
+			m_options.minChromosomeLength.value(),
+			m_options.maxChromosomeLength.value()
+		);
+	}
+}
+
+Population AlgorithmRunner::randomiseDuplicates(
+	Population _population,
+	size_t _minChromosomeLength,
+	size_t _maxChromosomeLength
+)
+{
+	if (_population.individuals().size() == 0)
+		return _population;
+
+	vector<Chromosome> chromosomes{_population.individuals()[0].chromosome};
+	size_t duplicateCount = 0;
+	for (size_t i = 1; i < _population.individuals().size(); ++i)
+		if (_population.individuals()[i].chromosome == _population.individuals()[i - 1].chromosome)
+			++duplicateCount;
+		else
+			chromosomes.push_back(_population.individuals()[i].chromosome);
+
+	return (
+		Population(_population.fitnessMetric(), chromosomes) +
+		Population::makeRandom(_population.fitnessMetric(), duplicateCount, _minChromosomeLength, _maxChromosomeLength)
 	);
 }

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -43,6 +43,9 @@ public:
 	{
 		std::optional<size_t> maxRounds = std::nullopt;
 		std::optional<std::string> populationAutosaveFile = std::nullopt;
+		bool randomiseDuplicates = false;
+		std::optional<size_t> minChromosomeLength = std::nullopt;
+		std::optional<size_t> maxChromosomeLength = std::nullopt;
 	};
 
 	AlgorithmRunner(
@@ -61,6 +64,12 @@ public:
 
 private:
 	void populationAutosave() const;
+	void randomiseDuplicates();
+	static Population randomiseDuplicates(
+		Population _population,
+		size_t _minChromosomeLength,
+		size_t _maxChromosomeLength
+	);
 
 	Population m_population;
 	Options m_options;

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -42,6 +42,7 @@ public:
 	struct Options
 	{
 		std::optional<size_t> maxRounds = std::nullopt;
+		std::optional<std::string> populationAutosaveFile = std::nullopt;
 	};
 
 	AlgorithmRunner(
@@ -59,6 +60,8 @@ public:
 	Population const& population() const { return m_population; }
 
 private:
+	void populationAutosave() const;
+
 	Population m_population;
 	Options m_options;
 	std::ostream& m_outputStream;

--- a/tools/yulPhaser/Common.cpp
+++ b/tools/yulPhaser/Common.cpp
@@ -1,0 +1,45 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <tools/yulPhaser/Common.h>
+
+#include <tools/yulPhaser/Exceptions.h>
+
+#include <libsolutil/Assertions.h>
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::phaser;
+
+vector<string> phaser::readLinesFromFile(string const& _path)
+{
+	ifstream inputStream(_path);
+	assertThrow(inputStream.is_open(), FileOpenError, "Could not open file '" + _path + "': " + strerror(errno));
+
+	string line;
+	vector<string> lines;
+	while (!getline(inputStream, line).fail())
+		lines.push_back(line);
+
+	assertThrow(!inputStream.bad(), FileReadError, "Error while reading from file '" + _path + "': " + strerror(errno));
+
+	return lines;
+}

--- a/tools/yulPhaser/Common.h
+++ b/tools/yulPhaser/Common.h
@@ -22,9 +22,18 @@
 
 #include <iostream>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace solidity::phaser
 {
+
+/// Loads the whole file into memory, splits the content into lines, strips newlines and
+/// returns the result as a list of strings.
+///
+/// Throws FileOpenError if the file does not exist or cannot be opened for reading.
+/// Throws FileReadError if any read operation fails during the whole process.
+std::vector<std::string> readLinesFromFile(std::string const& _path);
 
 /// Reads a token from the input stream and translates it to a string using a map.
 /// Sets the failbit in the stream if there's no matching value in the map.

--- a/tools/yulPhaser/Exceptions.h
+++ b/tools/yulPhaser/Exceptions.h
@@ -27,4 +27,7 @@ struct InvalidProgram: virtual BadInput {};
 struct NoInputFiles: virtual BadInput {};
 struct MissingFile: virtual BadInput {};
 
+struct FileOpenError: virtual util::Exception {};
+struct FileReadError: virtual util::Exception {};
+
 }

--- a/tools/yulPhaser/Exceptions.h
+++ b/tools/yulPhaser/Exceptions.h
@@ -29,5 +29,6 @@ struct MissingFile: virtual BadInput {};
 
 struct FileOpenError: virtual util::Exception {};
 struct FileReadError: virtual util::Exception {};
+struct FileWriteError: virtual util::Exception {};
 
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -57,6 +57,9 @@ public:
 		m_program(std::move(_program)),
 		m_repetitionCount(_repetitionCount) {}
 
+	Program const& program() const { return m_program; }
+	size_t repetitionCount() const { return m_repetitionCount; }
+
 	size_t evaluate(Chromosome const& _chromosome) const override;
 
 private:

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -81,6 +81,8 @@ public:
 		assert(_options.isValid());
 	}
 
+	Options const& options() const { return m_options; }
+
 	Population runNextRound(Population _population) override;
 
 private:
@@ -128,6 +130,8 @@ public:
 	{
 		assert(_options.isValid());
 	}
+
+	Options const& options() const { return m_options; }
 
 	Population runNextRound(Population _population) override;
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -438,6 +438,9 @@ AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map c
 	return {
 		_arguments.count("rounds") > 0 ? static_cast<optional<size_t>>(_arguments["rounds"].as<size_t>()) : nullopt,
 		_arguments.count("population-autosave") > 0 ? static_cast<optional<string>>(_arguments["population-autosave"].as<string>()) : nullopt,
+		false,
+		nullopt,
+		nullopt,
 	};
 }
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -295,6 +295,13 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			"Algorithm"
 		)
 		(
+			"no-randomise-duplicates",
+			po::bool_switch(),
+			"By default, after each round of the algorithm duplicate chromosomes are removed from"
+			"the population and replaced with randomly generated ones. "
+			"This option disables this postprocessing."
+		)
+		(
 			"min-chromosome-length",
 			po::value<size_t>()->value_name("<NUM>")->default_value(12),
 			"Minimum length of randomly generated chromosomes."
@@ -438,9 +445,9 @@ AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map c
 	return {
 		_arguments.count("rounds") > 0 ? static_cast<optional<size_t>>(_arguments["rounds"].as<size_t>()) : nullopt,
 		_arguments.count("population-autosave") > 0 ? static_cast<optional<string>>(_arguments["population-autosave"].as<string>()) : nullopt,
-		false,
-		nullopt,
-		nullopt,
+		!_arguments["no-randomise-duplicates"].as<bool>(),
+		_arguments["min-chromosome-length"].as<size_t>(),
+		_arguments["max-chromosome-length"].as<size_t>(),
 	};
 }
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -120,6 +120,9 @@ PopulationFactory::Options PopulationFactory::Options::fromCommandLine(po::varia
 		_arguments.count("random-population") > 0 ?
 			_arguments["random-population"].as<vector<size_t>>() :
 			vector<size_t>{},
+		_arguments.count("population-from-file") > 0 ?
+			_arguments["population-from-file"].as<vector<string>>() :
+			vector<string>{},
 	};
 }
 
@@ -138,6 +141,9 @@ Population PopulationFactory::build(
 		combinedSize,
 		_fitnessMetric
 	);
+
+	for (string const& populationFilePath: _options.populationFromFile)
+		population = move(population) + buildFromFile(populationFilePath, _fitnessMetric);
 
 	return population;
 }
@@ -165,6 +171,14 @@ Population PopulationFactory::buildRandom(
 		MinChromosomeLength,
 		MaxChromosomeLength
 	);
+}
+
+Population PopulationFactory::buildFromFile(
+	string const& _filePath,
+	shared_ptr<FitnessMetric> _fitnessMetric
+)
+{
+	return buildFromStrings(readLinesFromFile(_filePath), move(_fitnessMetric));
 }
 
 ProgramFactory::Options ProgramFactory::Options::fromCommandLine(po::variables_map const& _arguments)
@@ -260,6 +274,11 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			"random-population",
 			po::value<vector<size_t>>()->value_name("<SIZE>"),
 			"The number of randomly generated chromosomes to be included in the initial population."
+		)
+		(
+			"population-from-file",
+			po::value<vector<string>>()->value_name("<FILE>"),
+			"A text file with a list of chromosomes (one per line) to be included in the initial population."
 		)
 	;
 	keywordDescription.add(populationDescription);

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -280,6 +280,11 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			po::value<vector<string>>()->value_name("<FILE>"),
 			"A text file with a list of chromosomes (one per line) to be included in the initial population."
 		)
+		(
+			"population-autosave",
+			po::value<string>()->value_name("<FILE>"),
+			"If specified, the population is saved in the specified file after each round. (default=autosave disabled)"
+		)
 	;
 	keywordDescription.add(populationDescription);
 
@@ -337,7 +342,8 @@ void Phaser::initialiseRNG(po::variables_map const& _arguments)
 AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map const& _arguments)
 {
 	return {
-		_arguments.count("rounds") > 0 ? static_cast<optional<size_t>>(_arguments["rounds"].as<size_t>()) : nullopt
+		_arguments.count("rounds") > 0 ? static_cast<optional<size_t>>(_arguments["rounds"].as<size_t>()) : nullopt,
+		_arguments.count("population-autosave") > 0 ? static_cast<optional<string>>(_arguments["population-autosave"].as<string>()) : nullopt,
 	};
 }
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -185,6 +185,11 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 		("help", "Show help message and exit.")
 		("input-file", po::value<string>()->required()->value_name("<PATH>"), "Input file.")
 		("seed", po::value<uint32_t>()->value_name("<NUM>"), "Seed for the random number generator.")
+		(
+			"rounds",
+			po::value<size_t>()->value_name("<NUM>"),
+			"The number of rounds after which the algorithm should stop. (default=no limit)."
+		)
 	;
 	keywordDescription.add(generalDescription);
 
@@ -249,6 +254,13 @@ void Phaser::initialiseRNG(po::variables_map const& _arguments)
 	cout << "Random seed: " << seed << endl;
 }
 
+AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map const& _arguments)
+{
+	return {
+		_arguments.count("rounds") > 0 ? static_cast<optional<size_t>>(_arguments["rounds"].as<size_t>()) : nullopt
+	};
+}
+
 void Phaser::runAlgorithm(po::variables_map const& _arguments)
 {
 	auto programOptions = ProgramFactory::Options::fromCommandLine(_arguments);
@@ -266,6 +278,6 @@ void Phaser::runAlgorithm(po::variables_map const& _arguments)
 		PopulationFactory::MaxChromosomeLength
 	);
 
-	AlgorithmRunner algorithmRunner(population, AlgorithmRunner::Options{}, cout);
+	AlgorithmRunner algorithmRunner(population, buildAlgorithmRunnerOptions(_arguments), cout);
 	algorithmRunner.run(*geneticAlgorithm);
 }

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <tools/yulPhaser/AlgorithmRunner.h>
+
 #include <boost/program_options.hpp>
 
 #include <istream>
@@ -147,6 +149,7 @@ private:
 	static CommandLineDescription buildCommandLineDescription();
 	static std::optional<boost::program_options::variables_map> parseCommandLine(int _argc, char** _argv);
 	static void initialiseRNG(boost::program_options::variables_map const& _arguments);
+	static AlgorithmRunner::Options buildAlgorithmRunnerOptions(boost::program_options::variables_map const& _arguments);
 
 	static void runAlgorithm(boost::program_options::variables_map const& _arguments);
 };

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -106,6 +106,7 @@ public:
 
 	struct Options
 	{
+		std::vector<std::string> population;
 		std::vector<size_t> randomPopulation;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
@@ -113,6 +114,10 @@ public:
 
 	static Population build(
 		Options const& _options,
+		std::shared_ptr<FitnessMetric> _fitnessMetric
+	);
+	static Population buildFromStrings(
+		std::vector<std::string> const& _geneSequences,
 		std::shared_ptr<FitnessMetric> _fitnessMetric
 	);
 	static Population buildRandom(

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -108,6 +108,7 @@ public:
 	{
 		std::vector<std::string> population;
 		std::vector<size_t> randomPopulation;
+		std::vector<std::string> populationFromFile;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
 	};
@@ -122,6 +123,10 @@ public:
 	);
 	static Population buildRandom(
 		size_t _populationSize,
+		std::shared_ptr<FitnessMetric> _fitnessMetric
+	);
+	static Population buildFromFile(
+		std::string const& _filePath,
 		std::shared_ptr<FitnessMetric> _fitnessMetric
 	);
 };

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -101,11 +101,22 @@ public:
 class PopulationFactory
 {
 public:
-	static constexpr size_t PopulationSize = 20;
 	static constexpr size_t MinChromosomeLength = 12;
 	static constexpr size_t MaxChromosomeLength = 30;
 
+	struct Options
+	{
+		std::vector<size_t> randomPopulation;
+
+		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
+	};
+
 	static Population build(
+		Options const& _options,
+		std::shared_ptr<FitnessMetric> _fitnessMetric
+	);
+	static Population buildRandom(
+		size_t _populationSize,
 		std::shared_ptr<FitnessMetric> _fitnessMetric
 	);
 };

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -64,15 +64,15 @@ public:
 	struct Options
 	{
 		Algorithm algorithm;
+		size_t minChromosomeLength;
+		size_t maxChromosomeLength;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
 	};
 
 	static std::unique_ptr<GeneticAlgorithm> build(
 		Options const& _options,
-		size_t _populationSize,
-		size_t _minChromosomeLength,
-		size_t _maxChromosomeLength
+		size_t _populationSize
 	);
 };
 
@@ -101,11 +101,10 @@ public:
 class PopulationFactory
 {
 public:
-	static constexpr size_t MinChromosomeLength = 12;
-	static constexpr size_t MaxChromosomeLength = 30;
-
 	struct Options
 	{
+		size_t minChromosomeLength;
+		size_t maxChromosomeLength;
 		std::vector<std::string> population;
 		std::vector<size_t> randomPopulation;
 		std::vector<std::string> populationFromFile;
@@ -123,6 +122,8 @@ public:
 	);
 	static Population buildRandom(
 		size_t _populationSize,
+		size_t _minChromosomeLength,
+		size_t _maxChromosomeLength,
 		std::shared_ptr<FitnessMetric> _fitnessMetric
 	);
 	static Population buildFromFile(

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -66,6 +66,13 @@ public:
 		Algorithm algorithm;
 		size_t minChromosomeLength;
 		size_t maxChromosomeLength;
+		std::optional<double> randomElitePoolSize;
+		double gewepMutationPoolSize;
+		double gewepCrossoverPoolSize;
+		double gewepRandomisationChance;
+		double gewepDeletionVsAdditionChance;
+		std::optional<double> gewepGenesToRandomise;
+		std::optional<double> gewepGenesToAddOrDelete;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
 	};

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -80,9 +80,15 @@ public:
 class FitnessMetricFactory
 {
 public:
-	static constexpr size_t RepetitionCount = 5;
+	struct Options
+	{
+		size_t chromosomeRepetitions;
+
+		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
+	};
 
 	static std::unique_ptr<FitnessMetric> build(
+		Options const& _options,
 		Program _program
 	);
 };


### PR DESCRIPTION
### Description
The tenth pull request implementing #7806. Depends on #8422.

This pull request adds a bunch of command-line options for constructing the population and configuring the algorithm:
- `--population`, `--random-population` and `--population-from-file` can be used together in any combination to add chromosomes to the initial population. Chromosomes can be specified on the command line (e. g. `--population afx LLcj ac`), generated randomly (e. g.`--random-population 20`) or loaded from a text file with one chromosome per line (e.g. `--population-from-file population.txt`). The initial population is now empty by default (rather than hard-coded to 20 random chromosomes) so using one of these options is mandatory.
- `--population-autosave`: saves the population to a file at the beginning of the program and after each round. The file has the same format as the one expected by `--population-from-file`. This allows restarting from the last known population state after stopping the application with Ctrl+C.
- `--min-chromosome-length` and `--max-chromosome-length` control the length of chromosomes randomly generated in various situations (in algorithms, in `--random-population`, in duplicate randomisation, etc.).
- `--chromosome-repetitions` specifies how many times the sequence should be repeated when computing metric values.
- `--rounds` specifies the number of rounds after which the algorithm should stop. By default there's no limit. Zero is useful when you want to load a population from file and have some information about it printed without actually running the algorithm. The extra output options added in one of the subsequent PRs are especially useful for that.
- Duplicate chromosomes in the population produced after a round of an algorithm are now automatically replaced with random ones. This can be disabled with `--no-randomise-duplicates`.
- All the algorithm-specific parameters have corresponding command-line options now.

### Example invocation
Minimal:
``` bash
tools/yul-phaser           \
    --random-population 20 \
    ../test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
```

With full range of options:
``` bash
echo "CfxCIiOglTiscTrvtuaxiciCcUMcl" > /tmp/population.txt
tools/yul-phaser                                                                                                                                             \
    --seed                              1                                                                                                                    \
    --population                        eamxfijlcTgisvtxMciCcUl exMaicisfcl IaficTrxuivjVsexmuOisgitafruxcujjVcu                                             \
    --population                        dhfoDgvulfnTUtnIfxarrscLMcCTUtTOntnfDIulLculVculjjeulxarulrulxarrcLgvifCTUcarrLsTOtfDncarrIulcjmuljuljulVcTOculjmul  \
    --random-population                 15                                                                                                                   \
    --population-from-file              /tmp/population.txt                                                                                                  \
    --population-autosave               /tmp/population.txt                                                                                                  \
    --min-chromosome-length             12                                                                                                                   \
    --max-chromosome-length             30                                                                                                                   \
    --chromosome-repetitions            2                                                                                                                    \
    --algorithm                         GEWEP                                                                                                                \
    --gewep-mutation-pool-size          0.25                                                                                                                 \
    --gewep-crossover-pool-size         0.25                                                                                                                 \
    --gewep-randomisation-chance        0.5                                                                                                                  \
    --gewep-deletion-vs-addition-chance 0.5                                                                                                                  \
    --gewep-genes-to-randomise          0.05                                                                                                                 \
    --gewep-genes-to-add-or-delete      0.05                                                                                                                 \
    --rounds                            1000                                                                                                                 \
    --no-randomise-duplicates                                                                                                                                \
    ../test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul
```

### Dependencies
This PR is based on #8422. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages