### PR TITLE
[SMTChecker] Fix tuple name for arrays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 Bugfixes:
  * Optimizer: Keep side-effects of ``x`` in ``byte(a, shr(b, x))`` even if the constants ``a`` and ``b`` would make the expression zero unconditionally. This optimizer rule is very hard if not impossible to trigger in a way that it can result in invalid code, though.
  * SMTChecker: Fix internal error in BMC function inlining.
+ * SMTChecker: Fix internal error on array implicit conversion.
  * SMTChecker: Fix internal error on fixed bytes index access.
  * References Resolver: Fix internal bug when using constructor for library.
 

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
@@ -20,6 +20,9 @@ contract LoopFor2 {
 		assert(b[0] == 900);
 	}
 }
+// ====
+// SMTSolvers: cvc4
 // ----
-// Warning 6328: (320-339): Assertion violation happens here
-// Warning 6328: (343-362): Assertion violation happens here.
+// Warning 4661: (296-316): Assertion violation happens here
+// Warning 4661: (320-339): Assertion violation happens here
+// Warning 4661: (343-362): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/array_aliasing_memory_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_aliasing_memory_1.sol
@@ -26,4 +26,4 @@ contract C
 	}
 }
 // ----
-// Warning 6328: (400-457): Assertion violation happens here
+// Warning 6328: (400-457): Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_1.sol
@@ -1,0 +1,7 @@
+pragma experimental SMTChecker;
+contract C {
+	uint[][] a;
+	function f(uint[1] memory x) public {
+		a.push(x);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_2.sol
@@ -1,0 +1,7 @@
+pragma experimental SMTChecker;
+contract C {
+	uint[][] a;
+	function f(uint[1][] memory x) public {
+		a.push(x[2]);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_3.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+contract D {
+	bytes16[] inner;
+	bytes32[][] data;
+	function t() public {
+		data.push(inner);
+	}
+}
+

--- a/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_4.sol
+++ b/test/libsolidity/smtCheckerTests/types/static_array_implicit_push_4.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+contract D {
+	int16[] inner;
+	int[][] data;
+	function t() public {
+		data.push(inner);
+	}
+}
+


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9234
Fixes https://github.com/ethereum/solidity/issues/9506

I'm not sure this fix is the best, but anyway, here's what it does:
Solidity arrays are represented in the SMT encoding as a tuple (Array Int) where the first element is the array and the second the length. This tuples needs a name because this name is used by the SMT solver to create a constructor and accessor functions for this tuple type. Solidity does implicit conversion also for arrays where the base type is implicitly convertible, so that
```
    uint8[] a;
    uint[] b;
    function f() public {
        b = a;
    }
```
is allowed. The SMT solver complains then, because `uint8[] != uint[]`.
The solution here is to ignore the size of the base type when it has a size.