### PR TITLE
Fix semantic urls for function and modifier overriding in documentation

### DIFF
--- a/docs/contracts/inheritance.rst
+++ b/docs/contracts/inheritance.rst
@@ -194,9 +194,9 @@ not known in the context of the class where it is used,
 although its type is known. This is similar for ordinary
 virtual method lookup.
 
-.. _function-overriding:
-
 .. index:: ! overriding;function
+
+.. _function-overriding:
 
 Function Overriding
 ===================
@@ -317,9 +317,9 @@ of the variable:
   While public state variables can override external functions, they themselves cannot
   be overridden.
 
-.. _modifier-overriding:
-
 .. index:: ! overriding;modifier
+
+.. _modifier-overriding:
 
 Modifier Overriding
 ===================


### PR DESCRIPTION
Currently urls for those sections are these:
https://solidity.readthedocs.io/en/latest/contracts.html#index-17
https://solidity.readthedocs.io/en/latest/contracts.html#index-18

This fix changes them to:
https://solidity.readthedocs.io/en/latest/contracts.html#function-overriding
https://solidity.readthedocs.io/en/latest/contracts.html#modifier-overriding