### PR TITLE
[SMTChecker] Replace explicit mod by slack variables

### DIFF
--- a/libsolidity/formal/EncodingContext.cpp
+++ b/libsolidity/formal/EncodingContext.cpp
@@ -32,10 +32,21 @@ EncodingContext::EncodingContext():
 void EncodingContext::reset()
 {
 	resetAllVariables();
+	resetSlackId();
 	m_expressions.clear();
 	m_globalContext.clear();
 	m_state.reset();
 	m_assertions.clear();
+}
+
+void EncodingContext::resetSlackId()
+{
+	m_nextSlackId = 0;
+}
+
+unsigned EncodingContext::newSlackId()
+{
+	return m_nextSlackId++;
 }
 
 void EncodingContext::clear()

--- a/libsolidity/formal/EncodingContext.h
+++ b/libsolidity/formal/EncodingContext.h
@@ -40,6 +40,10 @@ public:
 	/// alive because of state variables and inlined function calls.
 	/// To be used in the beginning of a root function visit.
 	void reset();
+	/// Resets the fresh id for slack variables.
+	void resetSlackId();
+	/// Returns the current fresh slack id and increments it.
+	unsigned newSlackId();
 	/// Clears the entire context, erasing everything.
 	/// To be used before a model checking engine starts.
 	void clear();
@@ -168,6 +172,9 @@ private:
 	/// Whether to conjoin assertions in the assertion stack.
 	bool m_accumulateAssertions = true;
 	//@}
+
+	/// Fresh ids for slack variables to be created deterministically.
+	unsigned m_nextSlackId = 0;
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/functions/functions_recursive_indirect.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_recursive_indirect.sol
@@ -22,4 +22,3 @@ contract C
 	}
 }
 // ----
-// Warning: (130-144): Error trying to invoke SMT solver.

--- a/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
@@ -14,6 +14,4 @@ contract C
 	}
 }
 // ----
-// Warning: (296-309): Error trying to invoke SMT solver.
 // Warning: (176-181): Overflow (resulting value larger than 2**256 - 1) happens here
-// Warning: (296-309): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
@@ -19,7 +19,5 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (317-337): Error trying to invoke SMT solver.
-// Warning: (317-337): Assertion violation happens here
 // Warning: (341-360): Assertion violation happens here
 // Warning: (364-383): Assertion violation happens here


### PR DESCRIPTION
This PR helps https://github.com/ethereum/solidity/pull/8950 and https://github.com/ethereum/solidity/pull/9041 against z3's nondeterminsm