### PR TITLE
[docs] Fix broken and outdated links

### DIFF
--- a/docs/brand-guide.rst
+++ b/docs/brand-guide.rst
@@ -43,7 +43,7 @@ Solidity Logo License
   :alt: Creative Commons License
 
 The Solidity logo is distributed and licensed under a `Creative Commons
-Attribution 4.0 International License <http://creativecommons.org/licenses/by/4.0/>`_.
+Attribution 4.0 International License <https://creativecommons.org/licenses/by/4.0/>`_.
 
 This is the most permissive Creative Commons license and allows reuse
 and modifications for any purpose.

--- a/docs/contracts/constant-state-variables.rst
+++ b/docs/contracts/constant-state-variables.rst
@@ -21,7 +21,7 @@ is copied to all the places in the code where they are accessed. For these value
 can sometimes be cheaper than immutable values.
 
 Not all types for constants and immutables are implemented at this time. The only supported types are
-`strings <strings>`_ (only for constants) and `value types <value-types>`_.
+:ref:`strings <strings>` (only for constants) and :ref:`value types <value-types>`.
 
 ::
 

--- a/docs/contracts/events.rst
+++ b/docs/contracts/events.rst
@@ -160,6 +160,6 @@ where the long hexadecimal number is equal to
 Additional Resources for Understanding Events
 ==============================================
 
-- `Javascript documentation <https://github.com/ethereum/wiki/wiki/JavaScript-API#contract-events>`_
+- `Javascript documentation <https://github.com/ethereum/web3.js/blob/1.x/docs/web3-eth-contract.rst#events>`_
 - `Example usage of events <https://github.com/debris/smart-exchange/blob/master/lib/contracts/SmartExchange.sol>`_
 - `How to access them in js <https://github.com/debris/smart-exchange/blob/master/lib/exchange_transactions.js>`_

--- a/docs/contracts/events.rst
+++ b/docs/contracts/events.rst
@@ -161,5 +161,5 @@ Additional Resources for Understanding Events
 ==============================================
 
 - `Javascript documentation <https://github.com/ethereum/web3.js/blob/1.x/docs/web3-eth-contract.rst#events>`_
-- `Example usage of events <https://github.com/debris/smart-exchange/blob/master/lib/contracts/SmartExchange.sol>`_
-- `How to access them in js <https://github.com/debris/smart-exchange/blob/master/lib/exchange_transactions.js>`_
+- `Example usage of events <https://github.com/ethchange/smart-exchange/blob/master/lib/contracts/SmartExchange.sol>`_
+- `How to access them in js <https://github.com/ethchange/smart-exchange/blob/master/lib/exchange_transactions.js>`_

--- a/docs/contracts/inheritance.rst
+++ b/docs/contracts/inheritance.rst
@@ -331,7 +331,7 @@ Modifier Overriding
 ===================
 
 Function modifiers can override each other. This works in the same way as
-`function overriding <function-overriding>`_ (except that there is no overloading for modifiers). The
+:ref:`function overriding <function-overriding>` (except that there is no overloading for modifiers). The
 ``virtual`` keyword must be used on the overridden modifier
 and the ``override`` keyword must be used in the overriding modifier:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -254,7 +254,7 @@ inside the input. We have a specialized binary called ``solfuzzer`` which takes 
 and fails whenever it encounters an internal compiler error, segmentation fault or similar, but
 does not fail if e.g., the code contains an error. This way, fuzzing tools can find internal problems in the compiler.
 
-We mainly use `AFL <http://lcamtuf.coredump.cx/afl/>`_ for fuzzing. You need to download and
+We mainly use `AFL <https://lcamtuf.coredump.cx/afl/>`_ for fuzzing. You need to download and
 install the AFL packages from your repositories (afl, afl-clang) or build them manually.
 Next, build Solidity (or just the ``solfuzzer`` binary) with AFL as your compiler:
 
@@ -388,7 +388,7 @@ local slang and references, making your language as clear to all readers as poss
 Title Case for Headings
 -----------------------
 
-Use `title case <http://titlecase.com>`_ for headings. This means capitalise all principal words in
+Use `title case <https://titlecase.com>`_ for headings. This means capitalise all principal words in
 titles, but not articles, conjunctions, and prepositions unless they start the
 title.
 

--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -114,7 +114,7 @@ In general, ECDSA signatures consist of two parameters,
 parameter called ``v``, that you can use to verify which
 account's private key was used to sign the message, and
 the transaction's sender. Solidity provides a built-in
-function `ecrecover <mathematical-and-cryptographic-functions>`_ that
+function :ref:`ecrecover <mathematical-and-cryptographic-functions>` that
 accepts a message along with the ``r``, ``s`` and ``v`` parameters
 and returns the address that was used to sign the message.
 
@@ -127,7 +127,7 @@ apart. You can do this on the client-side, but doing it inside
 the smart contract means you only need to send one signature
 parameter rather than three. Splitting apart a byte array into
 its constituent parts is a mess, so we use
-`inline assembly <assembly>`_ to do the job in the ``splitSignature``
+:doc:`inline assembly <assembly>` to do the job in the ``splitSignature``
 function (the third function in the full contract at the end of this section).
 
 Computing the Message Hash

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,10 +72,10 @@ Community volunteers help translate this documentation into several languages.
 They have varying degrees of completeness and up-to-dateness. The English
 version stands as a reference.
 
-* `French <http://solidity-fr.readthedocs.io>`_ (in progress)
+* `French <https://solidity-fr.readthedocs.io>`_ (in progress)
 * `Italian <https://github.com/damianoazzolini/solidity>`_ (in progress)
 * `Japanese <https://solidity-jp.readthedocs.io>`_
-* `Korean <http://solidity-kr.readthedocs.io>`_ (in progress)
+* `Korean <https://solidity-kr.readthedocs.io>`_ (in progress)
 * `Russian <https://github.com/ethereum/wiki/wiki/%5BRussian%5D-%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE-Solidity>`_ (rather outdated)
 * `Simplified Chinese <https://learnblockchain.cn/docs/solidity/>`_ (in progress)
 * `Spanish <https://solidity-es.readthedocs.io>`_

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -205,7 +205,7 @@ The following are dependencies for all builds of Solidity:
 | `cvc4`_ (Optional)                | For use with SMT checker.                             |
 +-----------------------------------+-------------------------------------------------------+
 
-.. _cvc4: http://cvc4.cs.stanford.edu/web/
+.. _cvc4: https://cvc4.cs.stanford.edu/web/
 .. _Git: https://git-scm.com/download
 .. _Boost: https://www.boost.org
 .. _CMake: https://cmake.org/download/
@@ -243,7 +243,7 @@ command-line builds:
 
     sudo xcodebuild -license accept
 
-Our OS X build script uses `the Homebrew <http://brew.sh>`_
+Our OS X build script uses `the Homebrew <https://brew.sh>`_
 package manager for installing external dependencies.
 Here's how to `uninstall Homebrew
 <https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew>`_,

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -246,7 +246,7 @@ command-line builds:
 Our OS X build script uses `the Homebrew <http://brew.sh>`_
 package manager for installing external dependencies.
 Here's how to `uninstall Homebrew
-<https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md#how-do-i-uninstall-homebrew>`_,
+<https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew>`_,
 if you ever want to start again from scratch.
 
 Prerequisites - Windows

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -285,7 +285,7 @@ likely it will be.
     since it is not up to the submitter of a transaction, but up to the miners to determine in which block the transaction is included.
 
     If you want to schedule future calls of your contract, you can use
-    the `alarm clock <http://www.ethereum-alarm-clock.com/>`_ or a similar oracle service.
+    the `alarm clock <https://www.ethereum-alarm-clock.com/>`_ or a similar oracle service.
 
 .. _the-ethereum-virtual-machine:
 

--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -22,7 +22,7 @@ Every source file should start with a comment indicating its license:
 
 The compiler does not validate that the license is part of the
 `list allowed by SPDX <https://spdx.org/licenses/>`_, but
-it does include the supplied string in the `bytecode metadata <metadata>`_.
+it does include the supplied string in the :ref:`bytecode metadata <metadata>`.
 
 If you do not want to specify a license or if the source code is
 not open-source, please use the special value ``UNLICENSED``.

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -202,6 +202,6 @@ This automatically verifies the metadata since its hash is part of the bytecode.
 Excess data corresponds to the constructor input data, which should be decoded
 according to the interface and presented to the user.
 
-In the repository `source-verify <https://github.com/ethereum/source-verify>`_
+In the repository `sourcify <https://github.com/ethereum/sourcify>`_
 (`npm package <https://www.npmjs.com/package/source-verify>`_) you can see
 example code that shows how to use this feature.

--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -36,7 +36,7 @@ for the purposes of NatSpec.
 
 -  For Vyper, use ``"""`` indented to the inner contents with bare
    comments. See `Vyper
-   documentation <https://vyper.readthedocs.io/en/latest/structure-of-a-contract.html#natspec-metadata>`__.
+   documentation <https://vyper.readthedocs.io/en/latest/natspec.html>`__.
 
 The following example shows a contract and a function using all available tags.
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -80,7 +80,7 @@ Solidity Integrations
 
 * Visual Studio Code:
 
-    * `Visual Studio Code extension <http://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
+    * `Visual Studio Code extension <https://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
         Solidity plugin for Microsoft Visual Studio Code that includes syntax highlighting and the Solidity compiler.
 
 Discontinued:

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -75,7 +75,7 @@ Solidity Integrations
     * `Vim Solidity <https://github.com/tomlion/vim-solidity/>`_
         Plugin for the Vim editor providing syntax highlighting.
 
-    * `Vim Syntastic <https://github.com/scrooloose/syntastic>`_
+    * `Vim Syntastic <https://github.com/vim-syntastic/syntastic>`_
         Plugin for the Vim editor providing compile checking.
 
 * Visual Studio Code:
@@ -145,5 +145,5 @@ Third-Party Solidity Parsers and Grammars
 * `solidity-parser <https://github.com/ConsenSys/solidity-parser>`_
     Solidity parser for JavaScript
 
-* `Solidity Grammar for ANTLR 4 <https://github.com/federicobond/solidity-antlr4>`_
+* `Solidity Grammar for ANTLR 4 <https://github.com/solidityj/solidity-antlr4>`_
     Solidity grammar for the ANTLR 4 parser generator

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -83,17 +83,6 @@ Solidity Integrations
     * `Visual Studio Code extension <https://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
         Solidity plugin for Microsoft Visual Studio Code that includes syntax highlighting and the Solidity compiler.
 
-Discontinued:
-
-* `Mix IDE <https://github.com/ethereum/mix/>`_
-    Qt based IDE for designing, debugging and testing solidity smart contracts.
-
-* `Ethereum Studio <https://live.ether.camp/>`_
-    Specialized web IDE that also provides shell access to a complete Ethereum environment.
-
-* `Visual Studio Extension <https://visualstudiogallery.msdn.microsoft.com/96221853-33c4-4531-bdd5-d2ea5acc4799/>`_
-    Solidity plugin for Microsoft Visual Studio that includes the Solidity compiler.
-
 Solidity Tools
 ~~~~~~~~~~~~~~
 
@@ -142,8 +131,5 @@ Solidity Tools
 Third-Party Solidity Parsers and Grammars
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* `solidity-parser <https://github.com/ConsenSys/solidity-parser>`_
-    Solidity parser for JavaScript
-
-* `Solidity Grammar for ANTLR 4 <https://github.com/solidityj/solidity-antlr4>`_
-    Solidity grammar for the ANTLR 4 parser generator
+* `Solidity Parser for JavaScript <https://github.com/solidity-parser/parser>`_
+    A Solidity parser for JS built on top of a robust ANTLR4 grammar.

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -259,7 +259,7 @@ more special edge cases for signed numbers.
 
 Try to use ``require`` to limit the size of inputs to a reasonable range and use the
 :ref:`SMT checker<smt_checker>` to find potential overflows, or use a library like
-`SafeMath <https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol>`_
+`SafeMath <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/math/SafeMath.sol>`_
 if you want all overflows to cause a revert.
 
 Code such as ``require((balanceOf[_to] + _value) >= balanceOf[_to])`` can also help you check if values are what you expect.

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1145,7 +1145,7 @@ NatSpec
 Solidity contracts can have a form of comments that are the basis of the
 Ethereum Natural Language Specification Format.
 
-Add comments above functions or contracts following `doxygen <http://www.doxygen.nl>`_ notation
+Add comments above functions or contracts following `doxygen <https://www.doxygen.nl>`_ notation
 of one or multiple lines starting with ``///`` or a
 multiline comment starting with ``/**`` and ending with ``*/``.
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1149,7 +1149,7 @@ Add comments above functions or contracts following `doxygen <http://www.doxygen
 of one or multiple lines starting with ``///`` or a
 multiline comment starting with ``/**`` and ending with ``*/``.
 
-For example, the contract from `a simple smart contract <simple-smart-contract>`_ with the comments
+For example, the contract from :ref:`a simple smart contract <simple-smart-contract>` with the comments
 added looks like the one below::
 
     // SPDX-License-Identifier: GPL-3.0
@@ -1176,6 +1176,6 @@ added looks like the one below::
         }
     }
 
-It is recommended that Solidity contracts are fully annotated using `NatSpec <natspec>`_ for all public interfaces (everything in the ABI).
+It is recommended that Solidity contracts are fully annotated using :ref:`NatSpec <natspec>` for all public interfaces (everything in the ABI).
 
-Please see the section about `NatSpec <natspec>`_ for a detailed explanation.
+Please see the section about :ref:`NatSpec <natspec>` for a detailed explanation.

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -201,7 +201,7 @@ Mathematical and Cryptographic Functions
 
     If you use ``ecrecover``, be aware that a valid signature can be turned into a different valid signature without
     requiring knowledge of the corresponding private key. In the Homestead hard fork, this issue was fixed
-    for _transaction_ signatures (see `EIP-2 <http://eips.ethereum.org/EIPS/eip-2#specification>`_), but
+    for _transaction_ signatures (see `EIP-2 <https://eips.ethereum.org/EIPS/eip-2#specification>`_), but
     the ecrecover function remained unchanged.
 
     This is usually not a problem unless you require signatures to be unique or

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -205,7 +205,7 @@ Mathematical and Cryptographic Functions
     the ecrecover function remained unchanged.
 
     This is usually not a problem unless you require signatures to be unique or
-    use them to identify items. OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.org/v2.3.0/api/cryptography#ecdsa>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
+    use them to identify items. OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.com/contracts/2.x/api/cryptography#ECDSA>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
 
 .. note::
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -195,7 +195,7 @@ Mathematical and Cryptographic Functions
     ``ecrecover`` returns an ``address``, and not an ``address payable``. See :ref:`address payable<address>` for
     conversion, in case you need to transfer funds to the recovered address.
 
-    For further details, read `example usage <https://ethereum.stackexchange.com/q/1777/222>`_.
+    For further details, read `example usage <https://ethereum.stackexchange.com/questions/1777/workflow-on-signing-a-string-with-private-key-followed-by-signature-verificatio>`_.
 
 .. warning::
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -160,6 +160,8 @@ more details on error handling and when to use which function.
 
 .. index:: keccak256, ripemd160, sha256, ecrecover, addmod, mulmod, cryptography,
 
+.. _mathematical-and-cryptographic-functions:
+
 Mathematical and Cryptographic Functions
 ----------------------------------------
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -101,7 +101,7 @@ case $(uname -s) in
         esac
 
         # Check for Homebrew install and abort if it is not installed.
-        brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - solidity requires a Homebrew install.  See http://brew.sh."; exit 1; }
+        brew -v > /dev/null 2>&1 || { echo >&2 "ERROR - solidity requires a Homebrew install.  See https://brew.sh."; exit 1; }
         brew update
         brew install boost
         brew install cmake


### PR DESCRIPTION
Resolves #9580.

In case of the internal links the problem was caused by using `` `title <url>`_ `` syntax and putting in an anchor name instead of an  URL (e.g. `` `strings <strings>`_ ``). The correct form would be `` :ref:`strings <strings>` `` for an internal refefence and `` :doc:`strings <strings>` `` to link to a local file called `docs.rst`. See [Sphinx docs > Cross-referencing syntax](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-syntax).

This is something that will keep popping up so I tried to find a way for Sphinx to detect this error for us automatically but unfortunately it's not that easy. Broken links are only detected if you use the `:ref:`/`:doc:` syntax. We could use the `linkcheck` to find broken links by running this from the `docs/` directory:
``` bash
sphinx-build -b linkcheck . _build/html
```
The problem with it is that it finds too many false-positives. For example it tries to check `https://github.com/ethereum/solidity/releases/download/v0.X.Y/solidity_0.X.Y.tar.gz` which only used in a code snippet. It also reports anchors on github as broken because they use `href="#anchor"` rather than `id="anchor"` (example: https://github.com/ethereum/solc-js#example-usage-with-smtsolver-callback).

In the end I gave up and just reviewed the output of `linkcheck` manually. There were quite a few broken or outdated links and this PR fixes them.