### PR TITLE
Add --show-metadata to enable metadata output.

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -96,7 +96,8 @@ CommonOptions::CommonOptions(std::string _caption):
 		("optimize", po::bool_switch(&optimize), "enables optimization")
 		("optimize-yul", po::bool_switch(&optimizeYul), "enables Yul optimization")
 		("abiencoderv2", po::bool_switch(&useABIEncoderV2), "enables abi encoder v2")
-		("show-messages", po::bool_switch(&showMessages), "enables message output");
+		("show-messages", po::bool_switch(&showMessages), "enables message output")
+		("show-metadata", po::bool_switch(&showMetadata), "enables metadata output");
 }
 
 void CommonOptions::validate() const

--- a/test/Common.h
+++ b/test/Common.h
@@ -50,6 +50,7 @@ struct CommonOptions: boost::noncopyable
 	bool disableSMT = false;
 	bool useABIEncoderV2 = false;
 	bool showMessages = false;
+	bool showMetadata = false;
 
 	langutil::EVMVersion evmVersion() const;
 

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -41,9 +41,9 @@ class SolidityExecutionFramework: public solidity::test::ExecutionFramework
 {
 
 public:
-	SolidityExecutionFramework() {}
+	SolidityExecutionFramework(): m_showMetadata(solidity::test::CommonOptions::get().showMetadata) {}
 	explicit SolidityExecutionFramework(langutil::EVMVersion _evmVersion):
-		ExecutionFramework(_evmVersion)
+		ExecutionFramework(_evmVersion), m_showMetadata(solidity::test::CommonOptions::get().showMetadata)
 	{}
 
 	virtual bytes const& compileAndRunWithoutCheck(
@@ -68,6 +68,7 @@ public:
 protected:
 	solidity::frontend::CompilerStack m_compiler;
 	bool m_compileViaYul = false;
+	bool m_showMetadata = false;
 	RevertStrings m_revertStrings = RevertStrings::Default;
 
 };


### PR DESCRIPTION
Adds command line option `--show-metadata` to `soltest` to enable metadata output. 