### PR TITLE
Refactoring `revertReasonIfDebug` in `YulUtilFunctions`.

### DIFF
--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -1541,5 +1541,5 @@ size_t ABIFunctions::numVariablesForType(Type const& _type, EncodingOptions cons
 
 std::string ABIFunctions::revertReasonIfDebug(std::string const& _message)
 {
-	return YulUtilFunctions::revertReasonIfDebug(m_revertStrings, _message);
+	return m_utils.revertReasonIfDebugAssembly(m_revertStrings, _message);
 }

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -529,7 +529,7 @@ LinkerObject const& CompilerContext::assembledObject() const
 
 string CompilerContext::revertReasonIfDebug(string const& _message)
 {
-	return YulUtilFunctions::revertReasonIfDebug(m_revertStrings, _message);
+	return m_yulUtilFunctions.revertReasonIfDebugAssembly(m_revertStrings, _message);
 }
 
 void CompilerContext::updateSourceLocation()

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2495,7 +2495,7 @@ string YulUtilFunctions::readFromMemoryOrCalldata(Type const& _type, bool _fromC
 	});
 }
 
-string YulUtilFunctions::revertReasonIfDebugAssembly(RevertStrings _revertStrings, std::string const& _message)
+string YulUtilFunctions::revertReasonIfDebugAssembly(RevertStrings _revertStrings, string const& _message)
 {
 	Whiskers templ(R"({
 		<?debugAndMessage>

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2515,8 +2515,13 @@ string YulUtilFunctions::revertReasonIfDebugAssembly(RevertStrings _revertString
 	templ("debugAndMessage", debugAndMessage);
 	if (debugAndMessage)
 	{
-		templ("sig", (u256(util::FixedHash<4>::Arith(util::FixedHash<4>(util::keccak256("Error(string)"))))
-				<< (256 - 32)).str());
+		templ(
+			"sig",
+			(
+				u256(util::FixedHash<4>::Arith(util::FixedHash<4>(util::keccak256("Error(string)")))) <<
+				(256 - 32)
+			).str()
+		);
 		templ("length", to_string(_message.length()));
 
 		size_t words = (_message.length() + 31) / 32;

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2511,7 +2511,7 @@ string YulUtilFunctions::revertReasonIfDebugAssembly(RevertStrings _revertString
 			revert(0, 0)
 		</debugAndMessage>
 	})");
-	bool debugAndMessage = _revertStrings >= RevertStrings::Debug && !_message.empty();
+	bool debugAndMessage = (_revertStrings >= RevertStrings::Debug && !_message.empty());
 	templ("debugAndMessage", debugAndMessage);
 	if (debugAndMessage)
 	{

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -335,9 +335,11 @@ public:
 	/// If revertStrings is debug, @returns inline assembly code that
 	/// stores @param _message in memory position 0 and reverts.
 	/// Otherwise returns "revert(0, 0)".
-	static std::string revertReasonIfDebug(RevertStrings revertStrings, std::string const& _message = "");
+	std::string revertReasonIfDebugAssembly(RevertStrings revertStrings, std::string const& _message = "");
 
-	std::string revertReasonIfDebug(std::string const& _message = "");
+	std::string revertReasonIfDebugFunction(RevertStrings revertStrings, std::string const& _message = "");
+
+	std::string revertReasonIfDebugFunction(std::string const& _message = "");
 
 	/// Returns the name of a function that decodes an error message.
 	/// signature: () -> arrayPtr

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -186,5 +186,5 @@ ABIFunctions IRGenerationContext::abiFunctions()
 
 std::string IRGenerationContext::revertReasonIfDebug(std::string const& _message)
 {
-	return YulUtilFunctions::revertReasonIfDebug(m_revertStrings, _message);
+	return utils().revertReasonIfDebugFunction(m_revertStrings, _message) + "()";
 }

--- a/test/cmdlineTests/standard_irOptimized_requested/output.json
+++ b/test/cmdlineTests/standard_irOptimized_requested/output.json
@@ -36,7 +36,7 @@ object \"C_6\" {
             revert(0, 0)
             function abi_decode_tuple_(headStart, dataEnd)
             {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { { revert(0, 0) } }
             }
             function abi_encode_tuple__to__fromStack(headStart) -> tail
             { tail := add(headStart, 0) }

--- a/test/cmdlineTests/standard_ir_requested/output.json
+++ b/test/cmdlineTests/standard_ir_requested/output.json
@@ -48,7 +48,11 @@ object \"C_6\" {
             revert(0, 0)
 
             function abi_decode_tuple_(headStart, dataEnd)   {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { {
+
+                        revert(0, 0)
+
+                } }
 
             }
 

--- a/test/cmdlineTests/yul_string_format_ascii/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii/output.json
@@ -48,7 +48,11 @@ object \"C_10\" {
             revert(0, 0)
 
             function abi_decode_tuple_(headStart, dataEnd)   {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { {
+
+                        revert(0, 0)
+
+                } }
 
             }
 

--- a/test/cmdlineTests/yul_string_format_ascii_bytes32/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_bytes32/output.json
@@ -48,7 +48,11 @@ object \"C_10\" {
             revert(0, 0)
 
             function abi_decode_tuple_(headStart, dataEnd)   {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { {
+
+                        revert(0, 0)
+
+                } }
 
             }
 

--- a/test/cmdlineTests/yul_string_format_ascii_bytes32_from_number/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_bytes32_from_number/output.json
@@ -48,7 +48,11 @@ object \"C_10\" {
             revert(0, 0)
 
             function abi_decode_tuple_(headStart, dataEnd)   {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { {
+
+                        revert(0, 0)
+
+                } }
 
             }
 

--- a/test/cmdlineTests/yul_string_format_ascii_long/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_long/output.json
@@ -48,7 +48,11 @@ object \"C_10\" {
             revert(0, 0)
 
             function abi_decode_tuple_(headStart, dataEnd)   {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { {
+
+                        revert(0, 0)
+
+                } }
 
             }
 

--- a/test/cmdlineTests/yul_string_format_hex/output.json
+++ b/test/cmdlineTests/yul_string_format_hex/output.json
@@ -48,7 +48,11 @@ object \"C_10\" {
             revert(0, 0)
 
             function abi_decode_tuple_(headStart, dataEnd)   {
-                if slt(sub(dataEnd, headStart), 0) { revert(0, 0) }
+                if slt(sub(dataEnd, headStart), 0) { {
+
+                        revert(0, 0)
+
+                } }
 
             }
 


### PR DESCRIPTION
Fixes #8456

In some places it is not possible to call function so, I split old function to assembly and function.
Where we were able to call function it is called, the rest is left with assembly inserted as it was before.

Also, I noticed that yul util function  that is being called with `CompilerContext::callYulFunction` can't have a call to another yul function in its body.