### PR TITLE
Fixes compilation with MSVC.

### DIFF
--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -37,7 +37,10 @@
 #include <utility>
 #include <type_traits>
 
-/// Operators need to stay in the global namespace.
+namespace std
+{
+
+/// Operator overloads for STL containers should be in std namespace for ADL to work properly.
 
 /// Concatenate the contents of a container onto a vector
 template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U& _b)
@@ -78,6 +81,7 @@ template <class U, class... T> std::set<T...>& operator+=(std::set<T...>& _a, U&
 		_a.insert(std::move(x));
 	return _a;
 }
+
 /// Concatenate two vectors of elements.
 template <class T>
 inline std::vector<T> operator+(std::vector<T> const& _a, std::vector<T> const& _b)
@@ -86,6 +90,7 @@ inline std::vector<T> operator+(std::vector<T> const& _a, std::vector<T> const& 
 	ret += _b;
 	return ret;
 }
+
 /// Concatenate two vectors of elements, moving them.
 template <class T>
 inline std::vector<T> operator+(std::vector<T>&& _a, std::vector<T>&& _b)
@@ -97,6 +102,7 @@ inline std::vector<T> operator+(std::vector<T>&& _a, std::vector<T>&& _b)
 		ret += std::move(_b);
 	return ret;
 }
+
 /// Concatenate something to a sets of elements.
 template <class T, class U>
 inline std::set<T> operator+(std::set<T> const& _a, U&& _b)
@@ -105,6 +111,7 @@ inline std::set<T> operator+(std::set<T> const& _a, U&& _b)
 	ret += std::forward<U>(_b);
 	return ret;
 }
+
 /// Concatenate something to a sets of elements, move variant.
 template <class T, class U>
 inline std::set<T> operator+(std::set<T>&& _a, U&& _b)
@@ -139,6 +146,8 @@ inline std::multiset<T...>& operator-=(std::multiset<T...>& _a, C const& _b)
 		_a.erase(x);
 	return _a;
 }
+
+} // end namespace std
 
 namespace solidity::util
 {


### PR DESCRIPTION
operator overloads for std::vector, std::set, std::multiset have been in `dev` namespace long time ago, then moved to global namespace by @leonardoalt last year (maybe as compilation fix?) Now, MSVC is complaining, so they're moved to `std` namespace, so that the operator overloads are in the same namespace as the arguments, to make ADL happy for all 3 major compilers (Clang, GCC, MSVC).

I do not know why gcc/clang behave differently and why it started to break on MSVC though?