### PR TITLE
Fix leftpad in SourceReferenceFormatterHuman

### DIFF
--- a/liblangutil/SourceReferenceFormatterHuman.cpp
+++ b/liblangutil/SourceReferenceFormatterHuman.cpp
@@ -70,35 +70,36 @@ void SourceReferenceFormatterHuman::printSourceLocation(SourceReference const& _
 	if (_ref.sourceName.empty())
 		return; // Nothing we can print here
 
-	int const leftpad = static_cast<int>(log10(max(_ref.position.line, 1))) + 1;
-
-	// line 0: source name
-	frameColored() << string(leftpad, ' ') << "--> ";
-
 	if (_ref.position.line < 0)
 	{
+		frameColored() << "--> ";
 		m_stream << _ref.sourceName << "\n";
 		return; // No line available, nothing else to print
 	}
 
-	m_stream << _ref.sourceName << ":" << (_ref.position.line + 1) << ":" << (_ref.position.column + 1) << ":" << '\n';
+	string line = std::to_string(_ref.position.line + 1); // one-based line number as string
+	string leftpad = string(line.size(), ' ');
+
+	// line 0: source name
+	frameColored() << leftpad << "--> ";
+	m_stream << _ref.sourceName << ":" << line << ":" << (_ref.position.column + 1) << ":" << '\n';
 
 	if (!_ref.multiline)
 	{
 		int const locationLength = _ref.endColumn - _ref.startColumn;
 
 		// line 1:
-		m_stream << string(leftpad, ' ');
+		m_stream << leftpad;
 		frameColored() << " |" << '\n';
 
 		// line 2:
-		frameColored() << (_ref.position.line + 1) << " | ";
+		frameColored() << line << " | ";
 		m_stream << _ref.text.substr(0, _ref.startColumn);
 		highlightColored() << _ref.text.substr(_ref.startColumn, locationLength);
 		m_stream << _ref.text.substr(_ref.endColumn) << '\n';
 
 		// line 3:
-		m_stream << string(leftpad, ' ');
+		m_stream << leftpad;
 		frameColored() << " | ";
 		for_each(
 			_ref.text.cbegin(),
@@ -110,16 +111,16 @@ void SourceReferenceFormatterHuman::printSourceLocation(SourceReference const& _
 	else
 	{
 		// line 1:
-		m_stream << string(leftpad, ' ');
+		m_stream << leftpad;
 		frameColored() << " |" << '\n';
 
 		// line 2:
-		frameColored() << (_ref.position.line + 1) << " | ";
+		frameColored() << line << " | ";
 		m_stream << _ref.text.substr(0, _ref.startColumn);
 		highlightColored() << _ref.text.substr(_ref.startColumn) << '\n';
 
 		// line 3:
-		frameColored() << string(leftpad, ' ') << " | ";
+		frameColored() << leftpad << " | ";
 		m_stream << string(_ref.startColumn, ' ');
 		diagColored() << "^ (Relevant source part starts here and spans across multiple lines).\n";
 	}

--- a/liblangutil/SourceReferenceFormatterHuman.cpp
+++ b/liblangutil/SourceReferenceFormatterHuman.cpp
@@ -21,7 +21,6 @@
 #include <liblangutil/SourceReferenceFormatterHuman.h>
 #include <liblangutil/Scanner.h>
 #include <liblangutil/Exceptions.h>
-#include <cmath>
 #include <iomanip>
 
 using namespace std;
@@ -72,8 +71,8 @@ void SourceReferenceFormatterHuman::printSourceLocation(SourceReference const& _
 
 	if (_ref.position.line < 0)
 	{
-		frameColored() << "--> ";
-		m_stream << _ref.sourceName << "\n";
+		frameColored() << "-->";
+		m_stream << ' ' << _ref.sourceName << '\n';
 		return; // No line available, nothing else to print
 	}
 
@@ -81,48 +80,55 @@ void SourceReferenceFormatterHuman::printSourceLocation(SourceReference const& _
 	string leftpad = string(line.size(), ' ');
 
 	// line 0: source name
-	frameColored() << leftpad << "--> ";
-	m_stream << _ref.sourceName << ":" << line << ":" << (_ref.position.column + 1) << ":" << '\n';
+	m_stream << leftpad;
+	frameColored() << "-->";
+	m_stream << ' ' << _ref.sourceName << ':' << line << ':' << (_ref.position.column + 1) << ":\n";
 
 	if (!_ref.multiline)
 	{
 		int const locationLength = _ref.endColumn - _ref.startColumn;
 
 		// line 1:
-		m_stream << leftpad;
-		frameColored() << " |" << '\n';
+		m_stream << leftpad << ' ';
+		frameColored() << '|';
+		m_stream << '\n';
 
 		// line 2:
-		frameColored() << line << " | ";
-		m_stream << _ref.text.substr(0, _ref.startColumn);
+		frameColored() << line << " |";
+		m_stream << ' ' << _ref.text.substr(0, _ref.startColumn);
 		highlightColored() << _ref.text.substr(_ref.startColumn, locationLength);
 		m_stream << _ref.text.substr(_ref.endColumn) << '\n';
 
 		// line 3:
-		m_stream << leftpad;
-		frameColored() << " | ";
+		m_stream << leftpad << ' ';
+		frameColored() << '|';
+		m_stream << ' ';
 		for_each(
 			_ref.text.cbegin(),
 			_ref.text.cbegin() + _ref.startColumn,
 			[this](char ch) { m_stream << (ch == '\t' ? '\t' : ' '); }
 		);
-		diagColored() << string(locationLength, '^') << '\n';
+		diagColored() << string(locationLength, '^');
+		m_stream << '\n';
 	}
 	else
 	{
 		// line 1:
-		m_stream << leftpad;
-		frameColored() << " |" << '\n';
+		m_stream << leftpad << ' ';
+		frameColored() << '|';
+		m_stream << '\n';
 
 		// line 2:
-		frameColored() << line << " | ";
-		m_stream << _ref.text.substr(0, _ref.startColumn);
+		frameColored() << line << " |";
+		m_stream << ' ' << _ref.text.substr(0, _ref.startColumn);
 		highlightColored() << _ref.text.substr(_ref.startColumn) << '\n';
 
 		// line 3:
-		frameColored() << leftpad << " | ";
-		m_stream << string(_ref.startColumn, ' ');
-		diagColored() << "^ (Relevant source part starts here and spans across multiple lines).\n";
+		m_stream << leftpad << ' ';
+		frameColored() << '|';
+		m_stream << ' ' << string(_ref.startColumn, ' ');
+		diagColored() << "^ (Relevant source part starts here and spans across multiple lines).";
+		m_stream << '\n';
 	}
 }
 

--- a/test/cmdlineTests/message_format/err
+++ b/test/cmdlineTests/message_format/err
@@ -1,0 +1,50 @@
+Warning: Source file does not specify required compiler version!
+--> message_format/input.sol
+
+Warning: Unused local variable.
+ --> message_format/input.sol:9:27:
+  |
+9 |     function f() public { int x; }
+  |                           ^^^^^
+
+Warning: Unused local variable.
+  --> message_format/input.sol:10:27:
+   |
+10 |     function g() public { int x; }
+   |                           ^^^^^
+
+Warning: Unused local variable.
+  --> message_format/input.sol:99:14:
+   |
+99 |         /**/ int a; /**/
+   |              ^^^^^
+
+Warning: Unused local variable.
+   --> message_format/input.sol:100:14:
+    |
+100 |         /**/ int b; /**/
+    |              ^^^^^
+
+Warning: Unused local variable.
+   --> message_format/input.sol:101:14:
+    |
+101 |         /**/ int c; /**/
+    |              ^^^^^
+
+Warning: Function state mutability can be restricted to pure
+ --> message_format/input.sol:9:5:
+  |
+9 |     function f() public { int x; }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Warning: Function state mutability can be restricted to pure
+  --> message_format/input.sol:10:5:
+   |
+10 |     function g() public { int x; }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Warning: Function state mutability can be restricted to pure
+  --> message_format/input.sol:11:5:
+   |
+11 |     function h() public {
+   |     ^ (Relevant source part starts here and spans across multiple lines).

--- a/test/cmdlineTests/message_format/input.sol
+++ b/test/cmdlineTests/message_format/input.sol
@@ -1,0 +1,103 @@
+// checks that error messages around power-or-10 lines are formatted correctly
+
+
+
+
+
+
+contract C {
+    function f() public { int x; }
+    function g() public { int x; }
+    function h() public {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        /**/ int a; /**/
+        /**/ int b; /**/
+        /**/ int c; /**/
+    }
+}

--- a/test/cmdlineTests/too_long_line/err
+++ b/test/cmdlineTests/too_long_line/err
@@ -1,5 +1,5 @@
 Warning: Source file does not specify required compiler version!
- --> too_long_line/input.sol
+--> too_long_line/input.sol
 
 Error: Identifier not found or not unique.
  --> too_long_line/input.sol:2:164:

--- a/test/cmdlineTests/too_long_line_both_sides_short/err
+++ b/test/cmdlineTests/too_long_line_both_sides_short/err
@@ -1,5 +1,5 @@
 Warning: Source file does not specify required compiler version!
- --> too_long_line_both_sides_short/input.sol
+--> too_long_line_both_sides_short/input.sol
 
 Error: Identifier not found or not unique.
  --> too_long_line_both_sides_short/input.sol:2:15:

--- a/test/cmdlineTests/too_long_line_edge_in/err
+++ b/test/cmdlineTests/too_long_line_edge_in/err
@@ -1,5 +1,5 @@
 Warning: Source file does not specify required compiler version!
- --> too_long_line_edge_in/input.sol
+--> too_long_line_edge_in/input.sol
 
 Error: Identifier not found or not unique.
  --> too_long_line_edge_in/input.sol:2:36:

--- a/test/cmdlineTests/too_long_line_edge_out/err
+++ b/test/cmdlineTests/too_long_line_edge_out/err
@@ -1,5 +1,5 @@
 Warning: Source file does not specify required compiler version!
- --> too_long_line_edge_out/input.sol
+--> too_long_line_edge_out/input.sol
 
 Error: Identifier not found or not unique.
  --> too_long_line_edge_out/input.sol:2:37:

--- a/test/cmdlineTests/too_long_line_left_short/err
+++ b/test/cmdlineTests/too_long_line_left_short/err
@@ -1,5 +1,5 @@
 Warning: Source file does not specify required compiler version!
- --> too_long_line_left_short/input.sol
+--> too_long_line_left_short/input.sol
 
 Error: Identifier not found or not unique.
  --> too_long_line_left_short/input.sol:2:15:

--- a/test/cmdlineTests/too_long_line_multiline/err
+++ b/test/cmdlineTests/too_long_line_multiline/err
@@ -5,4 +5,4 @@ Error: No visibility specified. Did you intend to add "public"?
   |     ^ (Relevant source part starts here and spans across multiple lines).
 
 Warning: Source file does not specify required compiler version!
- --> too_long_line_multiline/input.sol
+--> too_long_line_multiline/input.sol

--- a/test/cmdlineTests/too_long_line_right_short/err
+++ b/test/cmdlineTests/too_long_line_right_short/err
@@ -1,5 +1,5 @@
 Warning: Source file does not specify required compiler version!
- --> too_long_line_right_short/input.sol
+--> too_long_line_right_short/input.sol
 
 Error: Identifier not found or not unique.
  --> too_long_line_right_short/input.sol:2:164:


### PR DESCRIPTION
The output of `SourceReferenceFormatterHuman::printSourceLocation()` was one space off for power of 10 lines:

```
Warning: Unused local variable.
  --> d:/tmp/bug.sol:100:9:
   |
100 |         int a;
   |         ^^^^^

Warning: Function state mutability can be restricted to pure
 --> d:/tmp/bug.sol:10:5:
  |
10 |     function f() public {
  |     ^ (Relevant source part starts here and spans across multiple lines).
```
