### PR TITLE
[Yul] Restrict `linkersymbol` to object dialect and add missing changelog entries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 Language Features:
  * General: Add unit denomination ``gwei``
+ * Yul: Support ``linkersymbol`` builtin in standalone assembly mode.
+ * Yul: Support using string literals exceeding 32 bytes as literal arguments for builtins.
 
 
 Compiler Features:

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -124,19 +124,18 @@ map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVe
 		)
 			builtins.emplace(createEVMFunction(instr.first, instr.second));
 
-	builtins.emplace(createFunction("linkersymbol", 1, 1, SideEffects{}, {true}, [](
-		FunctionCall const& _call,
-		AbstractAssembly& _assembly,
-		BuiltinContext&,
-		function<void(Expression const&)>
-	) {
-		yulAssert(_call.arguments.size() == 1, "");
-		Expression const& arg = _call.arguments.front();
-		_assembly.appendLinkerSymbol(std::get<Literal>(arg).value.str());
-	}));
-
 	if (_objectAccess)
 	{
+		builtins.emplace(createFunction("linkersymbol", 1, 1, SideEffects{}, {true}, [](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext&,
+			function<void(Expression const&)>
+		) {
+			yulAssert(_call.arguments.size() == 1, "");
+			Expression const& arg = _call.arguments.front();
+			_assembly.appendLinkerSymbol(std::get<Literal>(arg).value.str());
+		}));
 		builtins.emplace(createFunction("datasize", 1, 1, SideEffects{}, {true}, [](
 			FunctionCall const& _call,
 			AbstractAssembly& _assembly,

--- a/test/libsolidity/syntaxTests/inlineAssembly/linkersymbol_builtin.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/linkersymbol_builtin.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      pop(linkersymbol("contract/library.sol:L"))
+    }
+  }
+}
+// ----
+// DeclarationError 4619: (67-79): Function not found.
+// TypeError 3950: (67-105): Expected expression to evaluate to one value, but got 0 values instead.

--- a/test/libsolidity/syntaxTests/inlineAssembly/linkersymbol_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/linkersymbol_function.sol
@@ -1,0 +1,10 @@
+contract C {
+  function f() public pure {
+    assembly {
+      function linkersymbol(a) {}
+
+      linkersymbol("contract/library.sol:L")
+    }
+  }
+}
+// ----


### PR DESCRIPTION
Part of #8078.

Without this the change would affect how `assembly` blocks work and would have to be considered a breaking change.

Changelog entries are for #9239 and #9240.