### PR TITLE
Fix MSVC ADL

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -157,9 +157,10 @@ elseif (DEFINED MSVC)
 	add_compile_options(/wd4800)					# disable forcing value to bool 'true' or 'false' (performance warning) (4800)
 	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
 	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
-	add_compile_options(/utf-8)					# enable utf-8 encoding (solves warning 4819)
+	add_compile_options(/utf-8)						# enable utf-8 encoding (solves warning 4819)
 	add_compile_options(-DBOOST_REGEX_NO_LIB)		# disable automatic boost::regex library selection
 	add_compile_options(-D_REGEX_MAX_STACK_COUNT=200000L)	# increase std::regex recursion depth limit
+	add_compile_options(/permissive-)				# specify standards conformance mode to the compiler
 
 	# disable empty object file warning
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -37,10 +37,7 @@
 #include <utility>
 #include <type_traits>
 
-namespace std
-{
-
-/// Operator overloads for STL containers should be in std namespace for ADL to work properly.
+/// Operators need to stay in the global namespace.
 
 /// Concatenate the contents of a container onto a vector
 template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U& _b)
@@ -146,8 +143,6 @@ inline std::multiset<T...>& operator-=(std::multiset<T...>& _a, C const& _b)
 		_a.erase(x);
 	return _a;
 }
-
-} // end namespace std
 
 namespace solidity::util
 {

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -97,12 +97,15 @@ u256 ExecutionFramework::gasLimit() const
 
 u256 ExecutionFramework::gasPrice() const
 {
-	return {EVMHost::convertFromEVMC(m_evmHost->tx_context.tx_gas_price)};
+	// here and below we use "return u256{....}" instead of just "return {....}"
+	// to please MSVC and avoid unexpected
+	// warning C4927 : illegal conversion; more than one user - defined conversion has been implicitly applied
+	return u256{EVMHost::convertFromEVMC(m_evmHost->tx_context.tx_gas_price)};
 }
 
 u256 ExecutionFramework::blockHash(u256 const& _number) const
 {
-	return {EVMHost::convertFromEVMC(
+	return u256{EVMHost::convertFromEVMC(
 		m_evmHost->get_block_hash(static_cast<int64_t>(_number & numeric_limits<uint64_t>::max()))
 	)};
 }


### PR DESCRIPTION
This suggests a fix for MSVC ADL compilation error, without adding function templates to the `stl` namespace (which, strictly speaking, seems to be UB).

The following program illustrates the issue:
```
#include <vector>
using namespace std;

void operator+(vector<int>, vector<int>) {}

namespace ns
{
    struct S {};
    class C {
        friend void operator+(S, S) {}
    };

    // clang: OK
    // msvc : OK if /permissive- is specified
    void f() { vector<int>() + vector<int>(); }
}

int main() {}
```

Without **/permissive-** flag, which enables the compiler standards conformance mode, msvc gives
> error C2676: binary '+': 'std::vector<int,std::allocator<int>>' does not define this operator or a conversion to a type acceptable to the predefined operator 

In our case, the error occurred because of the recently introduced `operator+` from `SideEffects`:
```
struct SideEffects
{
    . . . .
    friend Effect operator+(Effect const& _a, Effect const& _b)
    {
        return static_cast<Effect>(std::max(static_cast<int>(_a), static_cast<int>(_b)));
    }
```
Replacing it with a simple function works too, but it would be just a workaround.
