### PR TITLE
[yul-phaser] Temporarily disable very slow tests for the classic algorithm

### DIFF
--- a/test/yulPhaser/GeneticAlgorithms.cpp
+++ b/test/yulPhaser/GeneticAlgorithms.cpp
@@ -212,7 +212,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_generate_individuals_in_the_crossove
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(ClassicGeneticAlgorithmTest)
 
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_proportional_to_fitness, ClassicGeneticAlgorithmFixture)
+// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_proportional_to_fitness, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
 {
 	constexpr double relativeTolerance = 0.1;
 	constexpr size_t populationSize = 1000;
@@ -253,7 +254,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_
 	BOOST_TEST(abs(meanSquaredError(newFitness, expectedValue) - variance) < variance * relativeTolerance);
 }
 
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_only_individuals_existing_in_the_original_population, ClassicGeneticAlgorithmFixture)
+// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_only_individuals_existing_in_the_original_population, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
 {
 	constexpr size_t populationSize = 1000;
 	auto population = Population::makeRandom(m_fitnessMetric, populationSize, 1, 10);
@@ -297,7 +299,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_crossover, ClassicGeneticAlgorith
 	BOOST_TEST(totalCrossed >= 2);
 }
 
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithmFixture)
+// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
 {
 	m_options.mutationChance = 0.6;
 	ClassicGeneticAlgorithm algorithm(m_options);
@@ -326,7 +329,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithm
 	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
 }
 
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithmFixture)
+// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
 {
 	m_options.deletionChance = 0.6;
 	ClassicGeneticAlgorithm algorithm(m_options);
@@ -355,7 +359,8 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithm
 	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
 }
 
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_addition, ClassicGeneticAlgorithmFixture)
+// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_addition, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
 {
 	m_options.additionChance = 0.6;
 	ClassicGeneticAlgorithm algorithm(m_options);


### PR DESCRIPTION
This disables the 5 tests that take 99% of `soltest` execution time with `--run_test=Phaser`.