### PR TITLE
Support for multiple evmc vm's.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(sources
     boostTest.cpp
     Common.cpp
     Common.h
+    ContractBytecode.h
     CommonSyntaxTest.cpp
     CommonSyntaxTest.h
     EVMHost.cpp

--- a/test/Common.h
+++ b/test/Common.h
@@ -24,18 +24,28 @@
 #include <boost/noncopyable.hpp>
 #include <boost/program_options.hpp>
 
+#include <vector>
+
 namespace solidity::test
 {
+
+class EVMHost;
 
 #ifdef _WIN32
 static constexpr auto evmoneFilename = "evmone.dll";
 static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.4.1/evmone-0.4.1-windows-amd64.zip";
+static constexpr auto heraFilename = "hera.dll";
+static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases";
 #elif defined(__APPLE__)
 static constexpr auto evmoneFilename = "libevmone.dylib";
 static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.4.1/evmone-0.4.1-darwin-x86_64.tar.gz";
+static constexpr auto heraFilename = "libhera.dylib";
+static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.2.5/hera-0.2.5-darwin-x86_64.tar.gz";
 #else
 static constexpr auto evmoneFilename = "libevmone.so";
 static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.4.1/evmone-0.4.1-linux-x86_64.tar.gz";
+static constexpr auto heraFilename = "libhera.so";
+static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.2.5/hera-0.2.5-linux-x86_64.tar.gz";
 #endif
 
 
@@ -44,6 +54,8 @@ struct ConfigException : public util::Exception {};
 struct CommonOptions: boost::noncopyable
 {
 	boost::filesystem::path evmonePath;
+	boost::filesystem::path heraPath;
+	std::vector<boost::filesystem::path> evmcPaths;
 	boost::filesystem::path testPath;
 	bool optimize = false;
 	bool enforceViaYul = false;

--- a/test/ContractBytecode.h
+++ b/test/ContractBytecode.h
@@ -1,0 +1,35 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolutil/Common.h>
+
+namespace solidity::test
+{
+
+struct ContractBytecode
+{
+	bytes evmBytecode;
+	bytes ewasmBytecode;
+
+	bool empty() const {
+		return evmBytecode.empty() || ewasmBytecode.empty();
+	}
+};
+
+} // namespace solidity::test

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -21,13 +21,19 @@
 
 #pragma once
 
-#include <test/evmc/mocked_host.hpp>
-#include <test/evmc/evmc.hpp>
 #include <test/evmc/evmc.h>
+#include <test/evmc/evmc.hpp>
+#include <test/evmc/mocked_host.hpp>
 
 #include <liblangutil/EVMVersion.h>
+#include <liblangutil/Exceptions.h>
 
 #include <libsolutil/FixedHash.h>
+
+#include <boost/filesystem/path.hpp>
+
+#include <map>
+#include <string>
 
 namespace solidity::test
 {
@@ -36,39 +42,61 @@ using Address = util::h160;
 class EVMHost: public evmc::MockedHost
 {
 public:
-	using MockedHost::get_code_size;
 	using MockedHost::get_balance;
+	using MockedHost::get_code_size;
 
 	/// Tries to dynamically load libevmone. @returns nullptr on failure.
 	/// The path has to be provided for the first successful run and will be ignored
 	/// afterwards.
-	static evmc::VM& getVM(std::string const& _path = {});
+	static evmc::VM& getVM(std::string _path = {});
 
 	explicit EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm = getVM());
 
-	void reset() { accounts.clear(); m_currentAddress = {}; }
-	void newBlock()
+	virtual bool executesEvmBytecode() const { return m_evm; }
+
+	virtual bool executesEwasmBytecode() const { return m_ewasm; }
+
+	virtual void reset()
+	{
+		accounts.clear();
+		m_currentAddress = {};
+	}
+
+	virtual void newBlock()
 	{
 		tx_context.block_number++;
 		tx_context.block_timestamp += 15;
 		recorded_logs.clear();
 	}
 
-	bool account_exists(evmc::address const& _addr) const noexcept final
+	bool account_exists(evmc::address const& _addr) const noexcept override
 	{
 		return evmc::MockedHost::account_exists(_addr);
 	}
 
-	void selfdestruct(evmc::address const& _addr, evmc::address const& _beneficiary) noexcept final;
+	virtual evmc::result execute(
+		evmc::Host& host, evmc_revision rev, const evmc_message& msg, const uint8_t* code, size_t code_size) noexcept
+	{
+		return m_vm.execute(Host::get_interface(), host.to_context(), rev, msg, code, code_size);
+	}
 
-	evmc::result call(evmc_message const& _message) noexcept final;
+	void selfdestruct(evmc::address const& _addr, evmc::address const& _beneficiary) noexcept override;
 
-	evmc::bytes32 get_block_hash(int64_t number) const noexcept final;
+	evmc::result call(evmc_message const& _message) noexcept override;
+
+	evmc::bytes32 get_block_hash(int64_t number) const noexcept override;
 
 	static Address convertFromEVMC(evmc::address const& _addr);
 	static evmc::address convertToEVMC(Address const& _addr);
 	static util::h256 convertFromEVMC(evmc::bytes32 const& _data);
 	static evmc::bytes32 convertToEVMC(util::h256 const& _data);
+
+	std::string toString() const
+	{
+		std::stringstream result;
+		result << m_vm.name() << " " << m_vm.version() << " @ " << std::hex << &m_vm;
+		return result.str();
+	}
 
 private:
 	evmc::address m_currentAddress = {};
@@ -91,7 +119,124 @@ private:
 	langutil::EVMVersion m_evmVersion;
 	// EVM version requested from EVMC (matches the above)
 	evmc_revision m_evmRevision;
+
+protected:
+	bool m_ewasm;
+	bool m_evm;
 };
 
+class EVMHosts: public EVMHost
+{
+public:
+	explicit EVMHosts(langutil::EVMVersion _evmVersion, std::vector<boost::filesystem::path> const& _paths)
+		: EVMHost(_evmVersion)
+	{
+		for (auto const& path: _paths)
+		{
+			evmc::VM& vm = EVMHost::getVM(path.string());
+			if (vm)
+			{
+				auto evmHost = std::make_shared<EVMHost>(_evmVersion, vm);
+				m_ewasm|= evmHost->executesEwasmBytecode();
+				m_evm |= evmHost->executesEvmBytecode();
+				m_evmHosts.emplace_back(evmHost);
+			}
+		}
+	}
+
+	static bool PreloadEvmcLibraries(std::vector<boost::filesystem::path> const& _paths)
+	{
+		bool success = true;
+		for (auto const& path: _paths)
+		{
+			evmc::VM& vm = solidity::test::EVMHost::getVM(path.string());
+			if (!vm)
+				success = false;
+		}
+		return success && !_paths.empty();
+	}
+
+	void forEach(std::function<void(EVMHost&)> _function)
+	{
+		for (auto& host: m_evmHosts)
+			_function(*host);
+	}
+
+	template<typename T>
+	T forEach(std::function<T(EVMHost&)> _function)
+	{
+		std::map<std::shared_ptr<EVMHost>, T> results;
+		for (auto& host: m_evmHosts)
+			results.insert(std::make_pair(host, _function(*host)));
+
+		bool error = false;
+		//		for (auto& result: results)
+		//			if (result.second != results.begin()->second)
+		//				error = true;
+
+		solAssert(!error, "");
+		return T{std::move(results.begin()->second)};
+	}
+
+	void reset() override
+	{
+		forEach([](EVMHost& _host) { _host.reset(); });
+	}
+
+	void newBlock() override
+	{
+		evmc_tx_context context = this->tx_context;
+		forEach([&context](EVMHost& _host) {
+		  _host.tx_context = context;
+		  _host.newBlock();
+		});
+		forEach([&context](EVMHost& _host) {
+			context = _host.tx_context;
+		});
+		tx_context = context;
+	}
+
+	bool account_exists(evmc::address const& _addr) const noexcept override
+	{
+		bool result = true;
+		for (auto& host: m_evmHosts)
+			result &= host->account_exists(_addr);
+		return result;
+	}
+
+	void selfdestruct(evmc::address const& _addr, evmc::address const& _beneficiary) noexcept override
+	{
+		forEach([&](EVMHost& _host) { _host.selfdestruct(_addr, _beneficiary); });
+	}
+
+	evmc::result call(evmc_message const& _message) noexcept override
+	{
+		return forEach<evmc::result>([&](EVMHost& _host) -> evmc::result { return _host.call(_message); });
+	}
+
+	evmc::result execute(
+		evmc::Host& host,
+		evmc_revision rev,
+		const evmc_message& msg,
+		const uint8_t* code,
+		size_t code_size) noexcept override
+	{
+		return forEach<evmc::result>(
+			[&](EVMHost& _host) -> evmc::result { return _host.execute(host, rev, msg, code, code_size); });
+	}
+
+	evmc::bytes32 get_block_hash(int64_t number) const noexcept override { return EVMHost::get_block_hash(number); }
+
+	size_t size() const {
+		return m_evmHosts.size();
+	}
+
+	bool empty() const {
+		return m_evmHosts.empty();
+	}
+
+private:
+	std::vector<std::shared_ptr<EVMHost>> m_evmHosts;
+};
 
 }

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -32,6 +32,8 @@
 #include <boost/algorithm/string/replace.hpp>
 
 #include <cstdlib>
+#include <memory>
+#include <tuple>
 
 using namespace std;
 using namespace solidity;
@@ -39,16 +41,17 @@ using namespace solidity::util;
 using namespace solidity::test;
 
 ExecutionFramework::ExecutionFramework():
-	ExecutionFramework(solidity::test::CommonOptions::get().evmVersion())
+	ExecutionFramework(solidity::test::CommonOptions::get().evmVersion(), solidity::test::CommonOptions::get().evmcPaths)
 {
 }
 
-ExecutionFramework::ExecutionFramework(langutil::EVMVersion _evmVersion):
+ExecutionFramework::ExecutionFramework(langutil::EVMVersion _evmVersion, std::vector<boost::filesystem::path> const& _evmPaths):
 	m_evmVersion(_evmVersion),
 	m_optimiserSettings(solidity::frontend::OptimiserSettings::minimal()),
-	m_showMessages(solidity::test::CommonOptions::get().showMessages),
-	m_evmHost(make_shared<EVMHost>(m_evmVersion))
+	m_showMessages(solidity::test::CommonOptions::get().showMessages)
 {
+	m_evmHost = make_shared<EVMHosts>(m_evmVersion, _evmPaths);
+
 	if (solidity::test::CommonOptions::get().optimize)
 		m_optimiserSettings = solidity::frontend::OptimiserSettings::standard();
 
@@ -57,10 +60,11 @@ ExecutionFramework::ExecutionFramework(langutil::EVMVersion _evmVersion):
 
 void ExecutionFramework::reset()
 {
-	m_evmHost->reset();
-	for (size_t i = 0; i < 10; i++)
-		m_evmHost->accounts[EVMHost::convertToEVMC(account(i))].balance =
-			EVMHost::convertToEVMC(u256(1) << 100);
+	m_evmHost->forEach([&](EVMHost& _host) {
+		_host.reset();
+		for (size_t i = 0; i < 10; i++)
+			_host.accounts[EVMHost::convertToEVMC(account(i))].balance = EVMHost::convertToEVMC(u256(1) << 100);
+	});
 }
 
 std::pair<bool, string> ExecutionFramework::compareAndCreateMessage(
@@ -89,15 +93,9 @@ std::pair<bool, string> ExecutionFramework::compareAndCreateMessage(
 	return make_pair(false, message);
 }
 
-u256 ExecutionFramework::gasLimit() const
-{
-	return {m_evmHost->tx_context.block_gas_limit};
-}
+u256 ExecutionFramework::gasLimit() const { return {m_evmHost->tx_context.block_gas_limit}; }
 
-u256 ExecutionFramework::gasPrice() const
-{
-	return {EVMHost::convertFromEVMC(m_evmHost->tx_context.tx_gas_price)};
-}
+u256 ExecutionFramework::gasPrice() const { return {EVMHost::convertFromEVMC(m_evmHost->tx_context.tx_gas_price)}; }
 
 u256 ExecutionFramework::blockHash(u256 const& _number) const
 {
@@ -106,81 +104,197 @@ u256 ExecutionFramework::blockHash(u256 const& _number) const
 
 u256 ExecutionFramework::blockNumber() const
 {
-	return m_evmHost->tx_context.block_number;
+	return m_evmHost->forEach<u256>([](EVMHost& _host) { return _host.tx_context.block_number; });
 }
 
-void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 const& _value)
+bool operator==(const evmc::result& a, const evmc::result& b)
 {
-	m_evmHost->newBlock();
+	bool result = false;
+	result = a.gas_left == b.gas_left && a.output_size == b.output_size && a.status_code == b.status_code;
+	result &= ::strncmp((const char*) a.create_address.bytes, (const char*) b.create_address.bytes, 20) == 0;
+	if (result && a.output_data != nullptr && b.output_data != nullptr)
+		result &= ::strncmp((const char*) a.output_data, (const char*) b.output_data, a.output_size) == 0;
+	return result;
+}
 
-	if (m_showMessages)
-	{
-		if (_isCreation)
-			cout << "CREATE " << m_sender.hex() << ":" << endl;
-		else
-			cout << "CALL   " << m_sender.hex() << " -> " << m_contractAddress.hex() << ":" << endl;
-		if (_value > 0)
-			cout << " value: " << _value << endl;
-		cout << " in:      " << toHex(_data) << endl;
-	}
-	evmc_message message = {};
-	message.input_data = _data.data();
-	message.input_size = _data.size();
-	message.sender = EVMHost::convertToEVMC(m_sender);
-	message.value = EVMHost::convertToEVMC(_value);
+bool operator!=(const evmc::result& a, const evmc::result& b) { return !(a == b); }
 
-	if (_isCreation)
-	{
+void ExecutionFramework::sendCreationMessage(
+	ContractBytecode const& _contractBytecode, bytes const& _arguments, u256 const& _value)
+{
+	solAssert(!m_evmHost->empty(), "");
+	std::vector<std::tuple<evmc::result, bytes, EVMHost*, Address>> results;
+
+	m_evmHost->forEach([&](EVMHost& _host) {
+		_host.newBlock();
+
+		bytes _data;
+
+		if (_host.executesEvmBytecode())
+			_data = _contractBytecode.evmBytecode + _arguments;
+		if (_host.executesEwasmBytecode())
+			_data = _contractBytecode.ewasmBytecode + _arguments;
+
+		evmc_message message = {};
+		message.input_data = _data.data();
+		message.input_size = _data.size();
+		message.sender = EVMHost::convertToEVMC(m_sender);
+		message.value = EVMHost::convertToEVMC(_value);
+
 		message.kind = EVMC_CREATE;
 		message.destination = EVMHost::convertToEVMC(Address{});
-	}
-	else
+		message.gas = m_gas.convert_to<int64_t>();
+
+		if (m_showMessages)
+		{
+			cout << "EVMC VM: " << _host.toString() << std::endl;
+			cout << "CREATE " << m_sender.hex() << ":" << endl;
+			if (_value > 0)
+				cout << " value: " << _value << endl;
+			cout << " in:      " << toHex(_data) << endl;
+		}
+
+		evmc::result result = _host.call(message);
+		bytes output = bytes(result.output_data, result.output_data + result.output_size);
+		Address address = EVMHost::convertFromEVMC(result.create_address);
+
+		if (m_showMessages)
+		{
+			cout << " out:     " << toHex(m_output) << endl;
+			cout << " result: " << size_t(result.status_code) << endl;
+			cout << " gas used: " << m_gasUsed.str() << endl;
+		}
+		results.emplace_back(std::make_tuple(std::move(result), std::move(output), &_host, address));
+	});
+	solAssert(!results.empty(), "");
+	bool same = true;
+	for (auto& result: results)
 	{
+		if (&result == &*results.begin())
+			continue;
+		if (std::get<0>(result) != std::get<0>(*results.begin()))
+			same = false;
+		if (same && std::get<1>(result) != std::get<1>(*results.begin()))
+			same = false;
+		if (same && std::get<3>(result) != std::get<3>(*results.begin()))
+			same = false;
+		if (!same)
+			break;
+	}
+	solAssert(same, "different results returned by different evmc vm's.");
+	if (m_showMessages)
+		cout << std::endl;
+
+	m_transactionSuccessful = std::get<0>(*results.begin()).status_code == EVMC_SUCCESS;
+	m_gasUsed = m_gas - std::get<0>(*results.begin()).gas_left;
+	m_output = std::get<1>(*results.begin());
+	m_evmHost->accounts = std::get<2>(*results.begin())->accounts;
+	m_evmHost->tx_context = std::get<2>(*results.begin())->tx_context;
+	m_evmHost->block_hash = std::get<2>(*results.begin())->block_hash;
+	m_evmHost->call_result = std::get<2>(*results.begin())->call_result;
+	m_evmHost->recorded_blockhashes = std::get<2>(*results.begin())->recorded_blockhashes;
+	m_evmHost->recorded_account_accesses = std::get<2>(*results.begin())->recorded_account_accesses;
+	m_evmHost->recorded_calls = std::get<2>(*results.begin())->recorded_calls;
+	m_evmHost->recorded_logs = std::get<2>(*results.begin())->recorded_logs;
+	m_evmHost->recorded_selfdestructs = std::get<2>(*results.begin())->recorded_selfdestructs;
+	m_contractAddress = std::get<3>(*results.begin());
+}
+
+void ExecutionFramework::sendMessage(bytes const& _data, u256 const& _value)
+{
+	solAssert(!m_evmHost->empty(), "");
+	std::vector<std::tuple<evmc::result, bytes, EVMHost*>> results;
+	m_evmHost->forEach([&](EVMHost& _host) {
+		_host.tx_context = m_evmHost->tx_context;
+		_host.newBlock();
+
+		evmc_message message = {};
+		message.input_data = _data.data();
+		message.input_size = _data.size();
+		message.sender = EVMHost::convertToEVMC(m_sender);
+		message.value = EVMHost::convertToEVMC(_value);
 		message.kind = EVMC_CALL;
 		message.destination = EVMHost::convertToEVMC(m_contractAddress);
-	}
-	message.gas = m_gas.convert_to<int64_t>();
+		message.gas = m_gas.convert_to<int64_t>();
 
-	evmc::result result = m_evmHost->call(message);
+		if (m_showMessages)
+		{
+			cout << "EVMC VM: " << _host.toString() << std::endl;
+			cout << "CALL   " << m_sender.hex() << " -> " << m_contractAddress.hex() << ":" << endl;
+			if (_value > 0)
+				cout << " value: " << _value << endl;
+			cout << " in:      " << toHex(_data) << endl;
+		}
 
-	m_output = bytes(result.output_data, result.output_data + result.output_size);
-	if (_isCreation)
-		m_contractAddress = EVMHost::convertFromEVMC(result.create_address);
+		evmc::result result = _host.call(message);
+		bytes output = bytes(result.output_data, result.output_data + result.output_size);
+		u256 gasUsed = m_gas - result.gas_left;
 
-	m_gasUsed = m_gas - result.gas_left;
-	m_transactionSuccessful = (result.status_code == EVMC_SUCCESS);
-
+		if (m_showMessages)
+		{
+			cout << " EVMC VM: " << _host.toString() << std::endl;
+			cout << " out:     " << toHex(output) << endl;
+			cout << " result: " << size_t(result.status_code) << endl;
+			cout << " gas used: " << gasUsed.str() << endl;
+		}
+		results.emplace_back(std::make_tuple(std::move(result), std::move(output), &_host));
+	});
+	solAssert(!results.empty(), "");
 	if (m_showMessages)
+		cout << std::endl;
+	bool same = true;
+	for (auto& result: results)
 	{
-		cout << " out:     " << toHex(m_output) << endl;
-		cout << " result: " << size_t(result.status_code) << endl;
-		cout << " gas used: " << m_gasUsed.str() << endl;
+		if (&result == &*results.begin())
+			continue;
+		if (std::get<0>(result) != std::get<0>(*results.begin()))
+			same = false;
+		if (same && std::get<1>(result) != std::get<1>(*results.begin()))
+			same = false;
+		if (!same)
+			break;
 	}
+	solAssert(same, "different results returned by different evmc vm's.");
+
+	m_transactionSuccessful = std::get<0>(*results.begin()).status_code == EVMC_SUCCESS;
+	m_gasUsed = m_gas - std::get<0>(*results.begin()).gas_left;
+	m_output = std::get<1>(*results.begin());
+	m_evmHost->accounts = std::get<2>(*results.begin())->accounts;
+	m_evmHost->tx_context = std::get<2>(*results.begin())->tx_context;
+	m_evmHost->block_hash = std::get<2>(*results.begin())->block_hash;
+	m_evmHost->call_result = std::get<2>(*results.begin())->call_result;
+	m_evmHost->recorded_blockhashes = std::get<2>(*results.begin())->recorded_blockhashes;
+	m_evmHost->recorded_account_accesses = std::get<2>(*results.begin())->recorded_account_accesses;
+	m_evmHost->recorded_calls = std::get<2>(*results.begin())->recorded_calls;
+	m_evmHost->recorded_logs = std::get<2>(*results.begin())->recorded_logs;
+	m_evmHost->recorded_selfdestructs = std::get<2>(*results.begin())->recorded_selfdestructs;
 }
 
 void ExecutionFramework::sendEther(Address const& _addr, u256 const& _amount)
 {
-	m_evmHost->newBlock();
+	m_evmHost->forEach([&](EVMHost& _host) {
+		_host.newBlock();
 
-	if (m_showMessages)
-	{
-		cout << "SEND_ETHER   " << m_sender.hex() << " -> " << _addr.hex() << ":" << endl;
-		if (_amount > 0)
-			cout << " value: " << _amount << endl;
-	}
-	evmc_message message = {};
-	message.sender = EVMHost::convertToEVMC(m_sender);
-	message.value = EVMHost::convertToEVMC(_amount);
-	message.kind = EVMC_CALL;
-	message.destination = EVMHost::convertToEVMC(_addr);
-	message.gas = m_gas.convert_to<int64_t>();
+		if (m_showMessages)
+		{
+			cout << "SEND_ETHER   " << m_sender.hex() << " -> " << _addr.hex() << ":" << endl;
+			if (_amount > 0)
+				cout << " value: " << _amount << endl;
+		}
+		evmc_message message = {};
+		message.sender = EVMHost::convertToEVMC(m_sender);
+		message.value = EVMHost::convertToEVMC(_amount);
+		message.kind = EVMC_CALL;
+		message.destination = EVMHost::convertToEVMC(_addr);
+		message.gas = m_gas.convert_to<int64_t>();
 
-	m_evmHost->call(message);
+		_host.call(message);
+	});
 }
 
 size_t ExecutionFramework::currentTimestamp()
 {
-	return m_evmHost->tx_context.block_timestamp;
+	return m_evmHost->forEach<int64_t>([](EVMHost& _host) -> int64_t { return _host.tx_context.block_timestamp; });
 }
 
 size_t ExecutionFramework::blockTimestamp(u256 _block)
@@ -198,40 +312,50 @@ Address ExecutionFramework::account(size_t _idx)
 
 bool ExecutionFramework::addressHasCode(Address const& _addr)
 {
-	return m_evmHost->get_code_size(EVMHost::convertToEVMC(_addr)) != 0;
+	return m_evmHost->forEach<bool>(
+		[&_addr](EVMHost& _host) -> bool { return _host.get_code_size(EVMHost::convertToEVMC(_addr)) != 0; });
 }
 
 size_t ExecutionFramework::numLogs() const
 {
-	return m_evmHost->recorded_logs.size();
+	return m_evmHost->forEach<size_t>([](EVMHost& _host) -> size_t { return _host.recorded_logs.size(); });
 }
 
 size_t ExecutionFramework::numLogTopics(size_t _logIdx) const
 {
-	return m_evmHost->recorded_logs.at(_logIdx).topics.size();
+	return m_evmHost->forEach<size_t>(
+		[&_logIdx](EVMHost& _host) -> size_t { return _host.recorded_logs.at(_logIdx).topics.size(); });
 }
 
 h256 ExecutionFramework::logTopic(size_t _logIdx, size_t _topicIdx) const
 {
-	return EVMHost::convertFromEVMC(m_evmHost->recorded_logs.at(_logIdx).topics.at(_topicIdx));
+	return m_evmHost->forEach<u256>([&_logIdx, &_topicIdx](EVMHost& _host) -> u256 {
+		return EVMHost::convertFromEVMC(_host.recorded_logs.at(_logIdx).topics.at(_topicIdx));
+	});
 }
 
 Address ExecutionFramework::logAddress(size_t _logIdx) const
 {
-	return EVMHost::convertFromEVMC(m_evmHost->recorded_logs.at(_logIdx).creator);
+	return m_evmHost->forEach<Address>([&_logIdx](EVMHost& _host) -> Address {
+		return EVMHost::convertFromEVMC(_host.recorded_logs.at(_logIdx).creator);
+	});
 }
 
 bytes ExecutionFramework::logData(size_t _logIdx) const
 {
-	const auto& data = m_evmHost->recorded_logs.at(_logIdx).data;
-	// TODO: Return a copy of log data, because this is expected from REQUIRE_LOG_DATA(),
-	//       but reference type like string_view would be preferable.
-	return {data.begin(), data.end()};
+	return m_evmHost->forEach<bytes>([&_logIdx](EVMHost& _host) -> bytes {
+		const auto& data = _host.recorded_logs.at(_logIdx).data;
+		// TODO: Return a copy of log data, because this is expected from REQUIRE_LOG_DATA(),
+		//       but reference type like string_view would be preferable.
+		return {data.begin(), data.end()};
+	});
 }
 
 u256 ExecutionFramework::balanceAt(Address const& _addr)
 {
-	return u256(EVMHost::convertFromEVMC(m_evmHost->get_balance(EVMHost::convertToEVMC(_addr))));
+	return m_evmHost->forEach<u256>([&](EVMHost& _host) {
+		return u256(EVMHost::convertFromEVMC(_host.get_balance(EVMHost::convertToEVMC(_addr))));
+	});
 }
 
 bool ExecutionFramework::storageEmpty(Address const& _addr)

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -38,6 +38,7 @@ public:
 	{
 		std::string filename;
 		langutil::EVMVersion evmVersion;
+		std::vector<boost::filesystem::path> evmPaths;
 		bool enforceCompileViaYul;
 	};
 

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -70,7 +70,7 @@ int registerTests(
 {
 	int numTestsAdded = 0;
 	fs::path fullpath = _basepath / _path;
-	TestCase::Config config{fullpath.string(), solidity::test::CommonOptions::get().evmVersion(), _enforceViaYul};
+	TestCase::Config config{fullpath.string(), solidity::test::CommonOptions::get().evmVersion(), solidity::test::CommonOptions::get().evmcPaths, _enforceViaYul};
 	if (fs::is_directory(fullpath))
 	{
 		test_suite* sub_suite = BOOST_TEST_SUITE(_path.filename().string());
@@ -150,7 +150,7 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 
 	initializeOptions();
 
-	bool disableSemantics = !solidity::test::EVMHost::getVM(solidity::test::CommonOptions::get().evmonePath.string());
+	bool disableSemantics = !solidity::test::EVMHosts::PreloadEvmcLibraries(solidity::test::CommonOptions::get().evmcPaths);
 	if (disableSemantics)
 	{
 		cout << "Unable to find " << solidity::test::evmoneFilename << ". Please provide the path using -- --evmonepath <path>." << endl;

--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -215,18 +215,18 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 }
 )DELIMITER";
 
-static LazyInit<bytes> s_compiledRegistrar;
+static LazyInit<solidity::test::ContractBytecode> s_compiledRegistrar;
 
 class AuctionRegistrarTestFramework: public SolidityExecutionFramework
 {
 protected:
 	void deployRegistrar()
 	{
-		bytes const& compiled = s_compiledRegistrar.init([&]{
+		solidity::test::ContractBytecode compiled = s_compiledRegistrar.init([&]{
 			return compileContract(registrarCode, "GlobalRegistrar");
 		});
 
-		sendMessage(compiled, true);
+		sendCreationMessage(compiled, {});
 		BOOST_REQUIRE(m_transactionSuccessful);
 		BOOST_REQUIRE(!m_output.empty());
 	}

--- a/test/contracts/FixedFeeRegistrar.cpp
+++ b/test/contracts/FixedFeeRegistrar.cpp
@@ -125,18 +125,18 @@ contract FixedFeeRegistrar is Registrar {
 }
 )DELIMITER";
 
-static LazyInit<bytes> s_compiledRegistrar;
+static LazyInit<solidity::test::ContractBytecode> s_compiledRegistrar;
 
 class RegistrarTestFramework: public SolidityExecutionFramework
 {
 protected:
 	void deployRegistrar()
 	{
-		bytes const& compiled = s_compiledRegistrar.init([&]{
+		solidity::test::ContractBytecode compiled = s_compiledRegistrar.init([&]{
 			return compileContract(registrarCode, "FixedFeeRegistrar");
 		});
 
-		sendMessage(compiled, true);
+		sendCreationMessage(compiled, {});
 		BOOST_REQUIRE(m_transactionSuccessful);
 		BOOST_REQUIRE(!m_output.empty());
 	}

--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -438,7 +438,7 @@ contract Wallet is multisig, multiowned, daylimit {
 }
 )DELIMITER";
 
-static LazyInit<bytes> s_compiledWallet;
+static LazyInit<solidity::test::ContractBytecode> s_compiledWallet;
 
 class WalletTestFramework: public SolidityExecutionFramework
 {
@@ -450,12 +450,12 @@ protected:
 		u256 _dailyLimit = 0
 	)
 	{
-		bytes const& compiled = s_compiledWallet.init([&]{
+		solidity::test::ContractBytecode compiled = s_compiledWallet.init([&]{
 			return compileContract(walletCode, "Wallet");
 		});
 
 		bytes args = encodeArgs(u256(0x60), _required, _dailyLimit, u256(_owners.size()), _owners);
-		sendMessage(compiled + args, true, _value);
+		sendCreationMessage(compiled, args, _value);
 		BOOST_REQUIRE(m_transactionSuccessful);
 		BOOST_REQUIRE(!m_output.empty());
 	}

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -89,7 +89,7 @@ public:
 		util::FixedHash<4> hash(util::keccak256(_sig));
 		for (bytes const& arguments: _argumentVariants)
 		{
-			sendMessage(hash.asBytes() + arguments, false, 0);
+			sendMessage(hash.asBytes() + arguments, 0);
 			BOOST_CHECK(m_transactionSuccessful);
 			gasUsed = max(gasUsed, m_gasUsed);
 			gas = max(gas, gasForTransaction(hash.asBytes() + arguments, false));

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -39,8 +39,8 @@ using namespace boost::unit_test;
 namespace fs = boost::filesystem;
 
 
-SemanticTest::SemanticTest(string const& _filename, langutil::EVMVersion _evmVersion, bool enforceViaYul):
-	SolidityExecutionFramework(_evmVersion),
+SemanticTest::SemanticTest(string const& _filename, langutil::EVMVersion _evmVersion, std::vector<boost::filesystem::path> const& _evmPaths, bool enforceViaYul):
+	SolidityExecutionFramework(_evmVersion, _evmPaths),
 	EVMVersionRestrictedTestCase(_filename),
 	m_enforceViaYul(enforceViaYul)
 {

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -40,9 +40,11 @@ class SemanticTest: public SolidityExecutionFramework, public EVMVersionRestrict
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _options)
-	{ return std::make_unique<SemanticTest>(_options.filename, _options.evmVersion, _options.enforceCompileViaYul); }
+	{
+		return std::make_unique<SemanticTest>(_options.filename, _options.evmVersion, _options.evmPaths, _options.enforceCompileViaYul);
+	}
 
-	explicit SemanticTest(std::string const& _filename, langutil::EVMVersion _evmVersion, bool _enforceViaYul = false);
+	explicit SemanticTest(std::string const& _filename, langutil::EVMVersion _evmVersion, std::vector<boost::filesystem::path> const& _evmPaths, bool _enforceViaYul = false);
 
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
 	void printSource(std::ostream &_stream, std::string const& _linePrefix = "", bool _formatted = false) const override;

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -164,6 +164,7 @@ TestTool::Result TestTool::process()
 			m_test = m_testCaseCreator(TestCase::Config{
 				m_path.string(),
 				m_options.evmVersion(),
+				m_options.evmcPaths,
 				m_options.enforceViaYul
 			});
 			if (m_test->shouldRun())
@@ -427,7 +428,7 @@ int main(int argc, char const *argv[])
 
 	auto& options = dynamic_cast<solidity::test::IsolTestOptions const&>(solidity::test::CommonOptions::get());
 
-	bool disableSemantics = !solidity::test::EVMHost::getVM(options.evmonePath.string());
+	bool disableSemantics = !solidity::test::EVMHosts::PreloadEvmcLibraries(solidity::test::CommonOptions::get().evmcPaths);
 	if (disableSemantics)
 	{
 		cout << "Unable to find " << solidity::test::evmoneFilename << ". Please provide the path using --evmonepath <path>." << endl;


### PR DESCRIPTION
- work in progress
- still incomplete, hacky & unoptimized, but probably the basic idea is already visible
- introduction of `EVMHosts`, that inherits from `EVMHost`.. `EVMHosts` is now used within `ExecutionFramework`, the different evm vms will be initialized via the command line option`--evmc`
- current idea is basically to distinguish between creation & normal calls to the evmc vms
- based on the capability of the evm, "evm" or "ewasm" bytecode is deployed to the evmc vm
- normal calls e.g. `sendMessage(..)` will basically iterate through the defined evms and call "`sendMessage`" per instance.. results will be collected and compared if they are the same
- if they are the same some members of `EVMHosts` will be set, so that e.g. `SolidityEndToEndTests.cpp` can still operate on the defined member variables, if they where not the same, an assertion will fail
- created a `fake-ewasm` branch of evmone here https://github.com/aarlt/evmone/tree/fake-ewasm, this special evmone will basically just set the `ewasm` capability flag
- right now no contract is compiled to ewasm, instead the bytecode for ewasm is just `evm` bytecode, appended with some additional bytes `fake-ewasm`.. I did this to be able to test the "deployment-behaviour" before hera supports evmc v7