### PR TITLE
[DOCS] Adds brand guide and updates team calls information in contributing

### DIFF
--- a/docs/brand-guide.rst
+++ b/docs/brand-guide.rst
@@ -1,0 +1,84 @@
+####################
+Solidity Brand Guide
+####################
+
+This brand guide features information on Solidity's brand policy and
+logo usage guidelines.
+
+The Solidity Brand
+==================
+
+The Solidity programming language is an open-source, community project
+governed by a core team. The core team is sponsored by the `Ethereum
+Foundation <https://ethereum.foundation/>`_.
+
+This document aims to provide information about how to best use the
+Solidity brand name and logo.
+
+We encourage you to read this document carefully before using the
+brand name or the logo. Your cooperation is highly appreciated!
+
+Solidity Brand Name
+===================
+
+"Solidity" should be used to refer to the Solidity programming language
+solely.
+
+Please do not use "Solidity":
+
+- To refer to any other programming language.
+
+- In a way that is misleading or may imply association of unrelated
+  modules, tools, documentation, or other resources with the Solidity
+  programming language.
+
+- In ways that confuse the community as to whether the Solidity
+  programming language is open-source and free to use.
+
+Solidity Logo License
+=====================
+
+.. image:: https://i.creativecommons.org/l/by/4.0/88x31.png
+  :width: 88
+  :alt: Creative Commons License
+
+The Solidity logo is distributed and licensed under a `Creative Commons
+Attribution 4.0 International License <http://creativecommons.org/licenses/by/4.0/>`_.
+
+This is the most permissive Creative Commons license and allows reuse
+and modifications for any purpose.
+
+You are free to:
+
+- **Share** — Copy and redistribute the material in any medium or format.
+
+- **Adapt** — Remix, transform, and build upon the material for any
+  purpose, even commercially.
+
+Under the following terms:
+
+- **Attribution** — You must give appropriate credit, provide a link to
+  the license, and indicate if changes were made. You may do so in any
+  reasonable manner, but not in any way that suggests the the Solidity
+  core team endorses you or your use.
+
+When using the Solidity logo, please respect the Solidity logo guidelines.
+
+Solidity Logo Guidelines
+========================
+
+.. image:: logo.svg
+  :width: 256
+
+Please do not:
+
+- Change the ratio of the logo (do not stretch it or cut it).
+
+- Change the colors of the logo, unless it is absolutely necessary.
+
+Credits
+=======
+
+This document was, in parts, derived from the `Python Software
+Foundation Trademark Usage Policy <https://www.python.org/psf/trademarks/>`_
+and the `Rust Media Guide <https://www.rust-lang.org/policies/media-guide>`_.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -27,10 +27,10 @@ Team Calls
 If you have issues or pull requests to discuss, or are interested in hearing what
 the team and contributors are working on, you can join our public team calls:
 
-- Monday at 12pm CET
-- Wednesday at 3pm CET
+- Mondays at 12pm CET/CEST
+- Wednesdays at 2pm CET/CEST
 
-Both calls take place on `Google Hangouts <https://hangouts.google.com/hangouts/_/ethereum.org/solidity-weekly>`_.
+Both calls take place on `Google Meet <https://meet.google.com/mrq-kbwv-edg>`_.
 
 How to Report Issues
 ====================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,3 +137,4 @@ Contents
    common-patterns.rst
    bugs.rst
    contributing.rst
+   brand-guide.rst


### PR DESCRIPTION
- adds `brand guide` section to the docs
- updates team call information and hangouts link in the `contributing` section

Closes #6516 

**Question: Do I need to add `brand-guide.rst` somewhere else for it to be added to the docs' nav bar on the left?**