### PR TITLE
Yul formatting: Reduce multiple consecutive empty lines to a single one.

### DIFF
--- a/libyul/Utilities.cpp
+++ b/libyul/Utilities.cpp
@@ -59,6 +59,13 @@ string solidity::yul::reindent(string const& _code)
 	for (string& line: lines)
 		boost::trim(line);
 
+	// Reduce multiple consecutive empty lines.
+	lines = fold(lines, vector<string>{}, [](auto&& _lines, auto&& _line) {
+		if (!(_line.empty() && !_lines.empty() && _lines.back().empty()))
+			_lines.emplace_back(std::move(_line));
+		return std::move(_lines);
+	});
+
 	stringstream out;
 	int depth = 0;
 

--- a/test/cmdlineTests/standard_ir_requested/output.json
+++ b/test/cmdlineTests/standard_ir_requested/output.json
@@ -16,11 +16,7 @@ object \"C_6\" {
         codecopy(0, dataoffset(\"C_6_deployed\"), datasize(\"C_6_deployed\"))
         return(0, datasize(\"C_6_deployed\"))
 
-
         function constructor_C_6() {
-
-
-
 
         }
 
@@ -50,7 +46,6 @@ object \"C_6\" {
             if iszero(calldatasize()) {  }
             revert(0, 0)
 
-
             function abi_decode_tuple_(headStart, dataEnd)   {
                 if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
 
@@ -70,7 +65,6 @@ object \"C_6\" {
             }
 
             function fun_f_5()  {
-
 
             }
 

--- a/test/cmdlineTests/yul_string_format_ascii/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii/output.json
@@ -16,11 +16,7 @@ object \"C_10\" {
         codecopy(0, dataoffset(\"C_10_deployed\"), datasize(\"C_10_deployed\"))
         return(0, datasize(\"C_10_deployed\"))
 
-
         function constructor_C_10() {
-
-
-
 
         }
 
@@ -49,7 +45,6 @@ object \"C_10\" {
             }
             if iszero(calldatasize()) {  }
             revert(0, 0)
-
 
             function abi_decode_tuple_(headStart, dataEnd)   {
                 if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
@@ -81,10 +76,7 @@ object \"C_10\" {
 
             function array_length_t_string_memory_ptr(value) -> length {
 
-
                 length := mload(value)
-
-
 
             }
 

--- a/test/cmdlineTests/yul_string_format_ascii_bytes32/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_bytes32/output.json
@@ -16,11 +16,7 @@ object \"C_10\" {
         codecopy(0, dataoffset(\"C_10_deployed\"), datasize(\"C_10_deployed\"))
         return(0, datasize(\"C_10_deployed\"))
 
-
         function constructor_C_10() {
-
-
-
 
         }
 
@@ -49,7 +45,6 @@ object \"C_10\" {
             }
             if iszero(calldatasize()) {  }
             revert(0, 0)
-
 
             function abi_decode_tuple_(headStart, dataEnd)   {
                 if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }

--- a/test/cmdlineTests/yul_string_format_ascii_bytes32_from_number/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_bytes32_from_number/output.json
@@ -16,11 +16,7 @@ object \"C_10\" {
         codecopy(0, dataoffset(\"C_10_deployed\"), datasize(\"C_10_deployed\"))
         return(0, datasize(\"C_10_deployed\"))
 
-
         function constructor_C_10() {
-
-
-
 
         }
 
@@ -49,7 +45,6 @@ object \"C_10\" {
             }
             if iszero(calldatasize()) {  }
             revert(0, 0)
-
 
             function abi_decode_tuple_(headStart, dataEnd)   {
                 if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }

--- a/test/cmdlineTests/yul_string_format_ascii_long/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_long/output.json
@@ -16,11 +16,7 @@ object \"C_10\" {
         codecopy(0, dataoffset(\"C_10_deployed\"), datasize(\"C_10_deployed\"))
         return(0, datasize(\"C_10_deployed\"))
 
-
         function constructor_C_10() {
-
-
-
 
         }
 
@@ -49,7 +45,6 @@ object \"C_10\" {
             }
             if iszero(calldatasize()) {  }
             revert(0, 0)
-
 
             function abi_decode_tuple_(headStart, dataEnd)   {
                 if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
@@ -81,10 +76,7 @@ object \"C_10\" {
 
             function array_length_t_string_memory_ptr(value) -> length {
 
-
                 length := mload(value)
-
-
 
             }
 

--- a/test/cmdlineTests/yul_string_format_hex/output.json
+++ b/test/cmdlineTests/yul_string_format_hex/output.json
@@ -16,11 +16,7 @@ object \"C_10\" {
         codecopy(0, dataoffset(\"C_10_deployed\"), datasize(\"C_10_deployed\"))
         return(0, datasize(\"C_10_deployed\"))
 
-
         function constructor_C_10() {
-
-
-
 
         }
 
@@ -49,7 +45,6 @@ object \"C_10\" {
             }
             if iszero(calldatasize()) {  }
             revert(0, 0)
-
 
             function abi_decode_tuple_(headStart, dataEnd)   {
                 if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }


### PR DESCRIPTION
I noticed that some of the templates in #8534 produce multiple empty lines.
We tried to counter this by modifying the template.
This PR is a simple change to the reindenter that reduces multiple consecutive empty lines to a single empty line.