### PR TITLE
[docs] Fix broken link to "Contract ABI" in natspec-format.rst

### DIFF
--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -195,8 +195,8 @@ JSON file as output:
     }
 
 Note that the key by which to find the methods is the function's
-canonical signature as defined in the `Contract
-ABI <Ethereum-Contract-ABI#signature>`__ and not simply the function's
+canonical signature as defined in the :ref:`Contract
+ABI <abi_function_selector>` and not simply the function's
 name.
 
 .. _header-developer-doc:


### PR DESCRIPTION
Resolves #6458.

While checking if I can just close the issue above I noticed that I missed one more broken link in #9587. This PR fixes it.