### PR TITLE
[yul-phaser] --prefix option

### DIFF
--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -285,6 +285,7 @@ ProgramFactory::Options ProgramFactory::Options::fromCommandLine(po::variables_m
 {
 	return {
 		_arguments["input-files"].as<vector<string>>(),
+		_arguments["prefix"].as<string>(),
 	};
 }
 
@@ -300,6 +301,8 @@ vector<Program> ProgramFactory::build(Options const& _options)
 			cerr << get<ErrorList>(programOrErrors) << endl;
 			assertThrow(false, InvalidProgram, "Failed to load program " + path);
 		}
+
+		get<Program>(programOrErrors).optimise(Chromosome(_options.prefix).optimisationSteps());
 		inputPrograms.push_back(move(get<Program>(programOrErrors)));
 	}
 
@@ -348,6 +351,18 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	generalDescription.add_options()
 		("help", "Show help message and exit.")
 		("input-files", po::value<vector<string>>()->required()->value_name("<PATH>"), "Input files.")
+		(
+			"prefix",
+			po::value<string>()->value_name("<CHROMOSOME>")->default_value(""),
+			"Initial optimisation steps automatically applied to every input program.\n"
+			"The result is treated as if it was the actual input, i.e. the steps are not considered "
+			"a part of the chromosomes and cannot be mutated. The values of relative metric values "
+			"are also relative to the fitness of a program with these steps applied rather than the "
+			"fitness of the original program.\n"
+			"Note that phaser always adds a 'hgo' prefix to ensure that chromosomes can "
+			"contain arbitrary optimisation steps. This implicit prefix cannot be changed or "
+			"or removed using this option. The value given here is applied after it."
+		)
 		("seed", po::value<uint32_t>()->value_name("<NUM>"), "Seed for the random number generator.")
 		(
 			"rounds",

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -169,6 +169,7 @@ public:
 	struct Options
 	{
 		std::vector<std::string> inputFiles;
+		std::string prefix;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
 	};


### PR DESCRIPTION
### Description
Part of the final set of PRs for #7806.

Adds `--prefix` option that lets user specify a series of initial optimisation steps automatically applied to every input program. The result is treated as if it was the actual input, i.e. the steps are not considered a part of the chromosomes and cannot be mutated. The values of relative metric values are also relative to the fitness of a program with these steps applied rather than the fitness of the original program.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages