### PR TITLE
ViewPureChecker::reportMutability: don't check visibility on constructors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ Compiler Features:
 
 Bugfixes:
  * Type Checker: Disallow ``virtual`` for modifiers in libraries.
-
+ * ViewPureChecker: Prevent visibility check on constructors.
 
 ### 0.7.1 (2020-09-02)
 

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -261,21 +261,24 @@ void ViewPureChecker::reportMutability(
 	{
 		// We do not warn for library functions because they cannot be payable anyway.
 		// Also internal functions should be allowed to use `msg.value`.
-		if (m_currentFunction->isPublic() && !m_currentFunction->libraryFunction())
+		if ((m_currentFunction->isConstructor() || m_currentFunction->isPublic()) && !m_currentFunction->libraryFunction())
 		{
 			if (_nestedLocation)
 				m_errorReporter.typeError(
 					4006_error,
 					_location,
 					SecondarySourceLocation().append("\"msg.value\" or \"callvalue()\" appear here inside the modifier.", *_nestedLocation),
-					"This modifier uses \"msg.value\" or \"callvalue()\" and thus the function has to be payable or internal."
+					m_currentFunction->isConstructor()  ?
+						"This modifier uses \"msg.value\" or \"callvalue()\" and thus the constructor has to be payable."
+						: "This modifier uses \"msg.value\" or \"callvalue()\" and thus the function has to be payable or internal."
 				);
 			else
 				m_errorReporter.typeError(
 					5887_error,
 					_location,
-					"\"msg.value\" and \"callvalue()\" can only be used in payable public functions. Make the function "
-					"\"payable\" or use an internal function to avoid this error."
+					m_currentFunction->isConstructor()  ?
+						"\"msg.value\" and \"callvalue()\" can only be used in payable constructors. Make the constructor \"payable\" to avoid this error."
+						: "\"msg.value\" and \"callvalue()\" can only be used in payable public functions. Make the function \"payable\" or use an internal function to avoid this error."
 				);
 			m_errors = true;
 		}

--- a/test/libsolidity/syntaxTests/constructor/msg_value_non_payable.sol
+++ b/test/libsolidity/syntaxTests/constructor/msg_value_non_payable.sol
@@ -1,0 +1,8 @@
+contract C {
+    uint256 value;
+    constructor() {
+        value = msg.value;
+    }
+}
+// ----
+// TypeError 5887: (68-77): "msg.value" and "callvalue()" can only be used in payable constructors. Make the constructor "payable" to avoid this error.

--- a/test/libsolidity/syntaxTests/functionCalls/msg_value_non_payable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/msg_value_non_payable.sol
@@ -1,0 +1,7 @@
+contract C {
+    function get() public view returns(uint256) {
+        return msg.value;
+    }
+}
+// ----
+// TypeError 5887: (78-87): "msg.value" and "callvalue()" can only be used in payable public functions. Make the function "payable" or use an internal function to avoid this error.


### PR DESCRIPTION
Fix #9629.