### PR TITLE
[yul-phaser] More output

### DIFF
--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -69,7 +69,7 @@ class AlgorithmRunnerFixture
 {
 protected:
 	// NOTE: Regexes here should not contain spaces because we strip them before matching
-	regex RoundSummaryRegex{R"(-+ROUND\d+-+)"};
+	regex RoundSummaryRegex{R"(-+ROUND\d+\[round:[0-9.]+s,total:[0-9.]+s\]-+)"};
 	regex InitialPopulationHeaderRegex{"-+INITIALPOPULATION-+"};
 
 	string individualPattern(Individual const& individual) const

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -70,6 +70,7 @@ class AlgorithmRunnerFixture
 protected:
 	// NOTE: Regexes here should not contain spaces because we strip them before matching
 	regex RoundSummaryRegex{R"(-+ROUND\d+-+)"};
+	regex InitialPopulationHeaderRegex{"-+INITIALPOPULATION-+"};
 
 	string individualPattern(Individual const& individual) const
 	{
@@ -133,6 +134,7 @@ BOOST_FIXTURE_TEST_CASE(run_should_call_runNextRound_once_per_round, AlgorithmRu
 BOOST_FIXTURE_TEST_CASE(run_should_print_round_summary_after_each_round, AlgorithmRunnerFixture)
 {
 	m_options.maxRounds = 1;
+	m_options.showInitialPopulation = false;
 	AlgorithmRunner runner(m_population, {}, m_options, m_output);
 	RandomisingAlgorithm algorithm;
 
@@ -145,6 +147,33 @@ BOOST_FIXTURE_TEST_CASE(run_should_print_round_summary_after_each_round, Algorit
 	BOOST_TEST(nextLineMatches(m_output, RoundSummaryRegex));
 	for (auto const& individual: runner.population().individuals())
 		BOOST_TEST(nextLineMatches(m_output, regex(individualPattern(individual))));
+	BOOST_TEST(m_output.peek() == EOF);
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_print_initial_population_if_requested, AlgorithmRunnerFixture)
+{
+	m_options.maxRounds = 0;
+	m_options.showInitialPopulation = true;
+	RandomisingAlgorithm algorithm;
+
+	AlgorithmRunner runner(m_population, {}, m_options, m_output);
+	runner.run(algorithm);
+
+	BOOST_TEST(nextLineMatches(m_output, InitialPopulationHeaderRegex));
+	for (auto const& individual: m_population.individuals())
+		BOOST_TEST(nextLineMatches(m_output, regex(individualPattern(individual))));
+	BOOST_TEST(m_output.peek() == EOF);
+}
+
+BOOST_FIXTURE_TEST_CASE(run_should_not_print_initial_population_if_not_requested, AlgorithmRunnerFixture)
+{
+	m_options.maxRounds = 0;
+	m_options.showInitialPopulation = false;
+	RandomisingAlgorithm algorithm;
+
+	AlgorithmRunner runner(m_population, {}, m_options, m_output);
+	runner.run(algorithm);
+
 	BOOST_TEST(m_output.peek() == EOF);
 }
 

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -84,7 +84,7 @@ protected:
 	string topChromosomePattern(size_t roundNumber, Individual const& individual) const
 	{
 		ostringstream output;
-		output << roundNumber << "\\|" << individualPattern(individual);
+		output << roundNumber << R"(\|[0-9.]+\|)" << individualPattern(individual);
 		return output.str();
 	}
 

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -90,6 +90,7 @@ protected:
 	}
 
 	shared_ptr<FitnessMetric> m_fitnessMetric = make_shared<ChromosomeLengthMetric>();
+	Population const m_population = Population::makeRandom(m_fitnessMetric, 5, 0, 20);
 	stringstream m_output;
 	AlgorithmRunner::Options m_options;
 };
@@ -109,7 +110,6 @@ public:
 protected:
 	TemporaryDirectory m_tempDir;
 	string const m_autosavePath = m_tempDir.memberPath("population-autosave.txt");
-	Population const m_population = Population::makeRandom(m_fitnessMetric, 5, 0, 20);
 	RandomisingAlgorithm m_algorithm;
 };
 
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_SUITE(AlgorithmRunnerTest)
 BOOST_FIXTURE_TEST_CASE(run_should_call_runNextRound_once_per_round, AlgorithmRunnerFixture)
 {
 	m_options.maxRounds = 5;
-	AlgorithmRunner runner(Population(m_fitnessMetric), {}, m_options, m_output);
+	AlgorithmRunner runner(m_population, {}, m_options, m_output);
 
 	CountingAlgorithm algorithm;
 
@@ -132,10 +132,8 @@ BOOST_FIXTURE_TEST_CASE(run_should_call_runNextRound_once_per_round, AlgorithmRu
 
 BOOST_FIXTURE_TEST_CASE(run_should_print_round_summary_after_each_round, AlgorithmRunnerFixture)
 {
-	Population population(m_fitnessMetric, {Chromosome("fcCUnDve"), Chromosome("jsxIOo"), Chromosome("ighTLM")});
-
 	m_options.maxRounds = 1;
-	AlgorithmRunner runner(population, {}, m_options, m_output);
+	AlgorithmRunner runner(m_population, {}, m_options, m_output);
 	RandomisingAlgorithm algorithm;
 
 	runner.run(algorithm);
@@ -269,7 +267,7 @@ BOOST_FIXTURE_TEST_CASE(run_should_clear_cache_at_the_beginning_and_update_it_be
 	};
 
 	m_options.maxRounds = 10;
-	AlgorithmRunner runner(Population(m_fitnessMetric), caches, m_options, m_output);
+	AlgorithmRunner runner(m_population, caches, m_options, m_output);
 	CountingAlgorithm algorithm;
 
 	BOOST_TEST(algorithm.m_currentRound == 0);

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -76,8 +76,7 @@ protected:
 	string individualPattern(Individual const& individual) const
 	{
 		ostringstream output;
-		output << "Fitness:" << individual.fitness << ",";
-		output << "optimisations:" << individual.chromosome;
+		output << individual.fitness << individual.chromosome;
 		return output.str();
 	}
 

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -31,6 +31,7 @@ using namespace solidity::phaser;
 void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 {
 	populationAutosave();
+	printInitialPopulation();
 	cacheClear();
 
 	for (size_t round = 0; !m_options.maxRounds.has_value() || round < m_options.maxRounds.value(); ++round)
@@ -45,6 +46,15 @@ void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 
 		populationAutosave();
 	}
+}
+
+void AlgorithmRunner::printInitialPopulation() const
+{
+	if (!m_options.showInitialPopulation)
+		return;
+
+	m_outputStream << "---------- INITIAL POPULATION ----------" << endl;
+	m_outputStream << m_population;
 }
 
 void AlgorithmRunner::populationAutosave() const

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -55,14 +55,14 @@ void AlgorithmRunner::printRoundSummary(
 	clock_t _totalTimeStart
 ) const
 {
+	clock_t now = clock();
+	double roundTime = static_cast<double>(now - _roundTimeStart) / CLOCKS_PER_SEC;
+	double totalTime = static_cast<double>(now - _totalTimeStart) / CLOCKS_PER_SEC;
+
 	if (!m_options.showOnlyTopChromosome)
 	{
 		if (m_options.showRoundInfo)
 		{
-			clock_t now = clock();
-			double roundTime = static_cast<double>(now - _roundTimeStart) / CLOCKS_PER_SEC;
-			double totalTime = static_cast<double>(now - _totalTimeStart) / CLOCKS_PER_SEC;
-
 			m_outputStream << "---------- ROUND " << _round + 1;
 			m_outputStream << " [round: " << fixed << setprecision(1) << roundTime << " s,";
 			m_outputStream << " total: " << fixed << setprecision(1) << totalTime << " s]";
@@ -76,7 +76,10 @@ void AlgorithmRunner::printRoundSummary(
 	else if (m_population.individuals().size() > 0)
 	{
 		if (m_options.showRoundInfo)
+		{
 			m_outputStream << setw(5) << _round + 1 << " | ";
+			m_outputStream << setw(5) << fixed << setprecision(1) << totalTime << " | ";
+		}
 
 		m_outputStream << m_population.individuals()[0] << endl;
 	}

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -41,10 +41,33 @@ void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 		m_population = _algorithm.runNextRound(m_population);
 		randomiseDuplicates();
 
-		m_outputStream << "---------- ROUND " << round + 1 << " ----------" << endl;
-		m_outputStream << m_population;
-
+		printRoundSummary(round);
 		populationAutosave();
+	}
+}
+
+void AlgorithmRunner::printRoundSummary(
+	size_t _round
+) const
+{
+	if (!m_options.showOnlyTopChromosome)
+	{
+		if (m_options.showRoundInfo)
+		{
+			m_outputStream << "---------- ROUND " << _round + 1;
+			m_outputStream << " ----------" << endl;
+		}
+		else if (m_population.individuals().size() > 0)
+			m_outputStream << endl;
+
+		m_outputStream << m_population;
+	}
+	else if (m_population.individuals().size() > 0)
+	{
+		if (m_options.showRoundInfo)
+			m_outputStream << setw(5) << _round + 1 << " | ";
+
+		m_outputStream << m_population.individuals()[0] << endl;
 	}
 }
 

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -34,27 +34,37 @@ void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 	printInitialPopulation();
 	cacheClear();
 
+	chrono::steady_clock::time_point totalTimeStart = std::chrono::steady_clock::now();
 	for (size_t round = 0; !m_options.maxRounds.has_value() || round < m_options.maxRounds.value(); ++round)
 	{
+		chrono::steady_clock::time_point roundTimeStart = std::chrono::steady_clock::now();
 		cacheStartRound(round + 1);
 
 		m_population = _algorithm.runNextRound(m_population);
 		randomiseDuplicates();
 
-		printRoundSummary(round);
+		printRoundSummary(round, roundTimeStart, totalTimeStart);
 		populationAutosave();
 	}
 }
 
 void AlgorithmRunner::printRoundSummary(
-	size_t _round
+	size_t _round,
+	chrono::steady_clock::time_point _roundTimeStart,
+	chrono::steady_clock::time_point _totalTimeStart
 ) const
 {
 	if (!m_options.showOnlyTopChromosome)
 	{
 		if (m_options.showRoundInfo)
 		{
+			chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+			auto roundTime = chrono::duration_cast<chrono::milliseconds>(now - _roundTimeStart).count();
+			auto totalTime = chrono::duration_cast<chrono::milliseconds>(now - _totalTimeStart).count();
+
 			m_outputStream << "---------- ROUND " << _round + 1;
+			m_outputStream << " [round: " << fixed << setprecision(1) << roundTime / 1000.0 << " s,";
+			m_outputStream << " total: " << fixed << setprecision(1) << totalTime / 1000.0 << " s]";
 			m_outputStream << " ----------" << endl;
 		}
 		else if (m_population.individuals().size() > 0)

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -34,10 +34,10 @@ void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 	printInitialPopulation();
 	cacheClear();
 
-	chrono::steady_clock::time_point totalTimeStart = std::chrono::steady_clock::now();
+	clock_t totalTimeStart = clock();
 	for (size_t round = 0; !m_options.maxRounds.has_value() || round < m_options.maxRounds.value(); ++round)
 	{
-		chrono::steady_clock::time_point roundTimeStart = std::chrono::steady_clock::now();
+		clock_t roundTimeStart = clock();
 		cacheStartRound(round + 1);
 
 		m_population = _algorithm.runNextRound(m_population);
@@ -51,21 +51,21 @@ void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
 
 void AlgorithmRunner::printRoundSummary(
 	size_t _round,
-	chrono::steady_clock::time_point _roundTimeStart,
-	chrono::steady_clock::time_point _totalTimeStart
+	clock_t _roundTimeStart,
+	clock_t _totalTimeStart
 ) const
 {
 	if (!m_options.showOnlyTopChromosome)
 	{
 		if (m_options.showRoundInfo)
 		{
-			chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-			auto roundTime = chrono::duration_cast<chrono::milliseconds>(now - _roundTimeStart).count();
-			auto totalTime = chrono::duration_cast<chrono::milliseconds>(now - _totalTimeStart).count();
+			clock_t now = clock();
+			double roundTime = static_cast<double>(now - _roundTimeStart) / CLOCKS_PER_SEC;
+			double totalTime = static_cast<double>(now - _totalTimeStart) / CLOCKS_PER_SEC;
 
 			m_outputStream << "---------- ROUND " << _round + 1;
-			m_outputStream << " [round: " << fixed << setprecision(1) << roundTime / 1000.0 << " s,";
-			m_outputStream << " total: " << fixed << setprecision(1) << totalTime / 1000.0 << " s]";
+			m_outputStream << " [round: " << fixed << setprecision(1) << roundTime << " s,";
+			m_outputStream << " total: " << fixed << setprecision(1) << totalTime << " s]";
 			m_outputStream << " ----------" << endl;
 		}
 		else if (m_population.individuals().size() > 0)

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -47,6 +47,7 @@ public:
 		bool randomiseDuplicates = false;
 		std::optional<size_t> minChromosomeLength = std::nullopt;
 		std::optional<size_t> maxChromosomeLength = std::nullopt;
+		bool showInitialPopulation = false;
 	};
 
 	AlgorithmRunner(
@@ -66,6 +67,7 @@ public:
 	Population const& population() const { return m_population; }
 
 private:
+	void printInitialPopulation() const;
 	void populationAutosave() const;
 	void randomiseDuplicates();
 	void cacheClear();

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -51,6 +51,7 @@ public:
 		bool showInitialPopulation = false;
 		bool showOnlyTopChromosome = false;
 		bool showRoundInfo = true;
+		bool showCacheStats = false;
 	};
 
 	AlgorithmRunner(
@@ -76,6 +77,7 @@ private:
 		std::chrono::steady_clock::time_point _totalTimeStart
 	) const;
 	void printInitialPopulation() const;
+	void printCacheStats() const;
 	void populationAutosave() const;
 	void randomiseDuplicates();
 	void cacheClear();

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -24,7 +24,7 @@
 #include <tools/yulPhaser/Population.h>
 #include <tools/yulPhaser/ProgramCache.h>
 
-#include <chrono>
+#include <ctime>
 #include <optional>
 #include <ostream>
 
@@ -73,8 +73,8 @@ public:
 private:
 	void printRoundSummary(
 		size_t _round,
-		std::chrono::steady_clock::time_point _roundTimeStart,
-		std::chrono::steady_clock::time_point _totalTimeStart
+		clock_t _roundTimeStart,
+		clock_t _totalTimeStart
 	) const;
 	void printInitialPopulation() const;
 	void printCacheStats() const;

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -71,7 +71,9 @@ public:
 
 private:
 	void printRoundSummary(
-		size_t _round
+		size_t _round,
+		std::chrono::steady_clock::time_point _roundTimeStart,
+		std::chrono::steady_clock::time_point _totalTimeStart
 	) const;
 	void printInitialPopulation() const;
 	void populationAutosave() const;

--- a/tools/yulPhaser/AlgorithmRunner.h
+++ b/tools/yulPhaser/AlgorithmRunner.h
@@ -24,6 +24,7 @@
 #include <tools/yulPhaser/Population.h>
 #include <tools/yulPhaser/ProgramCache.h>
 
+#include <chrono>
 #include <optional>
 #include <ostream>
 
@@ -48,6 +49,8 @@ public:
 		std::optional<size_t> minChromosomeLength = std::nullopt;
 		std::optional<size_t> maxChromosomeLength = std::nullopt;
 		bool showInitialPopulation = false;
+		bool showOnlyTopChromosome = false;
+		bool showRoundInfo = true;
 	};
 
 	AlgorithmRunner(
@@ -67,6 +70,9 @@ public:
 	Population const& population() const { return m_population; }
 
 private:
+	void printRoundSummary(
+		size_t _round
+	) const;
 	void printInitialPopulation() const;
 	void populationAutosave() const;
 	void randomiseDuplicates();

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -581,6 +581,11 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			po::bool_switch(),
 			"Print information about cache size and effectiveness after each round."
 		)
+		(
+			"show-seed",
+			po::bool_switch(),
+			"Print the selected random seed."
+		)
 	;
 	keywordDescription.add(outputDescription);
 
@@ -622,7 +627,8 @@ void Phaser::initialiseRNG(po::variables_map const& _arguments)
 		seed = SimulationRNG::generateSeed();
 
 	SimulationRNG::reset(seed);
-	cout << "Random seed: " << seed << endl;
+	if (_arguments["show-seed"].as<bool>())
+		cout << "Random seed: " << seed << endl;
 }
 
 AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map const& _arguments)

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -46,6 +46,12 @@ namespace po = boost::program_options;
 namespace
 {
 
+map<PhaserMode, string> const PhaserModeToStringMap =
+{
+	{PhaserMode::RunAlgorithm, "run-algorithm"},
+};
+map<string, PhaserMode> const StringToPhaserModeMap = invertMap(PhaserModeToStringMap);
+
 map<Algorithm, string> const AlgorithmToStringMap =
 {
 	{Algorithm::Random, "random"},
@@ -71,6 +77,8 @@ map<string, MetricAggregatorChoice> const StringToMetricAggregatorChoiceMap = in
 
 }
 
+istream& phaser::operator>>(istream& _inputStream, PhaserMode& _phaserMode) { return deserializeChoice(_inputStream, _phaserMode, StringToPhaserModeMap); }
+ostream& phaser::operator<<(ostream& _outputStream, PhaserMode _phaserMode) { return serializeChoice(_outputStream, _phaserMode, PhaserModeToStringMap); }
 istream& phaser::operator>>(istream& _inputStream, Algorithm& _algorithm) { return deserializeChoice(_inputStream, _algorithm, StringToAlgorithmMap); }
 ostream& phaser::operator<<(ostream& _outputStream, Algorithm _algorithm) { return serializeChoice(_outputStream, _algorithm, AlgorithmToStringMap); }
 istream& phaser::operator>>(istream& _inputStream, MetricChoice& _metric) { return deserializeChoice(_inputStream, _metric, StringToMetricChoiceMap); }
@@ -348,7 +356,7 @@ void Phaser::main(int _argc, char** _argv)
 
 	initialiseRNG(arguments.value());
 
-	runAlgorithm(arguments.value());
+	runPhaser(arguments.value());
 }
 
 Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
@@ -391,6 +399,12 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			"rounds",
 			po::value<size_t>()->value_name("<NUM>"),
 			"The number of rounds after which the algorithm should stop. (default=no limit)."
+		)
+		(
+			"mode",
+			po::value<PhaserMode>()->value_name("<NAME>")->default_value(PhaserMode::RunAlgorithm),
+			"Mode of operation. The default is to run the algorithm but you can also tell phaser "
+			"to do something else with its parameters, e.g. just print the optimised programs and exit."
 		)
 	;
 	keywordDescription.add(generalDescription);
@@ -618,13 +632,12 @@ AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map c
 	};
 }
 
-void Phaser::runAlgorithm(po::variables_map const& _arguments)
+void Phaser::runPhaser(po::variables_map const& _arguments)
 {
 	auto programOptions = ProgramFactory::Options::fromCommandLine(_arguments);
 	auto cacheOptions = ProgramCacheFactory::Options::fromCommandLine(_arguments);
 	auto metricOptions = FitnessMetricFactory::Options::fromCommandLine(_arguments);
 	auto populationOptions = PopulationFactory::Options::fromCommandLine(_arguments);
-	auto algorithmOptions = GeneticAlgorithmFactory::Options::fromCommandLine(_arguments);
 
 	vector<Program> programs = ProgramFactory::build(programOptions);
 	vector<shared_ptr<ProgramCache>> programCaches = ProgramCacheFactory::build(cacheOptions, programs);
@@ -632,11 +645,23 @@ void Phaser::runAlgorithm(po::variables_map const& _arguments)
 	unique_ptr<FitnessMetric> fitnessMetric = FitnessMetricFactory::build(metricOptions, move(programs), programCaches);
 	Population population = PopulationFactory::build(populationOptions, move(fitnessMetric));
 
+	if (_arguments["mode"].as<PhaserMode>() == PhaserMode::RunAlgorithm)
+		runAlgorithm(_arguments, move(population), move(programCaches));
+}
+
+void Phaser::runAlgorithm(
+	po::variables_map const& _arguments,
+	Population _population,
+	vector<shared_ptr<ProgramCache>> _programCaches
+)
+{
+	auto algorithmOptions = GeneticAlgorithmFactory::Options::fromCommandLine(_arguments);
+
 	unique_ptr<GeneticAlgorithm> geneticAlgorithm = GeneticAlgorithmFactory::build(
 		algorithmOptions,
-		population.individuals().size()
+		_population.individuals().size()
 	);
 
-	AlgorithmRunner algorithmRunner(population, move(programCaches), buildAlgorithmRunnerOptions(_arguments), cout);
+	AlgorithmRunner algorithmRunner(move(_population), move(_programCaches), buildAlgorithmRunnerOptions(_arguments), cout);
 	algorithmRunner.run(*geneticAlgorithm);
 }

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -543,6 +543,16 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	;
 	keywordDescription.add(cacheDescription);
 
+	po::options_description outputDescription("OUTPUT", lineLength, minDescriptionLength);
+	outputDescription.add_options()
+		(
+			"show-initial-population",
+			po::bool_switch(),
+			"Print the state of the population before the algorithm starts."
+		)
+	;
+	keywordDescription.add(outputDescription);
+
 	po::positional_options_description positionalDescription;
 	positionalDescription.add("input-files", -1);
 
@@ -592,6 +602,7 @@ AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map c
 		!_arguments["no-randomise-duplicates"].as<bool>(),
 		_arguments["min-chromosome-length"].as<size_t>(),
 		_arguments["max-chromosome-length"].as<size_t>(),
+		_arguments["show-initial-population"].as<bool>(),
 	};
 }
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -576,6 +576,11 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			po::bool_switch(),
 			"Hide information about the current round (round number and elapsed time)."
 		)
+		(
+			"show-cache-stats",
+			po::bool_switch(),
+			"Print information about cache size and effectiveness after each round."
+		)
 	;
 	keywordDescription.add(outputDescription);
 
@@ -631,6 +636,7 @@ AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map c
 		_arguments["show-initial-population"].as<bool>(),
 		_arguments["show-only-top-chromosome"].as<bool>(),
 		!_arguments["hide-round"].as<bool>(),
+		_arguments["show-cache-stats"].as<bool>(),
 	};
 }
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -550,6 +550,16 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 			po::bool_switch(),
 			"Print the state of the population before the algorithm starts."
 		)
+		(
+			"show-only-top-chromosome",
+			po::bool_switch(),
+			"Print only the best chromosome found in each round rather than the whole population."
+		)
+		(
+			"hide-round",
+			po::bool_switch(),
+			"Hide information about the current round (round number and elapsed time)."
+		)
 	;
 	keywordDescription.add(outputDescription);
 
@@ -603,6 +613,8 @@ AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map c
 		_arguments["min-chromosome-length"].as<size_t>(),
 		_arguments["max-chromosome-length"].as<size_t>(),
 		_arguments["show-initial-population"].as<bool>(),
+		_arguments["show-only-top-chromosome"].as<bool>(),
+		!_arguments["hide-round"].as<bool>(),
 	};
 }
 

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -50,6 +50,8 @@ class ProgramCache;
 enum class PhaserMode
 {
 	RunAlgorithm,
+	PrintOptimisedPrograms,
+	PrintOptimisedASTs,
 };
 
 enum class Algorithm
@@ -235,6 +237,12 @@ private:
 		boost::program_options::variables_map const& _arguments,
 		Population _population,
 		std::vector<std::shared_ptr<ProgramCache>> _programCaches
+	);
+	static void printOptimisedProgramsOrASTs(
+		boost::program_options::variables_map const& _arguments,
+		Population const& _population,
+		std::vector<Program> _programs,
+		PhaserMode phaserMode
 	);
 };
 

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -47,6 +47,11 @@ class Population;
 class Program;
 class ProgramCache;
 
+enum class PhaserMode
+{
+	RunAlgorithm,
+};
+
 enum class Algorithm
 {
 	Random,
@@ -67,6 +72,8 @@ enum class MetricAggregatorChoice
 	Minimum,
 };
 
+std::istream& operator>>(std::istream& _inputStream, solidity::phaser::PhaserMode& _phaserMode);
+std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::PhaserMode _phaserMode);
 std::istream& operator>>(std::istream& _inputStream, solidity::phaser::Algorithm& _algorithm);
 std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::Algorithm _algorithm);
 std::istream& operator>>(std::istream& _inputStream, solidity::phaser::MetricChoice& _metric);
@@ -223,7 +230,12 @@ private:
 	static void initialiseRNG(boost::program_options::variables_map const& _arguments);
 	static AlgorithmRunner::Options buildAlgorithmRunnerOptions(boost::program_options::variables_map const& _arguments);
 
-	static void runAlgorithm(boost::program_options::variables_map const& _arguments);
+	static void runPhaser(boost::program_options::variables_map const& _arguments);
+	static void runAlgorithm(
+		boost::program_options::variables_map const& _arguments,
+		Population _population,
+		std::vector<std::shared_ptr<ProgramCache>> _programCaches
+	);
 };
 
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -43,8 +43,7 @@ ostream& operator<<(ostream& _stream, Population const& _population);
 
 ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
 {
-	_stream << "Fitness: " << _individual.fitness;
-	_stream << ", optimisations: " << _individual.chromosome;
+	_stream << _individual.fitness << " " << _individual.chromosome;
 
 	return _stream;
 }


### PR DESCRIPTION
### Description
The thirteenth pull request implementing #7806. Depends on #8451.

This pull request adds extra options for controlling phaser output:
- `--show-initial-population`: Prints the population and its fitness just before the algorithm starts. Useful in combination with `--rounds 0` and `--population-from-file` to see fitness in a different metric.
- `--show-only-top-chromosome` gives more compact output - only one chromosome per round.
    - Normal output is also more compact, without labels, more suitable for capture and processing via scripts.
- `--hide-round` hides the round header.
- Elapsed CPU time is now printed after each round.
- `--mode` specifies mode of operation:
    - `run-algorithm`: runs the algorithm as usual. This is the default
    - `print-optimised-programs` prints the Yul code of the optimised programs from the initial population. It's most useful with `--rounds 0` and a single chromosome as input.
    - `print-optimised-asts`: works like `print-optimised-programs` but prints the JSON-serialised ASTs instead of Yul code.
- `--show-cache-stats` tells you how the cache is performing. In particular the number of cached and non-cached intermediate programs.
- The program no longer prints the random seed on startup. Use `--show-seed` option to see it.

### Dependencies
This PR is based on #8451. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages