### PR TITLE
Swapped parameters of ErrorReporter::warning(), for consistency

### DIFF
--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -52,8 +52,8 @@ void ErrorReporter::warning(
 
 void ErrorReporter::warning(
 	SourceLocation const& _location,
-	string const& _description,
-	SecondarySourceLocation const& _secondaryLocation
+	SecondarySourceLocation const& _secondaryLocation,
+	string const& _description
 )
 {
 	error(Error::Type::Warning, _location, _secondaryLocation, _description);

--- a/liblangutil/ErrorReporter.h
+++ b/liblangutil/ErrorReporter.h
@@ -56,8 +56,8 @@ public:
 
 	void warning(
 		SourceLocation const& _location,
-		std::string const& _description,
-		SecondarySourceLocation const& _secondaryLocation
+		SecondarySourceLocation const& _secondaryLocation,
+		std::string const& _description
 	);
 
 	void error(

--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -440,7 +440,7 @@ void ContractLevelChecker::checkPayableFallbackWithoutReceive(ContractDefinition
 		if (fallback->isPayable() && !_contract.interfaceFunctionList().empty() && !_contract.receiveFunction())
 			m_errorReporter.warning(
 				_contract.location(),
-				"This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function.",
-				SecondarySourceLocation{}.append("The payable fallback function is defined here.", fallback->location())
+				SecondarySourceLocation{}.append("The payable fallback function is defined here.", fallback->location()),
+				"This contract has a payable fallback function, but no receive ether function. Consider adding a receive ether function."
 			);
 }

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -494,8 +494,8 @@ bool DeclarationRegistrationHelper::registerDeclaration(
 			auto shadowedLocation = shadowedDeclaration->location();
 			_errorReporter.warning(
 				_declaration.location(),
-				"This declaration shadows an existing declaration.",
-				SecondarySourceLocation().append("The shadowed declaration is here:", shadowedLocation)
+				SecondarySourceLocation().append("The shadowed declaration is here:", shadowedLocation),
+				"This declaration shadows an existing declaration."
 			);
 		}
 	}

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -758,23 +758,23 @@ void BMC::checkCondition(
 				modelMessage << "  " << eval.first << " = " << eval.second << "\n";
 			m_errorReporter.warning(
 				_location,
-				message.str(),
 				SecondarySourceLocation().append(modelMessage.str(), SourceLocation{})
 				.append(SMTEncoder::callStackMessage(callStack))
-				.append(move(secondaryLocation))
+				.append(move(secondaryLocation)),
+				message.str()
 			);
 		}
 		else
 		{
 			message << ".";
-			m_errorReporter.warning(_location, message.str(), secondaryLocation);
+			m_errorReporter.warning(_location, secondaryLocation, message.str());
 		}
 		break;
 	}
 	case smt::CheckResult::UNSATISFIABLE:
 		break;
 	case smt::CheckResult::UNKNOWN:
-		m_errorReporter.warning(_location, _description + " might happen here.", secondaryLocation);
+		m_errorReporter.warning(_location, secondaryLocation, _description + " might happen here.");
 		break;
 	case smt::CheckResult::CONFLICTING:
 		m_errorReporter.warning(_location, "At least two SMT solvers provided conflicting answers. Results might not be sound.");
@@ -822,7 +822,7 @@ void BMC::checkBooleanNotConstant(
 		// can't do anything.
 	}
 	else if (positiveResult == smt::CheckResult::UNSATISFIABLE && negatedResult == smt::CheckResult::UNSATISFIABLE)
-		m_errorReporter.warning(_condition.location(), "Condition unreachable.", SMTEncoder::callStackMessage(_callStack));
+		m_errorReporter.warning(_condition.location(), SMTEncoder::callStackMessage(_callStack), "Condition unreachable.");
 	else
 	{
 		string value;
@@ -839,8 +839,8 @@ void BMC::checkBooleanNotConstant(
 		}
 		m_errorReporter.warning(
 			_condition.location(),
-			boost::algorithm::replace_all_copy(_description, "$VALUE", value),
-			SMTEncoder::callStackMessage(_callStack)
+			SMTEncoder::callStackMessage(_callStack),
+			boost::algorithm::replace_all_copy(_description, "$VALUE", value)
 		);
 	}
 }


### PR DESCRIPTION
Besides consistency, it makes sense to have `_description` as the last parameter, which can eventually evolve into `_format, _arg0, _arg1, ...`.