### PR TITLE
[SMTChecker] Refactor verification targets

### DIFF
--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -63,7 +63,7 @@ public:
 		smtutil::SMTSolverChoice _enabledSolvers
 	);
 
-	void analyze(SourceUnit const& _sources, std::set<Expression const*> _safeAssertions);
+	void analyze(SourceUnit const& _sources, std::map<ASTNode const*, std::set<VerificationTarget::Type>> _solvedTargets);
 
 	/// This is used if the SMT solver is not directly linked into this binary.
 	/// @returns a list of inputs to the SMT solver that were not part of the argument to
@@ -180,8 +180,8 @@ private:
 
 	std::vector<BMCVerificationTarget> m_verificationTargets;
 
-	/// Assertions that are known to be safe.
-	std::set<Expression const*> m_safeAssertions;
+	/// Targets that were already proven.
+	std::map<ASTNode const*, std::set<VerificationTarget::Type>> m_solvedTargets;
 };
 
 }

--- a/libsolidity/formal/EncodingContext.cpp
+++ b/libsolidity/formal/EncodingContext.cpp
@@ -32,21 +32,21 @@ EncodingContext::EncodingContext():
 void EncodingContext::reset()
 {
 	resetAllVariables();
-	resetSlackId();
+	resetUniqueId();
 	m_expressions.clear();
 	m_globalContext.clear();
 	m_state.reset();
 	m_assertions.clear();
 }
 
-void EncodingContext::resetSlackId()
+void EncodingContext::resetUniqueId()
 {
-	m_nextSlackId = 0;
+	m_nextUniqueId = 0;
 }
 
-unsigned EncodingContext::newSlackId()
+unsigned EncodingContext::newUniqueId()
 {
-	return m_nextSlackId++;
+	return m_nextUniqueId++;
 }
 
 void EncodingContext::clear()

--- a/libsolidity/formal/EncodingContext.h
+++ b/libsolidity/formal/EncodingContext.h
@@ -41,9 +41,9 @@ public:
 	/// To be used in the beginning of a root function visit.
 	void reset();
 	/// Resets the fresh id for slack variables.
-	void resetSlackId();
+	void resetUniqueId();
 	/// Returns the current fresh slack id and increments it.
-	unsigned newSlackId();
+	unsigned newUniqueId();
 	/// Clears the entire context, erasing everything.
 	/// To be used before a model checking engine starts.
 	void clear();
@@ -173,8 +173,8 @@ private:
 	bool m_accumulateAssertions = true;
 	//@}
 
-	/// Fresh ids for slack variables to be created deterministically.
-	unsigned m_nextSlackId = 0;
+	/// Central source of unique ids.
+	unsigned m_nextUniqueId = 0;
 };
 
 }

--- a/libsolidity/formal/ModelChecker.cpp
+++ b/libsolidity/formal/ModelChecker.cpp
@@ -41,7 +41,12 @@ void ModelChecker::analyze(SourceUnit const& _source)
 		return;
 
 	m_chc.analyze(_source);
-	m_bmc.analyze(_source, m_chc.safeAssertions());
+
+	auto solvedTargets = m_chc.safeTargets();
+	for (auto const& target: m_chc.unsafeTargets())
+		solvedTargets[target.first] += target.second;
+
+	m_bmc.analyze(_source, solvedTargets);
 }
 
 vector<string> ModelChecker::unhandledQueries()

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1262,7 +1262,7 @@ pair<smtutil::Expression, smtutil::Expression> SMTEncoder::arithmeticOperation(
 	auto symbMax = smt::maxValue(*intType);
 
 	smtutil::Expression intValueRange = (0 - symbMin) + symbMax + 1;
-	string suffix = to_string(_operation.id()) + "_" + to_string(m_context.newSlackId());
+	string suffix = to_string(_operation.id()) + "_" + to_string(m_context.newUniqueId());
 	smt::SymbolicIntVariable k(intType, intType, "k_" + suffix, m_context);
 	smt::SymbolicIntVariable m(intType, intType, "m_" + suffix, m_context);
 


### PR DESCRIPTION
Split off https://github.com/ethereum/solidity/pull/9113 since it has been problematic and we need the code here so https://github.com/ethereum/solidity/pull/9352 can move on.

Simple refactoring of how the verification targets are run in CHC, no tests affected.