### PR TITLE
[yul-phaser] Crossover operators

### DIFF
--- a/test/yulPhaser/GeneticAlgorithms.cpp
+++ b/test/yulPhaser/GeneticAlgorithms.cpp
@@ -51,6 +51,8 @@ protected:
 		/* mutationChance = */ 0.0,
 		/* deletionChance = */ 0.0,
 		/* additionChance = */ 0.0,
+		/* CrossoverChoice = */ CrossoverChoice::SinglePoint,
+		/* uniformCrossoverSwapChance= */ 0.5,
 	};
 };
 
@@ -113,6 +115,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_preserve_elite_and_regenerate_rest_o
 		/* deletionVsAdditionChance = */ 1.0,
 		/* percentGenesToRandomise = */ 0.0,
 		/* percentGenesToAddOrDelete = */ 1.0,
+		/* CrossoverChoice = */ CrossoverChoice::SinglePoint,
+		/* uniformCrossoverSwapChance= */ 0.5,
 	};
 	GenerationalElitistWithExclusivePools algorithm(options);
 
@@ -133,6 +137,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_not_replace_elite_with_worse_individ
 		/* deletionVsAdditionChance = */ 0.0,
 		/* percentGenesToRandomise = */ 0.0,
 		/* percentGenesToAddOrDelete = */ 1.0,
+		/* CrossoverChoice = */ CrossoverChoice::SinglePoint,
+		/* uniformCrossoverSwapChance= */ 0.5,
 	};
 	GenerationalElitistWithExclusivePools algorithm(options);
 
@@ -152,6 +158,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_generate_individuals_in_the_crossove
 		/* deletionVsAdditionChance = */ 0.5,
 		/* percentGenesToRandomise = */ 1.0,
 		/* percentGenesToAddOrDelete = */ 1.0,
+		/* CrossoverChoice = */ CrossoverChoice::SinglePoint,
+		/* uniformCrossoverSwapChance= */ 0.5,
 	};
 	GenerationalElitistWithExclusivePools algorithm(options);
 
@@ -179,6 +187,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_generate_individuals_in_the_crossove
 		/* deletionVsAdditionChance = */ 0.0,
 		/* percentGenesToRandomise = */ 0.0,
 		/* percentGenesToAddOrDelete = */ 0.0,
+		/* CrossoverChoice = */ CrossoverChoice::SinglePoint,
+		/* uniformCrossoverSwapChance= */ 0.5,
 	};
 	GenerationalElitistWithExclusivePools algorithm(options);
 

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -45,6 +45,8 @@ protected:
 		/* algorithm = */ Algorithm::Random,
 		/* minChromosomeLength = */ 50,
 		/* maxChromosomeLength = */ 100,
+		/* CrossoverChoice = */ CrossoverChoice::Uniform,
+		/* uniformCrossoverSwapChance = */ 0.5,
 		/* randomElitePoolSize = */ 0.5,
 		/* gewepMutationPoolSize = */ 0.1,
 		/* gewepCrossoverPoolSize = */ 0.1,
@@ -121,6 +123,9 @@ BOOST_FIXTURE_TEST_CASE(build_should_select_the_right_algorithm_and_pass_the_opt
 
 	auto gewepAlgorithm = dynamic_cast<GenerationalElitistWithExclusivePools*>(algorithm2.get());
 	BOOST_REQUIRE(gewepAlgorithm != nullptr);
+	BOOST_TEST(gewepAlgorithm->options().crossover == m_options.crossover);
+	BOOST_TEST(gewepAlgorithm->options().uniformCrossoverSwapChance.has_value());
+	BOOST_TEST(gewepAlgorithm->options().uniformCrossoverSwapChance.value() == m_options.uniformCrossoverSwapChance);
 	BOOST_TEST(gewepAlgorithm->options().mutationPoolSize == m_options.gewepMutationPoolSize);
 	BOOST_TEST(gewepAlgorithm->options().crossoverPoolSize == m_options.gewepCrossoverPoolSize);
 	BOOST_TEST(gewepAlgorithm->options().randomisationChance == m_options.gewepRandomisationChance);
@@ -134,6 +139,8 @@ BOOST_FIXTURE_TEST_CASE(build_should_select_the_right_algorithm_and_pass_the_opt
 
 	auto classicAlgorithm = dynamic_cast<ClassicGeneticAlgorithm*>(algorithm3.get());
 	BOOST_REQUIRE(classicAlgorithm != nullptr);
+	BOOST_TEST(classicAlgorithm->options().uniformCrossoverSwapChance.has_value());
+	BOOST_TEST(classicAlgorithm->options().uniformCrossoverSwapChance.value() == m_options.uniformCrossoverSwapChance);
 	BOOST_TEST(classicAlgorithm->options().elitePoolSize == m_options.classicElitePoolSize);
 	BOOST_TEST(classicAlgorithm->options().crossoverChance == m_options.classicCrossoverChance);
 	BOOST_TEST(classicAlgorithm->options().mutationChance == m_options.classicMutationChance);

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -96,7 +96,10 @@ Population GenerationalElitistWithExclusivePools::runNextRound(Population _popul
 			geneAddition(m_options.percentGenesToAddOrDelete)
 		)
 	);
-	std::function<Crossover> crossoverOperator = randomPointCrossover();
+	std::function<Crossover> crossoverOperator = buildCrossoverOperator(
+		m_options.crossover,
+		m_options.uniformCrossoverSwapChance
+	);
 
 	return
 		_population.select(elitePool) +
@@ -111,10 +114,15 @@ Population ClassicGeneticAlgorithm::runNextRound(Population _population)
 
 	Population selectedPopulation = select(_population, rest.individuals().size());
 
+	std::function<SymmetricCrossover> crossoverOperator = buildSymmetricCrossoverOperator(
+		m_options.crossover,
+		m_options.uniformCrossoverSwapChance
+	);
+
 	Population crossedPopulation = Population::combine(
 		selectedPopulation.symmetricCrossoverWithRemainder(
 			PairsFromRandomSubset(m_options.crossoverChance),
-			symmetricRandomPointCrossover()
+			crossoverOperator
 		)
 	);
 

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -21,7 +21,46 @@
 #include <tools/yulPhaser/PairSelections.h>
 
 using namespace std;
+using namespace solidity;
 using namespace solidity::phaser;
+
+function<Crossover> phaser::buildCrossoverOperator(
+	CrossoverChoice _choice,
+	optional<double> _uniformCrossoverSwapChance
+)
+{
+	switch (_choice)
+	{
+		case CrossoverChoice::SinglePoint:
+			return randomPointCrossover();
+		case CrossoverChoice::TwoPoint:
+			return randomTwoPointCrossover();
+		case CrossoverChoice::Uniform:
+			assert(_uniformCrossoverSwapChance.has_value());
+			return uniformCrossover(_uniformCrossoverSwapChance.value());
+		default:
+			assertThrow(false, solidity::util::Exception, "Invalid CrossoverChoice value.");
+	};
+}
+
+function<SymmetricCrossover> phaser::buildSymmetricCrossoverOperator(
+	CrossoverChoice _choice,
+	optional<double> _uniformCrossoverSwapChance
+)
+{
+	switch (_choice)
+	{
+		case CrossoverChoice::SinglePoint:
+			return symmetricRandomPointCrossover();
+		case CrossoverChoice::TwoPoint:
+			return symmetricRandomTwoPointCrossover();
+		case CrossoverChoice::Uniform:
+			assert(_uniformCrossoverSwapChance.has_value());
+			return symmetricUniformCrossover(_uniformCrossoverSwapChance.value());
+		default:
+			assertThrow(false, solidity::util::Exception, "Invalid CrossoverChoice value.");
+	};
+}
 
 Population RandomAlgorithm::runNextRound(Population _population)
 {

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -130,6 +130,8 @@ public:
 		double deletionVsAdditionChance;  ///< The chance of choosing @a geneDeletion as the mutation if randomisation was not chosen.
 		double percentGenesToRandomise;   ///< The chance of any given gene being mutated in gene randomisation.
 		double percentGenesToAddOrDelete; ///< The chance of a gene being added (or deleted) in gene addition (or deletion).
+		CrossoverChoice crossover;        ///< The crossover operator to use.
+		std::optional<double> uniformCrossoverSwapChance; ///< Chance of a pair of genes being swapped in uniform crossover.
 
 		bool isValid() const
 		{
@@ -140,6 +142,7 @@ public:
 				0 <= deletionVsAdditionChance && deletionVsAdditionChance <= 1.0 &&
 				0 <= percentGenesToRandomise && percentGenesToRandomise <= 1.0 &&
 				0 <= percentGenesToAddOrDelete && percentGenesToAddOrDelete <= 1.0 &&
+				0 <= uniformCrossoverSwapChance && uniformCrossoverSwapChance <= 1.0 &&
 				mutationPoolSize + crossoverPoolSize <= 1.0
 			);
 		}
@@ -185,6 +188,8 @@ public:
 		double mutationChance;     ///< The chance of a particular gene being randomised in @a geneRandomisation mutation.
 		double deletionChance;     ///< The chance of a particular gene being deleted in @a geneDeletion mutation.
 		double additionChance;     ///< The chance of a particular gene being added in @a geneAddition mutation.
+		CrossoverChoice crossover; ///< The crossover operator to use
+		std::optional<double> uniformCrossoverSwapChance; ///< Chance of a pair of genes being swapped in uniform crossover.
 
 		bool isValid() const
 		{
@@ -193,7 +198,8 @@ public:
 				0 <= crossoverChance && crossoverChance <= 1.0 &&
 				0 <= mutationChance && mutationChance <= 1.0 &&
 				0 <= deletionChance && deletionChance <= 1.0 &&
-				0 <= additionChance && additionChance <= 1.0
+				0 <= additionChance && additionChance <= 1.0 &&
+				0 <= uniformCrossoverSwapChance && uniformCrossoverSwapChance <= 1.0
 			);
 		}
 	};

--- a/tools/yulPhaser/GeneticAlgorithms.h
+++ b/tools/yulPhaser/GeneticAlgorithms.h
@@ -20,10 +20,30 @@
 
 #pragma once
 
+#include <tools/yulPhaser/Mutations.h>
 #include <tools/yulPhaser/Population.h>
+
+#include <optional>
 
 namespace solidity::phaser
 {
+
+enum class CrossoverChoice
+{
+	SinglePoint,
+	TwoPoint,
+	Uniform,
+};
+
+std::function<Crossover> buildCrossoverOperator(
+	CrossoverChoice _choice,
+	std::optional<double> _uniformCrossoverSwapChance
+);
+
+std::function<SymmetricCrossover> buildSymmetricCrossoverOperator(
+	CrossoverChoice _choice,
+	std::optional<double> _uniformCrossoverSwapChance
+);
 
 /**
  * Abstract base class for genetic algorithms.

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -145,7 +145,7 @@ function<Crossover> phaser::randomPointCrossover()
 		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
 
 		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
-		size_t minPoint = (minLength > 0? 1 : 0);
+		size_t minPoint = (minLength > 0 ? 1 : 0);
 		assert(minPoint <= minLength);
 
 		size_t randomPoint = SimulationRNG::uniformInt(minPoint, minLength);
@@ -160,7 +160,7 @@ function<SymmetricCrossover> phaser::symmetricRandomPointCrossover()
 		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
 
 		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
-		size_t minPoint = (minLength > 0? 1 : 0);
+		size_t minPoint = (minLength > 0 ? 1 : 0);
 		assert(minPoint <= minLength);
 
 		size_t randomPoint = SimulationRNG::uniformInt(minPoint, minLength);

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -180,3 +180,138 @@ function<Crossover> phaser::fixedPointCrossover(double _crossoverPoint)
 		return get<0>(fixedPointSwap(_chromosome1, _chromosome2, concretePoint));
 	};
 }
+
+namespace
+{
+
+ChromosomePair fixedTwoPointSwap(
+	Chromosome const& _chromosome1,
+	Chromosome const& _chromosome2,
+	size_t _crossoverPoint1,
+	size_t _crossoverPoint2
+)
+{
+	assert(_crossoverPoint1 <= _chromosome1.length());
+	assert(_crossoverPoint1 <= _chromosome2.length());
+	assert(_crossoverPoint2 <= _chromosome1.length());
+	assert(_crossoverPoint2 <= _chromosome2.length());
+
+	size_t lowPoint = min(_crossoverPoint1, _crossoverPoint2);
+	size_t highPoint = max(_crossoverPoint1, _crossoverPoint2);
+
+	auto begin1 = _chromosome1.optimisationSteps().begin();
+	auto begin2 = _chromosome2.optimisationSteps().begin();
+	auto end1 = _chromosome1.optimisationSteps().end();
+	auto end2 = _chromosome2.optimisationSteps().end();
+
+	return {
+		Chromosome(
+			vector<string>(begin1, begin1 + lowPoint) +
+			vector<string>(begin2 + lowPoint, begin2 + highPoint) +
+			vector<string>(begin1 + highPoint, end1)
+		),
+		Chromosome(
+			vector<string>(begin2, begin2 + lowPoint) +
+			vector<string>(begin1 + lowPoint, begin1 + highPoint) +
+			vector<string>(begin2 + highPoint, end2)
+		),
+	};
+}
+
+}
+
+function<Crossover> phaser::randomTwoPointCrossover()
+{
+	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+	{
+		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+
+		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
+		size_t minPoint = (minLength > 0 ? 1 : 0);
+		assert(minPoint <= minLength);
+
+		size_t randomPoint1 = SimulationRNG::uniformInt(minPoint, minLength);
+		size_t randomPoint2 = SimulationRNG::uniformInt(randomPoint1, minLength);
+		return get<0>(fixedTwoPointSwap(_chromosome1, _chromosome2, randomPoint1, randomPoint2));
+	};
+}
+
+function<SymmetricCrossover> phaser::symmetricRandomTwoPointCrossover()
+{
+	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+	{
+		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+
+		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
+		size_t minPoint = (minLength > 0 ? 1 : 0);
+		assert(minPoint <= minLength);
+
+		size_t randomPoint1 = SimulationRNG::uniformInt(minPoint, minLength);
+		size_t randomPoint2 = SimulationRNG::uniformInt(randomPoint1, minLength);
+		return fixedTwoPointSwap(_chromosome1, _chromosome2, randomPoint1, randomPoint2);
+	};
+}
+
+namespace
+{
+
+ChromosomePair uniformSwap(Chromosome const& _chromosome1, Chromosome const& _chromosome2, double _swapChance)
+{
+	vector<string> steps1;
+	vector<string> steps2;
+
+	size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+	for (size_t i = 0; i < minLength; ++i)
+		if (SimulationRNG::bernoulliTrial(_swapChance))
+		{
+			steps1.push_back(_chromosome2.optimisationSteps()[i]);
+			steps2.push_back(_chromosome1.optimisationSteps()[i]);
+		}
+		else
+		{
+			steps1.push_back(_chromosome1.optimisationSteps()[i]);
+			steps2.push_back(_chromosome2.optimisationSteps()[i]);
+		}
+
+	auto begin1 = _chromosome1.optimisationSteps().begin();
+	auto begin2 = _chromosome2.optimisationSteps().begin();
+	auto end1 = _chromosome1.optimisationSteps().end();
+	auto end2 = _chromosome2.optimisationSteps().end();
+
+	bool swapTail = SimulationRNG::bernoulliTrial(_swapChance);
+	if (_chromosome1.length() > minLength)
+	{
+		if (swapTail)
+			steps2.insert(steps2.end(), begin1 + minLength, end1);
+		else
+			steps1.insert(steps1.end(), begin1 + minLength, end1);
+	}
+
+	if (_chromosome2.length() > minLength)
+	{
+		if (swapTail)
+			steps1.insert(steps1.end(), begin2 + minLength, end2);
+		else
+			steps2.insert(steps2.end(), begin2 + minLength, end2);
+	}
+
+	return {Chromosome(steps1), Chromosome(steps2)};
+}
+
+}
+
+function<Crossover> phaser::uniformCrossover(double _swapChance)
+{
+	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+	{
+		return get<0>(uniformSwap(_chromosome1, _chromosome2, _swapChance));
+	};
+}
+
+function<SymmetricCrossover> phaser::symmetricUniformCrossover(double _swapChance)
+{
+	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
+	{
+		return uniformSwap(_chromosome1, _chromosome2, _swapChance);
+	};
+}

--- a/tools/yulPhaser/Mutations.h
+++ b/tools/yulPhaser/Mutations.h
@@ -80,4 +80,22 @@ std::function<SymmetricCrossover> symmetricRandomPointCrossover();
 /// unless there is no other choice (i.e. one of the chromosomes is empty).
 std::function<Crossover> fixedPointCrossover(double _crossoverPoint);
 
+/// Creates a crossover operator that randomly selects two points between 0 and 1 and swaps genes
+/// from the resulting interval. The interval may be empty in which case no genes are swapped.
+std::function<Crossover> randomTwoPointCrossover();
+
+/// Symmetric version of @a randomTwoPointCrossover(). Creates an operator that returns a pair
+/// containing both possible results for the same crossover points.
+std::function<SymmetricCrossover> symmetricRandomTwoPointCrossover();
+
+/// Creates a crossover operator that goes over the length of the shorter chromosomes and for
+/// each gene independently decides whether to swap it or not (with probability given by
+/// @a _swapChance). The tail of the longer chromosome (the part that's past the length of the
+/// shorter one) is treated as a single gene and can potentially be swapped too.
+std::function<Crossover> uniformCrossover(double _swapChance);
+
+/// Symmetric version of @a uniformCrossover(). Creates an operator that returns a pair
+/// containing both possible results for the same set or swap decisions.
+std::function<SymmetricCrossover> symmetricUniformCrossover(double _swapChance);
+
 }

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <tools/yulPhaser/AlgorithmRunner.h>
+#include <tools/yulPhaser/GeneticAlgorithms.h>
 
 #include <boost/program_options.hpp>
 
@@ -83,6 +84,8 @@ std::istream& operator>>(std::istream& _inputStream, solidity::phaser::MetricCho
 std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::MetricChoice _metric);
 std::istream& operator>>(std::istream& _inputStream, solidity::phaser::MetricAggregatorChoice& _aggregator);
 std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::MetricAggregatorChoice _aggregator);
+std::istream& operator>>(std::istream& _inputStream, solidity::phaser::CrossoverChoice& _crossover);
+std::ostream& operator<<(std::ostream& _outputStream, solidity::phaser::CrossoverChoice _crossover);
 
 /**
  * Builds and validates instances of @a GeneticAlgorithm and its derived classes.
@@ -95,13 +98,18 @@ public:
 		Algorithm algorithm;
 		size_t minChromosomeLength;
 		size_t maxChromosomeLength;
+		CrossoverChoice crossover;
+		double uniformCrossoverSwapChance;
+
 		std::optional<double> randomElitePoolSize;
+
 		double gewepMutationPoolSize;
 		double gewepCrossoverPoolSize;
 		double gewepRandomisationChance;
 		double gewepDeletionVsAdditionChance;
 		std::optional<double> gewepGenesToRandomise;
 		std::optional<double> gewepGenesToAddOrDelete;
+
 		double classicElitePoolSize;
 		double classicCrossoverChance;
 		double classicMutationChance;


### PR DESCRIPTION
### Description
Part of the final set of PRs for #7806.

This PR implements two-point and uniform crossover operators. The performance of these operators was analysed in my recent [experiment report](https://github.com/ethereum/solidity/issues/7806#issuecomment-598644491).

It also adds an option for selecting the operator from command line (`--crossover`).

### Dependencies
This PR is based on #8515. Unfortunately changes from that base PR will show through in the combined diff and on the commit list until it gets merged.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [x] Used meaningful commit messages