### PR TITLE
Improved .clang_format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,26 +6,35 @@
 # Note that clang-format cannot express the style that closing parentheses
 # behave similar to closing curly braces in a multi-line setting in that
 # they have to be on a line of their own at the same indentation level
-# as the opening part.
+# as the opening part (aka "dangling parenthesis", see https://reviews.llvm.org/D33029).
 
 Language: Cpp
 BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
 AlignEscapedNewlinesLeft: true
 AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
 BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Allman
 ColumnLimit: 120
 ContinuationIndentWidth: 4
+FixNamespaceComments: false
 IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 PenaltyBreakBeforeFirstCallParameter: 2000
+PointerAlignment: Left
 SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeCtorInitializerColon: false
+SpaceBeforeInheritanceColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
 TabWidth: 4
-UseTab: ForIndentation
+UseTab: Always
 
 # Local Variables:
 # mode: yaml

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -141,7 +141,7 @@ struct MeanSigma
 double const d = 0;
 int i = 0;
 int j = 0;
-char* s;
+char* s = nullptr;
 MeanAndSigma ms meanAndSigma(std::vector<float> const& _v, Accuracy _a);
 Derived* x = dynamic_cast<Derived*>(base);
 for (auto i = x->begin(); i != x->end(); ++i) {}


### PR DESCRIPTION
This improves `.clang-format`.

Please note that even with the proposed changes solidity is still not clang-format-ready.

For instance, clang-format does not support
```
void func(
    param1,
    param2
);
```
and formats the code as
```
void func(
    param1,
    param2);
```

----

#### AccessModifierOffset: -4
aligns `{` and `public:` etc.

#### AlignAfterOpenBracket: AlwaysBreak
```
void f(
    a,
    b,
    ...
```

#### AlwaysBreakTemplateDeclarations: Yes
```
template<...>
void f(...)
```

#### FixNamespaceComments: false
prenents `} // namespace ...`

#### PointerAlignment: Left
alligns pointers and references like `int& x`

#### SpaceBeforeCtorInitializerColon: false
for `ctor(): ...`

#### SpaceBeforeInheritanceColon: false
for `class C: public B`

#### SpaceBeforeRangeBasedForLoopColon: false
for `for(auto x: list)`

#### UseTab: Always
prevents mix of leading tabs and spaces (in particular prevents leading spaces in comment blocks)
