### PR TITLE
Upgrade json-cpp to 1.9.3.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Bugfixes:
  * Type Checker: Fix internal compiler error related to oversized types.
 
 Compiler Features:
+ * Build System: Update internal dependency of jsoncpp to 1.9.3.
  * Optimizer: Add rule to remove shifts inside the byte opcode.
 
 

--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -37,15 +37,16 @@ endif()
 ExternalProject_Add(jsoncpp-project
     PREFIX "${prefix}"
     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
-    DOWNLOAD_NAME jsoncpp-1.9.2.tar.gz
-    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
-    URL_HASH SHA256=77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0
+    DOWNLOAD_NAME jsoncpp-1.9.3.tar.gz
+    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
+    URL_HASH SHA256=8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d
     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DCMAKE_INSTALL_LIBDIR=lib
                # Build static lib but suitable to be included in a shared lib.
                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+               -DJSONCPP_WITH_EXAMPLE=OFF
                -DJSONCPP_WITH_TESTS=OFF
                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF
                -DCMAKE_CXX_FLAGS=${JSONCPP_CXX_FLAGS}

--- a/libsolutil/JSON.cpp
+++ b/libsolutil/JSON.cpp
@@ -32,8 +32,8 @@
 using namespace std;
 
 static_assert(
-	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 9) && (JSONCPP_VERSION_PATCH == 2),
-	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.2."
+	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 9) && (JSONCPP_VERSION_PATCH == 3),
+	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.3."
 );
 
 namespace solidity::util

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -31,7 +31,7 @@ REPO_ROOT="$(dirname "$0")"/..
     fi
     # Add dependencies
     mkdir -p "$SOLDIR/deps/downloads/" 2>/dev/null || true
-    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.9.2.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
+    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.9.3.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
     mkdir -p "$REPO_ROOT/upload"
     tar --owner 0 --group 0 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
     rm -r "$TEMPDIR"

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -107,7 +107,7 @@ mv solidity solc
 
 # Fetch jsoncpp dependency
 mkdir -p ./solc/deps/downloads/ 2>/dev/null || true
-wget -O ./solc/deps/downloads/jsoncpp-1.9.2.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
+wget -O ./solc/deps/downloads/jsoncpp-1.9.3.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
 
 # Determine version
 cd solc


### PR DESCRIPTION
The release notes read generally favorable: https://github.com/open-source-parsers/jsoncpp/releases

And json-cpp 1.9.2 is slower to build and causing issues with clang-10 and the ossfuzz builds, stalling the docker image work of @aarlt.