### PR TITLE
Fix error reporting source code format

### DIFF
--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -220,7 +220,9 @@ void ContractLevelChecker::checkAbstractDefinitions(ContractDefinition const& _c
 		for (auto declaration: _contract.annotation().unimplementedDeclarations)
 			ssl.append("Missing implementation: ", declaration->location());
 		m_errorReporter.typeError(
-			3656_error,_contract.location(), ssl,
+			3656_error,
+			_contract.location(),
+			ssl,
 			"Contract \"" + _contract.annotation().canonicalName
 			+ "\" should be marked as abstract.");
 

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -291,7 +291,8 @@ bool SyntaxChecker::visit(ContractDefinition const& _contract)
 	for (FunctionDefinition const* function: _contract.definedFunctions())
 		if (function->name() == contractName)
 			m_errorReporter.syntaxError(
-				5796_error,function->location(),
+				5796_error,
+				function->location(),
 				"Functions are not allowed to have the same name as the contract. "
 				"If you intend this to be a constructor, use \"constructor(...) { ... }\" to define it."
 			);

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -493,7 +493,8 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 					unsupportedTypes.emplace_back(param->toString());
 			if (!unsupportedTypes.empty())
 				m_errorReporter.typeError(
-					2763_error,_variable.location(),
+					2763_error,
+					_variable.location(),
 					"The following types are only supported for getters in ABIEncoderV2: " +
 					joinHumanReadable(unsupportedTypes) +
 					". Either remove \"public\" or use \"pragma experimental ABIEncoderV2;\" to enable the feature."
@@ -3125,8 +3126,7 @@ void TypeChecker::requireLValue(Expression const& _expression, bool _ordinaryAss
 	if (_expression.annotation().isLValue)
 		return;
 
-	return m_errorReporter.typeError(
-		1123_error,_expression.location(), [&]() {
+	return m_errorReporter.typeError(1123_error, _expression.location(), [&]() {
 		if (_expression.annotation().isConstant)
 			return "Cannot assign to a constant variable.";
 


### PR DESCRIPTION
Due to unexpected style like
```
func(param0,
   param1
);
```
automatically added error tags caused minor misformatting.