### PR TITLE
Remove unused instructionNames() function in AsmParser

### DIFF
--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -297,20 +297,6 @@ Expression Parser::parseExpression()
 	}
 }
 
-std::map<evmasm::Instruction, string> const& Parser::instructionNames()
-{
-	static map<evmasm::Instruction, string> s_instructionNames;
-	if (s_instructionNames.empty())
-	{
-		for (auto const& instr: instructions())
-			s_instructionNames[instr.second] = instr.first;
-		// set the ambiguous instructions to a clear default
-		s_instructionNames[evmasm::Instruction::SELFDESTRUCT] = "selfdestruct";
-		s_instructionNames[evmasm::Instruction::KECCAK256] = "keccak256";
-	}
-	return s_instructionNames;
-}
-
 Parser::ElementaryOperation Parser::parseElementaryOperation()
 {
 	RecursionGuard recursionGuard(*this);

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -86,7 +86,6 @@ protected:
 	ForLoop parseForLoop();
 	/// Parses a functional expression that has to push exactly one stack element
 	Expression parseExpression();
-	static std::map<evmasm::Instruction, std::string> const& instructionNames();
 	/// Parses an elementary operation, i.e. a literal, identifier, instruction or
 	/// builtin functian call (only the name).
 	ElementaryOperation parseElementaryOperation();


### PR DESCRIPTION
This should have been removed latest in 0.6.0.