### PR TITLE
Update EVMC to 7.2.0 and enable Berlin support

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -81,12 +81,14 @@ EVMHost::EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm):
 		m_evmRevision = EVMC_BYZANTIUM;
 	else if (_evmVersion == langutil::EVMVersion::constantinople())
 		m_evmRevision = EVMC_CONSTANTINOPLE;
+	else if (_evmVersion == langutil::EVMVersion::petersburg())
+		m_evmRevision = EVMC_PETERSBURG;
 	else if (_evmVersion == langutil::EVMVersion::istanbul())
 		m_evmRevision = EVMC_ISTANBUL;
 	else if (_evmVersion == langutil::EVMVersion::berlin())
-		assertThrow(false, Exception, "Berlin is not supported yet.");
-	else //if (_evmVersion == langutil::EVMVersion::petersburg())
-		m_evmRevision = EVMC_PETERSBURG;
+		m_evmRevision = EVMC_BERLIN;
+	else
+		assertThrow(false, Exception, "Unsupported EVM version");
 
 	// Mark all precompiled contracts as existing. Existing here means to have a balance (as per EIP-161).
 	// NOTE: keep this in sync with `EVMHost::call` below.

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -99,17 +99,16 @@ EVMHost::EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm):
 		evmc::address address{};
 		address.bytes[19] = precompiledAddress;
 		// 1wei
-		accounts[address].balance.bytes[31] = 1;
+		accounts[address].balance = evmc::uint256be{1};
 	}
 
-	// TODO: support short literals in EVMC and use them here
-	tx_context.block_difficulty = convertToEVMC(u256("200000000"));
+	tx_context.block_difficulty = evmc::uint256be{200000000};
 	tx_context.block_gas_limit = 20000000;
 	tx_context.block_coinbase = 0x7878787878787878787878787878787878787878_address;
-	tx_context.tx_gas_price = convertToEVMC(u256("3000000000"));
+	tx_context.tx_gas_price = evmc::uint256be{3000000000};
 	tx_context.tx_origin = 0x9292929292929292929292929292929292929292_address;
 	// Mainnet according to EIP-155
-	tx_context.chain_id = convertToEVMC(u256(1));
+	tx_context.chain_id = evmc::uint256be{1};
 }
 
 void EVMHost::selfdestruct(const evmc::address& _addr, const evmc::address& _beneficiary) noexcept

--- a/test/evmc/README.md
+++ b/test/evmc/README.md
@@ -1,3 +1,3 @@
 # EVMC
 
-This is an import of [EVMC](https://github.com/ethereum/evmc) version [7.1.0](https://github.com/ethereum/evmc/releases/tag/v7.1.0).
+This is an import of [EVMC](https://github.com/ethereum/evmc) version [7.2.0](https://github.com/ethereum/evmc/releases/tag/v7.2.0).

--- a/test/evmc/evmc.h
+++ b/test/evmc/evmc.h
@@ -345,8 +345,8 @@ struct evmc_result
     /**
      * The amount of gas left after the execution.
      *
-     *  If evmc_result::code is not ::EVMC_SUCCESS nor ::EVMC_REVERT
-     *  the value MUST be 0.
+     * If evmc_result::status_code is neither ::EVMC_SUCCESS nor ::EVMC_REVERT
+     * the value MUST be 0.
      */
     int64_t gas_left;
 

--- a/test/evmc/mocked_host.hpp
+++ b/test/evmc/mocked_host.hpp
@@ -133,10 +133,11 @@ public:
     /// The record of all SELFDESTRUCTs from the selfdestruct() method.
     std::vector<selfdestuct_record> recorded_selfdestructs;
 
-protected:
+private:
     /// The copy of call inputs for the recorded_calls record.
     std::vector<bytes> m_recorded_calls_inputs;
 
+public:
     /// Record an account access.
     /// @param addr  The address of the accessed account.
     void record_account_access(const address& addr) const


### PR DESCRIPTION
Note: this doesn't really do anything, but will allow testing the subroutines PR.

Also it is unclear whether Berlin will have any changes which require breaking EVMC API changes.