### PR TITLE
Added error for interface functions that have modifiers; test case

### DIFF
--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -303,7 +303,9 @@ bool SyntaxChecker::visit(FunctionDefinition const& _function)
 		);
 	}
 
-	if (!_function.isImplemented() && !_function.modifiers().empty())
+	if (m_isInterface && !_function.modifiers().empty())
+		m_errorReporter.syntaxError(_function.location(), "Functions in interfaces cannot have modifiers.");
+	else if (!_function.isImplemented() && !_function.modifiers().empty())
 		m_errorReporter.syntaxError(_function.location(), "Functions without implementation cannot have modifiers.");
 
 	return true;

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/588_interface_function_modifier.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/588_interface_function_modifier.sol
@@ -1,0 +1,6 @@
+interface I {
+  function f() external m pure returns (uint);
+  modifier m() { _; }
+}
+// ----
+// SyntaxError: (16-60): Functions in interfaces cannot have modifiers.


### PR DESCRIPTION
Fixed https://github.com/ethereum/solidity/issues/8544

Will change the error message for this context to "**Functions in interfaces cannot have modifiers.**"

The output from test case.

```
Error: Functions in interfaces cannot have modifiers.
 --> /tmp/interface.sol:2:3:
  |
2 |   function f() external m pure returns (uint);
  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```