### PR TITLE
Rename libsolidity/SolidityScanner to liblangutil/Scanner in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ detect_stray_source_files("${libevmasm_sources}" "libevmasm/")
 
 set(liblangutil_sources
     liblangutil/CharStream.cpp
+    liblangutil/Scanner.cpp
     liblangutil/SourceLocation.cpp
 )
 detect_stray_source_files("${liblangutil_sources}" "liblangutil/")
@@ -92,7 +93,6 @@ set(libsolidity_sources
     libsolidity/SolidityNatspecJSON.cpp
     libsolidity/SolidityOptimizer.cpp
     libsolidity/SolidityParser.cpp
-    libsolidity/SolidityScanner.cpp
     libsolidity/SolidityTypes.cpp
     libsolidity/StandardCompiler.cpp
     libsolidity/SyntaxTest.cpp

--- a/test/liblangutil/CharStream.cpp
+++ b/test/liblangutil/CharStream.cpp
@@ -31,7 +31,7 @@
 namespace solidity::langutil::test
 {
 
-BOOST_AUTO_TEST_SUITE(CharStreamtest)
+BOOST_AUTO_TEST_SUITE(CharStreamTest)
 
 BOOST_AUTO_TEST_CASE(test_fail)
 {

--- a/test/liblangutil/Scanner.cpp
+++ b/test/liblangutil/Scanner.cpp
@@ -21,15 +21,16 @@
  */
 
 #include <liblangutil/Scanner.h>
+
 #include <boost/test/unit_test.hpp>
 
 using namespace std;
 using namespace solidity::langutil;
 
-namespace solidity::frontend::test
+namespace solidity::langutil::test
 {
 
-BOOST_AUTO_TEST_SUITE(SolidityScanner)
+BOOST_AUTO_TEST_SUITE(ScannerTest)
 
 BOOST_AUTO_TEST_CASE(test_empty)
 {

--- a/test/libyul/EwasmTranslationTest.cpp
+++ b/test/libyul/EwasmTranslationTest.cpp
@@ -28,6 +28,7 @@
 #include <libyul/AsmParser.h>
 #include <libyul/AssemblyStack.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/Object.h>
 
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/SourceReferenceFormatter.h>

--- a/test/libyul/EwasmTranslationTest.h
+++ b/test/libyul/EwasmTranslationTest.h
@@ -19,13 +19,17 @@
 #pragma once
 
 #include <test/TestCase.h>
-#include <libyul/Object.h>
 
 namespace solidity::langutil
 {
 class Scanner;
 class Error;
 using ErrorList = std::vector<std::shared_ptr<Error const>>;
+}
+
+namespace solidity::yul
+{
+struct Object;
 }
 
 namespace solidity::yul::test


### PR DESCRIPTION
The scanner is not only a solidity scanner.