### PR TITLE
Yul interpreter: Smaller execution timeout for tests and additional test cases

### DIFF
--- a/test/libyul/YulInterpreterTest.cpp
+++ b/test/libyul/YulInterpreterTest.cpp
@@ -87,8 +87,8 @@ bool YulInterpreterTest::parse(ostream& _stream, string const& _linePrefix, bool
 string YulInterpreterTest::interpret()
 {
 	InterpreterState state;
-	state.maxTraceSize = 10000;
-	state.maxSteps = 10000;
+	state.maxTraceSize = 10;
+	state.maxSteps = 150;
 	try
 	{
 		Interpreter::run(state, EVMDialect::strictAssemblyForEVMObjects(langutil::EVMVersion{}), *m_ast);

--- a/test/libyul/yulInterpreterTests/infinite_recursion.yul
+++ b/test/libyul/yulInterpreterTests/infinite_recursion.yul
@@ -1,0 +1,11 @@
+{
+  function f() {
+    f()
+  }
+  f()
+}
+// ----
+// Trace:
+//   Interpreter execution step limit reached.
+// Memory dump:
+// Storage dump:

--- a/test/libyul/yulInterpreterTests/infinite_recursion_tracelimit.yul
+++ b/test/libyul/yulInterpreterTests/infinite_recursion_tracelimit.yul
@@ -1,0 +1,22 @@
+{
+  function f() {
+    log0(0x0, 0x0)
+    f()
+  }
+  f()
+}
+// ----
+// Trace:
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   LOG0(0, 0)
+//   Trace size limit reached.
+// Memory dump:
+// Storage dump:

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -91,24 +91,21 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 
 	ostringstream os1;
 	ostringstream os2;
-	yulFuzzerUtil::TerminationReason termReason = yulFuzzerUtil::interpret(
+	yulFuzzerUtil::interpret(
 		os1,
 		stack.parserResult()->code,
 		EVMDialect::strictAssemblyForEVMObjects(version)
 	);
 
-	if (
-		termReason == yulFuzzerUtil::TerminationReason::StepLimitReached ||
-		termReason == yulFuzzerUtil::TerminationReason::TraceLimitReached
-	)
-		return;
-
 	stack.optimize();
-	yulFuzzerUtil::interpret(
+	yulFuzzerUtil::TerminationReason termReason = yulFuzzerUtil::interpret(
 		os2,
 		stack.parserResult()->code,
 		EVMDialect::strictAssemblyForEVMObjects(version)
 	);
+
+	if (termReason == yulFuzzerUtil::TerminationReason::StepLimitReached)
+		return;
 
 	bool isTraceEq = (os1.str() == os2.str());
 	yulAssert(isTraceEq, "Interpreted traces for optimized and unoptimized code differ.");


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/7943 (see https://github.com/ethereum/solidity/issues/7943#issuecomment-662019812)

Also do not match traces in the fuzzer if optimized code runs out of execution steps because there is no guarantee that the traces are going to be the same.