### PR TITLE
Stop after parsing.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Compiler Features:
  * SMTChecker: Support ``addmod`` and ``mulmod``.
  * Optimizer: Optimize ``exp`` when base is -1.
  * Code generator: Implemented events with function type as one of its indexed parameters.
+ * General: Option to stop compilation after parsing stage. Can be used with ``solc --stop-after parsing``
 
 
 ### 0.7.2 (2020-09-28)

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -200,6 +200,8 @@ Input Description
       // Optional
       "settings":
       {
+        // Optional: Stop compilation after the given stage. Currently only "parsing" is valid here
+        "stopAfter": "parsing",
         // Optional: Sorted list of remappings
         "remappings": [ ":g=/dir" ],
         // Optional: Optimizer settings

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -23,6 +23,7 @@
 #include <libsolidity/ast/ASTJsonConverter.h>
 
 #include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/TypeProvider.h>
 
 #include <libyul/AsmJsonConverter.h>
 #include <libyul/AsmData.h>
@@ -69,8 +70,9 @@ void addIfSet(std::vector<pair<string, Json::Value>>& _attributes, string const&
 namespace solidity::frontend
 {
 
-ASTJsonConverter::ASTJsonConverter(bool _legacy, map<string, unsigned> _sourceIndices):
+ASTJsonConverter::ASTJsonConverter(bool _legacy, CompilerStack::State _stackState, map<string, unsigned> _sourceIndices):
 	m_legacy(_legacy),
+	m_stackState(_stackState),
 	m_sourceIndices(std::move(_sourceIndices))
 {
 }
@@ -204,13 +206,15 @@ void ASTJsonConverter::appendExpressionAttributes(
 {
 	std::vector<pair<string, Json::Value>> exprAttributes = {
 		make_pair("typeDescriptions", typePointerToJson(_annotation.type)),
-		make_pair("lValueRequested", _annotation.willBeWrittenTo),
 		make_pair("argumentTypes", typePointerToJson(_annotation.arguments))
 	};
 
 	addIfSet(exprAttributes, "isLValue", _annotation.isLValue);
 	addIfSet(exprAttributes, "isPure", _annotation.isPure);
 	addIfSet(exprAttributes, "isConstant", _annotation.isConstant);
+
+	if (m_stackState > CompilerStack::State::ParsedAndImported)
+		exprAttributes.emplace_back("lValueRequested", _annotation.willBeWrittenTo);
 
 	_attributes += exprAttributes;
 }
@@ -260,6 +264,7 @@ bool ASTJsonConverter::visit(SourceUnit const& _node)
 	addIfSet(attributes, "absolutePath", _node.annotation().path);
 
 	setJsonNode(_node, "SourceUnit", std::move(attributes));
+
 	return false;
 }
 
@@ -268,7 +273,7 @@ bool ASTJsonConverter::visit(PragmaDirective const& _node)
 	Json::Value literals(Json::arrayValue);
 	for (auto const& literal: _node.literals())
 		literals.append(literal);
-	setJsonNode( _node, "PragmaDirective", {
+	setJsonNode(_node, "PragmaDirective", {
 		make_pair("literals", std::move(literals))
 	});
 	return false;
@@ -278,7 +283,7 @@ bool ASTJsonConverter::visit(ImportDirective const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("file", _node.path()),
-		make_pair(m_legacy ? "SourceUnit" : "sourceUnit", nodeId(*_node.annotation().sourceUnit)),
+		make_pair(m_legacy ? "SourceUnit" : "sourceUnit", idOrNull(_node.annotation().sourceUnit)),
 		make_pair("scope", idOrNull(_node.scope()))
 	};
 
@@ -395,18 +400,11 @@ bool ASTJsonConverter::visit(OverrideSpecifier const& _node)
 
 bool ASTJsonConverter::visit(FunctionDefinition const& _node)
 {
-	Visibility visibility;
-	if (_node.isConstructor())
-		visibility = _node.annotation().contract->abstract() ? Visibility::Internal : Visibility::Public;
-	else
-		visibility = _node.visibility();
-
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("name", _node.name()),
 		make_pair("documentation", _node.documentation() ? toJson(*_node.documentation()) : Json::nullValue),
 		make_pair("kind", _node.isFree() ? "freeFunction" : TokenTraits::toString(_node.kind())),
 		make_pair("stateMutability", stateMutabilityToString(_node.stateMutability())),
-		make_pair("visibility", Declaration::visibilityToString(visibility)),
 		make_pair("virtual", _node.markedVirtual()),
 		make_pair("overrides", _node.overrides() ? toJson(*_node.overrides()) : Json::nullValue),
 		make_pair("parameters", toJson(_node.parameterList())),
@@ -417,7 +415,19 @@ bool ASTJsonConverter::visit(FunctionDefinition const& _node)
 		make_pair("scope", idOrNull(_node.scope()))
 	};
 
-	if (_node.isPartOfExternalInterface())
+	optional<Visibility> visibility;
+	if (_node.isConstructor())
+	{
+		if (_node.annotation().contract)
+			visibility = _node.annotation().contract->abstract() ? Visibility::Internal : Visibility::Public;
+	}
+	else
+		visibility = _node.visibility();
+
+	if (visibility)
+		attributes.emplace_back("visibility", Declaration::visibilityToString(*visibility));
+
+	if (_node.isPartOfExternalInterface() && m_stackState > CompilerStack::State::ParsedAndImported)
 		attributes.emplace_back("functionSelector", _node.externalIdentifierHex());
 	if (!_node.annotation().baseFunctions.empty())
 		attributes.emplace_back(make_pair("baseFunctions", getContainerIds(_node.annotation().baseFunctions, true)));
@@ -718,7 +728,7 @@ bool ASTJsonConverter::visit(Assignment const& _node)
 		make_pair("rightHandSide", toJson(_node.rightHandSide()))
 	};
 	appendExpressionAttributes(attributes, _node.annotation());
-	setJsonNode( _node, "Assignment", std::move(attributes));
+	setJsonNode(_node, "Assignment", std::move(attributes));
 	return false;
 }
 
@@ -770,15 +780,19 @@ bool ASTJsonConverter::visit(FunctionCall const& _node)
 		make_pair("tryCall", _node.annotation().tryCall)
 	};
 
-	FunctionCallKind nodeKind = *_node.annotation().kind;
-
-	if (m_legacy)
+	if (_node.annotation().kind.set())
 	{
-		attributes.emplace_back("isStructConstructorCall", nodeKind == FunctionCallKind::StructConstructorCall);
-		attributes.emplace_back("type_conversion", nodeKind == FunctionCallKind::TypeConversion);
+		FunctionCallKind nodeKind = *_node.annotation().kind;
+
+		if (m_legacy)
+		{
+			attributes.emplace_back("isStructConstructorCall", nodeKind == FunctionCallKind::StructConstructorCall);
+			attributes.emplace_back("type_conversion", nodeKind == FunctionCallKind::TypeConversion);
+		}
+		else
+			attributes.emplace_back("kind", functionCallKind(nodeKind));
 	}
-	else
-		attributes.emplace_back("kind", functionCallKind(nodeKind));
+
 	appendExpressionAttributes(attributes, _node.annotation());
 	setJsonNode(_node, "FunctionCall", std::move(attributes));
 	return false;

--- a/libsolidity/ast/ASTJsonConverter.h
+++ b/libsolidity/ast/ASTJsonConverter.h
@@ -25,6 +25,7 @@
 
 #include <libsolidity/ast/ASTAnnotations.h>
 #include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/interface/CompilerStack.h>
 #include <liblangutil/Exceptions.h>
 
 #include <json/json.h>
@@ -51,9 +52,11 @@ class ASTJsonConverter: public ASTConstVisitor
 public:
 	/// Create a converter to JSON for the given abstract syntax tree.
 	/// @a _legacy if true, use legacy format
+	/// @a _stackState state of the compiler stack to avoid outputting incomplete data
 	/// @a _sourceIndices is used to abbreviate source names in source locations.
 	explicit ASTJsonConverter(
 		bool _legacy,
+		CompilerStack::State _stackState,
 		std::map<std::string, unsigned> _sourceIndices = std::map<std::string, unsigned>()
 	);
 	/// Output the json representation of the AST to _stream.
@@ -189,6 +192,7 @@ private:
 	}
 
 	bool m_legacy = false; ///< if true, use legacy format
+	CompilerStack::State m_stackState = CompilerStack::State::Empty; ///< Used to only access information that already exists
 	bool m_inEvent = false; ///< whether we are currently inside an event or not
 	Json::Value m_currentValue;
 	std::map<std::string, unsigned> m_sourceIndices;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -140,7 +140,9 @@ util::Result<TypePointers> transformParametersToExternal(TypePointers const& _pa
 
 	for (auto const& type: _parameters)
 	{
-		if (TypePointer ext = type->interfaceType(_inLibrary).get())
+		if (!type)
+			return util::Result<TypePointers>::err("Type information not present.");
+		else if (TypePointer ext = type->interfaceType(_inLibrary).get())
 			transformed.push_back(ext);
 		else
 			return util::Result<TypePointers>::err("Parameter should have external type.");

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -124,7 +124,7 @@ std::optional<CompilerStack::Remapping> CompilerStack::parseRemapping(string con
 
 void CompilerStack::setRemappings(vector<Remapping> const& _remappings)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set remappings before parsing."));
 	for (auto const& remapping: _remappings)
 		solAssert(!remapping.prefix.empty(), "");
@@ -133,21 +133,21 @@ void CompilerStack::setRemappings(vector<Remapping> const& _remappings)
 
 void CompilerStack::setEVMVersion(langutil::EVMVersion _version)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set EVM version before parsing."));
 	m_evmVersion = _version;
 }
 
 void CompilerStack::setSMTSolverChoice(smtutil::SMTSolverChoice _enabledSMTSolvers)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set enabled SMT solvers before parsing."));
 	m_enabledSMTSolvers = _enabledSMTSolvers;
 }
 
 void CompilerStack::setLibraries(std::map<std::string, util::h160> const& _libraries)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set libraries before parsing."));
 	m_libraries = _libraries;
 }
@@ -161,14 +161,14 @@ void CompilerStack::setOptimiserSettings(bool _optimize, unsigned _runs)
 
 void CompilerStack::setOptimiserSettings(OptimiserSettings _settings)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set optimiser settings before parsing."));
 	m_optimiserSettings = std::move(_settings);
 }
 
 void CompilerStack::setRevertStringBehaviour(RevertStrings _revertStrings)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set revert string settings before parsing."));
 	solUnimplementedAssert(_revertStrings != RevertStrings::VerboseDebug, "");
 	m_revertStrings = _revertStrings;
@@ -176,21 +176,21 @@ void CompilerStack::setRevertStringBehaviour(RevertStrings _revertStrings)
 
 void CompilerStack::useMetadataLiteralSources(bool _metadataLiteralSources)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set use literal sources before parsing."));
 	m_metadataLiteralSources = _metadataLiteralSources;
 }
 
 void CompilerStack::setMetadataHash(MetadataHash _metadataHash)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set metadata hash before parsing."));
 	m_metadataHash = _metadataHash;
 }
 
 void CompilerStack::addSMTLib2Response(h256 const& _hash, string const& _response)
 {
-	if (m_stackState >= ParsingPerformed)
+	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must add SMTLib2 responses before parsing."));
 	m_smtlib2Responses[_hash] = _response;
 }
@@ -214,6 +214,7 @@ void CompilerStack::reset(bool _keepSettings)
 		m_optimiserSettings = OptimiserSettings::minimal();
 		m_metadataLiteralSources = false;
 		m_metadataHash = MetadataHash::IPFS;
+		m_stopAfter = State::CompilationSuccessful;
 	}
 	m_globalContext.reset();
 	m_sourceOrder.clear();
@@ -247,6 +248,7 @@ bool CompilerStack::parse()
 	vector<string> sourcesToParse;
 	for (auto const& s: m_sources)
 		sourcesToParse.push_back(s.first);
+
 	for (size_t i = 0; i < sourcesToParse.size(); ++i)
 	{
 		string const& path = sourcesToParse[i];
@@ -258,19 +260,26 @@ bool CompilerStack::parse()
 		else
 		{
 			source.ast->annotation().path = path;
-			for (auto const& newSource: loadMissingSources(*source.ast, path))
-			{
-				string const& newPath = newSource.first;
-				string const& newContents = newSource.second;
-				m_sources[newPath].scanner = make_shared<Scanner>(CharStream(newContents, newPath));
-				sourcesToParse.push_back(newPath);
-			}
+			if (m_stopAfter >= ParsedAndImported)
+				for (auto const& newSource: loadMissingSources(*source.ast, path))
+				{
+					string const& newPath = newSource.first;
+					string const& newContents = newSource.second;
+					m_sources[newPath].scanner = make_shared<Scanner>(CharStream(newContents, newPath));
+					sourcesToParse.push_back(newPath);
+				}
 		}
 	}
 
-	m_stackState = ParsingPerformed;
+	if (m_stopAfter <= Parsed)
+		m_stackState = Parsed;
+	else
+		m_stackState = ParsedAndImported;
 	if (!Error::containsOnlyWarnings(m_errorReporter.errors()))
 		m_hasError = true;
+
+	storeContractDefinitions();
+
 	return !m_hasError;
 }
 
@@ -290,13 +299,15 @@ void CompilerStack::importASTs(map<string, Json::Value> const& _sources)
 		source.scanner = scanner;
 		m_sources[path] = source;
 	}
-	m_stackState = ParsingPerformed;
+	m_stackState = ParsedAndImported;
 	m_importedSources = true;
+
+	storeContractDefinitions();
 }
 
 bool CompilerStack::analyze()
 {
-	if (m_stackState != ParsingPerformed || m_stackState >= AnalysisPerformed)
+	if (m_stackState != ParsedAndImported || m_stackState >= AnalysisPerformed)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must call analyze only after parsing was performed."));
 	resolveImports();
 
@@ -335,26 +346,6 @@ bool CompilerStack::analyze()
 		for (Source const* source: m_sourceOrder)
 			if (source->ast && !resolver.resolveNamesAndTypes(*source->ast))
 				return false;
-
-		// Store contract definitions.
-		for (Source const* source: m_sourceOrder)
-			if (source->ast)
-				for (
-					ContractDefinition const* contract:
-					ASTNode::filteredNodes<ContractDefinition>(source->ast->nodes())
-				)
-				{
-					// Note that we now reference contracts by their fully qualified names, and
-					// thus contracts can only conflict if declared in the same source file. This
-					// should already cause a double-declaration error elsewhere.
-					if (!m_contracts.count(contract->fullyQualifiedName()))
-						m_contracts[contract->fullyQualifiedName()].contract = contract;
-					else
-						solAssert(
-							m_errorReporter.hasErrors(),
-							"Contract already present (name clash?), but no error was reported."
-						);
-				}
 
 		DeclarationTypeChecker declarationTypeChecker(m_errorReporter, m_evmVersion);
 		for (Source const* source: m_sourceOrder)
@@ -469,9 +460,13 @@ bool CompilerStack::analyze()
 	return !m_hasError;
 }
 
-bool CompilerStack::parseAndAnalyze()
+bool CompilerStack::parseAndAnalyze(State _stopAfter)
 {
+	m_stopAfter = _stopAfter;
+
 	bool success = parse();
+	if (m_stackState >= m_stopAfter)
+		return success;
 	if (success || m_parserErrorRecovery)
 		success = analyze();
 	return success;
@@ -502,11 +497,15 @@ bool CompilerStack::isRequestedContract(ContractDefinition const& _contract) con
 	return false;
 }
 
-bool CompilerStack::compile()
+bool CompilerStack::compile(State _stopAfter)
 {
+	m_stopAfter = _stopAfter;
 	if (m_stackState < AnalysisPerformed)
-		if (!parseAndAnalyze())
+		if (!parseAndAnalyze(_stopAfter))
 			return false;
+
+	if (m_stackState >= m_stopAfter)
+		return true;
 
 	if (m_hasError)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Called compile with errors."));
@@ -574,7 +573,7 @@ void CompilerStack::link()
 
 vector<string> CompilerStack::contractNames() const
 {
-	if (m_stackState < AnalysisPerformed)
+	if (m_stackState < Parsed)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
 	vector<string> contractNames;
 	for (auto const& contract: m_contracts)
@@ -921,7 +920,7 @@ Scanner const& CompilerStack::scanner(string const& _sourceName) const
 
 SourceUnit const& CompilerStack::ast(string const& _sourceName) const
 {
-	if (m_stackState < ParsingPerformed)
+	if (m_stackState < Parsed)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing not yet performed."));
 	if (!source(_sourceName).ast && !m_parserErrorRecovery)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
@@ -994,7 +993,7 @@ string const& CompilerStack::Source::ipfsUrl() const
 
 StringMap CompilerStack::loadMissingSources(SourceUnit const& _ast, std::string const& _sourcePath)
 {
-	solAssert(m_stackState < ParsingPerformed, "");
+	solAssert(m_stackState < ParsedAndImported, "");
 	StringMap newSources;
 	try
 	{
@@ -1038,7 +1037,7 @@ StringMap CompilerStack::loadMissingSources(SourceUnit const& _ast, std::string 
 
 string CompilerStack::applyRemapping(string const& _path, string const& _context)
 {
-	solAssert(m_stackState < ParsingPerformed, "");
+	solAssert(m_stackState < ParsedAndImported, "");
 	// Try to find the longest prefix match in all remappings that are active in the current context.
 	auto isPrefixOf = [](string const& _a, string const& _b)
 	{
@@ -1080,7 +1079,7 @@ string CompilerStack::applyRemapping(string const& _path, string const& _context
 
 void CompilerStack::resolveImports()
 {
-	solAssert(m_stackState == ParsingPerformed, "");
+	solAssert(m_stackState == ParsedAndImported, "");
 
 	// topological sorting (depth first search) of the import graph, cutting potential cycles
 	vector<Source const*> sourceOrder;
@@ -1108,6 +1107,29 @@ void CompilerStack::resolveImports()
 			toposort(&sourcePair.second);
 
 	swap(m_sourceOrder, sourceOrder);
+}
+
+void CompilerStack::storeContractDefinitions()
+{
+	for (auto const& pair: m_sources)
+		if (pair.second.ast)
+			for (
+				ContractDefinition const* contract:
+				ASTNode::filteredNodes<ContractDefinition>(pair.second.ast->nodes())
+			)
+			{
+				string fullyQualifiedName = *pair.second.ast->annotation().path + ":" + contract->name();
+				// Note that we now reference contracts by their fully qualified names, and
+				// thus contracts can only conflict if declared in the same source file. This
+				// should already cause a double-declaration error elsewhere.
+				if (!m_contracts.count(fullyQualifiedName))
+					m_contracts[fullyQualifiedName].contract = contract;
+				else
+					solAssert(
+						m_errorReporter.hasErrors(),
+						"Contract already present (name clash?), but no error was reported."
+					);
+			}
 }
 
 namespace

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -90,7 +90,8 @@ public:
 	enum State {
 		Empty,
 		SourcesSet,
-		ParsingPerformed,
+		Parsed,
+		ParsedAndImported,
 		AnalysisPerformed,
 		CompilationSuccessful
 	};
@@ -216,11 +217,11 @@ public:
 
 	/// Parses and analyzes all source units that were added
 	/// @returns false on error.
-	bool parseAndAnalyze();
+	bool parseAndAnalyze(State _stopAfter = State::CompilationSuccessful);
 
 	/// Compiles the source units that were previously added and parsed.
 	/// @returns false on error.
-	bool compile();
+	bool compile(State _stopAfter = State::CompilationSuccessful);
 
 	/// @returns the list of sources (paths) used
 	std::vector<std::string> sourceNames() const;
@@ -373,6 +374,9 @@ private:
 	std::string applyRemapping(std::string const& _path, std::string const& _context);
 	void resolveImports();
 
+	/// Store the contract definitions in m_contracts.
+	void storeContractDefinitions();
+
 	/// @returns true if the source is requested to be compiled.
 	bool isRequestedSource(std::string const& _sourceName) const;
 
@@ -446,6 +450,7 @@ private:
 	ReadCallback::Callback m_readFile;
 	OptimiserSettings m_optimiserSettings;
 	RevertStrings m_revertStrings = RevertStrings::Default;
+	State m_stopAfter = State::CompilationSuccessful;
 	langutil::EVMVersion m_evmVersion;
 	smtutil::SMTSolverChoice m_enabledSMTSolvers;
 	std::map<std::string, std::set<std::string>> m_requestedContractNames;

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -60,6 +60,7 @@ private:
 		std::string language;
 		Json::Value errors;
 		bool parserErrorRecovery = false;
+		CompilerStack::State stopAfter = CompilerStack::State::CompilationSuccessful;
 		std::map<std::string, std::string> sources;
 		std::map<util::h256, std::string> smtLib2Responses;
 		langutil::EVMVersion evmVersion;

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -127,6 +127,7 @@ private:
 	std::map<std::string, util::h160> m_libraries;
 	/// Solidity compiler stack
 	std::unique_ptr<frontend::CompilerStack> m_compiler;
+	CompilerStack::State m_stopAfter = CompilerStack::State::CompilationSuccessful;
 	/// EVM version to use
 	langutil::EVMVersion m_evmVersion;
 	/// How to handle revert strings

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -439,6 +439,9 @@ SOLTMPDIR=$(mktemp -d)
 )
 rm -rf "$SOLTMPDIR"
 
+printTask "Testing AST export with stop-after=parsing..."
+"$REPO_ROOT/test/stopAfterParseTests.sh"
+
 printTask "Testing soljson via the fuzzer..."
 SOLTMPDIR=$(mktemp -d)
 (

--- a/test/cmdlineTests/standard_empty_file_name/output.json
+++ b/test/cmdlineTests/standard_empty_file_name/output.json
@@ -1,4 +1,4 @@
 {"errors":[{"component":"general","errorCode":"2904","formattedMessage":":2:24: DeclarationError: Declaration \"A\" not found in \"\" (referenced as \".\").
 pragma solidity >=0.0; import {A} from \".\";
                        ^------------------^
-","message":"Declaration \"A\" not found in \"\" (referenced as \".\").","severity":"error","type":"DeclarationError"}],"sources":{}}
+","message":"Declaration \"A\" not found in \"\" (referenced as \".\").","severity":"error","type":"DeclarationError"}],"sources":{"":{"id":0}}}

--- a/test/libsolidity/ASTJSON/abstract_contract_parseOnly.json
+++ b/test/libsolidity/ASTJSON/abstract_contract_parseOnly.json
@@ -1,0 +1,54 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": true,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "37:4:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "constructor",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "34:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "src": "23:18:1",
+          "stateMutability": "nonpayable",
+          "virtual": false
+        }
+      ],
+      "src": "0:43:1"
+    }
+  ],
+  "src": "0:44:1"
+}

--- a/test/libsolidity/ASTJSON/address_payable_parseOnly.json
+++ b/test/libsolidity/ASTJSON/address_payable_parseOnly.json
@@ -1,0 +1,370 @@
+{
+  "absolutePath": "a",
+  "id": 40,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 39,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 4,
+          "mutability": "mutable",
+          "name": "m",
+          "nodeType": "VariableDeclaration",
+          "src": "17:44:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 3,
+            "keyType":
+            {
+              "id": 1,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "25:7:1",
+              "typeDescriptions": {}
+            },
+            "nodeType": "Mapping",
+            "src": "17:35:1",
+            "typeDescriptions": {},
+            "valueType":
+            {
+              "id": 2,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "36:15:1",
+              "stateMutability": "payable",
+              "typeDescriptions": {}
+            }
+          },
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 37,
+            "nodeType": "Block",
+            "src": "134:122:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  12
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 12,
+                    "mutability": "mutable",
+                    "name": "a",
+                    "nodeType": "VariableDeclaration",
+                    "src": "144:17:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 11,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "144:15:1",
+                      "stateMutability": "payable",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 16,
+                "initialValue":
+                {
+                  "baseExpression":
+                  {
+                    "id": 13,
+                    "name": "m",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "src": "164:1:1",
+                    "typeDescriptions": {}
+                  },
+                  "id": 15,
+                  "indexExpression":
+                  {
+                    "id": 14,
+                    "name": "arg",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "src": "166:3:1",
+                    "typeDescriptions": {}
+                  },
+                  "nodeType": "IndexAccess",
+                  "src": "164:6:1",
+                  "typeDescriptions": {}
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "144:26:1"
+              },
+              {
+                "expression":
+                {
+                  "id": 19,
+                  "leftHandSide":
+                  {
+                    "id": 17,
+                    "name": "r",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "src": "180:1:1",
+                    "typeDescriptions": {}
+                  },
+                  "nodeType": "Assignment",
+                  "operator": "=",
+                  "rightHandSide":
+                  {
+                    "id": 18,
+                    "name": "arg",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "src": "184:3:1",
+                    "typeDescriptions": {}
+                  },
+                  "src": "180:7:1",
+                  "typeDescriptions": {}
+                },
+                "id": 20,
+                "nodeType": "ExpressionStatement",
+                "src": "180:7:1"
+              },
+              {
+                "assignments":
+                [
+                  22
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 22,
+                    "mutability": "mutable",
+                    "name": "c",
+                    "nodeType": "VariableDeclaration",
+                    "src": "197:9:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 21,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "197:7:1",
+                      "stateMutability": "nonpayable",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 27,
+                "initialValue":
+                {
+                  "arguments":
+                  [
+                    {
+                      "id": 25,
+                      "name": "this",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "src": "217:4:1",
+                      "typeDescriptions": {}
+                    }
+                  ],
+                  "expression":
+                  {
+                    "id": 24,
+                    "nodeType": "ElementaryTypeNameExpression",
+                    "src": "209:7:1",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 23,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "209:7:1",
+                      "typeDescriptions": {}
+                    }
+                  },
+                  "id": 26,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "209:13:1",
+                  "tryCall": false,
+                  "typeDescriptions": {}
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "197:25:1"
+              },
+              {
+                "expression":
+                {
+                  "id": 35,
+                  "leftHandSide":
+                  {
+                    "baseExpression":
+                    {
+                      "id": 28,
+                      "name": "m",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "src": "232:1:1",
+                      "typeDescriptions": {}
+                    },
+                    "id": 30,
+                    "indexExpression":
+                    {
+                      "id": 29,
+                      "name": "c",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "src": "234:1:1",
+                      "typeDescriptions": {}
+                    },
+                    "nodeType": "IndexAccess",
+                    "src": "232:4:1",
+                    "typeDescriptions": {}
+                  },
+                  "nodeType": "Assignment",
+                  "operator": "=",
+                  "rightHandSide":
+                  {
+                    "arguments":
+                    [
+                      {
+                        "hexValue": "30",
+                        "id": 33,
+                        "kind": "number",
+                        "nodeType": "Literal",
+                        "src": "247:1:1",
+                        "typeDescriptions": {},
+                        "value": "0"
+                      }
+                    ],
+                    "expression":
+                    {
+                      "id": 32,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "239:7:1",
+                      "typeDescriptions": {},
+                      "typeName":
+                      {
+                        "id": 31,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "239:7:1",
+                        "typeDescriptions": {}
+                      }
+                    },
+                    "id": 34,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "239:10:1",
+                    "tryCall": false,
+                    "typeDescriptions": {}
+                  },
+                  "src": "232:17:1",
+                  "typeDescriptions": {}
+                },
+                "id": 36,
+                "nodeType": "ExpressionStatement",
+                "src": "232:17:1"
+              }
+            ]
+          },
+          "id": 38,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 6,
+                "mutability": "mutable",
+                "name": "arg",
+                "nodeType": "VariableDeclaration",
+                "src": "78:19:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {},
+                "typeName":
+                {
+                  "id": 5,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "78:15:1",
+                  "stateMutability": "payable",
+                  "typeDescriptions": {}
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "77:21:1"
+          },
+          "returnParameters":
+          {
+            "id": 10,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 9,
+                "mutability": "mutable",
+                "name": "r",
+                "nodeType": "VariableDeclaration",
+                "src": "115:17:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {},
+                "typeName":
+                {
+                  "id": 8,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "115:15:1",
+                  "stateMutability": "payable",
+                  "typeDescriptions": {}
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "114:19:1"
+          },
+          "src": "67:189:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:258:1"
+    }
+  ],
+  "src": "0:259:1"
+}

--- a/test/libsolidity/ASTJSON/array_type_name_parseOnly.json
+++ b/test/libsolidity/ASTJSON/array_type_name_parseOnly.json
@@ -1,0 +1,49 @@
+{
+  "absolutePath": "a",
+  "id": 5,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 4,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 3,
+          "mutability": "mutable",
+          "name": "i",
+          "nodeType": "VariableDeclaration",
+          "src": "13:8:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "baseType":
+            {
+              "id": 1,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "13:4:1",
+              "typeDescriptions": {}
+            },
+            "id": 2,
+            "nodeType": "ArrayTypeName",
+            "src": "13:6:1",
+            "typeDescriptions": {}
+          },
+          "visibility": "internal"
+        }
+      ],
+      "src": "0:24:1"
+    }
+  ],
+  "src": "0:25:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/call_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/call_parseOnly.json
@@ -1,0 +1,152 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "37:59:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "56:34:1",
+                  "statements":
+                  [
+                    {
+                      "expression":
+                      {
+                        "arguments":
+                        [
+                          {
+                            "arguments":
+                            [
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "67:1:1",
+                                "type": "",
+                                "value": "0"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "70:1:1",
+                                "type": "",
+                                "value": "1"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "73:1:1",
+                                "type": "",
+                                "value": "2"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "76:1:1",
+                                "type": "",
+                                "value": "3"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "79:1:1",
+                                "type": "",
+                                "value": "4"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "82:1:1",
+                                "type": "",
+                                "value": "5"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "85:1:1",
+                                "type": "",
+                                "value": "6"
+                              }
+                            ],
+                            "functionName":
+                            {
+                              "name": "call",
+                              "nodeType": "YulIdentifier",
+                              "src": "62:4:1"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "62:25:1"
+                          }
+                        ],
+                        "functionName":
+                        {
+                          "name": "pop",
+                          "nodeType": "YulIdentifier",
+                          "src": "58:3:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "58:30:1"
+                      },
+                      "nodeType": "YulExpressionStatement",
+                      "src": "58:30:1"
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "47:43:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "j",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "src": "17:79:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:98:1"
+    }
+  ],
+  "src": "0:99:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/empty_block_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block_parseOnly.json
@@ -1,0 +1,77 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:31:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:6:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulBlock",
+                      "src": "63:2:1",
+                      "statements": []
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:15:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "g",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "17:56:1",
+          "stateMutability": "view",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:75:1"
+    }
+  ],
+  "src": "0:76:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/function_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/function_parseOnly.json
@@ -1,0 +1,139 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:68:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:43:1",
+                  "statements":
+                  [
+                    {
+                      "body":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "76:22:1",
+                        "statements":
+                        [
+                          {
+                            "expression":
+                            {
+                              "arguments":
+                              [
+                                {
+                                  "arguments":
+                                  [
+                                    {
+                                      "kind": "number",
+                                      "nodeType": "YulLiteral",
+                                      "src": "92:2:1",
+                                      "type": "",
+                                      "value": "20"
+                                    }
+                                  ],
+                                  "functionName":
+                                  {
+                                    "name": "blockhash",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "82:9:1"
+                                  },
+                                  "nodeType": "YulFunctionCall",
+                                  "src": "82:13:1"
+                                }
+                              ],
+                              "functionName":
+                              {
+                                "name": "pop",
+                                "nodeType": "YulIdentifier",
+                                "src": "78:3:1"
+                              },
+                              "nodeType": "YulFunctionCall",
+                              "src": "78:18:1"
+                            },
+                            "nodeType": "YulExpressionStatement",
+                            "src": "78:18:1"
+                          }
+                        ]
+                      },
+                      "name": "g",
+                      "nodeType": "YulFunctionDefinition",
+                      "src": "63:35:1"
+                    },
+                    {
+                      "expression":
+                      {
+                        "arguments": [],
+                        "functionName":
+                        {
+                          "name": "g",
+                          "nodeType": "YulIdentifier",
+                          "src": "99:1:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "99:3:1"
+                      },
+                      "nodeType": "YulExpressionStatement",
+                      "src": "99:3:1"
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:52:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "h",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "17:93:1",
+          "stateMutability": "view",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:112:1"
+    }
+  ],
+  "src": "0:113:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/leave_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/leave_parseOnly.json
@@ -1,0 +1,89 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "37:51:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "56:26:1",
+                  "statements":
+                  [
+                    {
+                      "body":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "71:9:1",
+                        "statements":
+                        [
+                          {
+                            "nodeType": "YulLeave",
+                            "src": "73:5:1"
+                          }
+                        ]
+                      },
+                      "name": "f",
+                      "nodeType": "YulFunctionDefinition",
+                      "src": "58:22:1"
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "47:35:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "l",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "src": "17:71:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:90:1"
+    }
+  ],
+  "src": "0:91:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/loop_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/loop_parseOnly.json
@@ -1,0 +1,152 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:74:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:49:1",
+                  "statements":
+                  [
+                    {
+                      "body":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "90:18:1",
+                        "statements":
+                        [
+                          {
+                            "nodeType": "YulBreak",
+                            "src": "92:5:1"
+                          },
+                          {
+                            "nodeType": "YulContinue",
+                            "src": "98:8:1"
+                          }
+                        ]
+                      },
+                      "condition":
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "70:1:1",
+                        "type": "",
+                        "value": "1"
+                      },
+                      "nodeType": "YulForLoop",
+                      "post":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "72:17:1",
+                        "statements":
+                        [
+                          {
+                            "expression":
+                            {
+                              "arguments":
+                              [
+                                {
+                                  "arguments":
+                                  [
+                                    {
+                                      "kind": "number",
+                                      "nodeType": "YulLiteral",
+                                      "src": "84:1:1",
+                                      "type": "",
+                                      "value": "0"
+                                    }
+                                  ],
+                                  "functionName":
+                                  {
+                                    "name": "sload",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "78:5:1"
+                                  },
+                                  "nodeType": "YulFunctionCall",
+                                  "src": "78:8:1"
+                                }
+                              ],
+                              "functionName":
+                              {
+                                "name": "pop",
+                                "nodeType": "YulIdentifier",
+                                "src": "74:3:1"
+                              },
+                              "nodeType": "YulFunctionCall",
+                              "src": "74:13:1"
+                            },
+                            "nodeType": "YulExpressionStatement",
+                            "src": "74:13:1"
+                          }
+                        ]
+                      },
+                      "pre":
+                      {
+                        "nodeType": "YulBlock",
+                        "src": "67:2:1",
+                        "statements": []
+                      },
+                      "src": "63:45:1"
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:58:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "g",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "17:99:1",
+          "stateMutability": "view",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:118:1"
+    }
+  ],
+  "src": "0:119:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/nested_functions_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions_legacy.json
@@ -37,7 +37,6 @@
         {
           "attributes":
           {
-            "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
             "kind": "function",

--- a/test/libsolidity/ASTJSON/assembly/nested_functions_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions_parseOnly.json
@@ -1,12 +1,5 @@
 {
   "absolutePath": "a",
-  "exportedSymbols":
-  {
-    "C":
-    [
-      8
-    ]
-  },
   "id": 9,
   "nodeType": "SourceUnit",
   "nodes":
@@ -17,10 +10,6 @@
       "contractDependencies": [],
       "contractKind": "contract",
       "id": 8,
-      "linearizedBaseContracts":
-      [
-        8
-      ],
       "name": "C",
       "nodeType": "ContractDefinition",
       "nodes":
@@ -119,7 +108,6 @@
                 "mutability": "mutable",
                 "name": "x",
                 "nodeType": "VariableDeclaration",
-                "scope": 7,
                 "src": "49:6:1",
                 "stateVariable": false,
                 "storageLocation": "default",
@@ -137,14 +125,12 @@
             ],
             "src": "48:8:1"
           },
-          "scope": 8,
           "src": "15:139:1",
           "stateMutability": "pure",
           "virtual": false,
           "visibility": "public"
         }
       ],
-      "scope": 9,
       "src": "0:156:1"
     }
   ],

--- a/test/libsolidity/ASTJSON/assembly/slot_offset_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset_parseOnly.json
@@ -1,0 +1,180 @@
+{
+  "absolutePath": "a",
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 11,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "id": 3,
+          "members":
+          [
+            {
+              "constant": false,
+              "id": 2,
+              "mutability": "mutable",
+              "name": "x",
+              "nodeType": "VariableDeclaration",
+              "src": "28:6:1",
+              "stateVariable": false,
+              "storageLocation": "default",
+              "typeDescriptions": {},
+              "typeName":
+              {
+                "id": 1,
+                "name": "uint",
+                "nodeType": "ElementaryTypeName",
+                "src": "28:4:1",
+                "typeDescriptions": {}
+              },
+              "visibility": "internal"
+            }
+          ],
+          "name": "S",
+          "nodeType": "StructDefinition",
+          "src": "17:20:1",
+          "visibility": "public"
+        },
+        {
+          "constant": false,
+          "id": 5,
+          "mutability": "mutable",
+          "name": "s",
+          "nodeType": "VariableDeclaration",
+          "src": "42:3:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 4,
+            "name": "S",
+            "nodeType": "UserDefinedTypeName",
+            "src": "42:1:1",
+            "typeDescriptions": {}
+          },
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "76:70:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "95:45:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "97:17:1",
+                      "value":
+                      {
+                        "name": "s.offset",
+                        "nodeType": "YulIdentifier",
+                        "src": "106:8:1"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "x",
+                          "nodeType": "YulTypedName",
+                          "src": "101:1:1",
+                          "type": ""
+                        }
+                      ]
+                    },
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "115:23:1",
+                      "value":
+                      {
+                        "arguments":
+                        [
+                          {
+                            "name": "s.slot",
+                            "nodeType": "YulIdentifier",
+                            "src": "128:6:1"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "136:1:1",
+                            "type": "",
+                            "value": "2"
+                          }
+                        ],
+                        "functionName":
+                        {
+                          "name": "mul",
+                          "nodeType": "YulIdentifier",
+                          "src": "124:3:1"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "124:14:1"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "y",
+                          "nodeType": "YulTypedName",
+                          "src": "119:1:1",
+                          "type": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 8,
+                "nodeType": "InlineAssembly",
+                "src": "86:54:1"
+              }
+            ]
+          },
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "e",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 6,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "61:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "76:0:1"
+          },
+          "src": "51:95:1",
+          "stateMutability": "pure",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:148:1"
+    }
+  ],
+  "src": "0:149:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/stringlit_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit_parseOnly.json
@@ -1,0 +1,93 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "37:43:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "56:18:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulVariableDeclaration",
+                      "src": "58:14:1",
+                      "value":
+                      {
+                        "kind": "string",
+                        "nodeType": "YulLiteral",
+                        "src": "67:5:1",
+                        "type": "",
+                        "value": "abc"
+                      },
+                      "variables":
+                      [
+                        {
+                          "name": "x",
+                          "nodeType": "YulTypedName",
+                          "src": "62:1:1",
+                          "type": ""
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "47:27:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "m",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "37:0:1"
+          },
+          "src": "17:63:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:82:1"
+    }
+  ],
+  "src": "0:83:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/switch_default_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default_parseOnly.json
@@ -1,0 +1,116 @@
+{
+  "absolutePath": "a",
+  "id": 7,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 6,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 4,
+            "nodeType": "Block",
+            "src": "42:58:1",
+            "statements":
+            [
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "61:33:1",
+                  "statements":
+                  [
+                    {
+                      "cases":
+                      [
+                        {
+                          "body":
+                          {
+                            "nodeType": "YulBlock",
+                            "src": "79:2:1",
+                            "statements": []
+                          },
+                          "nodeType": "YulCase",
+                          "src": "72:9:1",
+                          "value":
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "77:1:1",
+                            "type": "",
+                            "value": "0"
+                          }
+                        },
+                        {
+                          "body":
+                          {
+                            "nodeType": "YulBlock",
+                            "src": "90:2:1",
+                            "statements": []
+                          },
+                          "nodeType": "YulCase",
+                          "src": "82:10:1",
+                          "value": "default"
+                        }
+                      ],
+                      "expression":
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "70:1:1",
+                        "type": "",
+                        "value": "0"
+                      },
+                      "nodeType": "YulSwitch",
+                      "src": "63:29:1"
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 3,
+                "nodeType": "InlineAssembly",
+                "src": "52:42:1"
+              }
+            ]
+          },
+          "id": 5,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "g",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "17:83:1",
+          "stateMutability": "view",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:102:1"
+    }
+  ],
+  "src": "0:103:1"
+}

--- a/test/libsolidity/ASTJSON/assembly/switch_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_legacy.json
@@ -37,7 +37,6 @@
         {
           "attributes":
           {
-            "functionSelector": "26121ff0",
             "implemented": true,
             "isConstructor": false,
             "kind": "function",

--- a/test/libsolidity/ASTJSON/assembly/switch_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_parseOnly.json
@@ -1,12 +1,5 @@
 {
   "absolutePath": "a",
-  "exportedSymbols":
-  {
-    "C":
-    [
-      6
-    ]
-  },
   "id": 7,
   "nodeType": "SourceUnit",
   "nodes":
@@ -17,10 +10,6 @@
       "contractDependencies": [],
       "contractKind": "contract",
       "id": 6,
-      "linearizedBaseContracts":
-      [
-        6
-      ],
       "name": "C",
       "nodeType": "ContractDefinition",
       "nodes":
@@ -156,23 +145,7 @@
                   ]
                 },
                 "evmVersion": %EVMVERSION%,
-                "externalReferences":
-                [
-                  {
-                    "declaration": 5,
-                    "isOffset": false,
-                    "isSlot": false,
-                    "src": "141:1:1",
-                    "valueSize": 18446744073709551615
-                  },
-                  {
-                    "declaration": 5,
-                    "isOffset": false,
-                    "isSlot": false,
-                    "src": "172:1:1",
-                    "valueSize": 18446744073709551615
-                  }
-                ],
+                "externalReferences": [],
                 "id": 3,
                 "nodeType": "InlineAssembly",
                 "src": "52:138:1"
@@ -199,14 +172,12 @@
             "parameters": [],
             "src": "42:0:1"
           },
-          "scope": 6,
           "src": "17:179:1",
           "stateMutability": "pure",
           "virtual": false,
           "visibility": "public"
         }
       ],
-      "scope": 7,
       "src": "0:198:1"
     }
   ],

--- a/test/libsolidity/ASTJSON/assembly/var_access_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access_parseOnly.json
@@ -1,0 +1,124 @@
+{
+  "absolutePath": "a",
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 9,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 7,
+            "nodeType": "Block",
+            "src": "42:51:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "mutability": "mutable",
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "src": "52:6:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "uint",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "52:4:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 5,
+                "nodeType": "VariableDeclarationStatement",
+                "src": "52:6:1"
+              },
+              {
+                "AST":
+                {
+                  "nodeType": "YulBlock",
+                  "src": "77:10:1",
+                  "statements":
+                  [
+                    {
+                      "nodeType": "YulAssignment",
+                      "src": "79:6:1",
+                      "value":
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "84:1:1",
+                        "type": "",
+                        "value": "7"
+                      },
+                      "variableNames":
+                      [
+                        {
+                          "name": "x",
+                          "nodeType": "YulIdentifier",
+                          "src": "79:1:1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "evmVersion": %EVMVERSION%,
+                "externalReferences": [],
+                "id": 6,
+                "nodeType": "InlineAssembly",
+                "src": "68:19:1"
+              }
+            ]
+          },
+          "id": 8,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "17:76:1",
+          "stateMutability": "pure",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:95:1"
+    }
+  ],
+  "src": "0:96:1"
+}

--- a/test/libsolidity/ASTJSON/constructor_parseOnly.json
+++ b/test/libsolidity/ASTJSON/constructor_parseOnly.json
@@ -1,0 +1,54 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "28:4:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "constructor",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "25:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "28:0:1"
+          },
+          "src": "14:18:1",
+          "stateMutability": "nonpayable",
+          "virtual": false
+        }
+      ],
+      "src": "0:34:1"
+    }
+  ],
+  "src": "0:35:1"
+}

--- a/test/libsolidity/ASTJSON/contract_dep_order_parseOnly.json
+++ b/test/libsolidity/ASTJSON/contract_dep_order_parseOnly.json
@@ -1,0 +1,124 @@
+{
+  "absolutePath": "a",
+  "id": 14,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 1,
+      "name": "A",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "0:14:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 2,
+            "name": "A",
+            "nodeType": "UserDefinedTypeName",
+            "src": "29:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 3,
+          "nodeType": "InheritanceSpecifier",
+          "src": "29:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 4,
+      "name": "B",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "15:19:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 5,
+            "name": "B",
+            "nodeType": "UserDefinedTypeName",
+            "src": "49:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 6,
+          "nodeType": "InheritanceSpecifier",
+          "src": "49:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 7,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "35:19:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 8,
+            "name": "C",
+            "nodeType": "UserDefinedTypeName",
+            "src": "69:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 9,
+          "nodeType": "InheritanceSpecifier",
+          "src": "69:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 10,
+      "name": "D",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "55:19:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 11,
+            "name": "D",
+            "nodeType": "UserDefinedTypeName",
+            "src": "89:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 12,
+          "nodeType": "InheritanceSpecifier",
+          "src": "89:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 13,
+      "name": "E",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "75:19:1"
+    }
+  ],
+  "src": "0:95:1"
+}

--- a/test/libsolidity/ASTJSON/documentation_parseOnly.json
+++ b/test/libsolidity/ASTJSON/documentation_parseOnly.json
@@ -1,0 +1,195 @@
+[
+{
+  "absolutePath": "a",
+  "id": 3,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation":
+      {
+        "id": 1,
+        "nodeType": "StructuredDocumentation",
+        "src": "0:27:1",
+        "text": "This contract is empty"
+      },
+      "id": 2,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "28:13:1"
+    }
+  ],
+  "src": "28:14:1"
+},
+{
+  "absolutePath": "b",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "documentation":
+      {
+        "id": 4,
+        "nodeType": "StructuredDocumentation",
+        "src": "0:61:2",
+        "text": "This contract is empty\nand has a line-breaking comment."
+      },
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "62:13:2"
+    }
+  ],
+  "src": "62:14:2"
+},
+{
+  "absolutePath": "c",
+  "id": 24,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 23,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 9,
+          "mutability": "mutable",
+          "name": "state",
+          "nodeType": "VariableDeclaration",
+          "src": "48:17:3",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 8,
+            "name": "uint",
+            "nodeType": "ElementaryTypeName",
+            "src": "48:4:3",
+            "typeDescriptions": {}
+          },
+          "visibility": "public"
+        },
+        {
+          "anonymous": false,
+          "documentation":
+          {
+            "id": 10,
+            "nodeType": "StructuredDocumentation",
+            "src": "69:26:3",
+            "text": "Some comment on Evt."
+          },
+          "id": 12,
+          "name": "Evt",
+          "nodeType": "EventDefinition",
+          "parameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "105:2:3"
+          },
+          "src": "96:12:3"
+        },
+        {
+          "body":
+          {
+            "id": 16,
+            "nodeType": "Block",
+            "src": "153:6:3",
+            "statements":
+            [
+              {
+                "id": 15,
+                "nodeType": "PlaceholderStatement",
+                "src": "155:1:3"
+              }
+            ]
+          },
+          "documentation":
+          {
+            "id": 13,
+            "nodeType": "StructuredDocumentation",
+            "src": "111:26:3",
+            "text": "Some comment on mod."
+          },
+          "id": 17,
+          "name": "mod",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 14,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "150:2:3"
+          },
+          "src": "138:21:3",
+          "virtual": false,
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 21,
+            "nodeType": "Block",
+            "src": "209:2:3",
+            "statements": []
+          },
+          "documentation":
+          {
+            "id": 18,
+            "nodeType": "StructuredDocumentation",
+            "src": "162:25:3",
+            "text": "Some comment on fn."
+          },
+          "id": 22,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "fn",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 19,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "199:2:3"
+          },
+          "returnParameters":
+          {
+            "id": 20,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "209:0:3"
+          },
+          "src": "188:23:3",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:213:3"
+    }
+  ],
+  "src": "0:214:3"
+}
+]

--- a/test/libsolidity/ASTJSON/enum_value_parseOnly.json
+++ b/test/libsolidity/ASTJSON/enum_value_parseOnly.json
@@ -1,0 +1,43 @@
+{
+  "absolutePath": "a",
+  "id": 5,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 4,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "id": 3,
+          "members":
+          [
+            {
+              "id": 1,
+              "name": "A",
+              "nodeType": "EnumValue",
+              "src": "22:1:1"
+            },
+            {
+              "id": 2,
+              "name": "B",
+              "nodeType": "EnumValue",
+              "src": "25:1:1"
+            }
+          ],
+          "name": "E",
+          "nodeType": "EnumDefinition",
+          "src": "13:15:1"
+        }
+      ],
+      "src": "0:30:1"
+    }
+  ],
+  "src": "0:31:1"
+}

--- a/test/libsolidity/ASTJSON/event_definition_parseOnly.json
+++ b/test/libsolidity/ASTJSON/event_definition_parseOnly.json
@@ -1,0 +1,36 @@
+{
+  "absolutePath": "a",
+  "id": 4,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 3,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "anonymous": false,
+          "id": 2,
+          "name": "E",
+          "nodeType": "EventDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "20:2:1"
+          },
+          "src": "13:10:1"
+        }
+      ],
+      "src": "0:25:1"
+    }
+  ],
+  "src": "0:26:1"
+}

--- a/test/libsolidity/ASTJSON/fallback_and_reveice_ether_parseOnly.json
+++ b/test/libsolidity/ASTJSON/fallback_and_reveice_ether_parseOnly.json
@@ -1,0 +1,88 @@
+{
+  "absolutePath": "a",
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 9,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "42:5:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "receive",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "22:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "15:32:1",
+          "stateMutability": "payable",
+          "virtual": false,
+          "visibility": "external"
+        },
+        {
+          "body":
+          {
+            "id": 7,
+            "nodeType": "Block",
+            "src": "78:5:1",
+            "statements": []
+          },
+          "id": 8,
+          "implemented": true,
+          "kind": "fallback",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 5,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "58:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 6,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "78:0:1"
+          },
+          "src": "50:33:1",
+          "stateMutability": "payable",
+          "virtual": false,
+          "visibility": "external"
+        }
+      ],
+      "src": "0:85:1"
+    }
+  ],
+  "src": "0:86:1"
+}

--- a/test/libsolidity/ASTJSON/fallback_parseOnly.json
+++ b/test/libsolidity/ASTJSON/fallback_parseOnly.json
@@ -1,0 +1,55 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "43:5:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "fallback",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "43:0:1"
+          },
+          "src": "15:33:1",
+          "stateMutability": "payable",
+          "virtual": false,
+          "visibility": "external"
+        }
+      ],
+      "src": "0:50:1"
+    }
+  ],
+  "src": "0:51:1"
+}

--- a/test/libsolidity/ASTJSON/fallback_payable_parseOnly.json
+++ b/test/libsolidity/ASTJSON/fallback_payable_parseOnly.json
@@ -1,0 +1,55 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "34:2:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "fallback",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "22:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "34:0:1"
+          },
+          "src": "14:22:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "external"
+        }
+      ],
+      "src": "0:38:1"
+    }
+  ],
+  "src": "0:39:1"
+}

--- a/test/libsolidity/ASTJSON/function_type_parseOnly.json
+++ b/test/libsolidity/ASTJSON/function_type_parseOnly.json
@@ -1,0 +1,173 @@
+{
+  "absolutePath": "a",
+  "id": 18,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 17,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 15,
+            "nodeType": "Block",
+            "src": "120:2:1",
+            "statements": []
+          },
+          "id": 16,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 6,
+                "mutability": "mutable",
+                "name": "x",
+                "nodeType": "VariableDeclaration",
+                "src": "24:44:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {},
+                "typeName":
+                {
+                  "id": 5,
+                  "nodeType": "FunctionTypeName",
+                  "parameterTypes":
+                  {
+                    "id": 1,
+                    "nodeType": "ParameterList",
+                    "parameters": [],
+                    "src": "32:2:1"
+                  },
+                  "returnParameterTypes":
+                  {
+                    "id": 4,
+                    "nodeType": "ParameterList",
+                    "parameters":
+                    [
+                      {
+                        "constant": false,
+                        "id": 3,
+                        "mutability": "mutable",
+                        "name": "",
+                        "nodeType": "VariableDeclaration",
+                        "src": "61:4:1",
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "typeDescriptions": {},
+                        "typeName":
+                        {
+                          "id": 2,
+                          "name": "uint",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "61:4:1",
+                          "typeDescriptions": {}
+                        },
+                        "visibility": "internal"
+                      }
+                    ],
+                    "src": "60:6:1"
+                  },
+                  "src": "24:44:1",
+                  "stateMutability": "payable",
+                  "typeDescriptions": {},
+                  "visibility": "external"
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:46:1"
+          },
+          "returnParameters":
+          {
+            "id": 14,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 13,
+                "mutability": "mutable",
+                "name": "",
+                "nodeType": "VariableDeclaration",
+                "src": "79:40:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {},
+                "typeName":
+                {
+                  "id": 12,
+                  "nodeType": "FunctionTypeName",
+                  "parameterTypes":
+                  {
+                    "id": 8,
+                    "nodeType": "ParameterList",
+                    "parameters": [],
+                    "src": "87:2:1"
+                  },
+                  "returnParameterTypes":
+                  {
+                    "id": 11,
+                    "nodeType": "ParameterList",
+                    "parameters":
+                    [
+                      {
+                        "constant": false,
+                        "id": 10,
+                        "mutability": "mutable",
+                        "name": "",
+                        "nodeType": "VariableDeclaration",
+                        "src": "113:4:1",
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "typeDescriptions": {},
+                        "typeName":
+                        {
+                          "id": 9,
+                          "name": "uint",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "113:4:1",
+                          "typeDescriptions": {}
+                        },
+                        "visibility": "internal"
+                      }
+                    ],
+                    "src": "112:6:1"
+                  },
+                  "src": "79:40:1",
+                  "stateMutability": "view",
+                  "typeDescriptions": {},
+                  "visibility": "external"
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "78:41:1"
+          },
+          "src": "13:109:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:124:1"
+    }
+  ],
+  "src": "0:125:1"
+}

--- a/test/libsolidity/ASTJSON/global_enum_parseOnly.json
+++ b/test/libsolidity/ASTJSON/global_enum_parseOnly.json
@@ -1,0 +1,24 @@
+{
+  "absolutePath": "a",
+  "id": 3,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 2,
+      "members":
+      [
+        {
+          "id": 1,
+          "name": "A",
+          "nodeType": "EnumValue",
+          "src": "9:1:1"
+        }
+      ],
+      "name": "E",
+      "nodeType": "EnumDefinition",
+      "src": "0:12:1"
+    }
+  ],
+  "src": "0:13:1"
+}

--- a/test/libsolidity/ASTJSON/global_struct_parseOnly.json
+++ b/test/libsolidity/ASTJSON/global_struct_parseOnly.json
@@ -1,0 +1,39 @@
+{
+  "absolutePath": "a",
+  "id": 4,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 3,
+      "members":
+      [
+        {
+          "constant": false,
+          "id": 2,
+          "mutability": "mutable",
+          "name": "a",
+          "nodeType": "VariableDeclaration",
+          "src": "11:9:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 1,
+            "name": "uint256",
+            "nodeType": "ElementaryTypeName",
+            "src": "11:7:1",
+            "typeDescriptions": {}
+          },
+          "visibility": "internal"
+        }
+      ],
+      "name": "S",
+      "nodeType": "StructDefinition",
+      "src": "0:23:1",
+      "visibility": "public"
+    }
+  ],
+  "src": "0:24:1"
+}

--- a/test/libsolidity/ASTJSON/inheritance_specifier_parseOnly.json
+++ b/test/libsolidity/ASTJSON/inheritance_specifier_parseOnly.json
@@ -1,0 +1,46 @@
+{
+  "absolutePath": "a",
+  "id": 5,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 1,
+      "name": "C1",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "0:14:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 2,
+            "name": "C1",
+            "nodeType": "UserDefinedTypeName",
+            "src": "30:2:1",
+            "typeDescriptions": {}
+          },
+          "id": 3,
+          "nodeType": "InheritanceSpecifier",
+          "src": "30:2:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 4,
+      "name": "C2",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "15:20:1"
+    }
+  ],
+  "src": "0:36:1"
+}

--- a/test/libsolidity/ASTJSON/license_parseOnly.json
+++ b/test/libsolidity/ASTJSON/license_parseOnly.json
@@ -1,0 +1,21 @@
+{
+  "absolutePath": "a",
+  "id": 2,
+  "license": "GPL-3.0",
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 1,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "36:13:1"
+    }
+  ],
+  "src": "36:14:1"
+}

--- a/test/libsolidity/ASTJSON/long_type_name_binary_operation_parseOnly.json
+++ b/test/libsolidity/ASTJSON/long_type_name_binary_operation_parseOnly.json
@@ -1,0 +1,118 @@
+{
+  "absolutePath": "a",
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 11,
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "33:19:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "mutability": "mutable",
+                    "name": "a",
+                    "nodeType": "VariableDeclaration",
+                    "src": "35:6:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "uint",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "35:4:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 8,
+                "initialValue":
+                {
+                  "commonType": {},
+                  "id": 7,
+                  "leftExpression":
+                  {
+                    "hexValue": "32",
+                    "id": 5,
+                    "kind": "number",
+                    "nodeType": "Literal",
+                    "src": "44:1:1",
+                    "typeDescriptions": {},
+                    "value": "2"
+                  },
+                  "nodeType": "BinaryOperation",
+                  "operator": "+",
+                  "rightExpression":
+                  {
+                    "hexValue": "33",
+                    "id": 6,
+                    "kind": "number",
+                    "nodeType": "Literal",
+                    "src": "48:1:1",
+                    "typeDescriptions": {},
+                    "value": "3"
+                  },
+                  "src": "44:5:1",
+                  "typeDescriptions": {}
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:14:1"
+              }
+            ]
+          },
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "src": "13:39:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:54:1"
+    }
+  ],
+  "src": "0:55:1"
+}

--- a/test/libsolidity/ASTJSON/long_type_name_identifier_parseOnly.json
+++ b/test/libsolidity/ASTJSON/long_type_name_identifier_parseOnly.json
@@ -1,0 +1,132 @@
+{
+  "absolutePath": "a",
+  "id": 16,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 15,
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 3,
+          "mutability": "mutable",
+          "name": "a",
+          "nodeType": "VariableDeclaration",
+          "src": "13:8:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "baseType":
+            {
+              "id": 1,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "13:4:1",
+              "typeDescriptions": {}
+            },
+            "id": 2,
+            "nodeType": "ArrayTypeName",
+            "src": "13:6:1",
+            "typeDescriptions": {}
+          },
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 13,
+            "nodeType": "Block",
+            "src": "43:25:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  10
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 10,
+                    "mutability": "mutable",
+                    "name": "b",
+                    "nodeType": "VariableDeclaration",
+                    "src": "45:16:1",
+                    "stateVariable": false,
+                    "storageLocation": "storage",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 8,
+                        "name": "uint",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "45:4:1",
+                        "typeDescriptions": {}
+                      },
+                      "id": 9,
+                      "nodeType": "ArrayTypeName",
+                      "src": "45:6:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 12,
+                "initialValue":
+                {
+                  "id": 11,
+                  "name": "a",
+                  "nodeType": "Identifier",
+                  "overloadedDeclarations": [],
+                  "src": "64:1:1",
+                  "typeDescriptions": {}
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "45:20:1"
+              }
+            ]
+          },
+          "id": 14,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 4,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 5,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "43:0:1"
+          },
+          "src": "23:45:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:70:1"
+    }
+  ],
+  "src": "0:71:1"
+}

--- a/test/libsolidity/ASTJSON/mappings_parseOnly.json
+++ b/test/libsolidity/ASTJSON/mappings_parseOnly.json
@@ -1,0 +1,154 @@
+{
+  "absolutePath": "a",
+  "id": 18,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 17,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "id": 4,
+          "members":
+          [
+            {
+              "id": 1,
+              "name": "A",
+              "nodeType": "EnumValue",
+              "src": "26:1:1"
+            },
+            {
+              "id": 2,
+              "name": "B",
+              "nodeType": "EnumValue",
+              "src": "29:1:1"
+            },
+            {
+              "id": 3,
+              "name": "C",
+              "nodeType": "EnumValue",
+              "src": "32:1:1"
+            }
+          ],
+          "name": "E",
+          "nodeType": "EnumDefinition",
+          "src": "17:18:1"
+        },
+        {
+          "constant": false,
+          "id": 8,
+          "mutability": "mutable",
+          "name": "a",
+          "nodeType": "VariableDeclaration",
+          "src": "40:20:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 7,
+            "keyType":
+            {
+              "id": 5,
+              "name": "C",
+              "nodeType": "UserDefinedTypeName",
+              "src": "48:1:1",
+              "typeDescriptions": {}
+            },
+            "nodeType": "Mapping",
+            "src": "40:18:1",
+            "typeDescriptions": {},
+            "valueType":
+            {
+              "id": 6,
+              "name": "bool",
+              "nodeType": "ElementaryTypeName",
+              "src": "53:4:1",
+              "typeDescriptions": {}
+            }
+          },
+          "visibility": "internal"
+        },
+        {
+          "constant": false,
+          "id": 12,
+          "mutability": "mutable",
+          "name": "b",
+          "nodeType": "VariableDeclaration",
+          "src": "66:26:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 11,
+            "keyType":
+            {
+              "id": 9,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "74:7:1",
+              "typeDescriptions": {}
+            },
+            "nodeType": "Mapping",
+            "src": "66:24:1",
+            "typeDescriptions": {},
+            "valueType":
+            {
+              "id": 10,
+              "name": "bool",
+              "nodeType": "ElementaryTypeName",
+              "src": "85:4:1",
+              "typeDescriptions": {}
+            }
+          },
+          "visibility": "internal"
+        },
+        {
+          "constant": false,
+          "id": 16,
+          "mutability": "mutable",
+          "name": "c",
+          "nodeType": "VariableDeclaration",
+          "src": "98:20:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 15,
+            "keyType":
+            {
+              "id": 13,
+              "name": "E",
+              "nodeType": "UserDefinedTypeName",
+              "src": "106:1:1",
+              "typeDescriptions": {}
+            },
+            "nodeType": "Mapping",
+            "src": "98:18:1",
+            "typeDescriptions": {},
+            "valueType":
+            {
+              "id": 14,
+              "name": "bool",
+              "nodeType": "ElementaryTypeName",
+              "src": "111:4:1",
+              "typeDescriptions": {}
+            }
+          },
+          "visibility": "internal"
+        }
+      ],
+      "src": "0:121:1"
+    }
+  ],
+  "src": "0:122:1"
+}

--- a/test/libsolidity/ASTJSON/modifier_definition_parseOnly.json
+++ b/test/libsolidity/ASTJSON/modifier_definition_parseOnly.json
@@ -1,0 +1,134 @@
+{
+  "absolutePath": "a",
+  "id": 15,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 14,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 5,
+            "nodeType": "Block",
+            "src": "32:6:1",
+            "statements":
+            [
+              {
+                "id": 4,
+                "nodeType": "PlaceholderStatement",
+                "src": "34:1:1"
+              }
+            ]
+          },
+          "id": 6,
+          "name": "M",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 3,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 2,
+                "mutability": "mutable",
+                "name": "i",
+                "nodeType": "VariableDeclaration",
+                "src": "24:6:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {},
+                "typeName":
+                {
+                  "id": 1,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "24:4:1",
+                  "typeDescriptions": {}
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:8:1"
+          },
+          "src": "13:25:1",
+          "virtual": false,
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 12,
+            "nodeType": "Block",
+            "src": "64:2:1",
+            "statements": []
+          },
+          "id": 13,
+          "implemented": true,
+          "kind": "function",
+          "modifiers":
+          [
+            {
+              "arguments":
+              [
+                {
+                  "hexValue": "31",
+                  "id": 9,
+                  "kind": "number",
+                  "nodeType": "Literal",
+                  "src": "54:1:1",
+                  "typeDescriptions": {},
+                  "value": "1"
+                }
+              ],
+              "id": 10,
+              "modifierName":
+              {
+                "id": 8,
+                "name": "M",
+                "nodeType": "Identifier",
+                "overloadedDeclarations": [],
+                "src": "52:1:1",
+                "typeDescriptions": {}
+              },
+              "nodeType": "ModifierInvocation",
+              "src": "52:4:1"
+            }
+          ],
+          "name": "F",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "49:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "64:0:1"
+          },
+          "src": "39:27:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:68:1"
+    }
+  ],
+  "src": "0:69:1"
+}

--- a/test/libsolidity/ASTJSON/modifier_invocation_parseOnly.json
+++ b/test/libsolidity/ASTJSON/modifier_invocation_parseOnly.json
@@ -1,0 +1,134 @@
+{
+  "absolutePath": "a",
+  "id": 15,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 14,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 5,
+            "nodeType": "Block",
+            "src": "32:6:1",
+            "statements":
+            [
+              {
+                "id": 4,
+                "nodeType": "PlaceholderStatement",
+                "src": "34:1:1"
+              }
+            ]
+          },
+          "id": 6,
+          "name": "M",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 3,
+            "nodeType": "ParameterList",
+            "parameters":
+            [
+              {
+                "constant": false,
+                "id": 2,
+                "mutability": "mutable",
+                "name": "i",
+                "nodeType": "VariableDeclaration",
+                "src": "24:6:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {},
+                "typeName":
+                {
+                  "id": 1,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "24:4:1",
+                  "typeDescriptions": {}
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:8:1"
+          },
+          "src": "13:25:1",
+          "virtual": false,
+          "visibility": "internal"
+        },
+        {
+          "body":
+          {
+            "id": 12,
+            "nodeType": "Block",
+            "src": "64:2:1",
+            "statements": []
+          },
+          "id": 13,
+          "implemented": true,
+          "kind": "function",
+          "modifiers":
+          [
+            {
+              "arguments":
+              [
+                {
+                  "hexValue": "31",
+                  "id": 9,
+                  "kind": "number",
+                  "nodeType": "Literal",
+                  "src": "54:1:1",
+                  "typeDescriptions": {},
+                  "value": "1"
+                }
+              ],
+              "id": 10,
+              "modifierName":
+              {
+                "id": 8,
+                "name": "M",
+                "nodeType": "Identifier",
+                "overloadedDeclarations": [],
+                "src": "52:1:1",
+                "typeDescriptions": {}
+              },
+              "nodeType": "ModifierInvocation",
+              "src": "52:4:1"
+            }
+          ],
+          "name": "F",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "49:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "64:0:1"
+          },
+          "src": "39:27:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:68:1"
+    }
+  ],
+  "src": "0:69:1"
+}

--- a/test/libsolidity/ASTJSON/mutability_parseOnly.json
+++ b/test/libsolidity/ASTJSON/mutability_parseOnly.json
@@ -1,0 +1,112 @@
+{
+  "absolutePath": "a",
+  "id": 11,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 10,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 3,
+          "mutability": "immutable",
+          "name": "a",
+          "nodeType": "VariableDeclaration",
+          "src": "17:27:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 1,
+            "name": "uint",
+            "nodeType": "ElementaryTypeName",
+            "src": "17:4:1",
+            "typeDescriptions": {}
+          },
+          "value":
+          {
+            "hexValue": "34",
+            "id": 2,
+            "kind": "number",
+            "nodeType": "Literal",
+            "src": "43:1:1",
+            "typeDescriptions": {},
+            "value": "4"
+          },
+          "visibility": "public"
+        },
+        {
+          "constant": true,
+          "id": 6,
+          "mutability": "constant",
+          "name": "b",
+          "nodeType": "VariableDeclaration",
+          "src": "50:26:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 4,
+            "name": "uint",
+            "nodeType": "ElementaryTypeName",
+            "src": "50:4:1",
+            "typeDescriptions": {}
+          },
+          "value":
+          {
+            "hexValue": "32",
+            "id": 5,
+            "kind": "number",
+            "nodeType": "Literal",
+            "src": "75:1:1",
+            "typeDescriptions": {},
+            "value": "2"
+          },
+          "visibility": "public"
+        },
+        {
+          "constant": false,
+          "id": 9,
+          "mutability": "mutable",
+          "name": "c",
+          "nodeType": "VariableDeclaration",
+          "src": "82:17:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 7,
+            "name": "uint",
+            "nodeType": "ElementaryTypeName",
+            "src": "82:4:1",
+            "typeDescriptions": {}
+          },
+          "value":
+          {
+            "hexValue": "33",
+            "id": 8,
+            "kind": "number",
+            "nodeType": "Literal",
+            "src": "98:1:1",
+            "typeDescriptions": {},
+            "value": "3"
+          },
+          "visibility": "public"
+        }
+      ],
+      "src": "0:102:1"
+    }
+  ],
+  "src": "0:103:1"
+}

--- a/test/libsolidity/ASTJSON/non_utf8_parseOnly.json
+++ b/test/libsolidity/ASTJSON/non_utf8_parseOnly.json
@@ -1,0 +1,98 @@
+{
+  "absolutePath": "a",
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 9,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 7,
+            "nodeType": "Block",
+            "src": "33:30:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "mutability": "mutable",
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "src": "35:15:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "string",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "35:6:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 6,
+                "initialValue":
+                {
+                  "hexValue": "ff",
+                  "id": 5,
+                  "kind": "hexString",
+                  "nodeType": "Literal",
+                  "src": "53:7:1",
+                  "typeDescriptions": {}
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:25:1"
+              }
+            ]
+          },
+          "id": 8,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "src": "13:50:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:65:1"
+    }
+  ],
+  "src": "0:66:1"
+}

--- a/test/libsolidity/ASTJSON/not_existing_import.sol
+++ b/test/libsolidity/ASTJSON/not_existing_import.sol
@@ -1,0 +1,8 @@
+import "notexisting.sol" as NotExisting;
+contract C is NotExisting.X
+{
+	NotExisting.SomeStruct public myStruct;
+	constructor() {}
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/not_existing_import_parseOnly.json
+++ b/test/libsolidity/ASTJSON/not_existing_import_parseOnly.json
@@ -1,0 +1,97 @@
+{
+  "absolutePath": "a",
+  "id": 11,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "file": "notexisting.sol",
+      "id": 1,
+      "nodeType": "ImportDirective",
+      "src": "0:40:1",
+      "symbolAliases": [],
+      "unitAlias": "NotExisting"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 2,
+            "name": "NotExisting.X",
+            "nodeType": "UserDefinedTypeName",
+            "src": "55:13:1",
+            "typeDescriptions": {}
+          },
+          "id": 3,
+          "nodeType": "InheritanceSpecifier",
+          "src": "55:13:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 10,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "constant": false,
+          "id": 5,
+          "mutability": "mutable",
+          "name": "myStruct",
+          "nodeType": "VariableDeclaration",
+          "src": "72:38:1",
+          "stateVariable": false,
+          "storageLocation": "default",
+          "typeDescriptions": {},
+          "typeName":
+          {
+            "id": 4,
+            "name": "NotExisting.SomeStruct",
+            "nodeType": "UserDefinedTypeName",
+            "src": "72:22:1",
+            "typeDescriptions": {}
+          },
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 8,
+            "nodeType": "Block",
+            "src": "127:2:1",
+            "statements": []
+          },
+          "id": 9,
+          "implemented": true,
+          "kind": "constructor",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 6,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "124:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "127:0:1"
+          },
+          "src": "113:16:1",
+          "stateMutability": "nonpayable",
+          "virtual": false
+        }
+      ],
+      "src": "41:90:1"
+    }
+  ],
+  "src": "0:132:1"
+}

--- a/test/libsolidity/ASTJSON/override_parseOnly.json
+++ b/test/libsolidity/ASTJSON/override_parseOnly.json
@@ -1,0 +1,273 @@
+{
+  "absolutePath": "a",
+  "id": 32,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "A",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "36:2:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "faa",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "26:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "36:0:1"
+          },
+          "src": "14:24:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:40:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 6,
+            "name": "A",
+            "nodeType": "UserDefinedTypeName",
+            "src": "55:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 7,
+          "nodeType": "InheritanceSpecifier",
+          "src": "55:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 16,
+      "name": "B",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "id": 10,
+          "implemented": false,
+          "kind": "function",
+          "modifiers": [],
+          "name": "foo",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 8,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "72:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 9,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "81:0:1"
+          },
+          "src": "60:22:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 14,
+            "nodeType": "Block",
+            "src": "115:2:1",
+            "statements": []
+          },
+          "id": 15,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "faa",
+          "nodeType": "FunctionDefinition",
+          "overrides":
+          {
+            "id": 12,
+            "nodeType": "OverrideSpecifier",
+            "overrides": [],
+            "src": "106:8:1"
+          },
+          "parameters":
+          {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "96:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 13,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "115:0:1"
+          },
+          "src": "84:33:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "41:78:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 17,
+            "name": "B",
+            "nodeType": "UserDefinedTypeName",
+            "src": "134:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 18,
+          "nodeType": "InheritanceSpecifier",
+          "src": "134:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 31,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 22,
+            "nodeType": "Block",
+            "src": "170:3:1",
+            "statements": []
+          },
+          "id": 23,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "foo",
+          "nodeType": "FunctionDefinition",
+          "overrides":
+          {
+            "id": 20,
+            "nodeType": "OverrideSpecifier",
+            "overrides": [],
+            "src": "161:8:1"
+          },
+          "parameters":
+          {
+            "id": 19,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "151:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 21,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "170:0:1"
+          },
+          "src": "139:34:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        },
+        {
+          "body":
+          {
+            "id": 29,
+            "nodeType": "Block",
+            "src": "212:2:1",
+            "statements": []
+          },
+          "id": 30,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "faa",
+          "nodeType": "FunctionDefinition",
+          "overrides":
+          {
+            "id": 27,
+            "nodeType": "OverrideSpecifier",
+            "overrides":
+            [
+              {
+                "id": 25,
+                "name": "A",
+                "nodeType": "UserDefinedTypeName",
+                "src": "206:1:1",
+                "typeDescriptions": {}
+              },
+              {
+                "id": 26,
+                "name": "B",
+                "nodeType": "UserDefinedTypeName",
+                "src": "209:1:1",
+                "typeDescriptions": {}
+              }
+            ],
+            "src": "197:14:1"
+          },
+          "parameters":
+          {
+            "id": 24,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "187:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 28,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "212:0:1"
+          },
+          "src": "175:39:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "120:96:1"
+    }
+  ],
+  "src": "0:217:1"
+}

--- a/test/libsolidity/ASTJSON/placeholder_statement_parseOnly.json
+++ b/test/libsolidity/ASTJSON/placeholder_statement_parseOnly.json
@@ -1,0 +1,51 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "24:6:1",
+            "statements":
+            [
+              {
+                "id": 2,
+                "nodeType": "PlaceholderStatement",
+                "src": "26:1:1"
+              }
+            ]
+          },
+          "id": 4,
+          "name": "M",
+          "nodeType": "ModifierDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "24:0:1"
+          },
+          "src": "13:17:1",
+          "virtual": false,
+          "visibility": "internal"
+        }
+      ],
+      "src": "0:32:1"
+    }
+  ],
+  "src": "0:33:1"
+}

--- a/test/libsolidity/ASTJSON/receive_ether_parseOnly.json
+++ b/test/libsolidity/ASTJSON/receive_ether_parseOnly.json
@@ -1,0 +1,55 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "42:5:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "receive",
+          "modifiers": [],
+          "name": "",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "22:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "42:0:1"
+          },
+          "src": "15:32:1",
+          "stateMutability": "payable",
+          "virtual": false,
+          "visibility": "external"
+        }
+      ],
+      "src": "0:49:1"
+    }
+  ],
+  "src": "0:50:1"
+}

--- a/test/libsolidity/ASTJSON/short_type_name_parseOnly.json
+++ b/test/libsolidity/ASTJSON/short_type_name_parseOnly.json
@@ -1,0 +1,96 @@
+{
+  "absolutePath": "a",
+  "id": 12,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 11,
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 9,
+            "nodeType": "Block",
+            "src": "33:20:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  7
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 7,
+                    "mutability": "mutable",
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "src": "35:15:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "id": 5,
+                        "name": "uint",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "35:4:1",
+                        "typeDescriptions": {}
+                      },
+                      "id": 6,
+                      "nodeType": "ArrayTypeName",
+                      "src": "35:6:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 8,
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:15:1"
+              }
+            ]
+          },
+          "id": 10,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "src": "13:40:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:55:1"
+    }
+  ],
+  "src": "0:56:1"
+}

--- a/test/libsolidity/ASTJSON/short_type_name_ref_parseOnly.json
+++ b/test/libsolidity/ASTJSON/short_type_name_ref_parseOnly.json
@@ -1,0 +1,103 @@
+{
+  "absolutePath": "a",
+  "id": 13,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 12,
+      "name": "c",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 10,
+            "nodeType": "Block",
+            "src": "33:25:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  8
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 8,
+                    "mutability": "mutable",
+                    "name": "rows",
+                    "nodeType": "VariableDeclaration",
+                    "src": "35:20:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "baseType":
+                      {
+                        "baseType":
+                        {
+                          "id": 5,
+                          "name": "uint",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "35:4:1",
+                          "typeDescriptions": {}
+                        },
+                        "id": 6,
+                        "nodeType": "ArrayTypeName",
+                        "src": "35:6:1",
+                        "typeDescriptions": {}
+                      },
+                      "id": 7,
+                      "nodeType": "ArrayTypeName",
+                      "src": "35:8:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 9,
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:20:1"
+              }
+            ]
+          },
+          "id": 11,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "src": "13:45:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:60:1"
+    }
+  ],
+  "src": "0:61:1"
+}

--- a/test/libsolidity/ASTJSON/smoke_parseOnly.json
+++ b/test/libsolidity/ASTJSON/smoke_parseOnly.json
@@ -1,0 +1,20 @@
+{
+  "absolutePath": "a",
+  "id": 2,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 1,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "0:13:1"
+    }
+  ],
+  "src": "0:14:1"
+}

--- a/test/libsolidity/ASTJSON/source_location_parseOnly.json
+++ b/test/libsolidity/ASTJSON/source_location_parseOnly.json
@@ -1,0 +1,122 @@
+{
+  "absolutePath": "a",
+  "id": 13,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 12,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 10,
+            "nodeType": "Block",
+            "src": "26:20:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "mutability": "mutable",
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "src": "28:6:1",
+                    "stateVariable": false,
+                    "storageLocation": "default",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "uint",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "28:4:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 6,
+                "initialValue":
+                {
+                  "hexValue": "32",
+                  "id": 5,
+                  "kind": "number",
+                  "nodeType": "Literal",
+                  "src": "37:1:1",
+                  "typeDescriptions": {},
+                  "value": "2"
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "28:10:1"
+              },
+              {
+                "expression":
+                {
+                  "id": 8,
+                  "nodeType": "UnaryOperation",
+                  "operator": "++",
+                  "prefix": false,
+                  "src": "40:3:1",
+                  "subExpression":
+                  {
+                    "id": 7,
+                    "name": "x",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "src": "40:1:1",
+                    "typeDescriptions": {}
+                  },
+                  "typeDescriptions": {}
+                },
+                "id": 9,
+                "nodeType": "ExpressionStatement",
+                "src": "40:3:1"
+              }
+            ]
+          },
+          "id": 11,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "26:0:1"
+          },
+          "src": "13:33:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:48:1"
+    }
+  ],
+  "src": "0:49:1"
+}

--- a/test/libsolidity/ASTJSON/string_parseOnly.json
+++ b/test/libsolidity/ASTJSON/string_parseOnly.json
@@ -1,0 +1,99 @@
+{
+  "absolutePath": "a",
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 9,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 7,
+            "nodeType": "Block",
+            "src": "33:36:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "mutability": "mutable",
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "src": "35:15:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "string",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "35:6:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 6,
+                "initialValue":
+                {
+                  "hexValue": "48656c6c6f20576f726c64",
+                  "id": 5,
+                  "kind": "string",
+                  "nodeType": "Literal",
+                  "src": "53:13:1",
+                  "typeDescriptions": {},
+                  "value": "Hello World"
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:31:1"
+              }
+            ]
+          },
+          "id": 8,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "src": "13:56:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:71:1"
+    }
+  ],
+  "src": "0:72:1"
+}

--- a/test/libsolidity/ASTJSON/two_base_functions_parseOnly.json
+++ b/test/libsolidity/ASTJSON/two_base_functions_parseOnly.json
@@ -1,0 +1,198 @@
+{
+  "absolutePath": "a",
+  "id": 23,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "A",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 3,
+            "nodeType": "Block",
+            "src": "45:2:1",
+            "statements": []
+          },
+          "id": 4,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "27:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "45:0:1"
+          },
+          "src": "17:30:1",
+          "stateMutability": "nonpayable",
+          "virtual": true,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:49:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 10,
+      "name": "B",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 8,
+            "nodeType": "Block",
+            "src": "95:2:1",
+            "statements": []
+          },
+          "id": 9,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 6,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "77:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "95:0:1"
+          },
+          "src": "67:30:1",
+          "stateMutability": "nonpayable",
+          "virtual": true,
+          "visibility": "public"
+        }
+      ],
+      "src": "50:49:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts":
+      [
+        {
+          "baseName":
+          {
+            "id": 11,
+            "name": "A",
+            "nodeType": "UserDefinedTypeName",
+            "src": "114:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 12,
+          "nodeType": "InheritanceSpecifier",
+          "src": "114:1:1"
+        },
+        {
+          "baseName":
+          {
+            "id": 13,
+            "name": "B",
+            "nodeType": "UserDefinedTypeName",
+            "src": "117:1:1",
+            "typeDescriptions": {}
+          },
+          "id": 14,
+          "nodeType": "InheritanceSpecifier",
+          "src": "117:1:1"
+        }
+      ],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 22,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 20,
+            "nodeType": "Block",
+            "src": "160:2:1",
+            "statements": []
+          },
+          "id": 21,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "overrides":
+          {
+            "id": 18,
+            "nodeType": "OverrideSpecifier",
+            "overrides":
+            [
+              {
+                "id": 16,
+                "name": "A",
+                "nodeType": "UserDefinedTypeName",
+                "src": "154:1:1",
+                "typeDescriptions": {}
+              },
+              {
+                "id": 17,
+                "name": "B",
+                "nodeType": "UserDefinedTypeName",
+                "src": "157:1:1",
+                "typeDescriptions": {}
+              }
+            ],
+            "src": "145:14:1"
+          },
+          "parameters":
+          {
+            "id": 15,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "135:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 19,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "160:0:1"
+          },
+          "src": "125:37:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "100:64:1"
+    }
+  ],
+  "src": "0:165:1"
+}

--- a/test/libsolidity/ASTJSON/unicode_parseOnly.json
+++ b/test/libsolidity/ASTJSON/unicode_parseOnly.json
@@ -1,0 +1,99 @@
+{
+  "absolutePath": "a",
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 9,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "body":
+          {
+            "id": 7,
+            "nodeType": "Block",
+            "src": "33:42:1",
+            "statements":
+            [
+              {
+                "assignments":
+                [
+                  4
+                ],
+                "declarations":
+                [
+                  {
+                    "constant": false,
+                    "id": 4,
+                    "mutability": "mutable",
+                    "name": "x",
+                    "nodeType": "VariableDeclaration",
+                    "src": "35:15:1",
+                    "stateVariable": false,
+                    "storageLocation": "memory",
+                    "typeDescriptions": {},
+                    "typeName":
+                    {
+                      "id": 3,
+                      "name": "string",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "35:6:1",
+                      "typeDescriptions": {}
+                    },
+                    "visibility": "internal"
+                  }
+                ],
+                "id": 6,
+                "initialValue":
+                {
+                  "hexValue": "48656c6c6f20f09f9883",
+                  "id": 5,
+                  "kind": "unicodeString",
+                  "nodeType": "Literal",
+                  "src": "53:19:1",
+                  "typeDescriptions": {},
+                  "value": "Hello \ud83d\ude03"
+                },
+                "nodeType": "VariableDeclarationStatement",
+                "src": "35:37:1"
+              }
+            ]
+          },
+          "id": 8,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nodeType": "FunctionDefinition",
+          "parameters":
+          {
+            "id": 1,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "23:2:1"
+          },
+          "returnParameters":
+          {
+            "id": 2,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "33:0:1"
+          },
+          "src": "13:62:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "src": "0:77:1"
+    }
+  ],
+  "src": "0:78:1"
+}

--- a/test/libsolidity/ASTJSON/using_for_directive_parseOnly.json
+++ b/test/libsolidity/ASTJSON/using_for_directive_parseOnly.json
@@ -1,0 +1,54 @@
+{
+  "absolutePath": "a",
+  "id": 6,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "library",
+      "id": 1,
+      "name": "L",
+      "nodeType": "ContractDefinition",
+      "nodes": [],
+      "src": "0:12:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "id": 5,
+      "name": "C",
+      "nodeType": "ContractDefinition",
+      "nodes":
+      [
+        {
+          "id": 4,
+          "libraryName":
+          {
+            "id": 2,
+            "name": "L",
+            "nodeType": "UserDefinedTypeName",
+            "src": "32:1:1",
+            "typeDescriptions": {}
+          },
+          "nodeType": "UsingForDirective",
+          "src": "26:17:1",
+          "typeName":
+          {
+            "id": 3,
+            "name": "uint",
+            "nodeType": "ElementaryTypeName",
+            "src": "38:4:1",
+            "typeDescriptions": {}
+          }
+        }
+      ],
+      "src": "13:32:1"
+    }
+  ],
+  "src": "0:46:1"
+}

--- a/test/libsolidity/ASTJSONTest.cpp
+++ b/test/libsolidity/ASTJSONTest.cpp
@@ -73,6 +73,7 @@ ASTJSONTest::ASTJSONTest(string const& _filename)
 		BOOST_THROW_EXCEPTION(runtime_error("Invalid test contract file name: \"" + _filename + "\"."));
 
 	m_astFilename = _filename.substr(0, _filename.size() - 4) + ".json";
+	m_astParseOnlyFilename = _filename.substr(0, _filename.size() - 4) + "_parseOnly.json";
 	m_legacyAstFilename = _filename.substr(0, _filename.size() - 4) + "_legacy.json";
 
 	ifstream file(_filename);
@@ -113,6 +114,15 @@ ASTJSONTest::ASTJSONTest(string const& _filename)
 	}
 
 	file.close();
+	file.open(m_astParseOnlyFilename);
+	if (file)
+	{
+		string line;
+		while (getline(file, line))
+			m_expectationParseOnly += line + "\n";
+	}
+
+	file.close();
 	file.open(m_legacyAstFilename);
 	if (file)
 	{
@@ -120,6 +130,7 @@ ASTJSONTest::ASTJSONTest(string const& _filename)
 		while (getline(file, line))
 			m_expectationLegacy += line + "\n";
 	}
+	file.close();
 }
 
 TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
@@ -136,8 +147,36 @@ TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefi
 	c.setSources(sources);
 	c.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 
+
+	if (!c.compile(CompilerStack::State::Parsed))
+	{
+		SourceReferenceFormatterHuman formatter(_stream, _formatted, false);
+		for (auto const& error: c.errors())
+			formatter.printErrorInformation(*error);
+		return TestResult::FatalError;
+	}
+
+	bool resultsMatch = runTest(
+		m_expectationParseOnly,
+		m_resultParseOnly,
+		sourceIndices,
+		c,
+		false,
+		"parseOnly",
+		_stream,
+		_linePrefix,
+		_formatted
+	);
+
+	c.reset();
+	c.setSources(sources);
+	c.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 	if (!c.parse())
 	{
+		// Empty Expectations means we expect failure
+		if (m_expectation.empty() && m_expectationLegacy.empty())
+			return resultsMatch ? TestResult::Success : TestResult::Failure;
+
 		SourceReferenceFormatterHuman formatter(_stream, _formatted, false);
 		for (auto const& error: c.errors())
 			formatter.printErrorInformation(*error);
@@ -146,7 +185,7 @@ TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefi
 
 	c.analyze();
 
-	bool resultsMatch = runTest(
+	resultsMatch = runTest(
 		m_expectation,
 		m_result,
 		sourceIndices,
@@ -156,7 +195,7 @@ TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefi
 		_stream,
 		_linePrefix,
 		_formatted
-	);
+	) && resultsMatch;
 
 	resultsMatch = runTest(
 		m_expectationLegacy,
@@ -191,7 +230,7 @@ bool ASTJSONTest::runTest(
 	for (size_t i = 0; i < m_sources.size(); i++)
 	{
 		ostringstream result;
-		ASTJsonConverter(_legacy, _sourceIndices).print(result, _compiler.ast(m_sources[i].first));
+		ASTJsonConverter(_legacy, _compiler.state(), _sourceIndices).print(result, _compiler.ast(m_sources[i].first));
 		_result += result.str();
 		if (i != m_sources.size() - 1)
 			_result += ",";
@@ -234,7 +273,7 @@ bool ASTJSONTest::runTest(
 		return false;
 	}
 
-	return true;;
+	return true;
 }
 
 void ASTJSONTest::printSource(ostream& _stream, string const& _linePrefix, bool const) const
@@ -255,6 +294,7 @@ void ASTJSONTest::printUpdatedExpectations(std::ostream&, std::string const&) co
 {
 	updateExpectation(m_astFilename, m_result, "");
 	updateExpectation(m_legacyAstFilename, m_resultLegacy, "legacy ");
+	updateExpectation(m_astParseOnlyFilename, m_resultParseOnly, "parseOnly ");
 }
 
 void ASTJSONTest::updateExpectation(string const& _filename, string const& _expectation, string const& _variation) const

--- a/test/libsolidity/ASTJSONTest.h
+++ b/test/libsolidity/ASTJSONTest.h
@@ -34,7 +34,6 @@ class CompilerStack;
 namespace solidity::frontend::test
 {
 
-
 class ASTJSONTest: public TestCase
 {
 public:
@@ -50,9 +49,9 @@ private:
 	bool runTest(
 		std::string& _expectation,
 		std::string& _result,
-		std::map<std::string, unsigned> const& _sourceIndicies,
+		std::map<std::string, unsigned> const& _sourceIndices,
 		CompilerStack& _compiler,
-		bool _legacy,
+		bool _parseOnly,
 		std::string const& _variation,
 		std::ostream& _stream,
 		std::string const& _linePrefix = "",
@@ -66,10 +65,13 @@ private:
 
 	std::vector<std::pair<std::string, std::string>> m_sources;
 	std::string m_expectationLegacy;
+	std::string m_expectationParseOnly;
 	std::string m_astFilename;
+	std::string m_astParseOnlyFilename;
 	std::string m_legacyAstFilename;
 	std::string m_result;
 	std::string m_resultLegacy;
+	std::string m_resultParseOnly;
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/imports/imported_fail_1.sol
+++ b/test/libsolidity/smtCheckerTests/imports/imported_fail_1.sol
@@ -1,4 +1,4 @@
-==== Source:  ====
+==== Source: C.sol ====
 import "B.sol";
 pragma experimental SMTChecker;
 contract C is B {
@@ -21,5 +21,4 @@ contract B is A {
 	}
 }
 // ----
-// Warning 6328: (103-117): CHC: Assertion violation happens here.
-// Warning 6328: (B.sol:71-85): CHC: Assertion violation happens here.
+// Warning 6328: (C.sol:103-117): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/imports/imported_fail_2.sol
+++ b/test/libsolidity/smtCheckerTests/imports/imported_fail_2.sol
@@ -1,4 +1,4 @@
-==== Source:  ====
+==== Source: C.sol ====
 import "B.sol";
 pragma experimental SMTChecker;
 contract C is B {
@@ -23,5 +23,5 @@ contract B is A {
 }
 // ----
 // Warning 6328: (B.sol:103-117): CHC: Assertion violation happens here.
-// Warning 6328: (103-117): CHC: Assertion violation happens here.
 // Warning 6328: (B.sol:103-117): CHC: Assertion violation happens here.
+// Warning 6328: (C.sol:103-117): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/imports/imported_fail_3.sol
+++ b/test/libsolidity/smtCheckerTests/imports/imported_fail_3.sol
@@ -1,4 +1,4 @@
-==== Source:  ====
+==== Source: C.sol ====
 import "A.sol";
 pragma experimental SMTChecker;
 contract C is A {
@@ -22,5 +22,5 @@ contract B is A {
 	}
 }
 // ----
-// Warning 6328: (103-117): CHC: Assertion violation happens here.
 // Warning 6328: (B.sol:103-117): CHC: Assertion violation happens here.
+// Warning 6328: (C.sol:103-117): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/imports/simple.sol
+++ b/test/libsolidity/smtCheckerTests/imports/simple.sol
@@ -1,6 +1,6 @@
 ==== Source: A.sol ====
 contract A { function f() public {} }
-==== Source:====
+==== Source: B.sol ====
 import "A.sol";
 pragma experimental SMTChecker;
 contract C is A {}

--- a/test/libsolidity/smtCheckerTests/imports/simple_imported_fail_no_pragma.sol
+++ b/test/libsolidity/smtCheckerTests/imports/simple_imported_fail_no_pragma.sol
@@ -1,4 +1,4 @@
-==== Source:  ====
+==== Source: B.sol ====
 import "A.sol";
 pragma experimental SMTChecker;
 contract C is A {}

--- a/test/libsolidity/smtCheckerTests/imports/simple_imported_fail_two_pragmas.sol
+++ b/test/libsolidity/smtCheckerTests/imports/simple_imported_fail_two_pragmas.sol
@@ -1,4 +1,4 @@
-==== Source:  ====
+==== Source: B.sol ====
 import "A.sol";
 pragma experimental SMTChecker;
 contract C is A {}

--- a/test/stopAfterParseTests.sh
+++ b/test/stopAfterParseTests.sh
@@ -1,0 +1,64 @@
+#! /usr/bin/env bash
+
+REPO_ROOT=$(readlink -f "$(dirname "$0")"/..)
+SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
+SOLC=${SOLIDITY_BUILD_DIR}/solc/solc
+SPLITSOURCES=${REPO_ROOT}/scripts/splitSources.py
+
+FILETMP=$(mktemp -d)
+cd "$FILETMP" || exit 1
+
+
+function testFile()
+{
+	ALLOUTPUT=$($SOLC --combined-json ast,compact-format --pretty-json "$@" --stop-after parsing 2>&1)
+	if test $? -ne 0; then
+		# solc returned failure. Compilation errors and unimplemented features
+		# are okay, everything else is a failed test (segfault)
+		if ! echo "$ALLOUTPUT" | grep -e "Unimplemented feature:" -e "Error:" -q; then
+			echo -n "Test failed on ";
+			echo "$@"
+			echo "$ALLOUTPUT"
+			return 1;
+		fi
+	else
+		echo -n .
+	fi
+
+	return 0;
+}
+
+while read -r file; do
+	OUTPUT=$($SPLITSOURCES "$file")
+	RETURN_CODE=$?
+	FAILED=0
+
+	if [ $RETURN_CODE -eq 0 ]
+	then
+		# shellcheck disable=SC2086
+		testFile $OUTPUT
+		FAILED=$?
+
+		rm "${FILETMP:?}/"* -r
+	elif [ $RETURN_CODE -eq 1 ]
+	then
+		testFile "$file"
+		FAILED=$?
+	elif [ $RETURN_CODE -eq 2 ]
+	then
+		echo -n "<skipping utf8 error>"
+	else
+		echo "Received unexpected return code $RETURN_CODE while processing $file: "
+		echo "-----"
+		echo "$OUTPUT"
+		exit 3
+	fi
+
+	if [ $FAILED -eq 1 ]
+	then
+		echo -n "Failure on "
+		echo "$file"
+		exit 1
+	fi
+done < <(find "${REPO_ROOT}/test" -iname "*.sol" -and -not -name "documentation.sol")
+echo


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8739

Todo:
 - [x] error out if binary was requested in combination with "stop after parsing"
 - [x] implement this in standard-io