### PR TITLE
Change build OSX CircleCI to Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,7 +531,7 @@ jobs:
       xcode: "11.0.0"
     environment:
       TERM: xterm
-      CMAKE_BUILD_TYPE: Debug
+      CMAKE_BUILD_TYPE: Release
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Fixes #3168 

The artifact generated in the `b_osx` task in CircleCI should be ready for release