### PR TITLE
[Sol->Yul] Move naming scheme for all IR functions and variables to IRNames (refactor)

### DIFF
--- a/libsolidity/codegen/ir/Common.cpp
+++ b/libsolidity/codegen/ir/Common.cpp
@@ -44,3 +44,43 @@ string IRNames::runtimeObject(ContractDefinition const& _contract)
 {
 	return _contract.name() + "_" + toString(_contract.id()) + "_deployed";
 }
+
+string IRNames::implicitConstructor(ContractDefinition const& _contract)
+{
+	return "constructor_" + _contract.name() + "_" + to_string(_contract.id());
+}
+
+string IRNames::constantValueFunction(VariableDeclaration const& _constant)
+{
+	solAssert(_constant.isConstant(), "");
+	return "constant_" + _constant.name() + "_" + to_string(_constant.id());
+}
+
+string IRNames::localVariable(VariableDeclaration const& _declaration)
+{
+	return "vloc_" + _declaration.name() + '_' + std::to_string(_declaration.id());
+}
+
+string IRNames::localVariable(Expression const& _expression)
+{
+	return "expr_" + to_string(_expression.id());
+}
+
+string IRNames::trySuccessConditionVariable(Expression const& _expression)
+{
+	auto annotation = dynamic_cast<FunctionCallAnnotation const*>(&_expression.annotation());
+	solAssert(annotation, "");
+	solAssert(annotation->tryCall, "Parameter must be a FunctionCall with tryCall-annotation set.");
+
+	return "trySuccessCondition_" + to_string(_expression.id());
+}
+
+string IRNames::tupleComponent(size_t _i)
+{
+	return "component_" + to_string(_i + 1);
+}
+
+string IRNames::zeroValue(Type const& _type, string const& _variableName)
+{
+	return "zero_value_for_type_" + _type.identifier() + _variableName;
+}

--- a/libsolidity/codegen/ir/Common.h
+++ b/libsolidity/codegen/ir/Common.h
@@ -33,6 +33,15 @@ struct IRNames
 	static std::string function(VariableDeclaration const& _varDecl);
 	static std::string creationObject(ContractDefinition const& _contract);
 	static std::string runtimeObject(ContractDefinition const& _contract);
+	static std::string implicitConstructor(ContractDefinition const& _contract);
+	static std::string constantValueFunction(VariableDeclaration const& _constant);
+	static std::string localVariable(VariableDeclaration const& _declaration);
+	static std::string localVariable(Expression const& _expression);
+	/// @returns the variable name that can be used to inspect the success or failure of an external
+	/// function call that was invoked as part of the try statement.
+	static std::string trySuccessConditionVariable(Expression const& _expression);
+	static std::string tupleComponent(size_t _i);
+	static std::string zeroValue(Type const& _type, std::string const& _variableName);
 };
 
 }

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -121,17 +121,6 @@ string IRGenerationContext::newYulVariable()
 	return "_" + to_string(++m_varCounter);
 }
 
-string IRGenerationContext::trySuccessConditionVariable(Expression const& _expression) const
-{
-	// NB: The TypeChecker already ensured that the Expression is of type FunctionCall.
-	solAssert(
-		static_cast<FunctionCallAnnotation const&>(_expression.annotation()).tryCall,
-		"Parameter must be a FunctionCall with tryCall-annotation set."
-	);
-
-	return "trySuccessCondition_" + to_string(_expression.id());
-}
-
 string IRGenerationContext::internalDispatch(size_t _in, size_t _out)
 {
 	string funName = "dispatch_internal_in_" + to_string(_in) + "_out_" + to_string(_out);

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -117,10 +117,6 @@ public:
 
 	RevertStrings revertStrings() const { return m_revertStrings; }
 
-	/// @returns the variable name that can be used to inspect the success or failure of an external
-	/// function call that was invoked as part of the try statement.
-	std::string trySuccessConditionVariable(Expression const& _expression) const;
-
 	std::set<ContractDefinition const*, ASTNode::CompareByID>& subObjectsCreated() { return m_subObjects; }
 
 private:

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -132,7 +132,7 @@ string IRGenerator::generate(
 	}
 	t("constructorParams", joinHumanReadable(constructorParams));
 	t("constructorHasParams", !constructorParams.empty());
-	t("implicitConstructor", implicitConstructorName(_contract));
+	t("implicitConstructor", IRNames::implicitConstructor(_contract));
 
 	t("deploy", deployCode(_contract));
 	generateImplicitConstructors(_contract);
@@ -378,7 +378,7 @@ void IRGenerator::generateImplicitConstructors(ContractDefinition const& _contra
 		ContractDefinition const* contract = _contract.annotation().linearizedBaseContracts[i];
 		baseConstructorParams.erase(contract);
 
-		m_context.functionCollector().createFunction(implicitConstructorName(*contract), [&]() {
+		m_context.functionCollector().createFunction(IRNames::implicitConstructor(*contract), [&]() {
 			Whiskers t(R"(
 				function <functionName>(<params><comma><baseParams>) {
 					<evalBaseArguments>
@@ -395,7 +395,7 @@ void IRGenerator::generateImplicitConstructors(ContractDefinition const& _contra
 			vector<string> baseParams = listAllParams(baseConstructorParams);
 			t("baseParams", joinHumanReadable(baseParams));
 			t("comma", !params.empty() && !baseParams.empty() ? ", " : "");
-			t("functionName", implicitConstructorName(*contract));
+			t("functionName", IRNames::implicitConstructor(*contract));
 			pair<string, map<ContractDefinition const*, vector<string>>> evaluatedArgs = evaluateConstructorArguments(*contract);
 			baseConstructorParams.insert(evaluatedArgs.second.begin(), evaluatedArgs.second.end());
 			t("evalBaseArguments", evaluatedArgs.first);
@@ -403,7 +403,7 @@ void IRGenerator::generateImplicitConstructors(ContractDefinition const& _contra
 			{
 				t("hasNextConstructor", true);
 				ContractDefinition const* nextContract = _contract.annotation().linearizedBaseContracts[i + 1];
-				t("nextConstructor", implicitConstructorName(*nextContract));
+				t("nextConstructor", IRNames::implicitConstructor(*nextContract));
 				t("nextParams", joinHumanReadable(listAllParams(baseConstructorParams)));
 			}
 			else
@@ -460,11 +460,6 @@ string IRGenerator::deployCode(ContractDefinition const& _contract)
 string IRGenerator::callValueCheck()
 {
 	return "if callvalue() { revert(0, 0) }";
-}
-
-string IRGenerator::implicitConstructorName(ContractDefinition const& _contract)
-{
-	return "constructor_" + _contract.name() + "_" + to_string(_contract.id());
 }
 
 string IRGenerator::dispatchRoutine(ContractDefinition const& _contract)

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -92,8 +92,6 @@ private:
 	std::string deployCode(ContractDefinition const& _contract);
 	std::string callValueCheck();
 
-	std::string implicitConstructorName(ContractDefinition const& _contract);
-
 	std::string dispatchRoutine(ContractDefinition const& _contract);
 
 	std::string memoryInit();

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -181,7 +181,7 @@ IRVariable IRGeneratorForStatements::evaluateExpression(Expression const& _expre
 
 string IRGeneratorForStatements::constantValueFunction(VariableDeclaration const& _constant)
 {
-	string functionName = "constant_" + _constant.name() + "_" + to_string(_constant.id());
+	string functionName = IRNames::constantValueFunction(_constant);
 	return m_context.functionCollector().createFunction(functionName, [&] {
 		Whiskers templ(R"(
 			function <functionName>() -> <ret> {
@@ -1890,7 +1890,7 @@ void IRGeneratorForStatements::appendExternalFunctionCall(
 	templ("pos", m_context.newYulVariable());
 	templ("end", m_context.newYulVariable());
 	if (_functionCall.annotation().tryCall)
-		templ("success", m_context.trySuccessConditionVariable(_functionCall));
+		templ("success", IRNames::trySuccessConditionVariable(_functionCall));
 	else
 		templ("success", m_context.newYulVariable());
 	templ("freeMemory", freeMemory());
@@ -2125,10 +2125,7 @@ void IRGeneratorForStatements::declareAssign(IRVariable const& _lhs, IRVariable 
 
 IRVariable IRGeneratorForStatements::zeroValue(Type const& _type, bool _splitFunctionTypes)
 {
-	IRVariable irVar{
-		"zero_value_for_type_" + _type.identifier() + m_context.newYulVariable(),
-		_type
-	};
+	IRVariable irVar{IRNames::zeroValue(_type, m_context.newYulVariable()), _type};
 	define(irVar) << m_utils.zeroValueFunction(_type, _splitFunctionTypes) << "()\n";
 	return irVar;
 }
@@ -2447,7 +2444,7 @@ bool IRGeneratorForStatements::visit(TryStatement const& _tryStatement)
 	Expression const& externalCall = _tryStatement.externalCall();
 	externalCall.accept(*this);
 
-	m_code << "switch iszero(" << m_context.trySuccessConditionVariable(externalCall) << ")\n";
+	m_code << "switch iszero(" << IRNames::trySuccessConditionVariable(externalCall) << ")\n";
 
 	m_code << "case 0 { // success case\n";
 	TryCatchClause const& successClause = *_tryStatement.clauses().front();

--- a/libsolidity/codegen/ir/IRVariable.cpp
+++ b/libsolidity/codegen/ir/IRVariable.cpp
@@ -14,6 +14,7 @@
 	You should have received a copy of the GNU General Public License
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <libsolidity/codegen/ir/Common.h>
 #include <libsolidity/codegen/ir/IRVariable.h>
 #include <libsolidity/ast/AST.h>
 #include <boost/range/adaptor/transformed.hpp>
@@ -30,19 +31,13 @@ IRVariable::IRVariable(std::string _baseName, Type const& _type):
 }
 
 IRVariable::IRVariable(VariableDeclaration const& _declaration):
-	IRVariable(
-		"vloc_" + _declaration.name() + '_' + std::to_string(_declaration.id()),
-		*_declaration.annotation().type
-	)
+	IRVariable(IRNames::localVariable(_declaration), *_declaration.annotation().type)
 {
 	solAssert(!_declaration.isStateVariable(), "");
 }
 
 IRVariable::IRVariable(Expression const& _expression):
-	IRVariable(
-		"expr_" + to_string(_expression.id()),
-		*_expression.annotation().type
-	)
+	IRVariable(IRNames::localVariable(_expression), *_expression.annotation().type)
 {
 }
 
@@ -99,7 +94,7 @@ IRVariable IRVariable::tupleComponent(size_t _i) const
 		m_type.category() == Type::Category::Tuple,
 		"Requested tuple component of non-tuple IR variable."
 	);
-	return part("component_" + std::to_string(_i + 1));
+	return part(IRNames::tupleComponent(_i));
 }
 
 string IRVariable::suffixedName(string const& _suffix) const


### PR DESCRIPTION
Requested in https://github.com/ethereum/solidity/pull/8948#pullrequestreview-412091409:
> In a subsequent PR, we could also move the naming scheme for local variables here, then everything is in one place.

I looked for `_` in the name so I might have missed some that don't have it. I think I got most of them though.

It came up during the work on #8797 though it's not strictly related.