### PR TITLE
Require inheritdoc tag to be non-empty.

### DIFF
--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -313,6 +313,16 @@ void ReferencesResolver::resolveInheritDoc(StructuredDocumentation const& _docum
 	case 1:
 	{
 		string const& name = _annotation.docTags.find("inheritdoc")->second.content;
+		if (name.empty())
+		{
+			m_errorReporter.docstringParsingError(
+				1933_error,
+				_documentation.location(),
+				"Expected contract name following documentation tag @inheritdoc."
+			);
+			return;
+		}
+
 		vector<string> path;
 		boost::split(path, name, boost::is_any_of("."));
 		Declaration const* result = m_resolver.pathFromCurrentScope(path);

--- a/test/libsolidity/syntaxTests/natspec/invalid/docstring_inheritdoc_emptys.sol
+++ b/test/libsolidity/syntaxTests/natspec/invalid/docstring_inheritdoc_emptys.sol
@@ -1,0 +1,7 @@
+contract C {
+    /// @inheritdoc
+    function f() internal {
+    }
+}
+// ----
+// DocstringParsingError 1933: (17-32): Expected contract name following documentation tag @inheritdoc.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9560