### PR TITLE
Fix variable name in Sol -> Yul

### DIFF
--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -324,6 +324,7 @@ Parser::ElementaryOperation Parser::parseElementaryOperation()
 	case Token::Byte:
 	case Token::Bool:
 	case Token::Address:
+	case Token::Var:
 	{
 		YulString literal{currentLiteral()};
 		if (m_dialect.builtin(literal))
@@ -513,6 +514,7 @@ YulString Parser::expectAsmIdentifier()
 	case Token::Address:
 	case Token::Bool:
 	case Token::Identifier:
+	case Token::Var:
 		break;
 	default:
 		expectToken(Token::Identifier);

--- a/test/libsolidity/semanticTests/viaYul/mapping_string_key.sol
+++ b/test/libsolidity/semanticTests/viaYul/mapping_string_key.sol
@@ -1,0 +1,10 @@
+contract C {
+	mapping (string => uint) map;
+	function set(string memory s) public {
+		map[s];
+	}
+}
+// ====
+// compileViaYul: true
+// ----
+// set(string): 0x20, 32, "01234567890123456789012345678901" ->


### PR DESCRIPTION
The code
```
contract C {
    mapping (string => uint) map;
    function set(string memory s) public {
        map[s];
    }
```
compiles to https://gist.github.com/leonardoalt/07eda89abbd05dd51d51741b741bf974 when the optimizer is enabled, which then doesn't compile because of variable `var`.

Sol -> Yul doesn't use `var` directly, it uses `var_X` where `X >= 0`, but the optimizer later on removes the index.
This is a quick fix. A proper fix would be to separate Solidity's and Yul's token lists.