### PR TITLE
IRGenerator: include assertion for FunctionType::Kind::Declaration

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -578,6 +578,9 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	solUnimplementedAssert(!functionType->bound(), "");
 	switch (functionType->kind())
 	{
+	case FunctionType::Kind::Declaration:
+		solAssert(false, "Attempted to generate code for calling a function definition.");
+		break;
 	case FunctionType::Kind::Internal:
 	{
 		vector<string> args;


### PR DESCRIPTION
Part of #8343.

Copied from https://github.com/ethereum/solidity/blob/develop/libsolidity/codegen/ExpressionCompiler.cpp#L568