### PR TITLE
Drop i386 from the PPA release script.

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -158,7 +158,7 @@ Vcs-Git: git://github.com/ethereum/solidity.git
 Vcs-Browser: https://github.com/ethereum/solidity
 
 Package: solc
-Architecture: any-i386 any-amd64
+Architecture: any-amd64
 Multi-Arch: same
 Depends: \${shlibs:Depends}, \${misc:Depends}
 Conflicts: libethereum (<= 1.2.9)


### PR DESCRIPTION
Ubuntu dropped support after bionic, so the builds for newer versions won't even attempt to build an i386 version - and the bionic i386 build has been failing for ages now with no-one complaining...

So at this point we might as well drop it from being marked as supported for the package.

The alternative would be to have a 32-bit linux test build...

Ping @chriseth