### PR TITLE
Fix ICE caused by an array of mappings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ Compiler Features:
  * SMTChecker: Support ``addmod`` and ``mulmod``.
 
 
+Bugfixes:
+ * Type Checker: Fix internal compiler error when calling `.push(<arg>)` for a storage array with a nested mapping.
+
+
 ### 0.7.2 (2020-09-28)
 
 Important Bugfixes:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2684,10 +2684,20 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				"Using \"." + memberName + "(...)\" is deprecated. Use \"{" + memberName + ": ...}\" instead."
 			);
 
+		if (
+			funType->kind() == FunctionType::Kind::ArrayPush &&
+			arguments.value().numArguments() != 0 &&
+			exprType->containsNestedMapping()
+		)
+			m_errorReporter.typeError(
+				8871_error,
+				_memberAccess.location(),
+				"Storage arrays with nested mappings do not support .push(<arg>)."
+			);
+
 		if (!funType->bound())
 			if (auto contractType = dynamic_cast<ContractType const*>(exprType))
 				requiredLookup = contractType->isSuper() ? VirtualLookup::Super : VirtualLookup::Virtual;
-
 	}
 
 	annotation.requiredLookup = requiredLookup;

--- a/test/libsolidity/syntaxTests/array/pop/storage_with_mapping_pop.sol
+++ b/test/libsolidity/syntaxTests/array/pop/storage_with_mapping_pop.sol
@@ -1,0 +1,7 @@
+contract C {
+    mapping(uint=>uint)[] array;
+    mapping(uint=>uint) map;
+    function f() public {
+        array.pop();
+    }
+}

--- a/test/libsolidity/syntaxTests/array/push/storage_with_mapping_push.sol
+++ b/test/libsolidity/syntaxTests/array/push/storage_with_mapping_push.sol
@@ -1,0 +1,10 @@
+contract C {
+    mapping(uint=>uint)[] array;
+    mapping(uint=>uint) map;
+    function f() public {
+        array.push();
+        array.push(map);
+    }
+}
+// ----
+// TypeError 8871: (131-141): Storage arrays with nested mappings do not support .push(<arg>).


### PR DESCRIPTION
Fixes #7410 by disallowing `.push(<arg>)` for storage arrays with mappings.

@chriseth @leonardoalt @hrkrshnn 

~~From the #7410 discussion, I somewhat concluded that the idea is to forbid arrays with (nested) mappings.~~

~~I added a simple check and updated several test cases (more needs to be updated). Is it the intended direction? The impact (in terms of the number of failing tests) is rather big.~~

Disallows `.push(<arg>)` ~~and `.pop()`~~ for storage arrays with nested mappings.
