### PR TITLE
[docs] Fix solidity code blocks using incorrect highlighter name

### DIFF
--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -46,7 +46,7 @@ The following example shows a contract and a function using all available tags.
   public. You are welcome to use similar comments for your internal and
   private functions, but those will not be parsed.
 
-.. code:: solidity
+.. code:: Solidity
 
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >0.6.10 <0.8.0;
@@ -126,7 +126,7 @@ JSON output, for example the end-user client software, may present this to the e
 
 For example, some client software will render:
 
-.. code:: solidity
+.. code:: Solidity
 
    /// @notice This function will multiply `a` by 7
 

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -637,7 +637,7 @@ Example
 
 Assume that you have the following contract in ``Source.sol``:
 
-.. code-block:: solidity
+.. code-block:: Solidity
 
     pragma solidity >=0.6.0 <0.6.4;
     // This will not compile after 0.7.0
@@ -691,7 +691,7 @@ It is recommended to explicitly specify the upgrade modules by using ``--modules
 The command above applies all changes as shown below. Please review them carefully (the pragmas will
 have to be updated manually.)
 
-.. code-block:: solidity
+.. code-block:: Solidity
 
     pragma solidity >0.6.99 <0.8.0;
     // SPDX-License-Identifier: GPL-3.0


### PR DESCRIPTION
Found while fixing #9580 / #9587.

Apparently the language name must be capitalized. Otherwise `scripts/docs.sh` exits with an error (exit code = 2):

```
Warning, treated as error:
/home/cameel/data/working-set/projects/solidity/docs/natspec-format.rst:49:Could not lex literal_block as "solidity". Highlighting skipped.
```

What's weird though - why doesn't it fail in CI? We do run the script in: https://github.com/ethereum/solidity/blob/v0.7.0/.circleci/config.yml#L635-L646
`sphinx` itself is is not listed in `docs/requirements.txt` so maybe CircleCI is running some outdated version?