### PR TITLE
Add variable name to the "Variable covers ...." warning

### DIFF
--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -163,7 +163,8 @@ bool StaticAnalyzer::visit(VariableDeclaration const& _variable)
 			m_errorReporter.warning(
 				3408_error,
 				_variable.location(),
-				"Variable covers a large part of storage and thus makes collisions likely. "
+				"Variable " + util::escapeAndQuoteString(_variable.name()) +
+				" covers a large part of storage and thus makes collisions likely. "
 				"Either use mappings or dynamic arrays and allow their size to be increased only "
 				"in small quantities per transaction."
 			);
@@ -171,7 +172,8 @@ bool StaticAnalyzer::visit(VariableDeclaration const& _variable)
 			m_errorReporter.warning(
 				7325_error,
 				_variable.location(),
-				"Type " + type->canonicalName() + " has large size and thus makes collisions likely. "
+				"Type " + util::escapeAndQuoteString(type->canonicalName()) +
+				" has large size and thus makes collisions likely. "
 				"Either use mappings or dynamic arrays and allow their size to be increased only "
 				"in small quantities per transaction."
 			);

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_array_mapping.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_array_mapping.sol
@@ -2,4 +2,4 @@ contract C {
     mapping(uint => uint[2**100]) x;
 }
 // ----
-// Warning 7325: (17-48): Type uint256[1267650600228229401496703205376] has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (17-48): Type "uint256[1267650600228229401496703205376]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_array_simple.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_array_simple.sol
@@ -2,4 +2,4 @@ contract C {
     uint[2**64] x;
 }
 // ----
-// Warning 3408: (17-30): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (17-30): Variable "x" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_arrays_struct.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_arrays_struct.sol
@@ -3,4 +3,4 @@ contract C {
     S[2**20] x;
 }
 // ----
-// Warning 3408: (64-74): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (64-74): Variable "x" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_structs.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_structs.sol
@@ -2,64 +2,66 @@ contract C {
     struct P { uint256[2**63] x; }
 
     struct S0 {
-        P[2**62] x;
+        P[101] x;
         P y;
     }
     S0 s0;
 
     struct S1 {
         P x;
-        P[2**62] y;
+        P[102] y;
     }
     S1 s1;
 
     struct S2 {
-        mapping(uint => P[2**62]) x;
-        mapping(uint => P[2**62]) y;
-        mapping(uint => S2) z;
+        mapping(uint => P[103]) x;
+        mapping(uint => P[103]) y;
+        mapping(uint => P[104]) z;
+        mapping(uint => S2) t;
     }
     S2 s2;
 
     struct Q0
     {
-        uint[1][][2**65] x;
-        uint[2**65][][1] y;
-        uint[][2**65] z;
-        uint[2**65][] t;
+        uint[1][][10**20 + 4] x;
+        uint[10**20 + 4][][1] y;
+        uint[][10**20 + 4] z;
+        uint[10**20 + 4][] t;
     }
     Q0 q0;
 
     struct Q1
     {
-        uint[1][][2**65] x;
+        uint[1][][10**20 + 5] x;
     }
     Q1 q1;
 
     struct Q2
     {
-        uint[2**65][][1] y;
+        uint[10**20 + 6][][1] y;
     }
     Q2 q2;
 
     struct Q3
     {
-        uint[][2**65] z;
+        uint[][10**20 + 7] x;
     }
     Q3 q3;
 
     struct Q4
     {
-        uint[2**65][] t;
+        uint[10**20 + 8][] y;
     }
     Q4 q4;
 }
 // ----
-// Warning 3408: (108-113): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (175-180): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (314-319): Type C.P[4611686018427387904] has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (458-463): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (458-463): Type uint256[36893488147419103232] has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (524-529): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (590-595): Type uint256[36893488147419103232] has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (653-658): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 7325: (716-721): Type uint256[36893488147419103232] has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (106-111): Variable "s0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (171-176): Variable "s1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (341-346): Type "C.P[103]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (341-346): Type "C.P[104]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (505-510): Variable "q0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (505-510): Type "uint256[100000000000000000004]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (576-581): Variable "q1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (647-652): Type "uint256[100000000000000000006]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (715-720): Variable "q3" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (783-788): Type "uint256[100000000000000000008]" has large size and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/types/rational_number_array_index_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_array_index_limit.sol
@@ -2,4 +2,4 @@ contract c {
     uint[2**253] data;
 }
 // ----
-// Warning 3408: (17-34): Variable covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (17-34): Variable "data" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.


### PR DESCRIPTION
The variable name is added to make the warning more explicit.
