### PR TITLE
Replaced all instances of lValueRequested to willBeWrittenTo

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -591,7 +591,7 @@ bool ControlFlowBuilder::visit(Identifier const& _identifier)
 	if (auto const* variableDeclaration = dynamic_cast<VariableDeclaration const*>(_identifier.annotation().referencedDeclaration))
 		m_currentNode->variableOccurrences.emplace_back(
 			*variableDeclaration,
-			static_cast<Expression const&>(_identifier).annotation().lValueRequested ?
+			static_cast<Expression const&>(_identifier).annotation().willBeWrittenTo ?
 			VariableOccurrence::Kind::Assignment :
 			VariableOccurrence::Kind::Access,
 			_identifier.location()

--- a/libsolidity/analysis/ImmutableValidator.cpp
+++ b/libsolidity/analysis/ImmutableValidator.cpp
@@ -160,7 +160,7 @@ void ImmutableValidator::analyseVariableReference(VariableDeclaration const& _va
 	if (!_variableReference.isStateVariable() || !_variableReference.immutable())
 		return;
 
-	if (_expression.annotation().lValueRequested && _expression.annotation().lValueOfOrdinaryAssignment)
+	if (_expression.annotation().willBeWrittenTo && _expression.annotation().lValueOfOrdinaryAssignment)
 	{
 		if (!m_currentConstructor)
 			m_errorReporter.typeError(

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1303,7 +1303,7 @@ bool TypeChecker::visit(Conditional const& _conditional)
 		_conditional.trueExpression().annotation().isPure &&
 		_conditional.falseExpression().annotation().isPure;
 
-	if (_conditional.annotation().lValueRequested)
+	if (_conditional.annotation().willBeWrittenTo)
 		m_errorReporter.typeError(
 				_conditional.location(),
 				"Conditional expression as left value is not supported yet."
@@ -1399,7 +1399,7 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 	vector<ASTPointer<Expression>> const& components = _tuple.components();
 	TypePointers types;
 
-	if (_tuple.annotation().lValueRequested)
+	if (_tuple.annotation().willBeWrittenTo)
 	{
 		if (_tuple.isInlineArray())
 			m_errorReporter.fatalTypeError(_tuple.location(), "Inline array type cannot be declared as LValue.");
@@ -3050,7 +3050,7 @@ bool TypeChecker::expectType(Expression const& _expression, Type const& _expecte
 
 void TypeChecker::requireLValue(Expression const& _expression, bool _ordinaryAssignment)
 {
-	_expression.annotation().lValueRequested = true;
+	_expression.annotation().willBeWrittenTo = true;
 	_expression.annotation().lValueOfOrdinaryAssignment = _ordinaryAssignment;
 	_expression.accept(*this);
 

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -197,7 +197,7 @@ void ViewPureChecker::endVisit(Identifier const& _identifier)
 
 	StateMutability mutability = StateMutability::Pure;
 
-	bool writes = _identifier.annotation().lValueRequested;
+	bool writes = _identifier.annotation().willBeWrittenTo;
 	if (VariableDeclaration const* varDecl = dynamic_cast<VariableDeclaration const*>(declaration))
 	{
 		if (varDecl->isStateVariable() && !varDecl->isConstant())
@@ -332,7 +332,7 @@ bool ViewPureChecker::visit(MemberAccess const& _memberAccess)
 void ViewPureChecker::endVisit(MemberAccess const& _memberAccess)
 {
 	StateMutability mutability = StateMutability::Pure;
-	bool writes = _memberAccess.annotation().lValueRequested;
+	bool writes = _memberAccess.annotation().willBeWrittenTo;
 
 	ASTString const& member = _memberAccess.memberName();
 	switch (_memberAccess.expression().annotation().type->category())
@@ -402,7 +402,7 @@ void ViewPureChecker::endVisit(IndexAccess const& _indexAccess)
 		solAssert(_indexAccess.annotation().type->category() == Type::Category::TypeType, "");
 	else
 	{
-		bool writes = _indexAccess.annotation().lValueRequested;
+		bool writes = _indexAccess.annotation().willBeWrittenTo;
 		if (_indexAccess.baseExpression().annotation().type->dataStoredIn(DataLocation::Storage))
 			reportMutability(writes ? StateMutability::NonPayable : StateMutability::View, _indexAccess.location());
 	}
@@ -410,7 +410,7 @@ void ViewPureChecker::endVisit(IndexAccess const& _indexAccess)
 
 void ViewPureChecker::endVisit(IndexRangeAccess const& _indexRangeAccess)
 {
-	bool writes = _indexRangeAccess.annotation().lValueRequested;
+	bool writes = _indexRangeAccess.annotation().willBeWrittenTo;
 	if (_indexRangeAccess.baseExpression().annotation().type->dataStoredIn(DataLocation::Storage))
 		reportMutability(writes ? StateMutability::NonPayable : StateMutability::View, _indexRangeAccess.location());
 }

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -234,7 +234,7 @@ struct ExpressionAnnotation: ASTAnnotation
 	/// Whether it is an LValue (i.e. something that can be assigned to).
 	bool isLValue = false;
 	/// Whether the expression is used in a context where the LValue is actually required.
-	bool lValueRequested = false;
+	bool willBeWrittenTo = false;
 	/// Whether the expression is an lvalue that is only assigned.
 	/// Would be false for --, ++, delete, +=, -=, ....
 	bool lValueOfOrdinaryAssignment = false;

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -182,7 +182,7 @@ void ASTJsonConverter::appendExpressionAttributes(
 		make_pair("isConstant", _annotation.isConstant),
 		make_pair("isPure", _annotation.isPure),
 		make_pair("isLValue", _annotation.isLValue),
-		make_pair("lValueRequested", _annotation.lValueRequested),
+		make_pair("lValueRequested", _annotation.willBeWrittenTo),
 		make_pair("argumentTypes", typePointerToJson(_annotation.arguments))
 	};
 	_attributes += exprAttributes;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -348,15 +348,15 @@ bool ExpressionCompiler::visit(TupleExpression const& _tuple)
 			if (component)
 			{
 				component->accept(*this);
-				if (_tuple.annotation().lValueRequested)
+				if (_tuple.annotation().willBeWrittenTo)
 				{
 					solAssert(!!m_currentLValue, "");
 					lvalues.push_back(move(m_currentLValue));
 				}
 			}
-			else if (_tuple.annotation().lValueRequested)
+			else if (_tuple.annotation().willBeWrittenTo)
 				lvalues.push_back(unique_ptr<LValue>());
-		if (_tuple.annotation().lValueRequested)
+		if (_tuple.annotation().willBeWrittenTo)
 		{
 			if (_tuple.components().size() == 1)
 				m_currentLValue = move(lvalues[0]);

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -148,7 +148,7 @@ void ExpressionCompiler::setLValue(Expression const& _expression, Arguments cons
 {
 	solAssert(!m_currentLValue, "Current LValue not reset before trying to set new one.");
 	std::unique_ptr<LValueType> lvalue = std::make_unique<LValueType>(m_context, _arguments...);
-	if (_expression.annotation().lValueRequested)
+	if (_expression.annotation().willBeWrittenTo)
 		m_currentLValue = move(lvalue);
 	else
 		lvalue->retrieveValue(_expression.location(), true);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -257,14 +257,14 @@ bool IRGeneratorForStatements::visit(TupleExpression const& _tuple)
 		solUnimplementedAssert(false, "");
 	else
 	{
-		bool lValueRequested = _tuple.annotation().lValueRequested;
-		if (lValueRequested)
+		bool willBeWrittenTo = _tuple.annotation().willBeWrittenTo;
+		if (willBeWrittenTo)
 			solAssert(!m_currentLValue, "");
 		if (_tuple.components().size() == 1)
 		{
 			solAssert(_tuple.components().front(), "");
 			_tuple.components().front()->accept(*this);
-			if (lValueRequested)
+			if (willBeWrittenTo)
 				solAssert(!!m_currentLValue, "");
 			else
 				define(_tuple, *_tuple.components().front());
@@ -276,7 +276,7 @@ bool IRGeneratorForStatements::visit(TupleExpression const& _tuple)
 				if (auto const& component = _tuple.components()[i])
 				{
 					component->accept(*this);
-					if (lValueRequested)
+					if (willBeWrittenTo)
 					{
 						solAssert(!!m_currentLValue, "");
 						lvalues.emplace_back(std::move(m_currentLValue));
@@ -285,10 +285,10 @@ bool IRGeneratorForStatements::visit(TupleExpression const& _tuple)
 					else
 						define(IRVariable(_tuple).tupleComponent(i), *component);
 				}
-				else if (lValueRequested)
+				else if (willBeWrittenTo)
 					lvalues.emplace_back();
 
-			if (_tuple.annotation().lValueRequested)
+			if (_tuple.annotation().willBeWrittenTo)
 				m_currentLValue.emplace(IRLValue{
 					*_tuple.annotation().type,
 					IRLValue::Tuple{std::move(lvalues)}
@@ -1694,7 +1694,7 @@ void IRGeneratorForStatements::setLValue(Expression const& _expression, IRLValue
 {
 	solAssert(!m_currentLValue, "");
 
-	if (_expression.annotation().lValueRequested)
+	if (_expression.annotation().willBeWrittenTo)
 	{
 		m_currentLValue.emplace(std::move(_lvalue));
 		solAssert(!_lvalue.type.dataStoredIn(DataLocation::CallData), "");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -139,7 +139,7 @@ private:
 	/// @returns a fresh IR variable containing the value of the lvalue @a _lvalue.
 	IRVariable readFromLValue(IRLValue const& _lvalue);
 
-	/// Stores the given @a _lvalue in m_currentLValue, if it will be written to (lValueRequested). Otherwise
+	/// Stores the given @a _lvalue in m_currentLValue, if it will be written to (willBeWrittenTo). Otherwise
 	/// defines the expression @a _expression by reading the value from @a _lvalue.
 	void setLValue(Expression const& _expression, IRLValue _lvalue);
 	void generateLoop(

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -467,7 +467,7 @@ void SMTEncoder::endVisit(UnaryOperation const& _op)
 	{
 
 		solAssert(smt::isInteger(_op.annotation().type->category()), "");
-		solAssert(_op.subExpression().annotation().lValueRequested, "");
+		solAssert(_op.subExpression().annotation().willBeWrittenTo, "");
 		if (auto identifier = dynamic_cast<Identifier const*>(&_op.subExpression()))
 		{
 			auto decl = identifierToVariable(*identifier);
@@ -704,7 +704,7 @@ void SMTEncoder::visitGasLeft(FunctionCall const& _funCall)
 
 void SMTEncoder::endVisit(Identifier const& _identifier)
 {
-	if (_identifier.annotation().lValueRequested)
+	if (_identifier.annotation().willBeWrittenTo)
 	{
 		// Will be translated as part of the node that requested the lvalue.
 	}

--- a/libsolidity/formal/VariableUsage.cpp
+++ b/libsolidity/formal/VariableUsage.cpp
@@ -40,15 +40,15 @@ set<VariableDeclaration const*> VariableUsage::touchedVariables(ASTNode const& _
 
 void VariableUsage::endVisit(Identifier const& _identifier)
 {
-	if (_identifier.annotation().lValueRequested)
+	if (_identifier.annotation().willBeWrittenTo)
 		checkIdentifier(_identifier);
 }
 
 void VariableUsage::endVisit(IndexAccess const& _indexAccess)
 {
-	if (_indexAccess.annotation().lValueRequested)
+	if (_indexAccess.annotation().willBeWrittenTo)
 	{
-		/// identifier.annotation().lValueRequested == false, that's why we
+		/// identifier.annotation().willBeWrittenTo == false, that's why we
 		/// need to check that before.
 		auto identifier = dynamic_cast<Identifier const*>(SMTEncoder::leftmostBase(_indexAccess));
 		if (identifier)


### PR DESCRIPTION
This was done to improve readability. See https://gitter.im/ethereum/solidity-dev?at=5e8ef6473a85536c431ad992 for context

Done automatically, so maybe a thorough review isn't needed.