### PR TITLE
Added error message for virtual (library) functions; test case

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ Bugfixes:
  * Inline Assembly: Fix internal error when accessing incorrect constant variables.
  * Inheritance: Allow public state variables to override functions with dynamic memory types in their return values.
  * JSON AST: Always add pointer suffix for memory reference types.
+ * Type Checker: Disallow virtual for library functions.
 
 
 ### 0.6.4 (2020-03-10)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -332,6 +332,8 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 			m_errorReporter.warning(_function.location(), "Interface functions are implicitly \"virtual\"");
 		if (_function.visibility() == Visibility::Private)
 			m_errorReporter.typeError(_function.location(), "\"virtual\" and \"private\" cannot be used together.");
+		if (isLibraryFunction)
+			m_errorReporter.typeError(_function.location(), "Library functions cannot be \"virtual\".");
 	}
 
 	if (_function.isPayable())

--- a/test/compilationTests/gnosis/Utils/Math.sol
+++ b/test/compilationTests/gnosis/Utils/Math.sol
@@ -177,7 +177,6 @@ library Math {
     /// @param nums Numbers to look through
     /// @return max Maximum number
     function max(int[] memory nums)
-        virtual
         public
         pure
         returns (int max)

--- a/test/libsolidity/syntaxTests/inheritance/virtual/library_err.sol
+++ b/test/libsolidity/syntaxTests/inheritance/virtual/library_err.sol
@@ -1,0 +1,5 @@
+library L {
+    function f() internal pure virtual returns (uint) { return 0; }
+}
+// ----
+// TypeError: (16-79): Library functions cannot be "virtual".


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8540

Adds a new error message: Library functions cannot be "virtual". Fixed a gnosis test set that had a library function with virtual.