### PR TITLE
Fixed seed for randomness, fixed conflicts in errorids

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -151,7 +151,7 @@ void DeclarationTypeChecker::endVisit(UserDefinedTypeName const& _typeName)
 	{
 		_typeName.annotation().type = TypeProvider::emptyTuple();
 		m_errorReporter.fatalTypeError(
-			9755_error,
+			5172_error,
 			_typeName.location(),
 			"Name has to refer to a struct, enum or contract."
 		);
@@ -176,7 +176,7 @@ bool DeclarationTypeChecker::visit(FunctionTypeName const& _typeName)
 			break;
 		default:
 			m_errorReporter.fatalTypeError(
-				7653_error,
+				6012_error,
 				_typeName.location(),
 				"Invalid visibility, can only be \"external\" or \"internal\"."
 			);
@@ -186,7 +186,7 @@ bool DeclarationTypeChecker::visit(FunctionTypeName const& _typeName)
 	if (_typeName.isPayable() && _typeName.visibility() != Visibility::External)
 	{
 		m_errorReporter.fatalTypeError(
-			6138_error,
+			7415_error,
 			_typeName.location(),
 			"Only external function types can be payable."
 		);
@@ -246,7 +246,7 @@ void DeclarationTypeChecker::endVisit(ArrayTypeName const& _typeName)
 	}
 	if (baseType->storageBytes() == 0)
 		m_errorReporter.fatalTypeError(
-			9390_error,
+			6493_error,
 			_typeName.baseType().location(),
 			"Illegal base type of storage size zero for array."
 		);
@@ -259,16 +259,16 @@ void DeclarationTypeChecker::endVisit(ArrayTypeName const& _typeName)
 		u256 lengthValue = 0;
 		if (!lengthType || !lengthType->mobileType())
 			m_errorReporter.typeError(
-				8922_error,
+				5462_error,
 				length->location(),
 				"Invalid array length, expected integer literal or constant expression."
 			);
 		else if (lengthType->isZero())
-			m_errorReporter.typeError(1220_error, length->location(), "Array with zero length specified.");
+			m_errorReporter.typeError(1406_error, length->location(), "Array with zero length specified.");
 		else if (lengthType->isFractional())
-			m_errorReporter.typeError(4323_error, length->location(), "Array with fractional length specified.");
+			m_errorReporter.typeError(3208_error, length->location(), "Array with fractional length specified.");
 		else if (lengthType->isNegative())
-			m_errorReporter.typeError(9308_error, length->location(), "Array with negative length specified.");
+			m_errorReporter.typeError(3658_error, length->location(), "Array with negative length specified.");
 		else
 			lengthValue = lengthType->literalValue(nullptr);
 		_typeName.annotation().type = TypeProvider::array(DataLocation::Storage, baseType, lengthValue);
@@ -345,7 +345,7 @@ void DeclarationTypeChecker::endVisit(VariableDeclaration const& _variable)
 				errorString += " for variable";
 		}
 		errorString += ", but " + locationToString(varLoc) + " was given.";
-		m_errorReporter.typeError(6160_error, _variable.location(), errorString);
+		m_errorReporter.typeError(6651_error, _variable.location(), errorString);
 
 		solAssert(!allowedDataLocations.empty(), "");
 		varLoc = *allowedDataLocations.begin();

--- a/libsolidity/analysis/OverrideChecker.cpp
+++ b/libsolidity/analysis/OverrideChecker.cpp
@@ -559,7 +559,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 				overrideError(
 					_overriding,
 					_super,
-					2837_error,
+					6959_error,
 					"Overriding function changes state mutability from \"" +
 					stateMutabilityToString(_super.stateMutability()) +
 					"\" to \"" +

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -119,7 +119,7 @@ bool ReferencesResolver::visit(Identifier const& _identifier)
 			else
 				errorMessage += " Did you mean " + std::move(suggestions) + "?";
 		}
-		m_errorReporter.declarationError(8051_error, _identifier.location(), errorMessage);
+		m_errorReporter.declarationError(7576_error, _identifier.location(), errorMessage);
 	}
 	else if (declarations.size() == 1)
 		_identifier.annotation().referencedDeclaration = declarations.front();
@@ -157,7 +157,7 @@ void ReferencesResolver::endVisit(UserDefinedTypeName const& _typeName)
 	Declaration const* declaration = m_resolver.pathFromCurrentScope(_typeName.namePath());
 	if (!declaration)
 	{
-		m_errorReporter.fatalDeclarationError(7556_error, _typeName.location(), "Identifier not found or not unique.");
+		m_errorReporter.fatalDeclarationError(7920_error, _typeName.location(), "Identifier not found or not unique.");
 		return;
 	}
 
@@ -210,7 +210,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 		if (realName.empty())
 		{
 			m_errorReporter.declarationError(
-				9553_error,
+				4794_error,
 				_identifier.location,
 				"In variable names _slot and _offset can only be used as a suffix."
 			);
@@ -221,7 +221,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 	if (declarations.size() > 1)
 	{
 		m_errorReporter.declarationError(
-			8827_error,
+			4718_error,
 			_identifier.location,
 			"Multiple matching identifiers. Resolving overloaded identifiers is not supported."
 		);
@@ -233,7 +233,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 		if (var->isLocalVariable() && m_yulInsideFunction)
 		{
 			m_errorReporter.declarationError(
-				8477_error,
+				6578_error,
 				_identifier.location,
 				"Cannot access local Solidity variables from inside an inline assembly function."
 			);
@@ -255,7 +255,7 @@ void ReferencesResolver::operator()(yul::VariableDeclaration const& _varDecl)
 		string namePrefix = identifier.name.str().substr(0, identifier.name.str().find('.'));
 		if (isSlot || isOffset)
 			m_errorReporter.declarationError(
-				8820_error,
+				9155_error,
 				identifier.location,
 				"In variable declarations _slot and _offset can not be used as a suffix."
 			);
@@ -269,7 +269,7 @@ void ReferencesResolver::operator()(yul::VariableDeclaration const& _varDecl)
 				ssl.append("The shadowed declaration is here:", decl->location());
 			if (!ssl.infos.empty())
 				m_errorReporter.declarationError(
-					6005_error,
+					3859_error,
 					identifier.location,
 					ssl,
 					namePrefix.size() < identifier.name.str().size() ?

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2611,7 +2611,7 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 						auto const* var = dynamic_cast<Identifier const*>(&_memberAccess.expression());
 						string varName = var ? var->name() : "...";
 						errorMsg += " Use \"address(" + varName + ")." + memberName + "\" to access this address member.";
-						return { 5256_error, errorMsg };
+						return { 3125_error, errorMsg };
 					}
 			}
 			else if (auto const* addressType = dynamic_cast<AddressType const*>(exprType))
@@ -2624,11 +2624,11 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 						"Expected address not-payable as members were not found"
 					);
 
-					return { 2604_error, "\"send\" and \"transfer\" are only available for objects of type \"address payable\", not \"" + exprType->toString() + "\"." };
+					return { 9862_error, "\"send\" and \"transfer\" are only available for objects of type \"address payable\", not \"" + exprType->toString() + "\"." };
 				}
 			}
 
-			return { 5856_error, errorMsg };
+			return { 9582_error, errorMsg };
 		}();
 
 		m_errorReporter.fatalTypeError(
@@ -2904,7 +2904,7 @@ bool TypeChecker::visit(IndexRangeAccess const& _access)
 	if (arrayType->location() != DataLocation::CallData || !arrayType->isDynamicallySized())
 		m_errorReporter.typeError(1227_error, _access.location(), "Index range access is only supported for dynamic calldata arrays.");
 	else if (arrayType->baseType()->isDynamicallyEncoded())
-		m_errorReporter.typeError(1878_error, _access.location(), "Index range access is not supported for arrays with dynamically encoded base types.");
+		m_errorReporter.typeError(2148_error, _access.location(), "Index range access is not supported for arrays with dynamically encoded base types.");
 	_access.annotation().type = TypeProvider::arraySlice(*arrayType);
 	_access.annotation().isLValue = isLValue;
 	_access.annotation().isPure = isPure;
@@ -3203,10 +3203,10 @@ void TypeChecker::requireLValue(Expression const& _expression, bool _ordinaryAss
 		if (auto indexAccess = dynamic_cast<IndexAccess const*>(&_expression))
 		{
 			if (type(indexAccess->baseExpression())->category() == Type::Category::FixedBytes)
-				return { 9222_error, "Single bytes in fixed bytes arrays cannot be modified." };
+				return { 4360_error, "Single bytes in fixed bytes arrays cannot be modified." };
 			else if (auto arrayType = dynamic_cast<ArrayType const*>(type(indexAccess->baseExpression())))
 				if (arrayType->dataStoredIn(DataLocation::CallData))
-					return { 3335_error, "Calldata arrays are read-only." };
+					return { 6182_error, "Calldata arrays are read-only." };
 		}
 
 		if (auto memberAccess = dynamic_cast<MemberAccess const*>(&_expression))
@@ -3214,7 +3214,7 @@ void TypeChecker::requireLValue(Expression const& _expression, bool _ordinaryAss
 			if (auto structType = dynamic_cast<StructType const*>(type(memberAccess->expression())))
 			{
 				if (structType->dataStoredIn(DataLocation::CallData))
-					return { 9942_error, "Calldata structs are read-only." };
+					return { 4156_error, "Calldata structs are read-only." };
 			}
 			else if (dynamic_cast<ArrayType const*>(type(memberAccess->expression())))
 				if (memberAccess->memberName() == "length")

--- a/scripts/correct_error_ids.py
+++ b/scripts/correct_error_ids.py
@@ -55,7 +55,6 @@ def get_used_ids(file_names):
 
 def get_id(available_ids, used_ids):
     while len(available_ids) > 0:
-        random.seed(len(available_ids))
         k = random.randrange(len(available_ids))
         id = list(available_ids.keys())[k]
         del available_ids[id]
@@ -117,6 +116,7 @@ def find_source_files(top_dir):
 
 
 def main():
+    random.seed()
     cwd = os.getcwd()
     answer = input(
         f"This script checks and corrects *_error literals in .h and .cpp files\n"


### PR DESCRIPTION
I think the seed for the random number generator was not set correctly. Consider the following situation: Two users creates a branch from develop. Adds a `0000_error` for new errors. If they run `correct_error_ids.py`, they would both get the same error-id as same replacements. Because their seeds were the same. (The new seed is set once, and is a call to system time.)

Also ran `correct_error_ids.py` to fix existing conflicts.