### PR TITLE
Fix internal compiler error related to oversized objects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Compiler Features:
 
 Bugfixes:
  * Type Checker: Fix overload resolution in combination with ``{value: ...}``.
+ * Type Checker: Fix internal compiler error related to oversized types.
 
 Compiler Features:
  * Optimizer: Add rule to remove shifts inside the byte opcode.

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -73,23 +73,6 @@ private:
 	bool visit(BinaryOperation const& _operation) override;
 	bool visit(FunctionCall const& _functionCall) override;
 
-	struct TypeComp
-	{
-		bool operator()(Type const* lhs, Type const* rhs) const
-		{
-			solAssert(lhs && rhs, "");
-			return lhs->richIdentifier() < rhs->richIdentifier();
-		}
-	};
-	using TypeSet = std::set<Type const*, TypeComp>;
-
-	/// @returns the size of this type in storage, including all sub-types.
-	static bigint structureSizeEstimate(
-		Type const& _type,
-		std::set<StructDefinition const*>& _structsSeen,
-		TypeSet& _oversizedSubTypes
-	);
-
 	langutil::ErrorReporter& m_errorReporter;
 
 	/// Flag that indicates whether the current contract definition is a library.

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -54,6 +54,14 @@ using rational = boost::rational<bigint>;
 using TypeResult = util::Result<TypePointer>;
 using BoolResult = util::Result<bool>;
 
+}
+
+namespace solidity::frontend
+{
+
+bigint storageSizeUpperBound(frontend::Type const& _type);
+std::vector<frontend::Type const*> oversizedSubtypes(frontend::Type const& _type);
+
 inline rational makeRational(bigint const& _numerator, bigint const& _denominator)
 {
 	solAssert(_denominator != 0, "division by zero");

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_array_mapping.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_array_mapping.sol
@@ -2,4 +2,4 @@ contract C {
     mapping(uint => uint[2**100]) x;
 }
 // ----
-// Warning 7325: (17-48): Type "uint256[1267650600228229401496703205376]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (17-46): Type "uint256[1267650600228229401496703205376]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_structs.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_structs.sol
@@ -23,9 +23,9 @@ contract C {
 
     struct Q0
     {
-        uint[1][][10**20 + 4] x;
-        uint[10**20 + 4][][1] y;
-        uint[][10**20 + 4] z;
+        uint[1][][10**20 + 1] x;
+        uint[10**20 + 2][][1] y;
+        uint[][10**20 + 3] z;
         uint[10**20 + 4][] t;
     }
     Q0 q0;
@@ -57,11 +57,12 @@ contract C {
 // ----
 // Warning 3408: (106-111): Variable "s0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 3408: (171-176): Variable "s1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (341-346): Type "C.P[103]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (341-346): Type "C.P[104]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (341-343): Type "C.P[103]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (341-343): Type "C.P[104]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 3408: (505-510): Variable "q0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (505-510): Type "uint256[100000000000000000004]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (505-507): Type "uint256[100000000000000000002]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (505-507): Type "uint256[100000000000000000004]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 3408: (576-581): Variable "q1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (647-652): Type "uint256[100000000000000000006]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (647-649): Type "uint256[100000000000000000006]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 3408: (715-720): Variable "q3" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (783-788): Type "uint256[100000000000000000008]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (783-785): Type "uint256[100000000000000000008]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_array.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_array.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >= 0.0;
+contract C {
+    uint[2**255][2] a;
+}
+// ----
+// TypeError 1534: (77-94): Type too large for storage.
+// TypeError 7676: (60-97): Contract too large for storage.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_contract.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_contract.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >= 0.0;
+contract C {
+    uint[2**255] a;
+    uint[2**255] b;
+}
+// ----
+// Warning 3408: (77-91): Variable "a" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (97-111): Variable "b" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// TypeError 7676: (60-114): Contract too large for storage.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_struct.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_struct.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >= 0.0;
+contract C {
+    struct S {
+        uint[2**255] a;
+        uint[2**255] b;
+    }
+    S s;
+}
+// ----
+// TypeError 1534: (146-149): Type too large for storage.
+// TypeError 7676: (60-152): Contract too large for storage.

--- a/test/libsolidity/syntaxTests/largeTypes/storage_parameter.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/storage_parameter.sol
@@ -1,0 +1,6 @@
+contract C {
+    struct S { uint256[2**255] x; }
+    function f(S storage) internal {}
+}
+// ----
+// Warning 2332: (64-65): Type "C.S" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.


### PR DESCRIPTION
As it is difficult to make an instance of an `ErrorReporter` available, we can throw instead.
Then we catch the error in a class which has `ErrorReporter` and report it normally.

If we do it here, we may also do it in PR #9007, instead of dragging `ErrorReporter` across classes.
