### PR TITLE
Refactor the index assignment logic in wasm::BinaryTransform

### DIFF
--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -253,13 +253,13 @@ bytes makeSection(Section _section, bytes _data)
 
 bytes BinaryTransform::run(Module const& _module)
 {
-	BinaryTransform bt;
-
 	map<Type, vector<string>> const types = typeToFunctionMap(_module.imports, _module.functions);
 
-	bt.m_globals = enumerateGlobals(_module);
-	bt.m_functions = enumerateFunctions(_module);
-	bt.m_functionTypes = enumerateFunctionTypes(types);
+	BinaryTransform bt(
+		enumerateGlobals(_module),
+		enumerateFunctions(_module),
+		enumerateFunctionTypes(types)
+	);
 
 	yulAssert(bt.m_globals.size() == _module.globals.size(), "");
 	yulAssert(bt.m_functions.size() == _module.imports.size() + _module.functions.size(), "");
@@ -576,7 +576,7 @@ bytes BinaryTransform::importSection(
 			encodeName(import.module) +
 			encodeName(import.externalName) +
 			toBytes(importKind) +
-			lebEncode(m_functionTypes[import.internalName]);
+			lebEncode(m_functionTypes.at(import.internalName));
 	}
 	return makeSection(Section::IMPORT, std::move(result));
 }

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -55,6 +55,16 @@ public:
 	bytes operator()(wasm::FunctionDefinition const& _function);
 
 private:
+	BinaryTransform(
+		std::map<std::string, size_t> _globals,
+		std::map<std::string, size_t> _functions,
+		std::map<std::string, size_t> _functionTypes
+	):
+		m_globals(std::move(_globals)),
+		m_functions(std::move(_functions)),
+		m_functionTypes(std::move(_functionTypes))
+	{}
+
 	using Type = std::pair<std::vector<std::uint8_t>, std::vector<std::uint8_t>>;
 	static Type typeOf(wasm::FunctionImport const& _import);
 	static Type typeOf(wasm::FunctionDefinition const& _funDef);
@@ -89,10 +99,11 @@ private:
 
 	static bytes encodeName(std::string const& _name);
 
+	std::map<std::string, size_t> const m_globals;
+	std::map<std::string, size_t> const m_functions;
+	std::map<std::string, size_t> const m_functionTypes;
+
 	std::map<std::string, size_t> m_locals;
-	std::map<std::string, size_t> m_globals;
-	std::map<std::string, size_t> m_functions;
-	std::map<std::string, size_t> m_functionTypes;
 	std::vector<std::string> m_labels;
 	std::map<std::string, std::pair<size_t, size_t>> m_subModulePosAndSize;
 };

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -58,11 +58,13 @@ private:
 	BinaryTransform(
 		std::map<std::string, size_t> _globals,
 		std::map<std::string, size_t> _functions,
-		std::map<std::string, size_t> _functionTypes
+		std::map<std::string, size_t> _functionTypes,
+		std::map<std::string, std::pair<size_t, size_t>> _subModulePosAndSize
 	):
 		m_globals(std::move(_globals)),
 		m_functions(std::move(_functions)),
-		m_functionTypes(std::move(_functionTypes))
+		m_functionTypes(std::move(_functionTypes)),
+		m_subModulePosAndSize(std::move(_subModulePosAndSize))
 	{}
 
 	using Type = std::pair<std::vector<std::uint8_t>, std::vector<std::uint8_t>>;
@@ -83,13 +85,19 @@ private:
 		std::map<Type, std::vector<std::string>> const& _typeToFunctionMap
 	);
 
-	bytes typeSection(std::map<Type, std::vector<std::string>> const& _typeToFunctionMap);
-	bytes importSection(std::vector<wasm::FunctionImport> const& _imports);
-	bytes functionSection(std::vector<wasm::FunctionDefinition> const& _functions);
-	bytes memorySection();
-	bytes globalSection();
-	bytes exportSection();
-	bytes customSection(std::string const& _name, bytes _data);
+	static bytes typeSection(std::map<Type, std::vector<std::string>> const& _typeToFunctionMap);
+	static bytes importSection(
+		std::vector<wasm::FunctionImport> const& _imports,
+		std::map<std::string, size_t> const& _functionTypes
+	);
+	static bytes functionSection(
+		std::vector<wasm::FunctionDefinition> const& _functions,
+		std::map<std::string, size_t> const& _functionTypes
+	);
+	static bytes memorySection();
+	static bytes globalSection(std::vector<wasm::GlobalVariableDeclaration> const& _globals);
+	static bytes exportSection(std::map<std::string, size_t> const& _functions);
+	static bytes customSection(std::string const& _name, bytes _data);
 	bytes codeSection(std::vector<wasm::FunctionDefinition> const& _functions);
 
 	bytes visit(std::vector<wasm::Expression> const& _expressions);
@@ -102,10 +110,10 @@ private:
 	std::map<std::string, size_t> const m_globals;
 	std::map<std::string, size_t> const m_functions;
 	std::map<std::string, size_t> const m_functionTypes;
+	std::map<std::string, std::pair<size_t, size_t>> const m_subModulePosAndSize;
 
 	std::map<std::string, size_t> m_locals;
 	std::vector<std::string> m_labels;
-	std::map<std::string, std::pair<size_t, size_t>> m_subModulePosAndSize;
 };
 
 }

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -61,11 +61,19 @@ private:
 
 	static uint8_t encodeType(std::string const& _typeName);
 	static std::vector<uint8_t> encodeTypes(std::vector<std::string> const& _typeNames);
-	bytes typeSection(
+
+	static std::map<Type, std::vector<std::string>> typeToFunctionMap(
 		std::vector<wasm::FunctionImport> const& _imports,
 		std::vector<wasm::FunctionDefinition> const& _functions
 	);
 
+	static std::map<std::string, size_t> enumerateGlobals(Module const& _module);
+	static std::map<std::string, size_t> enumerateFunctions(Module const& _module);
+	static std::map<std::string, size_t> enumerateFunctionTypes(
+		std::map<Type, std::vector<std::string>> const& _typeToFunctionMap
+	);
+
+	bytes typeSection(std::map<Type, std::vector<std::string>> const& _typeToFunctionMap);
 	bytes importSection(std::vector<wasm::FunctionImport> const& _imports);
 	bytes functionSection(std::vector<wasm::FunctionDefinition> const& _functions);
 	bytes memorySection();

--- a/libyul/backends/wasm/BinaryTransform.h
+++ b/libyul/backends/wasm/BinaryTransform.h
@@ -56,13 +56,13 @@ public:
 
 private:
 	BinaryTransform(
-		std::map<std::string, size_t> _globals,
-		std::map<std::string, size_t> _functions,
+		std::map<std::string, size_t> _globalIDs,
+		std::map<std::string, size_t> _functionIDs,
 		std::map<std::string, size_t> _functionTypes,
 		std::map<std::string, std::pair<size_t, size_t>> _subModulePosAndSize
 	):
-		m_globals(std::move(_globals)),
-		m_functions(std::move(_functions)),
+		m_globalIDs(std::move(_globalIDs)),
+		m_functionIDs(std::move(_functionIDs)),
 		m_functionTypes(std::move(_functionTypes)),
 		m_subModulePosAndSize(std::move(_subModulePosAndSize))
 	{}
@@ -96,7 +96,7 @@ private:
 	);
 	static bytes memorySection();
 	static bytes globalSection(std::vector<wasm::GlobalVariableDeclaration> const& _globals);
-	static bytes exportSection(std::map<std::string, size_t> const& _functions);
+	static bytes exportSection(std::map<std::string, size_t> const& _functionIDs);
 	static bytes customSection(std::string const& _name, bytes _data);
 	bytes codeSection(std::vector<wasm::FunctionDefinition> const& _functions);
 
@@ -107,8 +107,8 @@ private:
 
 	static bytes encodeName(std::string const& _name);
 
-	std::map<std::string, size_t> const m_globals;
-	std::map<std::string, size_t> const m_functions;
+	std::map<std::string, size_t> const m_globalIDs;
+	std::map<std::string, size_t> const m_functionIDs;
 	std::map<std::string, size_t> const m_functionTypes;
 	std::map<std::string, std::pair<size_t, size_t>> const m_subModulePosAndSize;
 


### PR DESCRIPTION
The way functions/globals/types are passed around in `BinaryTransform` is not very obvious. At times it looks as if the same thing is passed to the same function twice in different ways (as noted by @axic in https://github.com/ethereum/solidity/pull/9142#discussion_r436198061 and https://github.com/ethereum/solidity/pull/9142#discussion_r436198299). I tried refactoring it a bit.

At minimum, the names could be clearer. The first commit does just that. I tried also moving some bits into separate functions, making some members constant (to make it clear that they're never reassigned in contrast to others) and even getting rid of passing the values via member variables.

One more thing I could do would be to extract the code for processing function definitions while walking the AST into a separate class. This is the only part that needs to access member variables and it has virtually no common parts with the code that generates sections (maybe except for the enums and small utility functions defined in the `.cpp` file). But the changes in this PR may already be enough or even too much so for now I decided not to do it.

When reviewing please look at individual commits. if some of them require more discussion, let me know and I'll put them in a separate PR (or remove them) so that this one can be dealt with quicker.