### PR TITLE
Allow `type(Contract).name` for abstract contracts and interfaces

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ Bugfixes:
  * References Resolver: Fix internal bug when using constructor for library.
  * Yul Optimizer: Make function inlining order more resilient to whether or not unrelated source files are present.
  * Type Checker: Disallow signed literals as exponent in exponentiation operator.
+ * Allow `type(Contract).name` for abstract contracts and interfaces.
 
 
 ### 0.7.0 (2020-07-28)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -4079,6 +4079,7 @@ MemberList::MemberMap MagicType::nativeMembers(ASTNode const*) const
 			else
 				return MemberList::MemberMap({
 					{"interfaceId", TypeProvider::fixedBytes(4)},
+					{"name", TypeProvider::stringMemory()},
 				});
 		}
 		else if (m_typeArgument->category() == Type::Category::Integer)

--- a/test/libsolidity/semanticTests/metaTypes/name_other_contract.sol
+++ b/test/libsolidity/semanticTests/metaTypes/name_other_contract.sol
@@ -1,0 +1,29 @@
+abstract contract A {
+    function f() virtual public pure;
+}
+
+interface I {
+    function f() external pure;
+}
+
+contract C {
+    function f() pure public {
+    }
+}
+
+contract Test {
+    function c() public pure returns (string memory) {
+        return type(C).name;
+    }
+    function a() public pure returns (string memory) {
+        return type(A).name;
+    }
+    function i() public pure returns (string memory) {
+        return type(I).name;
+    }
+}
+
+// ----
+// c() -> 0x20, 1, "C"
+// a() -> 0x20, 1, "A"
+// i() -> 0x20, 1, "I"

--- a/test/libsolidity/syntaxTests/metaTypes/name_other_contract.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/name_other_contract.sol
@@ -2,6 +2,20 @@ contract Test {
     function f() public pure returns (string memory) {
         return type(C).name;
     }
+    function g() public pure returns (string memory) {
+        return type(A).name;
+    }
+    function h() public pure returns (string memory) {
+        return type(I).name;
+    }
+}
+
+abstract contract A {
+	function f() virtual public pure;
+}
+
+interface I {
+	function f() external pure;
 }
 
 contract C {


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/9478