### PR TITLE
[SMTChecker] Add redundant type constraints to assertion block

### DIFF
--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -161,6 +161,12 @@ private:
 	/// local variables.
 	std::vector<smtutil::Expression> currentBlockVariables();
 
+	/// Adds the type constraints for _function's input, output and local variables.
+	void addVariablesTypeConstraints(FunctionDefinition const& _function);
+	/// Adds the type constraints for _contract's state variables.
+	void addVariablesTypeConstraints(ContractDefinition const& _contract);
+	void addVariablesTypeConstraints(FunctionDefinition const& _function, ContractDefinition const& _contract);
+
 	/// @returns the predicate name for a given node.
 	std::string predicateName(ASTNode const* _node, ContractDefinition const* _contract = nullptr);
 	/// @returns a predicate application over the current scoped variables.

--- a/test/libsolidity/smtCheckerTests/functions/functions_recursive_indirect.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_recursive_indirect.sol
@@ -22,4 +22,3 @@ contract C
 	}
 }
 // ----
-// Warning: (130-144): Error trying to invoke SMT solver.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
@@ -19,7 +19,5 @@ contract LoopFor2 {
 	}
 }
 // ----
-// Warning: (317-337): Error trying to invoke SMT solver.
-// Warning: (317-337): Assertion violation happens here
 // Warning: (341-360): Assertion violation happens here
 // Warning: (364-383): Assertion violation happens here


### PR DESCRIPTION
This PR readds the type constraints for all state, input and output variables at the assertion point.
The reasoning is that sometimes the solver can't reuse these constraints that are added at the constructor, for example, because of how the queries are modeled - with nonlinear Horn clauses.