### PR TITLE
Bug that ignored return tag when no other devdoc tags were present

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@ Bugfixes:
  * ABI: Skip ``private`` or ``internal`` constructors.
  * Type Checker: Disallow accessing ``runtimeCode`` for contract types that contain immutable state variables.
  * Fixed an "Assembly Exception in Bytecode" error where requested functions were generated twice.
-
+ * Natspec: Fixed a bug that ignored ``@return`` tag when no other developer-documentation tags were present.
 
 
 ### 0.6.7 (2020-05-04)

--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -99,16 +99,14 @@ Json::Value Natspec::devDocumentation(ContractDefinition const& _contractDef)
 		if (auto fun = dynamic_cast<FunctionDefinition const*>(&it.second->declaration()))
 		{
 			Json::Value method(devDocumentation(fun->annotation().docTags));
+			// add the function, only if we have any documentation to add
+			Json::Value jsonReturn = extractReturnParameterDocs(fun->annotation().docTags, *fun);
+
+			if (!jsonReturn.empty())
+				method["returns"] = jsonReturn;
+
 			if (!method.empty())
-			{
-				// add the function, only if we have any documentation to add
-				Json::Value jsonReturn = extractReturnParameterDocs(fun->annotation().docTags, *fun);
-
-				if (!jsonReturn.empty())
-					method["returns"] = jsonReturn;
-
 				methods[it.second->externalSignature()] = method;
-			}
 		}
 	}
 

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -355,6 +355,27 @@ BOOST_AUTO_TEST_CASE(dev_multiple_functions)
 	checkNatspec(sourceCode, "test", natspec, false);
 }
 
+BOOST_AUTO_TEST_CASE(dev_return_no_params)
+{
+	char const* sourceCode = R"(
+		contract test {
+			/// @return d The result of the multiplication
+			function mul(uint a, uint second) public returns (uint d) { return a * 7 + second; }
+		}
+	)";
+
+	char const* natspec = R"ABCDEF(
+	{
+		"methods": {
+			"mul(uint256,uint256)": {
+				"returns": { "d": "The result of the multiplication"
+			}
+		}
+	})ABCDEF";
+
+	checkNatspec(sourceCode, "test", natspec, false);
+}
+
 BOOST_AUTO_TEST_CASE(dev_return)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/8905