### PR TITLE
[yul-phaser] Multi-program support

### DIFF
--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -38,7 +38,7 @@ class DummyProgramBasedMetric: public ProgramBasedMetric
 {
 public:
 	using ProgramBasedMetric::ProgramBasedMetric;
-	size_t evaluate(Chromosome const&) const override { return 0; }
+	size_t evaluate(Chromosome const&) override { return 0; }
 };
 
 class ProgramBasedMetricFixture

--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -78,6 +78,21 @@ protected:
 	Program m_optimisedProgram = optimisedProgram(m_program);
 };
 
+class FitnessMetricCombinationFixture: public ProgramBasedMetricFixture
+{
+protected:
+	vector<shared_ptr<FitnessMetric>> m_simpleMetrics = {
+		make_shared<ProgramSize>(m_program, 1),
+		make_shared<ProgramSize>(m_program, 2),
+		make_shared<ProgramSize>(m_program, 3),
+	};
+	vector<size_t> m_fitness = {
+		m_simpleMetrics[0]->evaluate(m_chromosome),
+		m_simpleMetrics[1]->evaluate(m_chromosome),
+		m_simpleMetrics[2]->evaluate(m_chromosome),
+	};
+};
+
 BOOST_AUTO_TEST_SUITE(Phaser)
 BOOST_AUTO_TEST_SUITE(FitnessMetricsTest)
 BOOST_AUTO_TEST_SUITE(ProgramBasedMetricTest)
@@ -171,6 +186,45 @@ BOOST_FIXTURE_TEST_CASE(evaluate_should_multiply_the_result_by_scaling_factor, P
 	BOOST_TEST(RelativeProgramSize(m_program, 2).evaluate(m_chromosome) == round(100.0 * sizeRatio));
 	BOOST_TEST(RelativeProgramSize(m_program, 3).evaluate(m_chromosome) == round(1000.0 * sizeRatio));
 	BOOST_TEST(RelativeProgramSize(m_program, 4).evaluate(m_chromosome) == round(10000.0 * sizeRatio));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE(FitnessMetricCombinationTest)
+
+BOOST_FIXTURE_TEST_CASE(FitnessMetricAverage_evaluate_should_compute_average_of_values_returned_by_metrics_passed_to_it, FitnessMetricCombinationFixture)
+{
+	FitnessMetricAverage metric(m_simpleMetrics);
+
+	assert(m_simpleMetrics.size() == 3);
+	BOOST_TEST(metric.evaluate(m_chromosome) == (m_fitness[0] + m_fitness[1] + m_fitness[2]) / 3);
+	BOOST_TEST(metric.metrics() == m_simpleMetrics);
+}
+
+BOOST_FIXTURE_TEST_CASE(FitnessMetricSum_evaluate_should_compute_sum_of_values_returned_by_metrics_passed_to_it, FitnessMetricCombinationFixture)
+{
+	FitnessMetricSum metric(m_simpleMetrics);
+
+	assert(m_simpleMetrics.size() == 3);
+	BOOST_TEST(metric.evaluate(m_chromosome) == m_fitness[0] + m_fitness[1] + m_fitness[2]);
+	BOOST_TEST(metric.metrics() == m_simpleMetrics);
+}
+
+BOOST_FIXTURE_TEST_CASE(FitnessMetricMaximum_evaluate_should_compute_maximum_of_values_returned_by_metrics_passed_to_it, FitnessMetricCombinationFixture)
+{
+	FitnessMetricMaximum metric(m_simpleMetrics);
+
+	assert(m_simpleMetrics.size() == 3);
+	BOOST_TEST(metric.evaluate(m_chromosome) == max(m_fitness[0], max(m_fitness[1], m_fitness[2])));
+	BOOST_TEST(metric.metrics() == m_simpleMetrics);
+}
+
+BOOST_FIXTURE_TEST_CASE(FitnessMetricMinimum_evaluate_should_compute_minimum_of_values_returned_by_metrics_passed_to_it, FitnessMetricCombinationFixture)
+{
+	FitnessMetricMinimum metric(m_simpleMetrics);
+
+	assert(m_simpleMetrics.size() == 3);
+	BOOST_TEST(metric.evaluate(m_chromosome) == min(m_fitness[0], min(m_fitness[1], m_fitness[2])));
+	BOOST_TEST(metric.metrics() == m_simpleMetrics);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -62,6 +62,7 @@ protected:
 	Program m_program = get<Program>(Program::load(m_sourceStream));
 	FitnessMetricFactory::Options m_options = {
 		/* metric = */ MetricChoice::CodeSize,
+		/* relativeMetricScale = */ 5,
 		/* chromosomeRepetitions = */ 1,
 	};
 };
@@ -161,6 +162,18 @@ BOOST_FIXTURE_TEST_CASE(build_should_respect_chromosome_repetitions_option, Fitn
 	auto programSizeMetric = dynamic_cast<ProgramSize*>(metric.get());
 	BOOST_REQUIRE(programSizeMetric != nullptr);
 	BOOST_TEST(programSizeMetric->repetitionCount() == m_options.chromosomeRepetitions);
+}
+
+BOOST_FIXTURE_TEST_CASE(build_should_set_relative_metric_scale, FitnessMetricFactoryFixture)
+{
+	m_options.metric = MetricChoice::RelativeCodeSize;
+	m_options.relativeMetricScale = 10;
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_program);
+	BOOST_REQUIRE(metric != nullptr);
+
+	auto relativeProgramSizeMetric = dynamic_cast<RelativeProgramSize*>(metric.get());
+	BOOST_REQUIRE(relativeProgramSizeMetric != nullptr);
+	BOOST_TEST(relativeProgramSizeMetric->fixedPointPrecision() == m_options.relativeMetricScale);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -61,6 +61,7 @@ protected:
 	CharStream m_sourceStream = CharStream("{}", "");
 	Program m_program = get<Program>(Program::load(m_sourceStream));
 	FitnessMetricFactory::Options m_options = {
+		/* metric = */ MetricChoice::CodeSize,
 		/* chromosomeRepetitions = */ 1,
 	};
 };
@@ -141,16 +142,18 @@ BOOST_AUTO_TEST_SUITE(FitnessMetricFactoryTest)
 
 BOOST_FIXTURE_TEST_CASE(build_should_create_metric_of_the_right_type, FitnessMetricFactoryFixture)
 {
+	m_options.metric = MetricChoice::RelativeCodeSize;
 	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_program);
 	BOOST_REQUIRE(metric != nullptr);
 
-	auto programSizeMetric = dynamic_cast<ProgramSize*>(metric.get());
-	BOOST_REQUIRE(programSizeMetric != nullptr);
-	BOOST_TEST(toString(programSizeMetric->program()) == toString(m_program));
+	auto relativeProgramSizeMetric = dynamic_cast<RelativeProgramSize*>(metric.get());
+	BOOST_REQUIRE(relativeProgramSizeMetric != nullptr);
+	BOOST_TEST(toString(relativeProgramSizeMetric->program()) == toString(m_program));
 }
 
 BOOST_FIXTURE_TEST_CASE(build_should_respect_chromosome_repetitions_option, FitnessMetricFactoryFixture)
 {
+	m_options.metric = MetricChoice::CodeSize;
 	m_options.chromosomeRepetitions = 5;
 	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_program);
 	BOOST_REQUIRE(metric != nullptr);

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -70,6 +70,7 @@ protected:
 	};
 	FitnessMetricFactory::Options m_options = {
 		/* metric = */ MetricChoice::CodeSize,
+		/* metricAggregator = */ MetricAggregatorChoice::Average,
 		/* relativeMetricScale = */ 5,
 		/* chromosomeRepetitions = */ 1,
 	};
@@ -152,15 +153,16 @@ BOOST_AUTO_TEST_SUITE(FitnessMetricFactoryTest)
 BOOST_FIXTURE_TEST_CASE(build_should_create_metric_of_the_right_type, FitnessMetricFactoryFixture)
 {
 	m_options.metric = MetricChoice::RelativeCodeSize;
+	m_options.metricAggregator = MetricAggregatorChoice::Sum;
 	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]});
 	BOOST_REQUIRE(metric != nullptr);
 
-	auto averageMetric = dynamic_cast<FitnessMetricAverage*>(metric.get());
-	BOOST_REQUIRE(averageMetric != nullptr);
-	BOOST_REQUIRE(averageMetric->metrics().size() == 1);
-	BOOST_REQUIRE(averageMetric->metrics()[0] != nullptr);
+	auto sumMetric = dynamic_cast<FitnessMetricSum*>(metric.get());
+	BOOST_REQUIRE(sumMetric != nullptr);
+	BOOST_REQUIRE(sumMetric->metrics().size() == 1);
+	BOOST_REQUIRE(sumMetric->metrics()[0] != nullptr);
 
-	auto relativeProgramSizeMetric = dynamic_cast<RelativeProgramSize*>(averageMetric->metrics()[0].get());
+	auto relativeProgramSizeMetric = dynamic_cast<RelativeProgramSize*>(sumMetric->metrics()[0].get());
 	BOOST_REQUIRE(relativeProgramSizeMetric != nullptr);
 	BOOST_TEST(toString(relativeProgramSizeMetric->program()) == toString(m_programs[0]));
 }
@@ -168,6 +170,7 @@ BOOST_FIXTURE_TEST_CASE(build_should_create_metric_of_the_right_type, FitnessMet
 BOOST_FIXTURE_TEST_CASE(build_should_respect_chromosome_repetitions_option, FitnessMetricFactoryFixture)
 {
 	m_options.metric = MetricChoice::CodeSize;
+	m_options.metricAggregator = MetricAggregatorChoice::Average;
 	m_options.chromosomeRepetitions = 5;
 	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]});
 	BOOST_REQUIRE(metric != nullptr);
@@ -185,6 +188,7 @@ BOOST_FIXTURE_TEST_CASE(build_should_respect_chromosome_repetitions_option, Fitn
 BOOST_FIXTURE_TEST_CASE(build_should_set_relative_metric_scale, FitnessMetricFactoryFixture)
 {
 	m_options.metric = MetricChoice::RelativeCodeSize;
+	m_options.metricAggregator = MetricAggregatorChoice::Average;
 	m_options.relativeMetricScale = 10;
 	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]});
 	BOOST_REQUIRE(metric != nullptr);

--- a/test/yulPhaser/TestHelpers.h
+++ b/test/yulPhaser/TestHelpers.h
@@ -51,7 +51,7 @@ class ChromosomeLengthMetric: public FitnessMetric
 {
 public:
 	using FitnessMetric::FitnessMetric;
-	size_t evaluate(Chromosome const& _chromosome) const override { return _chromosome.length(); }
+	size_t evaluate(Chromosome const& _chromosome) override { return _chromosome.length(); }
 };
 
 // MUTATIONS

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -20,11 +20,16 @@
 using namespace std;
 using namespace solidity::phaser;
 
-size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
+Program ProgramBasedMetric::optimisedProgram(Chromosome const& _chromosome) const
 {
 	Program programCopy = m_program;
 	for (size_t i = 0; i < m_repetitionCount; ++i)
 		programCopy.optimise(_chromosome.optimisationSteps());
 
-	return programCopy.codeSize();
+	return programCopy;
+}
+
+size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
+{
+	return optimisedProgram(_chromosome).codeSize();
 }

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -50,3 +50,47 @@ size_t RelativeProgramSize::evaluate(Chromosome const& _chromosome)
 		static_cast<double>(optimisedSize) / unoptimisedSize * scalingFactor
 	));
 }
+
+size_t FitnessMetricAverage::evaluate(Chromosome const& _chromosome)
+{
+	assert(m_metrics.size() > 0);
+
+	size_t total = m_metrics[0]->evaluate(_chromosome);
+	for (size_t i = 1; i < m_metrics.size(); ++i)
+		total += m_metrics[i]->evaluate(_chromosome);
+
+	return total / m_metrics.size();
+}
+
+size_t FitnessMetricSum::evaluate(Chromosome const& _chromosome)
+{
+	assert(m_metrics.size() > 0);
+
+	size_t total = m_metrics[0]->evaluate(_chromosome);
+	for (size_t i = 1; i < m_metrics.size(); ++i)
+		total += m_metrics[i]->evaluate(_chromosome);
+
+	return total;
+}
+
+size_t FitnessMetricMaximum::evaluate(Chromosome const& _chromosome)
+{
+	assert(m_metrics.size() > 0);
+
+	size_t maximum = m_metrics[0]->evaluate(_chromosome);
+	for (size_t i = 1; i < m_metrics.size(); ++i)
+		maximum = max(maximum, m_metrics[i]->evaluate(_chromosome));
+
+	return maximum;
+}
+
+size_t FitnessMetricMinimum::evaluate(Chromosome const& _chromosome)
+{
+	assert(m_metrics.size() > 0);
+
+	size_t minimum = m_metrics[0]->evaluate(_chromosome);
+	for (size_t i = 1; i < m_metrics.size(); ++i)
+		minimum = min(minimum, m_metrics[i]->evaluate(_chromosome));
+
+	return minimum;
+}

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -17,6 +17,8 @@
 
 #include <tools/yulPhaser/FitnessMetrics.h>
 
+#include <cmath>
+
 using namespace std;
 using namespace solidity::phaser;
 
@@ -32,4 +34,19 @@ Program ProgramBasedMetric::optimisedProgram(Chromosome const& _chromosome) cons
 size_t ProgramSize::evaluate(Chromosome const& _chromosome)
 {
 	return optimisedProgram(_chromosome).codeSize();
+}
+
+size_t RelativeProgramSize::evaluate(Chromosome const& _chromosome)
+{
+	size_t const scalingFactor = pow(10, m_fixedPointPrecision);
+
+	size_t unoptimisedSize = optimisedProgram(Chromosome("")).codeSize();
+	if (unoptimisedSize == 0)
+		return scalingFactor;
+
+	size_t optimisedSize = optimisedProgram(_chromosome).codeSize();
+
+	return static_cast<size_t>(round(
+		static_cast<double>(optimisedSize) / unoptimisedSize * scalingFactor
+	));
 }

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -29,7 +29,7 @@ Program ProgramBasedMetric::optimisedProgram(Chromosome const& _chromosome) cons
 	return programCopy;
 }
 
-size_t ProgramSize::evaluate(Chromosome const& _chromosome) const
+size_t ProgramSize::evaluate(Chromosome const& _chromosome)
 {
 	return optimisedProgram(_chromosome).codeSize();
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -43,7 +43,7 @@ public:
 	FitnessMetric& operator=(FitnessMetric const&) = delete;
 	virtual ~FitnessMetric() = default;
 
-	virtual size_t evaluate(Chromosome const& _chromosome) const = 0;
+	virtual size_t evaluate(Chromosome const& _chromosome) = 0;
 };
 
 /**
@@ -84,7 +84,7 @@ class ProgramSize: public ProgramBasedMetric
 {
 public:
 	using ProgramBasedMetric::ProgramBasedMetric;
-	size_t evaluate(Chromosome const& _chromosome) const override;
+	size_t evaluate(Chromosome const& _chromosome) override;
 };
 
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -87,4 +87,30 @@ public:
 	size_t evaluate(Chromosome const& _chromosome) override;
 };
 
+/**
+ * Fitness metric based on the size of a specific program after applying the optimisations from the
+ * chromosome to it in relation to the original, unoptimised program.
+ *
+ * Since metric values are integers, the class multiplies the ratio by 10^@a _fixedPointPrecision
+ * before rounding it.
+ */
+class RelativeProgramSize: public ProgramBasedMetric
+{
+public:
+	explicit RelativeProgramSize(
+		Program _program,
+		size_t _fixedPointPrecision,
+		size_t _repetitionCount = 1
+	):
+		ProgramBasedMetric(std::move(_program), _repetitionCount),
+		m_fixedPointPrecision(_fixedPointPrecision) {}
+
+	size_t fixedPointPrecision() const { return m_fixedPointPrecision; }
+
+	size_t evaluate(Chromosome const& _chromosome) override;
+
+private:
+	size_t m_fixedPointPrecision;
+};
+
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -47,24 +47,44 @@ public:
 };
 
 /**
- * Fitness metric based on the size of a specific program after applying the optimisations from the
- * chromosome to it.
+ * Abstract base class for fitness metrics that return values based on program size.
+ *
+ * The class provides utilities for optimising programs according to the information stored in
+ * chromosomes.
+ *
+ * It can also store weights for the @a CodeSize metric. It does not do anything with
+ * them because it does not actually compute the code size but they are readily available for use
+ * by derived classes.
  */
-class ProgramSize: public FitnessMetric
+class ProgramBasedMetric: public FitnessMetric
 {
 public:
-	explicit ProgramSize(Program _program, size_t _repetitionCount = 1):
+	explicit ProgramBasedMetric(
+		Program _program,
+		size_t _repetitionCount = 1
+	):
 		m_program(std::move(_program)),
 		m_repetitionCount(_repetitionCount) {}
 
 	Program const& program() const { return m_program; }
 	size_t repetitionCount() const { return m_repetitionCount; }
 
-	size_t evaluate(Chromosome const& _chromosome) const override;
+	Program optimisedProgram(Chromosome const& _chromosome) const;
 
 private:
 	Program m_program;
 	size_t m_repetitionCount;
+};
+
+/**
+ * Fitness metric based on the size of a specific program after applying the optimisations from the
+ * chromosome to it.
+ */
+class ProgramSize: public ProgramBasedMetric
+{
+public:
+	using ProgramBasedMetric::ProgramBasedMetric;
+	size_t evaluate(Chromosome const& _chromosome) const override;
 };
 
 }

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -113,4 +113,60 @@ private:
 	size_t m_fixedPointPrecision;
 };
 
+/**
+ * Abstract base class for fitness metrics that compute their value based on values of multiple
+ * other, nested metrics.
+ */
+class FitnessMetricCombination: public FitnessMetric
+{
+public:
+	explicit FitnessMetricCombination(std::vector<std::shared_ptr<FitnessMetric>> _metrics):
+		m_metrics(std::move(_metrics)) {}
+
+	std::vector<std::shared_ptr<FitnessMetric>> const& metrics() const { return m_metrics; }
+
+protected:
+	std::vector<std::shared_ptr<FitnessMetric>> m_metrics;
+};
+
+/**
+ * Fitness metric that returns the average of values of its nested metrics.
+ */
+class FitnessMetricAverage: public FitnessMetricCombination
+{
+public:
+	using FitnessMetricCombination::FitnessMetricCombination;
+	size_t evaluate(Chromosome const& _chromosome) override;
+};
+
+/**
+ * Fitness metric that returns the sum of values of its nested metrics.
+ */
+class FitnessMetricSum: public FitnessMetricCombination
+{
+public:
+	using FitnessMetricCombination::FitnessMetricCombination;
+	size_t evaluate(Chromosome const& _chromosome) override;
+};
+
+/**
+ * Fitness metric that returns the highest of values of its nested metrics.
+ */
+class FitnessMetricMaximum: public FitnessMetricCombination
+{
+public:
+	using FitnessMetricCombination::FitnessMetricCombination;
+	size_t evaluate(Chromosome const& _chromosome) override;
+};
+
+/**
+ * Fitness metric that returns the lowest of values of its nested metrics.
+ */
+class FitnessMetricMinimum: public FitnessMetricCombination
+{
+public:
+	using FitnessMetricCombination::FitnessMetricCombination;
+	size_t evaluate(Chromosome const& _chromosome) override;
+};
+
 }

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -463,7 +463,7 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	metricsDescription.add_options()
 		(
 			"metric",
-			po::value<MetricChoice>()->value_name("<NAME>")->default_value(MetricChoice::CodeSize),
+			po::value<MetricChoice>()->value_name("<NAME>")->default_value(MetricChoice::RelativeCodeSize),
 			"Metric used to evaluate the fitness of a chromosome."
 		)
 		(

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -139,6 +139,7 @@ FitnessMetricFactory::Options FitnessMetricFactory::Options::fromCommandLine(po:
 {
 	return {
 		_arguments["metric"].as<MetricChoice>(),
+		_arguments["relative-metric-scale"].as<size_t>(),
 		_arguments["chromosome-repetitions"].as<size_t>(),
 	};
 }
@@ -158,7 +159,7 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 		case MetricChoice::RelativeCodeSize:
 			return make_unique<RelativeProgramSize>(
 				move(_program),
-				3,
+				_options.relativeMetricScale,
 				_options.chromosomeRepetitions
 			);
 		default:
@@ -420,6 +421,18 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			"metric",
 			po::value<MetricChoice>()->value_name("<NAME>")->default_value(MetricChoice::CodeSize),
 			"Metric used to evaluate the fitness of a chromosome."
+		)
+		(
+			"relative-metric-scale",
+			po::value<size_t>()->value_name("<EXPONENT>")->default_value(3),
+			"Scaling factor for values produced by relative fitness metrics. \n"
+			"Since all metrics must produce integer values, the fractional part of the result is discarded. "
+			"To keep the numbers meaningful, a relative metric multiples its values by a scaling factor "
+			"and this option specifies the exponent of this factor. "
+			"For example with value of 3 the factor is 10^3 = 1000 and the metric will return "
+			"500 to represent 0.5, 1000 for 1.0, 2000 for 2.0 and so on. "
+			"Using a bigger factor allows discerning smaller relative differences between chromosomes "
+			"but makes the numbers less readable and may also lose precision if the numbers are very large."
 		)
 		(
 			"chromosome-repetitions",

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -58,10 +58,20 @@ enum class MetricChoice
 	RelativeCodeSize,
 };
 
+enum class MetricAggregatorChoice
+{
+	Average,
+	Sum,
+	Maximum,
+	Minimum,
+};
+
 std::istream& operator>>(std::istream& _inputStream, solidity::phaser::Algorithm& _algorithm);
 std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::Algorithm _algorithm);
 std::istream& operator>>(std::istream& _inputStream, solidity::phaser::MetricChoice& _metric);
 std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::MetricChoice _metric);
+std::istream& operator>>(std::istream& _inputStream, solidity::phaser::MetricAggregatorChoice& _aggregator);
+std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::MetricAggregatorChoice _aggregator);
 
 /**
  * Builds and validates instances of @a GeneticAlgorithm and its derived classes.
@@ -100,6 +110,7 @@ public:
 	struct Options
 	{
 		MetricChoice metric;
+		MetricAggregatorChoice metricAggregator;
 		size_t relativeMetricScale;
 		size_t chromosomeRepetitions;
 

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -108,7 +108,7 @@ public:
 
 	static std::unique_ptr<FitnessMetric> build(
 		Options const& _options,
-		Program _program
+		std::vector<Program> _programs
 	);
 };
 
@@ -157,12 +157,12 @@ class ProgramFactory
 public:
 	struct Options
 	{
-		std::string inputFile;
+		std::vector<std::string> inputFiles;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
 	};
 
-	static Program build(Options const& _options);
+	static std::vector<Program> build(Options const& _options);
 
 private:
 	static langutil::CharStream loadSource(std::string const& _sourcePath);

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -52,8 +52,16 @@ enum class Algorithm
 	GEWEP,
 };
 
+enum class MetricChoice
+{
+	CodeSize,
+	RelativeCodeSize,
+};
+
 std::istream& operator>>(std::istream& _inputStream, solidity::phaser::Algorithm& _algorithm);
 std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::Algorithm _algorithm);
+std::istream& operator>>(std::istream& _inputStream, solidity::phaser::MetricChoice& _metric);
+std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::MetricChoice _metric);
 
 /**
  * Builds and validates instances of @a GeneticAlgorithm and its derived classes.
@@ -91,6 +99,7 @@ class FitnessMetricFactory
 public:
 	struct Options
 	{
+		MetricChoice metric;
 		size_t chromosomeRepetitions;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -100,6 +100,7 @@ public:
 	struct Options
 	{
 		MetricChoice metric;
+		size_t relativeMetricScale;
 		size_t chromosomeRepetitions;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -59,7 +59,7 @@ bool phaser::isFitter(Individual const& a, Individual const& b)
 }
 
 Population Population::makeRandom(
-	shared_ptr<FitnessMetric const> _fitnessMetric,
+	shared_ptr<FitnessMetric> _fitnessMetric,
 	size_t _size,
 	function<size_t()> _chromosomeLengthGenerator
 )
@@ -72,7 +72,7 @@ Population Population::makeRandom(
 }
 
 Population Population::makeRandom(
-	shared_ptr<FitnessMetric const> _fitnessMetric,
+	shared_ptr<FitnessMetric> _fitnessMetric,
 	size_t _size,
 	size_t _minChromosomeLength,
 	size_t _maxChromosomeLength
@@ -145,7 +145,7 @@ ostream& phaser::operator<<(ostream& _stream, Population const& _population)
 }
 
 vector<Individual> Population::chromosomesToIndividuals(
-	FitnessMetric const& _fitnessMetric,
+	FitnessMetric& _fitnessMetric,
 	vector<Chromosome> _chromosomes
 )
 {

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -55,7 +55,7 @@ struct Individual
 	Individual(Chromosome _chromosome, size_t _fitness):
 		chromosome(std::move(_chromosome)),
 		fitness(_fitness) {}
-	Individual(Chromosome _chromosome, FitnessMetric const& _fitnessMetric):
+	Individual(Chromosome _chromosome, FitnessMetric& _fitnessMetric):
 		chromosome(std::move(_chromosome)),
 		fitness(_fitnessMetric.evaluate(chromosome)) {}
 
@@ -85,7 +85,7 @@ class Population
 {
 public:
 	explicit Population(
-		std::shared_ptr<FitnessMetric const> _fitnessMetric,
+		std::shared_ptr<FitnessMetric> _fitnessMetric,
 		std::vector<Chromosome> _chromosomes = {}
 	):
 		Population(
@@ -94,12 +94,12 @@ public:
 		) {}
 
 	static Population makeRandom(
-		std::shared_ptr<FitnessMetric const> _fitnessMetric,
+		std::shared_ptr<FitnessMetric> _fitnessMetric,
 		size_t _size,
 		std::function<size_t()> _chromosomeLengthGenerator
 	);
 	static Population makeRandom(
-		std::shared_ptr<FitnessMetric const> _fitnessMetric,
+		std::shared_ptr<FitnessMetric> _fitnessMetric,
 		size_t _size,
 		size_t _minChromosomeLength,
 		size_t _maxChromosomeLength
@@ -110,7 +110,7 @@ public:
 	Population crossover(PairSelection const& _selection, std::function<Crossover> _crossover) const;
 	friend Population (::operator+)(Population _a, Population _b);
 
-	std::shared_ptr<FitnessMetric const> fitnessMetric() const { return m_fitnessMetric; }
+	std::shared_ptr<FitnessMetric> fitnessMetric() { return m_fitnessMetric; }
 	std::vector<Individual> const& individuals() const { return m_individuals; }
 
 	static size_t uniformChromosomeLength(size_t _min, size_t _max) { return SimulationRNG::uniformInt(_min, _max); }
@@ -122,17 +122,17 @@ public:
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(std::shared_ptr<FitnessMetric const> _fitnessMetric, std::vector<Individual> _individuals):
+	explicit Population(std::shared_ptr<FitnessMetric> _fitnessMetric, std::vector<Individual> _individuals):
 		m_fitnessMetric(std::move(_fitnessMetric)),
 		m_individuals{sortedIndividuals(std::move(_individuals))} {}
 
 	static std::vector<Individual> chromosomesToIndividuals(
-		FitnessMetric const& _fitnessMetric,
+		FitnessMetric& _fitnessMetric,
 		std::vector<Chromosome> _chromosomes
 	);
 	static std::vector<Individual> sortedIndividuals(std::vector<Individual> _individuals);
 
-	std::shared_ptr<FitnessMetric const> m_fitnessMetric;
+	std::shared_ptr<FitnessMetric> m_fitnessMetric;
 	std::vector<Individual> m_individuals;
 };
 


### PR DESCRIPTION
### Description
The eleventh pull request implementing #7806. Depends on #8423.

This pull request introduces new fitness metrics that allow the phaser to work with multiple input programs:
- Multiple metrics can now be passed to classes derived from `FitnessMetricCombination` to compute average, sum, minimum or maximum. This way we can compute fitness given more than one program.
- `RelativeProgramSize` is a new metric that computes the ratio between the optimised and unoptimised program size. This should be more useful than the absolute `ProgramSize` for multiple programs that differ in size.
- `--metric` and `--metric-aggregator` options allow selecting metric type and the way to combine it for multiple programs. The default is the average of relative sizes.
- Since metrics currently operate on integer values, we need to scale the results from the relative metric before rounding them if we want to have any precision at all. `--relative-metric-scale x` option makes the metric multiply its results by `10^x`. E.g. with `--relative-metric-scale 4`: 1.0 becomes 10000, 0.5 becomes 5000, 2.0 becomes 20000 and so on.
- Turns out it's useful to have some mutable state in the metric (in particular: the program cache introduced in the next PR). `FitnessMetric::evaluate()` is now non-`const`.

### Example invocation
Minimal:
``` bash
tools/yul-phaser                                                   \
    $(find ../test/libyul/yulOptimizerTests/fullSuite -name *.yul) \
    --random-population 20                                         \
    --metric relative-code-size                                    \
    --metric-aggregator average                                    \
    --relative-metric-scale 1000
```

### Dependencies
This PR is based on #8423. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages