### PR TITLE
Added raspbian to install_deps

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -170,7 +170,7 @@ case $(uname -s) in
 # Debian
 #------------------------------------------------------------------------------
 
-            Debian*)
+            Debian*|Raspbian)
                 #Debian
                 . /etc/os-release
                 install_z3=""


### PR DESCRIPTION
In my tests, raspbian apt and packages are largely identical to debian, at least in so far as solidity is concerned. So this adds raspbian to the debian swithch case. Version numbers and names in os-release also match.