### PR TITLE
[Sol->Yul] Move name functions from IR context to the new `Common` module (refactor)

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -79,6 +79,8 @@ set(sources
 	codegen/ReturnInfo.cpp
 	codegen/YulUtilFunctions.h
 	codegen/YulUtilFunctions.cpp
+	codegen/ir/Common.cpp
+	codegen/ir/Common.h
 	codegen/ir/IRGenerator.cpp
 	codegen/ir/IRGenerator.h
 	codegen/ir/IRGeneratorForStatements.cpp

--- a/libsolidity/codegen/ir/Common.cpp
+++ b/libsolidity/codegen/ir/Common.cpp
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <libsolidity/codegen/ir/Common.h>
+
+#include <libsolutil/CommonIO.h>
+
+using namespace std;
+using namespace solidity::util;
+using namespace solidity::frontend;
+
+string IRNames::function(FunctionDefinition const& _function)
+{
+	// @TODO previously, we had to distinguish creation context and runtime context,
+	// but since we do not work with jump positions anymore, this should not be a problem, right?
+	return "fun_" + _function.name() + "_" + to_string(_function.id());
+}
+
+string IRNames::function(VariableDeclaration const& _varDecl)
+{
+	return "getter_fun_" + _varDecl.name() + "_" + to_string(_varDecl.id());
+}
+
+string IRNames::creationObject(ContractDefinition const& _contract)
+{
+	return _contract.name() + "_" + toString(_contract.id());
+}
+
+string IRNames::runtimeObject(ContractDefinition const& _contract)
+{
+	return _contract.name() + "_" + toString(_contract.id()) + "_deployed";
+}

--- a/libsolidity/codegen/ir/Common.h
+++ b/libsolidity/codegen/ir/Common.h
@@ -1,0 +1,38 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Miscellaneous utilities for use in IR generator.
+ */
+
+#pragma once
+
+#include <libsolidity/ast/AST.h>
+
+#include <string>
+
+namespace solidity::frontend
+{
+
+struct IRNames
+{
+	static std::string function(FunctionDefinition const& _function);
+	static std::string function(VariableDeclaration const& _varDecl);
+	static std::string creationObject(ContractDefinition const& _contract);
+	static std::string runtimeObject(ContractDefinition const& _contract);
+};
+
+}

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -36,7 +36,7 @@ using namespace solidity::frontend;
 
 string IRGenerationContext::enqueueFunctionForCodeGeneration(FunctionDefinition const& _function)
 {
-	string name = functionName(_function);
+	string name = IRNames::function(_function);
 
 	if (!m_functions.contains(name))
 		m_functionGenerationQueue.insert(&_function);
@@ -116,27 +116,6 @@ void IRGenerationContext::addStateVariable(
 	m_stateVariables[&_declaration] = make_pair(move(_storageOffset), _byteOffset);
 }
 
-string IRGenerationContext::functionName(FunctionDefinition const& _function)
-{
-	// @TODO previously, we had to distinguish creation context and runtime context,
-	// but since we do not work with jump positions anymore, this should not be a problem, right?
-	return "fun_" + _function.name() + "_" + to_string(_function.id());
-}
-
-string IRGenerationContext::functionName(VariableDeclaration const& _varDecl)
-{
-	return "getter_fun_" + _varDecl.name() + "_" + to_string(_varDecl.id());
-}
-
-string IRGenerationContext::creationObjectName(ContractDefinition const& _contract) const
-{
-	return _contract.name() + "_" + toString(_contract.id());
-}
-string IRGenerationContext::runtimeObjectName(ContractDefinition const& _contract) const
-{
-	return _contract.name() + "_" + toString(_contract.id()) + "_deployed";
-}
-
 string IRGenerationContext::newYulVariable()
 {
 	return "_" + to_string(++m_varCounter);
@@ -196,7 +175,7 @@ string IRGenerationContext::internalDispatch(size_t _in, size_t _out)
 
 					functions.emplace_back(map<string, string> {
 						{ "funID", to_string(function->id()) },
-						{ "name", functionName(*function)}
+						{ "name", IRNames::function(*function)}
 					});
 
 					enqueueFunctionForCodeGeneration(*function);

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -26,6 +26,7 @@
 #include <libsolidity/interface/DebugSettings.h>
 
 #include <libsolidity/codegen/MultiUseYulFunctionCollector.h>
+#include <libsolidity/codegen/ir/Common.h>
 
 #include <liblangutil/EVMVersion.h>
 
@@ -98,12 +99,6 @@ public:
 	{
 		return m_stateVariables.at(&_varDecl);
 	}
-
-	std::string functionName(FunctionDefinition const& _function);
-	std::string functionName(VariableDeclaration const& _varDecl);
-
-	std::string creationObjectName(ContractDefinition const& _contract) const;
-	std::string runtimeObjectName(ContractDefinition const& _contract) const;
 
 	std::string newYulVariable();
 

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -114,7 +114,7 @@ string IRGenerator::generate(
 	for (VariableDeclaration const* var: ContractType(_contract).immutableVariables())
 		m_context.registerImmutableVariable(*var);
 
-	t("CreationObject", m_context.creationObjectName(_contract));
+	t("CreationObject", IRNames::creationObject(_contract));
 	t("memoryInit", memoryInit());
 	t("notLibrary", !_contract.isLibrary());
 
@@ -127,7 +127,7 @@ string IRGenerator::generate(
 			constructorParams.emplace_back(m_context.newYulVariable());
 		t(
 			"copyConstructorArguments",
-			m_utils.copyConstructorArgumentsToMemoryFunction(_contract, m_context.creationObjectName(_contract))
+			m_utils.copyConstructorArgumentsToMemoryFunction(_contract, IRNames::creationObject(_contract))
 		);
 	}
 	t("constructorParams", joinHumanReadable(constructorParams));
@@ -142,7 +142,7 @@ string IRGenerator::generate(
 
 	resetContext(_contract);
 	// Do not register immutables to avoid assignment.
-	t("RuntimeObject", m_context.runtimeObjectName(_contract));
+	t("RuntimeObject", IRNames::runtimeObject(_contract));
 	t("dispatch", dispatchRoutine(_contract));
 	generateQueuedFunctions();
 	t("runtimeFunctions", m_context.functionCollector().requestedFunctions());
@@ -166,7 +166,7 @@ void IRGenerator::generateQueuedFunctions()
 
 string IRGenerator::generateFunction(FunctionDefinition const& _function)
 {
-	string functionName = m_context.functionName(_function);
+	string functionName = IRNames::function(_function);
 	return m_context.functionCollector().createFunction(functionName, [&]() {
 		Whiskers t(R"(
 			function <functionName>(<params>)<?+retParams> -> <retParams></+retParams> {
@@ -195,7 +195,7 @@ string IRGenerator::generateFunction(FunctionDefinition const& _function)
 
 string IRGenerator::generateGetter(VariableDeclaration const& _varDecl)
 {
-	string functionName = m_context.functionName(_varDecl);
+	string functionName = IRNames::function(_varDecl);
 
 	Type const* type = _varDecl.annotation().type;
 
@@ -431,7 +431,7 @@ string IRGenerator::deployCode(ContractDefinition const& _contract)
 
 		return(0, datasize("<object>"))
 	)X");
-	t("object", m_context.runtimeObjectName(_contract));
+	t("object", IRNames::runtimeObject(_contract));
 
 	vector<map<string, string>> loadImmutables;
 	vector<map<string, string>> storeImmutables;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1103,7 +1103,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		t("memEnd", m_context.newYulVariable());
 		t("allocateTemporaryMemory", m_utils.allocationTemporaryMemoryFunction());
 		t("releaseTemporaryMemory", m_utils.releaseTemporaryMemoryFunction());
-		t("object", m_context.creationObjectName(*contract));
+		t("object", IRNames::creationObject(*contract));
 		t("abiEncode",
 			m_context.abiFunctions().tupleEncoder(argumentTypes, functionType->parameterTypes(), false)
 		);
@@ -1371,7 +1371,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			)")
 			("allocationFunction", m_utils.allocationFunction())
 			("size", m_context.newYulVariable())
-			("objectName", m_context.creationObjectName(contract))
+			("objectName", IRNames::creationObject(contract))
 			("result", IRVariable(_memberAccess).commaSeparatedList()).render();
 		}
 		else if (member == "name")


### PR DESCRIPTION
Refactoring changes extracted from #8943 (and before that from #8797). Does not affect functionality.
Related to #6788 and #8485.