### PR TITLE
Disallow the exponent to be a signed integer literal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
  * SMTChecker: Fix internal error on fixed bytes index access.
  * References Resolver: Fix internal bug when using constructor for library.
  * Yul Optimizer: Make function inlining order more resilient to whether or not unrelated source files are present.
+ * Type Checker: Disallow signed literals as exponent in exponentiation operator.
 
 
 ### 0.7.0 (2020-07-28)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -712,6 +712,8 @@ TypeResult IntegerType::binaryOperatorResult(Token _operator, Type const* _other
 				return TypeResult::err("Exponent is fractional.");
 			if (!rationalNumberType->integerType())
 				return TypeResult::err("Exponent too large.");
+			if (rationalNumberType->isNegative())
+				return TypeResult::err("Exponentiation power is not allowed to be a negative integer literal.");
 		}
 		return this;
 	}

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/201_integer_signed_exp_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/201_integer_signed_exp_signed.sol
@@ -1,8 +1,10 @@
 contract test {
     function f() public { int x = 3; int y = 4; x ** y; }
     function h() public { uint8 x = 3; int16 y = 4; x ** y; }
+    function i() public { int16 x = 4; x ** -3; }
 }
 // ----
 // TypeError 2271: (64-70): Operator ** not compatible with types int256 and int256. Exponentiation power is not allowed to be a signed integer type.
 // TypeError 2271: (126-132): Operator ** not compatible with types uint8 and int16. Exponentiation power is not allowed to be a signed integer type.
 // Warning 3149: (126-132): The result type of the exponentiation operation is equal to the type of the first operand (uint8) ignoring the (larger) type of the second operand (int16) which might be unexpected. Silence this warning by either converting the first or the second operand to the type of the other.
+// TypeError 2271: (175-182): Operator ** not compatible with types int16 and int_const -3. Exponentiation power is not allowed to be a negative integer literal.


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/9548