### PR TITLE
YulUtilFunctions: convertionFunction() to also handle array string/memory casts

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1469,22 +1469,34 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 			break;
 		case Type::Category::Array:
 		{
-			bool equal = _from == _to;
-
-			if (!equal)
+			if (_from == _to)
+				body = "converted := value";
+			else
 			{
 				ArrayType const& from = dynamic_cast<decltype(from)>(_from);
 				ArrayType const& to = dynamic_cast<decltype(to)>(_to);
 
-				if (*from.mobileType() == *to.mobileType())
-					equal = true;
+				switch (to.location())
+				{
+				case DataLocation::Storage:
+					// Other cases are done explicitly in LValue::storeValue, and only possible by assignment.
+					solAssert(
+						(to.isPointer() || (from.isByteArray() && to.isByteArray())) &&
+						from.location() == DataLocation::Storage,
+						"Invalid conversion to storage type."
+					);
+					body = "converted := value";
+					break;
+				case DataLocation::Memory:
+					// Copy the array to a free position in memory, unless it is already in memory.
+					solUnimplementedAssert(from.location() == DataLocation::Memory, "Not implemented yet.");
+					body = "converted := value";
+					break;
+				case DataLocation::CallData:
+					solUnimplemented("Conversion of calldata types not yet implemented.");
+					break;
+				}
 			}
-
-			if (equal)
-				body = "converted := value";
-			else
-				solUnimplementedAssert(false, "Array conversion not implemented.");
-
 			break;
 		}
 		case Type::Category::Struct:

--- a/test/libsolidity/semanticTests/conversions/string_to_bytes.sol
+++ b/test/libsolidity/semanticTests/conversions/string_to_bytes.sol
@@ -1,0 +1,9 @@
+contract C {
+	function f(string memory s) public pure returns (bytes memory t) {
+		t = bytes(s);
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(string): 32, 5, "Hello" -> 32, 5, "Hello"


### PR DESCRIPTION
This is a prerequisite for #8246.