### PR TITLE
[BREAKING] solidity-upgrade dot syntax for gas and value

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(solidity-upgrade
     solidityUpgrade/UpgradeSuite.h
     solidityUpgrade/Upgrade050.cpp
     solidityUpgrade/Upgrade060.cpp
+    solidityUpgrade/Upgrade070.cpp
     solidityUpgrade/SourceTransform.h
     solidityUpgrade/SourceUpgrade.cpp
 )

--- a/tools/solidityUpgrade/SourceTransform.h
+++ b/tools/solidityUpgrade/SourceTransform.h
@@ -50,7 +50,8 @@ public:
  * on a textual base. They utilize regular expression to search for
  * keywords or to determine formatting.
  */
-class SourceAnalysis {
+class SourceAnalysis
+{
 public:
 	static bool isMultilineKeyword(
 		langutil::SourceLocation const& _location,
@@ -103,6 +104,7 @@ public:
 		for (auto inheritedContract: _contracts)
 			overrideList += inheritedContract->name() + ",";
 
+		// Note: Can create incorrect replacements
 		return "override(" + overrideList.substr(0, overrideList.size() - 1) + ")";
 	}
 };
@@ -123,11 +125,21 @@ public:
 		std::string const& _expression
 	)
 	{
-		return regex_replace(
-			_location.text(),
-			std::regex{"(\\b" + _keyword + "\\b)"},
-			_expression + " " + _keyword
-		);
+		auto _regex = std::regex{"(\\b" + _keyword + "\\b)"};
+		if (regex_search(_location.text(), _regex))
+			return regex_replace(
+				_location.text(),
+				_regex,
+				_expression + " " + _keyword
+			);
+		else
+			solAssert(
+				false,
+				LocationHelper() << "Could not fix: " << _location.text() << " at " << _location <<
+				"\nNeeds to be fixed manually."
+			);
+
+		return "";
 	}
 
 	/// Searches for the keyword given and appends the expression.
@@ -142,7 +154,17 @@ public:
 		std::string toAppend = isMultiline ? ("\n        " + _expression) : (" " + _expression);
 		std::regex keyword{"(\\b" + _keyword + "\\b)"};
 
-		return regex_replace(_location.text(), keyword, _keyword + toAppend);
+		if (regex_search(_location.text(), keyword))
+			return regex_replace(_location.text(), keyword, _keyword + toAppend);
+		else
+			solAssert(
+				false,
+				LocationHelper() << "Could not fix: " << _location.text() << " at " << _location <<
+				"\nNeeds to be fixed manually."
+			);
+
+		return "";
+
 	}
 
 	/// Searches for the first right parenthesis and appends the expression
@@ -153,11 +175,21 @@ public:
 		std::string const& _expression
 	)
 	{
-		return regex_replace(
-			_location.text(),
-			std::regex{"(\\))"},
-			") " + _expression
-		);
+		auto _regex = std::regex{"(\\))"};
+		if (regex_search(_location.text(), _regex))
+			return regex_replace(
+				_location.text(),
+				std::regex{"(\\))"},
+				") " + _expression
+			);
+		else
+			solAssert(
+				false,
+				LocationHelper() << "Could not fix: " << _location.text() << " at " << _location <<
+				"\nNeeds to be fixed manually."
+			);
+
+		return "";
 	}
 
 	/// Searches for the `function` keyword and its identifier and replaces
@@ -169,11 +201,21 @@ public:
 		std::string const& _expression
 	)
 	{
-		return regex_replace(
-			_location.text(),
-			std::regex{"(\\bfunction\\s*" + _name + "\\b)"},
-			_expression
-		);
+		auto _regex = std::regex{ "(\\bfunction\\s*" + _name + "\\b)"};
+		if (regex_search(_location.text(), _regex))
+			return regex_replace(
+				_location.text(),
+				_regex,
+				_expression
+			);
+		else
+			solAssert(
+				false,
+				LocationHelper() << "Could not fix: " << _location.text() << " at " << _location <<
+				"\nNeeds to be fixed manually."
+			);
+
+		return "";
 	}
 
 	static std::string gasUpdate(langutil::SourceLocation const& _location)
@@ -194,11 +236,9 @@ public:
 		else
 			solAssert(
 				false,
-				LocationHelper()
-				<< "Regex count not match: " << _location.text() << " at " << _location
-				<< "\nNeeds to be fixed manually."
+				LocationHelper() << "Could not fix: " << _location.text() << " at " << _location <<
+				"\nNeeds to be fixed manually."
 			);
-
 
 		return "";
 	}
@@ -221,9 +261,8 @@ public:
 		else
 			solAssert(
 				false,
-				LocationHelper()
-				<< "Regex count not match: " << _location.text() << " at " << _location
-				<< "\nNeeds to be fixed manually"
+				LocationHelper() << "Could not fix: " << _location.text() << " at " << _location <<
+				"\nNeeds to be fixed manually."
 			);
 
 		return "";

--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -194,6 +194,8 @@ Allowed options)",
 				m_suite.activateModule(Module::OverridingFunction);
 			else if (module == "virtual")
 				m_suite.activateModule(Module::VirtualFunction);
+			else if (module == "dotsyntax")
+				m_suite.activateModule(Module::DotSyntax);
 			else
 			{
 				error() << "Unknown upgrade module \"" + module + "\"" << endl;

--- a/tools/solidityUpgrade/SourceUpgrade.h
+++ b/tools/solidityUpgrade/SourceUpgrade.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 	This file is part of solidity.
 
 	solidity is free software: you can redistribute it and/or modify
@@ -19,6 +19,7 @@
 #include <tools/solidityUpgrade/UpgradeChange.h>
 #include <tools/solidityUpgrade/Upgrade050.h>
 #include <tools/solidityUpgrade/Upgrade060.h>
+#include <tools/solidityUpgrade/Upgrade070.h>
 
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/DebugSettings.h>
@@ -56,7 +57,8 @@ private:
 		VisibilitySpecifier,
 		AbstractContract,
 		OverridingFunction,
-		VirtualFunction
+		VirtualFunction,
+		DotSyntax
 	};
 
 	/// Upgrade suite that hosts all available modules.
@@ -78,6 +80,10 @@ private:
 				OverridingFunction{m_changes}.analyze(_sourceUnit);
 			if (isActivated(Module::VirtualFunction))
 				VirtualFunction{m_changes}.analyze(_sourceUnit);
+
+			/// Solidity 0.7.0
+			if (isActivated(Module::DotSyntax))
+				DotSyntax{m_changes}.analyze(_sourceUnit);
 		}
 
 		void activateModule(Module _module) { m_modules.insert(_module); }
@@ -96,7 +102,8 @@ private:
 			Module::VisibilitySpecifier,
 			Module::AbstractContract,
 			Module::OverridingFunction,
-			Module::VirtualFunction
+			Module::VirtualFunction,
+			Module::DotSyntax
 		};
 	};
 

--- a/tools/solidityUpgrade/Upgrade070.cpp
+++ b/tools/solidityUpgrade/Upgrade070.cpp
@@ -1,0 +1,42 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+n	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <tools/solidityUpgrade/Upgrade070.h>
+#include <tools/solidityUpgrade/SourceTransform.h>
+
+using namespace solidity::frontend;
+using namespace solidity::tools;
+
+void DotSyntax::endVisit(FunctionCall const& _functionCall)
+{
+	TypePointer type = _functionCall.annotation().type;
+	if (auto const funcType = dynamic_cast<FunctionType const*>(type))
+	{
+		if (funcType->valueSet())
+			m_changes.emplace_back(
+				UpgradeChange::Level::Safe,
+				_functionCall.location(),
+				SourceTransform::valueUpdate(_functionCall.location())
+			);
+
+		if (funcType->gasSet())
+			m_changes.emplace_back(
+				UpgradeChange::Level::Safe,
+				_functionCall.location(),
+				SourceTransform::gasUpdate(_functionCall.location())
+			);
+	}
+}

--- a/tools/solidityUpgrade/Upgrade070.h
+++ b/tools/solidityUpgrade/Upgrade070.h
@@ -1,0 +1,35 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <tools/solidityUpgrade/UpgradeSuite.h>
+
+#include <libsolidity/ast/AST.h>
+
+namespace solidity::tools
+{
+
+class DotSyntax: public AnalysisUpgrade
+{
+public:
+	using AnalysisUpgrade::AnalysisUpgrade;
+	void analyze(frontend::SourceUnit const& _sourceUnit) { _sourceUnit.accept(*this); }
+private:
+	void endVisit(frontend::FunctionCall const& _expression) override;
+};
+
+}

--- a/tools/solidityUpgrade/main.cpp
+++ b/tools/solidityUpgrade/main.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/exception/all.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
@@ -74,8 +75,16 @@ int main(int argc, char** argv)
 	if (!upgrade.parseArguments(argc, argv))
 		return 1;
 	upgrade.printPrologue();
-	if (!upgrade.processInput())
-		return 1;
+
+	try
+	{
+		if (!upgrade.processInput())
+			return 1;
+	}
+	catch (boost::exception const& _exception)
+	{
+		cerr << "Exception while processing input: " << boost::diagnostic_information(_exception) << endl;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8700

Uses libsolidity to understand context and then use regex to replace `.gas(...)` and `..value(...)` syntax to `{gas: ...}` and `{value: ...}.`

1. Note that replacements are done using `regex_replace` and therefore not perfect. An example of bad input is `f.value /* a comment */ (5)()`
2. This code (with argument `--module dotsyntax`)  was tested on external tests (see https://github.com/ethereum/solidity/pull/8589)
3. I modified some existing `regex_replace` calls to avoid infinite loops, when regex match doesn't occur. This was happening while running on external-tests.