### PR TITLE
Oldosxbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
 set(PROJECT_VERSION "0.6.5")
+# OSX target needed in order to support std::visit
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
 project(solidity VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 
 include(TestBigEndian)


### PR DESCRIPTION
This was needed in order to be able to build on macos High Sierra. 
Somewhat mysteriously, the `OSX_DEPLOYMENT_TARGET` is set to higher than what I'm on (High Sierra is `10.13`), but at least others seem to share this experience https://stackoverflow.com/questions/52310835/xcode-10-call-to-unavailable-function-stdvisit