### PR TITLE
Fixed bug when two empty NatSpec comments led to scanning past EOL

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Bugfixes:
  * Type Checker: Fix internal error when assigning to empty tuples.
  * Type Checker: Perform recursiveness check on structs declared at the file level.
  * Standard Json Input: Fix error when using prefix ``file://`` in the field ``urls``.
+ * Scanner: Fix bug when two empty NatSpec comments lead to scanning past EOL.
 
 Build System:
  * soltest.sh: ``SOLIDITY_BUILD_DIR`` is no longer relative to ``REPO_ROOT`` to allow for build directories outside of the source tree.

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -331,6 +331,11 @@ int Scanner::scanSingleLineDocComment()
 			{
 				addCommentLiteralChar('\n');
 				m_char = m_source->advanceAndGet(3);
+				if (tryScanEndOfLine())
+				{
+					addCommentLiteralChar('\n');
+					break;
+				}
 			}
 			else
 				break; // next line is not a documentation comment, we are done

--- a/test/libsolidity/syntaxTests/natspec/docstring_double_empty.sol
+++ b/test/libsolidity/syntaxTests/natspec/docstring_double_empty.sol
@@ -1,0 +1,6 @@
+contract C {
+  ///
+  ///
+  function vote(uint id) public {}
+}
+// ----


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8789

The problem was that the scanner was not prepared to see `\n` character after the second `\\\` line. It assumed the `\n` character was part of the comment, advanced, and kept reading comments until the next `\n` (therefore creeping into the next line.)

```solidity
\\\
\\\
function f()
```
In the above example, `function f()` was considered as part of the comment.
