### PR TITLE
AsmAnalysis: Fixes a superfluous whitespace in an error string

### DIFF
--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -555,7 +555,7 @@ bool AsmAnalyzer::warnOnInstructions(evmasm::Instruction _instr, SourceLocation 
 			+ "\" instruction is " +
 			vmKindMessage +
 			" VMs " +
-			" (you are currently compiling for \"" +
+			"(you are currently compiling for \"" +
 			m_evmVersion.name() +
 			"\")."
 		);

--- a/test/libsolidity/syntaxTests/inlineAssembly/istanbul_on_petersburg.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/istanbul_on_petersburg.sol
@@ -13,7 +13,7 @@ contract C {
 // ====
 // EVMVersion: =petersburg
 // ----
-// TypeError: (101-108): The "chainid" instruction is only available for Istanbul-compatible VMs  (you are currently compiling for "petersburg").
+// TypeError: (101-108): The "chainid" instruction is only available for Istanbul-compatible VMs (you are currently compiling for "petersburg").
 // DeclarationError: (95-110): Variable count does not match number of values (1 vs. 0)
-// TypeError: (215-226): The "selfbalance" instruction is only available for Istanbul-compatible VMs  (you are currently compiling for "petersburg").
+// TypeError: (215-226): The "selfbalance" instruction is only available for Istanbul-compatible VMs (you are currently compiling for "petersburg").
 // DeclarationError: (209-228): Variable count does not match number of values (1 vs. 0)


### PR DESCRIPTION
actually just deleted a double-whitespace. This issue did exist before and I found it by accident while doing another PR.