### PR TITLE
Refactor oversized type checking

### DIFF
--- a/test/libsolidity/syntaxTests/iceRegressionTests/large_array_in_memory_struct_2.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/large_array_in_memory_struct_2.sol
@@ -10,3 +10,4 @@ contract C {
 }
 // ----
 // TypeError 1534: (169-181): Type too large for memory.
+// TypeError 1534: (191-207): Type too large for memory.

--- a/test/libsolidity/syntaxTests/largeTypes/large_mapping.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_mapping.sol
@@ -1,0 +1,5 @@
+contract C {
+    mapping (uint => uint[2][2**255]) A;
+}
+// ----
+// TypeError 1534: (17-52): Type too large for storage.

--- a/test/libsolidity/syntaxTests/largeTypes/large_mapping_in_array.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_mapping_in_array.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public {
+        mapping (uint => uint[2][2**255])[][] storage A;
+        mapping (uint => uint[2][2**255])[2] storage B;
+    }
+}
+// ----
+// TypeError 1534: (47-94): Type too large for storage.
+// TypeError 1534: (104-150): Type too large for storage.

--- a/test/libsolidity/syntaxTests/largeTypes/large_mapping_in_struct.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/large_mapping_in_struct.sol
@@ -1,0 +1,8 @@
+contract C {
+    struct S {
+        mapping (uint => uint[2][2**255]) A;
+    }
+    S s;
+}
+// ----
+// TypeError 1534: (83-86): Type too large for storage.


### PR DESCRIPTION
Oversized types lead to compilation errors and collision warnings. The logic of both cases is similar, but not the same. This PR suggests some unification.