### PR TITLE
Proof script should only run on existing files.

### DIFF
--- a/scripts/run_proofs.sh
+++ b/scripts/run_proofs.sh
@@ -10,16 +10,18 @@ git fetch origin
 error=0
 for new_proof in $(git diff origin/develop --name-only test/formal/)
 do
-	set +e
-	echo "Proving $new_proof..."
-	output=$(python3 "$new_proof")
-	result=$?
-	set -e
+	if [ -e "$new_proof" ]; then
+		set +e
+		echo "Proving $new_proof..."
+		output=$(python3 "$new_proof")
+		result=$?
+		set -e
 
-	if [[ "$result" != 0 ]]
-	then
-		echo "Proof $(basename "$new_proof" ".py") failed: $output."
-		error=1
+		if [[ "$result" != 0 ]]
+		then
+			echo "Proof $(basename "$new_proof" ".py") failed: $output."
+			error=1
+		fi
 	fi
 done
 


### PR DESCRIPTION
Otherwise non-rebased PRs will attempt to run non-existing files because of a negative diff.