### PR TITLE
TypeChecker error when encoding functions with call options; tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 Bugfixes:
  * SMTChecker: Fix internal error in the CHC engine when calling inherited functions internally.
+ * Type Checker: Error when trying to encode functions with call options gas and value.
 
 
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3112,6 +3112,8 @@ MemberList::MemberMap FunctionType::nativeMembers(ContractDefinition const* _sco
 
 TypePointer FunctionType::encodingType() const
 {
+	if (m_gasSet || m_valueSet)
+		return nullptr;
 	// Only external functions can be encoded, internal functions cannot leave code boundaries.
 	if (m_kind == Kind::External)
 		return this;

--- a/test/libsolidity/syntaxTests/specialFunctions/functionCallOptions_err.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/functionCallOptions_err.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() public payable {
+		abi.encode(this.f{value: 2});
+		abi.encode(this.f{gas: 2});
+		abi.encode(this.f{value: 2, gas: 1});
+    }
+}
+// ----
+// TypeError: (60-76): This type cannot be encoded.
+// TypeError: (92-106): This type cannot be encoded.
+// TypeError: (122-146): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_internal_functions.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/types_with_unspecified_encoding_internal_functions.sol
@@ -1,12 +1,11 @@
 contract C {
     function f() public pure {
-        bytes32 h = keccak256(abi.encodePacked(keccak256, f, this.f.gas, blockhash));
+        bytes32 h = keccak256(abi.encodePacked(keccak256, f, this.f{gas: 2}, blockhash));
         h;
     }
 }
 // ----
-// Warning: (105-115): Using ".gas(...)" is deprecated. Use "{gas: ...}" instead.
 // TypeError: (91-100): This type cannot be encoded.
 // TypeError: (102-103): This type cannot be encoded.
-// TypeError: (105-115): This type cannot be encoded.
-// TypeError: (117-126): This type cannot be encoded.
+// TypeError: (105-119): This type cannot be encoded.
+// TypeError: (121-130): This type cannot be encoded.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8590