### PR TITLE
Fix Yul codegen when dynamic array is used as rhs of assignment

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1588,7 +1588,7 @@ void IRGeneratorForStatements::writeToLValue(IRLValue const& _lvalue, IRVariable
 					solAssert(dynamic_cast<ReferenceType const*>(&_lvalue.type), "");
 					auto const* valueReferenceType = dynamic_cast<ReferenceType const*>(&_value.type());
 					solAssert(valueReferenceType && valueReferenceType->dataStoredIn(DataLocation::Memory), "");
-					m_code << "mstore(" + _memory.address + ", " + _value.name() + ")\n";
+					m_code << "mstore(" + _memory.address + ", " + _value.part("mpos").name() + ")\n";
 				}
 			},
 			[&](IRLValue::Stack const& _stack) { assign(_stack.variable, _value); },

--- a/test/libsolidity/semanticTests/viaYul/array_2d_assignment.sol
+++ b/test/libsolidity/semanticTests/viaYul/array_2d_assignment.sol
@@ -1,0 +1,14 @@
+contract C {
+	function f(uint n) public pure returns (uint) {
+		uint[][] memory a = new uint[][](2);
+		for (uint i = 0; i < 2; ++i)
+			a[i] = new uint[](3);
+		a[1][1] = n;
+		uint[] memory b = a[1];
+		return b[1];
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256): 42 -> 42

--- a/test/libsolidity/semanticTests/viaYul/array_2d_new.sol
+++ b/test/libsolidity/semanticTests/viaYul/array_2d_new.sol
@@ -1,0 +1,12 @@
+contract C {
+	function f(uint n) public pure returns (uint) {
+		uint[][] memory a = new uint[][](2);
+		for (uint i = 0; i < 2; ++i)
+			a[i] = new uint[](3);
+		return a[0][0] = n;
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256): 42 -> 42

--- a/test/libsolidity/semanticTests/viaYul/array_3d_assignment.sol
+++ b/test/libsolidity/semanticTests/viaYul/array_3d_assignment.sol
@@ -1,0 +1,19 @@
+contract C {
+	function f(uint n) public pure returns (uint) {
+		uint[][][] memory a = new uint[][][](2);
+		for (uint i = 0; i < 2; ++i)
+		{
+			a[i] = new uint[][](3);
+			for (uint j = 0; j < 3; ++j)
+				a[i][j] = new uint[](4);
+		}
+		a[1][1][1] = n;
+		uint[][] memory b = a[1];
+		uint[] memory c = b[1];
+		return c[1];
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256): 42 -> 42

--- a/test/libsolidity/semanticTests/viaYul/array_3d_new.sol
+++ b/test/libsolidity/semanticTests/viaYul/array_3d_new.sol
@@ -1,0 +1,16 @@
+contract C {
+	function f(uint n) public pure returns (uint) {
+		uint[][][] memory a = new uint[][][](2);
+		for (uint i = 0; i < 2; ++i)
+		{
+			a[i] = new uint[][](3);
+			for (uint j = 0; j < 3; ++j)
+				a[i][j] = new uint[](4);
+		}
+		return a[1][1][1] = n;
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256): 42 -> 42


### PR DESCRIPTION
The added tests used to throw.

Found when working on https://github.com/ethereum/solidity/pull/8462