### PR TITLE
Add note about initialisation in 060-breaking-changes

### DIFF
--- a/docs/060-breaking-changes.rst
+++ b/docs/060-breaking-changes.rst
@@ -42,7 +42,8 @@ For most of the topics the compiler will provide suggestions.
   storage arrays.
 
 * The new keyword ``abstract`` can be used to mark contracts as abstract. It has to be used
-  if a contract does not implement all its functions.
+  if a contract does not implement all its functions. Abstract contracts cannot be initialised and solidity outputs no
+  no bytecode when compiling them.
 
 * Libraries have to implement all their functions, not only the internal ones.
 


### PR DESCRIPTION
The information I added may seem redundant for the seasoned programmer - yet, there are many noobs [like me](https://github.com/ethers-io/ethers.js/issues/870) who will spend a lot of time figuring out why their abstract contract cannot be initialised.

It's likely that with time, tools like Ethers, Truffle and Buidler will start warning users when they attempt to interact with the non-existent bytecode of an abstract contract, but as of today this can cause great confusion:

https://github.com/ethers-io/ethers.js/issues/870