### PR TITLE
solc: clickable links in file names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * NatSpec: Add fields "kind" and "version" to the JSON output.
  * Commandline Interface: Prevent some incompatible commandline options from being used together.
+ * Commandline Interface: Adds new option ``--hyperlinks`` and ``--no-hyperlinks`` for clickable file names in diagnostics.
 
 
 Bugfixes:

--- a/liblangutil/SourceReferenceFormatterHuman.cpp
+++ b/liblangutil/SourceReferenceFormatterHuman.cpp
@@ -23,7 +23,9 @@
 #include <liblangutil/Exceptions.h>
 #include <libsolutil/UTF8.h>
 #include <iomanip>
+#include <iostream>
 #include <string_view>
+
 
 using namespace std;
 using namespace solidity;
@@ -88,7 +90,7 @@ void SourceReferenceFormatterHuman::printSourceLocation(SourceReference const& _
 	if (_ref.position.line < 0)
 	{
 		frameColored() << "-->";
-		m_stream << ' ' << _ref.sourceName << '\n';
+		m_stream << ' ' << m_hyperlink(_ref.sourceName) << '\n';
 		return; // No line available, nothing else to print
 	}
 
@@ -98,7 +100,7 @@ void SourceReferenceFormatterHuman::printSourceLocation(SourceReference const& _
 	// line 0: source name
 	m_stream << leftpad;
 	frameColored() << "-->";
-	m_stream << ' ' << _ref.sourceName << ':' << line << ':' << (_ref.position.column + 1) << ":\n";
+	m_stream << ' ' << m_hyperlink(_ref.sourceName) << ':' << line << ':' << (_ref.position.column + 1) << ":\n";
 
 	string_view text = _ref.text;
 

--- a/liblangutil/SourceReferenceFormatterHuman.h
+++ b/liblangutil/SourceReferenceFormatterHuman.h
@@ -24,6 +24,7 @@
 #include <liblangutil/SourceReferenceFormatter.h> // SourceReferenceFormatterBase
 
 #include <libsolutil/AnsiColorized.h>
+#include <libsolutil/hyperlink.h>
 
 #include <ostream>
 #include <sstream>
@@ -35,8 +36,8 @@ namespace solidity::langutil
 class SourceReferenceFormatterHuman: public SourceReferenceFormatter
 {
 public:
-	SourceReferenceFormatterHuman(std::ostream& _stream, bool _colored, bool _withErrorIds):
-		SourceReferenceFormatter{_stream}, m_colored{_colored}, m_withErrorIds(_withErrorIds)
+	SourceReferenceFormatterHuman(std::ostream& _stream, bool _colored, bool _withErrorIds, bool _hyperlinks):
+		SourceReferenceFormatter{_stream}, m_colored{_colored}, m_withErrorIds(_withErrorIds), m_hyperlink{_hyperlinks}
 	{}
 
 	void printSourceLocation(SourceReference const& _ref) override;
@@ -47,12 +48,13 @@ public:
 		util::Exception const& _exception,
 		std::string const& _name,
 		bool _colored = false,
-		bool _withErrorIds = false
+		bool _withErrorIds = false,
+		bool _hyperlinks = false
 	)
 	{
 		std::ostringstream errorOutput;
 
-		SourceReferenceFormatterHuman formatter(errorOutput, _colored, _withErrorIds);
+		SourceReferenceFormatterHuman formatter(errorOutput, _colored, _withErrorIds, _hyperlinks);
 		formatter.printExceptionInformation(_exception, _name);
 		return errorOutput.str();
 	}
@@ -69,6 +71,7 @@ private:
 private:
 	bool m_colored;
 	bool m_withErrorIds;
+	util::Hyperlink m_hyperlink;
 };
 
 }

--- a/libsolutil/hyperlink.h
+++ b/libsolutil/hyperlink.h
@@ -1,0 +1,72 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <boost/filesystem.hpp>
+
+#include <iostream>
+#include <string>
+
+// Required for gethostname()
+#if defined(_WIN32)
+#include <Winsock2.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace solidity::util
+{
+
+struct Hyperlink
+{
+	bool enabled = false;
+
+	struct Ref { bool enabled; std::string text; };
+
+	Ref operator()(std::string const& _ref) { return Ref{enabled, _ref}; }
+};
+
+inline std::ostream& operator<<(std::ostream& _os, Hyperlink::Ref const& _hyperlink)
+{
+	auto const path = boost::filesystem::path{_hyperlink.text};
+	bool const candidate = boost::filesystem::is_regular_file(path) && (&_os == &std::cout || &_os == &std::cerr);
+
+	if (_hyperlink.enabled && candidate)
+	{
+		static std::string const hostname = []() -> std::string {
+			char hostname[80] = {0};
+			if (gethostname(hostname, sizeof(hostname)) < 0)
+				return std::string{};
+			return std::string{hostname};
+		}();
+
+		auto const abspath = boost::filesystem::canonical(boost::filesystem::absolute(path));
+		auto constexpr OSC8 = "\033]8;;";
+		auto constexpr ST = "\033\\";
+
+		_os << OSC8 << "file://" << hostname << abspath.generic_string() << ST;
+		_os << _hyperlink.text;
+		_os << OSC8 << ST;
+	}
+	else
+		_os << _hyperlink.text;
+
+	return _os;
+}
+
+} // end namespace

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -136,6 +136,8 @@ private:
 	bool m_coloredOutput = true;
 	/// Whether or not to output error IDs.
 	bool m_withErrorIds = false;
+	/// Whether or not error diagnostics may construct text with hyperlink anchors.
+	bool m_hyperlinks = false;
 };
 
 }

--- a/test/libsolidity/ASTJSONTest.cpp
+++ b/test/libsolidity/ASTJSONTest.cpp
@@ -134,7 +134,7 @@ TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefi
 		c.analyze();
 	else
 	{
-		SourceReferenceFormatterHuman formatter(_stream, _formatted, false);
+		SourceReferenceFormatterHuman formatter(_stream, _formatted, false, false);
 		for (auto const& error: c.errors())
 			formatter.printErrorInformation(*error);
 		return TestResult::FatalError;

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -118,7 +118,7 @@ TestCase::TestResult GasTest::run(ostream& _stream, string const& _linePrefix, b
 
 	if (!compiler().parseAndAnalyze() || !compiler().compile())
 	{
-		SourceReferenceFormatterHuman formatter(_stream, _formatted, false);
+		SourceReferenceFormatterHuman formatter(_stream, _formatted, false, false);
 		for (auto const& error: compiler().errors())
 			formatter.printErrorInformation(*error);
 		return TestResult::FatalError;

--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -390,7 +390,7 @@ void SourceUpgrade::applyChange(
 
 void SourceUpgrade::printErrors() const
 {
-	auto formatter = make_unique<langutil::SourceReferenceFormatterHuman>(cout, true, false);
+	auto formatter = make_unique<langutil::SourceReferenceFormatterHuman>(cout, true, false, false);
 
 	for (auto const& error: m_compiler->errors())
 		if (error->type() != langutil::Error::Type::Warning)

--- a/tools/solidityUpgrade/UpgradeChange.cpp
+++ b/tools/solidityUpgrade/UpgradeChange.cpp
@@ -36,7 +36,7 @@ void UpgradeChange::apply()
 void UpgradeChange::log(bool const _shorten) const
 {
 	stringstream os;
-	SourceReferenceFormatterHuman formatter{os, true, false};
+	SourceReferenceFormatterHuman formatter{os, true, false, false};
 
 	string start = to_string(m_location.start);
 	string end = to_string(m_location.end);


### PR DESCRIPTION
### Motivation

I did that because I'm actually seeing a lot of errors when compiling external contracts with latest solc builds. It actually helps a lot in quickly opening those files that contain the error.

### What it does

Adds support for OSC-8 in error diagnostics, that is, you can click the file names in the error reports.

This is by default auto-detected, can be actively disabled (including auto-detection), or forcefully enabled.

A non-supporting terminal will silently ignore the generated hyperlink
anchor and just print the file name.


# References

* See https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#supporting-apps for an incomplete list of supporting terminals.