### PR TITLE
Use assert to check if return tag applies to a public state-variable

### DIFF
--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -165,12 +165,7 @@ void DocStringTagParser::parseDocStrings(
 			returnTagsVisited++;
 			if (auto const* varDecl = dynamic_cast<VariableDeclaration const*>(&_node))
 			{
-				if (!varDecl->isPublic())
-					m_errorReporter.docstringParsingError(
-						9440_error,
-						_node.documentation()->location(),
-						"Documentation tag \"@" + docTag.first + "\" is only allowed on public state-variables."
-					);
+				solAssert(varDecl->isPublic(), "@return is only allowed on public state-variables.");
 				if (returnTagsVisited > 1)
 					m_errorReporter.docstringParsingError(
 						5256_error,


### PR DESCRIPTION
Used `solAssert` to check for unexpected state, instead of error reporting.
