### PR TITLE
Replace acute accent with grave accent

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1306,7 +1306,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 				1719_error,
 				_statement.location(),
 				"Use of the \"var\" keyword is disallowed. "
-				"Use explicit declaration `" + createTupleDecl(variables) + " = ...´ instead."
+				"Use explicit declaration `" + createTupleDecl(variables) + " = ...` instead."
 			);
 	}
 

--- a/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
@@ -12,4 +12,4 @@ contract b {
 // Warning 2519: (105-110): This declaration shadows an existing declaration.
 // Warning 3408: (66-69): Variable "d" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
 // Warning 2332: (105-110): Type "b.c" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// SyntaxError 1719: (105-114): Use of the "var" keyword is disallowed. Use explicit declaration `struct b.c storage pointer d = ...´ instead.
+// SyntaxError 1719: (105-114): Use of the "var" keyword is disallowed. Use explicit declaration `struct b.c storage pointer d = ...` instead.

--- a/test/libsolidity/syntaxTests/types/var_type_suggest.sol
+++ b/test/libsolidity/syntaxTests/types/var_type_suggest.sol
@@ -20,11 +20,11 @@ contract C {
     }
 }
 // ----
-// SyntaxError 1719: (224-238): Use of the "var" keyword is disallowed. Use explicit declaration `int16 s = ...´ instead.
-// SyntaxError 1719: (248-261): Use of the "var" keyword is disallowed. Use explicit declaration `uint16 i = ...´ instead.
-// SyntaxError 1719: (271-287): Use of the "var" keyword is disallowed. Use explicit declaration `string memory t = ...´ instead.
-// SyntaxError 1719: (297-307): Use of the "var" keyword is disallowed. Use explicit declaration `function (uint256) pure returns (uint256) g2 = ...´ instead.
+// SyntaxError 1719: (224-238): Use of the "var" keyword is disallowed. Use explicit declaration `int16 s = ...` instead.
+// SyntaxError 1719: (248-261): Use of the "var" keyword is disallowed. Use explicit declaration `uint16 i = ...` instead.
+// SyntaxError 1719: (271-287): Use of the "var" keyword is disallowed. Use explicit declaration `string memory t = ...` instead.
+// SyntaxError 1719: (297-307): Use of the "var" keyword is disallowed. Use explicit declaration `function (uint256) pure returns (uint256) g2 = ...` instead.
 // SyntaxError 3478: (317-350): Use of the "var" keyword is disallowed. Type cannot be expressed in syntax.
-// SyntaxError 1719: (360-384): Use of the "var" keyword is disallowed. Use explicit declaration `(uint8 a, string memory b) = ...´ instead.
-// SyntaxError 1719: (394-411): Use of the "var" keyword is disallowed. Use explicit declaration `(uint256 x, , uint256 z) = ...´ instead.
+// SyntaxError 1719: (360-384): Use of the "var" keyword is disallowed. Use explicit declaration `(uint8 a, string memory b) = ...` instead.
+// SyntaxError 1719: (394-411): Use of the "var" keyword is disallowed. Use explicit declaration `(uint256 x, , uint256 z) = ...` instead.
 // TypeError 7364: (421-438): Different number of components on the left hand side (2) than on the right hand side (1).


### PR DESCRIPTION
The single acute accent, besides appearing in our code base only once, was also UTF-8 encoded, causing potential misprinting:

![utf8](https://user-images.githubusercontent.com/60588784/87993806-c2a5ea00-caeb-11ea-88cc-3151efbf218b.png)

**Side remark 1**
There seems to be just one other case where the source file contains a UTF-8 character (test/libsolidity/SolidityEndToEndTest.cpp). We may want to fix it and create a new validation rule to enforce ASCII.

**Side remark 2**
The quotation marks in messages are different. We use ` " `, ` ' `, `` ` ``. Or sometimes nothing.
The message above is using both ` " ` (`"var"`) and `` ` `` (`` `uint8 x ....`). Do we have any guidelines? 
