### PR TITLE
Selecting Yul optimisation steps in strict assembly mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 
 Compiler Features:
+ * Commandline Interface: Don't ignore `--yul-optimizations` in assembly mode.
 
 
 

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1041,13 +1041,13 @@ Optimization step sequence
 --------------------------
 
 By default the Yul optimizer applies its predefined sequence of optimization steps to the generated assembly.
-You can override this sequence and supply your own using the `--yul-optimizations` option:
+You can override this sequence and supply your own using the ``--yul-optimizations`` option:
 
 .. code-block:: sh
 
     solc --optimize --ir-optimized --yul-optimizations 'dhfoD[xarrscLMcCTU]uljmul'
 
-By enclosing part of the sequence in square brackets (`[]`) you tell the optimizer to repeatedly
+By enclosing part of the sequence in square brackets (``[]``) you tell the optimizer to repeatedly
 apply that part until it no longer improves the size of the resulting assembly.
 You can use brackets multiple times in a single sequence but they cannot be nested.
 
@@ -1056,37 +1056,37 @@ The following optimization steps are available:
 ============ ===============================
 Abbreviation Full name
 ============ ===============================
-f            `BlockFlattener`
-l            `CircularReferencesPruner`
-c            `CommonSubexpressionEliminator`
-C            `ConditionalSimplifier`
-U            `ConditionalUnsimplifier`
-n            `ControlFlowSimplifier`
-D            `DeadCodeEliminator`
-v            `EquivalentFunctionCombiner`
-e            `ExpressionInliner`
-j            `ExpressionJoiner`
-s            `ExpressionSimplifier`
-x            `ExpressionSplitter`
-I            `ForLoopConditionIntoBody`
-O            `ForLoopConditionOutOfBody`
-o            `ForLoopInitRewriter`
-i            `FullInliner`
-g            `FunctionGrouper`
-h            `FunctionHoister`
-T            `LiteralRematerialiser`
-L            `LoadResolver`
-M            `LoopInvariantCodeMotion`
-r            `RedundantAssignEliminator`
-m            `Rematerialiser`
-V            `SSAReverser`
-a            `SSATransform`
-t            `StructuralSimplifier`
-u            `UnusedPruner`
-d            `VarDeclInitializer`
+``f``        ``BlockFlattener``
+``l``        ``CircularReferencesPruner``
+``c``        ``CommonSubexpressionEliminator``
+``C``        ``ConditionalSimplifier``
+``U``        ``ConditionalUnsimplifier``
+``n``        ``ControlFlowSimplifier``
+``D``        ``DeadCodeEliminator``
+``v``        ``EquivalentFunctionCombiner``
+``e``        ``ExpressionInliner``
+``j``        ``ExpressionJoiner``
+``s``        ``ExpressionSimplifier``
+``x``        ``ExpressionSplitter``
+``I``        ``ForLoopConditionIntoBody``
+``O``        ``ForLoopConditionOutOfBody``
+``o``        ``ForLoopInitRewriter``
+``i``        ``FullInliner``
+``g``        ``FunctionGrouper``
+``h``        ``FunctionHoister``
+``T``        ``LiteralRematerialiser``
+``L``        ``LoadResolver``
+``M``        ``LoopInvariantCodeMotion``
+``r``        ``RedundantAssignEliminator``
+``m``        ``Rematerialiser``
+``V``        ``SSAReverser``
+``a``        ``SSATransform``
+``t``        ``StructuralSimplifier``
+``u``        ``UnusedPruner``
+``d``        ``VarDeclInitializer``
 ============ ===============================
 
-Some steps depend on properties ensured by `BlockFlattener`, `FunctionGrouper`, `ForLoopInitRewriter`.
+Some steps depend on properties ensured by ``BlockFlattener``, ``FunctionGrouper``, ``ForLoopInitRewriter``.
 For this reason the Yul optimizer always applies them before applying any steps supplied by the user.
 
 

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1041,8 +1041,7 @@ Optimization step sequence
 --------------------------
 
 By default the Yul optimizer applies its predefined sequence of optimization steps to the generated assembly.
-You can override this sequence and supply your own using the `--yul-optimizations` option when compiling
-in Solidity mode:
+You can override this sequence and supply your own using the `--yul-optimizations` option:
 
 .. code-block:: sh
 

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1047,6 +1047,9 @@ You can override this sequence and supply your own using the ``--yul-optimizatio
 
     solc --optimize --ir-optimized --yul-optimizations 'dhfoD[xarrscLMcCTU]uljmul'
 
+The order of steps is significant and affects the quality of the output.
+Moreover, applying a step may uncover new optimization opportunities for others that were already
+applied so repeating steps is often beneficial.
 By enclosing part of the sequence in square brackets (``[]``) you tell the optimizer to repeatedly
 apply that part until it no longer improves the size of the resulting assembly.
 You can use brackets multiple times in a single sequence but they cannot be nested.

--- a/libyul/optimiser/README.md
+++ b/libyul/optimiser/README.md
@@ -4,6 +4,7 @@ planned state of the optimiser.
 
 Table of Contents:
 
+- [Selecting optimisations](#selecting-optimisations)
 - [Preprocessing](#preprocessing)
 - [Pseudo-SSA Transformation](#pseudo-ssa-transformation)
 - [Tools](#tools)
@@ -32,6 +33,17 @@ the following transformation steps are the main components:
  - [Expression Simplifier](#expression-simplifier)
  - [Redundant Assign Eliminator](#redundant-assign-eliminator)
  - [Full Function Inliner](#full-function-inliner)
+
+## Selecting optimisations
+
+By default the optimiser applies its predefined sequence of optimisation steps to the generated assembly.
+You can override this sequence and supply your own using the `--yul-optimizations` option:
+
+``` bash
+solc --optimize --ir-optimized --yul-optimizations 'dhfoD[xarrscLMcCTU]uljmul'
+```
+
+There's a [table listing available abbreviations in the optimiser docs](/docs/yul.rst#optimization-step-sequence).
 
 ## Preprocessing
 

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -56,7 +56,12 @@ private:
 	/// @returns the full object with library placeholder hints in hex.
 	static std::string objectWithLinkRefsHex(evmasm::LinkerObject const& _obj);
 
-	bool assemble(yul::AssemblyStack::Language _language, yul::AssemblyStack::Machine _targetMachine, bool _optimize);
+	bool assemble(
+		yul::AssemblyStack::Language _language,
+		yul::AssemblyStack::Machine _targetMachine,
+		bool _optimize,
+		std::optional<std::string> _yulOptimiserSteps = std::nullopt
+	);
 
 	void outputCompilationResults();
 

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -245,7 +245,18 @@ printTask "Running general commandline tests..."
             stdoutExpectationFile="${tdir}/output.json"
             args="--standard-json "$(cat ${tdir}/args 2>/dev/null || true)
         else
-            inputFile="${tdir}input.sol"
+            if [[ -e "${tdir}input.yul" && -e "${tdir}input.sol" ]]
+            then
+                printError "Ambiguous input. Found both input.sol and input.yul."
+                exit 1
+            fi
+
+            if [ -e "${tdir}input.yul" ]
+            then
+                inputFile="${tdir}input.yul"
+            else
+                inputFile="${tdir}input.sol"
+            fi
             stdin=""
             stdout="$(cat ${tdir}/output 2>/dev/null || true)"
             stdoutExpectationFile="${tdir}/output"

--- a/test/cmdlineTests/standard_yul_optimiserSteps/input.json
+++ b/test/cmdlineTests/standard_yul_optimiserSteps/input.json
@@ -1,0 +1,26 @@
+{
+	"language": "Yul",
+	"sources":
+	{
+		"A":
+		{
+			"content": "{ let x := mload(0) sstore(add(x, 0), 0) }"
+		}
+	},
+	"settings":
+	{
+		"optimizer": {
+			"enabled": true,
+			"details": {
+				"yul": true,
+				"yulDetails": {
+					"optimizerSteps": "dhfoDgvulfnTUtnIf"
+				}
+			}
+		},
+		"outputSelection":
+		{
+			"*": { "*": ["*"], "": [ "*" ] }
+		}
+	}
+}

--- a/test/cmdlineTests/standard_yul_optimiserSteps/output.json
+++ b/test/cmdlineTests/standard_yul_optimiserSteps/output.json
@@ -1,0 +1,30 @@
+{"contracts":{"A":{"object":{"evm":{"assembly":"    /* \"A\":17:18   */
+  0x00
+    /* \"A\":11:19   */
+  mload
+    /* \"A\":38:39   */
+  0x00
+    /* \"A\":34:35   */
+  0x00
+    /* \"A\":31:32   */
+  dup3
+    /* \"A\":27:36   */
+  add
+    /* \"A\":20:40   */
+  sstore
+  pop
+","bytecode":{"linkReferences":{},"object":"bytecode removed","opcodes":"opcodes removed","sourceMap":"sourceMap removed"}},"ir":"object \"object\" {
+    code {
+        let x := mload(0)
+        sstore(add(x, 0), 0)
+    }
+}
+","irOptimized":"object \"object\" {
+    code {
+        {
+            let x := mload(0)
+            sstore(add(x, 0), 0)
+        }
+    }
+}
+"}}},"errors":[{"component":"general","formattedMessage":"Yul is still experimental. Please use the output with care.","message":"Yul is still experimental. Please use the output with care.","severity":"warning","type":"Warning"}]}

--- a/test/cmdlineTests/strict_asm_optimizer_steps/args
+++ b/test/cmdlineTests/strict_asm_optimizer_steps/args
@@ -1,0 +1,1 @@
+--strict-assembly --optimize --yul-optimizations dhfoDgvulfnTUtnIf

--- a/test/cmdlineTests/strict_asm_optimizer_steps/err
+++ b/test/cmdlineTests/strict_asm_optimizer_steps/err
@@ -1,0 +1,1 @@
+Warning: Yul is still experimental. Please use the output with care.

--- a/test/cmdlineTests/strict_asm_optimizer_steps/input.yul
+++ b/test/cmdlineTests/strict_asm_optimizer_steps/input.yul
@@ -1,0 +1,27 @@
+object "C_6" {
+    code {
+        mstore(64, 128)
+        if callvalue() { revert(0, 0) }
+        codecopy(0, dataoffset("C_6_deployed"), datasize("C_6_deployed"))
+        return(0, datasize("C_6_deployed"))
+    }
+    object "C_6_deployed" {
+        code {
+            {
+                mstore(64, 128)
+                if iszero(lt(calldatasize(), 4))
+                {
+                    let selector := shift_right_224_unsigned(calldataload(0))
+                    pop(selector)
+                }
+                pop(iszero(calldatasize()))
+                revert(0, 0)
+            }
+
+            function shift_right_224_unsigned(value) -> newValue
+            {
+                newValue := shr(224, value)
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/strict_asm_optimizer_steps/output
+++ b/test/cmdlineTests/strict_asm_optimizer_steps/output
@@ -1,0 +1,88 @@
+
+======= strict_asm_optimizer_steps/input.yul (EVM) =======
+
+Pretty printed source:
+object "C_6" {
+    code {
+        {
+            mstore(64, 128)
+            if callvalue() { revert(0, 0) }
+            codecopy(0, dataoffset("C_6_deployed"), datasize("C_6_deployed"))
+            return(0, datasize("C_6_deployed"))
+        }
+    }
+    object "C_6_deployed" {
+        code {
+            {
+                mstore(64, 128)
+                pop(iszero(lt(calldatasize(), 4)))
+                revert(0, 0)
+            }
+        }
+    }
+}
+
+
+Binary representation:
+60806040523415600f5760006000fd5b6010601d60003960106000f3fe608060405260043610155060006000fd
+
+Text representation:
+    /* "strict_asm_optimizer_steps/input.yul":45:48   */
+  0x80
+    /* "strict_asm_optimizer_steps/input.yul":41:43   */
+  0x40
+    /* "strict_asm_optimizer_steps/input.yul":34:49   */
+  mstore
+    /* "strict_asm_optimizer_steps/input.yul":61:72   */
+  callvalue
+    /* "strict_asm_optimizer_steps/input.yul":58:60   */
+  iszero
+  tag_1
+  jumpi
+    /* "strict_asm_optimizer_steps/input.yul":85:86   */
+  0x00
+    /* "strict_asm_optimizer_steps/input.yul":82:83   */
+  0x00
+    /* "strict_asm_optimizer_steps/input.yul":75:87   */
+  revert
+    /* "strict_asm_optimizer_steps/input.yul":58:60   */
+tag_1:
+    /* "strict_asm_optimizer_steps/input.yul":98:163   */
+  dataSize(sub_0)
+  dataOffset(sub_0)
+    /* "strict_asm_optimizer_steps/input.yul":107:108   */
+  0x00
+    /* "strict_asm_optimizer_steps/input.yul":98:163   */
+  codecopy
+    /* "strict_asm_optimizer_steps/input.yul":172:207   */
+  dataSize(sub_0)
+    /* "strict_asm_optimizer_steps/input.yul":179:180   */
+  0x00
+    /* "strict_asm_optimizer_steps/input.yul":172:207   */
+  return
+stop
+
+sub_0: assembly {
+        /* "strict_asm_optimizer_steps/input.yul":298:301   */
+      0x80
+        /* "strict_asm_optimizer_steps/input.yul":294:296   */
+      0x40
+        /* "strict_asm_optimizer_steps/input.yul":287:302   */
+      mstore
+        /* "strict_asm_optimizer_steps/input.yul":348:349   */
+      0x04
+        /* "strict_asm_optimizer_steps/input.yul":332:346   */
+      calldatasize
+        /* "strict_asm_optimizer_steps/input.yul":329:350   */
+      lt
+        /* "strict_asm_optimizer_steps/input.yul":322:351   */
+      iszero
+        /* "strict_asm_optimizer_steps/input.yul":319:321   */
+      pop
+        /* "strict_asm_optimizer_steps/input.yul":570:571   */
+      0x00
+        /* "strict_asm_optimizer_steps/input.yul":567:568   */
+      0x00
+        /* "strict_asm_optimizer_steps/input.yul":560:572   */
+      revert
+}

--- a/tools/yulPhaser/README.md
+++ b/tools/yulPhaser/README.md
@@ -66,14 +66,11 @@ tools/yul-phaser *.yul                    \
 `yul-phaser` can process the intermediate representation produced by `solc`:
 
 ``` bash
-solc/solc <sol file>  \
-    --ir              \
-    --no-optimize-yul \
-    --output-dir <output directory>
+solc/solc <sol file> --ir --output-dir <output directory>
 ```
 
 After running this command you'll find one or more .yul files in the output directory.
-These files contain whole Yul objects rather than just raw Yul programs but `yul-phaser` is prepared to handle them.
+These files contain whole Yul objects rather than just raw Yul programs but `yul-phaser` is prepared to handle them too.
 
 ### How to choose good parameters
 Choosing good parameters for a genetic algorithm is not a trivial task but phaser's defaults are generally enough to find a sequence that gives results comparable or better than one hand-crafted by an experienced developer for a given set of programs.

--- a/tools/yulPhaser/README.md
+++ b/tools/yulPhaser/README.md
@@ -9,7 +9,7 @@ The input is a set of one or more [Yul](/docs/yul.rst) programs and each sequenc
 Optimised programs are given numeric scores according to the selected metric.
 
 Optimisation step sequences are presented in an abbreviated form - as strings of letters where each character represents one step.
-The abbreviations are defined in [`OptimiserSuite::stepNameToAbbreviationMap()`](/libyul/optimiser/Suite.cpp#L388-L423).
+There's a [table listing available abbreviations in the optimiser docs](/docs/yul.rst#optimization-step-sequence).
 
 ### How to use it
 The application has sensible defaults for most parameters.
@@ -71,6 +71,13 @@ solc/solc <sol file> --ir --output-dir <output directory>
 
 After running this command you'll find one or more .yul files in the output directory.
 These files contain whole Yul objects rather than just raw Yul programs but `yul-phaser` is prepared to handle them too.
+
+#### Using optimisation step sequences with the compiler
+You can tell Yul optimiser to use a specific sequence for your code by passing `--yul-optimizations` option to `solc`:
+
+``` bash
+solc/solc <sol file> --optimize --ir-optimized --yul-optimizations <sequence>
+```
 
 ### How to choose good parameters
 Choosing good parameters for a genetic algorithm is not a trivial task but phaser's defaults are generally enough to find a sequence that gives results comparable or better than one hand-crafted by an experienced developer for a given set of programs.


### PR DESCRIPTION
This is a mixed bag of small changes related to `--yul-optimizations` option:
1) Makes `--yul-optimizations` option work with `--strict-assembly`
2) Adds more info about the option to docs and READMEs
    - I was supposed to link to the table with step abbreviations from "Using the compiler" page but I don't really see a good way to include it. IR generation is an experimental feature and Yul optimiser is not even mentioned there so telling the user that he can choose optimisation steps for it seems a bit off-topic.
3) Refactors `CommandLineInterface` to consistently use constants instead of hard-coded option names
4) Modifies `cmdlineTests.sh` to allow using `input.yul` instead of `input.sol`.

3 and 4 could really be separate PRs but they're very small and the other stuff depends on them so I decided to include them all together.