### PR TITLE
Do not generally override CXX standard.

### DIFF
--- a/cmake/EthToolchains.cmake
+++ b/cmake/EthToolchains.cmake
@@ -1,5 +1,7 @@
 # Require C++17.
-set(CMAKE_CXX_STANDARD 17) # This requires at least CMake 3.8 to accept this C++17 flag.
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17) # This requires at least CMake 3.8 to accept this C++17 flag.
+endif ()
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
Fixes a small oversight in https://github.com/ethereum/solidity/pull/9693

(without this change CMake will overwrite the externally set flag and will still use a C++17 build in the C++20 build run)