### PR TITLE
Use latest docker image for chk_proofs and t_ems_solcjs CI runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
 
   chk_proofs:
     docker:
-      - image: buildpack-deps:disco
+      - image: buildpack-deps:latest
     environment:
       TERM: xterm
     steps:
@@ -661,7 +661,7 @@ jobs:
 
   t_ems_solcjs:
     docker:
-      - image: ethereum/solidity-buildpack-deps:ubuntu1904
+      - image: buildpack-deps:latest
     environment:
       TERM: xterm
     steps:


### PR DESCRIPTION
There were some problems with the run recently... this seems to fix it.

See e.g.
https://circleci.com/gh/ethereum/solidity/297395?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link