### PR TITLE
Trivial documentation fixes in reference-types.rst

### DIFF
--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -500,7 +500,7 @@ shown in the following example:
 
 The contract does not provide the full functionality of a crowdfunding
 contract, but it contains the basic concepts necessary to understand structs.
-Struct types can be used inside mappings and arrays and they can itself
+Struct types can be used inside mappings and arrays and they can themselves
 contain mappings and arrays.
 
 It is not possible for a struct to contain a member of its own type,

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -387,7 +387,7 @@ If ``start`` is greater than ``end`` or if ``end`` is greater
 than the length of the array, an exception is thrown.
 
 Both ``start`` and ``end`` are optional: ``start`` defaults
- to ``0`` and ``end`` defaults to the length of the array.
+to ``0`` and ``end`` defaults to the length of the array.
 
 Array slices do not have any members. They are implicitly
 convertible to arrays of their underlying type


### PR DESCRIPTION
Two tiny fixes:
1. The sentence about slices had a space at the beginning of the wrapped line which caused it to be rendered in a weird way (first part bold, second part indented). See how it gets rendered in https://solidity.readthedocs.io/en/latest/types.html#array-slices.
2. Correction of a small grammatical mistake.