### PR TITLE
[SMTChecker] Add support to array member length

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ Language Features:
 Compiler Features:
  * Metadata: Added support for IPFS hashes of large files that need to be split in multiple chunks.
  * Commandline Interface: Enable output of storage layout with `--storage-layout`.
+ * SMTChecker: Support array member ``length``.
+
 
 
 Bugfixes:

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -78,6 +78,12 @@ private:
 	void visitAssert(FunctionCall const& _funCall);
 	void internalFunctionCall(FunctionCall const& _funCall);
 	void unknownFunctionCall(FunctionCall const& _funCall);
+
+	/// Handles access to array length.
+	void arrayLength(MemberAccess const& _arrayLength) override;
+	/// Asserts that the length of an array is the same after
+	/// an assignment to an element.
+	void copyOldArrayLength(TypePointer _type, std::shared_ptr<smt::SymbolicVariable> const& _symbVar) override;
 	//@}
 
 	struct IdCompare
@@ -98,6 +104,13 @@ private:
 	void setCurrentBlock(smt::SymbolicFunctionVariable const& _block, std::vector<smt::Expression> const* _arguments = nullptr);
 	std::set<Expression const*, IdCompare> transactionAssertions(ASTNode const* _txRoot);
 	static std::vector<VariableDeclaration const*> stateVariablesIncludingInheritedAndPrivate(ContractDefinition const& _contract);
+
+	/// Creates the array that contains array lengths for the given type.
+	void createArrayLengths(Type const& _type);
+	/// Creates the array that contains array lengths for state variables.
+	void createContractArrayLengths(ContractDefinition const& _contract);
+	/// Creates the array that contains array lengths for function variables.
+	void createFunctionArrayLengths(FunctionDefinition const& _function);
 	//@}
 
 	/// Sort helpers.
@@ -119,9 +132,11 @@ private:
 	/// @returns a new block of given _sort and _name.
 	std::unique_ptr<smt::SymbolicFunctionVariable> createSymbolicBlock(smt::SortPointer _sort, std::string const& _name);
 
-	/// Creates summary predicates for all functions of all contracts
+	/// Creates the symbolic entities that are used by predicates:
+	/// interfaces, summaries and array length functions
+	/// for all functions of all contracts
 	/// in a given _source.
-	void defineInterfacesAndSummaries(SourceUnit const& _source);
+	void defineSymbols(SourceUnit const& _source);
 
 	/// Genesis predicate.
 	smt::Expression genesis() { return (*m_genesisPredicate)({}); }
@@ -231,6 +246,12 @@ private:
 	/// State variables.
 	/// Used to create all predicates.
 	std::vector<VariableDeclaration const*> m_stateVariables;
+
+	/// Maps an array type (from its canonical name) to a symbolic
+	/// array that maps arrays to their lengths.
+	/// Ideally this would be an Uninterpreted Function, but z3
+	/// does not allow functions as arguments (second order).
+	std::map<std::string, smt::SymbolicArrayVariable> m_arrayLengths;
 	//@}
 
 	/// Verification targets.

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -136,6 +136,9 @@ protected:
 	void arrayAssignment();
 	/// Handles assignment to SMT array index.
 	void arrayIndexAssignment(Expression const& _expr, smt::Expression const& _rightHandSide);
+	/// Asserts that the length of an array is the same after
+	/// an assignment to an element.
+	virtual void copyOldArrayLength(TypePointer /*_type*/, std::shared_ptr<smt::SymbolicVariable> const& /*_symbVar*/) {}
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -237,6 +240,9 @@ protected:
 
 	/// @returns a note to be added to warnings.
 	std::string extraComment();
+
+	/// Allows each engine to handle array length.
+	virtual void arrayLength(MemberAccess const& /*_arrayLength*/) {}
 
 	struct VerificationTarget
 	{

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -218,15 +218,28 @@ SymbolicArrayVariable::SymbolicArrayVariable(
 	solAssert(isArray(m_type->category()), "");
 }
 
+SymbolicArrayVariable::SymbolicArrayVariable(
+	SortPointer _sort,
+	string _uniqueName,
+	EncodingContext& _context
+):
+	SymbolicVariable(move(_sort), move(_uniqueName), _context)
+{
+	solAssert(m_sort->kind == Kind::Array, "");
+}
+
 smt::Expression SymbolicArrayVariable::currentValue(frontend::TypePointer const& _targetType) const
 {
 	if (_targetType)
+	{
+		solAssert(m_originalType, "");
 		// StringLiterals are encoded as SMT arrays in the generic case,
 		// but they can also be compared/assigned to fixed bytes, in which
 		// case they'd need to be encoded as numbers.
 		if (auto strType = dynamic_cast<StringLiteralType const*>(m_originalType))
 			if (_targetType->category() == frontend::Type::Category::FixedBytes)
 				return smt::Expression(u256(toHex(util::asBytes(strType->value()), util::HexPrefix::Add)));
+	}
 
 	return SymbolicVariable::currentValue(_targetType);
 }

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -47,6 +47,8 @@ public:
 		EncodingContext& _context
 	);
 
+	SymbolicVariable(SymbolicVariable&&) = default;
+
 	virtual ~SymbolicVariable() = default;
 
 	virtual Expression currentValue(frontend::TypePointer const& _targetType = TypePointer{}) const;
@@ -212,6 +214,13 @@ public:
 		std::string _uniqueName,
 		EncodingContext& _context
 	);
+	SymbolicArrayVariable(
+		SortPointer _sort,
+		std::string _uniqueName,
+		EncodingContext& _context
+	);
+
+	SymbolicArrayVariable(SymbolicArrayVariable&&) = default;
 
 	Expression currentValue(frontend::TypePointer const& _targetType = TypePointer{}) const override;
 };

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_assignment_2d_memory_to_memory.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_assignment_2d_memory_to_memory.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+pragma experimental ABIEncoderV2;
+
+contract C {
+	function f(uint[][] memory arr) public pure {
+		uint[][] memory arr2 = arr;
+		assert(arr2[0].length == arr[0].length);
+		assert(arr.length == arr2.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_assignment_2d_storage_to_storage.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_assignment_2d_storage_to_storage.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+pragma experimental ABIEncoderV2;
+
+contract C {
+	uint[][] arr;
+	uint[][] arr2;
+	function f() public view {
+		assert(arr2[0].length == arr[0].length);
+		assert(arr2.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_copy_2d_memory_to_storage.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_copy_2d_memory_to_storage.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+pragma experimental ABIEncoderV2;
+
+contract C {
+	uint[][] arr;
+	function f(uint[][] memory arr2) public {
+		arr = arr2;
+		assert(arr2[0].length == arr[0].length);
+		assert(arr2.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_copy_2d_storage_to_memory.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_copy_2d_storage_to_memory.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+pragma experimental ABIEncoderV2;
+
+contract C {
+	uint[][] arr;
+	function f() public view {
+		uint[][] memory arr2 = arr;
+		assert(arr2[0].length == arr[0].length);
+		assert(arr2.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_mapping_array_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_mapping_array_1.sol
@@ -1,0 +1,8 @@
+pragma experimental SMTChecker;
+
+contract C {
+	mapping (uint => uint[]) map;
+	function f() public view {
+		assert(map[0].length == map[1].length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_mapping_array_2.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_mapping_array_2.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	mapping (uint => uint[]) map;
+	function f(uint x, uint y) public view {
+		require(x == y);
+		assert(map[x].length == map[y].length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_mapping_array_2d_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_mapping_array_2d_1.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	mapping (uint => uint[][]) map;
+	function f(uint x, uint y) public view {
+		require(x == y);
+		assert(map[x][0].length == map[y][0].length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_struct_array_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_struct_array_1.sol
@@ -1,0 +1,20 @@
+pragma experimental SMTChecker;
+
+contract C {
+	struct S {
+		uint[] arr;
+	}
+	S s1;
+	S s2;
+	function f() public view {
+		assert(s1.arr.length == s2.arr.length);
+	}
+}
+// ----
+// Warning: (76-80): Assertion checker does not yet support the type of this variable.
+// Warning: (83-87): Assertion checker does not yet support the type of this variable.
+// Warning: (126-132): Assertion checker does not yet support this expression.
+// Warning: (126-128): Assertion checker does not yet implement type struct C.S storage ref
+// Warning: (143-149): Assertion checker does not yet support this expression.
+// Warning: (143-145): Assertion checker does not yet implement type struct C.S storage ref
+// Warning: (119-157): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/length_1d_struct_array_2d_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_1d_struct_array_2d_1.sol
@@ -1,0 +1,22 @@
+pragma experimental SMTChecker;
+
+contract C {
+	struct S {
+		uint[][] arr;
+	}
+	S s1;
+	S s2;
+	function f() public view {
+		assert(s1.arr[0].length == s2.arr[0].length);
+	}
+}
+// ----
+// Warning: (78-82): Assertion checker does not yet support the type of this variable.
+// Warning: (85-89): Assertion checker does not yet support the type of this variable.
+// Warning: (128-134): Assertion checker does not yet support this expression.
+// Warning: (128-130): Assertion checker does not yet implement type struct C.S storage ref
+// Warning: (128-137): Assertion checker does not yet implement this expression.
+// Warning: (148-154): Assertion checker does not yet support this expression.
+// Warning: (148-150): Assertion checker does not yet implement type struct C.S storage ref
+// Warning: (148-157): Assertion checker does not yet implement this expression.
+// Warning: (121-165): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/length_assignment_2d_memory_to_memory.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_assignment_2d_memory_to_memory.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+pragma experimental ABIEncoderV2;
+
+contract C {
+	function f(uint[][] memory arr) public pure {
+		uint[][] memory arr2 = arr;
+		assert(arr2.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_assignment_memory_to_memory.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_assignment_memory_to_memory.sol
@@ -1,0 +1,8 @@
+pragma experimental SMTChecker;
+
+contract C {
+	function f(uint[] memory arr) public pure {
+		uint[] memory arr2 = arr;
+		assert(arr2.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_assignment_storage_to_storage.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_assignment_storage_to_storage.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] arr;
+	uint[] arr2;
+	function f() public {
+		arr2 = arr;
+		assert(arr2.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_basic.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_basic.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] arr;
+	function f() public view {
+		uint x = arr.length;
+		uint y = x;
+		assert(arr.length == y);
+		assert(arr.length != y);
+	}
+}
+// ----
+// Warning: (153-176): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/length_copy_memory_to_storage.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_copy_memory_to_storage.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] arr;
+	function f(uint[] memory marr) public {
+		arr = marr;
+		assert(marr.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_copy_storage_to_memory.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_copy_storage_to_memory.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] arr;
+	function f() public view {
+		uint[] memory marr = arr;
+		assert(marr.length == arr.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_function_call.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_function_call.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] arr;
+	function f() public view {
+		assert(arr.length == g().length);
+	}
+	function g() internal pure returns (uint[] memory) {
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] arr;
+	function f() public view {
+		uint[] memory arr2 = arr;
+		arr2[2] = 3;
+		assert(arr.length == arr2.length);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_2.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_2.sol
@@ -1,0 +1,15 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] arr;
+	uint[][] arr2;
+	function f() public {
+		uint x = arr[2].length;
+		uint y = arr[3].length;
+		uint z = arr.length;
+		arr[2][333] = 444;
+		assert(arr[2].length == x);
+		assert(arr[3].length == y);
+		assert(arr.length == z);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_2_fail.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_2_fail.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] arr;
+	uint[][] arr2;
+	function f() public {
+		uint x = arr[2].length;
+		uint y = arr[3].length;
+		uint z = arr.length;
+		arr[2][333] = 444;
+		assert(arr[2].length != x);
+		assert(arr[3].length != y);
+		assert(arr.length != z);
+	}
+}
+// ----
+// Warning: (198-224): Assertion violation happens here
+// Warning: (228-254): Assertion violation happens here
+// Warning: (258-281): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_3.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_3.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] arr;
+	uint[][] arr2;
+	function f() public {
+		uint x = arr[2].length;
+		uint y = arr[3].length;
+		uint z = arr.length;
+		uint t = arr[5].length;
+		arr[5] = arr[8];
+		assert(arr[2].length == x);
+		assert(arr[3].length == y);
+		assert(arr.length == z);
+		assert(arr[5].length == t);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_3_fail.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/length_same_after_assignment_3_fail.sol
@@ -1,0 +1,22 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] arr;
+	uint[][] arr2;
+	function f() public {
+		uint x = arr[2].length;
+		uint y = arr[3].length;
+		uint z = arr.length;
+		uint t = arr[5].length;
+		arr[5] = arr[8];
+		assert(arr[2].length != x);
+		assert(arr[3].length != y);
+		assert(arr.length != z);
+		assert(arr[5].length != t);
+	}
+}
+// ----
+// Warning: (222-248): Assertion violation happens here
+// Warning: (252-278): Assertion violation happens here
+// Warning: (282-305): Assertion violation happens here
+// Warning: (309-335): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/complex/MerkleProof.sol
+++ b/test/libsolidity/smtCheckerTests/complex/MerkleProof.sol
@@ -34,9 +34,7 @@ library MerkleProof {
 }
 
 // ----
-// Warning: (755-767): Assertion checker does not yet support this expression.
 // Warning: (988-991): Assertion checker does not yet implement type abi
 // Warning: (988-1032): Assertion checker does not yet implement this type of function call.
 // Warning: (1175-1178): Assertion checker does not yet implement type abi
 // Warning: (1175-1219): Assertion checker does not yet implement this type of function call.
-// Warning: (755-767): Assertion checker does not yet support this expression.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_memory.sol
@@ -1,11 +1,12 @@
 pragma experimental SMTChecker;
 
 contract LoopFor2 {
-	function testUnboundedForLoop(uint n, uint[] memory b, uint[] memory c) public pure {
+	function testUnboundedForLoop(uint[] memory b, uint[] memory c) public pure {
 		b[0] = 900;
 		uint[] memory a = b;
-		require(n > 0 && n < 100);
-		for (uint i = 0; i < n; i += 1) {
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
+		for (uint i = 0; i < b.length; i++) {
 			b[i] = i + 1;
 			c[i] = b[i];
 		}
@@ -15,6 +16,7 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (281-301): Assertion violation happens here
-// Warning: (305-324): Assertion violation happens here
-// Warning: (328-347): Assertion violation happens here
+// Warning: (295-300): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (324-344): Assertion violation happens here
+// Warning: (348-367): Assertion violation happens here
+// Warning: (371-390): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_storage.sol
@@ -3,11 +3,12 @@ pragma experimental SMTChecker;
 contract LoopFor2 {
 	uint[] a;
 
-	function testUnboundedForLoop(uint n, uint[] memory b, uint[] memory c) public {
+	function testUnboundedForLoop(uint[] memory b, uint[] memory c) public {
 		b[0] = 900;
 		a = b;
-		require(n > 0 && n < 100);
-		for (uint i = 0; i < n; i += 1) {
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
+		for (uint i = 0; i < b.length; i++) {
 			b[i] = i + 1;
 			c[i] = b[i];
 		}
@@ -16,8 +17,7 @@ contract LoopFor2 {
 		assert(b[0] == 900);
 	}
 }
-// ====
-// SMTSolvers: z3
 // ----
-// Warning: (274-294): Assertion violation happens here
-// Warning: (321-340): Assertion violation happens here
+// Warning: (288-293): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (317-337): Assertion violation happens here
+// Warning: (364-383): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_memory.sol
@@ -7,8 +7,9 @@ contract LoopFor2 {
 	function testUnboundedForLoop(uint n) public {
 		b[0] = 900;
 		uint[] memory a = b;
-		require(n > 0 && n < 100);
-		for (uint i = 0; i < n; i += 1) {
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
+		for (uint i = 0; i < b.length; i++) {
 			b[i] = i + 1;
 			c[i] = b[i];
 		}
@@ -19,5 +20,7 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (316-336): Assertion violation happens here
-// Warning: (363-382): Assertion violation happens here
+// Warning: (107-113): Unused function parameter. Remove or comment out the variable name to silence this warning.
+// Warning: (287-292): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (367-387): Assertion violation happens here
+// Warning: (414-433): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
@@ -4,11 +4,12 @@ contract LoopFor2 {
 	uint[] b;
 	uint[] c;
 
-	function testUnboundedForLoop(uint n) public {
+	function testUnboundedForLoop() public {
 		b[0] = 900;
 		uint[] storage a = b;
-		require(n > 0 && n < 100);
-		for (uint i = 0; i < n; i += 1) {
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
+		for (uint i = 0; i < b.length; i++) {
 			b[i] = i + 1;
 			c[i] = b[i];
 		}
@@ -19,6 +20,7 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (317-337): Assertion violation happens here
-// Warning: (341-360): Assertion violation happens here
-// Warning: (364-383): Assertion violation happens here
+// Warning: (282-287): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (362-382): Assertion violation happens here
+// Warning: (386-405): Assertion violation happens here
+// Warning: (409-428): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_memory_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_memory_memory.sol
@@ -1,12 +1,13 @@
 pragma experimental SMTChecker;
 
 contract LoopFor2 {
-	function testUnboundedForLoop(uint n, uint[] memory b, uint[] memory c) public pure {
+	function testUnboundedForLoop(uint[] memory b, uint[] memory c) public pure {
 		b[0] = 900;
 		uint[] memory a = b;
-		require(n > 0 && n < 100);
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
 		uint i;
-		while (i < n) {
+		while (i < b.length) {
 			b[i] = i + 1;
 			c[i] = b[i];
 			++i;
@@ -16,9 +17,9 @@ contract LoopFor2 {
 		assert(b[0] == 900);
 	}
 }
-// ====
-// SMTSolvers: z3
 // ----
-// Warning: (281-301): Assertion violation happens here
-// Warning: (305-324): Assertion violation happens here
-// Warning: (328-347): Assertion violation happens here
+// Warning: (290-295): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (316-319): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (327-347): Assertion violation happens here
+// Warning: (351-370): Assertion violation happens here
+// Warning: (374-393): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_memory_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_memory_storage.sol
@@ -3,12 +3,13 @@ pragma experimental SMTChecker;
 contract LoopFor2 {
 	uint[] a;
 
-	function testUnboundedForLoop(uint n, uint[] memory b, uint[] memory c) public {
+	function testUnboundedForLoop(uint[] memory b, uint[] memory c) public {
 		b[0] = 900;
 		a = b;
-		require(n > 0 && n < 100);
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
 		uint i;
-		while (i < n) {
+		while (i < b.length) {
 			b[i] = i + 1;
 			c[i] = b[i];
 			++i;
@@ -20,8 +21,8 @@ contract LoopFor2 {
 		assert(b[0] == 900);
 	}
 }
-// ====
-// SMTSolvers: z3
 // ----
-// Warning: (362-382): Assertion violation happens here
-// Warning: (409-428): Assertion violation happens here
+// Warning: (283-288): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (309-312): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (408-428): Assertion violation happens here
+// Warning: (455-474): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
@@ -4,12 +4,13 @@ contract LoopFor2 {
 	uint[] b;
 	uint[] c;
 
-	function testUnboundedForLoop(uint n) public {
+	function testUnboundedForLoop() public {
 		b[0] = 900;
 		uint[] storage a = b;
-		require(n > 0 && n < 100);
+		require(b.length == c.length);
+		require(b.length > 0 && b.length < 100);
 		uint i;
-		while (i < n) {
+		while (i < b.length) {
 			b[i] = i + 1;
 			c[i] = b[i];
 			++i;
@@ -21,6 +22,8 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (296-316): Assertion violation happens here
-// Warning: (320-339): Assertion violation happens here
-// Warning: (343-362): Assertion violation happens here
+// Warning: (277-282): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (303-306): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning: (344-364): Assertion violation happens here
+// Warning: (368-387): Assertion violation happens here
+// Warning: (391-410): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/special/msg_data.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_data.sol
@@ -7,5 +7,4 @@ contract C
 	}
 }
 // ----
-// Warning: (86-101): Assertion checker does not yet support this expression.
 // Warning: (79-106): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/string_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/string_1.sol
@@ -7,6 +7,4 @@ contract C
 	}
 }
 // ----
-// Warning: (117-133): Assertion checker does not yet support this expression.
-// Warning: (137-153): Assertion checker does not yet support this expression.
 // Warning: (110-154): Assertion violation happens here


### PR DESCRIPTION
Ref https://github.com/ethereum/solidity/issues/6048

Missing:
- [x] Inner arrays, as part of arrays, mappings and structs: `uint[][] arr; arr[0].length` etc
- [x] Arrays in different locations have a different type (storage vs memory). So either disregard location (easier) or add constraint that lengths are the same when copy storage -> memory / memory -> storage.
- [x] Assert that the lengths are still the same after an assignment