### PR TITLE
Disable Z3 in fuzzer builds

### DIFF
--- a/cmake/toolchains/ossfuzz.cmake
+++ b/cmake/toolchains/ossfuzz.cmake
@@ -1,7 +1,8 @@
 # Inherit default options
 include("${CMAKE_CURRENT_LIST_DIR}/default.cmake")
-# Disable CVC4.
+# Disable CVC4 and Z3.
 set(USE_CVC4 OFF CACHE BOOL "Disable CVC4" FORCE)
+set(USE_Z3 OFF CACHE BOOL "Disable Z3" FORCE)
 # Enable fuzzers
 set(OSSFUZZ ON CACHE BOOL "Enable fuzzer build" FORCE)
 set(LIB_FUZZING_ENGINE $ENV{LIB_FUZZING_ENGINE} CACHE STRING "Use fuzzer back-end defined by environment variable" FORCE)


### PR DESCRIPTION
Disables Z3 for fuzzer builds in favour of speed (because z3 queries can take a longish time to finish)

Another reason to disable Z3 is we should no longer care about Z3 issues e.g., memory corruption. This should be done by the Z3 team if they think it is necessary.