### PR TITLE
Use Spacer option to improve performance of constant arrays

### DIFF
--- a/libsolidity/formal/Z3CHCInterface.cpp
+++ b/libsolidity/formal/Z3CHCInterface.cpp
@@ -43,6 +43,7 @@ Z3CHCInterface::Z3CHCInterface():
 	p.set("fp.spacer.mbqi", false);
 	// Ground pobs by using values from a model.
 	p.set("fp.spacer.ground_pobs", false);
+	p.set("fp.spacer.weak_abs", false);
 	m_solver.set(p);
 }
 

--- a/test/libsolidity/smtCheckerTests/types/unused_mapping.sol
+++ b/test/libsolidity/smtCheckerTests/types/unused_mapping.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x;
+	uint y;
+	mapping (address => bool) public never_used;
+
+	function inc() public {
+		require(x < 10);
+		require(y < 10);
+
+		if(x == 0) x = 0; // noop state var read
+		x++;
+		y++;
+		assert(y == x);
+	}
+}


### PR DESCRIPTION
In the other PR this cause a constant memory leak in Spacer. Opening again to investigate that.