### PR TITLE
Output error when forward referencing constants in inline assembly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ Bugfixes:
  * Type Checker: Fix internal compiler error when accessing members of array slices.
  * Type Checker: Fix internal compiler error when trying to decode too large static arrays.
  * Type Checker: Fix wrong compiler error when referencing an overridden function without calling it.
+ * Type Checker: Fix internal compiler error when forward referencing non-literal constants from inline assembly.
  * NatSpec: DocString block is terminated when encountering an empty line.
  * Scanner: Fix bug when two empty NatSpec comments lead to scanning past EOL.
  * Code Generator: Trigger proper unimplemented errors on certain array copy operations.

--- a/test/libsolidity/syntaxTests/inlineAssembly/const_forward_reference.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/const_forward_reference.sol
@@ -1,0 +1,8 @@
+contract C {
+  function f() public pure {
+    assembly {
+      pop(add(add(1, 2), c))
+    }
+  }
+  int constant c = 1;
+}

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/const_forward_reference.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/const_forward_reference.sol
@@ -1,0 +1,12 @@
+contract C {
+  function f() {
+    assembly {
+      c := add(add(1, 2), c)
+    }
+  }
+  int constant c = 0 + 1;
+}
+// ----
+// SyntaxError: (15-83): No visibility specified. Did you intend to add "public"?
+// TypeError: (71-72): Constant variables with non-literal values cannot be forward referenced from inline assembly.
+// TypeError: (51-52): Constant variables cannot be assigned to.


### PR DESCRIPTION
fix #8881