### PR TITLE
Changed canonicalName() to toString() because of internal functions

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -616,7 +616,7 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 			if (_variable.isStateVariable())
 				m_errorReporter.warning(3408_error, _variable.location(), collisionMessage(_variable.name(), true));
 			else
-				m_errorReporter.warning(2332_error, _variable.typeName().location(), collisionMessage(varType->canonicalName(), false));
+				m_errorReporter.warning(2332_error, _variable.typeName().location(), collisionMessage(varType->toString(true), false));
 		}
 		vector<Type const*> oversizedSubtypes = frontend::oversizedSubtypes(*varType);
 		for (Type const* subtype: oversizedSubtypes)

--- a/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/oversized_var.sol
@@ -4,11 +4,15 @@ contract b {
     }
 
     c d;
+
     function e() public view {
         c storage x = d;
-	x.a[0];
+        x.a[0];
+        function()[3**44] storage fs;
     }
 }
 // ----
 // Warning 3408: (66-69): Variable "d" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
-// Warning 2332: (110-111): Type "b.c" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 2332: (111-112): Type "struct b.c" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 2332: (152-169): Type "function ()[984770902183611232881]" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 2072: (152-180): Unused local variable.

--- a/test/libsolidity/syntaxTests/largeTypes/storage_parameter.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/storage_parameter.sol
@@ -3,4 +3,4 @@ contract C {
     function f(S storage) internal {}
 }
 // ----
-// Warning 2332: (64-65): Type "C.S" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.
+// Warning 2332: (64-65): Type "struct C.S" covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/9666

The problem is that `canonicalName()` can only be called for external functions.