### PR TITLE
[SMTChecker] Add test that has an unused mapping

### DIFF
--- a/test/libsolidity/smtCheckerTests/types/unused_mapping.sol
+++ b/test/libsolidity/smtCheckerTests/types/unused_mapping.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x;
+	uint y;
+	mapping (address => bool) public never_used;
+
+	function inc() public {
+		require(x < 10);
+		require(y < 10);
+
+		if(x == 0) x = 0; // noop state var read
+		x++;
+		y++;
+		assert(y == x);
+	}
+}


### PR DESCRIPTION
Adds the test that got removed when we had to revert the first PR related to https://github.com/ethereum/solidity/pull/8788.
It passes now with z3 4.8.8