### PR TITLE
Rename drop to i64.drop in WasmDialect

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
  * Type Checker: Fix internal error related to ``using for`` applied to non-libraries.
  * Type Checker: Do not disallow assigning to calldata variables.
  * Wasm backend: Fix code generation for for-loops with pre statements.
+ * Wasm backend: Properly support both ``i32.drop`` and ``i64.drop``, and remove ``drop``.
  * Yul: Fix source location of variable multi-assignment.
 
 

--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -390,7 +390,7 @@ bytes BinaryTransform::operator()(BuiltinCall const& _call)
 		return toBytes(Opcode::Unreachable);
 	else if (_call.functionName == "nop")
 		return toBytes(Opcode::Nop);
-	else if (_call.functionName == "drop")
+	else if (_call.functionName == "i32.drop" || _call.functionName == "i64.drop")
 		return toBytes(Opcode::Drop);
 	else
 	{

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -94,7 +94,10 @@ string TextTransform::operator()(wasm::GlobalVariable const& _identifier)
 string TextTransform::operator()(wasm::BuiltinCall const& _builtinCall)
 {
 	string args = joinTransformed(_builtinCall.arguments);
-	return "(" + _builtinCall.functionName + (args.empty() ? "" : " " + args) + ")";
+	string funcName = _builtinCall.functionName;
+	if (funcName == "i32.drop" || funcName == "i64.drop")
+		funcName = "drop";
+	return "(" + funcName + (args.empty() ? "" : " " + args) + ")";
 }
 
 string TextTransform::operator()(wasm::FunctionCall const& _functionCall)

--- a/libyul/backends/wasm/WasmDialect.cpp
+++ b/libyul/backends/wasm/WasmDialect.cpp
@@ -91,9 +91,9 @@ WasmDialect::WasmDialect()
 	m_functions["i64.load"_yulstring].sideEffects.sideEffectFreeIfNoMSize = true;
 
 	// Drop is actually overloaded for all types, but Yul does not support that.
-	// Because of that, we introduce "i32.drop".
-	addFunction("drop", {i64}, {});
+	// Because of that, we introduce "i32.drop" and "i64.drop".
 	addFunction("i32.drop", {i32}, {});
+	addFunction("i64.drop", {i64}, {});
 
 	addFunction("nop", {}, {});
 	addFunction("unreachable", {}, {}, false);
@@ -122,7 +122,7 @@ BuiltinFunction const* WasmDialect::discardFunction(YulString _type) const
 	if (_type == "i32"_yulstring)
 		return builtin("i32.drop"_yulstring);
 	yulAssert(_type == "i64"_yulstring, "");
-	return builtin("drop"_yulstring);
+	return builtin("i64.drop"_yulstring);
 }
 
 BuiltinFunction const* WasmDialect::equalityFunction(YulString _type) const

--- a/test/tools/yulInterpreter/EwasmBuiltinInterpreter.cpp
+++ b/test/tools/yulInterpreter/EwasmBuiltinInterpreter.cpp
@@ -93,7 +93,7 @@ u256 EwasmBuiltinInterpreter::evalBuiltin(YulString _fun, vector<u256> const& _a
 			);
 		return 0;
 	}
-	else if (_fun == "drop"_yulstring || _fun == "nop"_yulstring)
+	else if (_fun == "i32.drop"_yulstring || _fun == "i64.drop"_yulstring || _fun == "nop"_yulstring)
 		return {};
 	else if (_fun == "i32.wrap_i64"_yulstring)
 		return arg.at(0) & uint32_t(-1);


### PR DESCRIPTION
Also properly implement support for both i32.drop and i64.drop in BinaryTransform, TextTransform, and YulInterpreter

Missed in #9142.