### PR TITLE
Allow modifier declaration without implementation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Language Features:
  * Add support for EIP 165 interface identifiers with `type(I).interfaceId`.
+ * Allow virtual modifiers inside abstract contracts to have empty body.
 
 
 Compiler Features:

--- a/docs/Solidity.g4
+++ b/docs/Solidity.g4
@@ -68,7 +68,7 @@ structDefinition
     '{' ( variableDeclaration ';' (variableDeclaration ';')* )? '}' ;
 
 modifierDefinition
-  : 'modifier' identifier parameterList? ( VirtualKeyword | overrideSpecifier )* block ;
+  : 'modifier' identifier parameterList? ( VirtualKeyword | overrideSpecifier )* ( ';' | block ) ;
 
 functionDefinition
   : functionDescriptor parameterList modifierList returnParameters? ( ';' | block ) ;

--- a/libsolidity/analysis/ContractLevelChecker.h
+++ b/libsolidity/analysis/ContractLevelChecker.h
@@ -61,7 +61,8 @@ private:
 	void checkDuplicateEvents(ContractDefinition const& _contract);
 	template <class T>
 	void findDuplicateDefinitions(std::map<std::string, std::vector<T>> const& _definitions, std::string _message);
-	void checkAbstractFunctions(ContractDefinition const& _contract);
+	/// Checks for unimplemented functions and modifiers.
+	void checkAbstractDefinitions(ContractDefinition const& _contract);
 	/// Checks that the base constructor arguments are properly provided.
 	/// Fills the list of unimplemented functions in _contract's annotations.
 	void checkBaseConstructorArguments(ContractDefinition const& _contract);

--- a/libsolidity/analysis/ImmutableValidator.cpp
+++ b/libsolidity/analysis/ImmutableValidator.cpp
@@ -148,7 +148,8 @@ bool ImmutableValidator::analyseCallable(CallableDeclaration const& _callableDec
 			funcDef->body().accept(*this);
 	}
 	else if (ModifierDefinition const* modDef = dynamic_cast<decltype(modDef)>(&_callableDeclaration))
-		modDef->body().accept(*this);
+		if (modDef->isImplemented())
+			modDef->body().accept(*this);
 
 	m_currentConstructor = prevConstructor;
 

--- a/libsolidity/analysis/OverrideChecker.cpp
+++ b/libsolidity/analysis/OverrideChecker.cpp
@@ -327,6 +327,16 @@ ModifierType const* OverrideProxy::modifierType() const
 	}, m_item);
 }
 
+
+Declaration const* OverrideProxy::declaration() const
+{
+	return std::visit(GenericVisitor{
+		[&](FunctionDefinition const* _function) -> Declaration const* { return _function; },
+		[&](VariableDeclaration const* _variable) -> Declaration const* { return _variable; },
+		[&](ModifierDefinition const* _modifier) -> Declaration const* { return _modifier; }
+	}, m_item);
+}
+
 SourceLocation const& OverrideProxy::location() const
 {
 	return std::visit(GenericVisitor{
@@ -365,7 +375,7 @@ bool OverrideProxy::unimplemented() const
 {
 	return std::visit(GenericVisitor{
 		[&](FunctionDefinition const* _item) { return !_item->isImplemented(); },
-		[&](ModifierDefinition const*) { return false; },
+		[&](ModifierDefinition const* _item) { return !_item->isImplemented(); },
 		[&](VariableDeclaration const*) { return false; }
 	}, m_item);
 }

--- a/libsolidity/analysis/OverrideChecker.h
+++ b/libsolidity/analysis/OverrideChecker.h
@@ -85,6 +85,8 @@ public:
 	FunctionType const* functionType() const;
 	ModifierType const* modifierType() const;
 
+	Declaration const* declaration() const;
+
 	langutil::SourceLocation const& location() const;
 
 	std::string astNodeName() const;

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -141,7 +141,7 @@ bool SyntaxChecker::visit(ModifierDefinition const&)
 
 void SyntaxChecker::endVisit(ModifierDefinition const& _modifier)
 {
-	if (!m_placeholderFound)
+	if (_modifier.isImplemented() && !m_placeholderFound)
 		m_errorReporter.syntaxError(_modifier.body().location(), "Modifier body does not contain '_'.");
 	m_placeholderFound = false;
 }

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -289,6 +289,12 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 		m_errorReporter.fatalTypeError(_usingFor.libraryName().location(), "Library name expected.");
 }
 
+void TypeChecker::endVisit(ModifierDefinition const& _modifier)
+{
+	if (!_modifier.isImplemented() && !_modifier.virtualSemantics())
+		m_errorReporter.typeError(_modifier.location(), "Modifiers without implementation must be marked virtual.");
+}
+
 bool TypeChecker::visit(FunctionDefinition const& _function)
 {
 	bool isLibraryFunction = _function.inContractKind() == ContractKind::Library;

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -112,6 +112,7 @@ private:
 
 	void endVisit(InheritanceSpecifier const& _inheritance) override;
 	void endVisit(UsingForDirective const& _usingFor) override;
+	void endVisit(ModifierDefinition const& _modifier) override;
 	bool visit(FunctionDefinition const& _function) override;
 	bool visit(VariableDeclaration const& _variable) override;
 	/// We need to do this manually because we want to pass the bases of the current contract in

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -969,7 +969,7 @@ private:
 /**
  * Definition of a function modifier.
  */
-class ModifierDefinition: public CallableDeclaration, public StructurallyDocumented
+class ModifierDefinition: public CallableDeclaration, public StructurallyDocumented, public ImplementationOptional
 {
 public:
 	ModifierDefinition(
@@ -980,18 +980,19 @@ public:
 		ASTPointer<ParameterList> const& _parameters,
 		bool _isVirtual,
 		ASTPointer<OverrideSpecifier> const& _overrides,
-		ASTPointer<Block> _body
+		ASTPointer<Block> const& _body
 	):
 		CallableDeclaration(_id, _location, _name, Visibility::Internal, _parameters, _isVirtual, _overrides),
 		StructurallyDocumented(_documentation),
-		m_body(std::move(_body))
+		ImplementationOptional(_body != nullptr),
+		m_body(_body)
 	{
 	}
 
 	void accept(ASTVisitor& _visitor) override;
 	void accept(ASTConstVisitor& _visitor) const override;
 
-	Block const& body() const { return *m_body; }
+	Block const& body() const { solAssert(m_body, ""); return *m_body; }
 
 	TypePointer type() const override;
 

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -140,8 +140,8 @@ struct StructDeclarationAnnotation: TypeDeclarationAnnotation
 
 struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, StructurallyDocumentedAnnotation
 {
-	/// List of functions without a body. Can also contain functions from base classes.
-	std::vector<FunctionDefinition const*> unimplementedFunctions;
+	/// List of functions and modifiers without a body. Can also contain functions from base classes.
+	std::vector<Declaration const*> unimplementedDeclarations;
 	/// List of all (direct and indirect) base contracts in order from derived to
 	/// base, including the contract itself.
 	std::vector<ContractDefinition const*> linearizedBaseContracts;

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -272,7 +272,7 @@ bool ASTJsonConverter::visit(ContractDefinition const& _node)
 		make_pair("documentation", _node.documentation() ? toJson(*_node.documentation()) : Json::nullValue),
 		make_pair("contractKind", contractKind(_node.contractKind())),
 		make_pair("abstract", _node.abstract()),
-		make_pair("fullyImplemented", _node.annotation().unimplementedFunctions.empty()),
+		make_pair("fullyImplemented", _node.annotation().unimplementedDeclarations.empty()),
 		make_pair("linearizedBaseContracts", getContainerIds(_node.annotation().linearizedBaseContracts)),
 		make_pair("baseContracts", toJson(_node.baseContracts())),
 		make_pair("contractDependencies", getContainerIds(_node.annotation().contractDependencies, true)),
@@ -407,7 +407,7 @@ bool ASTJsonConverter::visit(ModifierDefinition const& _node)
 		make_pair("parameters", toJson(_node.parameterList())),
 		make_pair("virtual", _node.markedVirtual()),
 		make_pair("overrides", _node.overrides() ? toJson(*_node.overrides()) : Json::nullValue),
-		make_pair("body", toJson(_node.body()))
+		make_pair("body", _node.isImplemented() ? toJson(_node.body()) : Json::nullValue)
 	};
 	if (!_node.annotation().baseFunctions.empty())
 		attributes.emplace_back(make_pair("baseModifiers", getContainerIds(_node.annotation().baseFunctions, true)));

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -453,7 +453,7 @@ ASTPointer<ModifierDefinition> ASTJsonImporter::createModifierDefinition(Json::V
 		createParameterList(member(_node, "parameters")),
 		memberAsBool(_node, "virtual"),
 		_node["overrides"].isNull() ? nullptr : createOverrideSpecifier(member(_node, "overrides")),
-		createBlock(member(_node, "body"))
+		_node["body"].isNull() ? nullptr: createBlock(member(_node, "body"))
 	);
 }
 

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -288,7 +288,8 @@ void ModifierDefinition::accept(ASTVisitor& _visitor)
 		m_parameters->accept(_visitor);
 		if (m_overrides)
 			m_overrides->accept(_visitor);
-		m_body->accept(_visitor);
+		if (m_body)
+			m_body->accept(_visitor);
 	}
 	_visitor.endVisit(*this);
 }
@@ -302,7 +303,8 @@ void ModifierDefinition::accept(ASTConstVisitor& _visitor) const
 		m_parameters->accept(_visitor);
 		if (m_overrides)
 			m_overrides->accept(_visitor);
-		m_body->accept(_visitor);
+		if (m_body)
+			m_body->accept(_visitor);
 	}
 	_visitor.endVisit(*this);
 }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1390,7 +1390,6 @@ public:
 	std::string richIdentifier() const override;
 	bool operator==(Type const& _other) const override;
 	std::string toString(bool _short) const override;
-
 protected:
 	std::vector<std::tuple<std::string, TypePointer>> makeStackItems() const override { return {}; }
 private:

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -194,7 +194,8 @@ void SMTEncoder::inlineModifierInvocation(ModifierInvocation const* _invocation,
 	pushCallStack({_definition, _invocation});
 	if (auto modifier = dynamic_cast<ModifierDefinition const*>(_definition))
 	{
-		modifier->body().accept(*this);
+		if (modifier->isImplemented())
+			modifier->body().accept(*this);
 		popCallStack();
 	}
 	else if (auto function = dynamic_cast<FunctionDefinition const*>(_definition))

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -595,13 +595,13 @@ ASTPointer<ASTNode> Parser::parseFunctionDefinition()
 
 	ASTPointer<Block> block;
 	nodeFactory.markEndPosition();
-	if (m_scanner->currentToken() != Token::Semicolon)
+	if (m_scanner->currentToken() == Token::Semicolon)
+		m_scanner->next();
+	else
 	{
 		block = parseBlock();
 		nodeFactory.setEndPositionFromNode(block);
 	}
-	else
-		m_scanner->next(); // just consume the ';'
 	return nodeFactory.createNode<FunctionDefinition>(
 		name,
 		header.visibility,
@@ -851,9 +851,16 @@ ASTPointer<ModifierDefinition> Parser::parseModifierDefinition()
 			break;
 	}
 
+	ASTPointer<Block> block;
+	nodeFactory.markEndPosition();
+	if (m_scanner->currentToken() != Token::Semicolon)
+	{
+		block = parseBlock();
+		nodeFactory.setEndPositionFromNode(block);
+	}
+	else
+		m_scanner->next(); // just consume the ';'
 
-	ASTPointer<Block> block = parseBlock();
-	nodeFactory.setEndPositionFromNode(block);
 	return nodeFactory.createNode<ModifierDefinition>(name, documentation, parameters, isVirtual, overrides, block);
 }
 

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(function_no_implementation)
 	std::vector<ASTPointer<ASTNode>> nodes = sourceUnit->nodes();
 	ContractDefinition* contract = dynamic_cast<ContractDefinition*>(nodes[1].get());
 	BOOST_REQUIRE(contract);
-	BOOST_CHECK(!contract->annotation().unimplementedFunctions.empty());
+	BOOST_CHECK(!contract->annotation().unimplementedDeclarations.empty());
 	BOOST_CHECK(!contract->definedFunctions()[0]->isImplemented());
 }
 
@@ -68,10 +68,10 @@ BOOST_AUTO_TEST_CASE(abstract_contract)
 	ContractDefinition* base = dynamic_cast<ContractDefinition*>(nodes[1].get());
 	ContractDefinition* derived = dynamic_cast<ContractDefinition*>(nodes[2].get());
 	BOOST_REQUIRE(base);
-	BOOST_CHECK(!base->annotation().unimplementedFunctions.empty());
+	BOOST_CHECK(!base->annotation().unimplementedDeclarations.empty());
 	BOOST_CHECK(!base->definedFunctions()[0]->isImplemented());
 	BOOST_REQUIRE(derived);
-	BOOST_CHECK(derived->annotation().unimplementedFunctions.empty());
+	BOOST_CHECK(derived->annotation().unimplementedDeclarations.empty());
 	BOOST_CHECK(derived->definedFunctions()[0]->isImplemented());
 }
 
@@ -87,9 +87,9 @@ BOOST_AUTO_TEST_CASE(abstract_contract_with_overload)
 	ContractDefinition* base = dynamic_cast<ContractDefinition*>(nodes[1].get());
 	ContractDefinition* derived = dynamic_cast<ContractDefinition*>(nodes[2].get());
 	BOOST_REQUIRE(base);
-	BOOST_CHECK(!base->annotation().unimplementedFunctions.empty());
+	BOOST_CHECK(!base->annotation().unimplementedDeclarations.empty());
 	BOOST_REQUIRE(derived);
-	BOOST_CHECK(!derived->annotation().unimplementedFunctions.empty());
+	BOOST_CHECK(!derived->annotation().unimplementedDeclarations.empty());
 }
 
 BOOST_AUTO_TEST_CASE(implement_abstract_via_constructor)
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(implement_abstract_via_constructor)
 	BOOST_CHECK_EQUAL(nodes.size(), 3);
 	ContractDefinition* derived = dynamic_cast<ContractDefinition*>(nodes[2].get());
 	BOOST_REQUIRE(derived);
-	BOOST_CHECK(!derived->annotation().unimplementedFunctions.empty());
+	BOOST_CHECK(!derived->annotation().unimplementedDeclarations.empty());
 }
 
 BOOST_AUTO_TEST_CASE(function_canonical_signature)

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_empty.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_empty.sol
@@ -1,0 +1,17 @@
+abstract contract A {
+    function f() public mod returns (bool r) {
+        return true;
+    }
+
+    modifier mod virtual;
+}
+
+
+contract C is A {
+    modifier mod override {
+        if (false) _;
+    }
+}
+
+// ----
+// f() -> false

--- a/test/libsolidity/syntaxTests/modifiers/empty_modifier_body.sol
+++ b/test/libsolidity/syntaxTests/modifiers/empty_modifier_body.sol
@@ -1,0 +1,14 @@
+abstract contract A { modifier mod(uint a) virtual;}
+contract B is A { modifier mod(uint a) override { _; } }
+
+abstract contract C {
+	modifier m virtual;
+	function f() m public {
+
+	}
+}
+contract D is C {
+	modifier m override {
+		_;
+	}
+}

--- a/test/libsolidity/syntaxTests/modifiers/empty_modifier_err.sol
+++ b/test/libsolidity/syntaxTests/modifiers/empty_modifier_err.sol
@@ -1,0 +1,10 @@
+contract A {modifier m virtual;}
+
+abstract contract B {modifier m virtual;}
+contract C is B { }
+
+abstract contract D {modifier m;}
+// ----
+// TypeError: (0-32): Contract "A" should be marked as abstract.
+// TypeError: (76-95): Contract "C" should be marked as abstract.
+// TypeError: (118-129): Modifiers without implementation must be marked virtual.

--- a/test/libsolidity/syntaxTests/modifiers/unimplemented_function_and_modifier.sol
+++ b/test/libsolidity/syntaxTests/modifiers/unimplemented_function_and_modifier.sol
@@ -1,0 +1,31 @@
+abstract contract A {
+  function foo() public virtual;
+  function foo(uint x) virtual public returns(uint);
+  modifier mod() virtual;
+}
+
+contract B is A {
+  function foo(uint x) override public returns(uint) {return x;}
+  modifier mod() override { _; }
+}
+
+contract C is A {
+  function foo() public override {}
+  modifier mod() override { _; }
+}
+
+contract D is A {
+  function foo() public override {}
+  function foo(uint x) override public returns(uint) {return x;}
+}
+
+/* No errors */
+contract E is A {
+  function foo() public override {}
+  function foo(uint x) override public returns(uint) {return x;}
+  modifier mod() override { _;}
+}
+// ----
+// TypeError: (137-254): Contract "B" should be marked as abstract.
+// TypeError: (256-344): Contract "C" should be marked as abstract.
+// TypeError: (346-466): Contract "D" should be marked as abstract.

--- a/tools/solidityUpgrade/Upgrade060.cpp
+++ b/tools/solidityUpgrade/Upgrade060.cpp
@@ -99,7 +99,7 @@ inline string appendVirtual(FunctionDefinition const& _function)
 
 void AbstractContract::endVisit(ContractDefinition const& _contract)
 {
-	bool isFullyImplemented = _contract.annotation().unimplementedFunctions.empty();
+	bool isFullyImplemented = _contract.annotation().unimplementedDeclarations.empty();
 
 	if (
 		!isFullyImplemented &&


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/3459

## Progress
- [x] Update parser for modifier to accept empty block.
- [x] Modifier class will inherit from `ImplementationOptional` class.
- [x] Fix syntax checks about modifiers with empty body and empty placeholders.
- [x] Deal with having empty body (for --ast-json etc.)
- [x] In Types.h, implement features to compare modifier definition, just like for functions.
- [x] Check for empty modifiers in non-abstract classes (especially in inheritance.)
- [x] Usage of keyword override in inherited classes (to discuss.)
- [x] Fix all cases where modifier body gets accepted without checking for it (example in SMTEncoder.cpp)
- [x] Write tests.
- [x] Changelog
- [x] Update solidity.g4 (modifier grammar)
- [x] Refactor `checkAbstractFunctions` to implement the functionality of `checkAbstractModifiers.`
- [x] Squash last two commits after review is done.

## New errors
- [x] Classes with empty modifier will be abstract and modifier should be virtual. (Also check this when modifiers get inherited.)