### PR TITLE
Down with unique_ptr!

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -582,9 +582,9 @@ string const* CompilerStack::sourceMapping(string const& _contractName) const
 	if (!c.sourceMapping)
 	{
 		if (auto items = assemblyItems(_contractName))
-			c.sourceMapping = make_unique<string>(evmasm::AssemblyItem::computeSourceMapping(*items, sourceIndices()));
+			c.sourceMapping.emplace(evmasm::AssemblyItem::computeSourceMapping(*items, sourceIndices()));
 	}
-	return c.sourceMapping.get();
+	return c.sourceMapping ? &*c.sourceMapping : nullptr;
 }
 
 string const* CompilerStack::runtimeSourceMapping(string const& _contractName) const
@@ -596,11 +596,11 @@ string const* CompilerStack::runtimeSourceMapping(string const& _contractName) c
 	if (!c.runtimeSourceMapping)
 	{
 		if (auto items = runtimeAssemblyItems(_contractName))
-			c.runtimeSourceMapping = make_unique<string>(
+			c.runtimeSourceMapping.emplace(
 				evmasm::AssemblyItem::computeSourceMapping(*items, sourceIndices())
 			);
 	}
-	return c.runtimeSourceMapping.get();
+	return c.runtimeSourceMapping ? &*c.runtimeSourceMapping : nullptr;
 }
 
 std::string const CompilerStack::filesystemFriendlyName(string const& _contractName) const

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -348,8 +348,8 @@ private:
 		util::LazyInit<Json::Value const> storageLayout;
 		util::LazyInit<Json::Value const> userDocumentation;
 		util::LazyInit<Json::Value const> devDocumentation;
-		mutable std::unique_ptr<std::string const> sourceMapping;
-		mutable std::unique_ptr<std::string const> runtimeSourceMapping;
+		mutable std::optional<std::string const> sourceMapping;
+		mutable std::optional<std::string const> runtimeSourceMapping;
 	};
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback

--- a/libyul/backends/wasm/WasmAST.h
+++ b/libyul/backends/wasm/WasmAST.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <optional>
 
 namespace solidity::yul::wasm
 {
@@ -76,7 +77,7 @@ struct FunctionImport {
 	std::string externalName;
 	std::string internalName;
 	std::vector<std::string> paramTypes;
-	std::unique_ptr<std::string> returnType;
+	std::optional<std::string> returnType;
 };
 
 struct FunctionDefinition

--- a/libyul/backends/wasm/WasmCodeTransform.cpp
+++ b/libyul/backends/wasm/WasmCodeTransform.cpp
@@ -29,6 +29,8 @@
 
 #include <liblangutil/Exceptions.h>
 
+#include <optional>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
@@ -125,7 +127,7 @@ wasm::Expression WasmCodeTransform::operator()(FunctionCall const& _call)
 					builtin->name.str().substr(4),
 					builtin->name.str(),
 					{},
-					builtin->returns.empty() ? nullptr : make_unique<string>(builtin->returns.front().str())
+					builtin->returns.empty() ? nullopt : make_optional<string>(builtin->returns.front().str())
 				};
 				for (auto const& param: builtin->parameters)
 					imp.paramTypes.emplace_back(param.str());

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -89,7 +89,10 @@ int registerTests(
 	}
 	else
 	{
-		static vector<unique_ptr<string>> filenames;
+		// This must be a vector of unique_ptrs because Boost.Test keeps the equivalent of a string_view to the filename
+		// that is passed in. If the strings were stored directly in the vector, pointers/references to them would be
+		// invalidated on reallocation.
+		static vector<unique_ptr<string const>> filenames;
 
 		filenames.emplace_back(make_unique<string>(_path.string()));
 		_suite.add(make_test_case(


### PR DESCRIPTION
There are places where it appears that `unique_ptr` is used as a poor man's optional. This is a bad thing because it forces unnecessary heap allocations and obscures intent.

This PR replaces `unique_ptr` data members with `optional` whenever it appears there are no lifetime concerns.