### PR TITLE
Add support for types in Wasm AST and code generation

### DIFF
--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -475,7 +476,7 @@ BinaryTransform::Type BinaryTransform::typeOf(FunctionImport const& _import)
 {
 	return {
 		encodeTypes(_import.paramTypes),
-		encodeTypes(_import.returnType ? vector<string>(1, *_import.returnType) : vector<string>())
+		encodeTypes(_import.returnType ? vector<wasm::Type>(1, *_import.returnType) : vector<wasm::Type>())
 	};
 }
 
@@ -483,26 +484,26 @@ BinaryTransform::Type BinaryTransform::typeOf(FunctionDefinition const& _funDef)
 {
 
 	return {
-		encodeTypes(vector<string>(_funDef.parameterNames.size(), "i64")),
-		encodeTypes(vector<string>(_funDef.returns ? 1 : 0, "i64"))
+		encodeTypes(vector<wasm::Type>(_funDef.parameterNames.size(), wasm::Type::i64)),
+		encodeTypes(vector<wasm::Type>(_funDef.returns ? 1 : 0, wasm::Type::i64))
 	};
 }
 
-uint8_t BinaryTransform::encodeType(string const& _typeName)
+uint8_t BinaryTransform::encodeType(wasm::Type _type)
 {
-	if (_typeName == "i32")
+	if (_type == wasm::Type::i32)
 		return uint8_t(ValueType::I32);
-	else if (_typeName == "i64")
+	else if (_type == wasm::Type::i64)
 		return uint8_t(ValueType::I64);
 	else
 		yulAssert(false, "");
 	return 0;
 }
 
-vector<uint8_t> BinaryTransform::encodeTypes(vector<string> const& _typeNames)
+vector<uint8_t> BinaryTransform::encodeTypes(vector<wasm::Type> const& _types)
 {
 	vector<uint8_t> result;
-	for (auto const& t: _typeNames)
+	for (wasm::Type t: _types)
 		result.emplace_back(encodeType(t));
 	return result;
 }

--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -298,7 +298,8 @@ bytes BinaryTransform::run(Module const& _module)
 
 bytes BinaryTransform::operator()(Literal const& _literal)
 {
-	return toBytes(Opcode::I64Const) + lebEncodeSigned(_literal.value);
+	yulAssert(holds_alternative<uint64_t>(_literal.value), "");
+	return toBytes(Opcode::I64Const) + lebEncodeSigned(get<uint64_t>(_literal.value));
 }
 
 bytes BinaryTransform::operator()(StringLiteral const&)
@@ -457,8 +458,8 @@ bytes BinaryTransform::operator()(FunctionDefinition const& _function)
 
 	m_locals.clear();
 	size_t varIdx = 0;
-	for (size_t i = 0; i < _function.parameterNames.size(); ++i)
-		m_locals[_function.parameterNames[i]] = varIdx++;
+	for (size_t i = 0; i < _function.parameters.size(); ++i)
+		m_locals[_function.parameters[i].name] = varIdx++;
 	for (size_t i = 0; i < _function.locals.size(); ++i)
 		m_locals[_function.locals[i].variableName] = varIdx++;
 
@@ -484,8 +485,8 @@ BinaryTransform::Type BinaryTransform::typeOf(FunctionDefinition const& _funDef)
 {
 
 	return {
-		encodeTypes(vector<wasm::Type>(_funDef.parameterNames.size(), wasm::Type::i64)),
-		encodeTypes(vector<wasm::Type>(_funDef.returns ? 1 : 0, wasm::Type::i64))
+		encodeTypes(vector<wasm::Type>(_funDef.parameters.size(), wasm::Type::i64)),
+		encodeTypes(vector<wasm::Type>(_funDef.returnType.has_value() ? 1 : 0, wasm::Type::i64))
 	};
 }
 

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -73,6 +73,7 @@ private:
 
 	static uint8_t encodeType(wasm::Type _type);
 	static std::vector<uint8_t> encodeTypes(std::vector<wasm::Type> const& _types);
+	static std::vector<uint8_t> encodeTypes(wasm::TypedNameList const& _typedNameList);
 
 	static std::map<Type, std::vector<std::string>> typeToFunctionMap(
 		std::vector<wasm::FunctionImport> const& _imports,

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -71,8 +71,8 @@ private:
 	static Type typeOf(wasm::FunctionImport const& _import);
 	static Type typeOf(wasm::FunctionDefinition const& _funDef);
 
-	static uint8_t encodeType(std::string const& _typeName);
-	static std::vector<uint8_t> encodeTypes(std::vector<std::string> const& _typeNames);
+	static uint8_t encodeType(wasm::Type _type);
+	static std::vector<uint8_t> encodeTypes(std::vector<wasm::Type> const& _types);
 
 	static std::map<Type, std::vector<std::string>> typeToFunctionMap(
 		std::vector<wasm::FunctionImport> const& _imports,

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -20,6 +20,8 @@
 
 #include <libyul/backends/wasm/TextTransform.h>
 
+#include <libyul/Exceptions.h>
+
 #include <libsolutil/StringUtils.h>
 
 #include <boost/algorithm/string/join.hpp>
@@ -44,9 +46,9 @@ string TextTransform::run(wasm::Module const& _module)
 	{
 		ret += "    (import \"" + imp.module + "\" \"" + imp.externalName + "\" (func $" + imp.internalName;
 		if (!imp.paramTypes.empty())
-			ret += " (param" + joinHumanReadablePrefixed(imp.paramTypes, " ", " ") + ")";
+			ret += " (param" + joinHumanReadablePrefixed(imp.paramTypes | boost::adaptors::transformed(encodeType), " ", " ") + ")";
 		if (imp.returnType)
-			ret += " (result " + *imp.returnType + ")";
+			ret += " (result " + encodeType(*imp.returnType) + ")";
 		ret += "))\n";
 	}
 
@@ -192,4 +194,14 @@ string TextTransform::joinTransformed(vector<wasm::Expression> const& _expressio
 		ret += move(t);
 	}
 	return ret;
+}
+
+string TextTransform::encodeType(wasm::Type _type)
+{
+	if (_type == wasm::Type::i32)
+		return "i32";
+	else if (_type == wasm::Type::i64)
+		return "i64";
+	else
+		yulAssert(false, "Invalid wasm type");
 }

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -67,7 +67,8 @@ string TextTransform::run(wasm::Module const& _module)
 
 string TextTransform::operator()(wasm::Literal const& _literal)
 {
-	return "(i64.const " + to_string(_literal.value) + ")";
+	yulAssert(holds_alternative<uint64_t>(_literal.value), "");
+	return "(i64.const " + to_string(get<uint64_t>(_literal.value)) + ")";
 }
 
 string TextTransform::operator()(wasm::StringLiteral const& _literal)
@@ -164,9 +165,9 @@ string TextTransform::indented(string const& _in)
 string TextTransform::transform(wasm::FunctionDefinition const& _function)
 {
 	string ret = "(func $" + _function.name + "\n";
-	for (auto const& param: _function.parameterNames)
-		ret += "    (param $" + param + " i64)\n";
-	if (_function.returns)
+	for (auto const& param: _function.parameters)
+		ret += "    (param $" + param.name + " i64)\n";
+	if (_function.returnType.has_value())
 		ret += "    (result i64)\n";
 	for (auto const& local: _function.locals)
 		ret += "    (local $" + local.variableName + " i64)\n";

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -23,6 +23,7 @@
 #include <libyul/Exceptions.h>
 
 #include <libsolutil/StringUtils.h>
+#include <libsolutil/Visitor.h>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/replace.hpp>
@@ -58,7 +59,7 @@ string TextTransform::run(wasm::Module const& _module)
 	ret += "    (export \"main\" (func $main))\n";
 
 	for (auto const& g: _module.globals)
-		ret += "    (global $" + g.variableName + " (mut i64) (i64.const 0))\n";
+		ret += "    (global $" + g.variableName + " (mut " + encodeType(g.type) + ") (" + encodeType(g.type) + ".const 0))\n";
 	ret += "\n";
 	for (auto const& f: _module.functions)
 		ret += transform(f) + "\n";
@@ -67,8 +68,10 @@ string TextTransform::run(wasm::Module const& _module)
 
 string TextTransform::operator()(wasm::Literal const& _literal)
 {
-	yulAssert(holds_alternative<uint64_t>(_literal.value), "");
-	return "(i64.const " + to_string(get<uint64_t>(_literal.value)) + ")";
+	return std::visit(GenericVisitor{
+		[&](uint32_t _value) -> string { return "(i32.const " + to_string(_value) + ")"; },
+		[&](uint64_t _value) -> string { return "(i64.const " + to_string(_value) + ")"; },
+	}, _literal.value);
 }
 
 string TextTransform::operator()(wasm::StringLiteral const& _literal)
@@ -166,11 +169,11 @@ string TextTransform::transform(wasm::FunctionDefinition const& _function)
 {
 	string ret = "(func $" + _function.name + "\n";
 	for (auto const& param: _function.parameters)
-		ret += "    (param $" + param.name + " i64)\n";
+		ret += "    (param $" + param.name + " " + encodeType(param.type) + ")\n";
 	if (_function.returnType.has_value())
-		ret += "    (result i64)\n";
+		ret += "    (result " + encodeType(_function.returnType.value()) + ")\n";
 	for (auto const& local: _function.locals)
-		ret += "    (local $" + local.variableName + " i64)\n";
+		ret += "    (local $" + local.variableName + " " + encodeType(local.type) + ")\n";
 	ret += indented(joinTransformed(_function.body, '\n'));
 	if (ret.back() != '\n')
 		ret += '\n';

--- a/libyul/backends/wasm/TextTransform.h
+++ b/libyul/backends/wasm/TextTransform.h
@@ -63,6 +63,8 @@ private:
 		std::vector<wasm::Expression> const& _expressions,
 		char _separator = ' '
 	);
+
+	static std::string encodeType(wasm::Type _type);
 };
 
 }

--- a/libyul/backends/wasm/WasmAST.h
+++ b/libyul/backends/wasm/WasmAST.h
@@ -36,6 +36,9 @@ enum class Type
 	i64,
 };
 
+struct TypedName { std::string name; Type type; };
+using TypedNameList = std::vector<TypedName>;
+
 struct Literal;
 struct StringLiteral;
 struct LocalVariable;
@@ -56,7 +59,7 @@ using Expression = std::variant<
 	Block, If, Loop, Branch, BranchIf, Return
 >;
 
-struct Literal { uint64_t value; };
+struct Literal { std::variant<uint32_t, uint64_t> value; };
 struct StringLiteral { std::string value; };
 struct LocalVariable { std::string name; };
 struct GlobalVariable { std::string name; };
@@ -76,8 +79,8 @@ struct Branch { Label label; };
 struct Return {};
 struct BranchIf { Label label; std::unique_ptr<Expression> condition; };
 
-struct VariableDeclaration { std::string variableName; };
-struct GlobalVariableDeclaration { std::string variableName; };
+struct VariableDeclaration { std::string variableName; Type type; };
+struct GlobalVariableDeclaration { std::string variableName; Type type; };
 struct FunctionImport {
 	std::string module;
 	std::string externalName;
@@ -89,8 +92,8 @@ struct FunctionImport {
 struct FunctionDefinition
 {
 	std::string name;
-	std::vector<std::string> parameterNames;
-	bool returns;
+	std::vector<TypedName> parameters;
+	std::optional<Type> returnType;
 	std::vector<VariableDeclaration> locals;
 	std::vector<Expression> body;
 };

--- a/libyul/backends/wasm/WasmAST.h
+++ b/libyul/backends/wasm/WasmAST.h
@@ -30,6 +30,12 @@
 namespace solidity::yul::wasm
 {
 
+enum class Type
+{
+	i32,
+	i64,
+};
+
 struct Literal;
 struct StringLiteral;
 struct LocalVariable;
@@ -76,8 +82,8 @@ struct FunctionImport {
 	std::string module;
 	std::string externalName;
 	std::string internalName;
-	std::vector<std::string> paramTypes;
-	std::optional<std::string> returnType;
+	std::vector<Type> paramTypes;
+	std::optional<Type> returnType;
 };
 
 struct FunctionDefinition

--- a/libyul/backends/wasm/WasmCodeTransform.h
+++ b/libyul/backends/wasm/WasmCodeTransform.h
@@ -89,6 +89,8 @@ private:
 	/// Makes sure that there are at least @a _amount global variables.
 	void allocateGlobals(size_t _amount);
 
+	static wasm::Type translatedType(yul::Type _yulType);
+
 	Dialect const& m_dialect;
 	NameDispenser m_nameDispenser;
 

--- a/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/args
+++ b/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/args
@@ -1,0 +1,1 @@
+--yul --yul-dialect ewasm --machine ewasm

--- a/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/err
+++ b/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/err
@@ -1,0 +1,1 @@
+Warning: Yul is still experimental. Please use the output with care.

--- a/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/input.yul
+++ b/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/input.yul
@@ -1,0 +1,17 @@
+object "object" {
+    code {
+        function main()
+        {
+            let m:i64, n:i32, p:i32, q:i64 := multireturn(1:i32, 2:i64, 3:i64, 4:i32)
+        }
+
+        function multireturn(a:i32, b:i64, c:i64, d:i32) -> x:i64, y:i32, z:i32, w:i64
+        {
+            x := b
+            w := c
+
+            y := a
+            z := d
+        }
+    }
+}

--- a/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/output
+++ b/test/cmdlineTests/wasm_to_wasm_function_returning_multiple_values/output
@@ -1,0 +1,73 @@
+
+======= wasm_to_wasm_function_returning_multiple_values/input.yul (Ewasm) =======
+
+Pretty printed source:
+object "object" {
+    code {
+        function main()
+        {
+            let m, n:i32, p:i32, q := multireturn(1:i32, 2, 3, 4:i32)
+        }
+        function multireturn(a:i32, b, c, d:i32) -> x, y:i32, z:i32, w
+        {
+            x := b
+            w := c
+            y := a
+            z := d
+        }
+    }
+}
+
+
+Binary representation:
+0061736d01000000010c0260000060047e7e7e7e017e020100030302000105030100010610037e0142000b7e0142000b7e0142000b071102066d656d6f72790200046d61696e00000a4a022201047e024002404201420242034204100121002300210123012102230221030b0b0b2501047e0240200121042002210720002105200321060b20052400200624012007240220040b
+
+Text representation:
+(module
+    (memory $memory (export "memory") 1)
+    (export "main" (func $main))
+    (global $global_ (mut i64) (i64.const 0))
+    (global $global__1 (mut i64) (i64.const 0))
+    (global $global__2 (mut i64) (i64.const 0))
+
+(func $main
+    (local $m i64)
+    (local $n i64)
+    (local $p i64)
+    (local $q i64)
+    (block $label_
+        (block
+            (local.set $m (call $multireturn (i64.const 1) (i64.const 2) (i64.const 3) (i64.const 4)))
+            (local.set $n (global.get $global_))
+            (local.set $p (global.get $global__1))
+            (local.set $q (global.get $global__2))
+
+        )
+
+    )
+)
+
+(func $multireturn
+    (param $a i64)
+    (param $b i64)
+    (param $c i64)
+    (param $d i64)
+    (result i64)
+    (local $x i64)
+    (local $y i64)
+    (local $z i64)
+    (local $w i64)
+    (block $label__3
+        (local.set $x (local.get $b))
+        (local.set $w (local.get $c))
+        (local.set $y (local.get $a))
+        (local.set $z (local.get $d))
+
+    )
+    (global.set $global_ (local.get $y))
+    (global.set $global__1 (local.get $z))
+    (global.set $global__2 (local.get $w))
+    (local.get $x)
+)
+
+)


### PR DESCRIPTION
Prerequisite for #8240.

This PR adds variable and literal types to Wasm AST and makes `BinaryTransform`/`TextTransform` able to use them when generating code. It **does not** enable their use in `WasmCodeTransform` yet so in practice they're always set to "i64" in the AST and generated Wasm code should not change.