### PR TITLE
Compilation fix.

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1350,7 +1350,7 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 			_from.identifier() +
 			"_to_" +
 			_to.identifier();
-		return m_functionCollector->createFunction(functionName, [&]() {
+		return m_functionCollector.createFunction(functionName, [&]() {
 			return Whiskers(R"(
 				function <functionName>(addr, functionId) -> outAddr, outFunctionId {
 					outAddr := addr


### PR DESCRIPTION
I am not sure how this compile error went into develop with all tests passing in prior merges. But this fixes the one being introduced by the shared_ptr-to-ref change in https://github.com/ethereum/solidity/pull/8409