### PR TITLE
Fix cmdlineTests.sh not removing all tmp.XXXXXX files

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -126,7 +126,7 @@ function test_solc_behaviour()
         # Remove trailing empty lines. Needs a line break to make OSX sed happy.
         sed -i.bak -e '1{/^$/d
 }' "$stderr_path"
-       rm "$stderr_path.bak"
+        rm "$stderr_path.bak" "$stdout_path.bak"
     fi
     # Remove path to cpp file
     sed -i.bak -e 's/^\(Exception while assembling:\).*/\1/' "$stderr_path"
@@ -175,6 +175,8 @@ function test_solc_behaviour()
             exit 1
         fi
     fi
+
+    rm -f "$stdout_path" "$stderr_path"
 }
 
 


### PR DESCRIPTION
- The script was leaving hundreds of loose `tmp.XXXXXX` and `tmp.XXXXXX.bak` files in `/tmp` after each run
- There's a trap handler that removes them but it's being registered multiple times in a loop and only the last one actually runs when the script exits. It's still useful because it removes the remaining files from the most recent iteration but on its own it's not enough to clean up everything.