### PR TITLE
[Sol->Yul] Populating internal dispatch on demand

### DIFF
--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -43,6 +43,8 @@ namespace solidity::frontend
 class YulUtilFunctions;
 class ABIFunctions;
 
+using InternalDispatchMap = std::map<YulArity, std::set<FunctionDefinition const*>>;
+
 /**
  * Class that contains contextual information during IR generation.
  */
@@ -102,7 +104,26 @@ public:
 
 	std::string newYulVariable();
 
-	std::string generateInternalDispatchFunction(YulArity const& _arity);
+	void initializeInternalDispatch(InternalDispatchMap _internalDispatchMap);
+	InternalDispatchMap consumeInternalDispatchMap();
+	bool internalDispatchClean() const { return m_internalDispatchMap.empty() && m_directInternalFunctionCalls.empty(); }
+
+	/// Notifies the context that a function call that needs to go through internal dispatch was
+	/// encountered while visiting the AST. This ensures that the corresponding dispatch function
+	/// gets added to the dispatch map even if there are no entries in it (which may happen if
+	/// the code contains a call to an uninitialized function variable).
+	void internalFunctionCalledThroughDispatch(YulArity const& _arity);
+
+	/// Notifies the context that a direct function call (i.e. not through internal dispatch) was
+	/// encountered while visiting the AST. This lets the context know that the function should
+	/// not be added to the dispatch (unless there are also indirect calls to it elsewhere else).
+	void internalFunctionCalledDirectly(Expression const& _expression);
+
+	/// Notifies the context that a name representing an internal function has been found while
+	/// visiting the AST. If the name has not been reported as a direct call using
+	/// @a internalFunctionCalledDirectly(), it's assumed to represent function variable access
+	/// and the function gets added to internal dispatch.
+	void internalFunctionAccessed(Expression const& _expression, FunctionDefinition const& _function);
 
 	/// @returns a new copy of the utility function generator (but using the same function set).
 	YulUtilFunctions utils();
@@ -120,8 +141,6 @@ public:
 	std::set<ContractDefinition const*, ASTNode::CompareByID>& subObjectsCreated() { return m_subObjects; }
 
 private:
-	std::set<FunctionDefinition const*> collectFunctionsOfArity(YulArity const& _arity);
-
 	langutil::EVMVersion m_evmVersion;
 	RevertStrings m_revertStrings;
 	OptimiserSettings m_optimiserSettings;
@@ -146,6 +165,13 @@ private:
 	/// long as the order of Yul functions in the generated code is deterministic and the same on
 	/// all platforms - which is a property guaranteed by MultiUseYulFunctionCollector.
 	std::set<FunctionDefinition const*> m_functionGenerationQueue;
+
+	/// Collection of functions that need to be callable via internal dispatch.
+	/// Note that having a key with an empty set of functions is a valid situation. It means that
+	/// the code contains a call via a pointer even though a specific function is never assigned to it.
+	/// It will fail at runtime but the code must still compile.
+	InternalDispatchMap m_internalDispatchMap;
+	std::set<Expression const*> m_directInternalFunctionCalls;
 
 	std::set<ContractDefinition const*, ASTNode::CompareByID> m_subObjects;
 };

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -65,6 +65,11 @@ private:
 	/// Generates code for all the functions from the function generation queue.
 	/// The resulting code is stored in the function collector in IRGenerationContext.
 	void generateQueuedFunctions();
+	/// Generates  all the internal dispatch functions necessary to handle any function that could
+	/// possibly be called via a pointer.
+	/// @return The content of the dispatch for reuse in runtime code. Reuse is necessary because
+	/// pointers to functions can be passed from the creation code in storage variables.
+	InternalDispatchMap generateInternalDispatchFunctions();
 	/// Generates code for and returns the name of the function.
 	std::string generateFunction(FunctionDefinition const& _function);
 	/// Generates a getter for the given declaration and returns its name

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -70,6 +70,7 @@ public:
 	void endVisit(Return const& _return) override;
 	void endVisit(UnaryOperation const& _unaryOperation) override;
 	bool visit(BinaryOperation const& _binOp) override;
+	bool visit(FunctionCall const& _funCall) override;
 	void endVisit(FunctionCall const& _funCall) override;
 	void endVisit(FunctionCallOptions const& _funCallOptions) override;
 	void endVisit(MemberAccess const& _memberAccess) override;

--- a/test/libsolidity/semanticTests/constructor/functions_called_by_constructor_through_dispatch.sol
+++ b/test/libsolidity/semanticTests/constructor/functions_called_by_constructor_through_dispatch.sol
@@ -1,0 +1,31 @@
+contract Test {
+    bytes6 name;
+
+    constructor() public {
+        function (bytes6 _name) internal setter = setName;
+        setter("abcdef");
+
+        applyShift(leftByteShift, 3);
+    }
+
+    function getName() public returns (bytes6 ret) {
+        return name;
+    }
+
+    function setName(bytes6 _name) private {
+        name = _name;
+    }
+
+    function leftByteShift(bytes6 _value, uint _shift) public returns (bytes6) {
+        return _value << _shift * 8;
+    }
+
+    function applyShift(function (bytes6 _value, uint _shift) internal returns (bytes6) _shiftOperator, uint _bytes) internal {
+        name = _shiftOperator(name, _bytes);
+    }
+}
+
+// ====
+// compileViaYul: also
+// ----
+// getName() -> "def\x00\x00\x00"

--- a/test/libsolidity/semanticTests/functionTypes/function_type_library_internal.sol
+++ b/test/libsolidity/semanticTests/functionTypes/function_type_library_internal.sol
@@ -22,5 +22,7 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f(uint256[]): 0x20, 0x3, 0x1, 0x7, 0x3 -> 11

--- a/test/libsolidity/semanticTests/intheritance/inherited_function_through_dispatch.sol
+++ b/test/libsolidity/semanticTests/intheritance/inherited_function_through_dispatch.sol
@@ -1,0 +1,21 @@
+contract A {
+    function f() internal virtual returns (uint256) {
+        return 1;
+    }
+}
+
+
+contract B is A {
+    function f() internal override returns (uint256) {
+        return 2;
+    }
+
+    function g() public returns (uint256) {
+        function() internal returns (uint256) ptr = A.f;
+        return ptr();
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// g() -> 1

--- a/test/libsolidity/semanticTests/libraries/internal_library_function_pointer.sol
+++ b/test/libsolidity/semanticTests/libraries/internal_library_function_pointer.sol
@@ -1,0 +1,17 @@
+library L {
+    function f() internal returns (uint) {
+        return 66;
+    }
+}
+
+contract C {
+    function g() public returns (uint) {
+        function() internal returns(uint) ptr;
+        ptr = L.f;
+        return ptr();
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// g() -> 66

--- a/test/libsolidity/semanticTests/virtualFunctions/internal_virtual_function_calls_through_dispatch.sol
+++ b/test/libsolidity/semanticTests/virtualFunctions/internal_virtual_function_calls_through_dispatch.sol
@@ -1,0 +1,26 @@
+contract Base {
+    function f() internal returns (uint256 i) {
+        function() internal returns (uint256) ptr = g;
+        return ptr();
+    }
+
+    function g() internal virtual returns (uint256 i) {
+        return 1;
+    }
+}
+
+
+contract Derived is Base {
+    function g() internal override returns (uint256 i) {
+        return 2;
+    }
+
+    function h() public returns (uint256 i) {
+        return f();
+    }
+}
+
+// ====
+// compileViaYul: also
+// ----
+// h() -> 2


### PR DESCRIPTION
Resolves #6788. Adds a mechanism necessary to implement code generation for internal library function calls via pointers in #8485.

~This is not a perfect solution because internal functions that are called directly rather than assigned to variables are still included in the internal dispatch. That's because generator treats both of these cases the same way, by storing function ID in a variable, and in the case of a direct call the variable is simply not used. I would have to detect that which is not easy and probably not even desirable. So I did not implement it and only functions that are never referenced at all will be skipped. It's still an improvement and it's the minimum needed for #8485.~ Edit: the mechanism has been changed and now functions that are called directly are detected and not included in the internal dispatch.

~The PR is not finished yet. Stuff that's missing:~
- [x] ~Docstrings for all new functions~
- [x] ~`semanticTests/viaYul/array_function_pointers` fails. Turns out that internal dispatch should be generated even if it's empty because calling an empty function pointer is a runtime error, not a compile-time one.~
- [x] ~I did not check the case of function pointers being initialized in constructor (as pointed out in the issue), but I suspect it's already handled.~

Status: **working on requested changes**
- [x] Get rid of excessive docs and reword in some places.
- [x] Minor changes to helpers and `internalDispatch()` in `IRGenerationContext`.
- [x] Generate dispatch functions even if they're not called - to simplify implementation.
- [x] Use `visit(FunctionCall)` to avoid having to add and remove candidates for dispatch.
- [x] ~Put dispatch generation in a separate class if it's still too complex after changes above.~