### PR TITLE
Fix wrong demo code on `docs/types/mapping-types`.

### DIFF
--- a/docs/types/mapping-types.rst
+++ b/docs/types/mapping-types.rst
@@ -138,8 +138,8 @@ the ``sum`` function iterates over to sum all the values.
             if (keyIndex > 0)
                 return true;
             else {
-                self.keys.push();
                 keyIndex = self.keys.length;
+                self.keys.push();
                 self.data[key].keyIndex = keyIndex + 1;
                 self.keys[keyIndex].key = key;
                 self.size++;


### PR DESCRIPTION
In old docs, these codes(as shown below) will make a runtime error.
https://github.com/ethereum/solidity/blob/602b29cba782bae83769c1723e2b9cae2221d05d/docs/types/mapping-types.rst#L141-L144
Because the `keyIndex` will always **out of bounds**.

To fix the change, we just put the `.push()` after we get `keyIndex`, so the access of this index won't beyond the boundary.