### PR TITLE
Delete copy and move operations for ASTVisitor and ASTConstVisitor

### DIFF
--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -41,7 +41,16 @@ namespace solidity::frontend
 class ASTVisitor
 {
 public:
+	ASTVisitor() = default;
+
+	ASTVisitor(ASTVisitor const&) = delete;
+	ASTVisitor(ASTVisitor&&) = delete;
+
+	ASTVisitor& operator=(ASTVisitor const&) = delete;
+	ASTVisitor& operator=(ASTVisitor&&) = delete;
+
 	virtual ~ASTVisitor() = default;
+
 	virtual bool visit(SourceUnit& _node) { return visitNode(_node); }
 	virtual bool visit(PragmaDirective& _node) { return visitNode(_node); }
 	virtual bool visit(ImportDirective& _node) { return visitNode(_node); }
@@ -158,7 +167,16 @@ protected:
 class ASTConstVisitor
 {
 public:
+	ASTConstVisitor() = default;
+
+	ASTConstVisitor(ASTConstVisitor const&) = delete;
+	ASTConstVisitor(ASTConstVisitor&&) = delete;
+
+	ASTConstVisitor& operator=(ASTConstVisitor const&) = delete;
+	ASTConstVisitor& operator=(ASTConstVisitor&&) = delete;
+
 	virtual ~ASTConstVisitor() = default;
+
 	virtual bool visit(SourceUnit const& _node) { return visitNode(_node); }
 	virtual bool visit(PragmaDirective const& _node) { return visitNode(_node); }
 	virtual bool visit(ImportDirective const& _node) { return visitNode(_node); }


### PR DESCRIPTION
As a general rule, polymorphic base classes should have deleted copy/move operations (see Core Guideline [C.67](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-copy-virtual)).

This PR deletes copy/move operations for `ASTVisitor` and `ASTConstVisitor`. In addition to prevent slicing, this improves safety since it is rarely (if ever) correct to copy a visitor.