### PR TITLE
[SMTChecker] Support array push/pop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * Build system: Update the soljson.js build to emscripten 1.39.15 and boost 1.73.0 and include Z3 for integrated SMTChecker support without the callback mechanism.
  * SMTChecker: Support array ``length``.
+ * SMTChecker: Support array ``push`` and ``pop``.
 
 
 Bugfixes:

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -661,10 +661,10 @@ vice-versa.
 Real World Assumptions
 ======================
 
-Some scenarios are expressive in Solidity and the EVM, but are expected to
+Some scenarios can be expressed in Solidity and the EVM, but are expected to
 never occur in practice.
-One of such cases is the length of a dynamic storage array overflowing after a
-push: If the ``push`` operation is applied to such array 2^256 times, its
+One of such cases is the length of a dynamic storage array overflowing during a
+push: If the ``push`` operation is applied to an array of length 2^256 - 1, its
 length silently overflows.
-However, this is unlikely to happen in practice, since the Earth, the sun and
-the universe might not be around anymore at the end of the 2^256 operations.
+However, this is unlikely to happen in practice, since the operations required
+to grow the array to that point would take billions of years to execute.

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -657,3 +657,14 @@ Notice that we do not clear knowledge about ``array`` and ``d`` because they
 are located in storage, even though they also have type ``uint[]``.  However,
 if ``d`` was assigned, we would need to clear knowledge about ``array`` and
 vice-versa.
+
+Real World Assumptions
+======================
+
+Some scenarios are expressive in Solidity and the EVM, but are expected to
+never occur in practice.
+One of such cases is the length of a dynamic storage array overflowing after a
+push: If the ``push`` operation is applied to such array 2^256 times, its
+length silently overflows.
+However, this is unlikely to happen in practice, since the Earth, the sun and
+the universe might not be around anymore at the end of the 2^256 operations.

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -78,6 +78,7 @@ private:
 	void visitAssert(FunctionCall const& _funCall);
 	void internalFunctionCall(FunctionCall const& _funCall);
 	void unknownFunctionCall(FunctionCall const& _funCall);
+	void makeArrayPopVerificationTarget(FunctionCall const& _arrayPop) override;
 	//@}
 
 	struct IdCompare
@@ -182,7 +183,9 @@ private:
 	/// @returns <false, model> otherwise.
 	std::pair<smt::CheckResult, std::vector<std::string>> query(smt::Expression const& _query, langutil::SourceLocation const& _location);
 
-	void addVerificationTarget(ASTNode const* _scope, smt::Expression _from, smt::Expression _constraints, smt::Expression _errorId);
+	void addVerificationTarget(ASTNode const* _scope, VerificationTarget::Type _type, smt::Expression _from, smt::Expression _constraints, smt::Expression _errorId);
+	void addAssertVerificationTarget(ASTNode const* _scope, smt::Expression _from, smt::Expression _constraints, smt::Expression _errorId);
+	void addArrayPopVerificationTarget(ASTNode const* _scope, smt::Expression _errorId);
 	//@}
 
 	/// Misc.
@@ -245,6 +248,8 @@ private:
 
 	/// Assertions proven safe.
 	std::set<Expression const*> m_safeAssertions;
+	/// Targets proven unsafe.
+	std::set<ASTNode const*> m_unsafeTargets;
 	//@}
 
 	/// Control-flow.

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -646,6 +646,12 @@ void SMTEncoder::endVisit(FunctionCall const& _funCall)
 		m_context.state().transfer(m_context.state().thisAddress(), expr(address), expr(*value));
 		break;
 	}
+	case FunctionType::Kind::ArrayPush:
+		arrayPush(_funCall);
+		break;
+	case FunctionType::Kind::ArrayPop:
+		arrayPop(_funCall);
+		break;
 	default:
 		m_errorReporter.warning(
 			4588_error,
@@ -905,16 +911,6 @@ bool SMTEncoder::visit(MemberAccess const& _memberAccess)
 				m_context
 			);
 		}
-		else
-		{
-			auto const& name = _memberAccess.memberName();
-			solAssert(name == "push" || name == "pop", "");
-			m_errorReporter.warning(
-				9098_error,
-				_memberAccess.location(),
-				"Assertion checker does not yet support array member \"" + name + "\"."
-			);
-		}
 		return false;
 	}
 	else
@@ -1080,6 +1076,71 @@ void SMTEncoder::arrayIndexAssignment(Expression const& _expr, smt::Expression c
 			break;
 		}
 	}
+}
+
+void SMTEncoder::arrayPush(FunctionCall const& _funCall)
+{
+	auto memberAccess = dynamic_cast<MemberAccess const*>(&_funCall.expression());
+	solAssert(memberAccess, "");
+	auto symbArray = dynamic_pointer_cast<smt::SymbolicArrayVariable>(m_context.expression(memberAccess->expression()));
+	solAssert(symbArray, "");
+	auto oldLength = symbArray->length();
+	auto const& arguments = _funCall.arguments();
+	smt::Expression element = arguments.empty() ?
+		smt::zeroValue(_funCall.annotation().type) :
+		expr(*arguments.front());
+	smt::Expression store = smt::Expression::store(
+		symbArray->elements(),
+		oldLength,
+		element
+	);
+	symbArray->increaseIndex();
+	m_context.addAssertion(symbArray->elements() == store);
+	auto newLength = smt::Expression::ite(
+		oldLength == smt::maxValue(*TypeProvider::uint256()),
+		0,
+		oldLength + 1
+	);
+	m_context.addAssertion(symbArray->length() == newLength);
+
+	if (arguments.empty())
+		defineExpr(_funCall, element);
+
+	arrayPushPopAssign(memberAccess->expression(), symbArray->currentValue());
+}
+
+void SMTEncoder::arrayPop(FunctionCall const& _funCall)
+{
+	auto memberAccess = dynamic_cast<MemberAccess const*>(&_funCall.expression());
+	solAssert(memberAccess, "");
+	auto symbArray = dynamic_pointer_cast<smt::SymbolicArrayVariable>(m_context.expression(memberAccess->expression()));
+	solAssert(symbArray, "");
+	auto oldElements = symbArray->elements();
+	auto oldLength = symbArray->length();
+	symbArray->increaseIndex();
+	m_context.addAssertion(symbArray->elements() == oldElements);
+	auto newLength = smt::Expression::ite(
+		oldLength == 0,
+		smt::maxValue(*TypeProvider::uint256()),
+		oldLength - 1
+	);
+	m_context.addAssertion(symbArray->length() == newLength);
+
+	arrayPushPopAssign(memberAccess->expression(), symbArray->currentValue());
+}
+
+void SMTEncoder::arrayPushPopAssign(Expression const& _expr, smt::Expression const& _array)
+{
+	if (auto const* id = dynamic_cast<Identifier const*>(&_expr))
+	{
+		auto varDecl = identifierToVariable(*id);
+		solAssert(varDecl, "");
+		m_context.addAssertion(m_context.newValue(*varDecl) == _array);
+	}
+	else if (auto const* indexAccess = dynamic_cast<IndexAccess const*>(&_expr))
+		arrayIndexAssignment(*indexAccess, _array);
+	else
+		solAssert(false, "");
 }
 
 void SMTEncoder::defineGlobalVariable(string const& _name, Expression const& _expr, bool _increaseIndex)

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1115,8 +1115,13 @@ void SMTEncoder::arrayPop(FunctionCall const& _funCall)
 	solAssert(memberAccess, "");
 	auto symbArray = dynamic_pointer_cast<smt::SymbolicArrayVariable>(m_context.expression(memberAccess->expression()));
 	solAssert(symbArray, "");
+
+	makeArrayPopVerificationTarget(_funCall);
+
 	auto oldElements = symbArray->elements();
 	auto oldLength = symbArray->length();
+	m_context.addAssertion(oldLength > 0);
+
 	symbArray->increaseIndex();
 	m_context.addAssertion(symbArray->elements() == oldElements);
 	auto newLength = smt::Expression::ite(
@@ -1124,7 +1129,7 @@ void SMTEncoder::arrayPop(FunctionCall const& _funCall)
 		smt::maxValue(*TypeProvider::uint256()),
 		oldLength - 1
 	);
-	m_context.addAssertion(symbArray->length() == newLength);
+	m_context.addAssertion(symbArray->length() == oldLength - 1);
 
 	arrayPushPopAssign(memberAccess->expression(), symbArray->currentValue());
 }

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -137,6 +137,10 @@ protected:
 	/// Handles assignment to SMT array index.
 	void arrayIndexAssignment(Expression const& _expr, smt::Expression const& _rightHandSide);
 
+	void arrayPush(FunctionCall const& _funCall);
+	void arrayPop(FunctionCall const& _funCall);
+	void arrayPushPopAssign(Expression const& _expr, smt::Expression const& _array);
+
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
 	smt::Expression division(smt::Expression _left, smt::Expression _right, IntegerType const& _type);

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -140,6 +140,9 @@ protected:
 	void arrayPush(FunctionCall const& _funCall);
 	void arrayPop(FunctionCall const& _funCall);
 	void arrayPushPopAssign(Expression const& _expr, smt::Expression const& _array);
+	/// Allows BMC and CHC to create verification targets for popping
+	/// an empty array.
+	virtual void makeArrayPopVerificationTarget(FunctionCall const&) {}
 
 	/// Division expression in the given type. Requires special treatment because
 	/// of rounding for signed division.
@@ -244,7 +247,7 @@ protected:
 
 	struct VerificationTarget
 	{
-		enum class Type { ConstantCondition, Underflow, Overflow, UnderOverflow, DivByZero, Balance, Assert } type;
+		enum class Type { ConstantCondition, Underflow, Overflow, UnderOverflow, DivByZero, Balance, Assert, PopEmptyArray } type;
 		smt::Expression value;
 		smt::Expression constraints;
 	};

--- a/test/libsolidity/smtCheckerTests/array_members/pop_1_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_1_safe.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.push();
+		a.pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/pop_1_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_1_unsafe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.pop();
+	}
+}
+// ----
+// Warning: (82-89): Empty array "pop" detected here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_2d_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_2d_safe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f() public {
+		a.push();
+		a[0].push();
+		a[0].pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
@@ -8,3 +8,5 @@ contract C {
 		a[1].pop();
 	}
 }
+// ----
+// Warning: (111-121): Empty array "pop" detected here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f() public {
+		a.push();
+		a[0].push();
+		a[1].pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/pop_constructor_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_constructor_safe.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	constructor() public {
+		a.push();
+		a.pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/pop_constructor_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_constructor_unsafe.sol
@@ -1,0 +1,8 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	constructor() public {
+		a.pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/pop_constructor_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_constructor_unsafe.sol
@@ -6,3 +6,5 @@ contract C {
 		a.pop();
 	}
 }
+// ----
+// Warning: (83-90): Empty array "pop" detected here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_loop_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_loop_safe.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f(uint l) public {
+		for (uint i = 0; i < l; ++i) {
+			a.push();
+			a.pop();
+		}
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/pop_loop_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_loop_unsafe.sol
@@ -10,3 +10,5 @@ contract C {
 		a.pop();
 	}
 }
+// ----
+// Warning: (150-157): Empty array "pop" detected here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_loop_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_loop_unsafe.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f(uint l) public {
+		for (uint i = 0; i < l; ++i) {
+			a.push();
+			a.pop();
+		}
+		a.pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f(uint x) public {
+		require(a.length < 100000);
+		a.push(x);
+		assert(a[a.length - 1] == x);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_2d.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_2d.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f(uint[] memory x, uint y) public {
+		require(a.length < 100000);
+		a.push(x);
+		assert(a[a.length - 1][0] == x[0]);
+		require(a[0].length < 100000);
+		a[0].push(y);
+		assert(a[0][a[0].length - 1] == y);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_2d_arg_1_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_2d_arg_1_safe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f(uint[] memory x, uint y) public {
+		a.push(x);
+		a[0].push(y);
+		assert(a[0][a[0].length - 1] == y);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_2d_arg_1_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_2d_arg_1_unsafe.sol
@@ -9,3 +9,6 @@ contract C {
 		assert(a[0][a[0].length - 1] == y);
 	}
 }
+// ----
+// Warning: (162-177): Underflow (resulting value less than 0) happens here
+// Warning: (150-184): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/push_2d_arg_1_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_2d_arg_1_unsafe.sol
@@ -3,11 +3,9 @@ pragma experimental SMTChecker;
 contract C {
 	uint[][] a;
 	function f(uint[] memory x, uint y) public {
-		require(a.length < 100000);
 		a.push(x);
-		assert(a[a.length - 1][0] == x[0]);
-		require(a[0].length < 100000);
 		a[0].push(y);
+		a[0].pop();
 		assert(a[0][a[0].length - 1] == y);
 	}
 }

--- a/test/libsolidity/smtCheckerTests/array_members/push_arg_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_arg_1.sol
@@ -3,7 +3,6 @@ pragma experimental SMTChecker;
 contract C {
 	uint[] a;
 	function f(uint x) public {
-		require(a.length < 100000);
 		a.push(x);
 		assert(a[a.length - 1] == x);
 	}

--- a/test/libsolidity/smtCheckerTests/array_members/push_overflow_1_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_overflow_1_safe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint256[] x;
+	constructor() public { x.push(42); }
+	function f() public {
+		x.push(23);
+		assert(x[0] == 42 || x[0] == 23);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_overflow_1_safe_no_overflow_assumption.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_overflow_1_safe_no_overflow_assumption.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint256[] x;
+	constructor() public { x.push(42); }
+	function f() public {
+		x.push(23);
+		assert(x[0] == 42);
+	}
+}
+// ----

--- a/test/libsolidity/smtCheckerTests/array_members/push_overflow_1_safe_no_overflow_assumption.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_overflow_1_safe_no_overflow_assumption.sol
@@ -8,4 +8,3 @@ contract C {
 		assert(x[0] == 42);
 	}
 }
-// ----

--- a/test/libsolidity/smtCheckerTests/array_members/push_overflow_2_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_overflow_2_safe.sol
@@ -1,0 +1,12 @@
+contract C {
+	uint256[] x;
+	function f(uint256 l) public {
+		require(x.length == 0);
+		x.push(42);
+		x.push(84);
+		for(uint256 i = 0; i < l; ++i)
+			x.push(23);
+		assert(x[0] == 42 || x[0] == 23);
+	}
+}
+

--- a/test/libsolidity/smtCheckerTests/array_members/push_overflow_2_safe_no_overflow_assumption.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_overflow_2_safe_no_overflow_assumption.sol
@@ -11,5 +11,3 @@ contract C {
 		assert(x[0] == 42);
 	}
 }
-
-// ----

--- a/test/libsolidity/smtCheckerTests/array_members/push_overflow_2_safe_no_overflow_assumption.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_overflow_2_safe_no_overflow_assumption.sol
@@ -1,0 +1,15 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint256[] x;
+	function f(uint256 l) public {
+		require(x.length == 0);
+		x.push(42);
+		x.push(84);
+		for(uint256 i = 0; i < l; ++i)
+			x.push(23);
+		assert(x[0] == 42);
+	}
+}
+
+// ----

--- a/test/libsolidity/smtCheckerTests/array_members/push_storage_ref_safe_aliasing.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_storage_ref_safe_aliasing.sol
@@ -1,0 +1,16 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f() public {
+		a.push();
+		uint[] storage b = a[0];
+		b.push(8);
+		assert(b[b.length - 1] == 8);
+		// Safe but fails due to aliasing.
+		assert(a[0][a[0].length - 1] == 8);
+	}
+}
+// ----
+// Warning: (217-232): Underflow (resulting value less than 0) happens here
+// Warning: (205-239): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/push_storage_ref_unsafe_aliasing.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_storage_ref_unsafe_aliasing.sol
@@ -1,0 +1,15 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f() public {
+		a.push();
+		a[0].push();
+		a[0][0] = 16;
+		uint[] storage b = a[0];
+		b[0] = 32;
+		assert(a[0][0] == 16);
+	}
+}
+// ----
+// Warning: (167-188): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/push_zero_2d_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_zero_2d_safe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f() public {
+		a.push();
+		a[0].push();
+		assert(a[a.length - 1][0] == 0);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_zero_2d_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_zero_2d_unsafe.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	function f() public {
+		a.push();
+		a[0].push();
+		assert(a[a.length - 1][0] == 100);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_zero_2d_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_zero_2d_unsafe.sol
@@ -8,3 +8,5 @@ contract C {
 		assert(a[a.length - 1][0] == 100);
 	}
 }
+// ----
+// Warning: (111-144): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/array_members/push_zero_safe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_zero_safe.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.push();
+		assert(a[a.length - 1] == 0);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_zero_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_zero_unsafe.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.push();
+		assert(a[a.length - 1] == 100);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/push_zero_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_zero_unsafe.sol
@@ -7,3 +7,5 @@ contract C {
 		assert(a[a.length - 1] == 100);
 	}
 }
+// ----
+// Warning: (94-124): Assertion violation happens here


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/6048
Depends on https://github.com/ethereum/solidity/pull/8848

- [x] Needs more tests
- [x] push: add implicit require that `array.length < 2^256 - 1` before the push (as a real world assumption)
- [x] document the assumption above
- [x] pop: add underflow verification target on `length - 1` and do not wrap