### PR TITLE
WIP: Natspec parsing moved into solidity parser for better error reporting

### DIFF
--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -314,6 +314,10 @@ size_t Scanner::scanSingleLineDocComment()
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
 	size_t endPosition = m_source->position();
 
+	m_skippedComments[NextNext].fragments.clear();
+	m_skippedComments[NextNext].fragments.emplace_back(
+			SourceLocation{static_cast<int>(m_source->position()), -1, m_source});
+
 	skipWhitespaceExceptUnicodeLinebreak();
 
 	while (!isSourcePastEndOfInput())
@@ -333,10 +337,14 @@ size_t Scanner::scanSingleLineDocComment()
 			{
 				if (!m_source->isPastEndOfInput(4) && m_source->get(3) == '/')
 					break; // "////" is not a documentation comment
+
+				m_skippedComments[NextNext].fragments.back().location.end = m_source->position();
+
 				m_char = m_source->advanceAndGet(3);
 				if (atEndOfLine())
 					continue;
 				addCommentLiteralChar('\n');
+				m_skippedComments[NextNext].fragments.emplace_back(SourceLocation{static_cast<int>(m_source->position()), -1, m_source});
 			}
 			else
 				break; // next line is not a documentation comment, we are done

--- a/libsolidity/analysis/DocStringAnalyser.cpp
+++ b/libsolidity/analysis/DocStringAnalyser.cpp
@@ -154,7 +154,7 @@ void DocStringAnalyser::parseDocStrings(
 	DocStringParser parser;
 	if (_node.documentation() && !_node.documentation()->text()->empty())
 	{
-		parser.parse(*_node.documentation()->text(), m_errorReporter);
+		parser.parse(*_node.documentation()->text(), _node.documentation()->location(), m_errorReporter);
 		_annotation.docTags = parser.tags();
 	}
 

--- a/libsolidity/parsing/DocStringParser.h
+++ b/libsolidity/parsing/DocStringParser.h
@@ -28,6 +28,7 @@
 namespace solidity::langutil
 {
 class ErrorReporter;
+struct SourceLocation;
 }
 
 namespace solidity::frontend
@@ -37,7 +38,11 @@ class DocStringParser
 {
 public:
 	/// Parse the given @a _docString and stores the parsed components internally.
-	void parse(std::string const& _docString, langutil::ErrorReporter& _errorReporter);
+	void parse(
+		std::string const& _docString,
+		langutil::SourceLocation const& _location,
+		langutil::ErrorReporter& _errorReporter
+	);
 
 	std::multimap<std::string, DocTag> const& tags() const { return m_docTags; }
 
@@ -55,6 +60,15 @@ private:
 	/// after the tag.
 	iter parseDocTag(iter _pos, iter _end, std::string const& _tag);
 
+	void docstringParsingError(langutil::ErrorId _error, std::string const& _description);
+
+	void docstringParsingError(
+		std::string::const_iterator const& _subRangeBegin,
+		std::string::const_iterator const& _subRangeEnd,
+		langutil::ErrorId _error,
+		std::string const& _description
+	);
+
 	/// Creates and inserts a new tag and adjusts m_lastTag.
 	void newTag(std::string const& _tagName);
 
@@ -62,6 +76,9 @@ private:
 	std::multimap<std::string, DocTag> m_docTags;
 	DocTag* m_lastTag = nullptr;
 	langutil::ErrorReporter* m_errorReporter = nullptr;
+
+	std::string const* m_docString = nullptr;
+	langutil::SourceLocation m_location{};
 };
 
 }

--- a/test/libsolidity/syntaxTests/natspec/docstring_empty_tag.sol
+++ b/test/libsolidity/syntaxTests/natspec/docstring_empty_tag.sol
@@ -1,5 +1,5 @@
 abstract contract C {
-    /// @param
+    ///  @param
     function vote(uint id) public {}
 }
 // ----


### PR DESCRIPTION
This PR isn't finished.

This PR moves the structured-documentation parsing up into the Solidity parser for more precise error parsing. It's not fully done yet, I've left some TODOs (especially in the project root there is a file).

It is for early (structural) feedback, and a few things I've not deleted inside yet in case I need them again (e.g. debug prints).