### PR TITLE
Missing changelog entries for a few of my PRs from this release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@ Bugfixes:
  * SMTChecker: Fix internal error when short circuiting Boolean expressions with function calls in state variable initialization.
  * SMTChecker: Fix internal error when assigning to index access inside branches.
  * SMTChecker: Fix internal error on try/catch clauses with parameters.
+ * Commandline Interface: Fix internal error when using ``--assemble`` or ``--yul`` options with ``--machine ewasm`` but without specifying ``--yul-dialect``.
 
 ### 0.6.8 (2020-05-14)
 


### PR DESCRIPTION
I was under impression that some stuff should not be listed in the changelog as basically irrelevant to the user. I.e. the IR codegen changes (which is still experimental) and tiny bug fixes (like #9074). I see that I was probably wrong so here are the missing entries for #9074, #8987 and #8797.

I also skipped these (let me know if any of them needs an entry too):
- refactoring (does not change anything visible to the user): #9084, #9060, #9026, #8997, #8955, #8952, #8951, #8949. #8948
- Stuff that got broken and then fixed within the release: #9032
- A fix for a bug that probably wasn't affecting functionality: #8984
- A refactor + yul-phaser feature (internal tool): #8453