### PR TITLE
Configurable CodeSize metric

### DIFF
--- a/libyul/optimiser/Metrics.h
+++ b/libyul/optimiser/Metrics.h
@@ -30,33 +30,67 @@ struct Dialect;
 struct EVMDialect;
 
 /**
- * Metric for the size of code.
- * More specifically, the number of AST nodes.
- * Ignores function definitions while traversing the AST by default.
- * If you want to know the size of a function, you have to invoke this on its body.
+ * Weights to be assigned to specific yul statements and expressions by a metric.
  *
- * As an exception, the following AST elements have a cost of zero:
+ * The default values are meant to reflect specifically the number of AST nodes.
+ *
+ * The following AST elements have a default cost of zero (because the cleanup phase would
+ * remove them anyway or they are just wrappers around something else will be counted instead):
  *  - expression statement (only the expression inside has a cost)
  *  - block (only the statements inside have a cost)
  *  - variable references
  *  - variable declarations (only the right hand side has a cost)
  *  - assignments (only the value has a cost)
  *
- * As another exception, each statement incurs and additional cost of one
+ * Each statement incurs and additional cost of one
  * per jump/branch. This means if, break and continue statements have a cost of 2,
  * switch statements have a cost of 1 plus the number of cases times two,
  * and for loops cost 3.
+*/
+struct CodeWeights
+{
+	// Statements
+	size_t expressionStatementCost = 0;
+	size_t assignmentCost = 0;
+	size_t variableDeclarationCost = 0;
+	size_t functionDefinitionCost = 1;
+	size_t ifCost = 2;
+	size_t switchCost = 1;
+	size_t caseCost = 2;
+	size_t forLoopCost = 3;
+	size_t breakCost = 2;
+	size_t continueCost = 2;
+	size_t leaveCost = 2;
+	size_t blockCost = 0;
+
+	// Expressions
+	size_t functionCallCost = 1;
+	size_t identifierCost = 0;
+	size_t literalCost = 1;
+
+	size_t costOf(Statement const& _statement) const;
+	size_t costOf(Expression const& _expression) const;
+};
+
+/**
+ * Metric for the size of code.
+ * Ignores function definitions while traversing the AST by default.
+ * If you want to know the size of a function, you have to invoke this on its body.
+ *
+ * The cost of each statement and expression type is configurable via CodeWeights.
  */
 class CodeSize: public ASTWalker
 {
 public:
-	static size_t codeSize(Statement const& _statement);
-	static size_t codeSize(Expression const& _expression);
-	static size_t codeSize(Block const& _block);
-	static size_t codeSizeIncludingFunctions(Block const& _block);
+	static size_t codeSize(Statement const& _statement, CodeWeights const& _weights = {});
+	static size_t codeSize(Expression const& _expression, CodeWeights const& _weights = {});
+	static size_t codeSize(Block const& _block, CodeWeights const& _weights = {});
+	static size_t codeSizeIncludingFunctions(Block const& _block, CodeWeights const& _weights = {});
 
 private:
-	CodeSize(bool _ignoreFunctions = true): m_ignoreFunctions(_ignoreFunctions) {}
+	CodeSize(bool _ignoreFunctions = true, CodeWeights const& _weights = {}):
+		m_ignoreFunctions(_ignoreFunctions),
+		m_weights(_weights) {}
 
 	void visit(Statement const& _statement) override;
 	void visit(Expression const& _expression) override;
@@ -64,6 +98,7 @@ private:
 private:
 	bool m_ignoreFunctions;
 	size_t m_size = 0;
+	CodeWeights m_weights;
 };
 
 /**

--- a/test/libyul/Metrics.cpp
+++ b/test/libyul/Metrics.cpp
@@ -36,14 +36,37 @@ namespace solidity::yul::test
 namespace
 {
 
-size_t codeSize(string const& _source)
+size_t codeSize(string const& _source, CodeWeights const _weights = {})
 {
 	shared_ptr<Block> ast = parse(_source, false).first;
 	BOOST_REQUIRE(ast);
-	return CodeSize::codeSize(*ast);
+	return CodeSize::codeSize(*ast, _weights);
 }
 
 }
+
+class CustomWeightFixture
+{
+protected:
+	CodeWeights m_weights{
+		/* expressionStatementCost = */ 1,
+		/* assignmentCost = */ 2,
+		/* variableDeclarationCost = */ 3,
+		/* functionDefinitionCost = */ 4,
+		/* ifCost = */ 5,
+		/* switchCost = */ 6,
+		/* caseCost = */ 7,
+		/* forLoopCost = */ 8,
+		/* breakCost = */ 9,
+		/* continueCost = */ 10,
+		/* leaveCost = */ 11,
+		/* blockCost = */ 12,
+
+		/* functionCallCost = */ 13,
+		/* identifierCost = */ 14,
+		/* literalCost = */ 15,
+	};
+};
 
 BOOST_AUTO_TEST_SUITE(YulCodeSize)
 
@@ -52,9 +75,19 @@ BOOST_AUTO_TEST_CASE(empty_code)
 	BOOST_CHECK_EQUAL(codeSize("{}"), 0);
 }
 
+BOOST_FIXTURE_TEST_CASE(empty_code_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(codeSize("{}", m_weights), 0);
+}
+
 BOOST_AUTO_TEST_CASE(nested_blocks)
 {
 	BOOST_CHECK_EQUAL(codeSize("{ {} {} {{ }} }"), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(nested_blocks_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ {} {} {{ }} }", m_weights), 4 * m_weights.blockCost);
 }
 
 BOOST_AUTO_TEST_CASE(instruction)
@@ -62,9 +95,26 @@ BOOST_AUTO_TEST_CASE(instruction)
 	BOOST_CHECK_EQUAL(codeSize("{ pop(calldatasize()) }"), 2);
 }
 
+BOOST_FIXTURE_TEST_CASE(instruction_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ pop(calldatasize()) }", m_weights),
+		2 * m_weights.functionCallCost +
+		1 * m_weights.expressionStatementCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(variables_are_free)
 {
 	BOOST_CHECK_EQUAL(codeSize("{ let x let y let a, b, c }"), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(variables_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ let x let y let a, b, c }", m_weights),
+		3 * m_weights.variableDeclarationCost
+	);
 }
 
 BOOST_AUTO_TEST_CASE(constants_cost_one)
@@ -72,9 +122,23 @@ BOOST_AUTO_TEST_CASE(constants_cost_one)
 	BOOST_CHECK_EQUAL(codeSize("{ let x := 3 }"), 1);
 }
 
+BOOST_FIXTURE_TEST_CASE(constants_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ let x := 3 }", m_weights),
+		1 * m_weights.variableDeclarationCost +
+		1 * m_weights.literalCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(functions_are_skipped)
 {
 	BOOST_CHECK_EQUAL(codeSize("{ function f(x) -> r { r := mload(x) } }"), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(functions_are_skipped_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(codeSize("{ function f(x) -> r { r := mload(x) } }", m_weights), 0);
 }
 
 BOOST_AUTO_TEST_CASE(function_with_arguments)
@@ -82,9 +146,30 @@ BOOST_AUTO_TEST_CASE(function_with_arguments)
 	BOOST_CHECK_EQUAL(codeSize("{ function f(x) { sstore(x, 2) } f(2) }"), 2);
 }
 
+BOOST_FIXTURE_TEST_CASE(function_with_arguments_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ function f(x) { sstore(x, 2) } f(2) }", m_weights),
+		1 * m_weights.expressionStatementCost +
+		1 * m_weights.functionCallCost +
+		1 * m_weights.literalCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(function_with_variables_as_arguments)
 {
 	BOOST_CHECK_EQUAL(codeSize("{ function f(x) { sstore(x, 2) } let y f(y) }"), 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(function_with_variables_as_arguments_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ function f(x) { sstore(x, 2) } let y f(y) }", m_weights),
+		1 * m_weights.variableDeclarationCost +
+		1 * m_weights.expressionStatementCost +
+		1 * m_weights.functionCallCost +
+		1 * m_weights.identifierCost
+	);
 }
 
 BOOST_AUTO_TEST_CASE(function_with_variables_and_constants_as_arguments)
@@ -94,9 +179,36 @@ BOOST_AUTO_TEST_CASE(function_with_variables_and_constants_as_arguments)
 	), 2);
 }
 
+BOOST_FIXTURE_TEST_CASE(
+	function_with_variables_and_constants_as_arguments_custom_weights,
+	CustomWeightFixture
+)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize(
+			"{ function f(x, r) -> z { sstore(x, r) z := r } let y let t := f(y, 2) }",
+			m_weights
+		),
+		2 * m_weights.variableDeclarationCost +
+		1 * m_weights.functionCallCost +
+		1 * m_weights.identifierCost +
+		1 * m_weights.literalCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(assignment)
 {
 	BOOST_CHECK_EQUAL(codeSize("{ let a a := 3 }"), 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(assignment_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ let a a := 3 }", m_weights),
+		1 * m_weights.variableDeclarationCost +
+		1 * m_weights.assignmentCost +
+		1 * m_weights.literalCost
+	);
 }
 
 BOOST_AUTO_TEST_CASE(assignments_between_vars_are_free)
@@ -104,9 +216,30 @@ BOOST_AUTO_TEST_CASE(assignments_between_vars_are_free)
 	BOOST_CHECK_EQUAL(codeSize("{ let a let b := a a := b }"), 0);
 }
 
+BOOST_FIXTURE_TEST_CASE(assignments_between_vars_are_free_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ let a let b := a a := b }", m_weights),
+		2 * m_weights.variableDeclarationCost +
+		1 * m_weights.assignmentCost +
+		2 * m_weights.identifierCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(assignment_complex)
 {
 	BOOST_CHECK_EQUAL(codeSize("{ let a let x := mload(a) a := sload(x) }"), 2);
+}
+
+BOOST_FIXTURE_TEST_CASE(assignment_complex_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ let a let x := mload(a) a := sload(x) }", m_weights),
+		2 * m_weights.variableDeclarationCost +
+		1 * m_weights.assignmentCost +
+		2 * m_weights.identifierCost +
+		2 * m_weights.functionCallCost
+	);
 }
 
 BOOST_AUTO_TEST_CASE(empty_for_loop)
@@ -116,11 +249,30 @@ BOOST_AUTO_TEST_CASE(empty_for_loop)
 	), 4);
 }
 
+BOOST_FIXTURE_TEST_CASE(empty_for_loop_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ for {} 1 {} {} }", m_weights),
+		1 * m_weights.forLoopCost +
+		1 * m_weights.literalCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(break_statement)
 {
 	BOOST_CHECK_EQUAL(codeSize(
 		"{ for {} 1 {} { break } }"
 	), 6);
+}
+
+BOOST_FIXTURE_TEST_CASE(break_statement_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ for {} 1 {} { break } }", m_weights),
+		1 * m_weights.forLoopCost +
+		1 * m_weights.literalCost +
+		1 * m_weights.breakCost
+	);
 }
 
 BOOST_AUTO_TEST_CASE(continue_statement)
@@ -130,6 +282,16 @@ BOOST_AUTO_TEST_CASE(continue_statement)
 	), 6);
 }
 
+BOOST_FIXTURE_TEST_CASE(continue_statement_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ for {} 1 {} { continue } }", m_weights),
+		1 * m_weights.forLoopCost +
+		1 * m_weights.literalCost +
+		1 * m_weights.continueCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(regular_for_loop)
 {
 	BOOST_CHECK_EQUAL(codeSize(
@@ -137,11 +299,34 @@ BOOST_AUTO_TEST_CASE(regular_for_loop)
 	), 10);
 }
 
+BOOST_FIXTURE_TEST_CASE(regular_for_loop_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ for { let x := 0 } lt(x, 10) { x := add(x, 1) } { mstore(x, 1) } }", m_weights),
+		1 * m_weights.forLoopCost +
+		1 * m_weights.variableDeclarationCost +
+		1 * m_weights.assignmentCost +
+		3 * m_weights.functionCallCost +
+		4 * m_weights.literalCost +
+		3 * m_weights.identifierCost +
+		1 * m_weights.expressionStatementCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(if_statement)
 {
 	BOOST_CHECK_EQUAL(codeSize(
 		"{ if 1 {} }"
 	), 3);
+}
+
+BOOST_FIXTURE_TEST_CASE(if_statement_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ if 1 {} }", m_weights),
+		1 * m_weights.ifCost +
+		1 * m_weights.literalCost
+	);
 }
 
 BOOST_AUTO_TEST_CASE(switch_statement_tiny)
@@ -158,6 +343,16 @@ BOOST_AUTO_TEST_CASE(switch_statement_small)
 	), 6);
 }
 
+BOOST_FIXTURE_TEST_CASE(switch_statement_small_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ switch calldatasize() case 0 {} default {} }", m_weights),
+		1 * m_weights.functionCallCost +
+		1 * m_weights.switchCost +
+		2 * m_weights.caseCost
+	);
+}
+
 BOOST_AUTO_TEST_CASE(switch_statement_medium)
 {
 	BOOST_CHECK_EQUAL(codeSize(
@@ -170,6 +365,16 @@ BOOST_AUTO_TEST_CASE(switch_statement_large)
 	BOOST_CHECK_EQUAL(codeSize(
 		"{ switch calldatasize() case 0 {} case 1 {} case 2 {} default {} }"
 	), 10);
+}
+
+BOOST_FIXTURE_TEST_CASE(switch_statement_large_custom_weights, CustomWeightFixture)
+{
+	BOOST_CHECK_EQUAL(
+		codeSize("{ switch calldatasize() case 0 {} case 1 {} case 2 {} default {} }", m_weights),
+		1 * m_weights.functionCallCost +
+		1 * m_weights.switchCost +
+		4 * m_weights.caseCost
+	);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -37,6 +37,7 @@ using namespace boost::unit_test::framework;
 using namespace boost::test_tools;
 using namespace solidity::langutil;
 using namespace solidity::util;
+using namespace solidity::yul;
 
 namespace fs = boost::filesystem;
 
@@ -299,8 +300,8 @@ BOOST_FIXTURE_TEST_CASE(run_should_print_cache_stats_if_requested, AlgorithmRunn
 		make_shared<ProgramCache>(programs[1]),
 	};
 	shared_ptr<FitnessMetric> fitnessMetric = make_shared<FitnessMetricAverage>(vector<shared_ptr<FitnessMetric>>{
-		make_shared<ProgramSize>(nullopt, caches[0]),
-		make_shared<ProgramSize>(nullopt, caches[1]),
+		make_shared<ProgramSize>(nullopt, caches[0], CodeWeights{}),
+		make_shared<ProgramSize>(nullopt, caches[1], CodeWeights{}),
 	});
 	Population population = Population::makeRandom(fitnessMetric, 2, 0, 5);
 

--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -62,12 +62,12 @@ protected:
 
 	Program optimisedProgram(Program _program) const
 	{
-		[[maybe_unused]] size_t originalSize = _program.codeSize();
+		[[maybe_unused]] size_t originalSize = _program.codeSize(m_weights);
 		Program result = move(_program);
 		result.optimise(m_chromosome.optimisationSteps());
 
 		// Make sure that the program and the chromosome we have chosen are suitable for the test
-		assert(result.codeSize() != originalSize);
+		assert(result.codeSize(m_weights) != originalSize);
 
 		return result;
 	}
@@ -77,15 +77,16 @@ protected:
 	Program m_program = get<Program>(Program::load(m_sourceStream));
 	Program m_optimisedProgram = optimisedProgram(m_program);
 	shared_ptr<ProgramCache> m_programCache = make_shared<ProgramCache>(m_program);
+	static constexpr CodeWeights m_weights{};
 };
 
 class FitnessMetricCombinationFixture: public ProgramBasedMetricFixture
 {
 protected:
 	vector<shared_ptr<FitnessMetric>> m_simpleMetrics = {
-		make_shared<ProgramSize>(m_program, nullptr, 1),
-		make_shared<ProgramSize>(m_program, nullptr, 2),
-		make_shared<ProgramSize>(m_program, nullptr, 3),
+		make_shared<ProgramSize>(m_program, nullptr, m_weights, 1),
+		make_shared<ProgramSize>(m_program, nullptr, m_weights, 2),
+		make_shared<ProgramSize>(m_program, nullptr, m_weights, 3),
 	};
 	vector<size_t> m_fitness = {
 		m_simpleMetrics[0]->evaluate(m_chromosome),
@@ -100,7 +101,7 @@ BOOST_AUTO_TEST_SUITE(ProgramBasedMetricTest)
 
 BOOST_FIXTURE_TEST_CASE(optimisedProgram_should_return_optimised_program_even_if_cache_not_available, ProgramBasedMetricFixture)
 {
-	string code = toString(DummyProgramBasedMetric(m_program, nullptr).optimisedProgram(m_chromosome));
+	string code = toString(DummyProgramBasedMetric(m_program, nullptr, m_weights).optimisedProgram(m_chromosome));
 
 	BOOST_TEST(code != toString(m_program));
 	BOOST_TEST(code == toString(m_optimisedProgram));
@@ -108,7 +109,7 @@ BOOST_FIXTURE_TEST_CASE(optimisedProgram_should_return_optimised_program_even_if
 
 BOOST_FIXTURE_TEST_CASE(optimisedProgram_should_use_cache_if_available, ProgramBasedMetricFixture)
 {
-	string code = toString(DummyProgramBasedMetric(nullopt, m_programCache).optimisedProgram(m_chromosome));
+	string code = toString(DummyProgramBasedMetric(nullopt, m_programCache, m_weights).optimisedProgram(m_chromosome));
 
 	BOOST_TEST(code != toString(m_program));
 	BOOST_TEST(code == toString(m_optimisedProgram));
@@ -117,7 +118,7 @@ BOOST_FIXTURE_TEST_CASE(optimisedProgram_should_use_cache_if_available, ProgramB
 
 BOOST_FIXTURE_TEST_CASE(optimisedProgramNoCache_should_return_optimised_program_even_if_cache_not_available, ProgramBasedMetricFixture)
 {
-	string code = toString(DummyProgramBasedMetric(m_program, nullptr).optimisedProgramNoCache(m_chromosome));
+	string code = toString(DummyProgramBasedMetric(m_program, nullptr, m_weights).optimisedProgramNoCache(m_chromosome));
 
 	BOOST_TEST(code != toString(m_program));
 	BOOST_TEST(code == toString(m_optimisedProgram));
@@ -125,7 +126,7 @@ BOOST_FIXTURE_TEST_CASE(optimisedProgramNoCache_should_return_optimised_program_
 
 BOOST_FIXTURE_TEST_CASE(optimisedProgramNoCache_should_not_use_cache_even_if_available, ProgramBasedMetricFixture)
 {
-	string code = toString(DummyProgramBasedMetric(nullopt, m_programCache).optimisedProgramNoCache(m_chromosome));
+	string code = toString(DummyProgramBasedMetric(nullopt, m_programCache, m_weights).optimisedProgramNoCache(m_chromosome));
 
 	BOOST_TEST(code != toString(m_program));
 	BOOST_TEST(code == toString(m_optimisedProgram));
@@ -137,18 +138,18 @@ BOOST_AUTO_TEST_SUITE(ProgramSizeTest)
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_compute_size_of_the_optimised_program, ProgramBasedMetricFixture)
 {
-	size_t fitness = ProgramSize(m_program, nullptr).evaluate(m_chromosome);
+	size_t fitness = ProgramSize(m_program, nullptr, m_weights).evaluate(m_chromosome);
 
-	BOOST_TEST(fitness != m_program.codeSize());
-	BOOST_TEST(fitness == m_optimisedProgram.codeSize());
+	BOOST_TEST(fitness != m_program.codeSize(m_weights));
+	BOOST_TEST(fitness == m_optimisedProgram.codeSize(m_weights));
 }
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_be_able_to_use_program_cache_if_available, ProgramBasedMetricFixture)
 {
-	size_t fitness = ProgramSize(nullopt, m_programCache).evaluate(m_chromosome);
+	size_t fitness = ProgramSize(nullopt, m_programCache, m_weights).evaluate(m_chromosome);
 
-	BOOST_TEST(fitness != m_program.codeSize());
-	BOOST_TEST(fitness == m_optimisedProgram.codeSize());
+	BOOST_TEST(fitness != m_program.codeSize(m_weights));
+	BOOST_TEST(fitness == m_optimisedProgram.codeSize(m_weights));
 	BOOST_TEST(m_programCache->size() == m_chromosome.length());
 }
 
@@ -157,21 +158,21 @@ BOOST_FIXTURE_TEST_CASE(evaluate_should_repeat_the_optimisation_specified_number
 	Program const& programOptimisedOnce = m_optimisedProgram;
 	Program programOptimisedTwice = optimisedProgram(programOptimisedOnce);
 
-	ProgramSize metric(m_program, nullptr, 2);
+	ProgramSize metric(m_program, nullptr, m_weights, 2);
 	size_t fitness = metric.evaluate(m_chromosome);
 
-	BOOST_TEST(fitness != m_program.codeSize());
-	BOOST_TEST(fitness != programOptimisedOnce.codeSize());
-	BOOST_TEST(fitness == programOptimisedTwice.codeSize());
+	BOOST_TEST(fitness != m_program.codeSize(m_weights));
+	BOOST_TEST(fitness != programOptimisedOnce.codeSize(m_weights));
+	BOOST_TEST(fitness == programOptimisedTwice.codeSize(m_weights));
 }
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_not_optimise_if_number_of_repetitions_is_zero, ProgramBasedMetricFixture)
 {
-	ProgramSize metric(m_program, nullptr, 0);
+	ProgramSize metric(m_program, nullptr, m_weights, 0);
 	size_t fitness = metric.evaluate(m_chromosome);
 
-	BOOST_TEST(fitness == m_program.codeSize());
-	BOOST_TEST(fitness != m_optimisedProgram.codeSize());
+	BOOST_TEST(fitness == m_program.codeSize(m_weights));
+	BOOST_TEST(fitness != m_optimisedProgram.codeSize(m_weights));
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -179,12 +180,18 @@ BOOST_AUTO_TEST_SUITE(RelativeProgramSizeTest)
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_compute_the_size_ratio_between_optimised_program_and_original_program, ProgramBasedMetricFixture)
 {
-	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 3).evaluate(m_chromosome) == round(1000.0 * m_optimisedProgram.codeSize() / m_program.codeSize()));
+	BOOST_TEST(
+		RelativeProgramSize(m_program, nullptr, 3, m_weights).evaluate(m_chromosome) ==
+		round(1000.0 * m_optimisedProgram.codeSize(m_weights) / m_program.codeSize(m_weights))
+	);
 }
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_be_able_to_use_program_cache_if_available, ProgramBasedMetricFixture)
 {
-	BOOST_TEST(RelativeProgramSize(nullopt, m_programCache, 3).evaluate(m_chromosome) == round(1000.0 * m_optimisedProgram.codeSize() / m_program.codeSize()));
+	BOOST_TEST(
+		RelativeProgramSize(nullopt, m_programCache, 3, m_weights).evaluate(m_chromosome) ==
+		round(1000.0 * m_optimisedProgram.codeSize(m_weights) / m_program.codeSize(m_weights))
+	);
 	BOOST_TEST(m_programCache->size() == m_chromosome.length());
 }
 
@@ -193,17 +200,17 @@ BOOST_FIXTURE_TEST_CASE(evaluate_should_repeat_the_optimisation_specified_number
 	Program const& programOptimisedOnce = m_optimisedProgram;
 	Program programOptimisedTwice = optimisedProgram(programOptimisedOnce);
 
-	RelativeProgramSize metric(m_program, nullptr, 3, 2);
+	RelativeProgramSize metric(m_program, nullptr, 3, m_weights, 2);
 	size_t fitness = metric.evaluate(m_chromosome);
 
 	BOOST_TEST(fitness != 1000);
-	BOOST_TEST(fitness != RelativeProgramSize(programOptimisedTwice, nullptr, 3, 1).evaluate(m_chromosome));
-	BOOST_TEST(fitness == round(1000.0 * programOptimisedTwice.codeSize() / m_program.codeSize()));
+	BOOST_TEST(fitness != RelativeProgramSize(programOptimisedTwice, nullptr, 3, m_weights, 1).evaluate(m_chromosome));
+	BOOST_TEST(fitness == round(1000.0 * programOptimisedTwice.codeSize(m_weights) / m_program.codeSize(m_weights)));
 }
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_return_one_if_number_of_repetitions_is_zero, ProgramBasedMetricFixture)
 {
-	RelativeProgramSize metric(m_program, nullptr, 3, 0);
+	RelativeProgramSize metric(m_program, nullptr, 3, m_weights, 0);
 
 	BOOST_TEST(metric.evaluate(m_chromosome) == 1000);
 }
@@ -213,7 +220,7 @@ BOOST_FIXTURE_TEST_CASE(evaluate_should_return_one_if_the_original_program_size_
 	CharStream sourceStream = CharStream("{}", "");
 	Program program = get<Program>(Program::load(sourceStream));
 
-	RelativeProgramSize metric(program, nullptr, 3);
+	RelativeProgramSize metric(program, nullptr, 3, m_weights);
 
 	BOOST_TEST(metric.evaluate(m_chromosome) == 1000);
 	BOOST_TEST(metric.evaluate(Chromosome("")) == 1000);
@@ -222,12 +229,12 @@ BOOST_FIXTURE_TEST_CASE(evaluate_should_return_one_if_the_original_program_size_
 
 BOOST_FIXTURE_TEST_CASE(evaluate_should_multiply_the_result_by_scaling_factor, ProgramBasedMetricFixture)
 {
-	double sizeRatio = static_cast<double>(m_optimisedProgram.codeSize()) / m_program.codeSize();
-	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 0).evaluate(m_chromosome) == round(1.0 * sizeRatio));
-	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 1).evaluate(m_chromosome) == round(10.0 * sizeRatio));
-	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 2).evaluate(m_chromosome) == round(100.0 * sizeRatio));
-	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 3).evaluate(m_chromosome) == round(1000.0 * sizeRatio));
-	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 4).evaluate(m_chromosome) == round(10000.0 * sizeRatio));
+	double sizeRatio = static_cast<double>(m_optimisedProgram.codeSize(m_weights)) / m_program.codeSize(m_weights);
+	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 0, m_weights).evaluate(m_chromosome) == round(1.0 * sizeRatio));
+	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 1, m_weights).evaluate(m_chromosome) == round(10.0 * sizeRatio));
+	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 2, m_weights).evaluate(m_chromosome) == round(100.0 * sizeRatio));
+	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 3, m_weights).evaluate(m_chromosome) == round(1000.0 * sizeRatio));
+	BOOST_TEST(RelativeProgramSize(m_program, nullptr, 4, m_weights).evaluate(m_chromosome) == round(10000.0 * sizeRatio));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -32,6 +32,7 @@
 using namespace std;
 using namespace solidity::util;
 using namespace solidity::langutil;
+using namespace solidity::yul;
 
 namespace fs = boost::filesystem;
 
@@ -86,6 +87,7 @@ protected:
 		/* relativeMetricScale = */ 5,
 		/* chromosomeRepetitions = */ 1,
 	};
+	CodeWeights const m_weights{};
 };
 
 class PoulationFactoryFixture
@@ -183,7 +185,7 @@ BOOST_FIXTURE_TEST_CASE(build_should_create_metric_of_the_right_type, FitnessMet
 {
 	m_options.metric = MetricChoice::RelativeCodeSize;
 	m_options.metricAggregator = MetricAggregatorChoice::Sum;
-	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]}, {nullptr});
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]}, {nullptr}, m_weights);
 	BOOST_REQUIRE(metric != nullptr);
 
 	auto sumMetric = dynamic_cast<FitnessMetricSum*>(metric.get());
@@ -201,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE(build_should_respect_chromosome_repetitions_option, Fitn
 	m_options.metric = MetricChoice::CodeSize;
 	m_options.metricAggregator = MetricAggregatorChoice::Average;
 	m_options.chromosomeRepetitions = 5;
-	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]}, {nullptr});
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]}, {nullptr}, m_weights);
 	BOOST_REQUIRE(metric != nullptr);
 
 	auto averageMetric = dynamic_cast<FitnessMetricAverage*>(metric.get());
@@ -219,7 +221,7 @@ BOOST_FIXTURE_TEST_CASE(build_should_set_relative_metric_scale, FitnessMetricFac
 	m_options.metric = MetricChoice::RelativeCodeSize;
 	m_options.metricAggregator = MetricAggregatorChoice::Average;
 	m_options.relativeMetricScale = 10;
-	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]}, {nullptr});
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, {m_programs[0]}, {nullptr}, m_weights);
 	BOOST_REQUIRE(metric != nullptr);
 
 	auto averageMetric = dynamic_cast<FitnessMetricAverage*>(metric.get());
@@ -237,7 +239,8 @@ BOOST_FIXTURE_TEST_CASE(build_should_create_metric_for_each_input_program, Fitne
 	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(
 		m_options,
 		m_programs,
-		vector<shared_ptr<ProgramCache>>(m_programs.size(), nullptr)
+		vector<shared_ptr<ProgramCache>>(m_programs.size(), nullptr),
+		m_weights
 	);
 	BOOST_REQUIRE(metric != nullptr);
 
@@ -256,7 +259,7 @@ BOOST_FIXTURE_TEST_CASE(build_should_pass_program_caches_to_metrics, FitnessMetr
 	};
 
 	m_options.metric = MetricChoice::RelativeCodeSize;
-	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_programs, caches);
+	unique_ptr<FitnessMetric> metric = FitnessMetricFactory::build(m_options, m_programs, caches, m_weights);
 	BOOST_REQUIRE(metric != nullptr);
 
 	auto combinedMetric = dynamic_cast<FitnessMetricCombination*>(metric.get());

--- a/test/yulPhaser/Program.cpp
+++ b/test/yulPhaser/Program.cpp
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(codeSize)
 	CharStream sourceStream(sourceCode, current_test_case().p_name);
 	Program program = get<Program>(Program::load(sourceStream));
 
-	BOOST_TEST(program.codeSize() == CodeSize::codeSizeIncludingFunctions(program.ast()));
+	BOOST_TEST(program.codeSize(CodeWeights{}) == CodeSize::codeSizeIncludingFunctions(program.ast()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/ProgramCache.cpp
+++ b/test/yulPhaser/ProgramCache.cpp
@@ -214,11 +214,11 @@ BOOST_FIXTURE_TEST_CASE(startRound_should_remove_entries_older_than_two_rounds, 
 
 BOOST_FIXTURE_TEST_CASE(gatherStats_should_return_cache_statistics, ProgramCacheFixture)
 {
-	size_t sizeI = optimisedProgram(m_program, "I").codeSize(CodeWeights{});
-	size_t sizeIu = optimisedProgram(m_program, "Iu").codeSize(CodeWeights{});
-	size_t sizeIuO = optimisedProgram(m_program, "IuO").codeSize(CodeWeights{});
-	size_t sizeL = optimisedProgram(m_program, "L").codeSize(CodeWeights{});
-	size_t sizeLT = optimisedProgram(m_program, "LT").codeSize(CodeWeights{});
+	size_t sizeI = optimisedProgram(m_program, "I").codeSize(CacheStats::StorageWeights);
+	size_t sizeIu = optimisedProgram(m_program, "Iu").codeSize(CacheStats::StorageWeights);
+	size_t sizeIuO = optimisedProgram(m_program, "IuO").codeSize(CacheStats::StorageWeights);
+	size_t sizeL = optimisedProgram(m_program, "L").codeSize(CacheStats::StorageWeights);
+	size_t sizeLT = optimisedProgram(m_program, "LT").codeSize(CacheStats::StorageWeights);
 
 	m_programCache.optimiseProgram("L");
 	m_programCache.optimiseProgram("Iu");

--- a/test/yulPhaser/ProgramCache.cpp
+++ b/test/yulPhaser/ProgramCache.cpp
@@ -18,6 +18,8 @@
 #include <tools/yulPhaser/ProgramCache.h>
 #include <tools/yulPhaser/Chromosome.h>
 
+#include <libyul/optimiser/Metrics.h>
+
 #include <liblangutil/CharStream.h>
 
 #include <libsolutil/CommonIO.h>
@@ -212,11 +214,11 @@ BOOST_FIXTURE_TEST_CASE(startRound_should_remove_entries_older_than_two_rounds, 
 
 BOOST_FIXTURE_TEST_CASE(gatherStats_should_return_cache_statistics, ProgramCacheFixture)
 {
-	size_t sizeI = optimisedProgram(m_program, "I").codeSize();
-	size_t sizeIu = optimisedProgram(m_program, "Iu").codeSize();
-	size_t sizeIuO = optimisedProgram(m_program, "IuO").codeSize();
-	size_t sizeL = optimisedProgram(m_program, "L").codeSize();
-	size_t sizeLT = optimisedProgram(m_program, "LT").codeSize();
+	size_t sizeI = optimisedProgram(m_program, "I").codeSize(CodeWeights{});
+	size_t sizeIu = optimisedProgram(m_program, "Iu").codeSize(CodeWeights{});
+	size_t sizeIuO = optimisedProgram(m_program, "IuO").codeSize(CodeWeights{});
+	size_t sizeL = optimisedProgram(m_program, "L").codeSize(CodeWeights{});
+	size_t sizeLT = optimisedProgram(m_program, "LT").codeSize(CodeWeights{});
 
 	m_programCache.optimiseProgram("L");
 	m_programCache.optimiseProgram("Iu");

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -23,6 +23,7 @@
 
 using namespace std;
 using namespace solidity::util;
+using namespace solidity::yul;
 using namespace solidity::phaser;
 
 Program const& ProgramBasedMetric::program() const
@@ -55,18 +56,18 @@ Program ProgramBasedMetric::optimisedProgramNoCache(Chromosome const& _chromosom
 
 size_t ProgramSize::evaluate(Chromosome const& _chromosome)
 {
-	return optimisedProgram(_chromosome).codeSize();
+	return optimisedProgram(_chromosome).codeSize(codeWeights());
 }
 
 size_t RelativeProgramSize::evaluate(Chromosome const& _chromosome)
 {
 	size_t const scalingFactor = pow(10, m_fixedPointPrecision);
 
-	size_t unoptimisedSize = optimisedProgram(Chromosome("")).codeSize();
+	size_t unoptimisedSize = optimisedProgram(Chromosome("")).codeSize(codeWeights());
 	if (unoptimisedSize == 0)
 		return scalingFactor;
 
-	size_t optimisedSize = optimisedProgram(_chromosome).codeSize();
+	size_t optimisedSize = optimisedProgram(_chromosome).codeSize(codeWeights());
 
 	return static_cast<size_t>(round(
 		static_cast<double>(optimisedSize) / unoptimisedSize * scalingFactor

--- a/tools/yulPhaser/FitnessMetrics.h
+++ b/tools/yulPhaser/FitnessMetrics.h
@@ -24,6 +24,8 @@
 #include <tools/yulPhaser/Program.h>
 #include <tools/yulPhaser/ProgramCache.h>
 
+#include <libyul/optimiser/Metrics.h>
+
 #include <cstddef>
 #include <optional>
 
@@ -64,10 +66,12 @@ public:
 	explicit ProgramBasedMetric(
 		std::optional<Program> _program,
 		std::shared_ptr<ProgramCache> _programCache,
+		yul::CodeWeights const& _codeWeights,
 		size_t _repetitionCount = 1
 	):
 		m_program(std::move(_program)),
 		m_programCache(std::move(_programCache)),
+		m_codeWeights(_codeWeights),
 		m_repetitionCount(_repetitionCount)
 	{
 		assert(m_program.has_value() == (m_programCache == nullptr));
@@ -75,6 +79,7 @@ public:
 
 	Program const& program() const;
 	ProgramCache const* programCache() const { return m_programCache.get(); }
+	yul::CodeWeights const& codeWeights() const { return m_codeWeights; }
 	size_t repetitionCount() const { return m_repetitionCount; }
 
 	Program optimisedProgram(Chromosome const& _chromosome);
@@ -83,6 +88,7 @@ public:
 private:
 	std::optional<Program> m_program;
 	std::shared_ptr<ProgramCache> m_programCache;
+	yul::CodeWeights m_codeWeights;
 	size_t m_repetitionCount;
 };
 
@@ -111,9 +117,10 @@ public:
 		std::optional<Program> _program,
 		std::shared_ptr<ProgramCache> _programCache,
 		size_t _fixedPointPrecision,
+		yul::CodeWeights const& _weights,
 		size_t _repetitionCount = 1
 	):
-		ProgramBasedMetric(std::move(_program), std::move(_programCache), _repetitionCount),
+		ProgramBasedMetric(std::move(_program), std::move(_programCache), _weights, _repetitionCount),
 		m_fixedPointPrecision(_fixedPointPrecision) {}
 
 	size_t fixedPointPrecision() const { return m_fixedPointPrecision; }

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -39,6 +39,7 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::util;
+using namespace solidity::yul;
 using namespace solidity::phaser;
 
 namespace po = boost::program_options;
@@ -216,6 +217,7 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 				metrics.push_back(make_unique<ProgramSize>(
 					_programCaches[i] != nullptr ? optional<Program>{} : move(_programs[i]),
 					move(_programCaches[i]),
+					CodeWeights{},
 					_options.chromosomeRepetitions
 				));
 
@@ -228,6 +230,7 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 					_programCaches[i] != nullptr ? optional<Program>{} : move(_programs[i]),
 					move(_programCaches[i]),
 					_options.relativeMetricScale,
+					CodeWeights{},
 					_options.chromosomeRepetitions
 				));
 			break;

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -680,9 +680,11 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 
 	po::options_description metricWeightDescription("METRIC WEIGHTS", lineLength, minDescriptionLength);
 	metricWeightDescription.add_options()
-		("expression-statement-cost", po::value<size_t>()->value_name("<COST>")->default_value(0))
-		("assignment-cost",           po::value<size_t>()->value_name("<COST>")->default_value(0))
-		("variable-declaration-cost", po::value<size_t>()->value_name("<COST>")->default_value(0))
+		// TODO: We need to figure out the best set of weights for the phaser.
+		// This one is just a stopgap to make sure no statement or expression has zero cost.
+		("expression-statement-cost", po::value<size_t>()->value_name("<COST>")->default_value(1))
+		("assignment-cost",           po::value<size_t>()->value_name("<COST>")->default_value(1))
+		("variable-declaration-cost", po::value<size_t>()->value_name("<COST>")->default_value(1))
 		("function-definition-cost",  po::value<size_t>()->value_name("<COST>")->default_value(1))
 		("if-cost",                   po::value<size_t>()->value_name("<COST>")->default_value(2))
 		("switch-cost",               po::value<size_t>()->value_name("<COST>")->default_value(1))
@@ -691,9 +693,9 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 		("break-cost",                po::value<size_t>()->value_name("<COST>")->default_value(2))
 		("continue-cost",             po::value<size_t>()->value_name("<COST>")->default_value(2))
 		("leave-cost",                po::value<size_t>()->value_name("<COST>")->default_value(2))
-		("block-cost",                po::value<size_t>()->value_name("<COST>")->default_value(0))
+		("block-cost",                po::value<size_t>()->value_name("<COST>")->default_value(1))
 		("function-call-cost",        po::value<size_t>()->value_name("<COST>")->default_value(1))
-		("identifier-cost",           po::value<size_t>()->value_name("<COST>")->default_value(0))
+		("identifier-cost",           po::value<size_t>()->value_name("<COST>")->default_value(1))
 		("literal-cost",              po::value<size_t>()->value_name("<COST>")->default_value(1))
 	;
 	keywordDescription.add(metricWeightDescription);

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -39,6 +39,13 @@ class CharStream;
 
 }
 
+namespace solidity::yul
+{
+
+struct CodeWeights;
+
+}
+
 namespace solidity::phaser
 {
 
@@ -126,6 +133,17 @@ public:
 };
 
 /**
+ * Builds and validates instances of @a CodeWeights.
+ */
+class CodeWeightFactory
+{
+public:
+	static yul::CodeWeights buildFromCommandLine(
+		boost::program_options::variables_map const& _arguments
+	);
+};
+
+/**
  * Builds and validates instances of @a FitnessMetric and its derived classes.
  */
 class FitnessMetricFactory
@@ -144,7 +162,8 @@ public:
 	static std::unique_ptr<FitnessMetric> build(
 		Options const& _options,
 		std::vector<Program> _programs,
-		std::vector<std::shared_ptr<ProgramCache>> _programCaches
+		std::vector<std::shared_ptr<ProgramCache>> _programCaches,
+		yul::CodeWeights const& _weights
 	);
 };
 

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -207,7 +207,7 @@ unique_ptr<Block> Program::applyOptimisationSteps(
 	return _ast;
 }
 
-size_t Program::computeCodeSize(Block const& _ast)
+size_t Program::computeCodeSize(Block const& _ast, CodeWeights const& _weights)
 {
-	return CodeSize::codeSizeIncludingFunctions(_ast);
+	return CodeSize::codeSizeIncludingFunctions(_ast, _weights);
 }

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -41,6 +41,7 @@ namespace solidity::yul
 
 struct AsmAnalysisInfo;
 struct Dialect;
+struct CodeWeights;
 
 }
 
@@ -78,7 +79,7 @@ public:
 	static std::variant<Program, langutil::ErrorList> load(langutil::CharStream& _sourceCode);
 	void optimise(std::vector<std::string> const& _optimisationSteps);
 
-	size_t codeSize() const { return computeCodeSize(*m_ast); }
+	size_t codeSize(yul::CodeWeights const& _weights) const { return computeCodeSize(*m_ast, _weights); }
 	yul::Block const& ast() const { return *m_ast; }
 
 	friend std::ostream& operator<<(std::ostream& _stream, Program const& _program);
@@ -113,7 +114,7 @@ private:
 		std::unique_ptr<yul::Block> _ast,
 		std::vector<std::string> const& _optimisationSteps
 	);
-	static size_t computeCodeSize(yul::Block const& _ast);
+	static size_t computeCodeSize(yul::Block const& _ast, yul::CodeWeights const& _weights);
 
 	std::unique_ptr<yul::Block> m_ast;
 	yul::Dialect const& m_dialect;

--- a/tools/yulPhaser/ProgramCache.cpp
+++ b/tools/yulPhaser/ProgramCache.cpp
@@ -17,6 +17,8 @@
 
 #include <tools/yulPhaser/ProgramCache.h>
 
+#include <libyul/optimiser/Metrics.h>
+
 #include <libyul/optimiser/Suite.h>
 
 using namespace std;
@@ -133,7 +135,7 @@ size_t ProgramCache::calculateTotalCachedCodeSize() const
 {
 	size_t size = 0;
 	for (auto const& pair: m_entries)
-		size += pair.second.program.codeSize();
+		size += pair.second.program.codeSize(CodeWeights{});
 
 	return size;
 }

--- a/tools/yulPhaser/ProgramCache.cpp
+++ b/tools/yulPhaser/ProgramCache.cpp
@@ -135,7 +135,7 @@ size_t ProgramCache::calculateTotalCachedCodeSize() const
 {
 	size_t size = 0;
 	for (auto const& pair: m_entries)
-		size += pair.second.program.codeSize(CodeWeights{});
+		size += pair.second.program.codeSize(CacheStats::StorageWeights);
 
 	return size;
 }

--- a/tools/yulPhaser/ProgramCache.h
+++ b/tools/yulPhaser/ProgramCache.h
@@ -19,6 +19,8 @@
 
 #include <tools/yulPhaser/Program.h>
 
+#include <libyul/optimiser/Metrics.h>
+
 #include <map>
 #include <string>
 
@@ -44,6 +46,29 @@ struct CacheEntry
  */
 struct CacheStats
 {
+	/// Weights used to compute totalCodeSize.
+	/// The goal here is to get a result proportional to the amount of memory taken by the AST.
+	/// Each statement/expression gets 1 just for existing. We add more if it contains any extra
+	/// data that won't be visited separately by ASTWalker.
+	static yul::CodeWeights constexpr StorageWeights = {
+		/* expressionStatementCost = */ 1,
+		/* assignmentCost = */ 1,
+		/* variableDeclarationCost = */ 1,
+		/* functionDefinitionCost = */ 1,
+		/* ifCost = */ 1,
+		/* switchCost = */ 1,
+		/* caseCost = */ 1,
+		/* forLoopCost = */ 1,
+		/* breakCost = */ 1,
+		/* continueCost = */ 1,
+		/* leaveCost = */ 1,
+		/* blockCost = */ 1,
+
+		/* functionCallCost = */ 1,
+		/* identifierCost = */ 1,
+		/* literalCost = */ 1,
+	};
+
 	size_t hits;
 	size_t misses;
 	size_t totalCodeSize;


### PR DESCRIPTION
### Description
The fourteenth pull request implementing #7806. Depends on #8452.

This PR modifies the `CodeSize` metric to add customizable weights for all possible statement and expression types. It provides defaults so that the metric keeps working as it used to if you don't change anything but allows `yul-phaser` to use different values at the same time.

The default for `yul-phaser` is similar to `CodeSize`'s default but with ones for items that `CodeSize` assigns zero to.

Weights can now also be controlled from the command-line.

### Example invocation
``` bash
tools/yul-phaser                                                \
    ../test/libyul/yulOptimizerTests/fullSuite/abi_example1.yul \
    --random-population         20                              \
    --expression-statement-cost  1                              \
    --assignment-cost            1                              \
    --variable-declaration-cost  1                              \
    --function-definition-cost   1                              \
    --if-cost                    2                              \
    --switch-cost                1                              \
    --case-cost                  2                              \
    --for-loop-cost              3                              \
    --break-cost                 2                              \
    --continue-cost              2                              \
    --leave-cost                 2                              \
    --block-cost                 1                              \
    --function-call-cost         1                              \
    --identifier-cost            1                              \
    --literal-cost               1
```

### Dependencies
This PR is based on #8452. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages

### Requested changes
- [ ] Use default values in `CodeWeights` instead of `DefaultWeights` constant.
- [ ] Check if the extra conditions slow down the optimizer.