### PR TITLE
Remove a dedicated error flag from DeclarationTypeChecker and other classes, continued

### DIFF
--- a/libsolidity/analysis/DocStringAnalyser.cpp
+++ b/libsolidity/analysis/DocStringAnalyser.cpp
@@ -34,10 +34,9 @@ using namespace solidity::frontend;
 
 bool DocStringAnalyser::analyseDocStrings(SourceUnit const& _sourceUnit)
 {
-	m_errorOccured = false;
+	auto errorWatcher = m_errorReporter.errorWatcher();
 	_sourceUnit.accept(*this);
-
-	return !m_errorOccured;
+	return errorWatcher.ok();
 }
 
 bool DocStringAnalyser::visit(ContractDefinition const& _contract)
@@ -152,8 +151,7 @@ void DocStringAnalyser::parseDocStrings(
 	DocStringParser parser;
 	if (_node.documentation() && !_node.documentation()->text()->empty())
 	{
-		if (!parser.parse(*_node.documentation()->text(), m_errorReporter))
-			m_errorOccured = true;
+		parser.parse(*_node.documentation()->text(), m_errorReporter);
 		_annotation.docTags = parser.tags();
 	}
 
@@ -210,6 +208,5 @@ void DocStringAnalyser::parseDocStrings(
 
 void DocStringAnalyser::appendError(SourceLocation const& _location, string const& _description)
 {
-	m_errorOccured = true;
 	m_errorReporter.docstringParsingError(7816_error, _location, _description);
 }

--- a/libsolidity/analysis/DocStringAnalyser.h
+++ b/libsolidity/analysis/DocStringAnalyser.h
@@ -83,7 +83,6 @@ private:
 
 	void appendError(langutil::SourceLocation const& _location, std::string const& _description);
 
-	bool m_errorOccured = false;
 	langutil::ErrorReporter& m_errorReporter;
 };
 

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -44,8 +44,9 @@ namespace solidity::frontend
 
 bool ReferencesResolver::resolve(ASTNode const& _root)
 {
+	auto errorWatcher = m_errorReporter.errorWatcher();
 	_root.accept(*this);
-	return !m_errorOccurred;
+	return errorWatcher.ok();
 }
 
 bool ReferencesResolver::visit(Block const& _block)
@@ -267,19 +268,16 @@ void ReferencesResolver::operator()(yul::VariableDeclaration const& _varDecl)
 
 void ReferencesResolver::declarationError(SourceLocation const& _location, string const& _description)
 {
-	m_errorOccurred = true;
 	m_errorReporter.declarationError(8532_error, _location, _description);
 }
 
 void ReferencesResolver::declarationError(SourceLocation const& _location, SecondarySourceLocation const& _ssl, string const& _description)
 {
-	m_errorOccurred = true;
 	m_errorReporter.declarationError(3881_error, _location, _ssl, _description);
 }
 
 void ReferencesResolver::fatalDeclarationError(SourceLocation const& _location, string const& _description)
 {
-	m_errorOccurred = true;
 	m_errorReporter.fatalDeclarationError(6546_error, _location, _description);
 }
 

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -103,7 +103,6 @@ private:
 	/// Stack of return parameters.
 	std::vector<ParameterList const*> m_returnParameters;
 	bool const m_resolveInsideCode;
-	bool m_errorOccurred = false;
 
 	InlineAssemblyAnnotation* m_yulAnnotation = nullptr;
 	bool m_yulInsideFunction = false;

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -77,10 +77,9 @@ string::const_iterator skipWhitespace(
 
 }
 
-bool DocStringParser::parse(string const& _docString, ErrorReporter& _errorReporter)
+void DocStringParser::parse(string const& _docString, ErrorReporter& _errorReporter)
 {
 	m_errorReporter = &_errorReporter;
-	m_errorsOccurred = false;
 	m_lastTag = nullptr;
 
 	auto currPos = _docString.begin();
@@ -119,7 +118,6 @@ bool DocStringParser::parse(string const& _docString, ErrorReporter& _errorRepor
 			currPos = nlPos + 1;
 		}
 	}
-	return !m_errorsOccurred;
 }
 
 DocStringParser::iter DocStringParser::parseDocTagLine(iter _pos, iter _end, bool _appending)
@@ -194,6 +192,5 @@ void DocStringParser::newTag(string const& _tagName)
 
 void DocStringParser::appendError(string const& _description)
 {
-	m_errorsOccurred = true;
 	m_errorReporter->docstringParsingError(9440_error, _description);
 }

--- a/libsolidity/parsing/DocStringParser.h
+++ b/libsolidity/parsing/DocStringParser.h
@@ -37,8 +37,7 @@ class DocStringParser
 {
 public:
 	/// Parse the given @a _docString and stores the parsed components internally.
-	/// @returns false on error and appends the error to @a _errors.
-	bool parse(std::string const& _docString, langutil::ErrorReporter& _errorReporter);
+	void parse(std::string const& _docString, langutil::ErrorReporter& _errorReporter);
 
 	std::multimap<std::string, DocTag> const& tags() const { return m_docTags; }
 
@@ -65,7 +64,6 @@ private:
 	std::multimap<std::string, DocTag> m_docTags;
 	DocTag* m_lastTag = nullptr;
 	langutil::ErrorReporter* m_errorReporter = nullptr;
-	bool m_errorsOccurred = false;
 };
 
 }


### PR DESCRIPTION
This is a continuation of PR #8915.
