### PR TITLE
[Sol->Yul] Remove wrong assumption about function declarations associated an expressions

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -675,8 +675,6 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 
 			solAssert(functionDef->isImplemented(), "");
 		}
-		else
-			solAssert(!functionType->hasDeclaration(), "");
 
 		solAssert(!functionType->takesArbitraryParameters(), "");
 

--- a/test/libsolidity/semanticTests/functionCall/call_internal_function_via_expression.sol
+++ b/test/libsolidity/semanticTests/functionCall/call_internal_function_via_expression.sol
@@ -1,0 +1,24 @@
+contract C {
+    function foo() internal returns (uint) {
+        return 42;
+    }
+
+    function get_ptr(function() internal returns (uint) ptr) internal returns(function() internal returns (uint)) {
+        return ptr;
+    }
+
+    function associated() public returns (uint) {
+        // This expression directly references function definition
+        return (foo)();
+    }
+
+    function unassociated() public returns (uint) {
+        // This expression is not associated with a specific function definition
+        return (get_ptr(foo))();
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// associated() -> 42
+// unassociated() -> 42


### PR DESCRIPTION
Part of the work on #6788 and #8485.

In https://github.com/ethereum/solidity/pull/8721#discussion_r413883747 I was asked to assert that in case of a function call, if it's a direct call, the associated function declaration matches `FunctionType.declaration`. While doing this I also incorrectly assumed the opposite - that if the call is being done via a function variable or expression, the declaration is missing.

Turns out the assumption was wrong. `FunctionType` of an expression will be associated with a declaration if and only if the expression directly refers the function by name.

A small inconsistency that threw me off the right track at first was that this example seemed to contradict this:

``` solidity
contract C {
    function f() internal {}
    function g() internal { (f)(); }
}
```

I thought that in the above the type of `(f)` was not associated with a definition because the assertion did not fail. Turns out that `g` simply does not go through code generation because it's not called by anything external.