### PR TITLE
Fix accessing memory reference types in yul codegen and clean up on memory reads.

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -204,7 +204,7 @@ public:
 	std::string readFromStorage(Type const& _type, size_t _offset, bool _splitFunctionTypes);
 	std::string readFromStorageDynamic(Type const& _type, bool _splitFunctionTypes);
 
-	/// @returns a function that reads a value type from memory.
+	/// @returns a function that reads a value type from memory. Performs cleanup.
 	/// signature: (addr) -> value
 	std::string readFromMemory(Type const& _type);
 	/// @returns a function that reads a value type from calldata.

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -117,10 +117,12 @@ struct CopyTranslate: public yul::ASTCopier
 			reference.isOffset == false && reference.isSlot == false,
 			"Should not be called for offset/slot"
 		);
+		auto const& var = m_context.localVariable(*varDecl);
+		solAssert(var.type().sizeOnStack() == 1, "");
 
 		return yul::Identifier{
 			_identifier.location,
-			yul::YulString{m_context.localVariable(*varDecl).name()}
+			yul::YulString{var.commaSeparatedList()}
 		};
 	}
 
@@ -2060,13 +2062,7 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 					")\n";
 		},
 		[&](IRLValue::Memory const& _memory) {
-			if (_memory.byteArrayElement)
-				define(result) <<
-					m_utils.cleanupFunction(_lvalue.type) <<
-					"(mload(" <<
-					_memory.address <<
-					"))\n";
-			else if (_lvalue.type.isValueType())
+			if (_lvalue.type.isValueType())
 				define(result) <<
 					m_utils.readFromMemory(_lvalue.type) <<
 					"(" <<

--- a/test/libsolidity/semanticTests/viaYul/dirty_memory_read.sol
+++ b/test/libsolidity/semanticTests/viaYul/dirty_memory_read.sol
@@ -1,0 +1,15 @@
+contract C {
+	function f() public pure returns (uint8 x, bool a, bool b) {
+		uint8[1] memory m;
+		assembly {
+			mstore(m, 257)
+		}
+		x = m[0];
+		a = (m[0] == 0x01);
+		b = (m[0] == 0x0101);
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 1, true, false


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8795
~~Depends on https://github.com/ethereum/solidity/pull/8845~~ 
