### PR TITLE
Add a missing DocStringParser error to tests

### DIFF
--- a/libsolidity/parsing/DocStringParser.h
+++ b/libsolidity/parsing/DocStringParser.h
@@ -50,7 +50,6 @@ private:
 	iter parseDocTagParam(iter _pos, iter _end);
 	iter appendDocTagParam(iter _pos, iter _end);
 	void parseDocString(std::string const& _string);
-	iter appendDocTag(iter _pos, iter _end);
 	/// Parses the doc tag named @a _tag, adds it to m_docTags and returns the position
 	/// after the tag.
 	iter parseDocTag(iter _pos, iter _end, std::string const& _tag);

--- a/test/libsolidity/syntaxTests/natspec/docstring_empty_tag.sol
+++ b/test/libsolidity/syntaxTests/natspec/docstring_empty_tag.sol
@@ -3,4 +3,4 @@ abstract contract C {
     function vote(uint id) public {}
 }
 // ----
-// DocstringParsingError 9222: End of tag @param not found
+// DocstringParsingError 3335: No param name given


### PR DESCRIPTION
The line
```
/// @param
```
caused different errors, depending on presence of a trailing whitespace.

The error **DocstringParsingError 3335: No param name given** added to tests.

The error **DocstringParsingError 9222: End of tag @param not found** removed completely.
If we do not want to allow empty or whitespace-only tags, then more accurate checks need to be added.
