### PR TITLE
Update tests/documentation to show that hex literals are not supported in Yul

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -476,9 +476,8 @@ which are explained in their own chapter.
     TypeName = Identifier
     TypedIdentifierList = Identifier ( ':' TypeName )? ( ',' Identifier ( ':' TypeName )? )*
     Literal =
-        (NumberLiteral | StringLiteral | HexLiteral | TrueLiteral | FalseLiteral) ( ':' TypeName )?
+        (NumberLiteral | StringLiteral | TrueLiteral | FalseLiteral) ( ':' TypeName )?
     NumberLiteral = HexNumber | DecimalNumber
-    HexLiteral = 'hex' ('"' ([0-9a-fA-F]{2})* '"' | '\'' ([0-9a-fA-F]{2})* '\'')
     StringLiteral = '"' ([^"\r\n\\] | '\\' .)* '"'
     TrueLiteral = 'true'
     FalseLiteral = 'false'
@@ -688,8 +687,6 @@ We will use a destructuring notation for the AST nodes.
         L'[$parami] = vi and L'[$reti] = 0 for all i.
         Let G'', L'', mode = E(Gn, L', block)
         G'', Ln, L''[$ret1], ..., L''[$retm]
-    E(G, L, l: HexLiteral) = G, L, hexString(l),
-        where hexString decodes l from hex and left-aligns it into 32 bytes
     E(G, L, l: StringLiteral) = G, L, utf8EncodeLeftAligned(l),
         where utf8EncodeLeftAligned performs a utf8 encoding of l
         and aligns it left into 32 bytes

--- a/test/libsolidity/syntaxTests/inlineAssembly/hex_assignment.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/hex_assignment.sol
@@ -1,0 +1,9 @@
+contract C {
+  function f() public pure {
+    assembly {
+      let x := hex"0011"
+    }
+  }
+}
+// ----
+// ParserError 1856: (72-81): Literal or identifier expected.

--- a/test/libsolidity/syntaxTests/inlineAssembly/hex_expression.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/hex_expression.sol
@@ -1,0 +1,9 @@
+contract C {
+  function f() public pure {
+    assembly {
+      pop(hex"2233")
+    }
+  }
+}
+// ----
+// ParserError 1856: (67-76): Literal or identifier expected.

--- a/test/libsolidity/syntaxTests/inlineAssembly/hex_switch_case.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/hex_switch_case.sol
@@ -1,0 +1,11 @@
+contract C {
+  function f() public pure {
+    assembly {
+      switch codesize()
+      case hex"00" {}
+      case hex"1122" {}
+    }
+  }
+}
+// ----
+// ParserError 1856: (92-99): Literal or identifier expected.

--- a/test/libsolidity/syntaxTests/inlineAssembly/string_literal_switch_case.yul
+++ b/test/libsolidity/syntaxTests/inlineAssembly/string_literal_switch_case.yul
@@ -1,0 +1,9 @@
+contract C {
+  function f() public pure {
+    assembly {
+      switch codesize()
+      case "1" {}
+      case "2" {}
+    }
+  }
+}

--- a/test/libyul/yulSyntaxTests/hex_assignment.yul
+++ b/test/libyul/yulSyntaxTests/hex_assignment.yul
@@ -1,0 +1,5 @@
+{
+    let x := hex"0011"
+}
+// ----
+// ParserError 1856: (15-24): Literal or identifier expected.

--- a/test/libyul/yulSyntaxTests/hex_expression.yul
+++ b/test/libyul/yulSyntaxTests/hex_expression.yul
@@ -1,0 +1,5 @@
+{
+    pop(hex"2233")
+}
+// ----
+// ParserError 1856: (10-19): Literal or identifier expected.

--- a/test/libyul/yulSyntaxTests/hex_switch_case.yul
+++ b/test/libyul/yulSyntaxTests/hex_switch_case.yul
@@ -1,0 +1,7 @@
+{
+    switch codesize()
+    case hex"00" {}
+    case hex"1122" {}
+}
+// ----
+// ParserError 1856: (33-40): Literal or identifier expected.

--- a/test/libyul/yulSyntaxTests/string_literal_switch_case.yul
+++ b/test/libyul/yulSyntaxTests/string_literal_switch_case.yul
@@ -1,0 +1,5 @@
+{
+    switch codesize()
+    case "1" {}
+    case "2" {}
+}


### PR DESCRIPTION
Fixes #8816.