### PR TITLE
Set type properly for event definition subexpressions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Compiler Features:
 Bugfixes:
  * SMTChecker: Fix internal error when using bitwise operators on fixed bytes type.
  * SMTChecker: Fix internal error when using compound bitwise operator assignments on array indices inside branches.
+ * SMTChecker: Fix error in events with indices of type static array.
  * Type Checker: Fix overload resolution in combination with ``{value: ...}``.
  * Type Checker: Fix internal compiler error related to oversized types.
  * Code Generator: Avoid double cleanup when copying to memory.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -664,7 +664,7 @@ bool TypeChecker::visit(EventDefinition const& _eventDef)
 		m_errorReporter.typeError(8598_error, _eventDef.location(), "More than 4 indexed arguments for anonymous event.");
 	else if (!_eventDef.isAnonymous() && numIndexed > 3)
 		m_errorReporter.typeError(7249_error, _eventDef.location(), "More than 3 indexed arguments for event.");
-	return false;
+	return true;
 }
 
 void TypeChecker::endVisit(FunctionTypeName const& _funType)

--- a/test/libsolidity/smtCheckerTests/types/event_with_rational_size_array.sol
+++ b/test/libsolidity/smtCheckerTests/types/event_with_rational_size_array.sol
@@ -1,0 +1,2 @@
+pragma experimental SMTChecker;
+contract a { event b(uint[(1 / 1)]); }

--- a/test/libsolidity/syntaxTests/types/event_with_rational_size_array.sol
+++ b/test/libsolidity/syntaxTests/types/event_with_rational_size_array.sol
@@ -1,0 +1,1 @@
+contract a { event b(uint[(1 / 1)]); }


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9434

Not sure if this is the correct fix. I haven't found any problems with further visiting the subexpressions of an event definition, but maybe there was a reason for that. @chriseth @axic ?