### PR TITLE
[SMTChecker] Erase knowledge when array variable is pushed/popped

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 Bugfixes:
  * SMTChecker: Fix internal error when encoding tuples of tuples.
+ * SMTChecker: Fix aliasing soundness after pushing to an array pointer.
 
 
 ### 0.6.9 (2020-06-04)

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -183,6 +183,9 @@ protected:
 	void initializeLocalVariables(FunctionDefinition const& _function);
 	void initializeFunctionCallParameters(CallableDeclaration const& _function, std::vector<smtutil::Expression> const& _callArgs);
 	void resetStateVariables();
+	/// Resets all references/pointers that have the same type or have
+	/// a subexpression of the same type as _varDecl.
+	void resetReferences(VariableDeclaration const& _varDecl);
 	/// @returns the type without storage pointer information if it has it.
 	TypePointer typeWithoutPointer(TypePointer const& _type);
 

--- a/test/libsolidity/smtCheckerTests/array_members/push_storage_ref_unsafe_length.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_storage_ref_unsafe_length.sol
@@ -1,0 +1,23 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[][] a;
+	uint[][][] c;
+	uint[] d;
+	function f() public {
+		a.push();
+		uint[] storage b = a[0];
+		c[0][0][0] = 12;
+		d[5] = 7;
+		b.push(8);
+		assert(a[0].length == 0);
+		// Safe but knowledge about `c` is erased because `b` could be pointing to `c[x][y]`.
+		assert(c[0][0][0] == 12);
+		// Safe but knowledge about `d` is erased because `b` could be pointing to `d`.
+		assert(d[5] == 7);
+	}
+}
+// ----
+// Warning: (193-217): Assertion violation happens here
+// Warning: (309-333): Assertion violation happens here
+// Warning: (419-436): Assertion violation happens here


### PR DESCRIPTION
When a reference type variable is assigned (or an index access is assigned), knowledge is erased for all variables of that same type, since they could be references to each other.
This should also be the case when a variable is pushed/popped, but wasn't done for all cases.
The first assertion in the added test is unsafe, but before this PR was considered safe because knowledge wasn't erased.