### PR TITLE
Update simplified chinese translation link.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ version stands as a reference.
 * `Japanese <https://solidity-jp.readthedocs.io>`_
 * `Korean <http://solidity-kr.readthedocs.io>`_ (in progress)
 * `Russian <https://github.com/ethereum/wiki/wiki/%5BRussian%5D-%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE-Solidity>`_ (rather outdated)
-* `Simplified Chinese <http://solidity-cn.readthedocs.io>`_ (in progress)
+* `Simplified Chinese <https://learnblockchain.cn/docs/solidity/>`_ (in progress)
 * `Spanish <https://solidity-es.readthedocs.io>`_
 * `Turkish <https://github.com/denizozzgur/Solidity_TR/blob/master/README.md>`_ (partial)
 


### PR DESCRIPTION
The implified chinese translation version now host on https://learnblockchain.cn/docs/solidity/ .  

This url will be keep updating .