### PR TITLE
Fix missing details in some error messages in cmdlineTests.sh

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -214,7 +214,7 @@ printTask "Testing unknown options..."
     then
         echo "Passed"
     else
-        printError "Incorrect response to unknown options: $STDERR"
+        printError "Incorrect response to unknown options: $output"
         exit 1
     fi
 )
@@ -385,7 +385,7 @@ SOLTMPDIR=$(mktemp -d)
     # This should fail
     if [[ !("$output" =~ "No input files given") || ($result == 0) ]]
     then
-        printError "Incorrect response to empty input arg list: $STDERR"
+        printError "Incorrect response to empty input arg list: $output"
         exit 1
     fi
 


### PR DESCRIPTION
As far as I know `$STDERR` is not a standard shell variable and it's not defined in the file either. `$output` works.