### PR TITLE
yul proto fuzzer: Remove assertion that no errors/warnings while pars…

### DIFF
--- a/test/tools/ossfuzz/yulProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/yulProtoFuzzer.cpp
@@ -59,13 +59,13 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	);
 
 	// Parse protobuf mutated YUL code
-	if (!stack.parseAndAnalyze("source", yul_source))
-		return;
-
-	yulAssert(stack.errors().empty(), "Parsed successfully but had errors.");
-
-	if (!stack.parserResult()->code || !stack.parserResult()->analysisInfo)
-		return;
+	if (
+		!stack.parseAndAnalyze("source", yul_source) ||
+		!stack.parserResult()->code ||
+		!stack.parserResult()->analysisInfo ||
+		!Error::containsOnlyWarnings(stack.errors())
+	)
+		yulAssert(false, "Proto fuzzer generated malformed program");
 
 	// Optimize
 	stack.optimize();

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -77,8 +77,12 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	);
 
 	// Parse protobuf mutated YUL code
-	if (!stack.parseAndAnalyze("source", yul_source) || !stack.parserResult()->code ||
-		!stack.parserResult()->analysisInfo)
+	if (
+		!stack.parseAndAnalyze("source", yul_source) ||
+		!stack.parserResult()->code ||
+		!stack.parserResult()->analysisInfo ||
+		!Error::containsOnlyWarnings(stack.errors())
+	)
 	{
 		printErrors(std::cout, stack.errors());
 		yulAssert(false, "Proto fuzzer generated malformed program");


### PR DESCRIPTION
…ing yul code

After the introduction of https://github.com/ethereum/solidity/pull/8913 (warn on PC), the assertion that there are no errors in assembly stack is no longer valid.

This PR ~~removes the said assertion since warnings may be produced if the fuzzer inserts a `pc` instruction.~~ replaces the said assertion with a more specific assertion for "no errors" (warnings okay).