### PR TITLE
CircleCI: Change from Ubuntu Disco (19.04) to Ubuntu Focal (20.04) due to support EOL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
 
   chk_coding_style:
     docker:
-      - image: buildpack-deps:disco
+      - image: buildpack-deps:focal
     steps:
       - checkout
       - run:


### PR DESCRIPTION
CircleCI: Change from Ubuntu Disco (19.04) to Ubuntu Focal (20.04) due to support EOL

NB: still requires an updated docker image to be built and uploaded (oh, i don't have docker installed right now. do you? @ekpyron)? :-)