### PR TITLE
Remove dead code from SolidityExecutionFramework::compileContract()

### DIFF
--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -72,14 +72,9 @@ bytes SolidityExecutionFramework::compileContract(
 					// get code that does not exhaust the stack.
 					OptimiserSettings::full()
 					);
-		if (!asmStack.parseAndAnalyze("", m_compiler.yulIROptimized(contractName)))
-		{
-			langutil::SourceReferenceFormatter formatter(std::cerr);
+		bool analysisSuccessful = asmStack.parseAndAnalyze("", m_compiler.yulIROptimized(contractName));
+		solAssert(analysisSuccessful, "Code that passed analysis in CompilerStack can't have errors");
 
-			for (auto const& error: asmStack.errors())
-				formatter.printErrorInformation(*error);
-			BOOST_ERROR("Assembly contract failed. IR: " + m_compiler.yulIROptimized({}));
-		}
 		asmStack.optimize();
 		obj = std::move(*asmStack.assemble(yul::AssemblyStack::Machine::EVM).bytecode);
 	}

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -66,12 +66,12 @@ bytes SolidityExecutionFramework::compileContract(
 	if (m_compileViaYul)
 	{
 		yul::AssemblyStack asmStack(
-					m_evmVersion,
-					yul::AssemblyStack::Language::StrictAssembly,
-					// Ignore optimiser settings here because we need Yul optimisation to
-					// get code that does not exhaust the stack.
-					OptimiserSettings::full()
-					);
+			m_evmVersion,
+			yul::AssemblyStack::Language::StrictAssembly,
+			// Ignore optimiser settings here because we need Yul optimisation to
+			// get code that does not exhaust the stack.
+			OptimiserSettings::full()
+		);
 		bool analysisSuccessful = asmStack.parseAndAnalyze("", m_compiler.yulIROptimized(contractName));
 		solAssert(analysisSuccessful, "Code that passed analysis in CompilerStack can't have errors");
 

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -76,7 +76,7 @@ bytes SolidityExecutionFramework::compileContract(
 		{
 			langutil::SourceReferenceFormatter formatter(std::cerr);
 
-			for (auto const& error: m_compiler.errors())
+			for (auto const& error: asmStack.errors())
 				formatter.printErrorInformation(*error);
 			BOOST_ERROR("Assembly contract failed. IR: " + m_compiler.yulIROptimized({}));
 		}


### PR DESCRIPTION
MInor tweaks after digging into Ewasm compilation.

I think that `parseAndAnalyze()` here won't ever fail because `CompilerStack` parses and analyzes the code first and reports any errors it finds.

And the dead code is buggy anyway. Apart from the bug fixed by the first commit, I think that `m_compiler.yulIROptimized({})` will always trigger an assertion. Its argument is not even a real collection (though it's a string which technically works like a collection so it does compile).