### PR TITLE
Free variables directly after visiting RHS of VarDecls EVMCodeTransform.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * Code Generator: Evaluate ``keccak256`` of string literals at compile-time.
  * Peephole Optimizer: Remove unnecessary masking of tags.
+ * Yul EVM Code Transform: Free stack slots directly after visiting the right-hand-side of variable declarations instead of at the end of the statement only.
 
 Bugfixes:
  * Type Checker: Fix overload resolution in combination with ``{value: ...}``.

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -161,8 +161,9 @@ protected:
 	bool unreferenced(Scope::Variable const& _var) const;
 	/// Marks slots of variables that are not used anymore
 	/// and were defined in the current scope for reuse.
-	/// Also POPs unused topmost stack slots.
-	void freeUnusedVariables();
+	/// Also POPs unused topmost stack slots,
+	/// unless @a _popUnusedSlotsAtStackTop is set to false.
+	void freeUnusedVariables(bool _popUnusedSlotsAtStackTop = true);
 	/// Marks the stack slot of @a _var to be reused.
 	void deleteVariable(Scope::Variable const& _var);
 

--- a/test/libyul/StackReuseCodegen.cpp
+++ b/test/libyul/StackReuseCodegen.cpp
@@ -345,6 +345,69 @@ BOOST_AUTO_TEST_CASE(reuse_slots_function_with_gaps)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(reuse_on_decl_assign_to_last_used)
+{
+	string in = R"({
+		let x := 5
+		let y := x // y should reuse the stack slot of x
+		sstore(y, y)
+	})";
+	BOOST_CHECK_EQUAL(assemble(in),
+		"PUSH1 0x5 "
+		"DUP1 SWAP1 POP "
+		"DUP1 DUP2 SSTORE "
+		"POP "
+	);
+}
+
+BOOST_AUTO_TEST_CASE(reuse_on_decl_assign_to_last_used_expr)
+{
+	string in = R"({
+		let x := 5
+		let y := add(x, 2) // y should reuse the stack slot of x
+		sstore(y, y)
+	})";
+	BOOST_CHECK_EQUAL(assemble(in),
+		"PUSH1 0x5 "
+		"PUSH1 0x2 DUP2 ADD "
+		"SWAP1 POP "
+		"DUP1 DUP2 SSTORE "
+		"POP "
+	);
+}
+
+BOOST_AUTO_TEST_CASE(reuse_on_decl_assign_to_not_last_used)
+{
+	string in = R"({
+		let x := 5
+		let y := x // y should not reuse the stack slot of x, since x is still used below
+		sstore(y, x)
+	})";
+	BOOST_CHECK_EQUAL(assemble(in),
+		"PUSH1 0x5 "
+		"DUP1 "
+		"DUP2 DUP2 SSTORE "
+		"POP POP "
+	);
+}
+
+BOOST_AUTO_TEST_CASE(reuse_on_decl_assign_not_same_scope)
+{
+	string in = R"({
+		let x := 5
+		{
+			let y := x // y should not reuse the stack slot of x, since x is not in the same scope
+			sstore(y, y)
+		}
+	})";
+	BOOST_CHECK_EQUAL(assemble(in),
+		"PUSH1 0x5 "
+		"DUP1 "
+		"DUP1 DUP2 SSTORE "
+		"POP POP "
+	);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
This optimizes for a very special case, but
1. I think this special case might not actually be that rare.
2. I think it's the only way to make https://github.com/ethereum/solidity/pull/9162#discussion_r452344015 work out nicely.
3. Any stack slot saved is a win :-).

I'd *like* for this to be extended beyond variables in the same scope, but that's a nightmare with loops and function arguments, etc. - so if at all I'd do it separately. Having it for the same scope should be mostly sufficient (we flatten blocks anyways).