### PR TITLE
Don't run old codegen, when not needed, in CompilerStack, StandardCompiler and tests.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * Standard JSON Interface: Do not run EVM bytecode code generation, if only Yul IR or EWasm output is requested.
  * Yul: Report error when using non-string literals for ``datasize()``, ``dataoffset()``, ``linkersymbol()``, ``loadimmutable()``, ``setimmutable()``.
 
 Bugfixes:

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -85,9 +85,6 @@ static int g_compilerStackCounts = 0;
 CompilerStack::CompilerStack(ReadCallback::Callback _readFile):
 	m_readFile{std::move(_readFile)},
 	m_enabledSMTSolvers{smtutil::SMTSolverChoice::All()},
-	m_generateIR{false},
-	m_generateEwasm{false},
-	m_errorList{},
 	m_errorReporter{m_errorList}
 {
 	// Because TypeProvider is currently a singleton API, we must ensure that
@@ -518,7 +515,8 @@ bool CompilerStack::compile()
 				{
 					try
 					{
-						compileContract(*contract, otherCompilers);
+						if (m_generateEvmBytecode)
+							compileContract(*contract, otherCompilers);
 					}
 					catch (Error const& _error)
 					{

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -176,6 +176,9 @@ public:
 		m_requestedContractNames = _contractNames;
 	}
 
+	/// Enable EVM Bytecode generation. This is enabled by default.
+	void enableEvmBytecodeGeneration(bool _enable = true) { m_generateEvmBytecode = _enable; }
+
 	/// Enable experimental generation of Yul IR code.
 	void enableIRGeneration(bool _enable = true) { m_generateIR = _enable; }
 
@@ -440,8 +443,9 @@ private:
 	langutil::EVMVersion m_evmVersion;
 	smtutil::SMTSolverChoice m_enabledSMTSolvers;
 	std::map<std::string, std::set<std::string>> m_requestedContractNames;
-	bool m_generateIR;
-	bool m_generateEwasm;
+	bool m_generateEvmBytecode = true;
+	bool m_generateIR = false;
+	bool m_generateEwasm = false;
 	std::map<std::string, util::h160> m_libraries;
 	/// list of path prefix remappings, e.g. mylibrary: github.com/ethereum = /usr/local/ethereum
 	/// "context:prefix=target"

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -257,6 +257,30 @@ bool isBinaryRequested(Json::Value const& _outputSelection)
 	return false;
 }
 
+/// @returns true if EVM bytecode was requested, i.e. we have to run the old code generator.
+bool isEvmBytecodeRequested(Json::Value const& _outputSelection)
+{
+	if (!_outputSelection.isObject())
+		return false;
+
+	static vector<string> const outputsThatRequireEvmBinaries{
+		"*",
+		"evm.deployedBytecode", "evm.deployedBytecode.object", "evm.deployedBytecode.opcodes",
+		"evm.deployedBytecode.sourceMap", "evm.deployedBytecode.linkReferences",
+		"evm.deployedBytecode.immutableReferences",
+		"evm.bytecode", "evm.bytecode.object", "evm.bytecode.opcodes", "evm.bytecode.sourceMap",
+		"evm.bytecode.linkReferences",
+		"evm.gasEstimates", "evm.legacyAssembly", "evm.assembly"
+	};
+
+	for (auto const& fileRequests: _outputSelection)
+		for (auto const& requests: fileRequests)
+			for (auto const& output: outputsThatRequireEvmBinaries)
+				if (isArtifactRequested(requests, output, false))
+					return true;
+	return false;
+}
+
 /// @returns true if any Ewasm code was requested. Note that as an exception, '*' does not
 /// yet match "ewasm.wast" or "ewasm"
 bool isEwasmRequested(Json::Value const& _outputSelection)
@@ -840,8 +864,8 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 	compilerStack.setMetadataHash(_inputsAndSettings.metadataHash);
 	compilerStack.setRequestedContractNames(requestedContractNames(_inputsAndSettings.outputSelection));
 
+	compilerStack.enableEvmBytecodeGeneration(isEvmBytecodeRequested(_inputsAndSettings.outputSelection));
 	compilerStack.enableIRGeneration(isIRRequested(_inputsAndSettings.outputSelection));
-
 	compilerStack.enableEwasmGeneration(isEwasmRequested(_inputsAndSettings.outputSelection));
 
 	Json::Value errors = std::move(_inputsAndSettings.errors);

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -48,6 +48,7 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 	m_compiler.setRevertStringBehaviour(m_revertStrings);
 	m_compiler.setEVMVersion(m_evmVersion);
 	m_compiler.setOptimiserSettings(m_optimiserSettings);
+	m_compiler.enableEvmBytecodeGeneration(!m_compileViaYul);
 	m_compiler.enableIRGeneration(m_compileViaYul);
 	m_compiler.setRevertStringBehaviour(m_revertStrings);
 	if (!m_compiler.compile())


### PR DESCRIPTION
Needed to properly enable https://github.com/ethereum/solidity/pull/9162
Part of https://github.com/ethereum/solidity/issues/9579, but excluding the CLI for now.