### PR TITLE
Handle file prefix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Bugfixes:
  * Type Checker: Fix several internal errors by performing size and recursiveness checks of types before the full type checking.
  * Type Checker: Fix internal error when assigning to empty tuples.
  * Type Checker: Perform recursiveness check on structs declared at the file level.
+ * Standard Json Input: Fix error when using prefix ``file://`` in the field ``urls``.
 
 Build System:
  * soltest.sh: ``SOLIDITY_BUILD_DIR`` is no longer relative to ``REPO_ROOT`` to allow for build directories outside of the source tree.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -953,7 +953,10 @@ bool CommandLineInterface::processInput()
 					"ReadFile callback used as callback kind " +
 					_kind
 				));
-			auto path = boost::filesystem::path(_path);
+			string validPath = _path;
+			if (validPath.find("file://") == 0)
+				validPath.erase(0, 7);
+			auto path = boost::filesystem::path(validPath);
 			auto canonicalPath = boost::filesystem::weakly_canonical(path);
 			bool isAllowed = false;
 			for (auto const& allowedDir: m_allowedDirectories)


### PR DESCRIPTION
Attempting to fix https://github.com/ethereum/solidity/issues/4884
The solution is straight (may be even too straight).
Btw, it looks like the bug is deeper, because another cases of `"urls"` (`bzzr://` and `ipfs://` is mentioned [in the doc](https://solidity.readthedocs.io/en/v0.5.0/using-the-compiler.html#input-description)  ) are not handling there.