### PR TITLE
Fix typo: "fallback" should be "receive"

### DIFF
--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -277,7 +277,7 @@ neither a receive Ether nor a payable fallback function is present, the
 contract cannot receive Ether through regular transactions and throws an
 exception.
 
-In the worst case, the fallback function can only rely on 2300 gas being
+In the worst case, the ``receive`` function can only rely on 2300 gas being
 available (for example when ``send`` or ``transfer`` is used), leaving little
 room to perform other operations except basic logging. The following operations
 will consume more gas than the 2300 gas stipend:


### PR DESCRIPTION
I believe the modified line is referring to the `receive` function instead of the fallback function.
If that's incorrect, I'd suggest rewording it to make it clear that we're discussing the fallback function in the `receive` section.
