### PR TITLE
[Sol->Yul] Remove unnecessary code for handling internal functions with arbitrary parameters (refactor)

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -663,12 +663,11 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		else
 			solAssert(!functionType->bound(), "");
 
+		solAssert(!functionType->takesArbitraryParameters(), "");
+
 		vector<string> args;
 		for (size_t i = 0; i < arguments.size(); ++i)
-			if (functionType->takesArbitraryParameters())
-				args += IRVariable(*arguments[i]).stackSlots();
-			else
-				args += convert(*arguments[i], *parameterTypes[i]).stackSlots();
+			args += convert(*arguments[i], *parameterTypes[i]).stackSlots();
 
 		if (functionDef)
 			define(_functionCall) <<


### PR DESCRIPTION
Extracted from https://github.com/ethereum/solidity/pull/8987#discussion_r427593742

- Internal functions cannot have arbitrary parameters