### PR TITLE
CMake toolchain file cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,7 @@ jobs:
     <<: *build_ubuntu2004
     environment:
       CMAKE_BUILD_TYPE: Debug
-      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/cxx20.cmake -DUSE_CVC4=OFF
+      CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=20 -DUSE_CVC4=OFF
       MAKEFLAGS: -j 10
     steps:
       - checkout

--- a/cmake/EthToolchains.cmake
+++ b/cmake/EthToolchains.cmake
@@ -1,3 +1,8 @@
+# Require C++17.
+set(CMAKE_CXX_STANDARD 17) # This requires at least CMake 3.8 to accept this C++17 flag.
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if(NOT CMAKE_TOOLCHAIN_FILE)
   # Use default toolchain file if none is provided.
   set(

--- a/cmake/toolchains/cxx20.cmake
+++ b/cmake/toolchains/cxx20.cmake
@@ -1,4 +1,0 @@
-# Require C++20.
-set(CMAKE_CXX_STANDARD 20) # This requires at least CMake 3.12 to understand this C++20 flag
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CMAKE_CXX_EXTENSIONS OFF)

--- a/cmake/toolchains/default.cmake
+++ b/cmake/toolchains/default.cmake
@@ -1,4 +1,0 @@
-# Require C++17.
-set(CMAKE_CXX_STANDARD 17) # This requires at least CMake 3.8 to accept this C++17 flag.
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Until now the toolchain file also mandated the C++ standard to compile the source code with. This always conflicted with my windows setup (and CI) when using VCPKG. 

This PR cleans this up, and I also changed our CI config to explicitly pass `CMAKE_CXX_VERSION=20` for test-compiling against C++20.