### PR TITLE
OSX: Fix readlink & ASTImportTest.sh issues.

### DIFF
--- a/scripts/test_antlr_grammar.sh
+++ b/scripts/test_antlr_grammar.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-ROOT_DIR=$(readlink -f "$(dirname "$0")"/..)
+READLINK=readlink
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    READLINK=greadlink
+fi
+ROOT_DIR=$(${READLINK} -f "$(dirname "$0")"/..)
 WORKDIR="${ROOT_DIR}/build/antlr"
 ANTLR_JAR="${ROOT_DIR}/build/deps/antlr4.jar"
 ANTLR_JAR_URI="https://www.antlr.org/download/antlr-4.8-complete.jar"
@@ -54,7 +58,7 @@ failed_count=0
 test_file()
 {
   local SOL_FILE
-  SOL_FILE="$(readlink -m "${1}")"
+  SOL_FILE="$(${READLINK}  -m "${1}")"
   local cur=${2}
   local max=${3}
   local solOrYul=${4}


### PR DESCRIPTION
Fix #9711 and #9712. Also see #9710. 

This is probably not the cleanest solution. 

- `scripts/splitSources.py` - system exception hook will print message and will result code `3`. This will be treated as a critical error by `scripts/ASTImportTest.sh`.  If an `UnicodeDecodeError` exception occurs, the script will result code `2`, `scripts/ASTImportTest.sh` will ignore this, but will print stdout of the python script. The semantic of result code `0` and `1` are the same as before: `0` means that there was code extracted from a multi-source file and `1` means that the file was not a multi-source file. Also regarding #9710: splitting of multi-source files containing invalid utf-8 sequences is still not implemented.

- `scripts/ASTImportTest.sh` - use of `greadlink` on osx #9712. fix that it silently ignores errors by adding result code handling for `scripts/splitSources.py` #9711. 

- `scripts/test_antlr_grammar.sh` - use of `greadlink` on osx.