### PR TITLE
Rename wasm::Break(If) to wasm::Branch(If) for clarity

### DIFF
--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -382,15 +382,15 @@ bytes BinaryTransform::operator()(Loop const& _loop)
 	return result;
 }
 
-bytes BinaryTransform::operator()(Break const& _break)
+bytes BinaryTransform::operator()(Branch const& _branch)
 {
-	return toBytes(Opcode::Br) + encodeLabelIdx(_break.label.name);
+	return toBytes(Opcode::Br) + encodeLabelIdx(_branch.label.name);
 }
 
-bytes BinaryTransform::operator()(BreakIf const& _breakIf)
+bytes BinaryTransform::operator()(BranchIf const& _branchIf)
 {
-	bytes result = std::visit(*this, *_breakIf.condition);
-	result += toBytes(Opcode::BrIf) + encodeLabelIdx(_breakIf.label.name);
+	bytes result = std::visit(*this, *_branchIf.condition);
+	result += toBytes(Opcode::BrIf) + encodeLabelIdx(_branchIf.label.name);
 	return result;
 }
 

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -48,8 +48,8 @@ public:
 	bytes operator()(wasm::GlobalAssignment const& _assignment);
 	bytes operator()(wasm::If const& _if);
 	bytes operator()(wasm::Loop const& _loop);
-	bytes operator()(wasm::Break const& _break);
-	bytes operator()(wasm::BreakIf const& _break);
+	bytes operator()(wasm::Branch const& _branch);
+	bytes operator()(wasm::BranchIf const& _branchIf);
 	bytes operator()(wasm::Return const& _return);
 	bytes operator()(wasm::Block const& _block);
 	bytes operator()(wasm::FunctionDefinition const& _function);

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -121,14 +121,14 @@ string TextTransform::operator()(wasm::Loop const& _loop)
 	return "(loop" + move(label) + "\n" + indented(joinTransformed(_loop.statements, '\n')) + ")\n";
 }
 
-string TextTransform::operator()(wasm::Break const& _break)
+string TextTransform::operator()(wasm::Branch const& _branch)
 {
-	return "(br $" + _break.label.name + ")\n";
+	return "(br $" + _branch.label.name + ")\n";
 }
 
-string TextTransform::operator()(wasm::BreakIf const& _break)
+string TextTransform::operator()(wasm::BranchIf const& _branchIf)
 {
-	return "(br_if $" + _break.label.name + " " + visit(*_break.condition) + ")\n";
+	return "(br_if $" + _branchIf.label.name + " " + visit(*_branchIf.condition) + ")\n";
 }
 
 string TextTransform::operator()(wasm::Return const&)

--- a/libyul/backends/wasm/TextTransform.h
+++ b/libyul/backends/wasm/TextTransform.h
@@ -48,9 +48,9 @@ public:
 	std::string operator()(wasm::GlobalAssignment const& _assignment);
 	std::string operator()(wasm::If const& _if);
 	std::string operator()(wasm::Loop const& _loop);
-	std::string operator()(wasm::Break const& _break);
+	std::string operator()(wasm::Branch const& _branch);
+	std::string operator()(wasm::BranchIf const& _branchIf);
 	std::string operator()(wasm::Return const& _return);
-	std::string operator()(wasm::BreakIf const& _break);
 	std::string operator()(wasm::Block const& _block);
 
 private:

--- a/libyul/backends/wasm/WasmAST.h
+++ b/libyul/backends/wasm/WasmAST.h
@@ -41,13 +41,13 @@ struct GlobalAssignment;
 struct Block;
 struct If;
 struct Loop;
-struct Break;
-struct BreakIf;
+struct Branch;
+struct BranchIf;
 struct Return;
 using Expression = std::variant<
 	Literal, StringLiteral, LocalVariable, GlobalVariable,
 	FunctionCall, BuiltinCall, LocalAssignment, GlobalAssignment,
-	Block, If, Loop, Break, BreakIf, Return
+	Block, If, Loop, Branch, BranchIf, Return
 >;
 
 struct Literal { uint64_t value; };
@@ -66,9 +66,9 @@ struct If {
 	std::unique_ptr<std::vector<Expression>> elseStatements;
 };
 struct Loop { std::string labelName; std::vector<Expression> statements; };
-struct Break { Label label; };
+struct Branch { Label label; };
 struct Return {};
-struct BreakIf { Label label; std::unique_ptr<Expression> condition; };
+struct BranchIf { Label label; std::unique_ptr<Expression> condition; };
 
 struct VariableDeclaration { std::string variableName; };
 struct GlobalVariableDeclaration { std::string variableName; };

--- a/libyul/backends/wasm/WasmCodeTransform.cpp
+++ b/libyul/backends/wasm/WasmCodeTransform.cpp
@@ -256,26 +256,26 @@ wasm::Expression WasmCodeTransform::operator()(ForLoop const& _for)
 	wasm::Loop loop;
 	loop.labelName = newLabel();
 	loop.statements = visit(_for.pre.statements);
-	loop.statements.emplace_back(wasm::BreakIf{wasm::Label{breakLabel}, make_unique<wasm::Expression>(
+	loop.statements.emplace_back(wasm::BranchIf{wasm::Label{breakLabel}, make_unique<wasm::Expression>(
 		wasm::BuiltinCall{"i64.eqz", make_vector<wasm::Expression>(
 			visitReturnByValue(*_for.condition)
 		)}
 	)});
 	loop.statements.emplace_back(wasm::Block{continueLabel, visit(_for.body.statements)});
 	loop.statements += visit(_for.post.statements);
-	loop.statements.emplace_back(wasm::Break{wasm::Label{loop.labelName}});
+	loop.statements.emplace_back(wasm::Branch{wasm::Label{loop.labelName}});
 
 	return { wasm::Block{breakLabel, make_vector<wasm::Expression>(move(loop))} };
 }
 
 wasm::Expression WasmCodeTransform::operator()(Break const&)
 {
-	return wasm::Break{wasm::Label{m_breakContinueLabelNames.top().first}};
+	return wasm::Branch{wasm::Label{m_breakContinueLabelNames.top().first}};
 }
 
 wasm::Expression WasmCodeTransform::operator()(Continue const&)
 {
-	return wasm::Break{wasm::Label{m_breakContinueLabelNames.top().second}};
+	return wasm::Branch{wasm::Label{m_breakContinueLabelNames.top().second}};
 }
 
 wasm::Expression WasmCodeTransform::operator()(Leave const&)


### PR DESCRIPTION
The specification refers to them as branching instructions and that's how they behave. This has caused confusion (and bugs) in the past.