### PR TITLE
[yul-phaser] Classic genetic algorithm

### DIFF
--- a/test/yulPhaser/GeneticAlgorithms.cpp
+++ b/test/yulPhaser/GeneticAlgorithms.cpp
@@ -31,6 +31,7 @@
 using namespace std;
 using namespace boost::unit_test::framework;
 using namespace boost::test_tools;
+using namespace solidity::util;
 
 namespace solidity::phaser::test
 {
@@ -39,6 +40,18 @@ class GeneticAlgorithmFixture
 {
 protected:
 	shared_ptr<FitnessMetric> m_fitnessMetric = make_shared<ChromosomeLengthMetric>();
+};
+
+class ClassicGeneticAlgorithmFixture: public GeneticAlgorithmFixture
+{
+protected:
+	ClassicGeneticAlgorithm::Options m_options = {
+		/* elitePoolSize = */ 0.0,
+		/* crossoverChance = */ 0.0,
+		/* mutationChance = */ 0.0,
+		/* deletionChance = */ 0.0,
+		/* additionChance = */ 0.0,
+	};
 };
 
 BOOST_AUTO_TEST_SUITE(Phaser)
@@ -184,6 +197,197 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_generate_individuals_in_the_crossove
 	BOOST_TEST(any_of(newIndividuals.begin() + 2, newIndividuals.end(), [](auto& individual){
 		return individual.chromosome != Chromosome("aa") && individual.chromosome != Chromosome("ff");
 	}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE(ClassicGeneticAlgorithmTest)
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_proportional_to_fitness, ClassicGeneticAlgorithmFixture)
+{
+	constexpr double relativeTolerance = 0.1;
+	constexpr size_t populationSize = 1000;
+	assert(populationSize % 4 == 0 && "Choose a number divisible by 4 for this test");
+
+	auto population =
+		Population::makeRandom(m_fitnessMetric, populationSize / 4, 0, 0) +
+		Population::makeRandom(m_fitnessMetric, populationSize / 4, 1, 1) +
+		Population::makeRandom(m_fitnessMetric, populationSize / 4, 2, 2) +
+		Population::makeRandom(m_fitnessMetric, populationSize / 4, 3, 3);
+
+	map<size_t, double> expectedProbabilities = {
+		{0, 4.0 / (4 + 3 + 2 + 1)},
+		{1, 3.0 / (4 + 3 + 2 + 1)},
+		{2, 2.0 / (4 + 3 + 2 + 1)},
+		{3, 1.0 / (4 + 3 + 2 + 1)},
+	};
+	double const expectedValue = (
+		0.0 * expectedProbabilities[0] +
+		1.0 * expectedProbabilities[1] +
+		2.0 * expectedProbabilities[2] +
+		3.0 * expectedProbabilities[3]
+	);
+	double const variance = (
+		(0.0 - expectedValue) * (0.0 - expectedValue) * expectedProbabilities[0] +
+		(1.0 - expectedValue) * (1.0 - expectedValue) * expectedProbabilities[1] +
+		(2.0 - expectedValue) * (2.0 - expectedValue) * expectedProbabilities[2] +
+		(3.0 - expectedValue) * (3.0 - expectedValue) * expectedProbabilities[3]
+	);
+
+	ClassicGeneticAlgorithm algorithm(m_options);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	BOOST_TEST(newPopulation.individuals().size() == population.individuals().size());
+
+	vector<size_t> newFitness = chromosomeLengths(newPopulation);
+	BOOST_TEST(abs(mean(newFitness) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(abs(meanSquaredError(newFitness, expectedValue) - variance) < variance * relativeTolerance);
+}
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_only_individuals_existing_in_the_original_population, ClassicGeneticAlgorithmFixture)
+{
+	constexpr size_t populationSize = 1000;
+	auto population = Population::makeRandom(m_fitnessMetric, populationSize, 1, 10);
+
+	set<string> originalSteps;
+	for (auto const& individual: population.individuals())
+		originalSteps.insert(toString(individual.chromosome));
+
+	ClassicGeneticAlgorithm algorithm(m_options);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	for (auto const& individual: newPopulation.individuals())
+		BOOST_TEST(originalSteps.count(toString(individual.chromosome)) == 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_crossover, ClassicGeneticAlgorithmFixture)
+{
+	auto population = Population(m_fitnessMetric, {
+		Chromosome("aa"), Chromosome("aa"), Chromosome("aa"),
+		Chromosome("ff"), Chromosome("ff"), Chromosome("ff"),
+		Chromosome("gg"), Chromosome("gg"), Chromosome("gg"),
+	});
+
+	set<string> originalSteps{"aa", "ff", "gg"};
+	set<string> crossedSteps{"af", "fa", "fg", "gf", "ga", "ag"};
+
+	m_options.crossoverChance = 0.8;
+	ClassicGeneticAlgorithm algorithm(m_options);
+
+	SimulationRNG::reset(1);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	size_t totalCrossed = 0;
+	size_t totalUnchanged = 0;
+	for (auto const& individual: newPopulation.individuals())
+	{
+		totalCrossed += crossedSteps.count(toString(individual.chromosome));
+		totalUnchanged += originalSteps.count(toString(individual.chromosome));
+	}
+	BOOST_TEST(totalCrossed + totalUnchanged == newPopulation.individuals().size());
+	BOOST_TEST(totalCrossed >= 2);
+}
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithmFixture)
+{
+	m_options.mutationChance = 0.6;
+	ClassicGeneticAlgorithm algorithm(m_options);
+
+	constexpr size_t populationSize = 1000;
+	constexpr double relativeTolerance = 0.05;
+	double const expectedValue = m_options.mutationChance;
+	double const variance = m_options.mutationChance * (1 - m_options.mutationChance);
+
+	Chromosome chromosome("aaaaaaaaaa");
+	vector<Chromosome> chromosomes(populationSize, chromosome);
+	Population population(m_fitnessMetric, chromosomes);
+
+	SimulationRNG::reset(1);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	vector<size_t> bernoulliTrials;
+	for (auto const& individual: newPopulation.individuals())
+	{
+		string steps = toString(individual.chromosome);
+		for (char step: steps)
+			bernoulliTrials.push_back(static_cast<size_t>(step != 'a'));
+	}
+
+	BOOST_TEST(abs(mean(bernoulliTrials) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
+}
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithmFixture)
+{
+	m_options.deletionChance = 0.6;
+	ClassicGeneticAlgorithm algorithm(m_options);
+
+	constexpr size_t populationSize = 1000;
+	constexpr double relativeTolerance = 0.05;
+	double const expectedValue = m_options.deletionChance;
+	double const variance = m_options.deletionChance * (1 - m_options.deletionChance);
+
+	Chromosome chromosome("aaaaaaaaaa");
+	vector<Chromosome> chromosomes(populationSize, chromosome);
+	Population population(m_fitnessMetric, chromosomes);
+
+	SimulationRNG::reset(1);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	vector<size_t> bernoulliTrials;
+	for (auto const& individual: newPopulation.individuals())
+	{
+		string steps = toString(individual.chromosome);
+		for (size_t i = 0; i < chromosome.length(); ++i)
+			bernoulliTrials.push_back(static_cast<size_t>(i >= steps.size()));
+	}
+
+	BOOST_TEST(abs(mean(bernoulliTrials) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
+}
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_addition, ClassicGeneticAlgorithmFixture)
+{
+	m_options.additionChance = 0.6;
+	ClassicGeneticAlgorithm algorithm(m_options);
+
+	constexpr size_t populationSize = 1000;
+	constexpr double relativeTolerance = 0.05;
+	double const expectedValue = m_options.additionChance;
+	double const variance = m_options.additionChance * (1 - m_options.additionChance);
+
+	Chromosome chromosome("aaaaaaaaaa");
+	vector<Chromosome> chromosomes(populationSize, chromosome);
+	Population population(m_fitnessMetric, chromosomes);
+
+	SimulationRNG::reset(1);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	vector<size_t> bernoulliTrials;
+	for (auto const& individual: newPopulation.individuals())
+	{
+		string steps = toString(individual.chromosome);
+		for (size_t i = 0; i < chromosome.length() + 1; ++i)
+		{
+			BOOST_REQUIRE(chromosome.length() <= steps.size() && steps.size() <= 2 * chromosome.length() + 1);
+			bernoulliTrials.push_back(static_cast<size_t>(i < steps.size() - chromosome.length()));
+		}
+	}
+
+	BOOST_TEST(abs(mean(bernoulliTrials) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
+}
+
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_preserve_elite, ClassicGeneticAlgorithmFixture)
+{
+	auto population = Population::makeRandom(m_fitnessMetric, 4, 3, 3) + Population::makeRandom(m_fitnessMetric, 6, 5, 5);
+	assert((chromosomeLengths(population) == vector<size_t>{3, 3, 3, 3, 5, 5, 5, 5, 5, 5}));
+
+	m_options.elitePoolSize = 0.5;
+	m_options.deletionChance = 1.0;
+	ClassicGeneticAlgorithm algorithm(m_options);
+	Population newPopulation = algorithm.runNextRound(population);
+
+	BOOST_TEST((chromosomeLengths(newPopulation) == vector<size_t>{0, 0, 0, 0, 0, 3, 3, 3, 3, 5}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/Mutations.cpp
+++ b/test/yulPhaser/Mutations.cpp
@@ -212,6 +212,39 @@ BOOST_AUTO_TEST_CASE(alternativeMutations_should_always_choose_second_mutation_i
 		BOOST_TEST(mutation(chromosome) == Chromosome("f"));
 }
 
+BOOST_AUTO_TEST_CASE(mutationSequence_should_apply_all_mutations)
+{
+	Chromosome chromosome("aaaaa");
+	function<Mutation> mutation = mutationSequence({
+		geneSubstitution(3, Chromosome("g").optimisationSteps()[0]),
+		geneSubstitution(2, Chromosome("f").optimisationSteps()[0]),
+		geneSubstitution(1, Chromosome("c").optimisationSteps()[0]),
+	});
+
+	BOOST_TEST(mutation(chromosome) == Chromosome("acfga"));
+}
+
+BOOST_AUTO_TEST_CASE(mutationSequence_apply_mutations_in_the_order_they_are_given)
+{
+	Chromosome chromosome("aa");
+	function<Mutation> mutation = mutationSequence({
+		geneSubstitution(0, Chromosome("g").optimisationSteps()[0]),
+		geneSubstitution(1, Chromosome("c").optimisationSteps()[0]),
+		geneSubstitution(0, Chromosome("f").optimisationSteps()[0]),
+		geneSubstitution(1, Chromosome("o").optimisationSteps()[0]),
+	});
+
+	BOOST_TEST(mutation(chromosome) == Chromosome("fo"));
+}
+
+BOOST_AUTO_TEST_CASE(mutationSequence_should_return_unmodified_chromosome_if_given_no_mutations)
+{
+	Chromosome chromosome("aa");
+	function<Mutation> mutation = mutationSequence({});
+
+	BOOST_TEST(mutation(chromosome) == chromosome);
+}
+
 BOOST_AUTO_TEST_CASE(randomPointCrossover_should_swap_chromosome_parts_at_random_point)
 {
 	function<Crossover> crossover = randomPointCrossover();

--- a/test/yulPhaser/Mutations.cpp
+++ b/test/yulPhaser/Mutations.cpp
@@ -225,6 +225,20 @@ BOOST_AUTO_TEST_CASE(randomPointCrossover_should_swap_chromosome_parts_at_random
 	BOOST_TEST(result2 == Chromosome("cccaaaaaaa"));
 }
 
+BOOST_AUTO_TEST_CASE(symmetricRandomPointCrossover_should_swap_chromosome_parts_at_random_point)
+{
+	function<SymmetricCrossover> crossover = symmetricRandomPointCrossover();
+
+	SimulationRNG::reset(1);
+	tuple<Chromosome, Chromosome> result1 = crossover(Chromosome("aaaaaaaaaa"), Chromosome("cccccc"));
+	tuple<Chromosome, Chromosome> expectedPair1 = {Chromosome("aaaccc"), Chromosome("cccaaaaaaa")};
+	BOOST_TEST(result1 == expectedPair1);
+
+	tuple<Chromosome, Chromosome> result2 = crossover(Chromosome("cccccc"), Chromosome("aaaaaaaaaa"));
+	tuple<Chromosome, Chromosome> expectedPair2 = {Chromosome("ccccccaaaa"), Chromosome("aaaaaa")};
+	BOOST_TEST(result2 == expectedPair2);
+}
+
 BOOST_AUTO_TEST_CASE(randomPointCrossover_should_only_consider_points_available_on_both_chromosomes)
 {
 	SimulationRNG::reset(1);

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -52,6 +52,11 @@ protected:
 		/* gewepDeletionVsAdditionChance = */ 0.3,
 		/* gewepGenesToRandomise = */ 0.4,
 		/* gewepGenesToAddOrDelete = */ 0.2,
+		/* classicElitePoolSize = */ 0.0,
+		/* classicCrossoverChance = */ 0.75,
+		/* classicMutationChance = */ 0.2,
+		/* classicDeletionChance = */ 0.2,
+		/* classicAdditionChance = */ 0.2,
 	};
 };
 
@@ -122,6 +127,18 @@ BOOST_FIXTURE_TEST_CASE(build_should_select_the_right_algorithm_and_pass_the_opt
 	BOOST_TEST(gewepAlgorithm->options().deletionVsAdditionChance == m_options.gewepDeletionVsAdditionChance);
 	BOOST_TEST(gewepAlgorithm->options().percentGenesToRandomise == m_options.gewepGenesToRandomise.value());
 	BOOST_TEST(gewepAlgorithm->options().percentGenesToAddOrDelete == m_options.gewepGenesToAddOrDelete.value());
+
+	m_options.algorithm = Algorithm::Classic;
+	unique_ptr<GeneticAlgorithm> algorithm3 = GeneticAlgorithmFactory::build(m_options, 100);
+	BOOST_REQUIRE(algorithm3 != nullptr);
+
+	auto classicAlgorithm = dynamic_cast<ClassicGeneticAlgorithm*>(algorithm3.get());
+	BOOST_REQUIRE(classicAlgorithm != nullptr);
+	BOOST_TEST(classicAlgorithm->options().elitePoolSize == m_options.classicElitePoolSize);
+	BOOST_TEST(classicAlgorithm->options().crossoverChance == m_options.classicCrossoverChance);
+	BOOST_TEST(classicAlgorithm->options().mutationChance == m_options.classicMutationChance);
+	BOOST_TEST(classicAlgorithm->options().deletionChance == m_options.classicDeletionChance);
+	BOOST_TEST(classicAlgorithm->options().additionChance == m_options.classicAdditionChance);
 }
 
 BOOST_FIXTURE_TEST_CASE(build_should_set_random_algorithm_elite_pool_size_based_on_population_size_if_not_specified, GeneticAlgorithmFactoryFixture)

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -104,6 +104,23 @@ BOOST_FIXTURE_TEST_CASE(constructor_should_copy_chromosomes_compute_fitness_and_
 	BOOST_TEST(individuals[2].chromosome == chromosomes[1]);
 }
 
+BOOST_FIXTURE_TEST_CASE(constructor_should_accept_individuals_without_recalculating_fitness, PopulationFixture)
+{
+	vector<Individual> customIndividuals = {
+		Individual(Chromosome("aaaccc"), 20),
+		Individual(Chromosome("aaa"), 10),
+		Individual(Chromosome("aaaf"), 30),
+	};
+	assert(customIndividuals[0].fitness != m_fitnessMetric->evaluate(customIndividuals[0].chromosome));
+	assert(customIndividuals[1].fitness != m_fitnessMetric->evaluate(customIndividuals[1].chromosome));
+	assert(customIndividuals[2].fitness != m_fitnessMetric->evaluate(customIndividuals[2].chromosome));
+
+	Population population(m_fitnessMetric, customIndividuals);
+
+	vector<Individual> expectedIndividuals{customIndividuals[1], customIndividuals[0], customIndividuals[2]};
+	BOOST_TEST(population.individuals() == expectedIndividuals);
+}
+
 BOOST_FIXTURE_TEST_CASE(makeRandom_should_get_chromosome_lengths_from_specified_generator, PopulationFixture)
 {
 	size_t chromosomeCount = 30;

--- a/test/yulPhaser/Population.cpp
+++ b/test/yulPhaser/Population.cpp
@@ -364,6 +364,14 @@ BOOST_FIXTURE_TEST_CASE(symmetricCrossoverWithRemainder_should_return_empty_popu
 	);
 }
 
+BOOST_FIXTURE_TEST_CASE(combine_should_add_two_populations_from_a_pair, PopulationFixture)
+{
+	Population population1(m_fitnessMetric, {Chromosome("aa"), Chromosome("hh")});
+	Population population2(m_fitnessMetric, {Chromosome("gg"), Chromosome("cc")});
+
+	BOOST_TEST(Population::combine({population1, population2}) == population1 + population2);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test/yulPhaser/TestHelpers.h
+++ b/test/yulPhaser/TestHelpers.h
@@ -33,11 +33,38 @@
 #include <tools/yulPhaser/Mutations.h>
 #include <tools/yulPhaser/Population.h>
 
+#include <boost/test/tools/detail/print_helper.hpp>
+
 #include <cassert>
 #include <functional>
 #include <map>
 #include <string>
+#include <tuple>
 #include <vector>
+
+// OPERATORS FOR BOOST::TEST
+
+/// Output operator for arbitrary two-element tuples.
+/// Necessary to make BOOST_TEST() work with such tuples.
+template<typename T1, typename T2>
+std::ostream& operator<<(std::ostream& _output, std::tuple<T1, T2> const& _tuple)
+{
+	_output << "(" << std::get<0>(_tuple) << ", " << std::get<1>(_tuple) << ")";
+	return _output;
+}
+
+namespace boost::test_tools::tt_detail
+{
+
+// Boost won't find find the << operator unless we put it in the std namespace which is illegal.
+// The recommended solution is to overload print_log_value<> struct and make it use our global operator.
+template<typename T1,typename T2>
+struct print_log_value<std::tuple<T1, T2>>
+{
+	void operator()(std::ostream& _output, std::tuple<T1, T2> const& _tuple) { ::operator<<(_output, _tuple); }
+};
+
+}
 
 namespace solidity::phaser::test
 {

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -187,16 +187,16 @@ Population AlgorithmRunner::randomiseDuplicates(
 	if (_population.individuals().size() == 0)
 		return _population;
 
-	vector<Chromosome> chromosomes{_population.individuals()[0].chromosome};
+	vector<Individual> individuals{_population.individuals()[0]};
 	size_t duplicateCount = 0;
 	for (size_t i = 1; i < _population.individuals().size(); ++i)
 		if (_population.individuals()[i].chromosome == _population.individuals()[i - 1].chromosome)
 			++duplicateCount;
 		else
-			chromosomes.push_back(_population.individuals()[i].chromosome);
+			individuals.push_back(_population.individuals()[i]);
 
 	return (
-		Population(_population.fitnessMetric(), chromosomes) +
+		Population(_population.fitnessMetric(), individuals) +
 		Population::makeRandom(_population.fitnessMetric(), duplicateCount, _minChromosomeLength, _maxChromosomeLength)
 	);
 }

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -139,4 +139,59 @@ private:
 	Options m_options;
 };
 
+/**
+ * A typical genetic algorithm that works in three distinct phases, each resulting in a new,
+ * modified population:
+ * - selection: chromosomes are selected from the population with probability proportional to their
+ *   fitness. A chromosome can be selected more than once. The new population has the same size as
+ *   the old one.
+ * - crossover: first, for each chromosome we decide whether it undergoes crossover or not
+ *   (according to crossover chance parameter). Then each selected chromosome is randomly paired
+ *   with one other selected chromosome. Each pair produces a pair of children and gets replaced by
+ *   it in the population.
+ * - mutation: we go over each gene in the population and independently decide whether to mutate it
+ *   or not (according to mutation chance parameters). This is repeated for every mutation type so
+ *   one gene can undergo mutations of multiple types in a single round.
+ *
+ * This implementation also has the ability to preserve the top chromosomes in each round.
+ */
+class ClassicGeneticAlgorithm: public GeneticAlgorithm
+{
+public:
+	struct Options
+	{
+		double elitePoolSize;      ///< Percentage of the population treated as the elite.
+		double crossoverChance;    ///< The chance of a particular chromosome being selected for crossover.
+		double mutationChance;     ///< The chance of a particular gene being randomised in @a geneRandomisation mutation.
+		double deletionChance;     ///< The chance of a particular gene being deleted in @a geneDeletion mutation.
+		double additionChance;     ///< The chance of a particular gene being added in @a geneAddition mutation.
+
+		bool isValid() const
+		{
+			return (
+				0 <= elitePoolSize && elitePoolSize <= 1.0 &&
+				0 <= crossoverChance && crossoverChance <= 1.0 &&
+				0 <= mutationChance && mutationChance <= 1.0 &&
+				0 <= deletionChance && deletionChance <= 1.0 &&
+				0 <= additionChance && additionChance <= 1.0
+			);
+		}
+	};
+
+	ClassicGeneticAlgorithm(Options const& _options):
+		m_options(_options)
+	{
+		assert(_options.isValid());
+	}
+
+	Options const& options() const { return m_options; }
+
+	Population runNextRound(Population _population) override;
+
+private:
+	static Population select(Population _population, size_t _selectionSize);
+
+	Options m_options;
+};
+
 }

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -98,7 +98,7 @@ function<Mutation> phaser::alternativeMutations(
 namespace
 {
 
-Chromosome buildChromosomesBySwappingParts(
+ChromosomePair fixedPointSwap(
 	Chromosome const& _chromosome1,
 	Chromosome const& _chromosome2,
 	size_t _crossoverPoint
@@ -109,11 +109,19 @@ Chromosome buildChromosomesBySwappingParts(
 
 	auto begin1 = _chromosome1.optimisationSteps().begin();
 	auto begin2 = _chromosome2.optimisationSteps().begin();
+	auto end1 = _chromosome1.optimisationSteps().end();
+	auto end2 = _chromosome2.optimisationSteps().end();
 
-	return Chromosome(
-		vector<string>(begin1, begin1 + _crossoverPoint) +
-		vector<string>(begin2 + _crossoverPoint, _chromosome2.optimisationSteps().end())
-	);
+	return {
+		Chromosome(
+			vector<string>(begin1, begin1 + _crossoverPoint) +
+			vector<string>(begin2 + _crossoverPoint, end2)
+		),
+		Chromosome(
+			vector<string>(begin2, begin2 + _crossoverPoint) +
+			vector<string>(begin1 + _crossoverPoint, end1)
+		),
+	};
 }
 
 }
@@ -129,7 +137,22 @@ function<Crossover> phaser::randomPointCrossover()
 		assert(minPoint <= minLength);
 
 		size_t randomPoint = SimulationRNG::uniformInt(minPoint, minLength);
-		return buildChromosomesBySwappingParts(_chromosome1, _chromosome2, randomPoint);
+		return get<0>(fixedPointSwap(_chromosome1, _chromosome2, randomPoint));
+	};
+}
+
+function<SymmetricCrossover> phaser::symmetricRandomPointCrossover()
+{
+	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+	{
+		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+
+		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
+		size_t minPoint = (minLength > 0? 1 : 0);
+		assert(minPoint <= minLength);
+
+		size_t randomPoint = SimulationRNG::uniformInt(minPoint, minLength);
+		return fixedPointSwap(_chromosome1, _chromosome2, randomPoint);
 	};
 }
 
@@ -142,6 +165,6 @@ function<Crossover> phaser::fixedPointCrossover(double _crossoverPoint)
 		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
 		size_t concretePoint = static_cast<size_t>(round(minLength * _crossoverPoint));
 
-		return buildChromosomesBySwappingParts(_chromosome1, _chromosome2, concretePoint);
+		return get<0>(fixedPointSwap(_chromosome1, _chromosome2, concretePoint));
 	};
 }

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -95,6 +95,18 @@ function<Mutation> phaser::alternativeMutations(
 	};
 }
 
+function<Mutation> phaser::mutationSequence(vector<function<Mutation>> _mutations)
+{
+	return [=](Chromosome const& _chromosome)
+	{
+		Chromosome mutatedChromosome = _chromosome;
+		for (size_t i = 0; i < _mutations.size(); ++i)
+			mutatedChromosome = _mutations[i](move(mutatedChromosome));
+
+		return mutatedChromosome;
+	};
+}
+
 namespace
 {
 

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -28,8 +28,11 @@
 namespace solidity::phaser
 {
 
+using ChromosomePair = std::tuple<Chromosome, Chromosome>;
+
 using Mutation = Chromosome(Chromosome const&);
 using Crossover = Chromosome(Chromosome const&, Chromosome const&);
+using SymmetricCrossover = ChromosomePair(Chromosome const&, Chromosome const&);
 
 // MUTATIONS
 
@@ -60,6 +63,10 @@ std::function<Mutation> alternativeMutations(
 /// Creates a crossover operator that randomly selects a number between 0 and 1 and uses it as the
 /// position at which to perform perform @a fixedPointCrossover.
 std::function<Crossover> randomPointCrossover();
+
+/// Symmetric version of @a randomPointCrossover(). Creates an operator that returns a pair
+/// containing both possible results for the same crossover point.
+std::function<SymmetricCrossover> symmetricRandomPointCrossover();
 
 /// Creates a crossover operator that always chooses a point that lies at @a _crossoverPoint
 /// percent of the length of the shorter chromosome. Then creates a new chromosome by

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -58,6 +58,9 @@ std::function<Mutation> alternativeMutations(
 	std::function<Mutation> _mutation2
 );
 
+/// Creates a mutation operator that sequentially applies all the operators given in @a _mutations.
+std::function<Mutation> mutationSequence(std::vector<std::function<Mutation>> _mutations);
+
 // CROSSOVER
 
 /// Creates a crossover operator that randomly selects a number between 0 and 1 and uses it as the

--- a/tools/yulPhaser/PairSelections.cpp
+++ b/tools/yulPhaser/PairSelections.cpp
@@ -17,6 +17,7 @@
 
 #include <tools/yulPhaser/PairSelections.h>
 
+#include <tools/yulPhaser/Selections.h>
 #include <tools/yulPhaser/SimulationRNG.h>
 
 #include <cmath>
@@ -45,6 +46,43 @@ vector<tuple<size_t, size_t>> RandomPairSelection::materialise(size_t _poolSize)
 	}
 
 	return selection;
+}
+
+vector<tuple<size_t, size_t>> PairsFromRandomSubset::materialise(size_t _poolSize) const
+{
+	vector<size_t> selectedIndices = RandomSubset(m_selectionChance).materialise(_poolSize);
+
+	if (selectedIndices.size() % 2 != 0)
+	{
+		if (selectedIndices.size() < _poolSize && SimulationRNG::bernoulliTrial(0.5))
+		{
+			do
+			{
+				size_t extraIndex = SimulationRNG::uniformInt(0, selectedIndices.size() - 1);
+				if (find(selectedIndices.begin(), selectedIndices.end(), extraIndex) == selectedIndices.end())
+					selectedIndices.push_back(extraIndex);
+			} while (selectedIndices.size() % 2 != 0);
+		}
+		else
+			selectedIndices.erase(selectedIndices.begin() + SimulationRNG::uniformInt(0, selectedIndices.size() - 1));
+	}
+	assert(selectedIndices.size() % 2 == 0);
+
+	vector<tuple<size_t, size_t>> selectedPairs;
+	for (size_t i = selectedIndices.size() / 2; i > 0; --i)
+	{
+		size_t position1 = SimulationRNG::uniformInt(0, selectedIndices.size() - 1);
+		size_t value1 = selectedIndices[position1];
+		selectedIndices.erase(selectedIndices.begin() + position1);
+		size_t position2 = SimulationRNG::uniformInt(0, selectedIndices.size() - 1);
+		size_t value2 = selectedIndices[position2];
+		selectedIndices.erase(selectedIndices.begin() + position2);
+
+		selectedPairs.push_back({value1, value2});
+	}
+	assert(selectedIndices.size() == 0);
+
+	return selectedPairs;
 }
 
 vector<tuple<size_t, size_t>> PairMosaicSelection::materialise(size_t _poolSize) const

--- a/tools/yulPhaser/PairSelections.h
+++ b/tools/yulPhaser/PairSelections.h
@@ -69,6 +69,28 @@ private:
 	double m_selectionSize;
 };
 
+
+/**
+ * A selection that goes over all elements in a container, for each one independently decides
+ * whether to select it or not and then randomly combines those elements into pairs. If the number
+ * of elements is odd, randomly decides whether to take one more or exclude one.
+ *
+ * Each element has the same chance of being selected and can be selected at most once.
+ * The number of selected elements is random and can be different with each call to
+ * @a materialise().
+ */
+class PairsFromRandomSubset: public PairSelection
+{
+public:
+	explicit PairsFromRandomSubset(double _selectionChance):
+		m_selectionChance(_selectionChance) {}
+
+	std::vector<std::tuple<size_t, size_t>> materialise(size_t _poolSize) const override;
+
+private:
+	double m_selectionChance;
+};
+
 /**
  * A selection that selects pairs of elements at specific, fixed positions indicated by a repeating
  * "pattern". If the positions in the pattern exceed the size of the container, they are capped at

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -58,6 +58,7 @@ map<Algorithm, string> const AlgorithmToStringMap =
 {
 	{Algorithm::Random, "random"},
 	{Algorithm::GEWEP, "GEWEP"},
+	{Algorithm::Classic, "classic"},
 };
 map<string, Algorithm> const StringToAlgorithmMap = invertMap(AlgorithmToStringMap);
 
@@ -107,6 +108,11 @@ GeneticAlgorithmFactory::Options GeneticAlgorithmFactory::Options::fromCommandLi
 		_arguments.count("gewep-genes-to-add-or-delete") > 0 ?
 			_arguments["gewep-genes-to-add-or-delete"].as<double>() :
 			optional<double>{},
+		_arguments["classic-elite-pool-size"].as<double>(),
+		_arguments["classic-crossover-chance"].as<double>(),
+		_arguments["classic-mutation-chance"].as<double>(),
+		_arguments["classic-deletion-chance"].as<double>(),
+		_arguments["classic-addition-chance"].as<double>(),
 	};
 }
 
@@ -149,6 +155,16 @@ unique_ptr<GeneticAlgorithm> GeneticAlgorithmFactory::build(
 				/* deletionVsAdditionChance = */ _options.gewepDeletionVsAdditionChance,
 				/* percentGenesToRandomise = */ percentGenesToRandomise,
 				/* percentGenesToAddOrDelete = */ percentGenesToAddOrDelete,
+			});
+		}
+		case Algorithm::Classic:
+		{
+			return make_unique<ClassicGeneticAlgorithm>(ClassicGeneticAlgorithm::Options{
+				/* elitePoolSize = */ _options.classicElitePoolSize,
+				/* crossoverChance = */ _options.classicCrossoverChance,
+				/* mutationChance = */ _options.classicMutationChance,
+				/* deletionChance = */ _options.classicDeletionChance,
+				/* additionChance = */ _options.classicAdditionChance,
 			});
 		}
 		default:
@@ -474,6 +490,36 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 		)
 	;
 	keywordDescription.add(gewepAlgorithmDescription);
+
+	po::options_description classicGeneticAlgorithmDescription("CLASSIC GENETIC ALGORITHM", lineLength, minDescriptionLength);
+	classicGeneticAlgorithmDescription.add_options()
+		(
+			"classic-elite-pool-size",
+			po::value<double>()->value_name("<FRACTION>")->default_value(0),
+			"Percentage of population to regenerate using mutations in each round."
+		)
+		(
+			"classic-crossover-chance",
+			po::value<double>()->value_name("<FRACTION>")->default_value(0.75),
+			"Chance of a chromosome being selected for crossover."
+		)
+		(
+			"classic-mutation-chance",
+			po::value<double>()->value_name("<FRACTION>")->default_value(0.01),
+			"Chance of a gene being mutated."
+		)
+		(
+			"classic-deletion-chance",
+			po::value<double>()->value_name("<PROBABILITY>")->default_value(0.01),
+			"Chance of a gene being deleted."
+		)
+		(
+			"classic-addition-chance",
+			po::value<double>()->value_name("<PROBABILITY>")->default_value(0.01),
+			"Chance of a random gene being added."
+		)
+	;
+	keywordDescription.add(classicGeneticAlgorithmDescription);
 
 	po::options_description randomAlgorithmDescription("RANDOM ALGORITHM", lineLength, minDescriptionLength);
 	randomAlgorithmDescription.add_options()

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -58,6 +58,7 @@ enum class Algorithm
 {
 	Random,
 	GEWEP,
+	Classic,
 };
 
 enum class MetricChoice
@@ -101,6 +102,11 @@ public:
 		double gewepDeletionVsAdditionChance;
 		std::optional<double> gewepGenesToRandomise;
 		std::optional<double> gewepGenesToAddOrDelete;
+		double classicElitePoolSize;
+		double classicCrossoverChance;
+		double classicMutationChance;
+		double classicDeletionChance;
+		double classicAdditionChance;
 
 		static Options fromCommandLine(boost::program_options::variables_map const& _arguments);
 	};

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -117,6 +117,37 @@ Population Population::crossover(PairSelection const& _selection, function<Cross
 	return Population(m_fitnessMetric, crossedIndividuals);
 }
 
+tuple<Population, Population> Population::symmetricCrossoverWithRemainder(
+	PairSelection const& _selection,
+	function<SymmetricCrossover> _symmetricCrossover
+) const
+{
+	vector<int> indexSelected(m_individuals.size(), false);
+
+	vector<Individual> crossedIndividuals;
+	for (auto const& [i, j]: _selection.materialise(m_individuals.size()))
+	{
+		auto children = _symmetricCrossover(
+			m_individuals[i].chromosome,
+			m_individuals[j].chromosome
+		);
+		crossedIndividuals.emplace_back(move(get<0>(children)), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(move(get<1>(children)), *m_fitnessMetric);
+		indexSelected[i] = true;
+		indexSelected[j] = true;
+	}
+
+	vector<Individual> remainder;
+	for (size_t i = 0; i < indexSelected.size(); ++i)
+		if (!indexSelected[i])
+			remainder.emplace_back(m_individuals[i]);
+
+	return {
+		Population(m_fitnessMetric, crossedIndividuals),
+		Population(m_fitnessMetric, remainder),
+	};
+}
+
 namespace solidity::phaser
 {
 

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -163,6 +163,11 @@ Population operator+(Population _a, Population _b)
 
 }
 
+Population Population::combine(std::tuple<Population, Population> _populationPair)
+{
+	return get<0>(_populationPair) + get<1>(_populationPair);
+}
+
 bool Population::operator==(Population const& _other) const
 {
 	// We consider populations identical only if they share the same exact instance of the metric.

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -100,6 +100,10 @@ public:
 	Population select(Selection const& _selection) const;
 	Population mutate(Selection const& _selection, std::function<Mutation> _mutation) const;
 	Population crossover(PairSelection const& _selection, std::function<Crossover> _crossover) const;
+	std::tuple<Population, Population> symmetricCrossoverWithRemainder(
+		PairSelection const& _selection,
+		std::function<SymmetricCrossover> _symmetricCrossover
+	) const;
 
 	friend Population operator+(Population _a, Population _b);
 

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -81,6 +81,9 @@ public:
 			_fitnessMetric,
 			chromosomesToIndividuals(*_fitnessMetric, std::move(_chromosomes))
 		) {}
+	explicit Population(std::shared_ptr<FitnessMetric> _fitnessMetric, std::vector<Individual> _individuals):
+		m_fitnessMetric(std::move(_fitnessMetric)),
+		m_individuals{sortedIndividuals(std::move(_individuals))} {}
 
 	static Population makeRandom(
 		std::shared_ptr<FitnessMetric> _fitnessMetric,
@@ -112,10 +115,6 @@ public:
 	friend std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 private:
-	explicit Population(std::shared_ptr<FitnessMetric> _fitnessMetric, std::vector<Individual> _individuals):
-		m_fitnessMetric(std::move(_fitnessMetric)),
-		m_individuals{sortedIndividuals(std::move(_individuals))} {}
-
 	static std::vector<Individual> chromosomesToIndividuals(
 		FitnessMetric& _fitnessMetric,
 		std::vector<Chromosome> _chromosomes

--- a/tools/yulPhaser/Population.h
+++ b/tools/yulPhaser/Population.h
@@ -106,6 +106,7 @@ public:
 	) const;
 
 	friend Population operator+(Population _a, Population _b);
+	static Population combine(std::tuple<Population, Population> _populationPair);
 
 	std::shared_ptr<FitnessMetric> fitnessMetric() { return m_fitnessMetric; }
 	std::vector<Individual> const& individuals() const { return m_individuals; }

--- a/tools/yulPhaser/Selections.cpp
+++ b/tools/yulPhaser/Selections.cpp
@@ -20,6 +20,7 @@
 #include <tools/yulPhaser/SimulationRNG.h>
 
 #include <cmath>
+#include <numeric>
 
 using namespace std;
 using namespace solidity::phaser;
@@ -58,3 +59,12 @@ vector<size_t> RandomSelection::materialise(size_t _poolSize) const
 	return selection;
 }
 
+vector<size_t> RandomSubset::materialise(size_t _poolSize) const
+{
+	vector<size_t> selection;
+	for (size_t index = 0; index < _poolSize; ++index)
+		if (SimulationRNG::bernoulliTrial(m_selectionChance))
+			selection.push_back(index);
+
+	return selection;
+}

--- a/tools/yulPhaser/Selections.h
+++ b/tools/yulPhaser/Selections.h
@@ -118,4 +118,26 @@ private:
 	double m_selectionSize;
 };
 
+/**
+ * A selection that goes over all elements in a container, for each one independently deciding
+ * whether to select it or not. Each element has the same chance of being selected and can be
+ * selected at most once. The order of selected elements is the same as the order of elements in
+ * the container. The number of selected elements is random and can be different with each call
+ * to @a materialise().
+ */
+class RandomSubset: public Selection
+{
+public:
+	explicit RandomSubset(double _selectionChance):
+		m_selectionChance(_selectionChance)
+	{
+		assert(0.0 <= _selectionChance && _selectionChance <= 1.0);
+	}
+
+	std::vector<size_t> materialise(size_t _poolSize) const override;
+
+private:
+	double m_selectionChance;
+};
+
 }


### PR DESCRIPTION
### Description
Part of the final set of PRs for #7806.

Adds an implementation of a classic genetic algorithm as described in "Genetic Algorithms + Data Structures = Evolution Programs" by Zbigniew Michalewicz (page  34) with some minor enhancements like support for elitism and variable-length chromosomes. For the analysis of the performace of this algorithm compared to GEWEP see my recent [experiment report](https://github.com/ethereum/solidity/issues/7806#issuecomment-598644491).

Includes a few structural changes needed for the implementation:
- Symmetric crossover operators. In the classic GA crossover produces two chromosomes from the same set of parents. I could not simulate this by just using the current crossover twice with swapped parameters because the results are random and subsequent calls could choose different crossover points.
- Support for returning the "remainder" of a population that did not take part in crossover. Since `Selection::materialise()` and `PairSelection::materialise()` may return different random results with each call, this was also not possible to simulate with two separate calls. This could be similarly implemented for `Population::mutate()` and `Population::select()` but in the end I only needed it for crossover.
- The classic algorithm has a custom `select()` method because the results of its selection phase depend on fitness of individuals which is not available to specialisations of `Selection`. `Selection` should be refactored to have access to that information but I did not think it was worth doing it right now just for this single algorithm.
- `mutationSequence()` simply applies a series of mutations passed to it. This is mostly an optimisation which allows us to have only one call to `Population::mutate()` per round. With three different mutations applied separately the population would unnecessarily recalculate fitness multiple times for individuals that undergo more than one mutation type.
- `Population` constructor that accepts `Individual`s is now public. This allows us to move individuals from one population to another without fitness recalculation. Necessary because of the custom selection in the classic algorithm. The downside is that you can create a population where fitness values do not match the metric (though this could also be a feature when used carefully).

### Dependencies
~This PR is based on #8453. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.~ Since this PR doesn't depend on anything from #8453 and all the other dependencies from below that PR are already merged, I rebased it on `develop`.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages