### PR TITLE
Fix segfault in oversized objects check in combination with var.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -571,7 +571,11 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 			if (_variable.isStateVariable())
 				m_errorReporter.warning(3408_error, _variable.location(), collisionMessage(_variable.name(), true));
 			else
-				m_errorReporter.warning(2332_error, _variable.typeName()->location(), collisionMessage(varType->canonicalName(), false));
+				m_errorReporter.warning(
+					2332_error,
+					_variable.typeName() ? _variable.typeName()->location() : _variable.location(),
+					collisionMessage(varType->canonicalName(), false)
+				);
 		}
 		vector<Type const*> oversizedSubtypes = frontend::oversizedSubtypes(*varType);
 		for (Type const* subtype: oversizedSubtypes)

--- a/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
@@ -1,0 +1,15 @@
+contract b {
+    struct c {
+        uint [2 ** 253] a;
+    }
+
+    c d;
+    function e() public {
+        var d = d;
+    }
+}
+// ----
+// Warning 2519: (105-110): This declaration shadows an existing declaration.
+// Warning 3408: (66-69): Variable "d" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 2332: (105-110): Type "b.c" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// SyntaxError 1719: (105-114): Use of the "var" keyword is disallowed. Use explicit declaration `struct b.c storage pointer d = ...´ instead.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9404
