### PR TITLE
Fix ownership.

### DIFF
--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -38,7 +38,7 @@
 /// Operators need to stay in the global namespace.
 
 /// Concatenate the contents of a container onto a vector
-template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U const& _b)
+template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U& _b)
 {
 	for (auto const& i: _b)
 		_a.push_back(i);


### PR DESCRIPTION
Fixes #8555.

## Example of problem

```cpp
bytes solidity::util::ipfsHash(string _data)
{
	...
	protobufEncodedData += bytes{0x12};
	protobufEncodedData += lengthAsVarint; // move append, after this lengthAsVarint is not valid anymore, because all items where moved out of the container
	...
	protobufEncodedData += bytes{0x18} + lengthAsVarint; // here lengthAsVarint is not valid anymore
	...
}
```

I think I understood now what was happening here, this is my interpretation:

We defined the following functions:
```
/// Concatenate the contents of a container onto a vector
template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U const& _b)

/// Concatenate the contents of a container onto a vector, move variant.
template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U&& _b);
```

The lvalue reference implementation was only used, if `_b` was of constant type. In all other cases the "rvalue reference" implementation was used. In our case it is not always necessarily a rvalue reference. Because of the template parameter, the actual type will be deduced and can bind rvalues and non-constant lvalues. This is quite similar to Scott Meyers "universal references".

So our implementation of the "move variant" was basically an implementation that was able to bind lvalues and rvalues with the exception of constant lvalue references. So the "move variant" function was also called if non-constant lvalues where used. 

By removing `const` from the lvalue reference implementation, we ensure that the rvalue reference implementation can only bind rvalue references and the lvalue reference implementation will only bind to lvalue references.