### PR TITLE
Fix calling unimplemented base function.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Inheritance: Fix incorrect error on calling unimplemented base functions.
  * isoltest: Added new keyword `wei` to express function value in semantic tests
  * Standard-JSON-Interface: Fix a bug related to empty filenames and imports.
  * SMTChecker: Fix internal errors when analysing tuples.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3471,7 +3471,15 @@ MemberList::MemberMap TypeType::nativeMembers(ContractDefinition const* _current
 				continue;
 
 			if (!contract.isLibrary() && inDerivingScope && declaration->isVisibleInDerivedContracts())
-				members.emplace_back(declaration->name(), declaration->type(), declaration);
+			{
+				if (
+					auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(declaration);
+					functionDefinition && !functionDefinition->isImplemented()
+				)
+					members.emplace_back(declaration->name(), declaration->typeViaContractName(), declaration);
+				else
+					members.emplace_back(declaration->name(), declaration->type(), declaration);
+			}
 			else if (
 				(contract.isLibrary() && declaration->isVisibleAsLibraryMember()) ||
 				declaration->isVisibleViaContractTypeAccess()

--- a/test/libsolidity/semanticTests/functionCall/call_unimplemented_base.sol
+++ b/test/libsolidity/semanticTests/functionCall/call_unimplemented_base.sol
@@ -1,0 +1,14 @@
+abstract contract I
+{
+    function a() internal view virtual returns(uint256);
+}
+abstract contract V is I
+{
+    function b() public view returns(uint256) { return a(); }
+}
+contract C is V
+{
+    function a() internal view override returns (uint256) { return 42;}
+}
+// ----
+// b() -> 42

--- a/test/libsolidity/syntaxTests/functionCalls/call_unimplemented_base.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/call_unimplemented_base.sol
@@ -1,0 +1,8 @@
+abstract contract I
+{
+    function a() internal view virtual returns(uint256);
+}
+abstract contract V is I
+{
+    function b() public view returns(uint256) { return a(); }
+}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8434.
About which I'm *extremely* embarrassed, that I apparently introduced it in 0.6.2, I don't know what I was thinking.
But I also can't believe that we didn't have a single test case for this.