### PR TITLE
Update travis config to move to next docker image revision.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ matrix:
           before_install:
               - nvm install 8
               - nvm use 8
-              - docker pull ethereum/solidity-buildpack-deps:emsdk-1.39.15-1
+              - docker pull ethereum/solidity-buildpack-deps:emsdk-1.39.15-2
           env:
               - SOLC_EMSCRIPTEN=On
               - SOLC_INSTALL_DEPS_TRAVIS=Off

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -34,5 +34,5 @@ else
     BUILD_DIR="$1"
 fi
 
-docker run -v $(pwd):/root/project -w /root/project ethereum/solidity-buildpack-deps:emsdk-1.39.15-1 \
+docker run -v $(pwd):/root/project -w /root/project ethereum/solidity-buildpack-deps:emsdk-1.39.15-2 \
     ./scripts/travis-emscripten/build_emscripten.sh $BUILD_DIR


### PR DESCRIPTION
Damn, I missed that last time...
This actually makes the respective changelog entry about switching from fastcomp to upstream emscripten off by one version... not sure if I should just move it...