### PR TITLE
[SMTChecker] Fix unary operator on lvalue tuple

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
  * SMTChecker: Fix internal error in BMC function inlining.
  * SMTChecker: Fix internal error on array implicit conversion.
  * SMTChecker: Fix internal error on fixed bytes index access.
+ * SMTChecker: Fix internal error on lvalue unary operators with tuples.
  * SMTChecker: Fix soundness of array ``pop``.
  * References Resolver: Fix internal bug when using constructor for library.
  * Yul Optimizer: Make function inlining order more resilient to whether or not unrelated source files are present.

--- a/libsmtutil/Z3Interface.h
+++ b/libsmtutil/Z3Interface.h
@@ -49,9 +49,7 @@ public:
 
 	// Z3 "basic resources" limit.
 	// This is used to make the runs more deterministic and platform/machine independent.
-	// The tests start failing for Z3 with less than 10000000,
-	// so using double that.
-	static int const resourceLimit = 20000000;
+	static int const resourceLimit = 12500000;
 
 private:
 	void declareFunction(std::string const& _name, Sort const& _sort);

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -54,8 +54,9 @@ public:
 	/// @returns the leftmost identifier in a multi-d IndexAccess.
 	static Expression const* leftmostBase(IndexAccess const& _indexAccess);
 
-	/// @returns the innermost element in a chain of 1-tuples.
-	static Expression const* innermostTuple(TupleExpression const& _tuple);
+	/// @returns the innermost element in a chain of 1-tuples if applicable,
+	/// otherwise _expr.
+	static Expression const* innermostTuple(Expression const& _expr);
 
 	/// @returns the FunctionDefinition of a FunctionCall
 	/// if possible or nullptr.

--- a/test/libsolidity/smtCheckerTests/operators/unary_operators_tuple_1.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_operators_tuple_1.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+contract C {
+	function f(bool b) public pure {
+		uint x;
+		if (b) ++(x);
+		if (b) --(x);
+		if (b) delete(b);
+		assert(x == 0);
+		assert(!b);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/operators/unary_operators_tuple_2.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_operators_tuple_2.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+contract C {
+	function f(bool b) public pure {
+		uint x;
+		if (b) ++((((((x))))));
+		if (b) --((((((x))))));
+		if (b) delete((((((b))))));
+		assert(x == 0);
+		assert(!b);
+	}
+}

--- a/test/libsolidity/smtCheckerTests/operators/unary_operators_tuple_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_operators_tuple_3.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+contract C {
+	function f(bool b) public pure {
+		uint x;
+		if (b) ++(x);
+		else x += 1;
+		assert(x == 1);
+		assert(!b);
+	}
+}
+// ----
+// Warning 6328: (140-150): Assertion violation happens here


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/8817