### PR TITLE
[SMTChecker] Fix ICE in tuples again

### DIFF
--- a/test/libsolidity/smtCheckerTests/types/tuple_array_pop_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_array_pop_1.sol
@@ -1,0 +1,7 @@
+pragma experimental SMTChecker;
+contract C {
+	int[] a;
+	function f() public { (a).pop();}
+}
+// ----
+// Warning 2529: (78-87): Empty array "pop" detected here.

--- a/test/libsolidity/smtCheckerTests/types/tuple_array_pop_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_array_pop_2.sol
@@ -1,0 +1,7 @@
+pragma experimental SMTChecker;
+contract C {
+	int[] a;
+	function f() public { (((((a))))).pop();}
+}
+// ----
+// Warning 2529: (78-95): Empty array "pop" detected here.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9519

No Changelog because same entry from https://github.com/ethereum/solidity/pull/9515

This needs to be called here again instead of unwrapping the tuple before the whole thing because we need the `_funCall` expression as well, and that contains the tuple.