### PR TITLE
[BREAKING] Removed null members from JSON output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Breaking changes:
  * Type Checker: Disallow virtual for library functions.
  * Deprecated dot syntax for `value` and `gas`.
  * Deprecated the identifier `now`.
+ * JSON AST: Removes members with ``null`` value from JSON output.
 
 Language Features:
 

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -201,7 +201,7 @@ Json::Value ASTJsonConverter::inlineAssemblyIdentifierToJson(pair<yul::Identifie
 
 void ASTJsonConverter::print(ostream& _stream, ASTNode const& _node)
 {
-	_stream << util::jsonPrettyPrint(toJson(_node));
+	_stream << util::jsonPrettyPrint(util::removeNullMembers(toJson(_node)));
 }
 
 Json::Value&& ASTJsonConverter::toJson(ASTNode const& _node)

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -884,7 +884,8 @@ ASTPointer<StructuredDocumentation> ASTJsonImporter::createDocumentation(Json::V
 
 Json::Value ASTJsonImporter::member(Json::Value const& _node, string const& _name)
 {
-	astAssert(_node.isMember(_name), "Node '" + _node["nodeType"].asString() + "' (id " + _node["id"].asString() + ") is missing field '" + _name + "'.");
+	if (!_node.isMember(_name))
+		return Json::nullValue;
 	return _node[_name];
 }
 

--- a/libsolidity/ast/AsmJsonImporter.cpp
+++ b/libsolidity/ast/AsmJsonImporter.cpp
@@ -63,7 +63,8 @@ T AsmJsonImporter::createAsmNode(Json::Value const& _node)
 
 Json::Value AsmJsonImporter::member(Json::Value const& _node, string const& _name)
 {
-	astAssert(_node.isMember(_name), "Node is missing field '" + _name + "'.");
+	if (!_node.isMember(_name))
+		return Json::nullValue;
 	return _node[_name];
 }
 

--- a/libsolutil/JSON.cpp
+++ b/libsolutil/JSON.cpp
@@ -87,7 +87,30 @@ bool parse(Json::CharReaderBuilder& _builder, string const& _input, Json::Value&
 	return reader->parse(_input.c_str(), _input.c_str() + _input.length(), &_json, _errs);
 }
 
+/// Takes a JSON value (@ _json) and removes all its members with value 'null' recursively.
+void removeNullMembersHelper(Json::Value& _json)
+{
+	if (_json.type() == Json::ValueType::arrayValue)
+		for (auto& child: _json)
+			removeNullMembersHelper(child);
+	else if (_json.type() == Json::ValueType::objectValue)
+		for (auto const& key: _json.getMemberNames())
+		{
+			Json::Value& value = _json[key];
+			if (value.isNull())
+				_json.removeMember(key);
+			else
+				removeNullMembersHelper(value);
+		}
+}
+
 } // end anonymous namespace
+
+Json::Value removeNullMembers(Json::Value _json)
+{
+	removeNullMembersHelper(_json);
+	return _json;
+}
 
 string jsonPrettyPrint(Json::Value const& _input)
 {

--- a/libsolutil/JSON.h
+++ b/libsolutil/JSON.h
@@ -28,6 +28,9 @@
 
 namespace solidity::util {
 
+/// Removes members with null value recursively from (@a _json).
+Json::Value removeNullMembers(Json::Value _json);
+
 /// Serialise the JSON object (@a _input) with indentation
 std::string jsonPrettyPrint(Json::Value const& _input);
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -433,7 +433,7 @@ void CommandLineInterface::handleABI(string const& _contract)
 	if (!m_args.count(g_argAbi))
 		return;
 
-	string data = jsonCompactPrint(m_compiler->contractABI(_contract));
+	string data = jsonCompactPrint(removeNullMembers(m_compiler->contractABI(_contract)));
 	if (m_args.count(g_argOutputDir))
 		createFile(m_compiler->filesystemFriendlyName(_contract) + ".abi", data);
 	else
@@ -445,7 +445,7 @@ void CommandLineInterface::handleStorageLayout(string const& _contract)
 	if (!m_args.count(g_argStorageLayout))
 		return;
 
-	string data = jsonCompactPrint(m_compiler->storageLayout(_contract));
+	string data = jsonCompactPrint(removeNullMembers(m_compiler->storageLayout(_contract)));
 	if (m_args.count(g_argOutputDir))
 		createFile(m_compiler->filesystemFriendlyName(_contract) + "_storage.json", data);
 	else
@@ -474,9 +474,11 @@ void CommandLineInterface::handleNatspec(bool _natspecDev, string const& _contra
 	if (m_args.count(argName))
 	{
 		std::string output = jsonPrettyPrint(
-			_natspecDev ?
-			m_compiler->natspecDev(_contract) :
-			m_compiler->natspecUser(_contract)
+			removeNullMembers(
+				_natspecDev ?
+				m_compiler->natspecDev(_contract) :
+				m_compiler->natspecUser(_contract)
+			)
 		);
 
 		if (m_args.count(g_argOutputDir))
@@ -1399,7 +1401,8 @@ void CommandLineInterface::handleCombinedJSON()
 		}
 	}
 
-	string json = m_args.count(g_argPrettyJson) ? jsonPrettyPrint(output) : jsonCompactPrint(output);
+	string json = m_args.count(g_argPrettyJson) ? jsonPrettyPrint(removeNullMembers(std::move(output))) :
+		jsonCompactPrint(removeNullMembers(std::move(output)));
 
 	if (m_args.count(g_argOutputDir))
 		createJson("combined", json);
@@ -1715,7 +1718,7 @@ void CommandLineInterface::outputCompilationResults()
 		{
 			string ret;
 			if (m_args.count(g_argAsmJson))
-				ret = jsonPrettyPrint(m_compiler->assemblyJSON(contract));
+				ret = jsonPrettyPrint(removeNullMembers(m_compiler->assemblyJSON(contract)));
 			else
 				ret = m_compiler->assemblyString(contract, m_sourceCodes);
 

--- a/test/cmdlineTests/recovery_ast_constructor/output
+++ b/test/cmdlineTests/recovery_ast_constructor/output
@@ -45,7 +45,6 @@ JSON AST:
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -59,7 +58,6 @@ JSON AST:
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": true,
             "kind": "constructor",
@@ -68,7 +66,6 @@ JSON AST:
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 18,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -123,7 +120,6 @@ JSON AST:
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "af11c34c",
             "implemented": true,
             "isConstructor": false,
@@ -133,7 +129,6 @@ JSON AST:
               null
             ],
             "name": "five",
-            "overrides": null,
             "scope": 18,
             "stateMutability": "view",
             "virtual": false,
@@ -163,12 +158,10 @@ JSON AST:
                     "constant": false,
                     "mutability": "mutable",
                     "name": "",
-                    "overrides": null,
                     "scope": 17,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "uint256",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -206,13 +199,11 @@ JSON AST:
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "hexvalue": "35",
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "lValueRequested": false,
-                        "subdenomination": null,
                         "token": "number",
                         "type": "int_const 5",
                         "value": "5"

--- a/test/libsolidity/ASTJSON/abstract_contract.json
+++ b/test/libsolidity/ASTJSON/abstract_contract.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -36,14 +34,12 @@
             "src": "44:4:1",
             "statements": []
           },
-          "documentation": null,
           "id": 4,
           "implemented": true,
           "kind": "constructor",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/abstract_contract_legacy.json
+++ b/test/libsolidity/ASTJSON/abstract_contract_legacy.json
@@ -8,8 +8,7 @@
       [
         5
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": true,
             "kind": "constructor",
@@ -49,7 +46,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/address_payable.json
+++ b/test/libsolidity/ASTJSON/address_payable.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 40,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 39,
       "linearizedBaseContracts":
@@ -35,7 +33,6 @@
           "mutability": "mutable",
           "name": "m",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 39,
           "src": "17:44:1",
           "stateVariable": true,
@@ -81,7 +78,6 @@
               }
             }
           },
-          "value": null,
           "visibility": "public"
         },
         {
@@ -105,7 +101,6 @@
                     "mutability": "mutable",
                     "name": "a",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 37,
                     "src": "144:17:1",
                     "stateVariable": false,
@@ -128,17 +123,14 @@
                         "typeString": "address payable"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 16,
                 "initialValue":
                 {
-                  "argumentTypes": null,
                   "baseExpression":
                   {
-                    "argumentTypes": null,
                     "id": 13,
                     "name": "m",
                     "nodeType": "Identifier",
@@ -154,7 +146,6 @@
                   "id": 15,
                   "indexExpression":
                   {
-                    "argumentTypes": null,
                     "id": 14,
                     "name": "arg",
                     "nodeType": "Identifier",
@@ -185,7 +176,6 @@
               {
                 "expression":
                 {
-                  "argumentTypes": null,
                   "id": 19,
                   "isConstant": false,
                   "isLValue": false,
@@ -193,7 +183,6 @@
                   "lValueRequested": false,
                   "leftHandSide":
                   {
-                    "argumentTypes": null,
                     "id": 17,
                     "name": "r",
                     "nodeType": "Identifier",
@@ -210,7 +199,6 @@
                   "operator": "=",
                   "rightHandSide":
                   {
-                    "argumentTypes": null,
                     "id": 18,
                     "name": "arg",
                     "nodeType": "Identifier",
@@ -247,7 +235,6 @@
                     "mutability": "mutable",
                     "name": "c",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 37,
                     "src": "197:9:1",
                     "stateVariable": false,
@@ -270,18 +257,15 @@
                         "typeString": "address"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 27,
                 "initialValue":
                 {
-                  "argumentTypes": null,
                   "arguments":
                   [
                     {
-                      "argumentTypes": null,
                       "id": 25,
                       "name": "this",
                       "nodeType": "Identifier",
@@ -322,11 +306,7 @@
                       "name": "address",
                       "nodeType": "ElementaryTypeName",
                       "src": "209:7:1",
-                      "typeDescriptions":
-                      {
-                        "typeIdentifier": null,
-                        "typeString": null
-                      }
+                      "typeDescriptions": {}
                     }
                   },
                   "id": 26,
@@ -351,7 +331,6 @@
               {
                 "expression":
                 {
-                  "argumentTypes": null,
                   "id": 35,
                   "isConstant": false,
                   "isLValue": false,
@@ -359,10 +338,8 @@
                   "lValueRequested": false,
                   "leftHandSide":
                   {
-                    "argumentTypes": null,
                     "baseExpression":
                     {
-                      "argumentTypes": null,
                       "id": 28,
                       "name": "m",
                       "nodeType": "Identifier",
@@ -378,7 +355,6 @@
                     "id": 30,
                     "indexExpression":
                     {
-                      "argumentTypes": null,
                       "id": 29,
                       "name": "c",
                       "nodeType": "Identifier",
@@ -407,11 +383,9 @@
                   "operator": "=",
                   "rightHandSide":
                   {
-                    "argumentTypes": null,
                     "arguments":
                     [
                       {
-                        "argumentTypes": null,
                         "hexValue": "30",
                         "id": 33,
                         "isConstant": false,
@@ -421,7 +395,6 @@
                         "lValueRequested": false,
                         "nodeType": "Literal",
                         "src": "247:1:1",
-                        "subdenomination": null,
                         "typeDescriptions":
                         {
                           "typeIdentifier": "t_rational_0_by_1",
@@ -457,11 +430,7 @@
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
                         "src": "239:7:1",
-                        "typeDescriptions":
-                        {
-                          "typeIdentifier": null,
-                          "typeString": null
-                        }
+                        "typeDescriptions": {}
                       }
                     },
                     "id": 34,
@@ -493,7 +462,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "fc68521a",
           "id": 38,
           "implemented": true,
@@ -501,7 +469,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 7,
@@ -514,7 +481,6 @@
                 "mutability": "mutable",
                 "name": "arg",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 38,
                 "src": "78:19:1",
                 "stateVariable": false,
@@ -537,7 +503,6 @@
                     "typeString": "address payable"
                   }
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],
@@ -555,7 +520,6 @@
                 "mutability": "mutable",
                 "name": "r",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 38,
                 "src": "115:17:1",
                 "stateVariable": false,
@@ -578,7 +542,6 @@
                     "typeString": "address payable"
                   }
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],

--- a/test/libsolidity/ASTJSON/address_payable_legacy.json
+++ b/test/libsolidity/ASTJSON/address_payable_legacy.json
@@ -8,8 +8,7 @@
       [
         39
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -44,12 +42,10 @@
             "functionSelector": "97682884",
             "mutability": "mutable",
             "name": "m",
-            "overrides": null,
             "scope": 39,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "mapping(address => address payable)",
-            "value": null,
             "visibility": "public"
           },
           "children":
@@ -95,7 +91,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "fc68521a",
             "implemented": true,
             "isConstructor": false,
@@ -105,7 +100,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 39,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -122,12 +116,10 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "arg",
-                    "overrides": null,
                     "scope": 38,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "address payable",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -162,12 +154,10 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "r",
-                    "overrides": null,
                     "scope": 38,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "address payable",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -212,12 +202,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "a",
-                        "overrides": null,
                         "scope": 37,
                         "stateVariable": false,
                         "storageLocation": "default",
                         "type": "address payable",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":
@@ -241,7 +229,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "isConstant": false,
                         "isLValue": true,
                         "isPure": false,
@@ -253,7 +240,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "overloadedDeclarations":
                             [
                               null
@@ -269,7 +255,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "overloadedDeclarations":
                             [
                               null
@@ -298,7 +283,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -311,7 +295,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "overloadedDeclarations":
                             [
                               null
@@ -327,7 +310,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "overloadedDeclarations":
                             [
                               null
@@ -366,12 +348,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "c",
-                        "overrides": null,
                         "scope": 37,
                         "stateVariable": false,
                         "storageLocation": "default",
                         "type": "address",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":
@@ -395,7 +375,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -432,8 +411,7 @@
                             {
                               "attributes":
                               {
-                                "name": "address",
-                                "type": null
+                                "name": "address"
                               },
                               "id": 23,
                               "name": "ElementaryTypeName",
@@ -447,7 +425,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "overloadedDeclarations":
                             [
                               null
@@ -476,7 +453,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -489,7 +465,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "isConstant": false,
                             "isLValue": true,
                             "isPure": false,
@@ -501,7 +476,6 @@
                             {
                               "attributes":
                               {
-                                "argumentTypes": null,
                                 "overloadedDeclarations":
                                 [
                                   null
@@ -517,7 +491,6 @@
                             {
                               "attributes":
                               {
-                                "argumentTypes": null,
                                 "overloadedDeclarations":
                                 [
                                   null
@@ -538,7 +511,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -575,8 +547,7 @@
                                 {
                                   "attributes":
                                   {
-                                    "name": "address",
-                                    "type": null
+                                    "name": "address"
                                   },
                                   "id": 31,
                                   "name": "ElementaryTypeName",
@@ -590,13 +561,11 @@
                             {
                               "attributes":
                               {
-                                "argumentTypes": null,
                                 "hexvalue": "30",
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
                                 "lValueRequested": false,
-                                "subdenomination": null,
                                 "token": "number",
                                 "type": "int_const 0",
                                 "value": "0"

--- a/test/libsolidity/ASTJSON/array_type_name.json
+++ b/test/libsolidity/ASTJSON/array_type_name.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 5,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 4,
       "linearizedBaseContracts":
@@ -34,7 +32,6 @@
           "mutability": "mutable",
           "name": "i",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 4,
           "src": "13:8:1",
           "stateVariable": true,
@@ -59,7 +56,6 @@
               }
             },
             "id": 2,
-            "length": null,
             "nodeType": "ArrayTypeName",
             "src": "13:6:1",
             "typeDescriptions":
@@ -68,7 +64,6 @@
               "typeString": "uint256[]"
             }
           },
-          "value": null,
           "visibility": "internal"
         }
       ],

--- a/test/libsolidity/ASTJSON/array_type_name_legacy.json
+++ b/test/libsolidity/ASTJSON/array_type_name_legacy.json
@@ -8,8 +8,7 @@
       [
         4
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -43,12 +41,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "i",
-            "overrides": null,
             "scope": 4,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "uint256[]",
-            "value": null,
             "visibility": "internal"
           },
           "children":
@@ -56,7 +52,6 @@
             {
               "attributes":
               {
-                "length": null,
                 "type": "uint256[]"
               },
               "children":

--- a/test/libsolidity/ASTJSON/assembly/call.json
+++ b/test/libsolidity/ASTJSON/assembly/call.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -133,7 +131,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "b582ec5f",
           "id": 5,
           "implemented": true,
@@ -141,7 +138,6 @@
           "modifiers": [],
           "name": "j",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/call_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/call_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "b582ec5f",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "j",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/empty_block.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -58,7 +56,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "e2179b8e",
           "id": 5,
           "implemented": true,
@@ -66,7 +63,6 @@
           "modifiers": [],
           "name": "g",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/empty_block_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "e2179b8e",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "g",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "view",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/function.json
+++ b/test/libsolidity/ASTJSON/assembly/function.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -120,7 +118,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "b8c9d365",
           "id": 5,
           "implemented": true,
@@ -128,7 +125,6 @@
           "modifiers": [],
           "name": "h",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/function_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/function_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "b8c9d365",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "h",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "view",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/leave.json
+++ b/test/libsolidity/ASTJSON/assembly/leave.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -70,7 +68,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "ece866b9",
           "id": 5,
           "implemented": true,
@@ -78,7 +75,6 @@
           "modifiers": [],
           "name": "l",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/leave_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/leave_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "ece866b9",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "l",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/loop.json
+++ b/test/libsolidity/ASTJSON/assembly/loop.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -133,7 +131,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "e2179b8e",
           "id": 5,
           "implemented": true,
@@ -141,7 +138,6 @@
           "modifiers": [],
           "name": "g",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/loop_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/loop_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "e2179b8e",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "g",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "view",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/nested_functions.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 9,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 8,
       "linearizedBaseContracts":
@@ -97,7 +95,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 7,
           "implemented": true,
@@ -105,7 +102,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,
@@ -125,29 +121,19 @@
                 "mutability": "mutable",
                 "name": "x",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 7,
                 "src": "49:6:1",
                 "stateVariable": false,
                 "storageLocation": "default",
-                "typeDescriptions":
-                {
-                  "typeIdentifier": null,
-                  "typeString": null
-                },
+                "typeDescriptions": {},
                 "typeName":
                 {
                   "id": 2,
                   "name": "uint",
                   "nodeType": "ElementaryTypeName",
                   "src": "49:4:1",
-                  "typeDescriptions":
-                  {
-                    "typeIdentifier": null,
-                    "typeString": null
-                  }
+                  "typeDescriptions": {}
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],

--- a/test/libsolidity/ASTJSON/assembly/nested_functions_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions_legacy.json
@@ -8,8 +8,7 @@
       [
         8
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 8,
             "stateMutability": "pure",
             "virtual": false,
@@ -80,12 +76,9 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "x",
-                    "overrides": null,
                     "scope": 7,
                     "stateVariable": false,
                     "storageLocation": "default",
-                    "type": null,
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -93,8 +86,7 @@
                     {
                       "attributes":
                       {
-                        "name": "uint",
-                        "type": null
+                        "name": "uint"
                       },
                       "id": 2,
                       "name": "ElementaryTypeName",

--- a/test/libsolidity/ASTJSON/assembly/slot_offset.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 12,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 11,
       "linearizedBaseContracts":
@@ -39,7 +37,6 @@
               "mutability": "mutable",
               "name": "x",
               "nodeType": "VariableDeclaration",
-              "overrides": null,
               "scope": 3,
               "src": "28:6:1",
               "stateVariable": false,
@@ -61,7 +58,6 @@
                   "typeString": "uint256"
                 }
               },
-              "value": null,
               "visibility": "internal"
             }
           ],
@@ -77,7 +73,6 @@
           "mutability": "mutable",
           "name": "s",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 11,
           "src": "42:3:1",
           "stateVariable": true,
@@ -89,7 +84,6 @@
           },
           "typeName":
           {
-            "contractScope": null,
             "id": 4,
             "name": "S",
             "nodeType": "UserDefinedTypeName",
@@ -101,7 +95,6 @@
               "typeString": "struct C.S"
             }
           },
-          "value": null,
           "visibility": "internal"
         },
         {
@@ -203,7 +196,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "ffae15ba",
           "id": 10,
           "implemented": true,
@@ -211,7 +203,6 @@
           "modifiers": [],
           "name": "e",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 6,

--- a/test/libsolidity/ASTJSON/assembly/slot_offset_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset_legacy.json
@@ -8,8 +8,7 @@
       [
         11
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -53,12 +51,10 @@
                 "constant": false,
                 "mutability": "mutable",
                 "name": "x",
-                "overrides": null,
                 "scope": 3,
                 "stateVariable": false,
                 "storageLocation": "default",
                 "type": "uint256",
-                "value": null,
                 "visibility": "internal"
               },
               "children":
@@ -89,12 +85,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "s",
-            "overrides": null,
             "scope": 11,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "struct C.S",
-            "value": null,
             "visibility": "internal"
           },
           "children":
@@ -102,7 +96,6 @@
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "S",
                 "referencedDeclaration": 3,
                 "type": "struct C.S"
@@ -119,7 +112,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "ffae15ba",
             "implemented": true,
             "isConstructor": false,
@@ -129,7 +121,6 @@
               null
             ],
             "name": "e",
-            "overrides": null,
             "scope": 11,
             "stateMutability": "pure",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/stringlit.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -74,7 +72,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "5a2ee019",
           "id": 5,
           "implemented": true,
@@ -82,7 +79,6 @@
           "modifiers": [],
           "name": "m",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/stringlit_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "5a2ee019",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "m",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/switch.json
+++ b/test/libsolidity/ASTJSON/assembly/switch.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -182,7 +180,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 5,
           "implemented": true,
@@ -190,7 +187,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/switch_default.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 7,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 6,
       "linearizedBaseContracts":
@@ -79,7 +77,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "e2179b8e",
           "id": 5,
           "implemented": true,
@@ -87,7 +84,6 @@
           "modifiers": [],
           "name": "g",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/switch_default_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "e2179b8e",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "g",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "view",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/switch_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_legacy.json
@@ -8,8 +8,7 @@
       [
         6
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 6,
             "stateMutability": "pure",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/assembly/var_access.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 10,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 9,
       "linearizedBaseContracts":
@@ -49,7 +47,6 @@
                     "mutability": "mutable",
                     "name": "x",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 7,
                     "src": "52:6:1",
                     "stateVariable": false,
@@ -71,12 +68,10 @@
                         "typeString": "uint256"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 5,
-                "initialValue": null,
                 "nodeType": "VariableDeclarationStatement",
                 "src": "52:6:1"
               },
@@ -126,7 +121,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 8,
           "implemented": true,
@@ -134,7 +128,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/assembly/var_access_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access_legacy.json
@@ -8,8 +8,7 @@
       [
         9
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 9,
             "stateMutability": "pure",
             "virtual": false,
@@ -93,8 +89,7 @@
                     "assignments":
                     [
                       4
-                    ],
-                    "initialValue": null
+                    ]
                   },
                   "children":
                   [
@@ -104,12 +99,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "x",
-                        "overrides": null,
                         "scope": 7,
                         "stateVariable": false,
                         "storageLocation": "default",
                         "type": "uint256",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":

--- a/test/libsolidity/ASTJSON/constructor.json
+++ b/test/libsolidity/ASTJSON/constructor.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -36,14 +34,12 @@
             "src": "35:4:1",
             "statements": []
           },
-          "documentation": null,
           "id": 4,
           "implemented": true,
           "kind": "constructor",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/constructor_legacy.json
+++ b/test/libsolidity/ASTJSON/constructor_legacy.json
@@ -8,8 +8,7 @@
       [
         5
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": true,
             "kind": "constructor",
@@ -49,7 +46,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/contract_dep_order.json
+++ b/test/libsolidity/ASTJSON/contract_dep_order.json
@@ -24,7 +24,6 @@
     ]
   },
   "id": 14,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -33,7 +32,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 1,
       "linearizedBaseContracts":
@@ -51,10 +49,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 2,
             "name": "A",
             "nodeType": "UserDefinedTypeName",
@@ -76,7 +72,6 @@
         1
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 4,
       "linearizedBaseContracts":
@@ -95,10 +90,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 5,
             "name": "B",
             "nodeType": "UserDefinedTypeName",
@@ -121,7 +114,6 @@
         4
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 7,
       "linearizedBaseContracts":
@@ -141,10 +133,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 8,
             "name": "C",
             "nodeType": "UserDefinedTypeName",
@@ -168,7 +158,6 @@
         7
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 10,
       "linearizedBaseContracts":
@@ -189,10 +178,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 11,
             "name": "D",
             "nodeType": "UserDefinedTypeName",
@@ -217,7 +204,6 @@
         10
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 13,
       "linearizedBaseContracts":

--- a/test/libsolidity/ASTJSON/contract_dep_order_legacy.json
+++ b/test/libsolidity/ASTJSON/contract_dep_order_legacy.json
@@ -24,8 +24,7 @@
       [
         13
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -42,7 +41,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -68,7 +66,6 @@
           1
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -85,16 +82,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "A",
                 "referencedDeclaration": 1,
                 "type": "contract A"
@@ -123,7 +116,6 @@
           4
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -141,16 +133,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "B",
                 "referencedDeclaration": 4,
                 "type": "contract B"
@@ -180,7 +168,6 @@
           7
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -199,16 +186,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "C",
                 "referencedDeclaration": 7,
                 "type": "contract C"
@@ -239,7 +222,6 @@
           10
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -259,16 +241,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "D",
                 "referencedDeclaration": 10,
                 "type": "contract D"

--- a/test/libsolidity/ASTJSON/documentation.json
+++ b/test/libsolidity/ASTJSON/documentation.json
@@ -9,7 +9,6 @@
     ]
   },
   "id": 3,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -50,7 +49,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -91,7 +89,6 @@
     ]
   },
   "id": 21,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -100,7 +97,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 20,
       "linearizedBaseContracts":
@@ -157,7 +153,6 @@
           "id": 14,
           "name": "mod",
           "nodeType": "ModifierDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 11,
@@ -191,7 +186,6 @@
           "modifiers": [],
           "name": "fn",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 16,

--- a/test/libsolidity/ASTJSON/documentation_legacy.json
+++ b/test/libsolidity/ASTJSON/documentation_legacy.json
@@ -8,8 +8,7 @@
       [
         20
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -76,7 +74,6 @@
           "attributes":
           {
             "name": "mod",
-            "overrides": null,
             "virtual": false,
             "visibility": "internal"
           },
@@ -134,7 +131,6 @@
               null
             ],
             "name": "fn",
-            "overrides": null,
             "scope": 20,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/enum_value.json
+++ b/test/libsolidity/ASTJSON/enum_value.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 5,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 4,
       "linearizedBaseContracts":

--- a/test/libsolidity/ASTJSON/enum_value_legacy.json
+++ b/test/libsolidity/ASTJSON/enum_value_legacy.json
@@ -8,8 +8,7 @@
       [
         4
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [

--- a/test/libsolidity/ASTJSON/event_definition.json
+++ b/test/libsolidity/ASTJSON/event_definition.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 4,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 3,
       "linearizedBaseContracts":
@@ -30,7 +28,6 @@
       [
         {
           "anonymous": false,
-          "documentation": null,
           "id": 2,
           "name": "E",
           "nodeType": "EventDefinition",

--- a/test/libsolidity/ASTJSON/event_definition_legacy.json
+++ b/test/libsolidity/ASTJSON/event_definition_legacy.json
@@ -8,8 +8,7 @@
       [
         3
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -41,7 +39,6 @@
           "attributes":
           {
             "anonymous": false,
-            "documentation": null,
             "name": "E"
           },
           "children":

--- a/test/libsolidity/ASTJSON/fallback.json
+++ b/test/libsolidity/ASTJSON/fallback.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -36,14 +34,12 @@
             "src": "43:5:1",
             "statements": []
           },
-          "documentation": null,
           "id": 4,
           "implemented": true,
           "kind": "fallback",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/fallback_and_reveice_ether.json
+++ b/test/libsolidity/ASTJSON/fallback_and_reveice_ether.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 10,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 9,
       "linearizedBaseContracts":
@@ -36,14 +34,12 @@
             "src": "42:5:1",
             "statements": []
           },
-          "documentation": null,
           "id": 4,
           "implemented": true,
           "kind": "receive",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,
@@ -72,14 +68,12 @@
             "src": "78:5:1",
             "statements": []
           },
-          "documentation": null,
           "id": 8,
           "implemented": true,
           "kind": "fallback",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 5,

--- a/test/libsolidity/ASTJSON/fallback_and_reveice_ether_legacy.json
+++ b/test/libsolidity/ASTJSON/fallback_and_reveice_ether_legacy.json
@@ -8,8 +8,7 @@
       [
         9
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": false,
             "kind": "receive",
@@ -49,7 +46,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 9,
             "stateMutability": "payable",
             "virtual": false,
@@ -104,7 +100,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": false,
             "kind": "fallback",
@@ -113,7 +108,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 9,
             "stateMutability": "payable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/fallback_legacy.json
+++ b/test/libsolidity/ASTJSON/fallback_legacy.json
@@ -8,8 +8,7 @@
       [
         5
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": false,
             "kind": "fallback",
@@ -49,7 +46,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "payable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/fallback_payable.json
+++ b/test/libsolidity/ASTJSON/fallback_payable.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -36,14 +34,12 @@
             "src": "34:2:1",
             "statements": []
           },
-          "documentation": null,
           "id": 4,
           "implemented": true,
           "kind": "fallback",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/fallback_payable_legacy.json
+++ b/test/libsolidity/ASTJSON/fallback_payable_legacy.json
@@ -8,8 +8,7 @@
       [
         5
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": false,
             "kind": "fallback",
@@ -49,7 +46,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "nonpayable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/function_type.json
+++ b/test/libsolidity/ASTJSON/function_type.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 18,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 17,
       "linearizedBaseContracts":
@@ -36,7 +34,6 @@
             "src": "120:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "d6cd4974",
           "id": 16,
           "implemented": true,
@@ -44,7 +41,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 7,
@@ -57,7 +53,6 @@
                 "mutability": "mutable",
                 "name": "x",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 16,
                 "src": "24:44:1",
                 "stateVariable": false,
@@ -90,7 +85,6 @@
                         "mutability": "mutable",
                         "name": "",
                         "nodeType": "VariableDeclaration",
-                        "overrides": null,
                         "scope": 5,
                         "src": "61:4:1",
                         "stateVariable": false,
@@ -112,7 +106,6 @@
                             "typeString": "uint256"
                           }
                         },
-                        "value": null,
                         "visibility": "internal"
                       }
                     ],
@@ -127,7 +120,6 @@
                   },
                   "visibility": "external"
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],
@@ -145,7 +137,6 @@
                 "mutability": "mutable",
                 "name": "",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 16,
                 "src": "79:40:1",
                 "stateVariable": false,
@@ -178,7 +169,6 @@
                         "mutability": "mutable",
                         "name": "",
                         "nodeType": "VariableDeclaration",
-                        "overrides": null,
                         "scope": 12,
                         "src": "113:4:1",
                         "stateVariable": false,
@@ -200,7 +190,6 @@
                             "typeString": "uint256"
                           }
                         },
-                        "value": null,
                         "visibility": "internal"
                       }
                     ],
@@ -215,7 +204,6 @@
                   },
                   "visibility": "external"
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],

--- a/test/libsolidity/ASTJSON/function_type_legacy.json
+++ b/test/libsolidity/ASTJSON/function_type_legacy.json
@@ -8,8 +8,7 @@
       [
         17
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "d6cd4974",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 17,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -67,12 +63,10 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "x",
-                    "overrides": null,
                     "scope": 16,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "function () payable external returns (uint256)",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -108,12 +102,10 @@
                                 "constant": false,
                                 "mutability": "mutable",
                                 "name": "",
-                                "overrides": null,
                                 "scope": 5,
                                 "stateVariable": false,
                                 "storageLocation": "default",
                                 "type": "uint256",
-                                "value": null,
                                 "visibility": "internal"
                               },
                               "children":
@@ -162,12 +154,10 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "",
-                    "overrides": null,
                     "scope": 16,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "function () view external returns (uint256)",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -203,12 +193,10 @@
                                 "constant": false,
                                 "mutability": "mutable",
                                 "name": "",
-                                "overrides": null,
                                 "scope": 12,
                                 "stateVariable": false,
                                 "storageLocation": "default",
                                 "type": "uint256",
-                                "value": null,
                                 "visibility": "internal"
                               },
                               "children":

--- a/test/libsolidity/ASTJSON/global_enum.json
+++ b/test/libsolidity/ASTJSON/global_enum.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 3,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [

--- a/test/libsolidity/ASTJSON/global_enum_legacy.json
+++ b/test/libsolidity/ASTJSON/global_enum_legacy.json
@@ -8,8 +8,7 @@
       [
         2
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [

--- a/test/libsolidity/ASTJSON/global_struct.json
+++ b/test/libsolidity/ASTJSON/global_struct.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 4,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -23,7 +22,6 @@
           "mutability": "mutable",
           "name": "a",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 3,
           "src": "11:9:1",
           "stateVariable": false,
@@ -45,7 +43,6 @@
               "typeString": "uint256"
             }
           },
-          "value": null,
           "visibility": "internal"
         }
       ],

--- a/test/libsolidity/ASTJSON/global_struct_legacy.json
+++ b/test/libsolidity/ASTJSON/global_struct_legacy.json
@@ -8,8 +8,7 @@
       [
         3
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -29,12 +28,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "a",
-            "overrides": null,
             "scope": 3,
             "stateVariable": false,
             "storageLocation": "default",
             "type": "uint256",
-            "value": null,
             "visibility": "internal"
           },
           "children":

--- a/test/libsolidity/ASTJSON/inheritance_specifier.json
+++ b/test/libsolidity/ASTJSON/inheritance_specifier.json
@@ -12,7 +12,6 @@
     ]
   },
   "id": 5,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -21,7 +20,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 1,
       "linearizedBaseContracts":
@@ -39,10 +37,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 2,
             "name": "C1",
             "nodeType": "UserDefinedTypeName",
@@ -64,7 +60,6 @@
         1
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 4,
       "linearizedBaseContracts":

--- a/test/libsolidity/ASTJSON/inheritance_specifier_legacy.json
+++ b/test/libsolidity/ASTJSON/inheritance_specifier_legacy.json
@@ -12,8 +12,7 @@
       [
         4
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -30,7 +29,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -56,7 +54,6 @@
           1
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -73,16 +70,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "C1",
                 "referencedDeclaration": 1,
                 "type": "contract C1"

--- a/test/libsolidity/ASTJSON/license.json
+++ b/test/libsolidity/ASTJSON/license.json
@@ -17,7 +17,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 1,
       "linearizedBaseContracts":

--- a/test/libsolidity/ASTJSON/license_legacy.json
+++ b/test/libsolidity/ASTJSON/license_legacy.json
@@ -26,7 +26,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [

--- a/test/libsolidity/ASTJSON/long_type_name_binary_operation.json
+++ b/test/libsolidity/ASTJSON/long_type_name_binary_operation.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 12,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 11,
       "linearizedBaseContracts":
@@ -49,7 +47,6 @@
                     "mutability": "mutable",
                     "name": "a",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 9,
                     "src": "35:6:1",
                     "stateVariable": false,
@@ -71,14 +68,12 @@
                         "typeString": "uint256"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 8,
                 "initialValue":
                 {
-                  "argumentTypes": null,
                   "commonType":
                   {
                     "typeIdentifier": "t_rational_5_by_1",
@@ -91,7 +86,6 @@
                   "lValueRequested": false,
                   "leftExpression":
                   {
-                    "argumentTypes": null,
                     "hexValue": "32",
                     "id": 5,
                     "isConstant": false,
@@ -101,7 +95,6 @@
                     "lValueRequested": false,
                     "nodeType": "Literal",
                     "src": "44:1:1",
-                    "subdenomination": null,
                     "typeDescriptions":
                     {
                       "typeIdentifier": "t_rational_2_by_1",
@@ -113,7 +106,6 @@
                   "operator": "+",
                   "rightExpression":
                   {
-                    "argumentTypes": null,
                     "hexValue": "33",
                     "id": 6,
                     "isConstant": false,
@@ -123,7 +115,6 @@
                     "lValueRequested": false,
                     "nodeType": "Literal",
                     "src": "48:1:1",
-                    "subdenomination": null,
                     "typeDescriptions":
                     {
                       "typeIdentifier": "t_rational_3_by_1",
@@ -143,7 +134,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 10,
           "implemented": true,
@@ -151,7 +141,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/long_type_name_binary_operation_legacy.json
+++ b/test/libsolidity/ASTJSON/long_type_name_binary_operation_legacy.json
@@ -8,8 +8,7 @@
       [
         11
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 11,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -103,12 +99,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "a",
-                        "overrides": null,
                         "scope": 9,
                         "stateVariable": false,
                         "storageLocation": "default",
                         "type": "uint256",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":
@@ -131,7 +125,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "commonType":
                         {
                           "typeIdentifier": "t_rational_5_by_1",
@@ -149,13 +142,11 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "hexvalue": "32",
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "lValueRequested": false,
-                            "subdenomination": null,
                             "token": "number",
                             "type": "int_const 2",
                             "value": "2"
@@ -167,13 +158,11 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "hexvalue": "33",
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "lValueRequested": false,
-                            "subdenomination": null,
                             "token": "number",
                             "type": "int_const 3",
                             "value": "3"

--- a/test/libsolidity/ASTJSON/long_type_name_identifier.json
+++ b/test/libsolidity/ASTJSON/long_type_name_identifier.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 16,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 15,
       "linearizedBaseContracts":
@@ -34,7 +32,6 @@
           "mutability": "mutable",
           "name": "a",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 15,
           "src": "13:8:1",
           "stateVariable": true,
@@ -59,7 +56,6 @@
               }
             },
             "id": 2,
-            "length": null,
             "nodeType": "ArrayTypeName",
             "src": "13:6:1",
             "typeDescriptions":
@@ -68,7 +64,6 @@
               "typeString": "uint256[]"
             }
           },
-          "value": null,
           "visibility": "internal"
         },
         {
@@ -92,7 +87,6 @@
                     "mutability": "mutable",
                     "name": "b",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 13,
                     "src": "45:16:1",
                     "stateVariable": false,
@@ -117,7 +111,6 @@
                         }
                       },
                       "id": 9,
-                      "length": null,
                       "nodeType": "ArrayTypeName",
                       "src": "45:6:1",
                       "typeDescriptions":
@@ -126,14 +119,12 @@
                         "typeString": "uint256[]"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 12,
                 "initialValue":
                 {
-                  "argumentTypes": null,
                   "id": 11,
                   "name": "a",
                   "nodeType": "Identifier",
@@ -151,7 +142,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 14,
           "implemented": true,
@@ -159,7 +149,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 4,

--- a/test/libsolidity/ASTJSON/long_type_name_identifier_legacy.json
+++ b/test/libsolidity/ASTJSON/long_type_name_identifier_legacy.json
@@ -8,8 +8,7 @@
       [
         15
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -43,12 +41,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "a",
-            "overrides": null,
             "scope": 15,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "uint256[]",
-            "value": null,
             "visibility": "internal"
           },
           "children":
@@ -56,7 +52,6 @@
             {
               "attributes":
               {
-                "length": null,
                 "type": "uint256[]"
               },
               "children":
@@ -84,7 +79,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -94,7 +88,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 15,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -147,12 +140,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "b",
-                        "overrides": null,
                         "scope": 13,
                         "stateVariable": false,
                         "storageLocation": "storage",
                         "type": "uint256[]",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":
@@ -160,7 +151,6 @@
                         {
                           "attributes":
                           {
-                            "length": null,
                             "type": "uint256[]"
                           },
                           "children":
@@ -188,7 +178,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "overloadedDeclarations":
                         [
                           null

--- a/test/libsolidity/ASTJSON/mappings.json
+++ b/test/libsolidity/ASTJSON/mappings.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 18,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 17,
       "linearizedBaseContracts":
@@ -62,7 +60,6 @@
           "mutability": "mutable",
           "name": "a",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 17,
           "src": "40:20:1",
           "stateVariable": true,
@@ -77,7 +74,6 @@
             "id": 7,
             "keyType":
             {
-              "contractScope": null,
               "id": 5,
               "name": "C",
               "nodeType": "UserDefinedTypeName",
@@ -109,7 +105,6 @@
               }
             }
           },
-          "value": null,
           "visibility": "internal"
         },
         {
@@ -118,7 +113,6 @@
           "mutability": "mutable",
           "name": "b",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 17,
           "src": "66:26:1",
           "stateVariable": true,
@@ -163,7 +157,6 @@
               }
             }
           },
-          "value": null,
           "visibility": "internal"
         },
         {
@@ -172,7 +165,6 @@
           "mutability": "mutable",
           "name": "c",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 17,
           "src": "98:20:1",
           "stateVariable": true,
@@ -187,7 +179,6 @@
             "id": 15,
             "keyType":
             {
-              "contractScope": null,
               "id": 13,
               "name": "E",
               "nodeType": "UserDefinedTypeName",
@@ -219,7 +210,6 @@
               }
             }
           },
-          "value": null,
           "visibility": "internal"
         }
       ],

--- a/test/libsolidity/ASTJSON/mappings_legacy.json
+++ b/test/libsolidity/ASTJSON/mappings_legacy.json
@@ -8,8 +8,7 @@
       [
         17
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -83,12 +81,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "a",
-            "overrides": null,
             "scope": 17,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "mapping(contract C => bool)",
-            "value": null,
             "visibility": "internal"
           },
           "children":
@@ -103,7 +99,6 @@
                 {
                   "attributes":
                   {
-                    "contractScope": null,
                     "name": "C",
                     "referencedDeclaration": 17,
                     "type": "contract C"
@@ -138,12 +133,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "b",
-            "overrides": null,
             "scope": 17,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "mapping(address => bool)",
-            "value": null,
             "visibility": "internal"
           },
           "children":
@@ -191,12 +184,10 @@
             "constant": false,
             "mutability": "mutable",
             "name": "c",
-            "overrides": null,
             "scope": 17,
             "stateVariable": true,
             "storageLocation": "default",
             "type": "mapping(enum C.E => bool)",
-            "value": null,
             "visibility": "internal"
           },
           "children":
@@ -211,7 +202,6 @@
                 {
                   "attributes":
                   {
-                    "contractScope": null,
                     "name": "E",
                     "referencedDeclaration": 4,
                     "type": "enum C.E"

--- a/test/libsolidity/ASTJSON/modifier_definition.json
+++ b/test/libsolidity/ASTJSON/modifier_definition.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 15,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 14,
       "linearizedBaseContracts":
@@ -43,11 +41,9 @@
               }
             ]
           },
-          "documentation": null,
           "id": 6,
           "name": "M",
           "nodeType": "ModifierDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 3,
@@ -60,7 +56,6 @@
                 "mutability": "mutable",
                 "name": "i",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 6,
                 "src": "24:6:1",
                 "stateVariable": false,
@@ -82,7 +77,6 @@
                     "typeString": "uint256"
                   }
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],
@@ -100,7 +94,6 @@
             "src": "64:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "28811f59",
           "id": 13,
           "implemented": true,
@@ -111,7 +104,6 @@
               "arguments":
               [
                 {
-                  "argumentTypes": null,
                   "hexValue": "31",
                   "id": 9,
                   "isConstant": false,
@@ -121,7 +113,6 @@
                   "lValueRequested": false,
                   "nodeType": "Literal",
                   "src": "54:1:1",
-                  "subdenomination": null,
                   "typeDescriptions":
                   {
                     "typeIdentifier": "t_rational_1_by_1",
@@ -133,7 +124,6 @@
               "id": 10,
               "modifierName":
               {
-                "argumentTypes": null,
                 "id": 8,
                 "name": "M",
                 "nodeType": "Identifier",
@@ -152,7 +142,6 @@
           ],
           "name": "F",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 7,

--- a/test/libsolidity/ASTJSON/modifier_definition_legacy.json
+++ b/test/libsolidity/ASTJSON/modifier_definition_legacy.json
@@ -8,8 +8,7 @@
       [
         14
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,9 +38,7 @@
         {
           "attributes":
           {
-            "documentation": null,
             "name": "M",
-            "overrides": null,
             "virtual": false,
             "visibility": "internal"
           },
@@ -57,12 +53,10 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "i",
-                    "overrides": null,
                     "scope": 6,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "uint256",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -108,13 +102,11 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "28811f59",
             "implemented": true,
             "isConstructor": false,
             "kind": "function",
             "name": "F",
-            "overrides": null,
             "scope": 14,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -154,7 +146,6 @@
                 {
                   "attributes":
                   {
-                    "argumentTypes": null,
                     "overloadedDeclarations":
                     [
                       null
@@ -170,13 +161,11 @@
                 {
                   "attributes":
                   {
-                    "argumentTypes": null,
                     "hexvalue": "31",
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
                     "lValueRequested": false,
-                    "subdenomination": null,
                     "token": "number",
                     "type": "int_const 1",
                     "value": "1"

--- a/test/libsolidity/ASTJSON/modifier_invocation.json
+++ b/test/libsolidity/ASTJSON/modifier_invocation.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 15,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 14,
       "linearizedBaseContracts":
@@ -43,11 +41,9 @@
               }
             ]
           },
-          "documentation": null,
           "id": 6,
           "name": "M",
           "nodeType": "ModifierDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 3,
@@ -60,7 +56,6 @@
                 "mutability": "mutable",
                 "name": "i",
                 "nodeType": "VariableDeclaration",
-                "overrides": null,
                 "scope": 6,
                 "src": "24:6:1",
                 "stateVariable": false,
@@ -82,7 +77,6 @@
                     "typeString": "uint256"
                   }
                 },
-                "value": null,
                 "visibility": "internal"
               }
             ],
@@ -100,7 +94,6 @@
             "src": "64:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "28811f59",
           "id": 13,
           "implemented": true,
@@ -111,7 +104,6 @@
               "arguments":
               [
                 {
-                  "argumentTypes": null,
                   "hexValue": "31",
                   "id": 9,
                   "isConstant": false,
@@ -121,7 +113,6 @@
                   "lValueRequested": false,
                   "nodeType": "Literal",
                   "src": "54:1:1",
-                  "subdenomination": null,
                   "typeDescriptions":
                   {
                     "typeIdentifier": "t_rational_1_by_1",
@@ -133,7 +124,6 @@
               "id": 10,
               "modifierName":
               {
-                "argumentTypes": null,
                 "id": 8,
                 "name": "M",
                 "nodeType": "Identifier",
@@ -152,7 +142,6 @@
           ],
           "name": "F",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 7,

--- a/test/libsolidity/ASTJSON/modifier_invocation_legacy.json
+++ b/test/libsolidity/ASTJSON/modifier_invocation_legacy.json
@@ -8,8 +8,7 @@
       [
         14
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,9 +38,7 @@
         {
           "attributes":
           {
-            "documentation": null,
             "name": "M",
-            "overrides": null,
             "virtual": false,
             "visibility": "internal"
           },
@@ -57,12 +53,10 @@
                     "constant": false,
                     "mutability": "mutable",
                     "name": "i",
-                    "overrides": null,
                     "scope": 6,
                     "stateVariable": false,
                     "storageLocation": "default",
                     "type": "uint256",
-                    "value": null,
                     "visibility": "internal"
                   },
                   "children":
@@ -108,13 +102,11 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "28811f59",
             "implemented": true,
             "isConstructor": false,
             "kind": "function",
             "name": "F",
-            "overrides": null,
             "scope": 14,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -154,7 +146,6 @@
                 {
                   "attributes":
                   {
-                    "argumentTypes": null,
                     "overloadedDeclarations":
                     [
                       null
@@ -170,13 +161,11 @@
                 {
                   "attributes":
                   {
-                    "argumentTypes": null,
                     "hexvalue": "31",
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
                     "lValueRequested": false,
-                    "subdenomination": null,
                     "token": "number",
                     "type": "int_const 1",
                     "value": "1"

--- a/test/libsolidity/ASTJSON/mutability.json
+++ b/test/libsolidity/ASTJSON/mutability.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 11,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 10,
       "linearizedBaseContracts":
@@ -35,7 +33,6 @@
           "mutability": "immutable",
           "name": "a",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 10,
           "src": "17:27:1",
           "stateVariable": true,
@@ -59,7 +56,6 @@
           },
           "value":
           {
-            "argumentTypes": null,
             "hexValue": "34",
             "id": 2,
             "isConstant": false,
@@ -69,7 +65,6 @@
             "lValueRequested": false,
             "nodeType": "Literal",
             "src": "43:1:1",
-            "subdenomination": null,
             "typeDescriptions":
             {
               "typeIdentifier": "t_rational_4_by_1",
@@ -86,7 +81,6 @@
           "mutability": "constant",
           "name": "b",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 10,
           "src": "50:26:1",
           "stateVariable": true,
@@ -110,7 +104,6 @@
           },
           "value":
           {
-            "argumentTypes": null,
             "hexValue": "32",
             "id": 5,
             "isConstant": false,
@@ -120,7 +113,6 @@
             "lValueRequested": false,
             "nodeType": "Literal",
             "src": "75:1:1",
-            "subdenomination": null,
             "typeDescriptions":
             {
               "typeIdentifier": "t_rational_2_by_1",
@@ -137,7 +129,6 @@
           "mutability": "mutable",
           "name": "c",
           "nodeType": "VariableDeclaration",
-          "overrides": null,
           "scope": 10,
           "src": "82:17:1",
           "stateVariable": true,
@@ -161,7 +152,6 @@
           },
           "value":
           {
-            "argumentTypes": null,
             "hexValue": "33",
             "id": 8,
             "isConstant": false,
@@ -171,7 +161,6 @@
             "lValueRequested": false,
             "nodeType": "Literal",
             "src": "98:1:1",
-            "subdenomination": null,
             "typeDescriptions":
             {
               "typeIdentifier": "t_rational_3_by_1",

--- a/test/libsolidity/ASTJSON/mutability_legacy.json
+++ b/test/libsolidity/ASTJSON/mutability_legacy.json
@@ -8,8 +8,7 @@
       [
         10
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -44,7 +42,6 @@
             "functionSelector": "0dbe671f",
             "mutability": "immutable",
             "name": "a",
-            "overrides": null,
             "scope": 10,
             "stateVariable": true,
             "storageLocation": "default",
@@ -66,13 +63,11 @@
             {
               "attributes":
               {
-                "argumentTypes": null,
                 "hexvalue": "34",
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
                 "lValueRequested": false,
-                "subdenomination": null,
                 "token": "number",
                 "type": "int_const 4",
                 "value": "4"
@@ -93,7 +88,6 @@
             "functionSelector": "4df7e3d0",
             "mutability": "constant",
             "name": "b",
-            "overrides": null,
             "scope": 10,
             "stateVariable": true,
             "storageLocation": "default",
@@ -115,13 +109,11 @@
             {
               "attributes":
               {
-                "argumentTypes": null,
                 "hexvalue": "32",
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
                 "lValueRequested": false,
-                "subdenomination": null,
                 "token": "number",
                 "type": "int_const 2",
                 "value": "2"
@@ -142,7 +134,6 @@
             "functionSelector": "c3da42b8",
             "mutability": "mutable",
             "name": "c",
-            "overrides": null,
             "scope": 10,
             "stateVariable": true,
             "storageLocation": "default",
@@ -164,13 +155,11 @@
             {
               "attributes":
               {
-                "argumentTypes": null,
                 "hexvalue": "33",
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
                 "lValueRequested": false,
-                "subdenomination": null,
                 "token": "number",
                 "type": "int_const 3",
                 "value": "3"

--- a/test/libsolidity/ASTJSON/non_utf8.json
+++ b/test/libsolidity/ASTJSON/non_utf8.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 9,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 8,
       "linearizedBaseContracts":
@@ -49,7 +47,6 @@
                     "mutability": "mutable",
                     "name": "x",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 6,
                     "src": "35:5:1",
                     "stateVariable": false,
@@ -59,15 +56,12 @@
                       "typeIdentifier": "t_string_memory_ptr",
                       "typeString": "string"
                     },
-                    "typeName": null,
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 5,
                 "initialValue":
                 {
-                  "argumentTypes": null,
                   "hexValue": "ff",
                   "id": 4,
                   "isConstant": false,
@@ -77,20 +71,17 @@
                   "lValueRequested": false,
                   "nodeType": "Literal",
                   "src": "43:7:1",
-                  "subdenomination": null,
                   "typeDescriptions":
                   {
                     "typeIdentifier": "t_stringliteral_8b1a944cf13a9a1c08facb2c9e98623ef3254d2ddb48113885c3e8e97fec8db9",
                     "typeString": "literal_string (contains invalid UTF-8 sequence at position 0)"
-                  },
-                  "value": null
+                  }
                 },
                 "nodeType": "VariableDeclarationStatement",
                 "src": "35:15:1"
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 7,
           "implemented": true,
@@ -98,7 +89,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/non_utf8_legacy.json
+++ b/test/libsolidity/ASTJSON/non_utf8_legacy.json
@@ -8,8 +8,7 @@
       [
         8
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 8,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -103,13 +99,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "x",
-                        "overrides": null,
                         "scope": 6,
                         "stateVariable": false,
                         "storageLocation": "default",
                         "type": "string",
-                        "typeName": null,
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children": [],
@@ -120,16 +113,13 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "hexvalue": "ff",
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "lValueRequested": false,
-                        "subdenomination": null,
                         "token": "string",
-                        "type": "literal_string (contains invalid UTF-8 sequence at position 0)",
-                        "value": null
+                        "type": "literal_string (contains invalid UTF-8 sequence at position 0)"
                       },
                       "id": 4,
                       "name": "Literal",

--- a/test/libsolidity/ASTJSON/override.json
+++ b/test/libsolidity/ASTJSON/override.json
@@ -16,7 +16,6 @@
     ]
   },
   "id": 32,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -25,7 +24,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -44,7 +42,6 @@
             "src": "36:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "a399b6a2",
           "id": 4,
           "implemented": true,
@@ -52,7 +49,6 @@
           "modifiers": [],
           "name": "faa",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,
@@ -82,10 +78,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 6,
             "name": "A",
             "nodeType": "UserDefinedTypeName",
@@ -107,7 +101,6 @@
         5
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": false,
       "id": 16,
       "linearizedBaseContracts":
@@ -120,8 +113,6 @@
       "nodes":
       [
         {
-          "body": null,
-          "documentation": null,
           "functionSelector": "c2985578",
           "id": 10,
           "implemented": false,
@@ -129,7 +120,6 @@
           "modifiers": [],
           "name": "foo",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 8,
@@ -162,7 +152,6 @@
             "src": "115:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "a399b6a2",
           "id": 15,
           "implemented": true,
@@ -206,10 +195,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 17,
             "name": "B",
             "nodeType": "UserDefinedTypeName",
@@ -232,7 +219,6 @@
         16
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 31,
       "linearizedBaseContracts":
@@ -257,7 +243,6 @@
             "src": "170:3:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "c2985578",
           "id": 23,
           "implemented": true,
@@ -304,7 +289,6 @@
             "src": "212:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "a399b6a2",
           "id": 30,
           "implemented": true,
@@ -319,7 +303,6 @@
             "overrides":
             [
               {
-                "contractScope": null,
                 "id": 25,
                 "name": "A",
                 "nodeType": "UserDefinedTypeName",
@@ -332,7 +315,6 @@
                 }
               },
               {
-                "contractScope": null,
                 "id": 26,
                 "name": "B",
                 "nodeType": "UserDefinedTypeName",

--- a/test/libsolidity/ASTJSON/override_legacy.json
+++ b/test/libsolidity/ASTJSON/override_legacy.json
@@ -16,8 +16,7 @@
       [
         31
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -34,7 +33,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -48,7 +46,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "a399b6a2",
             "implemented": true,
             "isConstructor": false,
@@ -58,7 +55,6 @@
               null
             ],
             "name": "faa",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -124,7 +120,6 @@
           5
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": false,
         "linearizedBaseContracts":
         [
@@ -137,16 +132,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "A",
                 "referencedDeclaration": 5,
                 "type": "contract A"
@@ -163,8 +154,6 @@
         {
           "attributes":
           {
-            "body": null,
-            "documentation": null,
             "functionSelector": "c2985578",
             "implemented": false,
             "isConstructor": false,
@@ -174,7 +163,6 @@
               null
             ],
             "name": "foo",
-            "overrides": null,
             "scope": 16,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -220,7 +208,6 @@
             [
               4
             ],
-            "documentation": null,
             "functionSelector": "a399b6a2",
             "implemented": true,
             "isConstructor": false,
@@ -308,7 +295,6 @@
           16
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -322,16 +308,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "B",
                 "referencedDeclaration": 16,
                 "type": "contract B"
@@ -352,7 +334,6 @@
             [
               10
             ],
-            "documentation": null,
             "functionSelector": "c2985578",
             "implemented": true,
             "isConstructor": false,
@@ -432,7 +413,6 @@
             [
               15
             ],
-            "documentation": null,
             "functionSelector": "a399b6a2",
             "implemented": true,
             "isConstructor": false,
@@ -455,7 +435,6 @@
                 {
                   "attributes":
                   {
-                    "contractScope": null,
                     "name": "A",
                     "referencedDeclaration": 5,
                     "type": "contract A"
@@ -467,7 +446,6 @@
                 {
                   "attributes":
                   {
-                    "contractScope": null,
                     "name": "B",
                     "referencedDeclaration": 16,
                     "type": "contract B"

--- a/test/libsolidity/ASTJSON/placeholder_statement.json
+++ b/test/libsolidity/ASTJSON/placeholder_statement.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -43,11 +41,9 @@
               }
             ]
           },
-          "documentation": null,
           "id": 4,
           "name": "M",
           "nodeType": "ModifierDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/placeholder_statement_legacy.json
+++ b/test/libsolidity/ASTJSON/placeholder_statement_legacy.json
@@ -8,8 +8,7 @@
       [
         5
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,9 +38,7 @@
         {
           "attributes":
           {
-            "documentation": null,
             "name": "M",
-            "overrides": null,
             "virtual": false,
             "visibility": "internal"
           },

--- a/test/libsolidity/ASTJSON/receive_ether.json
+++ b/test/libsolidity/ASTJSON/receive_ether.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -36,14 +34,12 @@
             "src": "42:5:1",
             "statements": []
           },
-          "documentation": null,
           "id": 4,
           "implemented": true,
           "kind": "receive",
           "modifiers": [],
           "name": "",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/receive_ether_legacy.json
+++ b/test/libsolidity/ASTJSON/receive_ether_legacy.json
@@ -8,8 +8,7 @@
       [
         5
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "implemented": true,
             "isConstructor": false,
             "kind": "receive",
@@ -49,7 +46,6 @@
               null
             ],
             "name": "",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "payable",
             "virtual": false,

--- a/test/libsolidity/ASTJSON/short_type_name.json
+++ b/test/libsolidity/ASTJSON/short_type_name.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 12,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 11,
       "linearizedBaseContracts":
@@ -49,7 +47,6 @@
                     "mutability": "mutable",
                     "name": "x",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 9,
                     "src": "35:15:1",
                     "stateVariable": false,
@@ -74,7 +71,6 @@
                         }
                       },
                       "id": 6,
-                      "length": null,
                       "nodeType": "ArrayTypeName",
                       "src": "35:6:1",
                       "typeDescriptions":
@@ -83,18 +79,15 @@
                         "typeString": "uint256[]"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 8,
-                "initialValue": null,
                 "nodeType": "VariableDeclarationStatement",
                 "src": "35:15:1"
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 10,
           "implemented": true,
@@ -102,7 +95,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/short_type_name_legacy.json
+++ b/test/libsolidity/ASTJSON/short_type_name_legacy.json
@@ -8,8 +8,7 @@
       [
         11
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 11,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -93,8 +89,7 @@
                     "assignments":
                     [
                       7
-                    ],
-                    "initialValue": null
+                    ]
                   },
                   "children":
                   [
@@ -104,12 +99,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "x",
-                        "overrides": null,
                         "scope": 9,
                         "stateVariable": false,
                         "storageLocation": "memory",
                         "type": "uint256[]",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":
@@ -117,7 +110,6 @@
                         {
                           "attributes":
                           {
-                            "length": null,
                             "type": "uint256[]"
                           },
                           "children":

--- a/test/libsolidity/ASTJSON/short_type_name_ref.json
+++ b/test/libsolidity/ASTJSON/short_type_name_ref.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 13,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 12,
       "linearizedBaseContracts":
@@ -49,7 +47,6 @@
                     "mutability": "mutable",
                     "name": "rows",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 10,
                     "src": "35:20:1",
                     "stateVariable": false,
@@ -76,7 +73,6 @@
                           }
                         },
                         "id": 6,
-                        "length": null,
                         "nodeType": "ArrayTypeName",
                         "src": "35:6:1",
                         "typeDescriptions":
@@ -86,7 +82,6 @@
                         }
                       },
                       "id": 7,
-                      "length": null,
                       "nodeType": "ArrayTypeName",
                       "src": "35:8:1",
                       "typeDescriptions":
@@ -95,18 +90,15 @@
                         "typeString": "uint256[][]"
                       }
                     },
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 9,
-                "initialValue": null,
                 "nodeType": "VariableDeclarationStatement",
                 "src": "35:20:1"
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 11,
           "implemented": true,
@@ -114,7 +106,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/short_type_name_ref_legacy.json
+++ b/test/libsolidity/ASTJSON/short_type_name_ref_legacy.json
@@ -8,8 +8,7 @@
       [
         12
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 12,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -93,8 +89,7 @@
                     "assignments":
                     [
                       8
-                    ],
-                    "initialValue": null
+                    ]
                   },
                   "children":
                   [
@@ -104,12 +99,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "rows",
-                        "overrides": null,
                         "scope": 10,
                         "stateVariable": false,
                         "storageLocation": "memory",
                         "type": "uint256[][]",
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children":
@@ -117,7 +110,6 @@
                         {
                           "attributes":
                           {
-                            "length": null,
                             "type": "uint256[][]"
                           },
                           "children":
@@ -125,7 +117,6 @@
                             {
                               "attributes":
                               {
-                                "length": null,
                                 "type": "uint256[]"
                               },
                               "children":

--- a/test/libsolidity/ASTJSON/smoke.json
+++ b/test/libsolidity/ASTJSON/smoke.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 2,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 1,
       "linearizedBaseContracts":

--- a/test/libsolidity/ASTJSON/smoke_legacy.json
+++ b/test/libsolidity/ASTJSON/smoke_legacy.json
@@ -8,8 +8,7 @@
       [
         1
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [

--- a/test/libsolidity/ASTJSON/source_location.json
+++ b/test/libsolidity/ASTJSON/source_location.json
@@ -8,7 +8,6 @@
     ]
   },
   "id": 12,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -17,7 +16,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 11,
       "linearizedBaseContracts":
@@ -49,7 +47,6 @@
                     "mutability": "mutable",
                     "name": "x",
                     "nodeType": "VariableDeclaration",
-                    "overrides": null,
                     "scope": 9,
                     "src": "28:5:1",
                     "stateVariable": false,
@@ -59,15 +56,12 @@
                       "typeIdentifier": "t_uint8",
                       "typeString": "uint8"
                     },
-                    "typeName": null,
-                    "value": null,
                     "visibility": "internal"
                   }
                 ],
                 "id": 5,
                 "initialValue":
                 {
-                  "argumentTypes": null,
                   "hexValue": "32",
                   "id": 4,
                   "isConstant": false,
@@ -77,7 +71,6 @@
                   "lValueRequested": false,
                   "nodeType": "Literal",
                   "src": "36:1:1",
-                  "subdenomination": null,
                   "typeDescriptions":
                   {
                     "typeIdentifier": "t_rational_2_by_1",
@@ -91,7 +84,6 @@
               {
                 "expression":
                 {
-                  "argumentTypes": null,
                   "id": 7,
                   "isConstant": false,
                   "isLValue": false,
@@ -103,7 +95,6 @@
                   "src": "39:3:1",
                   "subExpression":
                   {
-                    "argumentTypes": null,
                     "id": 6,
                     "name": "x",
                     "nodeType": "Identifier",
@@ -128,7 +119,6 @@
               }
             ]
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 10,
           "implemented": true,
@@ -136,7 +126,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,

--- a/test/libsolidity/ASTJSON/source_location_legacy.json
+++ b/test/libsolidity/ASTJSON/source_location_legacy.json
@@ -8,8 +8,7 @@
       [
         11
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -26,7 +25,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -40,7 +38,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -50,7 +47,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 11,
             "stateMutability": "nonpayable",
             "virtual": false,
@@ -103,13 +99,10 @@
                         "constant": false,
                         "mutability": "mutable",
                         "name": "x",
-                        "overrides": null,
                         "scope": 9,
                         "stateVariable": false,
                         "storageLocation": "default",
                         "type": "uint8",
-                        "typeName": null,
-                        "value": null,
                         "visibility": "internal"
                       },
                       "children": [],
@@ -120,13 +113,11 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "hexvalue": "32",
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "lValueRequested": false,
-                        "subdenomination": null,
                         "token": "number",
                         "type": "int_const 2",
                         "value": "2"
@@ -146,7 +137,6 @@
                     {
                       "attributes":
                       {
-                        "argumentTypes": null,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -160,7 +150,6 @@
                         {
                           "attributes":
                           {
-                            "argumentTypes": null,
                             "overloadedDeclarations":
                             [
                               null

--- a/test/libsolidity/ASTJSON/two_base_functions.json
+++ b/test/libsolidity/ASTJSON/two_base_functions.json
@@ -16,7 +16,6 @@
     ]
   },
   "id": 23,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -25,7 +24,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -44,7 +42,6 @@
             "src": "45:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 4,
           "implemented": true,
@@ -52,7 +49,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 1,
@@ -82,7 +78,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 10,
       "linearizedBaseContracts":
@@ -101,7 +96,6 @@
             "src": "95:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 9,
           "implemented": true,
@@ -109,7 +103,6 @@
           "modifiers": [],
           "name": "f",
           "nodeType": "FunctionDefinition",
-          "overrides": null,
           "parameters":
           {
             "id": 6,
@@ -139,10 +132,8 @@
       "baseContracts":
       [
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 11,
             "name": "A",
             "nodeType": "UserDefinedTypeName",
@@ -159,10 +150,8 @@
           "src": "114:1:1"
         },
         {
-          "arguments": null,
           "baseName":
           {
-            "contractScope": null,
             "id": 13,
             "name": "B",
             "nodeType": "UserDefinedTypeName",
@@ -185,7 +174,6 @@
         10
       ],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 22,
       "linearizedBaseContracts":
@@ -211,7 +199,6 @@
             "src": "160:2:1",
             "statements": []
           },
-          "documentation": null,
           "functionSelector": "26121ff0",
           "id": 21,
           "implemented": true,
@@ -226,7 +213,6 @@
             "overrides":
             [
               {
-                "contractScope": null,
                 "id": 16,
                 "name": "A",
                 "nodeType": "UserDefinedTypeName",
@@ -239,7 +225,6 @@
                 }
               },
               {
-                "contractScope": null,
                 "id": 17,
                 "name": "B",
                 "nodeType": "UserDefinedTypeName",

--- a/test/libsolidity/ASTJSON/two_base_functions_legacy.json
+++ b/test/libsolidity/ASTJSON/two_base_functions_legacy.json
@@ -16,8 +16,7 @@
       [
         22
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -34,7 +33,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -48,7 +46,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -58,7 +55,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 5,
             "stateMutability": "nonpayable",
             "virtual": true,
@@ -128,7 +124,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -142,7 +137,6 @@
         {
           "attributes":
           {
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -152,7 +146,6 @@
               null
             ],
             "name": "f",
-            "overrides": null,
             "scope": 10,
             "stateMutability": "nonpayable",
             "virtual": true,
@@ -219,7 +212,6 @@
           10
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -233,16 +225,12 @@
       "children":
       [
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "A",
                 "referencedDeclaration": 5,
                 "type": "contract A"
@@ -257,16 +245,12 @@
           "src": "114:1:1"
         },
         {
-          "attributes":
-          {
-            "arguments": null
-          },
+          "attributes": {},
           "children":
           [
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "B",
                 "referencedDeclaration": 10,
                 "type": "contract B"
@@ -288,7 +272,6 @@
               4,
               9
             ],
-            "documentation": null,
             "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
@@ -311,7 +294,6 @@
                 {
                   "attributes":
                   {
-                    "contractScope": null,
                     "name": "A",
                     "referencedDeclaration": 5,
                     "type": "contract A"
@@ -323,7 +305,6 @@
                 {
                   "attributes":
                   {
-                    "contractScope": null,
                     "name": "B",
                     "referencedDeclaration": 10,
                     "type": "contract B"

--- a/test/libsolidity/ASTJSON/using_for_directive.json
+++ b/test/libsolidity/ASTJSON/using_for_directive.json
@@ -12,7 +12,6 @@
     ]
   },
   "id": 6,
-  "license": null,
   "nodeType": "SourceUnit",
   "nodes":
   [
@@ -21,7 +20,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "library",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 1,
       "linearizedBaseContracts":
@@ -39,7 +37,6 @@
       "baseContracts": [],
       "contractDependencies": [],
       "contractKind": "contract",
-      "documentation": null,
       "fullyImplemented": true,
       "id": 5,
       "linearizedBaseContracts":
@@ -54,7 +51,6 @@
           "id": 4,
           "libraryName":
           {
-            "contractScope": null,
             "id": 2,
             "name": "L",
             "nodeType": "UserDefinedTypeName",

--- a/test/libsolidity/ASTJSON/using_for_directive_legacy.json
+++ b/test/libsolidity/ASTJSON/using_for_directive_legacy.json
@@ -12,8 +12,7 @@
       [
         1
       ]
-    },
-    "license": null
+    }
   },
   "children":
   [
@@ -30,7 +29,6 @@
           null
         ],
         "contractKind": "library",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -60,7 +58,6 @@
           null
         ],
         "contractKind": "contract",
-        "documentation": null,
         "fullyImplemented": true,
         "linearizedBaseContracts":
         [
@@ -77,7 +74,6 @@
             {
               "attributes":
               {
-                "contractScope": null,
                 "name": "L",
                 "referencedDeclaration": 1,
                 "type": "library L"

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -119,7 +119,7 @@ ostream& phaser::operator<<(ostream& _stream, Program const& _program)
 string Program::toJson() const
 {
 	Json::Value serializedAst = AsmJsonConverter(0)(*m_ast);
-	return jsonPrettyPrint(serializedAst);
+	return jsonPrettyPrint(removeNullMembers(std::move(serializedAst)));
 }
 
 variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _dialect, CharStream _source)


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7897

Members with value `null` are removed by recursively going through the JSON representation and removing such members.


TODO
1. [x] What about null inside arrays? I think `arrayValue: [null]` and `arrayValue: []` are different, so currently arrays can have null as members.

