### PR TITLE
[BREAKING] Distinguish between stringLiteral and hexStringLiteral in the JSON AST

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Breaking changes:
  * Inline Assembly: Disallow ``.`` in user-defined function and variable names.
  * Inline Assembly: Slot and offset of storage pointer variable ``x`` are accessed via ``x.slot`` and ``x.offset`` instead of ``x_slot`` and ``x_offset``.
+ * JSON AST: Mark hex string literals with ``kind: "hexString"``.
  * JSON AST: Remove members with ``null`` value from JSON output.
  * Parser: Disallow ``gwei`` as identifier.
  * Parser: Disallow dot syntax for ``value`` and ``gas``.

--- a/docs/070-breaking-changes.rst
+++ b/docs/070-breaking-changes.rst
@@ -104,6 +104,7 @@ Declarations
 Interface Changes
 =================
 
+* JSON AST: Mark hex string literals with ``kind: "hexString"``.
 * JSON AST: Members with value ``null`` are removed from JSON output.
 * NatSpec: Constructors and functions have consistent userdoc output.
 

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -919,8 +919,9 @@ string ASTJsonConverter::literalTokenKind(Token _token)
 	case Token::Number:
 		return "number";
 	case Token::StringLiteral:
-	case Token::HexStringLiteral:
 		return "string";
+	case Token::HexStringLiteral:
+		return "hexString";
 	case Token::TrueLiteral:
 	case Token::FalseLiteral:
 		return "bool";

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -943,6 +943,8 @@ Token ASTJsonImporter::literalTokenKind(Json::Value const& _node)
 		tok = Token::Number;
 	else if (_node["kind"].asString() == "string")
 		tok = Token::StringLiteral;
+	else if (_node["kind"].asString() == "hexString")
+		tok = Token::HexStringLiteral;
 	else if (_node["kind"].asString() == "bool")
 		tok = (member(_node, "value").asString() == "true") ? Token::TrueLiteral : Token::FalseLiteral;
 	else

--- a/test/libsolidity/ASTJSON/non_utf8.json
+++ b/test/libsolidity/ASTJSON/non_utf8.json
@@ -79,7 +79,7 @@
                   "isConstant": false,
                   "isLValue": false,
                   "isPure": true,
-                  "kind": "string",
+                  "kind": "hexString",
                   "lValueRequested": false,
                   "nodeType": "Literal",
                   "src": "53:7:1",

--- a/test/libsolidity/ASTJSON/non_utf8_legacy.json
+++ b/test/libsolidity/ASTJSON/non_utf8_legacy.json
@@ -130,7 +130,7 @@
                         "isLValue": false,
                         "isPure": true,
                         "lValueRequested": false,
-                        "token": "string",
+                        "token": "hexString",
                         "type": "literal_string (contains invalid UTF-8 sequence at position 0)"
                       },
                       "id": 5,


### PR DESCRIPTION
Part of #9412.

The JSON AST prior to this change can not be used to completely represent the source, because the string literal kind is lost. The node also contains two values: `value` which is filled out if it is representable in JSON (and if it is, it may contain unicode escapes), and `hexValue` which is also a hex string.

This has not been a huge issue, because both string literals support unrestricted values. After #9412 this will not be possible (as the regular string literal wont accept a lot of characters), but I still felt it makes sense to do this as a separate PR. Let me know if it should be just folded into the soon-to-be-monster #9412.

I also thought about changing that behaviour of `value` using unicode escapes and things, but realised that we have to keep it in such a way because we are restricted by what is valid in JSON.