### PR TITLE
Complete error coverage of ReferenceResolver

### DIFF
--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -231,15 +231,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 			string(".slot").size() :
 			string(".offset").size()
 		));
-		if (realName.empty())
-		{
-			m_errorReporter.declarationError(
-				4794_error,
-				_identifier.location,
-				"In variable names .slot and .offset can only be used as a suffix."
-			);
-			return;
-		}
+		solAssert(!realName.empty(), "Empty name.");
 		declarations = m_resolver.nameFromCurrentScope(realName);
 		if (!declarations.empty())
 			// To support proper path resolution, we have to use pathFromCurrentScope.

--- a/test/libsolidity/syntaxTests/natspec/invalid/docstring_inheritdoc_twice.sol
+++ b/test/libsolidity/syntaxTests/natspec/invalid/docstring_inheritdoc_twice.sol
@@ -1,0 +1,9 @@
+contract B {}
+
+contract C {
+    /// @inheritdoc B
+    /// @inheritdoc B
+    function f() internal {}
+}
+// ----
+// DocstringParsingError 5142: (32-71): Documentation tag @inheritdoc can only be given once.


### PR DESCRIPTION
Covered  `"Documentation tag @inheritdoc can only be given once."` error.

Removed `"In variable declarations _slot and _offset can not be used as a suffix."` error. Should not be relevant any longer, as `.slot` and `.offset`, contrary to `_slot` and `_offset`, are not valid identifiers. The error message also disappears in fc2e9ec.
