### PR TITLE
Disallow ``using for`` directive for interfaces.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Bugfixes:
  * Type Checker: Disallow signed literals as exponent in exponentiation operator.
  * Allow `type(Contract).name` for abstract contracts and interfaces.
  * Type Checker: Disallow structs containing nested mapping in memory as parameters for library functions.
+ * Type Checker: Disallow ``using for`` directive inside interfaces.
 
 
 ### 0.7.0 (2020-07-28)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3148,6 +3148,16 @@ void TypeChecker::endVisit(Literal const& _literal)
 	_literal.annotation().isPure = true;
 }
 
+void TypeChecker::endVisit(UsingForDirective const& _usingFor)
+{
+	if (m_currentContract->isInterface())
+		m_errorReporter.typeError(
+			9088_error,
+			_usingFor.location(),
+			"The \"using for\" directive is not allowed inside interfaces."
+		);
+}
+
 bool TypeChecker::contractDependenciesAreCyclic(
 	ContractDefinition const& _contract,
 	std::set<ContractDefinition const*> const& _seenContracts

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -143,6 +143,7 @@ private:
 	bool visit(Identifier const& _identifier) override;
 	void endVisit(ElementaryTypeNameExpression const& _expr) override;
 	void endVisit(Literal const& _literal) override;
+	void endVisit(UsingForDirective const& _usingForDirective) override;
 
 	bool contractDependenciesAreCyclic(
 		ContractDefinition const& _contract,

--- a/test/libsolidity/syntaxTests/bound/interface_using_for.sol
+++ b/test/libsolidity/syntaxTests/bound/interface_using_for.sol
@@ -1,0 +1,10 @@
+library L {
+    function f() public {}
+}
+
+interface I {
+    using L for int;
+    function g() external;
+}
+// ----
+// TypeError 9088: (60-76): The "using for" directive is not allowed inside interfaces.


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/9611