### PR TITLE
Temporarily disable pushing emscripten builds to solc-bin from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ env:
         - ENCRYPTION_LABEL="6d4541b72666"
         - SOLC_BUILD_TYPE=RelWithDebInfo
         - SOLC_EMSCRIPTEN=Off
+        # FIXME: Pushing solcjson.js to solc-bin disabled until we fix the cause of #9261
+        - SOLC_PUBLISH_EMSCRIPTEN=Off
         - SOLC_INSTALL_DEPS_TRAVIS=On
         - SOLC_RELEASE=On
         - SOLC_TESTS=On
@@ -213,7 +215,7 @@ deploy:
     # scripts because TravisCI doesn't provide much in the way of conditional logic.
 
     - provider: script
-      script: test $SOLC_EMSCRIPTEN != On || (scripts/release_emscripten.sh)
+      script: test $SOLC_PUBLISH_EMSCRIPTEN != On || $SOLC_EMSCRIPTEN != On || (scripts/release_emscripten.sh)
       skip_cleanup: true
       on:
           branch:


### PR DESCRIPTION
A safety measure to prevent subsequent nightly builds from breaking external tools until we find and fix the root cause of #9261.