### PR TITLE
Control flow analysis for inline assembly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
  * Inline Assembly: Allow assigning to `_slot` of local storage variable pointers.
  * General: Deprecated `value(...)` and `gas(...)` in favor of `{value: ...}` and `{gas: ...}`
+ * Inline Assembly: Perform control flow analysis on inline assembly. Allows storage returns to be set in assembly only.
 
 
 Compiler Features:

--- a/libevmasm/SemanticInformation.cpp
+++ b/libevmasm/SemanticInformation.cpp
@@ -155,6 +155,26 @@ bool SemanticInformation::terminatesControlFlow(Instruction _instruction)
 	}
 }
 
+bool SemanticInformation::reverts(AssemblyItem const& _item)
+{
+	if (_item.type() != Operation)
+		return false;
+	else
+		return reverts(_item.instruction());
+}
+
+bool SemanticInformation::reverts(Instruction _instruction)
+{
+	switch (_instruction)
+	{
+		case Instruction::INVALID:
+		case Instruction::REVERT:
+			return true;
+		default:
+			return false;
+	}
+}
+
 bool SemanticInformation::isDeterministic(AssemblyItem const& _item)
 {
 	if (_item.type() != Operation)

--- a/libevmasm/SemanticInformation.h
+++ b/libevmasm/SemanticInformation.h
@@ -47,6 +47,8 @@ struct SemanticInformation
 	static bool altersControlFlow(AssemblyItem const& _item);
 	static bool terminatesControlFlow(AssemblyItem const& _item);
 	static bool terminatesControlFlow(Instruction _instruction);
+	static bool reverts(AssemblyItem const& _item);
+	static bool reverts(Instruction _instruction);
 	/// @returns false if the value put on the stack by _item depends on anything else than
 	/// the information in the current block header, memory, storage or stack.
 	static bool isDeterministic(AssemblyItem const& _item);

--- a/libsolidity/analysis/ControlFlowAnalyzer.h
+++ b/libsolidity/analysis/ControlFlowAnalyzer.h
@@ -36,9 +36,9 @@ public:
 private:
 	/// Checks for uninitialized variable accesses in the control flow between @param _entry and @param _exit.
 	void checkUninitializedAccess(CFGNode const* _entry, CFGNode const* _exit) const;
-	/// Checks for unreachable code, i.e. code ending in @param _exit or @param _revert
+	/// Checks for unreachable code, i.e. code ending in @param _exit, @param _revert or @param _transactionReturn
 	/// that can not be reached from @param _entry.
-	void checkUnreachable(CFGNode const* _entry, CFGNode const* _exit, CFGNode const* _revert) const;
+	void checkUnreachable(CFGNode const* _entry, CFGNode const* _exit, CFGNode const* _revert, CFGNode const* _transactionReturn) const;
 
 	CFG const& m_cfg;
 	langutil::ErrorReporter& m_errorReporter;

--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -20,6 +20,7 @@
 #include <libsolidity/analysis/ControlFlowGraph.h>
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/ast/ASTVisitor.h>
+#include <libyul/optimiser/ASTWalker.h>
 
 #include <array>
 #include <memory>
@@ -30,7 +31,7 @@ namespace solidity::frontend {
  * Modifiers are not yet applied to the functions. This is done in a second
  * step in the CFG class.
  */
-class ControlFlowBuilder: private ASTConstVisitor
+class ControlFlowBuilder: private ASTConstVisitor, private yul::ASTWalker
 {
 public:
 	static std::unique_ptr<FunctionFlow> createFunctionFlow(
@@ -39,7 +40,10 @@ public:
 	);
 
 private:
-	explicit ControlFlowBuilder(CFG::NodeContainer& _nodeContainer, FunctionFlow const& _functionFlow);
+	explicit ControlFlowBuilder(
+		CFG::NodeContainer& _nodeContainer,
+		FunctionFlow const& _functionFlow
+	);
 
 	// Visits for constructing the control flow.
 	bool visit(BinaryOperation const& _operation) override;
@@ -62,6 +66,17 @@ private:
 	// Visits for filling variable occurrences.
 	bool visit(FunctionTypeName const& _functionTypeName) override;
 	bool visit(InlineAssembly const& _inlineAssembly) override;
+	void visit(yul::Statement const& _statement) override;
+	void operator()(yul::If const& _if) override;
+	void operator()(yul::Switch const& _switch) override;
+	void operator()(yul::ForLoop const& _for) override;
+	void operator()(yul::Break const&) override;
+	void operator()(yul::Continue const&) override;
+	void operator()(yul::Identifier const& _identifier) override;
+	void operator()(yul::Assignment const& _assignment) override;
+	void operator()(yul::FunctionCall const& _functionCall) override;
+	void operator()(yul::FunctionDefinition const& _functionDefinition) override;
+	void operator()(yul::Leave const& _leave) override;
 	bool visit(VariableDeclaration const& _variableDeclaration) override;
 	bool visit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
 	bool visit(Identifier const& _identifier) override;
@@ -70,6 +85,9 @@ protected:
 	bool visitNode(ASTNode const&) override;
 
 private:
+	using ASTConstVisitor::visit;
+	using yul::ASTWalker::visit;
+	using yul::ASTWalker::operator();
 
 	/// Appends the control flow of @a _node to the current control flow.
 	void appendControlFlow(ASTNode const& _node);
@@ -136,6 +154,7 @@ private:
 	CFGNode* m_currentNode = nullptr;
 	CFGNode* m_returnNode = nullptr;
 	CFGNode* m_revertNode = nullptr;
+	CFGNode* m_transactionReturnNode = nullptr;
 
 	/// The current jump destination of break Statements.
 	CFGNode* m_breakJump = nullptr;
@@ -144,6 +163,8 @@ private:
 
 	CFGNode* m_placeholderEntry = nullptr;
 	CFGNode* m_placeholderExit = nullptr;
+
+	InlineAssembly const* m_inlineAssembly = nullptr;
 
 	/// Helper class that replaces the break and continue jump destinations for the
 	/// current scope and restores the originals at the end of the scope.

--- a/libsolidity/analysis/ControlFlowGraph.h
+++ b/libsolidity/analysis/ControlFlowGraph.h
@@ -20,6 +20,7 @@
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/ast/ASTVisitor.h>
 #include <liblangutil/ErrorReporter.h>
+#include <liblangutil/EVMVersion.h>
 #include <liblangutil/SourceLocation.h>
 
 #include <map>
@@ -33,8 +34,8 @@ namespace solidity::frontend
 /**
  * Occurrence of a variable in a block of control flow.
  * Stores the declaration of the referenced variable, the
- * kind of the occurrence and possibly the node at which
- * it occurred.
+ * kind of the occurrence and possibly the source location
+ * at which it occurred.
  */
 class VariableOccurrence
 {
@@ -47,7 +48,7 @@ public:
 		Assignment,
 		InlineAssembly
 	};
-	VariableOccurrence(VariableDeclaration const& _declaration, Kind _kind, ASTNode const* _occurrence):
+	VariableOccurrence(VariableDeclaration const& _declaration, Kind _kind, std::optional<langutil::SourceLocation> const& _occurrence = {}):
 		m_declaration(_declaration), m_occurrenceKind(_kind), m_occurrence(_occurrence)
 	{
 	}
@@ -57,8 +58,8 @@ public:
 	{
 		if (m_occurrence && _rhs.m_occurrence)
 		{
-			if (m_occurrence->id() < _rhs.m_occurrence->id()) return true;
-			if (_rhs.m_occurrence->id() < m_occurrence->id()) return false;
+			if (*m_occurrence < *_rhs.m_occurrence) return true;
+			if (*_rhs.m_occurrence < *m_occurrence) return false;
 		}
 		else if (_rhs.m_occurrence)
 			return true;
@@ -74,14 +75,14 @@ public:
 
 	VariableDeclaration const& declaration() const { return m_declaration; }
 	Kind kind() const { return m_occurrenceKind; };
-	ASTNode const* occurrence() const { return m_occurrence; }
+	std::optional<langutil::SourceLocation> const& occurrence() const { return m_occurrence; }
 private:
 	/// Declaration of the occurring variable.
 	VariableDeclaration const& m_declaration;
 	/// Kind of occurrence.
 	Kind m_occurrenceKind = Kind::Access;
-	/// AST node at which the variable occurred, if available (may be nullptr).
-	ASTNode const* m_occurrence = nullptr;
+	/// Source location at which the variable occurred, if available (may be nullptr).
+	std::optional<langutil::SourceLocation> m_occurrence;
 };
 
 /**
@@ -119,6 +120,10 @@ struct FunctionFlow
 	/// This node is empty does not have any exits, but may have multiple entries
 	/// (e.g. all assert, require, revert and throw statements).
 	CFGNode* revert = nullptr;
+	/// Transaction return node. Destination node for inline assembly "return" calls.
+	/// This node is empty and does not have any exits, but may have multiple entries
+	/// (e.g. all inline assembly return calls).
+	CFGNode* transactionReturn = nullptr;
 };
 
 class CFG: private ASTConstVisitor
@@ -140,7 +145,6 @@ public:
 		std::vector<std::unique_ptr<CFGNode>> m_nodes;
 	};
 private:
-
 	langutil::ErrorReporter& m_errorReporter;
 
 	/// Node container.

--- a/libyul/ControlFlowSideEffects.h
+++ b/libyul/ControlFlowSideEffects.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <set>
+
+namespace solidity::yul
+{
+
+/**
+ * Side effects of code related to control flow.
+ */
+struct ControlFlowSideEffects
+{
+	/// If true, this code terminates the control flow.
+	/// State may or may not be reverted as indicated by the ``reverts`` flag.
+	bool terminates = false;
+	/// If true, this code reverts all state changes in the transaction.
+	/// Whenever this is true, ``terminates`` has to be true as well.
+	bool reverts = false;
+};
+
+}

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -22,6 +22,7 @@
 
 #include <libyul/YulString.h>
 #include <libyul/SideEffects.h>
+#include <libyul/ControlFlowSideEffects.h>
 
 #include <boost/noncopyable.hpp>
 
@@ -42,6 +43,7 @@ struct BuiltinFunction
 	std::vector<Type> parameters;
 	std::vector<Type> returns;
 	SideEffects sideEffects;
+	ControlFlowSideEffects controlFlowSideEffects;
 	/// If true, this is the msize instruction.
 	bool isMSize = false;
 	/// If true, can only accept literals as arguments and they cannot be moved to variables.

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -52,6 +52,8 @@ pair<YulString, BuiltinFunctionForEVM> createEVMFunction(
 	f.parameters.resize(info.args);
 	f.returns.resize(info.ret);
 	f.sideEffects = EVMDialect::sideEffectsOfInstruction(_instruction);
+	f.controlFlowSideEffects.terminates = evmasm::SemanticInformation::terminatesControlFlow(_instruction);
+	f.controlFlowSideEffects.reverts = evmasm::SemanticInformation::reverts(_instruction);
 	f.isMSize = _instruction == evmasm::Instruction::MSIZE;
 	f.literalArguments = false;
 	f.instruction = _instruction;

--- a/libyul/backends/wasm/WasmDialect.cpp
+++ b/libyul/backends/wasm/WasmDialect.cpp
@@ -99,6 +99,8 @@ WasmDialect::WasmDialect()
 	addFunction("unreachable", {}, {}, false);
 	m_functions["unreachable"_yulstring].sideEffects.invalidatesStorage = false;
 	m_functions["unreachable"_yulstring].sideEffects.invalidatesMemory = false;
+	m_functions["unreachable"_yulstring].controlFlowSideEffects.terminates = true;
+	m_functions["unreachable"_yulstring].controlFlowSideEffects.reverts = true;
 
 	addFunction("datasize", {i64}, {i64}, true, true);
 	addFunction("dataoffset", {i64}, {i64}, true, true);
@@ -147,7 +149,12 @@ void WasmDialect::addEthereumExternals()
 	static string const i64{"i64"};
 	static string const i32{"i32"};
 	static string const i32ptr{"i32"}; // Uses "i32" on purpose.
-	struct External { string name; vector<string> parameters; vector<string> returns; };
+	struct External {
+		string name;
+		vector<string> parameters;
+		vector<string> returns;
+		ControlFlowSideEffects controlFlowSideEffects = {};
+	};
 	static vector<External> externals{
 		{"getAddress", {i32ptr}, {}},
 		{"getExternalBalance", {i32ptr, i32ptr}, {}},
@@ -175,11 +182,11 @@ void WasmDialect::addEthereumExternals()
 		{"log", {i32ptr, i32, i32, i32ptr, i32ptr, i32ptr, i32ptr}, {}},
 		{"getBlockNumber", {}, {i64}},
 		{"getTxOrigin", {i32ptr}, {}},
-		{"finish", {i32ptr, i32}, {}},
-		{"revert", {i32ptr, i32}, {}},
+		{"finish", {i32ptr, i32}, {}, {true, false}},
+		{"revert", {i32ptr, i32}, {}, {true, true}},
 		{"getReturnDataSize", {}, {i32}},
 		{"returnDataCopy", {i32ptr, i32, i32}, {}},
-		{"selfDestruct", {i32ptr}, {}},
+		{"selfDestruct", {i32ptr}, {}, {true, false}},
 		{"getBlockTimestamp", {}, {i64}}
 	};
 	for (External const& ext: externals)
@@ -193,6 +200,7 @@ void WasmDialect::addEthereumExternals()
 			f.returns.emplace_back(YulString(p));
 		// TODO some of them are side effect free.
 		f.sideEffects = SideEffects::worst();
+		f.controlFlowSideEffects = ext.controlFlowSideEffects;
 		f.isMSize = false;
 		f.sideEffects.invalidatesStorage = (ext.name == "storageStore");
 		f.literalArguments = false;

--- a/test/libsolidity/syntaxTests/controlFlow/leave_inside_function.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/leave_inside_function.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() public pure {
+        assembly {
+            function f() {
+                // Make sure this doesn't trigger the unimplemented assertion in the control flow builder.
+                leave
+            }
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/controlFlow/leave_outside_function.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/leave_outside_function.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f() public pure {
+        assembly {
+            // Make sure this doesn't trigger the unimplemented assertion in the control flow builder.
+            leave
+        }
+    }
+}
+// ----
+// SyntaxError: (178-183): Keyword "leave" can only be used inside a function.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/for_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/for_err.sol
@@ -1,0 +1,29 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f() internal pure returns (S storage c) {
+        assembly {
+            for {} eq(0,0) { c_slot := s_slot } {}
+        }
+    }
+    function g() internal pure returns (S storage c) {
+        assembly {
+            for {} eq(0,1) { c_slot := s_slot } {}
+        }
+    }
+    function h() internal pure returns (S storage c) {
+        assembly {
+            for {} eq(0,0) {} { c_slot := s_slot }
+        }
+    }
+    function i() internal pure returns (S storage c) {
+        assembly {
+            for {} eq(0,1) {} { c_slot := s_slot }
+        }
+    }
+}
+// ----
+// TypeError: (87-98): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
+// TypeError: (228-239): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
+// TypeError: (369-380): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
+// TypeError: (510-521): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/for_fine.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/for_fine.sol
@@ -1,0 +1,15 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f() internal pure returns (S storage c) {
+        assembly {
+            for { c_slot := s_slot } iszero(0) {} {}
+        }
+    }
+    function g() internal pure returns (S storage c) {
+        assembly {
+            for { c_slot := s_slot } iszero(1) {} {}
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/if_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/if_err.sol
@@ -1,0 +1,11 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f(bool flag) internal pure returns (S storage c) {
+        assembly {
+            if flag { c_slot := s_slot }
+        }
+    }
+}
+// ----
+// TypeError: (96-107): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/returning_function.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/returning_function.sol
@@ -1,0 +1,13 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f() internal pure returns (S storage c) {
+        // this should warn about unreachable code, but currently function flow is ignored
+        assembly {
+            function f() { return(0, 0) }
+            f()
+            c_slot := s_slot
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/reverting_function.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/reverting_function.sol
@@ -1,0 +1,13 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f() internal pure returns (S storage c) {
+        // this could be allowed, but currently control flow for functions is not analysed
+        assembly {
+            function f() { revert(0, 0) }
+            f()
+        }
+    }
+}
+// ----
+// TypeError: (87-98): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/stub.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/stub.sol
@@ -1,0 +1,10 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f() internal pure returns (S storage c) {
+        assembly {
+            c_slot := s_slot
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/switch_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/switch_err.sol
@@ -1,0 +1,27 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f(uint256 a) internal pure returns (S storage c) {
+        assembly {
+            switch a
+            case 0 { c_slot := s_slot }
+        }
+    }
+    function g(bool flag) internal pure returns (S storage c) {
+        assembly {
+            switch flag
+            case 0 { c_slot := s_slot }
+            case 1 { c_slot := s_slot }
+        }
+    }
+    function h(uint256 a) internal pure returns (S storage c) {
+        assembly {
+            switch a
+            case 0 { c_slot := s_slot }
+            default { return(0,0) }
+        }
+    }
+}
+// ----
+// TypeError: (96-107): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
+// TypeError: (256-267): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/switch_fine.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/assembly/switch_fine.sol
@@ -1,0 +1,25 @@
+contract C {
+    struct S { bool f; }
+    S s;
+    function f(uint256 a) internal pure returns (S storage c) {
+        assembly {
+            switch a
+            default { c_slot := s_slot }
+        }
+    }
+    function g(bool flag) internal pure returns (S storage c) {
+        assembly {
+            switch flag
+            case 0 { c_slot := s_slot }
+            default { c_slot := s_slot }
+        }
+    }
+    function h(uint256 a) internal pure returns (S storage c) {
+        assembly {
+            switch a
+            case 0 { revert(0, 0) }
+            default { c_slot := s_slot }
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/assembly.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/assembly.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError: (92-116): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.
+// TypeError: (107-113): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/double_revert.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/double_revert.sol
@@ -1,0 +1,17 @@
+contract C {
+    function f() public pure {
+        assembly {
+            revert(0, 0)
+            revert(0, 0)
+        }
+    }
+    function g() public pure {
+        assembly {
+            revert(0, 0)
+        }
+        revert();
+    }
+}
+// ----
+// Warning: (100-112): Unreachable code.
+// Warning: (222-230): Unreachable code.

--- a/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/for_break.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/for_break.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f() public pure {
+        assembly {
+            for { let a := 0} lt(a,1) { a := add(a, 1) } {
+                break
+                let b := 42
+            }
+        }
+    }
+}
+// ----
+// Warning: (103-117): Unreachable code.
+// Warning: (160-171): Unreachable code.

--- a/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/for_continue.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/for_continue.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f() public pure {
+        assembly {
+            for { let a := 0} lt(a,1) { a := add(a, 1) } {
+                continue
+                let b := 42
+            }
+        }
+    }
+}
+// ----
+// Warning: (163-174): Unreachable code.

--- a/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/return.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/return.sol
@@ -1,0 +1,17 @@
+contract C {
+    function f(uint256 y) public pure returns (uint256 x) {
+        assembly {
+            return(0, 0)
+            x := y
+        }
+    }
+    function g(uint256 y) public pure returns (uint256 x) {
+        assembly {
+            return(0, 0)
+        }
+        x = y;
+    }
+}
+// ----
+// Warning: (129-135): Unreachable code.
+// Warning: (274-279): Unreachable code.

--- a/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/revert.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/unreachableCode/assembly/revert.sol
@@ -1,0 +1,17 @@
+contract C {
+    function f(uint256 y) public pure returns (uint256 x) {
+        assembly {
+            revert(0, 0)
+            x := y
+        }
+    }
+    function g(uint256 y) public pure returns (uint256 x) {
+        assembly {
+            revert(0, 0)
+        }
+        x = y;
+    }
+}
+// ----
+// Warning: (129-135): Unreachable code.
+// Warning: (274-279): Unreachable code.

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(builtins_analysis)
 		{
 			return _name == "builtin"_yulstring ? &f : nullptr;
 		}
-		BuiltinFunction f{"builtin"_yulstring, vector<Type>(2), vector<Type>(3), {}};
+		BuiltinFunction f{"builtin"_yulstring, vector<Type>(2), vector<Type>(3), {}, {}};
 	};
 
 	SimpleDialect dialect;


### PR DESCRIPTION
Now depends on https://github.com/ethereum/solidity/pull/8429

Fixes https://github.com/ethereum/solidity/issues/8375. At least for the most part - inline assembly functions and calls to them are ignored so far, which creates one loop-hole when an assembly function uses "return" and some false positives, if the assembly function always "reverts" (otherwise external variables cannot be accessed via assembly functions, so that's not a danger).

Function calls are also ignored in the solidity CFG analysis at the moment, though - however there is no similar loop-hole for storage returns for them.

I'm thinking about detecting returns in functions defined in assembly or to generally handle function calls both for solidity and assembly, but that would complicate the analysis (especially with e.g. mutually recursive calls, etc.).

However, calling "return" from inline assembly is generally a bit flaky for this analysis, since there is no way to properly analyze the returndata...