### PR TITLE
Refactor storageSizeUpperBound.

### DIFF
--- a/libsolidity/analysis/ContractLevelChecker.h
+++ b/libsolidity/analysis/ContractLevelChecker.h
@@ -83,6 +83,8 @@ private:
 
 	/// Warns if the contract has a payable fallback, but no receive ether function.
 	void checkPayableFallbackWithoutReceive(ContractDefinition const& _contract);
+	/// Error if the contract requires too much storage
+	void checkStorageSize(ContractDefinition const& _contract);
 
 	OverrideChecker m_overrideChecker;
 	langutil::ErrorReporter& m_errorReporter;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -59,7 +59,6 @@ using BoolResult = util::Result<bool>;
 namespace solidity::frontend
 {
 
-bigint storageSizeUpperBound(frontend::Type const& _type);
 std::vector<frontend::Type const*> oversizedSubtypes(frontend::Type const& _type);
 
 inline rational makeRational(bigint const& _numerator, bigint const& _denominator)
@@ -251,6 +250,10 @@ public:
 	/// @returns the number of storage slots required to hold this value in storage.
 	/// For dynamically "allocated" types, it returns the size of the statically allocated head,
 	virtual u256 storageSize() const { return 1; }
+	/// @returns an upper bound on the total storage size required by this type, descending
+	/// into structs and statically-sized arrays. This is mainly to ensure that the storage
+	/// slot allocation algorithm does not overflow, it is not a protection against collisions.
+	virtual bigint storageSizeUpperBound() const { return 1; }
 	/// Multiple small types can be packed into a single storage slot. If such a packing is possible
 	/// this function @returns the size in bytes smaller than 32. Data is moved to the next slot if
 	/// it does not fit.
@@ -788,6 +791,7 @@ public:
 	unsigned calldataEncodedTailSize() const override;
 	bool isDynamicallySized() const override { return m_hasDynamicLength; }
 	bool isDynamicallyEncoded() const override;
+	bigint storageSizeUpperBound() const override;
 	u256 storageSize() const override;
 	bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
 	bool nameable() const override { return true; }
@@ -952,6 +956,7 @@ public:
 	unsigned calldataEncodedTailSize() const override;
 	bool isDynamicallyEncoded() const override;
 	u256 memoryDataSize() const override;
+	bigint storageSizeUpperBound() const override;
 	u256 storageSize() const override;
 	bool canLiveOutsideStorage() const override { return true; }
 	bool nameable() const override { return true; }

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_array.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_array.sol
@@ -4,5 +4,5 @@ contract C {
     uint[2**255][2] a;
 }
 // ----
-// TypeError 1534: (77-94): Type too large for storage.
 // TypeError 7676: (60-97): Contract too large for storage.
+// TypeError 1534: (77-94): Type too large for storage.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_contract_inheritance.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_contract_inheritance.sol
@@ -2,9 +2,11 @@
 pragma solidity >= 0.0;
 contract C {
     uint[2**255] a;
+}
+contract D is C {
     uint[2**255] b;
 }
 // ----
-// TypeError 7676: (60-114): Contract too large for storage.
+// TypeError 7676: (95-134): Contract too large for storage.
 // Warning 3408: (77-91): Variable "a" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (97-111): Variable "b" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 3408: (117-131): Variable "b" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_struct.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_struct.sol
@@ -8,5 +8,5 @@ contract C {
     S s;
 }
 // ----
-// TypeError 1534: (146-149): Type too large for storage.
 // TypeError 7676: (60-152): Contract too large for storage.
+// TypeError 1534: (146-149): Type too large for storage.


### PR DESCRIPTION
Remove the ineffective recursion check and turn into member functions.