### PR TITLE
Fix exponentiation bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Bugfixes:
  * Fixed an "Assembly Exception in Bytecode" error where requested functions were generated twice.
  * Natspec: Fixed a bug that ignored ``@return`` tag when no other developer-documentation tags were present.
  * Yul assembler: Fix source location of variable declarations without value.
+ * Type checker: Checks if a literal exponent in the ``**`` operation is too large or fractional.
 
 
 ### 0.6.7 (2020-05-04)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -613,6 +613,13 @@ TypeResult IntegerType::binaryOperatorResult(Token _operator, Type const* _other
 		}
 		else if (dynamic_cast<FixedPointType const*>(_other))
 			return nullptr;
+		else if (auto rationalNumberType = dynamic_cast<RationalNumberType const*>(_other))
+		{
+			if (rationalNumberType->isFractional())
+				return TypeResult::err("Exponent is fractional.");
+			if (!rationalNumberType->integerType())
+				return TypeResult::err("Exponent too large.");
+		}
 		return this;
 	}
 

--- a/test/libsolidity/syntaxTests/literalOperations/exponent.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/exponent.sol
@@ -1,0 +1,10 @@
+contract C {
+    function g() public pure {
+        int a;
+        a ** 1E1233;
+        a ** (1/2);
+    }
+}
+// ----
+// TypeError: (67-78): Operator ** not compatible with types int256 and int_const 1000...(1226 digits omitted)...0000. Exponent too large.
+// TypeError: (88-98): Operator ** not compatible with types int256 and rational_const 1 / 2. Exponent is fractional.

--- a/test/libsolidity/syntaxTests/literalOperations/exponent_fine.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/exponent_fine.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        uint a;
+        a = a ** 1E5;
+        a = 0 ** 1E1233;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/8297
Closes https://github.com/ethereum/solidity/issues/8929


Issues an error saying literal too large if the exponent in the `**` operation is too big for the result type.