### PR TITLE
Do not disallow assigning to external parameters.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Compiler Features:
 Bugfixes:
  * NatSpec: Do not consider ``////`` and ``/***`` as NatSpec comments.
  * Type Checker: Fix internal error related to ``using for`` applied to non-libraries.
+ * Type Checker: Do not disallow assigning to calldata variables.
  * Yul: Fix source location of variable multi-assignment.
 
 

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -492,12 +492,7 @@ DeclarationAnnotation& Declaration::annotation() const
 bool VariableDeclaration::isLValue() const
 {
 	// Constant declared variables are Read-Only
-	if (isConstant())
-		return false;
-	// External function arguments of reference type are Read-Only
-	if (isExternalCallableParameter() && dynamic_cast<ReferenceType const*>(type()))
-		return false;
-	return true;
+	return !isConstant();
 }
 
 bool VariableDeclaration::isLocalVariable() const

--- a/test/libsolidity/syntaxTests/lvalues/external_reference_argument.sol
+++ b/test/libsolidity/syntaxTests/lvalues/external_reference_argument.sol
@@ -4,4 +4,3 @@ contract C {
     }
 }
 // ----
-// TypeError 7128: (96-97): External function arguments of reference type are read-only.

--- a/test/libsolidity/syntaxTests/structs/memory_to_calldata.sol
+++ b/test/libsolidity/syntaxTests/structs/memory_to_calldata.sol
@@ -5,7 +5,5 @@ contract Test {
     function g(S calldata s) external { S memory m; s = m; }
 }
 // ----
-// TypeError 7128: (114-115): External function arguments of reference type are read-only.
 // TypeError 7407: (118-122): Type struct Test.S memory is not implicitly convertible to expected type struct Test.S calldata.
-// TypeError 7128: (178-179): External function arguments of reference type are read-only.
 // TypeError 7407: (182-183): Type struct Test.S memory is not implicitly convertible to expected type struct Test.S calldata.


### PR DESCRIPTION
It seems this was a leftover of the calldata relaxation.