### PR TITLE
OptimiserSuite::runSequence() overload for step abbreviations

### DIFF
--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -93,161 +93,30 @@ void OptimiserSuite::run(
 
 	OptimiserSuite suite(_dialect, reservedIdentifiers, Debug::None, ast);
 
-	suite.runSequence({
-		VarDeclInitializer::name,
-		FunctionHoister::name,
-		BlockFlattener::name,
-		ForLoopInitRewriter::name,
-		DeadCodeEliminator::name,
-		FunctionGrouper::name,
-		EquivalentFunctionCombiner::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-		BlockFlattener::name,
-		ControlFlowSimplifier::name,
-		LiteralRematerialiser::name,
-		ConditionalUnsimplifier::name,
-		StructuralSimplifier::name,
-		ControlFlowSimplifier::name,
-		ForLoopConditionIntoBody::name,
-		BlockFlattener::name
-	}, ast);
+	suite.runSequence(
+		"dhfoDgvulfnTUtnIf"            // None of these can make stack problems worse
+		"("
+			"xarrscLM"                 // Turn into SSA and simplify
+			"cCTUtTOntnfDIul"          // Perform structural simplification
+			"Lcul"                     // Simplify again
+			"Vcul jj"                  // Reverse SSA
 
-	// None of the above can make stack problems worse.
+			// should have good "compilability" property here.
 
-	suite.runSequenceUntilStable({
-		// Turn into SSA and simplify
-		ExpressionSplitter::name,
-		SSATransform::name,
-		RedundantAssignEliminator::name,
-		RedundantAssignEliminator::name,
-		ExpressionSimplifier::name,
-		CommonSubexpressionEliminator::name,
-		LoadResolver::name,
-		LoopInvariantCodeMotion::name,
-
-		// perform structural simplification
-		CommonSubexpressionEliminator::name,
-		ConditionalSimplifier::name,
-		LiteralRematerialiser::name,
-		ConditionalUnsimplifier::name,
-		StructuralSimplifier::name,
-		LiteralRematerialiser::name,
-		ForLoopConditionOutOfBody::name,
-		ControlFlowSimplifier::name,
-		StructuralSimplifier::name,
-		ControlFlowSimplifier::name,
-		BlockFlattener::name,
-		DeadCodeEliminator::name,
-		ForLoopConditionIntoBody::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		// simplify again
-		LoadResolver::name,
-		CommonSubexpressionEliminator::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		// reverse SSA
-		SSAReverser::name,
-		CommonSubexpressionEliminator::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		ExpressionJoiner::name,
-		ExpressionJoiner::name,
-
-		// should have good "compilability" property here.
-
-		// run functional expression inliner
-		ExpressionInliner::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		// Prune a bit more in SSA
-		ExpressionSplitter::name,
-		SSATransform::name,
-		RedundantAssignEliminator::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-		RedundantAssignEliminator::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		// Turn into SSA again and simplify
-		ExpressionSplitter::name,
-		SSATransform::name,
-		RedundantAssignEliminator::name,
-		RedundantAssignEliminator::name,
-		CommonSubexpressionEliminator::name,
-		LoadResolver::name,
-
-		// run full inliner
-		FunctionGrouper::name,
-		EquivalentFunctionCombiner::name,
-		FullInliner::name,
-		BlockFlattener::name,
-
-		// SSA plus simplify
-		ConditionalSimplifier::name,
-		LiteralRematerialiser::name,
-		ConditionalUnsimplifier::name,
-		CommonSubexpressionEliminator::name,
-		SSATransform::name,
-		RedundantAssignEliminator::name,
-		RedundantAssignEliminator::name,
-		LoadResolver::name,
-		ExpressionSimplifier::name,
-		LiteralRematerialiser::name,
-		ForLoopConditionOutOfBody::name,
-		StructuralSimplifier::name,
-		BlockFlattener::name,
-		DeadCodeEliminator::name,
-		ControlFlowSimplifier::name,
-		CommonSubexpressionEliminator::name,
-		SSATransform::name,
-		RedundantAssignEliminator::name,
-		RedundantAssignEliminator::name,
-		ForLoopConditionIntoBody::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-		CommonSubexpressionEliminator::name,
-	}, ast);
-
-	// Make source short and pretty.
-
-	suite.runSequence({
-		ExpressionJoiner::name,
-		Rematerialiser::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-		ExpressionJoiner::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-		ExpressionJoiner::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		SSAReverser::name,
-		CommonSubexpressionEliminator::name,
-		LiteralRematerialiser::name,
-		ForLoopConditionOutOfBody::name,
-		CommonSubexpressionEliminator::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-
-		ExpressionJoiner::name,
-		Rematerialiser::name,
-		UnusedPruner::name,
-		CircularReferencesPruner::name,
-	}, ast);
+			"eul"                      // Run functional expression inliner
+			"xarulrul"                 // Prune a bit more in SSA
+			"xarrcL"                   // Turn into SSA again and simplify
+			"gvif"                     // Run full inliner
+			"CTUcarrLsTOtfDncarrIulc"  // SSA plus simplify
+		")"
+		"jmuljuljul VcTOcul jmul",     // Make source short and pretty
+		ast
+	);
 
 	// This is a tuning parameter, but actually just prevents infinite loops.
 	size_t stackCompressorMaxIterations = 16;
-	suite.runSequence(vector<string>{
-		FunctionGrouper::name,
-	}, ast);
+	suite.runSequence("g", ast);
+
 	// We ignore the return value because we will get a much better error
 	// message once we perform code generation.
 	StackCompressor::run(
@@ -256,16 +125,7 @@ void OptimiserSuite::run(
 		_optimizeStackAllocation,
 		stackCompressorMaxIterations
 	);
-	suite.runSequence({
-		BlockFlattener::name,
-		DeadCodeEliminator::name,
-		ControlFlowSimplifier::name,
-		LiteralRematerialiser::name,
-		ForLoopConditionOutOfBody::name,
-		CommonSubexpressionEliminator::name,
-
-		FunctionGrouper::name,
-	}, ast);
+	suite.runSequence("fDnTOc g", ast);
 
 	if (EVMDialect const* dialect = dynamic_cast<EVMDialect const*>(&_dialect))
 	{

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -62,6 +62,7 @@ public:
 	);
 
 	void runSequence(std::vector<std::string> const& _steps, Block& _ast);
+	void runSequence(std::string const& _stepAbbreviations, Block& _ast);
 	void runSequenceUntilStable(
 		std::vector<std::string> const& _steps,
 		Block& _ast,

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -45,6 +45,8 @@ struct Object;
 class OptimiserSuite
 {
 public:
+	static constexpr size_t MaxRounds = 12;
+
 	enum class Debug
 	{
 		None,
@@ -60,6 +62,11 @@ public:
 	);
 
 	void runSequence(std::vector<std::string> const& _steps, Block& _ast);
+	void runSequenceUntilStable(
+		std::vector<std::string> const& _steps,
+		Block& _ast,
+		size_t maxRounds = MaxRounds
+	);
 
 	static std::map<std::string, std::unique_ptr<OptimiserStep>> const& allSteps();
 	static std::map<std::string, char> const& stepNameToAbbreviationMap();


### PR DESCRIPTION
### Description
This PR is related to #7806 but is independent from the other `yul-phaser` PRs and based directly on `develop`.

The PR modifies `OptimiserSuite` to allow executing optimisation steps specified using abbreviation strings produced by `yul-phaser`. The new function can also repeat parts wrapped in parentheses and ignores whitespace added for readability.

I don't expect it to be merged as is. It's just a proposal that needs to be discussed first:
1. I have replaced the current sequence with an abbreviated one but this is unfortunately harder to decipher than full step names. I can easily remove that commit if we don't want that.
    - On the other hand the current sequence is going to be replaced by the one from `yul-phaser` in the future anyway so maybe having full names in it until then isn't such a big concern.
2. I could add any tests for newly added code because the public API of `OptimiserSuite` currently does not allow creating new instances. Only the `run()` method can create one but it never returns it.
    - We could try to test that `run()` itself executes the right steps but such a test would be very fragile and complex. It's not worth it in my opinion.
3. The function does not support nested parentheses since I don't think it such a feature would be useful in practice.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages