### PR TITLE
[isoltest] Improve parameter formatting.

### DIFF
--- a/test/libsolidity/semanticTests/isoltestFormatting.sol
+++ b/test/libsolidity/semanticTests/isoltestFormatting.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f() public returns (uint[5] memory) {
+        uint[5] memory a = [4, 11, 0x111, uint(3355443), 2222222222222222222];
+        return a;
+    }
+    function g() public returns (uint[5] memory) {
+        uint[5] memory a = [16, 256, 257, uint(0x333333), 0x1ed6eb565788e38e];
+        return a;
+    }
+}
+// ----
+// f() -> 4, 11, 0x0111, 0x333333, 2222222222222222222
+// g() -> 0x10, 0x0100, 0x0101, 0x333333, 2222222222222222222


### PR DESCRIPTION
Fixes #7195.

I liked @a3d4 's idea to compare shannon entropies to determine whether decimal or hexadecimal output looks nicer.