### PR TITLE
Correct immutableReferences documentation from array to object

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -441,11 +441,11 @@ Output Description
               },
               "deployedBytecode": {
                 ..., // The same layout as above.
-                "immutableReferences": [
+                "immutableReferences": {
                   // There are two references to the immutable with AST ID 3, both 32 bytes long. One is
                   // at bytecode offset 42, the other at bytecode offset 80.
                   "3": [{ "start": 42, "length": 32 }, { "start": 80, "length": 32 }]
-                ]
+                }
               },
               // The list of function hashes
               "methodIdentifiers": {


### PR DESCRIPTION
Just noticed this mistake in the documentation.  Figured this is simple enough it made sense for me to open a PR directly rather than opening an issue.  Thanks!