### PR TITLE
Remove a dedicated error flag from DeclarationTypeChecker and other classes

### DIFF
--- a/liblangutil/ErrorReporter.h
+++ b/liblangutil/ErrorReporter.h
@@ -134,6 +134,12 @@ public:
 		return m_errorCount > 0;
 	}
 
+	/// @returns the number of errors (ignores warnings).
+	unsigned errorCount() const
+	{
+		return m_errorCount;
+	}
+
 	// @returns true if the maximum error count has been reached.
 	bool hasExcessiveErrors() const;
 

--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -361,24 +361,22 @@ void DeclarationTypeChecker::endVisit(VariableDeclaration const& _variable)
 
 void DeclarationTypeChecker::typeError(SourceLocation const& _location, string const& _description)
 {
-	m_errorOccurred = true;
 	m_errorReporter.typeError(2311_error, _location, _description);
 }
 
 void DeclarationTypeChecker::fatalTypeError(SourceLocation const& _location, string const& _description)
 {
-	m_errorOccurred = true;
 	m_errorReporter.fatalTypeError(5651_error, _location, _description);
 }
 
 void DeclarationTypeChecker::fatalDeclarationError(SourceLocation const& _location, string const& _description)
 {
-	m_errorOccurred = true;
 	m_errorReporter.fatalDeclarationError(2046_error, _location, _description);
 }
 
 bool DeclarationTypeChecker::check(ASTNode const& _node)
 {
+	unsigned errorCount = m_errorReporter.errorCount();
 	_node.accept(*this);
-	return !m_errorOccurred;
+	return m_errorReporter.errorCount() == errorCount;
 }

--- a/libsolidity/analysis/DeclarationTypeChecker.h
+++ b/libsolidity/analysis/DeclarationTypeChecker.h
@@ -69,7 +69,6 @@ private:
 	void fatalDeclarationError(langutil::SourceLocation const& _location, std::string const& _description);
 
 	langutil::ErrorReporter& m_errorReporter;
-	bool m_errorOccurred = false;
 	langutil::EVMVersion m_evmVersion;
 	bool m_insideFunctionType = false;
 	bool m_recursiveStructSeen = false;

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
@@ -3,5 +3,3 @@ contract test {
 }
 // ----
 // DeclarationError: (31-55): The "constant" keyword can only be used for state variables.
-// TypeError: (31-55): Constants of non-value type not yet implemented.
-// TypeError: (31-55): Uninitialized "constant" variable.

--- a/test/libsolidity/syntaxTests/parsing/location_specifiers_for_params.sol
+++ b/test/libsolidity/syntaxTests/parsing/location_specifiers_for_params.sol
@@ -3,5 +3,3 @@ contract Foo {
 }
 // ----
 // DeclarationError: (30-55): The "constant" keyword can only be used for state variables.
-// TypeError: (30-55): Constants of non-value type not yet implemented.
-// TypeError: (30-55): Uninitialized "constant" variable.


### PR DESCRIPTION
There are five classes (`DeclarationTypeChecker`, `DocStringAnalyser`, `ReferencesResolver`, `DocStringParser`, `AsmAnalyzer`) which use a similar pattern. Namely, a few error reporter functions are wrapped in order to set an **error-occured-flag**.

It creates an extra indirection error and some amount of boiler-plate code, which would be good to avoid.

(This PR a part of the unique-error-ID saga.)
