### PR TITLE
Use assert to check zero size base type

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -243,12 +243,7 @@ void DeclarationTypeChecker::endVisit(ArrayTypeName const& _typeName)
 		solAssert(!m_errorReporter.errors().empty(), "");
 		return;
 	}
-	if (baseType->storageBytes() == 0)
-		m_errorReporter.fatalTypeError(
-			6493_error,
-			_typeName.baseType().location(),
-			"Illegal base type of storage size zero for array."
-		);
+	solAssert(baseType->storageBytes() != 0, "Illegal base type of storage size zero for array.");
 	if (Expression const* length = _typeName.length())
 	{
 		TypePointer& lengthTypeGeneric = length->annotation().type;


### PR DESCRIPTION
```
if (baseType->storageBytes() == 0)
    m_errorReporter.fatalTypeError(
    . . . .
```
replaced with `solAssert`.

Checking the sources, I did not find a way to get zero from `storageBytes`. Attempts to use an empty struct or a zero-size array as a base type lead to other errors.
