### PR TITLE
[yul-phaser] Parsing Yul objects

### DIFF
--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -78,7 +78,7 @@ variant<Program, ErrorList> Program::load(CharStream& _sourceCode)
 	// ASSUMPTION: parseSource() rewinds the stream on its own
 	Dialect const& dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion{});
 
-	variant<unique_ptr<Block>, ErrorList> astOrErrors = parseSource(dialect, _sourceCode);
+	variant<unique_ptr<Block>, ErrorList> astOrErrors = parseObject(dialect, _sourceCode);
 	if (holds_alternative<ErrorList>(astOrErrors))
 		return get<ErrorList>(astOrErrors);
 
@@ -120,21 +120,6 @@ string Program::toJson() const
 {
 	Json::Value serializedAst = AsmJsonConverter(0)(*m_ast);
 	return jsonPrettyPrint(serializedAst);
-}
-
-variant<unique_ptr<Block>, ErrorList> Program::parseSource(Dialect const& _dialect, CharStream _source)
-{
-	ErrorList errors;
-	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<Scanner>(move(_source));
-	Parser parser(errorReporter, _dialect);
-
-	unique_ptr<Block> ast = parser.parse(scanner, false);
-	if (ast == nullptr)
-		return errors;
-
-	assert(errorReporter.errors().empty());
-	return variant<unique_ptr<Block>, ErrorList>(move(ast));
 }
 
 variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _dialect, CharStream _source)

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -26,6 +26,7 @@
 #include <libyul/AsmJsonConverter.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmPrinter.h>
+#include <libyul/ObjectParser.h>
 #include <libyul/YulString.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/Disambiguator.h>
@@ -134,6 +135,46 @@ variant<unique_ptr<Block>, ErrorList> Program::parseSource(Dialect const& _diale
 
 	assert(errorReporter.errors().empty());
 	return variant<unique_ptr<Block>, ErrorList>(move(ast));
+}
+
+variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _dialect, CharStream _source)
+{
+	ErrorList errors;
+	ErrorReporter errorReporter(errors);
+	auto scanner = make_shared<Scanner>(move(_source));
+
+	ObjectParser parser(errorReporter, _dialect);
+	shared_ptr<Object> object = parser.parse(scanner, false);
+	if (object == nullptr || !errorReporter.errors().empty())
+		// NOTE: It's possible to get errors even if the returned object is non-null.
+		// For example when there are errors in a nested object.
+		return errors;
+
+	Object* deployedObject = nullptr;
+	if (object->subObjects.size() > 0)
+		for (auto& subObject: object->subObjects)
+			// solc --ir produces an object with a subobject of the same name as the outer object
+			// but suffixed with  "_deployed".
+			// The other object references the nested one which makes analysis fail. Below we try to
+			// extract just the nested one for that reason. This is just a heuristic. If there's no
+			// subobject with such a suffix we fall back to accepting the whole object as is.
+			if (subObject != nullptr && subObject->name.str() == object->name.str() + "_deployed")
+			{
+				deployedObject = dynamic_cast<Object*>(subObject.get());
+				if (deployedObject != nullptr)
+					break;
+			}
+	Object* selectedObject = (deployedObject != nullptr ? deployedObject : object.get());
+
+	// NOTE: I'm making a copy of the whole AST to get unique_ptr rather than shared_ptr.
+	// This is a slight performance hit but it's much less than the parsing itself.
+	// unique_ptr lets me be sure that two Program instances can never share the AST by mistake.
+	// The public API of the class does not provide access to the smart pointer so it won't be hard
+	// to switch to shared_ptr if the copying turns out to be an issue (though it would be better
+	// to refactor ObjectParser and Object to use unique_ptr instead).
+	auto astCopy = make_unique<Block>(get<Block>(ASTCopier{}(*selectedObject->code)));
+
+	return variant<unique_ptr<Block>, ErrorList>(move(astCopy));
 }
 
 variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect const& _dialect, Block const& _ast)

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -94,10 +94,6 @@ private:
 		m_nameDispenser(_dialect, *m_ast, {})
 	{}
 
-	static std::variant<std::unique_ptr<yul::Block>, langutil::ErrorList> parseSource(
-		yul::Dialect const& _dialect,
-		langutil::CharStream _source
-	);
 	static std::variant<std::unique_ptr<yul::Block>, langutil::ErrorList> parseObject(
 		yul::Dialect const& _dialect,
 		langutil::CharStream _source

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -98,6 +98,10 @@ private:
 		yul::Dialect const& _dialect,
 		langutil::CharStream _source
 	);
+	static std::variant<std::unique_ptr<yul::Block>, langutil::ErrorList> parseObject(
+		yul::Dialect const& _dialect,
+		langutil::CharStream _source
+	);
 	static std::variant<std::unique_ptr<yul::AsmAnalysisInfo>, langutil::ErrorList> analyzeAST(
 		yul::Dialect const& _dialect,
 		yul::Block const& _ast


### PR DESCRIPTION
### Description
Part of the final set of PRs for #7806.

Makes `yul-phaser` properly parse .yul files containing `object`s. This allows it to directly read files produced by `solc --ir`.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages