### PR TITLE
Constants for flags in wasm::BinaryTransform (refactor)

### DIFF
--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -39,6 +39,18 @@ bytes toBytes(uint8_t _b)
 	return bytes(1, _b);
 }
 
+enum class LimitsKind: uint8_t
+{
+	Min = 0x00,
+	MinMax = 0x01,
+};
+
+enum class Mutability: uint8_t
+{
+	Const = 0x00,
+	Var = 0x01,
+};
+
 enum class Section: uint8_t
 {
 	CUSTOM = 0x00,
@@ -530,8 +542,8 @@ bytes BinaryTransform::functionSection(vector<FunctionDefinition> const& _functi
 bytes BinaryTransform::memorySection()
 {
 	bytes result = lebEncode(1);
-	result.push_back(0); // flags
-	result.push_back(1); // initial
+	result.push_back(static_cast<uint8_t>(LimitsKind::Min));
+	result.push_back(1); // initial length
 	return makeSection(Section::MEMORY, std::move(result));
 }
 
@@ -540,8 +552,8 @@ bytes BinaryTransform::globalSection()
 	bytes result = lebEncode(m_globals.size());
 	for (size_t i = 0; i < m_globals.size(); ++i)
 		result +=
-			// mutable i64
-			bytes{uint8_t(ValueType::I64), 1} +
+			toBytes(ValueType::I64) +
+			lebEncode(static_cast<uint8_t>(Mutability::Var)) +
 			toBytes(Opcode::I64Const) +
 			lebEncodeSigned(0) +
 			toBytes(Opcode::End);


### PR DESCRIPTION
Small refactor extracted from #8240.

I think it's better to have constants here instead of using comments to explain the 1s and 0s. It took me a moment to realize what the comment was even referring to.