### PR TITLE
Natspec: change events() to interfaceEvents()

### DIFF
--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -82,7 +82,7 @@ Json::Value Natspec::userDocumentation(ContractDefinition const& _contractDef)
 			}
 		}
 
-	for (auto const& event: _contractDef.events())
+	for (auto const& event: _contractDef.interfaceEvents())
 	{
 		string value = extractDoc(event->annotation().docTags, "notice");
 		if (!value.empty())


### PR DESCRIPTION
The NatSpec for events will also have inherited events.

[This](https://gist.github.com/hrkrshnn/09bd5673b60051256c38b615fac1a0b6) is the NatSpec of the deposit contract.