### PR TITLE
Issue state mutability restriction for overriding and not for virtual functions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Breaking changes:
  * Remove the finney and szabo denominations.
 
 Language Features:
+ * State mutability: Do not issue recommendation for stricter mutability for virtual functions but do issue it for functions that override.
  * Yul: Disallow EVM instruction `pc()`.
  * Yul: Disallow consecutive and trailing dots in identifiers. Leading dots were already disallowed.
 

--- a/docs/contracts/abstract-contracts.rst
+++ b/docs/contracts/abstract-contracts.rst
@@ -27,11 +27,11 @@ all defined functions. The usage of an abstract contract as a base class is show
     pragma solidity >=0.6.0 <0.8.0;
 
     abstract contract Feline {
-        function utterance() public virtual returns (bytes32);
+        function utterance() public pure virtual returns (bytes32);
     }
 
     contract Cat is Feline {
-        function utterance() public override returns (bytes32) { return "miaow"; }
+        function utterance() public pure override returns (bytes32) { return "miaow"; }
     }
 
 If a contract inherits from an abstract contract and does not implement all non-implemented

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -168,7 +168,7 @@ void ViewPureChecker::endVisit(FunctionDefinition const& _funDef)
 		!_funDef.isConstructor() &&
 		!_funDef.isFallback() &&
 		!_funDef.isReceive() &&
-		!_funDef.overrides()
+		!_funDef.virtualSemantics()
 	)
 		m_errorReporter.warning(
 			2018_error,

--- a/test/libsolidity/syntaxTests/inheritance/interface/diamond/diamond_no_relist.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/diamond/diamond_no_relist.sol
@@ -1,10 +1,10 @@
 interface Parent {
-    function test() external returns (uint256);
+    function test() external pure returns (uint256);
 }
 
 interface SubA is Parent {}
 interface SubB is Parent {}
 
 contract C is SubA, SubB {
-    function test() external override returns (uint256) { return 42; }
+    function test() external override pure returns (uint256) { return 42; }
 }

--- a/test/libsolidity/syntaxTests/inheritance/interface/diamond/diamond_with_relist.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/diamond/diamond_with_relist.sol
@@ -1,15 +1,15 @@
 interface Parent {
-    function test() external returns (uint256);
+    function test() external pure returns (uint256);
 }
 
 interface SubA is Parent {
-    function test() external override returns (uint256);
+    function test() external pure override returns (uint256);
 }
 
 interface SubB is Parent {
-    function test() external override returns (uint256);
+    function test() external pure override returns (uint256);
 }
 
 contract C is SubA, SubB {
-    function test() external override(SubA, SubB) returns (uint256) { return 42; }
+    function test() external pure override(SubA, SubB) returns (uint256) { return 42; }
 }

--- a/test/libsolidity/syntaxTests/inheritance/interface/implementation/complete.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/implementation/complete.sol
@@ -1,17 +1,17 @@
 interface ParentA {
-    function testA() external returns (uint256);
+    function testA() external pure returns (uint256);
 }
 
 interface ParentB {
-    function testB() external returns (uint256);
+    function testB() external pure returns (uint256);
 }
 
 interface Sub is ParentA, ParentB {
-    function testSub() external returns (uint256);
+    function testSub() external pure returns (uint256);
 }
 
 contract SubImpl is Sub {
-    function testA() external override returns (uint256) { return 12; }
-    function testB() external override(ParentB) returns (uint256) { return 42; }
-    function testSub() external override returns (uint256) { return 99; }
+    function testA() external pure override returns (uint256) { return 12; }
+    function testB() external pure override(ParentB) returns (uint256) { return 42; }
+    function testSub() external pure override returns (uint256) { return 99; }
 }

--- a/test/libsolidity/syntaxTests/inheritance/override/restrict_mutability_for_override_only.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/restrict_mutability_for_override_only.sol
@@ -1,0 +1,14 @@
+contract A {
+    // no "state mutability can be restricted"-warning here
+    function foo() external virtual returns (uint) { return 1; }
+}
+contract B is A {
+    // no "state mutability can be restricted"-warning here
+    function foo() external virtual override returns (uint) { return 2; }
+}
+contract C is B {
+    // warning is here
+    function foo() external override returns (uint) { return 3; }
+}
+// ----
+// Warning 2018: (339-400): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/149_test_for_bug_override_function_with_bytearray_type.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/149_test_for_bug_override_function_with_bytearray_type.sol
@@ -5,4 +5,4 @@ contract Bike is Vehicle {
     function f(bytes calldata) override external returns (uint256 r) {r = 42;}
 }
 // ----
-// Warning 2018: (23-95): Function state mutability can be restricted to pure
+// Warning 2018: (129-203): Function state mutability can be restricted to pure


### PR DESCRIPTION
It turns out we did not warn for functions that override, but together with #3412 it makes much more sense to not warn for virtual functions instead.