### PR TITLE
fix typo in docstring error message

### DIFF
--- a/libsolidity/analysis/DocStringAnalyser.cpp
+++ b/libsolidity/analysis/DocStringAnalyser.cpp
@@ -153,7 +153,7 @@ void DocStringAnalyser::parseDocStrings(
 						appendError(
 							_node.documentation()->location(),
 							"Documentation tag \"@" + docTag.first + " " + docTag.second.content + "\"" +
-							" exceedes the number of return parameters."
+							" exceeds the number of return parameters."
 						);
 					else
 					{


### PR DESCRIPTION
### What I did
Fixed a typo in one of the docstring error messages.