### PR TITLE
Out-of-tree SOLIDITY_BUILD_DIR

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ Compiler Features:
 Bugfixes:
  * Type Checker: Disallow ``virtual`` and ``override`` for constructors.
 
+Build System:
+ * soltest.sh: ``SOLIDITY_BUILD_DIR`` is no longer relative to ``REPO_ROOT`` to allow for build directories outside of the source tree.
+
 
 
 ### 0.6.6 (2020-04-09)

--- a/scripts/ASTImportTest.sh
+++ b/scripts/ASTImportTest.sh
@@ -5,8 +5,8 @@
 # and exporting it again. The second JSON should be identical to the first
 
 REPO_ROOT=$(readlink -f "$(dirname "$0")"/..)
-SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
-SOLC=${REPO_ROOT}/${SOLIDITY_BUILD_DIR}/solc/solc
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
+SOLC=${SOLIDITY_BUILD_DIR}/solc/solc
 SPLITSOURCES=${REPO_ROOT}/scripts/splitSources.py
 
 SYNTAXTESTS_DIR="${REPO_ROOT}/test/libsolidity/syntaxTests"

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -28,7 +28,7 @@ set -e
 ## GLOBAL VARIABLES
 
 REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
-SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 source "${REPO_ROOT}/scripts/common.sh"
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
 

--- a/scripts/soltest.sh
+++ b/scripts/soltest.sh
@@ -6,7 +6,7 @@ USE_DEBUGGER=0
 DEBUGGER="gdb --args"
 BOOST_OPTIONS=
 SOLTEST_OPTIONS=
-SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 
 usage() {
 	echo 2>&1 "
@@ -23,7 +23,7 @@ Options:
 
 Important environment variables:
 
-SOLIDITY_BUILD_DIR: Sets directory under the repository root of where test/soltest should be found.
+SOLIDITY_BUILD_DIR: Sets directory where test/soltest should be found.
            The default is \"${SOLIDITY_BUILD_DIR}\".
 "
 }
@@ -64,4 +64,4 @@ if [ "$USE_DEBUGGER" -ne "0" ]; then
 	DEBUG_PREFIX=${DEBUGGER}
 fi
 
-exec ${DEBUG_PREFIX} ${REPO_ROOT}/${SOLIDITY_BUILD_DIR}/test/soltest ${BOOST_OPTIONS} -- --testpath ${REPO_ROOT}/test ${SOLTEST_OPTIONS}
+exec ${DEBUG_PREFIX} ${SOLIDITY_BUILD_DIR}/test/soltest ${BOOST_OPTIONS} -- --testpath ${REPO_ROOT}/test ${SOLTEST_OPTIONS}

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -29,7 +29,7 @@
 set -e
 
 REPO_ROOT="$(dirname "$0")/.."
-SOLIDITY_BUILD_DIR="${SOLIDITY_BUILD_DIR:-build}"
+SOLIDITY_BUILD_DIR="${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}"
 
 source "${REPO_ROOT}/scripts/common.sh"
 
@@ -116,7 +116,7 @@ do
             fi
 
             set +e
-            "$REPO_ROOT"/${SOLIDITY_BUILD_DIR}/test/soltest --show-progress $log -- --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $force_abiv2_flag
+            "${SOLIDITY_BUILD_DIR}"/test/soltest --show-progress $log -- --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $force_abiv2_flag
 
             if test "0" -ne "$?"; then
                 exit 1

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -31,19 +31,19 @@ set -e
 ## GLOBAL VARIABLES
 
 REPO_ROOT=$(cd $(dirname "$0")/.. && pwd)
-SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-build}
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 source "${REPO_ROOT}/scripts/common.sh"
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
 
 case "$OSTYPE" in
     msys)
-        SOLC="$REPO_ROOT/${SOLIDITY_BUILD_DIR}/solc/Release/solc.exe"
+        SOLC="${SOLIDITY_BUILD_DIR}/solc/Release/solc.exe"
 
         # prevents msys2 path translation for a remapping test
         export MSYS2_ARG_CONV_EXCL="="
         ;;
     *)
-        SOLC="$REPO_ROOT/${SOLIDITY_BUILD_DIR}/solc/solc"
+        SOLC="${SOLIDITY_BUILD_DIR}/solc/solc"
         ;;
 esac
 echo "${SOLC}"
@@ -431,8 +431,8 @@ SOLTMPDIR=$(mktemp -d)
     "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/test/
     "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/ docs
 
-    echo *.sol | xargs -P 4 -n 50 "$REPO_ROOT"/${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer --quiet --input-files
-    echo *.sol | xargs -P 4 -n 50 "$REPO_ROOT"/${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer --without-optimizer --quiet --input-files
+    echo *.sol | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
+    echo *.sol | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
 )
 rm -rf "$SOLTMPDIR"
 


### PR DESCRIPTION
I'd like to propose a change that allows `SOLIDITY_BUILD_DIR` to be outside of `REPO_ROOT`. That's how I have it on my machine and everything was fine until I noticed that the command-line tests need to be executed separately from `soltest`. `cmdlineTests.sh` requires `solc` to be in `$REPO_ROOT/$SOLIDITY_BUILD_DIR`. I could work around it by using a path with several `..` but being able to set them independently seems more logical.

This might break scripts for users who set `SOLIDITY_BUILD_DIR` before running our scripts. We never do it in our repo and this includes the CI scripts (because AFAIK everything related to CI is in the repo). I searched github and virtually all uses of this variable were in `cmdlineTests.sh` copied or forked from here. There was exactly one instance where the variable was used to change the location of the build directory:
- https://github.com/coolparadox/ethereum-gentoo-overlay/blob/master/dev-lang/solidity/solidity-0.6.1.ebuild

Note: This PR depends on #8693. I set it as a base branch to avoid its changes showing up in the diff.