### PR TITLE
Report error if literal is not a string for datasize/dataoffset in Yul

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ Compiler Features:
 
 Bugfixes:
  * SMTChecker: Fix internal error on fixed bytes index access.
-
+ * Yul: Report error when using non-string literals for ``datasize()`` and ``dataoffset()``.
 
 ### 0.7.0 (2020-07-28)
 

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -338,12 +338,21 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 				_funCall.functionName.name.str() == "datasize" ||
 				_funCall.functionName.name.str() == "dataoffset"
 			)
-				if (!m_dataNames.count(std::get<Literal>(arg).value))
+			{
+				auto const lit = std::get<Literal>(arg);
+				if (lit.kind != LiteralKind::String)
+					m_errorReporter.typeError(
+						9427_error,
+						_funCall.functionName.location,
+						"Data object name is expected to be a string."
+					);
+				else if (!m_dataNames.count(lit.value))
 					m_errorReporter.typeError(
 						3517_error,
 						_funCall.functionName.location,
 						"Unknown data object \"" + std::get<Literal>(arg).value.str() + "\"."
 					);
+			}
 		}
 	}
 	std::reverse(argTypes.begin(), argTypes.end());

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -258,6 +258,16 @@ BOOST_AUTO_TEST_CASE(arg_to_dataoffset_must_be_literal)
 	CHECK_ERROR(code, TypeError, "Function expects direct literals as arguments.");
 }
 
+BOOST_AUTO_TEST_CASE(arg_to_dataoffset_must_be_string_literal)
+{
+	string code = R"(
+		object "outer" {
+			code { let y := dataoffset(0) }
+		}
+	)";
+	CHECK_ERROR(code, TypeError, "Data object name is expected to be a string.");
+}
+
 BOOST_AUTO_TEST_CASE(arg_to_datasize_must_be_literal)
 {
 	string code = R"(
@@ -266,6 +276,16 @@ BOOST_AUTO_TEST_CASE(arg_to_datasize_must_be_literal)
 		}
 	)";
 	CHECK_ERROR(code, TypeError, "Function expects direct literals as arguments.");
+}
+
+BOOST_AUTO_TEST_CASE(arg_to_datasize_must_be_string_literal)
+{
+	string code = R"(
+		object "outer" {
+			code { let y := datasize(0) }
+		}
+	)";
+	CHECK_ERROR(code, TypeError, "Data object name is expected to be a string.");
 }
 
 BOOST_AUTO_TEST_CASE(args_to_datacopy_are_arbitrary)

--- a/test/libyul/yulSyntaxTests/datacopy.yul
+++ b/test/libyul/yulSyntaxTests/datacopy.yul
@@ -1,0 +1,12 @@
+{
+    datacopy(0, 1, 2)
+    datasize("")
+    datasize(0) // This should not be valid.
+    dataoffset("")
+    dataoffset(0) // This should not be valid.
+}
+// ----
+// TypeError 3517: (28-36): Unknown data object "".
+// TypeError 9427: (45-53): Data object name is expected to be a string.
+// TypeError 3517: (90-100): Unknown data object "".
+// TypeError 9427: (109-119): Data object name is expected to be a string.


### PR DESCRIPTION
Pulled out of #9549.