### PR TITLE
Remove boost::filesystem where it is not needed

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -166,7 +166,7 @@ if (NOT (${Z3_FOUND} OR ${CVC4_FOUND}))
 endif()
 
 add_library(solidity ${sources} ${z3_SRCS} ${cvc4_SRCS})
-target_link_libraries(solidity PUBLIC yul evmasm langutil solutil Boost::boost Boost::filesystem Boost::system)
+target_link_libraries(solidity PUBLIC yul evmasm langutil solutil Boost::boost Boost::system)
 
 if (${Z3_FOUND})
   target_link_libraries(solidity PUBLIC z3::libz3)

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -166,7 +166,7 @@ if (NOT (${Z3_FOUND} OR ${CVC4_FOUND}))
 endif()
 
 add_library(solidity ${sources} ${z3_SRCS} ${cvc4_SRCS})
-target_link_libraries(solidity PUBLIC yul evmasm langutil solutil Boost::boost Boost::system)
+target_link_libraries(solidity PUBLIC yul evmasm langutil solutil Boost::boost)
 
 if (${Z3_FOUND})
   target_link_libraries(solidity PUBLIC z3::libz3)

--- a/libsolidity/formal/CHCSmtLib2Interface.cpp
+++ b/libsolidity/formal/CHCSmtLib2Interface.cpp
@@ -21,7 +21,6 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <array>
 #include <fstream>

--- a/libsolidity/formal/SMTLib2Interface.cpp
+++ b/libsolidity/formal/SMTLib2Interface.cpp
@@ -21,7 +21,6 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #include <array>
 #include <fstream>

--- a/libsolutil/CommonIO.h
+++ b/libsolutil/CommonIO.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <libsolutil/Common.h>
-#include <boost/filesystem.hpp>
 #include <sstream>
 #include <string>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -187,7 +187,7 @@ add_executable(soltest ${sources}
     ${libsolidity_util_sources}
     ${yul_phaser_sources}
 )
-target_link_libraries(soltest PRIVATE libsolc yul solidity yulInterpreter evmasm solutil Boost::boost Boost::program_options Boost::unit_test_framework evmc)
+target_link_libraries(soltest PRIVATE libsolc yul solidity yulInterpreter evmasm solutil Boost::boost Boost::filesystem Boost::program_options Boost::unit_test_framework evmc)
 
 
 # Special compilation flag for Visual Studio (version 2019 at least affected)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,6 +42,6 @@ add_executable(yul-phaser
 	yulPhaser/SimulationRNG.h
 	yulPhaser/SimulationRNG.cpp
 )
-target_link_libraries(yul-phaser PRIVATE solidity Boost::program_options)
+target_link_libraries(yul-phaser PRIVATE solidity Boost::filesystem Boost::program_options)
 
 install(TARGETS yul-phaser DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
A two uses in CommonIO remain for the compiler (plus testing/tools use it extensively)

Part of #7259.