### PR TITLE
Fix toHex() in case of empty data and non-empty prefix

### DIFF
--- a/libsolutil/CommonData.cpp
+++ b/libsolutil/CommonData.cpp
@@ -53,9 +53,6 @@ string solidity::util::toHex(uint8_t _data, HexCase _case)
 
 string solidity::util::toHex(bytes const& _data, HexPrefix _prefix, HexCase _case)
 {
-	if (_data.empty())
-		return {};
-
 	std::string ret(_data.size() * 2 + (_prefix == HexPrefix::Add ? 2 : 0), 0);
 
 	size_t i = 0;


### PR DESCRIPTION
Problem reported in the original review but not before the PR was merged: https://github.com/ethereum/solidity/pull/9083#discussion_r433864302