### PR TITLE
Refactor subtype size check.

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -362,10 +362,7 @@ void DeclarationTypeChecker::endVisit(VariableDeclaration const& _variable)
 		solAssert(varLoc == Location::Unspecified, "");
 		typeLoc = (_variable.isConstant() || _variable.immutable()) ? DataLocation::Memory : DataLocation::Storage;
 	}
-	else if (
-		dynamic_cast<StructDefinition const*>(_variable.scope()) ||
-		dynamic_cast<EnumDefinition const*>(_variable.scope())
-	)
+	else if (_variable.isStructMember() || _variable.isEnumMember())
 		// The actual location will later be changed depending on how the type is used.
 		typeLoc = DataLocation::Storage;
 	else

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -940,6 +940,8 @@ public:
 	/// Can only be called after reference resolution.
 	bool hasReferenceOrMappingType() const;
 	bool isStateVariable() const { return m_isStateVariable; }
+	bool isStructMember() const { solAssert(annotation().scope, ""); return dynamic_cast<StructDefinition const*>(annotation().scope); }
+	bool isEnumMember() const { solAssert(annotation().scope, ""); return dynamic_cast<EnumDefinition const*>(annotation().scope); }
 	bool isIndexed() const { return m_isIndexed; }
 	Mutability mutability() const { return m_mutability; }
 	bool isConstant() const { return m_mutability == Mutability::Constant; }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -59,8 +59,6 @@ using BoolResult = util::Result<bool>;
 namespace solidity::frontend
 {
 
-std::vector<frontend::Type const*> oversizedSubtypes(frontend::Type const& _type);
-
 inline rational makeRational(bigint const& _numerator, bigint const& _denominator)
 {
 	solAssert(_denominator != 0, "division by zero");

--- a/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
@@ -10,6 +10,4 @@ contract b {
 }
 // ----
 // Warning 2519: (105-110): This declaration shadows an existing declaration.
-// Warning 3408: (66-69): Variable "d" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 2332: (105-110): Type "b.c" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // SyntaxError 1719: (105-114): Use of the "var" keyword is disallowed. Use explicit declaration `struct b.c storage pointer d = ...´ instead.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_array_simple.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_array_simple.sol
@@ -2,4 +2,4 @@ contract C {
     uint[2**64] x;
 }
 // ----
-// Warning 3408: (17-30): Variable "x" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (17-28): Type "uint256[18446744073709551616]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_arrays_struct.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_arrays_struct.sol
@@ -3,4 +3,4 @@ contract C {
     S[2**20] x;
 }
 // ----
-// Warning 3408: (64-74): Variable "x" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (64-72): Type "C.S[1048576]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/large_storage_structs.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_storage_structs.sol
@@ -55,14 +55,14 @@ contract C {
     Q4 q4;
 }
 // ----
-// Warning 3408: (106-111): Variable "s0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (171-176): Variable "s1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (106-108): Type "C.S0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (171-173): Type "C.S1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 7325: (341-343): Type "C.P[103]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 7325: (341-343): Type "C.P[104]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (505-510): Variable "q0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 7325: (505-507): Type "uint256[100000000000000000002]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 7325: (505-507): Type "uint256[100000000000000000004]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (576-581): Variable "q1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (505-507): Type "C.Q0" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (576-578): Type "C.Q1" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 7325: (647-649): Type "uint256[100000000000000000006]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (715-720): Variable "q3" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (715-717): Type "C.Q3" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 7325: (783-785): Type "uint256[100000000000000000008]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_contract.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_contract.sol
@@ -6,5 +6,3 @@ contract C {
 }
 // ----
 // TypeError 7676: (60-114): Contract too large for storage.
-// Warning 3408: (77-91): Variable "a" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (97-111): Variable "b" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/oversized_contract_inheritance.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/oversized_contract_inheritance.sol
@@ -8,5 +8,3 @@ contract D is C {
 }
 // ----
 // TypeError 7676: (95-134): Contract too large for storage.
-// Warning 3408: (77-91): Variable "a" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 3408: (117-131): Variable "b" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/largeTypes/storage_parameter.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/storage_parameter.sol
@@ -3,4 +3,4 @@ contract C {
     function f(S storage) internal {}
 }
 // ----
-// Warning 2332: (64-65): Type "C.S" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (64-65): Type "C.S" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/types/rational_number_array_index_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_array_index_limit.sol
@@ -2,4 +2,4 @@ contract c {
     uint[2**253] data;
 }
 // ----
-// Warning 3408: (17-34): Variable "data" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 7325: (17-29): Type "uint256[14474011154664524427946373126085988481658748083205070504932198000989141204992]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.


### PR DESCRIPTION
@a3d4 I remember you asking where the check should be and I said "as early as possible". I thought this was about preventing an internal error but this does not seem the case and thus I think the static analyzer is better suited since the type checker should mainly validate that operators can properly applied to types and it is already doing a lot of other checks.