### PR TITLE
Option groups in command-line help

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -752,7 +752,10 @@ Allowed options)").c_str(),
 			"Select desired EVM version. Either homestead, tangerineWhistle, spuriousDragon, "
 			"byzantium, constantinople, petersburg, istanbul (default) or berlin."
 		)
-		(g_argPrettyJson.c_str(), "Output JSON in pretty format. Currently it only works with the combined JSON output.")
+		(
+			g_argPrettyJson.c_str(),
+			"Output JSON in pretty format. Currently it only works with the combined JSON output."
+		)
 		(
 			g_argLibraries.c_str(),
 			po::value<vector<string>>()->value_name("libs"),
@@ -770,13 +773,19 @@ Allowed options)").c_str(),
 			po::value<string>()->value_name("path"),
 			"If given, creates one file per component and contract/file at the specified directory."
 		)
-		(g_strOverwrite.c_str(), "Overwrite existing files (used together with -o).")
+		(
+			g_strOverwrite.c_str(),
+			"Overwrite existing files (used together with -o)."
+		)
 		(
 			g_argCombinedJson.c_str(),
 			po::value<string>()->value_name(boost::join(g_combinedJsonArgs, ",")),
 			"Output a single json document containing the specified information."
 		)
-		(g_argGas.c_str(), "Print an estimate of the maximal gas usage for each function.")
+		(
+			g_argGas.c_str(),
+			"Print an estimate of the maximal gas usage for each function."
+		)
 		(
 			g_argStandardJSON.c_str(),
 			"Switch to Standard JSON input / output mode, ignoring all options. "
@@ -826,7 +835,10 @@ Allowed options)").c_str(),
 			po::value<string>()->value_name(boost::join(g_metadataHashArgs, ",")),
 			"Choose hash method for the bytecode metadata or disable it."
 		)
-		(g_argMetadataLiteral.c_str(), "Store referenced sources as literal data in the metadata output.")
+		(
+			g_argMetadataLiteral.c_str(),
+			"Store referenced sources as literal data in the metadata output."
+		)
 		(
 			g_argAllowPaths.c_str(),
 			po::value<string>()->value_name("path(s)"),
@@ -837,12 +849,29 @@ Allowed options)").c_str(),
 			po::value<string>()->value_name("path"),
 			"Use the given path as the root of the source tree instead of the root of the filesystem."
 		)
-		(g_argColor.c_str(), "Force colored output.")
-		(g_argNoColor.c_str(), "Explicitly disable colored output, disabling terminal auto-detection.")
-		(g_argOldReporter.c_str(), "Enables old diagnostics reporter.")
-		(g_argErrorRecovery.c_str(), "Enables additional parser error recovery.")
-		(g_argIgnoreMissingFiles.c_str(), "Ignore missing files.");
+		(
+			g_argColor.c_str(),
+			"Force colored output."
+		)
+		(
+			g_argNoColor.c_str(),
+			"Explicitly disable colored output, disabling terminal auto-detection."
+		)
+		(
+			g_argOldReporter.c_str(),
+			"Enables old diagnostics reporter."
+		)
+		(
+			g_argErrorRecovery.c_str(),
+			"Enables additional parser error recovery."
+		)
+		(
+			g_argIgnoreMissingFiles.c_str(),
+			"Ignore missing files."
+		)
+	;
 	po::options_description optimizerOptions("Optimizer options");
+
 	optimizerOptions.add_options()
 		(g_argOptimize.c_str(), "Enable bytecode optimizer.")
 		(
@@ -851,14 +880,22 @@ Allowed options)").c_str(),
 			"Set for how many contract runs to optimize. "
 			"Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
 		)
-		(g_strOptimizeYul.c_str(), ("Legacy option, ignored. Use the general --" + g_argOptimize + " to enable Yul optimizer.").c_str())
-		(g_strNoOptimizeYul.c_str(), "Disable Yul optimizer in Solidity.")
+		(
+			g_strOptimizeYul.c_str(),
+			("Legacy option, ignored. Use the general --" + g_argOptimize + " to enable Yul optimizer.").c_str()
+		)
+		(
+			g_strNoOptimizeYul.c_str(),
+			"Disable Yul optimizer in Solidity."
+		)
 		(
 			g_strYulOptimizations.c_str(),
 			po::value<string>()->value_name("steps"),
 			"Forces yul optimizer to use the specified sequence of optimization steps instead of the built-in one."
-		);
+		)
+	;
 	desc.add(optimizerOptions);
+
 	po::options_description outputComponents("Output Components");
 	outputComponents.add_options()
 		(g_argAstJson.c_str(), "AST of all source files in JSON format.")
@@ -876,7 +913,8 @@ Allowed options)").c_str(),
 		(g_argNatspecUser.c_str(), "Natspec user documentation of all contracts.")
 		(g_argNatspecDev.c_str(), "Natspec developer documentation of all contracts.")
 		(g_argMetadata.c_str(), "Combined Metadata JSON whose Swarm hash is stored on-chain.")
-		(g_argStorageLayout.c_str(), "Slots, offsets and types of the contract's state variables.");
+		(g_argStorageLayout.c_str(), "Slots, offsets and types of the contract's state variables.")
+	;
 	desc.add(outputComponents);
 
 	po::options_description allOptions = desc;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -878,7 +878,7 @@ General Information)").c_str(),
 		)
 		(
 			g_argOldReporter.c_str(),
-			"Enables old diagnostics reporter."
+			"Enables old diagnostics reporter (legacy option, will be removed)."
 		)
 	;
 	desc.add(outputFormatting);

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -738,7 +738,7 @@ remap paths using the context:prefix=path syntax.
 Example:
 solc --)" + g_argBinary + R"( -o /tmp/solcoutput dapp-bin=/usr/local/lib/dapp-bin contract.sol
 
-Allowed options)").c_str(),
+General Information)").c_str(),
 		po::options_description::m_default_line_length,
 		po::options_description::m_default_line_length - 23
 	);
@@ -746,28 +746,33 @@ Allowed options)").c_str(),
 		(g_argHelp.c_str(), "Show help message and exit.")
 		(g_argVersion.c_str(), "Show version and exit.")
 		(g_strLicense.c_str(), "Show licensing information and exit.")
+	;
+
+	po::options_description inputOptions("Input Options");
+	inputOptions.add_options()
 		(
-			g_strEVMVersion.c_str(),
-			po::value<string>()->value_name("version"),
-			"Select desired EVM version. Either homestead, tangerineWhistle, spuriousDragon, "
-			"byzantium, constantinople, petersburg, istanbul (default) or berlin."
+			g_argBasePath.c_str(),
+			po::value<string>()->value_name("path"),
+			"Use the given path as the root of the source tree instead of the root of the filesystem."
 		)
 		(
-			g_argPrettyJson.c_str(),
-			"Output JSON in pretty format. Currently it only works with the combined JSON output."
+			g_argAllowPaths.c_str(),
+			po::value<string>()->value_name("path(s)"),
+			"Allow a given path for imports. A list of paths can be supplied by separating them with a comma."
 		)
 		(
-			g_argLibraries.c_str(),
-			po::value<vector<string>>()->value_name("libs"),
-			"Direct string or file containing library addresses. Syntax: "
-			"<libraryName>:<address> [, or whitespace] ...\n"
-			"Address is interpreted as a hex string optionally prefixed by 0x."
+			g_argIgnoreMissingFiles.c_str(),
+			"Ignore missing files."
 		)
 		(
-			g_strRevertStrings.c_str(),
-			po::value<string>()->value_name(boost::join(g_revertStringsArgs, ",")),
-			"Strip revert (and require) reason strings or add additional debugging information."
+			g_argErrorRecovery.c_str(),
+			"Enables additional parser error recovery."
 		)
+	;
+	desc.add(inputOptions);
+
+	po::options_description outputOptions("Output Options");
+	outputOptions.add_options()
 		(
 			(g_argOutputDir + ",o").c_str(),
 			po::value<string>()->value_name("path"),
@@ -778,24 +783,30 @@ Allowed options)").c_str(),
 			"Overwrite existing files (used together with -o)."
 		)
 		(
-			g_argCombinedJson.c_str(),
-			po::value<string>()->value_name(boost::join(g_combinedJsonArgs, ",")),
-			"Output a single json document containing the specified information."
+			g_strEVMVersion.c_str(),
+			po::value<string>()->value_name("version"),
+			"Select desired EVM version. Either homestead, tangerineWhistle, spuriousDragon, "
+			"byzantium, constantinople, petersburg, istanbul (default) or berlin."
 		)
 		(
-			g_argGas.c_str(),
-			"Print an estimate of the maximal gas usage for each function."
+			g_strRevertStrings.c_str(),
+			po::value<string>()->value_name(boost::join(g_revertStringsArgs, ",")),
+			"Strip revert (and require) reason strings or add additional debugging information."
 		)
+	;
+	desc.add(outputOptions);
+
+	po::options_description alternativeInputModes("Alternative Input Modes");
+	alternativeInputModes.add_options()
 		(
 			g_argStandardJSON.c_str(),
 			"Switch to Standard JSON input / output mode, ignoring all options. "
 			"It reads from standard input, if no input file was given, otherwise it reads from the provided input file. The result will be written to standard output."
 		)
 		(
-			g_argImportAst.c_str(),
-			("Import ASTs to be compiled, assumes input holds the AST in compact JSON format. "
-			"Supported Inputs is the output of the --" + g_argStandardJSON + " or the one produced by "
-			"--" + g_argCombinedJson + " " + g_strAst + "," + g_strCompactJSON).c_str()
+			g_argLink.c_str(),
+			("Switch to linker mode, ignoring all options apart from --" + g_argLibraries + " "
+			"and modify binaries in place.").c_str()
 		)
 		(
 			g_argAssemble.c_str(),
@@ -816,38 +827,46 @@ Allowed options)").c_str(),
 			"and assumes input is strict assembly.").c_str()
 		)
 		(
-			g_strYulDialect.c_str(),
-			po::value<string>()->value_name(boost::join(g_yulDialectArgs, ",")),
-			"Input dialect to use in assembly or yul mode."
+			g_argImportAst.c_str(),
+			("Import ASTs to be compiled, assumes input holds the AST in compact JSON format. "
+			"Supported Inputs is the output of the --" + g_argStandardJSON + " or the one produced by "
+			"--" + g_argCombinedJson + " " + g_strAst + "," + g_strCompactJSON).c_str()
 		)
+	;
+	desc.add(alternativeInputModes);
+
+	po::options_description assemblyModeOptions("Assembly Mode Options");
+	assemblyModeOptions.add_options()
 		(
 			g_argMachine.c_str(),
 			po::value<string>()->value_name(boost::join(g_machineArgs, ",")),
 			"Target machine in assembly or Yul mode."
 		)
 		(
-			g_argLink.c_str(),
-			("Switch to linker mode, ignoring all options apart from --" + g_argLibraries + " "
-			"and modify binaries in place.").c_str()
+			g_strYulDialect.c_str(),
+			po::value<string>()->value_name(boost::join(g_yulDialectArgs, ",")),
+			"Input dialect to use in assembly or yul mode."
 		)
+	;
+	desc.add(assemblyModeOptions);
+
+	po::options_description linkerModeOptions("Linker Mode Options");
+	linkerModeOptions.add_options()
 		(
-			g_argMetadataHash.c_str(),
-			po::value<string>()->value_name(boost::join(g_metadataHashArgs, ",")),
-			"Choose hash method for the bytecode metadata or disable it."
+			g_argLibraries.c_str(),
+			po::value<vector<string>>()->value_name("libs"),
+			"Direct string or file containing library addresses. Syntax: "
+			"<libraryName>:<address> [, or whitespace] ...\n"
+			"Address is interpreted as a hex string optionally prefixed by 0x."
 		)
+	;
+	desc.add(linkerModeOptions);
+
+	po::options_description outputFormatting("Output Formatting");
+	outputFormatting.add_options()
 		(
-			g_argMetadataLiteral.c_str(),
-			"Store referenced sources as literal data in the metadata output."
-		)
-		(
-			g_argAllowPaths.c_str(),
-			po::value<string>()->value_name("path(s)"),
-			"Allow a given path for imports. A list of paths can be supplied by separating them with a comma."
-		)
-		(
-			g_argBasePath.c_str(),
-			po::value<string>()->value_name("path"),
-			"Use the given path as the root of the source tree instead of the root of the filesystem."
+			g_argPrettyJson.c_str(),
+			"Output JSON in pretty format. Currently it only works with the combined JSON output."
 		)
 		(
 			g_argColor.c_str(),
@@ -861,40 +880,8 @@ Allowed options)").c_str(),
 			g_argOldReporter.c_str(),
 			"Enables old diagnostics reporter."
 		)
-		(
-			g_argErrorRecovery.c_str(),
-			"Enables additional parser error recovery."
-		)
-		(
-			g_argIgnoreMissingFiles.c_str(),
-			"Ignore missing files."
-		)
 	;
-	po::options_description optimizerOptions("Optimizer options");
-
-	optimizerOptions.add_options()
-		(g_argOptimize.c_str(), "Enable bytecode optimizer.")
-		(
-			g_argOptimizeRuns.c_str(),
-			po::value<unsigned>()->value_name("n")->default_value(200),
-			"Set for how many contract runs to optimize. "
-			"Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
-		)
-		(
-			g_strOptimizeYul.c_str(),
-			("Legacy option, ignored. Use the general --" + g_argOptimize + " to enable Yul optimizer.").c_str()
-		)
-		(
-			g_strNoOptimizeYul.c_str(),
-			"Disable Yul optimizer in Solidity."
-		)
-		(
-			g_strYulOptimizations.c_str(),
-			po::value<string>()->value_name("steps"),
-			"Forces yul optimizer to use the specified sequence of optimization steps instead of the built-in one."
-		)
-	;
-	desc.add(optimizerOptions);
+	desc.add(outputFormatting);
 
 	po::options_description outputComponents("Output Components");
 	outputComponents.add_options()
@@ -916,6 +903,62 @@ Allowed options)").c_str(),
 		(g_argStorageLayout.c_str(), "Slots, offsets and types of the contract's state variables.")
 	;
 	desc.add(outputComponents);
+
+	po::options_description extraOutput("Extra Output");
+	extraOutput.add_options()
+		(
+			g_argGas.c_str(),
+			"Print an estimate of the maximal gas usage for each function."
+		)
+		(
+			g_argCombinedJson.c_str(),
+			po::value<string>()->value_name(boost::join(g_combinedJsonArgs, ",")),
+			"Output a single json document containing the specified information."
+		)
+	;
+	desc.add(extraOutput);
+
+	po::options_description metadataOptions("Metadata Options");
+	metadataOptions.add_options()
+		(
+			g_argMetadataHash.c_str(),
+			po::value<string>()->value_name(boost::join(g_metadataHashArgs, ",")),
+			"Choose hash method for the bytecode metadata or disable it."
+		)
+		(
+			g_argMetadataLiteral.c_str(),
+			"Store referenced sources as literal data in the metadata output."
+		)
+	;
+	desc.add(metadataOptions);
+
+	po::options_description optimizerOptions("Optimizer Options");
+	optimizerOptions.add_options()
+		(
+			g_argOptimize.c_str(),
+			"Enable bytecode optimizer."
+		)
+		(
+			g_argOptimizeRuns.c_str(),
+			po::value<unsigned>()->value_name("n")->default_value(200),
+			"Set for how many contract runs to optimize. "
+			"Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
+		)
+		(
+			g_strOptimizeYul.c_str(),
+			("Legacy option, ignored. Use the general --" + g_argOptimize + " to enable Yul optimizer.").c_str()
+		)
+		(
+			g_strNoOptimizeYul.c_str(),
+			"Disable Yul optimizer in Solidity."
+		)
+		(
+			g_strYulOptimizations.c_str(),
+			po::value<string>()->value_name("steps"),
+			"Forces yul optimizer to use the specified sequence of optimization steps instead of the built-in one."
+		)
+	;
+	desc.add(optimizerOptions);
 
 	po::options_description allOptions = desc;
 	allOptions.add_options()(g_argInputFile.c_str(), po::value<vector<string>>(), "input file");


### PR DESCRIPTION
Related to #9075. The current command-line help is a big list with very little organization and this does not make it easy to see which options will be ignored when used in combination. While this PR does not solve this problem, I think that grouping the options makes relations between them a bit clearer.

Here's how it would look like if this PR was merged. This is the best I could come up with on my own but some choices are pretty arbitrary so feedback is welcome:
```
solc, the Solidity commandline compiler.

This program comes with ABSOLUTELY NO WARRANTY. This is free software, and you
are welcome to redistribute it under certain conditions. See 'solc --license'
for details.

Usage: solc [options] [input_file...]
Compiles the given Solidity input files (or the standard input if none given or
"-" is used as a file name) and outputs the components specified in the options
at standard output or in files in the output directory, if specified.
Imports are automatically read from the filesystem, but it is also possible to
remap paths using the context:prefix=path syntax.
Example:
solc --bin -o /tmp/solcoutput dapp-bin=/usr/local/lib/dapp-bin contract.sol

General Information:
  --help               Show help message and exit.
  --version            Show version and exit.
  --license            Show licensing information and exit.

Input Options:
  --base-path path     Use the given path as the root of the source tree 
                       instead of the root of the filesystem.
  --allow-paths path(s)
                       Allow a given path for imports. A list of paths can be 
                       supplied by separating them with a comma.
  --ignore-missing     Ignore missing files.
  --error-recovery     Enables additional parser error recovery.

Output Options:
  -o [ --output-dir ] path
                       If given, creates one file per component and 
                       contract/file at the specified directory.
  --overwrite          Overwrite existing files (used together with -o).
  --evm-version version
                       Select desired EVM version. Either homestead, 
                       tangerineWhistle, spuriousDragon, byzantium, 
                       constantinople, petersburg, istanbul (default) or 
                       berlin.
  --revert-strings debug,default,strip,verboseDebug
                       Strip revert (and require) reason strings or add 
                       additional debugging information.

Alternative Input Modes:
  --standard-json      Switch to Standard JSON input / output mode, ignoring 
                       all options. It reads from standard input, if no input 
                       file was given, otherwise it reads from the provided 
                       input file. The result will be written to standard 
                       output.
  --link               Switch to linker mode, ignoring all options apart from 
                       --libraries and modify binaries in place.
  --assemble           Switch to assembly mode, ignoring all options except 
                       --machine, --yul-dialect, --optimize and 
                       --yul-optimizations and assumes input is assembly.
  --yul                Switch to Yul mode, ignoring all options except 
                       --machine, --yul-dialect, --optimize and 
                       --yul-optimizations and assumes input is Yul.
  --strict-assembly    Switch to strict assembly mode, ignoring all options 
                       except --machine, --yul-dialect, --optimize and 
                       --yul-optimizations and assumes input is strict 
                       assembly.
  --import-ast         Import ASTs to be compiled, assumes input holds the AST 
                       in compact JSON format. Supported Inputs is the output 
                       of the --standard-json or the one produced by 
                       --combined-json ast,compact-format

Assembly Mode Options:
  --machine evm,evm15,ewasm
                       Target machine in assembly or Yul mode.
  --yul-dialect evm,ewasm
                       Input dialect to use in assembly or yul mode.

Linker Mode Options:
  --libraries libs     Direct string or file containing library addresses.
                       Syntax: <libraryName>:<address> [, or whitespace] ...
                       Address is interpreted as a hex string optionally
                       prefixed by 0x.

Output Formatting:
  --pretty-json        Output JSON in pretty format. Currently it only works
                       with the combined JSON output.
  --color              Force colored output.
  --no-color           Explicitly disable colored output, disabling terminal
                       auto-detection.
  --old-reporter       Enables old diagnostics reporter (legacy option, will be
                       removed).

Output Components:
  --ast-json           AST of all source files in JSON format.
  --ast-compact-json   AST of all source files in a compact JSON format.
  --asm                EVM assembly of the contracts.
  --asm-json           EVM assembly of the contracts in JSON format.
  --opcodes            Opcodes of the contracts.
  --bin                Binary of the contracts in hex.
  --bin-runtime        Binary of the runtime part of the contracts in hex.
  --abi                ABI specification of the contracts.
  --ir                 Intermediate Representation (IR) of all contracts
                       (EXPERIMENTAL).
  --ir-optimized       Optimized intermediate Representation (IR) of all
                       contracts (EXPERIMENTAL).
  --ewasm              Ewasm text representation of all contracts
                       (EXPERIMENTAL).
  --hashes             Function signature hashes of the contracts.
  --userdoc            Natspec user documentation of all contracts.
  --devdoc             Natspec developer documentation of all contracts.
  --metadata           Combined Metadata JSON whose Swarm hash is stored
                       on-chain.
  --storage-layout     Slots, offsets and types of the contract's state
                       variables.

Extra Output:
  --gas                Print an estimate of the maximal gas usage for each
                       function.
  --combined-json abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,storage-layout,userdoc
                       Output a single json document containing the specified
                       information.

Metadata Options:
  --metadata-hash ipfs,none,swarm
                       Choose hash method for the bytecode metadata or disable
                       it.
  --metadata-literal   Store referenced sources as literal data in the metadata
                       output.

Optimizer Options:
  --optimize           Enable bytecode optimizer.
  --optimize-runs n (=200)
                       Set for how many contract runs to optimize. Lower values
                       will optimize more for initial deployment cost, higher
                       values will optimize more for high-frequency usage.
  --optimize-yul       Legacy option, ignored. Use the general --optimize to
                       enable Yul optimizer.
  --no-optimize-yul    Disable Yul optimizer in Solidity.
  --yul-optimizations steps
                       Forces yul optimizer to use the specified sequence of
                       optimization steps instead of the built-in one.
```