### PR TITLE
Fix ICE when trying to decode too large static arrays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * Optimizer: Fixed a bug in BlockDeDuplicator.
  * Type Checker: Disallow assignments to storage variables of type ``mapping``.
  * Type Checker: Fix internal compiler error when accessing members of array slices.
+ * Type Checker: Fix internal compiler error when trying to decode too large static arrays.
  * NatSpec: DocString block is terminated when encountering an empty line.
  * Scanner: Fix bug when two empty NatSpec comments lead to scanning past EOL.
  * Code Generator: Trigger proper unimplemented errors on certain array copy operations.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -193,6 +193,18 @@ TypePointers TypeChecker::typeCheckABIDecodeAndRetrieveReturnType(FunctionCall c
 					typeArgument->location(),
 					"Decoding type " + actualType->toString(false) + " not supported."
 				);
+
+			if (auto referenceType = dynamic_cast<ReferenceType const*>(actualType))
+			{
+				auto result = referenceType->validForLocation(referenceType->location());
+				if (!result)
+					m_errorReporter.typeError(
+						6118_error,
+						typeArgument->location(),
+						result.message()
+					);
+			}
+
 			components.push_back(actualType);
 		}
 		else

--- a/test/libsolidity/syntaxTests/array/length/abi_decode_length_too_large.sol
+++ b/test/libsolidity/syntaxTests/array/length/abi_decode_length_too_large.sol
@@ -1,0 +1,8 @@
+// Used to cause ICE
+contract C {
+	function f() public {
+		abi.decode("", (byte[999999999]));
+	}
+}
+// ----
+// TypeError: (75-90): Type too large for memory.


### PR DESCRIPTION
fixes #8923