### PR TITLE
[Sol->Yul] Simplify end visit for internal calls (refactor)

### DIFF
--- a/libsolidity/codegen/ir/Common.cpp
+++ b/libsolidity/codegen/ir/Common.cpp
@@ -99,3 +99,13 @@ string IRNames::zeroValue(Type const& _type, string const& _variableName)
 {
 	return "zero_value_for_type_" + _type.identifier() + _variableName;
 }
+
+FunctionDefinition const* IRHelpers::referencedFunctionDeclaration(Expression const& _expression)
+{
+	if (auto memberAccess = dynamic_cast<MemberAccess const*>(&_expression))
+		return dynamic_cast<FunctionDefinition const*>(memberAccess->annotation().referencedDeclaration);
+	else if (auto identifier = dynamic_cast<Identifier const*>(&_expression))
+		return dynamic_cast<FunctionDefinition const*>(identifier->annotation().referencedDeclaration);
+	else
+		return nullptr;
+}

--- a/libsolidity/codegen/ir/Common.h
+++ b/libsolidity/codegen/ir/Common.h
@@ -62,6 +62,11 @@ struct IRNames
 	static std::string zeroValue(Type const& _type, std::string const& _variableName);
 };
 
+struct IRHelpers
+{
+	static FunctionDefinition const* referencedFunctionDeclaration(Expression const& _expression);
+};
+
 }
 
 // Overloading std::less() makes it possible to use YulArity as a map key. We could define operator<


### PR DESCRIPTION
~Based on #8951 which needs to be merged first. Could also be rebased on #8949 which is immediately below but this requires resolving a minor conflict so I left them one on the other.~ It's based on `develop` now.

Refactoring changes extracted from #8943 (and before that from #8797). Does not affect functionality.
Related to #6788 and #8485.