### PR TITLE
Type Checker: Disallow ``virtual`` for modifiers in libraries.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
  * Yul Optimizer: Prune unused parameters in functions.
 
 Bugfixes:
+ * Type Checker: Disallow ``virtual`` for modifiers in libraries.
 
 
 ### 0.7.1 (2020-09-02)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -320,6 +320,15 @@ void TypeChecker::endVisit(InheritanceSpecifier const& _inheritance)
 
 void TypeChecker::endVisit(ModifierDefinition const& _modifier)
 {
+	if (_modifier.virtualSemantics())
+		if (auto const* contractDef = dynamic_cast<ContractDefinition const*>(_modifier.scope()))
+			if (contractDef->isLibrary())
+				m_errorReporter.typeError(
+					3275_error,
+					_modifier.location(),
+					"Modifiers in a library cannot be virtual."
+				);
+
 	if (!_modifier.isImplemented() && !_modifier.virtualSemantics())
 		m_errorReporter.typeError(8063_error, _modifier.location(), "Modifiers without implementation must be marked virtual.");
 }

--- a/test/libsolidity/syntaxTests/inheritance/virtual/modifier_virtual_err.sol
+++ b/test/libsolidity/syntaxTests/inheritance/virtual/modifier_virtual_err.sol
@@ -1,0 +1,7 @@
+library test {
+    modifier m virtual;
+    function f() m public {
+    }
+}
+// ----
+// TypeError 3275: (19-38): Modifiers in a library cannot be virtual.


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/9745