### PR TITLE
Fixing various signedness warnings

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -629,8 +629,8 @@ bool CommandLineInterface::parseLibraryOption(string const& _input)
 				serr() << "Colon separator missing in library address specifier \"" << lib << "\"" << endl;
 				return false;
 			}
-			string libName(lib.begin(), lib.begin() + colon);
-			string addrString(lib.begin() + colon + 1, lib.end());
+			string libName(lib.begin(), lib.begin() + static_cast<ptrdiff_t>(colon));
+			string addrString(lib.begin() + static_cast<ptrdiff_t>(colon) + 1, lib.end());
 			boost::trim(libName);
 			boost::trim(addrString);
 			if (addrString.substr(0, 2) == "0x")

--- a/test/CommonSyntaxTest.cpp
+++ b/test/CommonSyntaxTest.cpp
@@ -116,11 +116,11 @@ void CommonSyntaxTest::printSource(ostream& _stream, string const& _linePrefix, 
 					for (int i = error.locationStart; i < error.locationEnd; i++)
 						if (isWarning)
 						{
-							if (sourceFormatting[i] == formatting::RESET)
-								sourceFormatting[i] = formatting::ORANGE_BACKGROUND_256;
+							if (sourceFormatting[static_cast<size_t>(i)] == formatting::RESET)
+								sourceFormatting[static_cast<size_t>(i)] = formatting::ORANGE_BACKGROUND_256;
 						}
 						else
-							sourceFormatting[i] = formatting::RED_BACKGROUND;
+							sourceFormatting[static_cast<size_t>(i)] = formatting::RED_BACKGROUND;
 				}
 
 			_stream << _linePrefix << sourceFormatting.front() << source.front();

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -223,7 +223,7 @@ evmc::result EVMHost::call(evmc_message const& _message) noexcept
 
 	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2)
 	{
-		result.gas_left -= evmasm::GasCosts::createDataGas * result.output_size;
+		result.gas_left -= static_cast<int64_t>(evmasm::GasCosts::createDataGas * result.output_size);
 		if (result.gas_left < 0)
 		{
 			result.gas_left = 0;

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -101,7 +101,9 @@ u256 ExecutionFramework::gasPrice() const
 
 u256 ExecutionFramework::blockHash(u256 const& _number) const
 {
-	return {EVMHost::convertFromEVMC(m_evmHost->get_block_hash(uint64_t(_number & numeric_limits<uint64_t>::max())))};
+	return {EVMHost::convertFromEVMC(
+		m_evmHost->get_block_hash(static_cast<int64_t>(_number & numeric_limits<uint64_t>::max()))
+	)};
 }
 
 u256 ExecutionFramework::blockNumber() const
@@ -153,7 +155,7 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 	if (m_showMessages)
 	{
 		cout << " out:     " << toHex(m_output) << endl;
-		cout << " result: " << size_t(result.status_code) << endl;
+		cout << " result: " << static_cast<size_t>(result.status_code) << endl;
 		cout << " gas used: " << m_gasUsed.str() << endl;
 	}
 }
@@ -180,7 +182,7 @@ void ExecutionFramework::sendEther(Address const& _addr, u256 const& _amount)
 
 size_t ExecutionFramework::currentTimestamp()
 {
-	return m_evmHost->tx_context.block_timestamp;
+	return static_cast<size_t>(m_evmHost->tx_context.block_timestamp);
 }
 
 size_t ExecutionFramework::blockTimestamp(u256 _block)
@@ -188,7 +190,7 @@ size_t ExecutionFramework::blockTimestamp(u256 _block)
 	if (_block > blockNumber())
 		return 0;
 	else
-		return size_t((currentTimestamp() / blockNumber()) * _block);
+		return static_cast<size_t>((currentTimestamp() / blockNumber()) * _block);
 }
 
 Address ExecutionFramework::account(size_t _idx)

--- a/test/Metadata.cpp
+++ b/test/Metadata.cpp
@@ -36,14 +36,14 @@ bytes onlyMetadata(bytes const& _bytecode)
 	unsigned size = _bytecode.size();
 	if (size < 5)
 		return bytes{};
-	size_t metadataSize = (_bytecode[size - 2] << 8) + _bytecode[size - 1];
+	size_t metadataSize = (static_cast<size_t>(_bytecode[size - 2]) << 8ul) + static_cast<size_t>(_bytecode[size - 1]);
 	if (size < (metadataSize + 2))
 		return bytes{};
 	// Sanity check: assume the first byte is a fixed-size CBOR array with 1, 2 or 3 entries
 	unsigned char firstByte = _bytecode[size - metadataSize - 2];
 	if (firstByte != 0xa1 && firstByte != 0xa2 && firstByte != 0xa3)
 		return bytes{};
-	return bytes(_bytecode.end() - metadataSize - 2, _bytecode.end() - 2);
+	return bytes(_bytecode.end() - static_cast<ptrdiff_t>(metadataSize) - 2, _bytecode.end() - 2);
 }
 
 bytes bytecodeSansMetadata(bytes const& _bytecode)

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -156,7 +156,7 @@ void FuzzerUtil::testConstantOptimizer(string const& _input, bool _quiet)
 		assembly.append(n);
 	}
 	for (bool isCreation: {false, true})
-		for (unsigned runs: {1, 2, 3, 20, 40, 100, 200, 400, 1000})
+		for (unsigned runs: {1u, 2u, 3u, 20u, 40u, 100u, 200u, 400u, 1000u})
 		{
 			// Make a copy here so that each time we start with the original state.
 			Assembly tmp = assembly;

--- a/tools/solidityUpgrade/UpgradeChange.cpp
+++ b/tools/solidityUpgrade/UpgradeChange.cpp
@@ -27,7 +27,10 @@ using namespace solidity::tools;
 
 void UpgradeChange::apply()
 {
-	m_source.replace(m_location.start, m_location.end - m_location.start, m_patch);
+	m_source.replace(
+		static_cast<size_t>(m_location.start),
+		static_cast<size_t>(m_location.end - m_location.start), m_patch
+	);
 }
 
 void UpgradeChange::log(bool const _shorten) const
@@ -56,7 +59,7 @@ void UpgradeChange::log(bool const _shorten) const
 	string line;
 	while (getline(output, line))
 	{
-		os << string(leftpad, ' ');
+		os << string(static_cast<size_t>(leftpad), ' ');
 		AnsiColorized(os, true, {formatting::BOLD, formatting::BLUE}) << "| ";
 		AnsiColorized(os, true, {}) << line << endl;
 	}


### PR DESCRIPTION
This is last part of fixing all signedness warnings in the code. After this PR, we can add `-Wsign-conversion` flag to cmake.