### PR TITLE
[SMTChecker] Fix soundness of array pop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
  * SMTChecker: Fix internal error in BMC function inlining.
  * SMTChecker: Fix internal error on array implicit conversion.
  * SMTChecker: Fix internal error on fixed bytes index access.
+ * SMTChecker: Fix soundness of array ``pop``.
  * References Resolver: Fix internal bug when using constructor for library.
  * Yul Optimizer: Make function inlining order more resilient to whether or not unrelated source files are present.
  * Type Checker: Disallow signed literals as exponent in exponentiation operator.

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1111,11 +1111,11 @@ void SMTEncoder::arrayPop(FunctionCall const& _funCall)
 	symbArray->increaseIndex();
 	m_context.addAssertion(symbArray->elements() == oldElements);
 	auto newLength = smtutil::Expression::ite(
-		oldLength == 0,
-		smt::maxValue(*TypeProvider::uint256()),
-		oldLength - 1
+		oldLength > 0,
+		oldLength - 1,
+		0
 	);
-	m_context.addAssertion(symbArray->length() == oldLength - 1);
+	m_context.addAssertion(symbArray->length() == newLength);
 
 	arrayPushPopAssign(memberAccess->expression(), symbArray->currentValue());
 }

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_1.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.pop();
+		a.push();
+	}
+}
+// ----
+// Warning 2529: (82-89): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_2.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_2.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.pop();
+		a.length;
+	}
+}
+// ----
+// Warning 2529: (82-89): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_3.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_3.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.pop();
+		a.pop();
+	}
+}
+// ----
+// Warning 2529: (82-89): Empty array "pop" detected here
+// Warning 2529: (93-100): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_4.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_4.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.length;
+		a.pop();
+	}
+}
+// ----
+// Warning 2529: (94-101): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_5.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_5.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function g() internal {
+		a.push();
+	}
+	function f() public {
+		a.pop();
+		g();
+	}
+}
+// ----
+// Warning 2529: (122-129): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_6.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_6.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function g() internal view {
+		a.length;
+	}
+	function f() public {
+		a.pop();
+		g();
+	}
+}
+// ----
+// Warning 2529: (127-134): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_7.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_7.sol
@@ -1,0 +1,9 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.push();
+		a.pop();
+	}
+}

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_8.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_8.sol
@@ -1,0 +1,16 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint[] a;
+	function f() public {
+		a.pop();
+		a.push();
+		a.push();
+		a.push();
+		a.pop();
+		a.pop();
+		a.pop();
+	}
+}
+// ----
+// Warning 2529: (82-89): Empty array "pop" detected here

--- a/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
@@ -9,4 +9,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (111-121): Empty array "pop" detected here.
+// Warning 2529: (111-121): Empty array "pop" detected here


### PR DESCRIPTION
Consider the following code snippet:
```
a.pop();
a.length;
```
where `a` is `uint[] a`.
Before this PR those statements were in the same CHC rule (block). The problem with that was that
- `a.pop()` adds the constraint `a_2.length = a_1.length - 1` and the check `a_1.length == 0`
- `a.length` adds the type constraints `a_2.length >= 0 /\ a_2.length < 2**256`
This implies that `a_1.length > 0` and the SMTChecker thinks the `pop` is safe, whereas it isn't.

The solution in this PR is to not decrease the length and not to wrap around when the length is 0 and `pop` is executed. At runtime this would revert. So if we want to go on and report further errors we behave as if this pop was never there, that is, by leaving the length as 0 - we do report the `empty pop detected` though.