### PR TITLE
Fix pragma solidity version in antlr grammar

### DIFF
--- a/docs/Solidity.g4
+++ b/docs/Solidity.g4
@@ -11,22 +11,10 @@ sourceUnit
   : (pragmaDirective | importDirective | structDefinition | enumDefinition | contractDefinition)* EOF ;
 
 pragmaDirective
-  : 'pragma' pragmaName pragmaValue ';' ;
+  : 'pragma' pragmaName ( ~';' )* ';' ;
 
 pragmaName
   : identifier ;
-
-pragmaValue
-  : version | expression ;
-
-version
-  : versionConstraint versionConstraint? ;
-
-versionConstraint
-  : versionOperator? VersionLiteral ;
-
-versionOperator
-  : '^' | '~' | '>=' | '>' | '<' | '<=' | '=' ;
 
 importDirective
   : 'import' StringLiteralFragment ('as' identifier)? ';'
@@ -472,9 +460,6 @@ DoubleQuotedStringCharacter
 fragment
 SingleQuotedStringCharacter
   : ~['\r\n\\] | ('\\' .) ;
-
-VersionLiteral
-  : [0-9]+ ( '.' [0-9]+ ('.' [0-9]+)? )? ;
 
 WS
   : [ \t\r\n\u000C]+ -> skip ;

--- a/test/libsolidity/syntaxTests/pragma/version_check.sol
+++ b/test/libsolidity/syntaxTests/pragma/version_check.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity < 142857;
+pragma solidity >= 0.0;
+pragma solidity >= 0.0.0;
+
+contract C {
+}


### PR DESCRIPTION
Previously, `pragma solidity > 0`, `pragma solidity > 0.0` or alike were not recognized by **Solidity.g4** grammar.

The problem was that the same input (e.g. `[0-9]`) could be `DecimalNumber` or `VersionLiteral`. The lexer makes its decision, and the parser gets an unexpected token.

The lexer _could_ have different modes (a pragma mode and the default mode) and produce proper tokens. But that would require pure lexer and pure parser grammars, instead of a the current compound lexer+parser one.

While separating lexer and parser grammars might be the right thing to do in the long run, here is a quick workaround. (Note that it allows `pragma solidity > .0`. Easy to fix, but would make rules a bit messy.)
