### PR TITLE
Add error IDs to OverrideChecker, BMC and ContractLevelChecker

### DIFF
--- a/libsolidity/analysis/ContractLevelChecker.h
+++ b/libsolidity/analysis/ContractLevelChecker.h
@@ -60,7 +60,7 @@ private:
 	void checkDuplicateFunctions(ContractDefinition const& _contract);
 	void checkDuplicateEvents(ContractDefinition const& _contract);
 	template <class T>
-	void findDuplicateDefinitions(std::map<std::string, std::vector<T>> const& _definitions, std::string _message);
+	void findDuplicateDefinitions(std::map<std::string, std::vector<T>> const& _definitions);
 	/// Checks for unimplemented functions and modifiers.
 	void checkAbstractDefinitions(ContractDefinition const& _contract);
 	/// Checks that the base constructor arguments are properly provided.

--- a/libsolidity/analysis/OverrideChecker.cpp
+++ b/libsolidity/analysis/OverrideChecker.cpp
@@ -506,12 +506,13 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 		);
 
 	if (!_overriding.overrides())
-		overrideError(_overriding, _super, "Overriding " + _overriding.astNodeName() + " is missing \"override\" specifier.");
+		overrideError(_overriding, _super, 9456_error, "Overriding " + _overriding.astNodeName() + " is missing \"override\" specifier.");
 
 	if (_super.isVariable())
 		overrideError(
 			_super,
 			_overriding,
+			1452_error,
 			"Cannot override public state variable.",
 			"Overriding " + _overriding.astNodeName() + " is here:"
 		);
@@ -519,6 +520,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 		overrideError(
 			_super,
 			_overriding,
+			4334_error,
 			"Trying to override non-virtual " + _super.astNodeName() + ". Did you forget to add \"virtual\"?",
 			"Overriding " + _overriding.astNodeName() + " is here:"
 		);
@@ -526,7 +528,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 	if (_overriding.isVariable())
 	{
 		if (_super.visibility() != Visibility::External)
-			overrideError(_overriding, _super, "Public state variables can only override functions with external visibility.");
+			overrideError(_overriding, _super, 5225_error, "Public state variables can only override functions with external visibility.");
 		solAssert(_overriding.visibility() == Visibility::External, "");
 	}
 	else if (_overriding.visibility() != _super.visibility())
@@ -537,7 +539,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 			_super.visibility() == Visibility::External &&
 			_overriding.visibility() == Visibility::Public
 		))
-			overrideError(_overriding, _super, "Overriding " + _overriding.astNodeName() + " visibility differs.");
+			overrideError(_overriding, _super, 9098_error, "Overriding " + _overriding.astNodeName() + " visibility differs.");
 	}
 
 	if (_super.isFunction())
@@ -548,7 +550,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 		solAssert(functionType->hasEqualParameterTypes(*superType), "Override doesn't have equal parameters!");
 
 		if (!functionType->hasEqualReturnTypes(*superType))
-			overrideError(_overriding, _super, "Overriding " + _overriding.astNodeName() + " return types differ.");
+			overrideError(_overriding, _super, 4822_error, "Overriding " + _overriding.astNodeName() + " return types differ.");
 
 		// This is only relevant for a function overriding a function.
 		if (_overriding.isFunction())
@@ -557,6 +559,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 				overrideError(
 					_overriding,
 					_super,
+					2837_error,
 					"Overriding function changes state mutability from \"" +
 					stateMutabilityToString(_super.stateMutability()) +
 					"\" to \"" +
@@ -568,6 +571,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 				overrideError(
 					_overriding,
 					_super,
+					4593_error,
 					"Overriding an implemented function with an unimplemented function is not allowed."
 				);
 		}
@@ -577,6 +581,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 void OverrideChecker::overrideListError(
 	OverrideProxy const& _item,
 	set<ContractDefinition const*, CompareByID> _secondary,
+	ErrorId _error,
 	string const& _message1,
 	string const& _message2
 )
@@ -594,7 +599,7 @@ void OverrideChecker::overrideListError(
 		contractSingularPlural = "contracts ";
 
 	m_errorReporter.typeError(
-		5883_error,
+		_error,
 		_item.overrides() ? _item.overrides()->location() : _item.location(),
 		ssl,
 		_message1 +
@@ -605,10 +610,10 @@ void OverrideChecker::overrideListError(
 	);
 }
 
-void OverrideChecker::overrideError(Declaration const& _overriding, Declaration const& _super, string const& _message, string const& _secondaryMsg)
+void OverrideChecker::overrideError(Declaration const& _overriding, Declaration const& _super, ErrorId _error, string const& _message, string const& _secondaryMsg)
 {
 	m_errorReporter.typeError(
-		9456_error,
+		_error,
 		_overriding.location(),
 		SecondarySourceLocation().append(_secondaryMsg, _super.location()),
 		_message
@@ -616,10 +621,10 @@ void OverrideChecker::overrideError(Declaration const& _overriding, Declaration 
 }
 
 
-void OverrideChecker::overrideError(OverrideProxy const& _overriding, OverrideProxy const& _super, string const& _message, string const& _secondaryMsg)
+void OverrideChecker::overrideError(OverrideProxy const& _overriding, OverrideProxy const& _super, ErrorId _error, string const& _message, string const& _secondaryMsg)
 {
 	m_errorReporter.typeError(
-		1452_error,
+		_error,
 		_overriding.location(),
 		SecondarySourceLocation().append(_secondaryMsg, _super.location()),
 		_message
@@ -773,11 +778,11 @@ void OverrideChecker::checkOverrideList(OverrideProxy _item, OverrideProxyBySign
 					4520_error,
 					list[i]->location(),
 					ssl,
-						"Duplicate contract \"" +
-						joinHumanReadable(list[i]->namePath(), ".") +
-						"\" found in override list of \"" +
-						_item.name() +
-						"\"."
+					"Duplicate contract \"" +
+					joinHumanReadable(list[i]->namePath(), ".") +
+					"\" found in override list of \"" +
+					_item.name() +
+					"\"."
 				);
 			}
 		}
@@ -810,6 +815,7 @@ void OverrideChecker::checkOverrideList(OverrideProxy _item, OverrideProxyBySign
 		overrideListError(
 			_item,
 			missingContracts,
+			4327_error,
 			_item.astNodeNameCapitalized() + " needs to specify overridden ",
 			""
 		);
@@ -819,6 +825,7 @@ void OverrideChecker::checkOverrideList(OverrideProxy _item, OverrideProxyBySign
 		overrideListError(
 			_item,
 			surplusContracts,
+			2353_error,
 			"Invalid ",
 			"specified in override list: "
 		);

--- a/libsolidity/analysis/OverrideChecker.h
+++ b/libsolidity/analysis/OverrideChecker.h
@@ -32,6 +32,7 @@
 namespace solidity::langutil
 {
 class ErrorReporter;
+struct ErrorId;
 struct SourceLocation;
 }
 
@@ -160,18 +161,21 @@ private:
 	void overrideListError(
 		OverrideProxy const& _item,
 		std::set<ContractDefinition const*, CompareByID> _secondary,
+		langutil::ErrorId _error,
 		std::string const& _message1,
 		std::string const& _message2
 	);
 	void overrideError(
 		Declaration const& _overriding,
 		Declaration const& _super,
+		langutil::ErrorId _error,
 		std::string const& _message,
 		std::string const& _secondaryMsg = "Overridden function is here:"
 	);
 	void overrideError(
 		OverrideProxy const& _overriding,
 		OverrideProxy const& _super,
+		langutil::ErrorId _error,
 		std::string const& _message,
 		std::string const& _secondaryMsg = "Overridden function is here:"
 	);

--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -44,6 +44,7 @@ using solidity::util::h256;
 namespace solidity::langutil
 {
 class ErrorReporter;
+struct ErrorId;
 struct SourceLocation;
 }
 
@@ -144,22 +145,22 @@ private:
 	/// Check that a condition can be satisfied.
 	void checkCondition(
 		smt::Expression _condition,
-		std::vector<CallStackEntry> const& callStack,
+		std::vector<CallStackEntry> const& _callStack,
 		std::pair<std::vector<smt::Expression>, std::vector<std::string>> const& _modelExpressions,
 		langutil::SourceLocation const& _location,
+		langutil::ErrorId _errorHappens,
+		langutil::ErrorId _errorMightHappen,
 		std::string const& _description,
 		std::string const& _additionalValueName = "",
 		smt::Expression const* _additionalValue = nullptr
 	);
 	/// Checks that a boolean condition is not constant. Do not warn if the expression
 	/// is a literal constant.
-	/// @param _description the warning string, $VALUE will be replaced by the constant value.
 	void checkBooleanNotConstant(
 		Expression const& _condition,
 		smt::Expression const& _constraints,
 		smt::Expression const& _value,
-		std::vector<CallStackEntry> const& _callStack,
-		std::string const& _description
+		std::vector<CallStackEntry> const& _callStack
 	);
 	std::pair<smt::CheckResult, std::vector<std::string>>
 	checkSatisfiableAndGenerateModel(std::vector<smt::Expression> const& _expressionsToEvaluate);


### PR DESCRIPTION
This is a continuation of PR #8680, PR #8879 journey.
