### PR TITLE
yul: Set non movable flag to true in simplification rule for byte of …

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Optimizer: Keep side-effects of ``x`` in ``byte(a, shr(b, x))`` even if the constants ``a`` and ``b`` would make the expression zero unconditionally. This optimizer rule is very hard if not impossible to trigger in a way that it can result in invalid code, though.
  * SMTChecker: Fix internal error on fixed bytes index access.
 
 

--- a/libevmasm/RuleList.h
+++ b/libevmasm/RuleList.h
@@ -581,9 +581,20 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart7(
 
 	rules.push_back({
 		Builtins::BYTE(A, Builtins::SHR(B, X)),
-		[=]() -> Pattern { return A.d() < B.d() / 8 ? Word(0) : Builtins::BYTE(A.d() - B.d() / 8, X); },
+		[=]() -> Pattern { return Word(0); },
+		true,
+		[=] {
+			return B.d() % 8 == 0 && A.d() < Pattern::WordSize / 8 && B.d() <= Pattern::WordSize && A.d() < B.d() / 8;
+		}
+	});
+
+	rules.push_back({
+		Builtins::BYTE(A, Builtins::SHR(B, X)),
+		[=]() -> Pattern { return Builtins::BYTE(A.d() - B.d() / 8, X); },
 		false,
-		[=] { return B.d() % 8 == 0 && A.d() < Pattern::WordSize / 8 && B.d() <= Pattern::WordSize; }
+		[=] {
+			return B.d() % 8 == 0 && A.d() < Pattern::WordSize / 8 && B.d() <= Pattern::WordSize && A.d() >= B.d() / 8;
+		}
 	});
 
 	return rules;

--- a/test/libyul/yulInterpreterTests/pop_byte_shr_call.yul
+++ b/test/libyul/yulInterpreterTests/pop_byte_shr_call.yul
@@ -1,0 +1,10 @@
+{
+  pop(byte(0, shr(0x8, call(0, 0, 0, 0, 0, 0, 0))))
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Trace:
+//   CALL(0, 0, 0, 0, 0, 0, 0)
+// Memory dump:
+// Storage dump:

--- a/test/libyul/yulInterpreterTests/pop_byte_shr_func.yul
+++ b/test/libyul/yulInterpreterTests/pop_byte_shr_func.yul
@@ -1,0 +1,11 @@
+{
+  function f() -> x { mstore(0, 0x1337) }
+  pop(byte(0, shr(0x8, f())))
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Trace:
+// Memory dump:
+//      0: 0000000000000000000000000000000000000000000000000000000000001337
+// Storage dump:

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/pop_byte_shr_call.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/pop_byte_shr_call.yul
@@ -1,0 +1,11 @@
+{
+  pop(byte(0, shr(0x8, call(0, 0, 0, 0, 0, 0, 0))))
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// step: expressionSimplifier
+//
+// {
+//     pop(byte(0, shr(0x8, call(0, 0, 0, 0, 0, 0, 0))))
+// }

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/pop_byte_shr_func.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/pop_byte_shr_func.yul
@@ -1,0 +1,14 @@
+{
+  function f() -> x { mstore(0, 1337) }
+  pop(byte(0, shr(0x8, f())))
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// step: expressionSimplifier
+//
+// {
+//     function f() -> x
+//     { mstore(0, 1337) }
+//     pop(byte(0, shr(0x8, f())))
+// }

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/pop_byte_shr_func_trivial.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/pop_byte_shr_func_trivial.yul
@@ -1,0 +1,14 @@
+{
+  function f() -> x {}
+  pop(byte(0, shr(0x8, f())))
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// step: expressionSimplifier
+//
+// {
+//     function f() -> x
+//     { }
+//     pop(byte(0, shr(0x8, f())))
+// }


### PR DESCRIPTION
…right-shifted expression

Fixes #9558 