### PR TITLE
Fix duplicate tag assert throw

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Compiler Features:
 Bugfixes:
  * ABI: Skip ``private`` or ``internal`` constructors.
  * Type Checker: Disallow accessing ``runtimeCode`` for contract types that contain immutable state variables.
+ * Fixed an "Assembly Exception in Bytecode" error where requested functions were generated twice.
 
 
 

--- a/libsolidity/codegen/Compiler.cpp
+++ b/libsolidity/codegen/Compiler.cpp
@@ -49,6 +49,9 @@ void Compiler::compileContract(
 	m_runtimeSub = creationCompiler.compileConstructor(_contract, _otherCompilers);
 
 	m_context.optimise(m_optimiserSettings);
+
+	solAssert(m_context.requestedYulFunctionsRan(), "requestedYulFunctions() was not called.");
+	solAssert(m_runtimeContext.requestedYulFunctionsRan(), "requestedYulFunctions() was not called.");
 }
 
 std::shared_ptr<evmasm::Assembly> Compiler::runtimeAssemblyPtr() const

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -192,6 +192,9 @@ void CompilerContext::appendMissingLowLevelFunctions()
 
 pair<string, set<string>> CompilerContext::requestedYulFunctions()
 {
+	solAssert(!m_requestedYulFunctionsRan, "requestedYulFunctions called more than once.");
+	m_requestedYulFunctionsRan = true;
+
 	set<string> empty;
 	swap(empty, m_externallyUsedYulFunctions);
 	return {m_yulFunctionCollector.requestedFunctions(), std::move(empty)};

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -167,6 +167,7 @@ public:
 	/// Clears the internal list, i.e. calling it again will result in an
 	/// empty return value.
 	std::pair<std::string, std::set<std::string>> requestedYulFunctions();
+	bool requestedYulFunctionsRan() const { return m_requestedYulFunctionsRan; }
 
 	/// Returns the distance of the given local variable from the bottom of the stack (of the current function).
 	unsigned baseStackOffsetOfVariable(Declaration const& _declaration) const;
@@ -389,6 +390,8 @@ private:
 	YulUtilFunctions m_yulUtilFunctions;
 	/// The queue of low-level functions to generate.
 	std::queue<std::tuple<std::string, unsigned, unsigned, std::function<void(CompilerContext&)>>> m_lowLevelFunctionGenerationQueue;
+	/// Flag to check that requestedYulFunctions() was called exactly once
+	bool m_requestedYulFunctionsRan = false;
 };
 
 }

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -103,8 +103,6 @@ void ContractCompiler::compileContract(
 	// and adds the function to the compilation queue. Additionally internal functions,
 	// which are referenced directly or indirectly will be added.
 	appendFunctionSelector(_contract);
-	// This processes the above populated queue until it is empty.
-	appendMissingFunctions();
 }
 
 size_t ContractCompiler::compileConstructor(
@@ -214,6 +212,9 @@ size_t ContractCompiler::deployLibrary(ContractDefinition const& _contract)
 {
 	solAssert(!!m_runtimeCompiler, "");
 	solAssert(_contract.isLibrary(), "Tried to deploy contract as library.");
+
+	appendMissingFunctions();
+	m_runtimeCompiler->appendMissingFunctions();
 
 	CompilerContext::LocationSetter locationSetter(m_context, _contract);
 

--- a/test/libsolidity/syntaxTests/missing_functions_duplicate_bug.sol
+++ b/test/libsolidity/syntaxTests/missing_functions_duplicate_bug.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.6.0;
+
+pragma experimental ABIEncoderV2;
+
+contract Ownable {
+    address private _owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Ownable: caller is not the owner");
+        _;
+    }
+
+    function renounceOwnership() public onlyOwner { }
+}
+
+library VoteTiming {
+    function init(uint phaseLength) internal pure {
+        require(true, "");
+    }
+}
+
+contract Voting is Ownable {
+    constructor() public {
+        VoteTiming.init(1);
+    }
+}
+// ----
+// Warning: (324-340): Unused function parameter. Remove or comment out the variable name to silence this warning.


### PR DESCRIPTION
fixes #8656

This is only a WIP. Currently missing is a check that the function is run exactly once and fixing/analysing the new test failures caused by this change