### PR TITLE
Changed external tests; current develop; Not a real PR

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -34,12 +34,12 @@ function colony_test
     FORCE_ABIv2=false
     CONFIG="truffle.js"
 
-    truffle_setup https://github.com/erak/colonyNetwork.git develop_060
+    truffle_setup https://github.com/solidity-external-tests/colonyNetwork.git develop_060
     run_install install_fn
 
     cd lib
     rm -Rf dappsys
-    git clone https://github.com/erak/dappsys-monolithic.git -b master_060 dappsys
+    git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_060 dappsys
     cd ..
 
     truffle_run_test compile_fn test_fn

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -33,10 +33,10 @@ function gnosis_safe_test
     OPTIMIZER_LEVEL=1
     CONFIG="truffle.js"
 
-    truffle_setup https://github.com/erak/safe-contracts.git development_060
+    truffle_setup https://github.com/solidity-external-tests/safe-contracts.git development_060
 
     force_truffle_version
-    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:erak/mock-contract#master_060|g' package.json
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_060|g' package.json
 
     run_install install_fn
     replace_libsolc_call
@@ -45,4 +45,3 @@ function gnosis_safe_test
 }
 
 external_test Gnosis-Safe gnosis_safe_test
-

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -33,7 +33,7 @@ function zeppelin_test
     OPTIMIZER_LEVEL=1
     CONFIG="truffle-config.js"
 
-    truffle_setup https://github.com/erak/openzeppelin-contracts.git master_060
+    truffle_setup https://github.com/solidity-external-tests/openzeppelin-contracts.git upgrade-0.7.0
     run_install install_fn
 
     truffle_run_test compile_fn test_fn


### PR DESCRIPTION
We plan to move all the external tests to the repos here: https://github.com/solidity-external-tests. This change is more relevant to the following breaking PR: https://github.com/ethereum/solidity/pull/8589