### PR TITLE
Fixes C++ narrowing conversion compile error

### DIFF
--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(helper_bool_result)
 
 	BoolResult r7{true};
 	// Attention: this will implicitly convert to bool.
-	BoolResult r8{"true"};
+	BoolResult r8("true"); // We cannot use {} initializer here because this does not allow narrowing conversion (at least MSVC breaks)
 	r7.merge(r8, logical_and<bool>());
 	BOOST_REQUIRE_EQUAL(r7.get(), true);
 	BOOST_REQUIRE_EQUAL(r7.message(), "");


### PR DESCRIPTION
This compile error only happens on MSVC (on the CircleCI), and while I understand why this error is being generated I wonder why no other compiler has caught it.

This PR is based on top of another PR https://github.com/ethereum/solidity/pull/9693