### PR TITLE
[BREAKING] Restrict dots in Yul identifiers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@ Breaking changes:
 
 Language Features:
  * Yul: Disallow EVM instruction `pc()`.
-
+ * Yul: Disallow consecutive and trailing dots in identifiers. Leading dots were already disallowed.
 
 Compiler Features:
 

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -108,6 +108,7 @@ private:
 	void checkAssignment(Identifier const& _variable, YulString _valueType);
 
 	Scope& scope(Block const* _block);
+	void expectValidIdentifier(YulString _identifier, langutil::SourceLocation const& _location);
 	void expectValidType(YulString _type, langutil::SourceLocation const& _location);
 	void expectType(YulString _expectedType, YulString _givenType, langutil::SourceLocation const& _location);
 

--- a/test/libyul/yulSyntaxTests/are_we_perl_yet.yul
+++ b/test/libyul/yulSyntaxTests/are_we_perl_yet.yul
@@ -4,3 +4,9 @@
     _...(a...)
 }
 // ----
+// SyntaxError 3384: (6-27): "_..." is not a valid identifier (ends with a dot).
+// SyntaxError 7771: (6-27): "_..." is not a valid identifier (contains consecutive dots).
+// SyntaxError 3384: (20-23): "$.." is not a valid identifier (ends with a dot).
+// SyntaxError 7771: (20-23): "$.." is not a valid identifier (contains consecutive dots).
+// SyntaxError 3384: (36-40): "a..." is not a valid identifier (ends with a dot).
+// SyntaxError 7771: (36-40): "a..." is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_consecutive_function.yul
+++ b/test/libyul/yulSyntaxTests/dot_consecutive_function.yul
@@ -2,3 +2,4 @@
     function x..y() {}
 }
 // ----
+// SyntaxError 7771: (6-24): "x..y" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_consecutive_function_arg.yul
+++ b/test/libyul/yulSyntaxTests/dot_consecutive_function_arg.yul
@@ -2,3 +2,4 @@
     function x(a..b) {}
 }
 // ----
+// SyntaxError 7771: (17-21): "a..b" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_consecutive_function_ret.yul
+++ b/test/libyul/yulSyntaxTests/dot_consecutive_function_ret.yul
@@ -2,3 +2,4 @@
     function x() -> a..b {}
 }
 // ----
+// SyntaxError 7771: (22-26): "a..b" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_consecutive_variabledeclaration.yul
+++ b/test/libyul/yulSyntaxTests/dot_consecutive_variabledeclaration.yul
@@ -2,3 +2,4 @@
     let a..b := 1
 }
 // ----
+// SyntaxError 7771: (10-14): "a..b" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_ellipse_function.yul
+++ b/test/libyul/yulSyntaxTests/dot_ellipse_function.yul
@@ -2,3 +2,4 @@
     function x...y() {}
 }
 // ----
+// SyntaxError 7771: (6-25): "x...y" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_ellipse_function_arg.yul
+++ b/test/libyul/yulSyntaxTests/dot_ellipse_function_arg.yul
@@ -2,3 +2,4 @@
     function x(a...b) {}
 }
 // ----
+// SyntaxError 7771: (17-22): "a...b" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_ellipse_function_ret.yul
+++ b/test/libyul/yulSyntaxTests/dot_ellipse_function_ret.yul
@@ -2,3 +2,4 @@
     function x() -> a...b {}
 }
 // ----
+// SyntaxError 7771: (22-27): "a...b" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_ellipse_variabledeclaration.yul
+++ b/test/libyul/yulSyntaxTests/dot_ellipse_variabledeclaration.yul
@@ -2,3 +2,4 @@
     let a...b := 1
 }
 // ----
+// SyntaxError 7771: (10-15): "a...b" is not a valid identifier (contains consecutive dots).

--- a/test/libyul/yulSyntaxTests/dot_trailing_function.yul
+++ b/test/libyul/yulSyntaxTests/dot_trailing_function.yul
@@ -2,3 +2,4 @@
     function x.() {}
 }
 // ----
+// SyntaxError 3384: (6-22): "x." is not a valid identifier (ends with a dot).

--- a/test/libyul/yulSyntaxTests/dot_trailing_function_arg.yul
+++ b/test/libyul/yulSyntaxTests/dot_trailing_function_arg.yul
@@ -2,3 +2,4 @@
     function x(a.) {}
 }
 // ----
+// SyntaxError 3384: (17-19): "a." is not a valid identifier (ends with a dot).

--- a/test/libyul/yulSyntaxTests/dot_trailing_function_ret.yul
+++ b/test/libyul/yulSyntaxTests/dot_trailing_function_ret.yul
@@ -2,3 +2,4 @@
     function x() -> a. {}
 }
 // ----
+// SyntaxError 3384: (22-24): "a." is not a valid identifier (ends with a dot).

--- a/test/libyul/yulSyntaxTests/dot_trailing_variabledeclaration.yul
+++ b/test/libyul/yulSyntaxTests/dot_trailing_variabledeclaration.yul
@@ -2,3 +2,4 @@
     let a. := 1
 }
 // ----
+// SyntaxError 3384: (10-12): "a." is not a valid identifier (ends with a dot).


### PR DESCRIPTION
Part of #7646.

This will need to go into the breaking branch, but we'll need to merge some PRs and merge develop into breaking first.