### PR TITLE
[SMTChecker] Refactor CHC predicates

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -100,6 +100,8 @@ set(sources
 	formal/EncodingContext.h
 	formal/ModelChecker.cpp
 	formal/ModelChecker.h
+	formal/Predicate.cpp
+	formal/Predicate.h
 	formal/SMTEncoder.cpp
 	formal/SMTEncoder.h
 	formal/SSAVariable.cpp

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -111,8 +111,6 @@ private:
 	void clearIndices(ContractDefinition const* _contract, FunctionDefinition const* _function = nullptr) override;
 	void setCurrentBlock(Predicate const& _block, std::vector<smtutil::Expression> const* _arguments = nullptr);
 	std::set<Expression const*, IdCompare> transactionAssertions(ASTNode const* _txRoot);
-	static std::vector<VariableDeclaration const*> stateVariablesIncludingInheritedAndPrivate(ContractDefinition const& _contract);
-	static std::vector<VariableDeclaration const*> stateVariablesIncludingInheritedAndPrivate(FunctionDefinition const& _function);
 	//@}
 
 	/// Sort helpers.

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -226,10 +226,6 @@ private:
 	/// _function = nullptr means the transaction was the deployment of a
 	/// contract without an explicit constructor.
 	std::string formatStateCounterexample(std::vector<VariableDeclaration const*> const& _stateVariables, FunctionDefinition const* _function, std::vector<std::string> const& _summaryValues);
-	/// @returns a formatted text representing a call to _function
-	/// with the concrete values for value type parameters and
-	/// the parameter name for reference types.
-	std::string formatFunctionCallCounterexample(std::vector<VariableDeclaration const*> const& _stateVariables, FunctionDefinition const& _function, std::vector<std::string> const& _summaryValues);
 
 	/// @returns a DAG in the dot format.
 	/// Used for debugging purposes.

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -225,7 +225,7 @@ private:
 	/// _function was executed.
 	/// _function = nullptr means the transaction was the deployment of a
 	/// contract without an explicit constructor.
-	std::string formatStateCounterexample(std::vector<VariableDeclaration const*> const& _stateVariables, FunctionDefinition const* _function, std::vector<std::string> const& _summaryValues);
+	std::string formatStateCounterexample(std::vector<VariableDeclaration const*> const& _stateVariables, std::vector<std::string> const& _values);
 
 	/// @returns a DAG in the dot format.
 	/// Used for debugging purposes.

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -38,6 +38,8 @@
 
 #include <libsmtutil/CHCSolverInterface.h>
 
+#include <boost/algorithm/string/join.hpp>
+
 #include <map>
 #include <optional>
 #include <set>
@@ -221,11 +223,23 @@ private:
 	);
 
 	std::optional<std::string> generateCounterexample(smtutil::CHCSolverInterface::CexGraph const& _graph, std::string const& _root);
-	/// @returns values for the _stateVariables after a transaction calling
-	/// _function was executed.
-	/// _function = nullptr means the transaction was the deployment of a
-	/// contract without an explicit constructor.
-	std::string formatStateCounterexample(std::vector<VariableDeclaration const*> const& _stateVariables, std::vector<std::string> const& _values);
+
+	/// @returns a set of pairs _var = _value separated by _separator.
+	template <typename T>
+	std::string formatVariableModel(std::vector<T> const& _variables, std::vector<std::string> const& _values, std::string const& _separator) const
+	{
+		solAssert(_variables.size() == _values.size(), "");
+
+		std::vector<std::string> assignments;
+		for (unsigned i = 0; i < _values.size(); ++i)
+		{
+			auto var = _variables.at(i);
+			if (var && var->type()->isValueType())
+				assignments.emplace_back(var->name() + " = " + _values.at(i));
+		}
+
+		return boost::algorithm::join(assignments, _separator);
+	}
 
 	/// @returns a DAG in the dot format.
 	/// Used for debugging purposes.

--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -214,3 +214,47 @@ vector<string> Predicate::summaryStateValues(vector<string> const& _args) const
 	solAssert(stateArgs.size() == stateVars->size(), "");
 	return stateArgs;
 }
+
+vector<string> Predicate::summaryPostInputValues(vector<string> const& _args) const
+{
+	/// The signature of a function summary predicate is: summary(error, preStateVars, preInputVars, postStateVars, postInputVars, outputVars).
+	/// Here we are interested in postInputVars.
+	auto const* function = programFunction();
+	solAssert(function, "");
+
+	auto stateVars = stateVariables();
+	solAssert(stateVars.has_value(), "");
+
+	auto const& inParams = function->parameters();
+
+	vector<string>::const_iterator first = _args.begin() + 1 + static_cast<int>(stateVars->size()) * 2 + static_cast<int>(inParams.size());
+	vector<string>::const_iterator last = first + static_cast<int>(inParams.size());
+
+	solAssert(first >= _args.begin() && first <= _args.end(), "");
+	solAssert(last >= _args.begin() && last <= _args.end(), "");
+
+	vector<string> inValues(first, last);
+	solAssert(inValues.size() == inParams.size(), "");
+	return inValues;
+}
+
+vector<string> Predicate::summaryPostOutputValues(vector<string> const& _args) const
+{
+	/// The signature of a function summary predicate is: summary(error, preStateVars, preInputVars, postStateVars, postInputVars, outputVars).
+	/// Here we are interested in outputVars.
+	auto const* function = programFunction();
+	solAssert(function, "");
+
+	auto stateVars = stateVariables();
+	solAssert(stateVars.has_value(), "");
+
+	auto const& inParams = function->parameters();
+
+	vector<string>::const_iterator first = _args.begin() + 1 + static_cast<int>(stateVars->size()) * 2 + static_cast<int>(inParams.size()) * 2;
+
+	solAssert(first >= _args.begin() && first <= _args.end(), "");
+
+	vector<string> outValues(first, _args.end());
+	solAssert(outValues.size() == function->returnParameters().size(), "");
+	return outValues;
+}

--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -1,0 +1,92 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/formal/Predicate.h>
+
+#include <libsolidity/ast/AST.h>
+
+#include <boost/algorithm/string/join.hpp>
+#include <utility>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::smtutil;
+using namespace solidity::frontend;
+using namespace solidity::frontend::smt;
+
+map<string, Predicate> Predicate::m_predicates;
+
+Predicate const* Predicate::create(
+	SortPointer _sort,
+	string _name,
+	EncodingContext& _context,
+	ASTNode const* _node
+)
+{
+	smt::SymbolicFunctionVariable predicate{_sort, move(_name), _context};
+	string functorName = predicate.currentName();
+	solAssert(!m_predicates.count(functorName), "");
+	return &m_predicates.emplace(
+		std::piecewise_construct,
+		std::forward_as_tuple(functorName),
+		std::forward_as_tuple(move(predicate), _node)
+	).first->second;
+}
+
+Predicate::Predicate(
+	smt::SymbolicFunctionVariable&& _predicate,
+	ASTNode const* _node
+):
+	m_predicate(move(_predicate)),
+	m_node(_node)
+{
+}
+
+Predicate const* Predicate::predicate(string const& _name)
+{
+	return &m_predicates.at(_name);
+}
+
+void Predicate::reset()
+{
+	m_predicates.clear();
+}
+
+smtutil::Expression Predicate::operator()(vector<smtutil::Expression> const& _args) const
+{
+	return m_predicate(_args);
+}
+
+smtutil::Expression Predicate::functor() const
+{
+	return m_predicate.currentFunctionValue();
+}
+
+smtutil::Expression Predicate::functor(unsigned _idx) const
+{
+	return m_predicate.functionValueAtIndex(_idx);
+}
+
+void Predicate::newFunctor()
+{
+	m_predicate.increaseIndex();
+}
+
+ASTNode const* Predicate::programNode() const {
+	return m_node;
+}

--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -182,3 +182,35 @@ string Predicate::formatSummaryCall(vector<string> const& _args) const
 	return fName + "(" + boost::algorithm::join(functionArgs, ", ") + ")";
 
 }
+
+vector<string> Predicate::summaryStateValues(vector<string> const& _args) const
+{
+	/// The signature of a function summary predicate is: summary(error, preStateVars, preInputVars, postStateVars, postInputVars, outputVars).
+	/// The signature of an implicit constructor summary predicate is: summary(error, postStateVars).
+	/// Here we are interested in postStateVars.
+
+	auto stateVars = stateVariables();
+	solAssert(stateVars.has_value(), "");
+
+	vector<string>::const_iterator stateFirst;
+	vector<string>::const_iterator stateLast;
+	if (auto const* function = programFunction())
+	{
+		stateFirst = _args.begin() + 1 + static_cast<int>(stateVars->size()) + static_cast<int>(function->parameters().size());
+		stateLast = stateFirst + static_cast<int>(stateVars->size());
+	}
+	else if (programContract())
+	{
+		stateFirst = _args.begin() + 1;
+		stateLast = stateFirst + static_cast<int>(stateVars->size());
+	}
+	else
+		solAssert(false, "");
+
+	solAssert(stateFirst >= _args.begin() && stateFirst <= _args.end(), "");
+	solAssert(stateLast >= _args.begin() && stateLast <= _args.end(), "");
+
+	vector<string> stateArgs(stateFirst, stateLast);
+	solAssert(stateArgs.size() == stateVars->size(), "");
+	return stateArgs;
+}

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -92,6 +92,10 @@ public:
 	/// with _args.
 	std::string formatSummaryCall(std::vector<std::string> const& _args) const;
 
+	/// @returns the values of the state variables from _args at the point
+	/// where this summary was reached.
+	std::vector<std::string> summaryStateValues(std::vector<std::string> const& _args) const;
+
 private:
 	/// The actual SMT expression.
 	smt::SymbolicFunctionVariable m_predicate;

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -1,0 +1,86 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsolidity/formal/SymbolicVariables.h>
+#include <libsolidity/formal/SymbolicVariables.h>
+
+#include <libsmtutil/Sorts.h>
+
+#include <map>
+#include <vector>
+
+namespace solidity::frontend
+{
+
+/**
+ * Represents a predicate used by the CHC engine.
+ */
+class Predicate
+{
+public:
+	static Predicate const* create(
+		smtutil::SortPointer _sort,
+		std::string _name,
+		smt::EncodingContext& _context,
+		ASTNode const* _node = nullptr
+	);
+
+	Predicate(
+		smt::SymbolicFunctionVariable&& _predicate,
+		ASTNode const* _node = nullptr
+	);
+
+	/// Predicate should not be copiable.
+	Predicate(Predicate const&) = delete;
+	Predicate& operator=(Predicate const&) = delete;
+
+	/// @returns the Predicate associated with _name.
+	static Predicate const* predicate(std::string const& _name);
+
+	/// Resets all the allocated predicates.
+	static void reset();
+
+	/// @returns a function application of the predicate over _args.
+	smtutil::Expression operator()(std::vector<smtutil::Expression> const& _args) const;
+
+	/// @returns the function declaration of the predicate.
+	smtutil::Expression functor() const;
+	/// @returns the function declaration of the predicate with index _idx.
+	smtutil::Expression functor(unsigned _idx) const;
+	/// Increases the index of the function declaration of the predicate.
+	void newFunctor();
+
+	/// @returns the program node this predicate represents.
+	ASTNode const* programNode() const;
+
+private:
+	/// The actual SMT expression.
+	smt::SymbolicFunctionVariable m_predicate;
+
+	/// The ASTNode that this predicate represents.
+	/// nullptr if this predicate is not associated with a specific program AST node.
+	ASTNode const* m_node = nullptr;
+
+	/// Maps the name of the predicate to the actual Predicate.
+	/// Used in counterexample generation.
+	static std::map<std::string, Predicate> m_predicates;
+};
+
+}

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -96,6 +96,14 @@ public:
 	/// where this summary was reached.
 	std::vector<std::string> summaryStateValues(std::vector<std::string> const& _args) const;
 
+	/// @returns the values of the function input variables from _args at the point
+	/// where this summary was reached.
+	std::vector<std::string> summaryPostInputValues(std::vector<std::string> const& _args) const;
+
+	/// @returns the values of the function output variables from _args at the point
+	/// where this summary was reached.
+	std::vector<std::string> summaryPostOutputValues(std::vector<std::string> const& _args) const;
+
 private:
 	/// The actual SMT expression.
 	smt::SymbolicFunctionVariable m_predicate;

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -24,6 +24,7 @@
 #include <libsmtutil/Sorts.h>
 
 #include <map>
+#include <optional>
 #include <vector>
 
 namespace solidity::frontend
@@ -69,6 +70,27 @@ public:
 
 	/// @returns the program node this predicate represents.
 	ASTNode const* programNode() const;
+
+	/// @returns the ContractDefinition that this predicate represents
+	/// or nullptr otherwise.
+	ContractDefinition const* programContract() const;
+
+	/// @returns the FunctionDefinition that this predicate represents
+	/// or nullptr otherwise.
+	FunctionDefinition const* programFunction() const;
+
+	/// @returns the program state variables in the scope of this predicate.
+	std::optional<std::vector<VariableDeclaration const*>> stateVariables() const;
+
+	/// @returns true if this predicate represents a summary.
+	bool isSummary() const;
+
+	/// @returns true if this predicate represents an interface.
+	bool isInterface() const;
+
+	/// @returns a formatted string representing a call to this predicate
+	/// with _args.
+	std::string formatSummaryCall(std::vector<std::string> const& _args) const;
 
 private:
 	/// The actual SMT expression.

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1982,6 +1982,20 @@ FunctionDefinition const* SMTEncoder::functionCallToDefinition(FunctionCall cons
 	return funDef;
 }
 
+vector<VariableDeclaration const*> SMTEncoder::stateVariablesIncludingInheritedAndPrivate(ContractDefinition const& _contract)
+{
+	return fold(
+		_contract.annotation().linearizedBaseContracts,
+		vector<VariableDeclaration const*>{},
+		[](auto&& _acc, auto _contract) { return _acc + _contract->stateVariables(); }
+	);
+}
+
+vector<VariableDeclaration const*> SMTEncoder::stateVariablesIncludingInheritedAndPrivate(FunctionDefinition const& _function)
+{
+	return stateVariablesIncludingInheritedAndPrivate(dynamic_cast<ContractDefinition const&>(*_function.scope()));
+}
+
 void SMTEncoder::createReturnedExpressions(FunctionCall const& _funCall)
 {
 	FunctionDefinition const* funDef = functionCallToDefinition(_funCall);

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -62,6 +62,9 @@ public:
 	/// if possible or nullptr.
 	static FunctionDefinition const* functionCallToDefinition(FunctionCall const& _funCall);
 
+	static std::vector<VariableDeclaration const*> stateVariablesIncludingInheritedAndPrivate(ContractDefinition const& _contract);
+	static std::vector<VariableDeclaration const*> stateVariablesIncludingInheritedAndPrivate(FunctionDefinition const& _function);
+
 protected:
 	// TODO: Check that we do not have concurrent reads and writes to a variable,
 	// because the order of expression evaluation is undefined

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_code_after_placeholder.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_code_after_placeholder.sol
@@ -21,5 +21,5 @@ contract C
 	}
 }
 // ----
-// Warning 4984: (203-208): Overflow (resulting value larger than 2**256 - 1) happens here
+// Warning 4984: (203-208): Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 6328: (136-149): Assertion violation happens here

--- a/test/libsolidity/smtCheckerTests/types/array_aliasing_memory_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_aliasing_memory_1.sol
@@ -26,4 +26,4 @@ contract C
 	}
 }
 // ----
-// Warning 6328: (400-457): Assertion violation happens here.
+// Warning 6328: (400-457): Assertion violation happens here


### PR DESCRIPTION
Fixes #9414 

Creates a new class `Predicate` that wraps `SymbolicFunctionVariable`, used as predicates in the CHC engine.
The predicates are owned by the static map `m_predicates`, as suggested by @chriseth , and the maps in CHC only use pointers to those predicates.
Furthermore, this PR also refactors the code that constructs counterexamples, mostly moving code into the new Predicate class, making the code more robust.

This PR is more easily reviewed by looking at each commit sequentially.