### PR TITLE
Corrected warning for homonymous, but not shadowing declarations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Compiler Features:
 
 Bugfixes:
  * Type Checker: Disallow ``virtual`` for modifiers in libraries.
+ * Type Checker: Correct the warning for homonymous, but not shadowing declarations.
  * ViewPureChecker: Prevent visibility check on constructors.
  * Type system: Fix internal error on implicit conversion of contract instance to the type of its ``super``.
  * Type system: Fix named parameters in overloaded function and event calls being matched incorrectly if the order differs from the declaration.

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -503,11 +503,20 @@ bool DeclarationRegistrationHelper::registerDeclaration(
 		else
 		{
 			auto shadowedLocation = shadowedDeclaration->location();
-			_errorReporter.warning(
-				2519_error,
-				_declaration.location(),
-				"This declaration shadows an existing declaration.",
-				SecondarySourceLocation().append("The shadowed declaration is here:", shadowedLocation)
+
+			if (!shadowedDeclaration->isVisibleInContract())
+				_errorReporter.warning(
+					8760_error,
+					_declaration.location(),
+					"This declaration has the same name as another declaration.",
+					SecondarySourceLocation().append("The other declaration is here:", shadowedLocation)
+				);
+			else
+				_errorReporter.warning(
+					2519_error,
+					_declaration.location(),
+					"This declaration shadows an existing declaration.",
+					SecondarySourceLocation().append("The shadowed declaration is here:", shadowedLocation)
 			);
 		}
 	}

--- a/test/libsolidity/syntaxTests/scoping/name_pseudo_shadowing.sol
+++ b/test/libsolidity/syntaxTests/scoping/name_pseudo_shadowing.sol
@@ -1,0 +1,6 @@
+contract test {
+    function e() external { }
+    function f() public pure { uint e; e = 0; }
+}
+// ----
+// Warning 8760: (77-83): This declaration has the same name as another declaration.

--- a/test/libsolidity/syntaxTests/scoping/name_shadowing2.sol
+++ b/test/libsolidity/syntaxTests/scoping/name_shadowing2.sol
@@ -1,0 +1,6 @@
+function e() {}
+contract test {
+    function f() pure public { uint e; e = 0; }
+}
+// ----
+// Warning 2519: (63-69): This declaration shadows an existing declaration.


### PR DESCRIPTION
Fixes #4558.