### PR TITLE
Add shortcut to to/fromHex for empty input and fix signedness warning

### DIFF
--- a/libsolutil/CommonData.cpp
+++ b/libsolutil/CommonData.cpp
@@ -53,6 +53,9 @@ string solidity::util::toHex(uint8_t _data, HexCase _case)
 
 string solidity::util::toHex(bytes const& _data, HexPrefix _prefix, HexCase _case)
 {
+	if (_data.empty())
+		return {};
+
 	std::string ret(_data.size() * 2 + (_prefix == HexPrefix::Add ? 2 : 0), 0);
 
 	size_t i = 0;
@@ -64,7 +67,7 @@ string solidity::util::toHex(bytes const& _data, HexPrefix _prefix, HexCase _cas
 
 	// Mixed case will be handled inside the loop.
 	char const* chars = _case == HexCase::Upper ? upperHexChars : lowerHexChars;
-	int rix = _data.size() - 1;
+	size_t rix = _data.size() - 1;
 	for (uint8_t c: _data)
 	{
 		// switch hex case every four hexchars
@@ -95,6 +98,9 @@ int solidity::util::fromHex(char _i, WhenError _throw)
 
 bytes solidity::util::fromHex(std::string const& _s, WhenError _throw)
 {
+	if (_s.empty())
+		return {};
+
 	unsigned s = (_s.size() >= 2 && _s[0] == '0' && _s[1] == 'x') ? 2 : 0;
 	std::vector<uint8_t> ret;
 	ret.reserve((_s.size() - s + 1) / 2);

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -299,7 +299,7 @@ template <class T>
 inline bytes toCompactBigEndian(T _val, unsigned _min = 0)
 {
 	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
-	int i = 0;
+	unsigned i = 0;
 	for (T v = _val; v; ++i, v >>= 8) {}
 	bytes ret(std::max<unsigned>(_min, i), 0);
 	toBigEndian(_val, ret);


### PR DESCRIPTION
This was my old branch on the topic.