### PR TITLE
Replace boost:variant with std::variant in StandardCompiler

### DIFF
--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -24,9 +24,9 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 
-#include <boost/variant.hpp>
 #include <optional>
 #include <utility>
+#include <variant>
 
 namespace solidity::frontend
 {
@@ -73,7 +73,7 @@ private:
 
 	/// Parses the input json (and potentially invokes the read callback) and either returns
 	/// it in condensed form or an error as a json object.
-	boost::variant<InputsAndSettings, Json::Value> parseInput(Json::Value const& _input);
+	std::variant<InputsAndSettings, Json::Value> parseInput(Json::Value const& _input);
 
 	Json::Value compileSolidity(InputsAndSettings _inputsAndSettings);
 	Json::Value compileYul(InputsAndSettings _inputsAndSettings);


### PR DESCRIPTION
This was missed earlier, like in #7751.

Part of #7259.