### PR TITLE
[SMTChecker] Refactor CHC sorts

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -104,6 +104,8 @@ set(sources
 	formal/ModelChecker.h
 	formal/Predicate.cpp
 	formal/Predicate.h
+	formal/PredicateSort.cpp
+	formal/PredicateSort.h
 	formal/SMTEncoder.cpp
 	formal/SMTEncoder.h
 	formal/SSAVariable.cpp

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -117,19 +117,8 @@ private:
 
 	/// Sort helpers.
 	//@{
-	static std::vector<smtutil::SortPointer> stateSorts(ContractDefinition const& _contract);
-	smtutil::SortPointer constructorSort();
-	smtutil::SortPointer interfaceSort();
-	smtutil::SortPointer nondetInterfaceSort();
-	static smtutil::SortPointer interfaceSort(ContractDefinition const& _const);
-	static smtutil::SortPointer nondetInterfaceSort(ContractDefinition const& _const);
-	smtutil::SortPointer arity0FunctionSort() const;
 	smtutil::SortPointer sort(FunctionDefinition const& _function);
 	smtutil::SortPointer sort(ASTNode const* _block);
-	/// @returns the sort of a predicate that represents the summary of _function in the scope of _contract.
-	/// The _contract is also needed because the same function might be in many contracts due to inheritance,
-	/// where the sort changes because the set of state variables might change.
-	static smtutil::SortPointer summarySort(FunctionDefinition const& _function, ContractDefinition const& _contract);
 	//@}
 
 	/// Predicate helpers.
@@ -246,9 +235,12 @@ private:
 
 	/// Misc.
 	//@{
-	/// Returns a prefix to be used in a new unique block name
+	/// @returns a prefix to be used in a new unique block name
 	/// and increases the block counter.
 	std::string uniquePrefix();
+
+	/// @returns a suffix to be used by contract related predicates.
+	std::string contractSuffix(ContractDefinition const& _contract);
 
 	/// @returns a new unique error id associated with _expr and stores
 	/// it into m_errorIds.
@@ -257,10 +249,6 @@ private:
 
 	/// Predicates.
 	//@{
-	/// Implicit constructor predicate.
-	/// Explicit constructors are handled as functions.
-	Predicate const* m_implicitConstructorPredicate = nullptr;
-
 	/// Constructor summary predicate, exists after the constructor
 	/// (implicit or explicit) and before the interface.
 	Predicate const* m_constructorSummaryPredicate = nullptr;
@@ -292,9 +280,6 @@ private:
 
 	/// Variables.
 	//@{
-	/// State variables sorts.
-	/// Used by all predicates.
-	std::vector<smtutil::SortPointer> m_stateSorts;
 	/// State variables.
 	/// Used to create all predicates.
 	std::vector<VariableDeclaration const*> m_stateVariables;

--- a/libsolidity/formal/PredicateSort.cpp
+++ b/libsolidity/formal/PredicateSort.cpp
@@ -1,0 +1,111 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/formal/PredicateSort.h>
+
+#include <libsolidity/formal/SMTEncoder.h>
+#include <libsolidity/formal/SymbolicTypes.h>
+
+using namespace std;
+using namespace solidity::util;
+using namespace solidity::smtutil;
+
+namespace solidity::frontend::smt
+{
+
+SortPointer interfaceSort(ContractDefinition const& _contract)
+{
+	return make_shared<FunctionSort>(
+		stateSorts(_contract),
+		SortProvider::boolSort
+	);
+}
+
+SortPointer nondetInterfaceSort(ContractDefinition const& _contract)
+{
+	auto varSorts = stateSorts(_contract);
+	return make_shared<FunctionSort>(
+		varSorts + varSorts,
+		SortProvider::boolSort
+	);
+}
+
+SortPointer implicitConstructorSort()
+{
+	return arity0FunctionSort();
+}
+
+SortPointer constructorSort(ContractDefinition const& _contract)
+{
+	if (auto const* constructor = _contract.constructor())
+		return functionSort(*constructor, &_contract);
+
+	return make_shared<FunctionSort>(
+		vector<SortPointer>{SortProvider::uintSort} + stateSorts(_contract),
+		SortProvider::boolSort
+	);
+}
+
+SortPointer functionSort(FunctionDefinition const& _function, ContractDefinition const* _contract)
+{
+	auto smtSort = [](auto _var) { return smt::smtSortAbstractFunction(*_var->type()); };
+	auto varSorts = _contract ? stateSorts(*_contract) : vector<SortPointer>{};
+	auto inputSorts = applyMap(_function.parameters(), smtSort);
+	auto outputSorts = applyMap(_function.returnParameters(), smtSort);
+	return make_shared<FunctionSort>(
+		vector<SortPointer>{SortProvider::uintSort} +
+			varSorts +
+			inputSorts +
+			varSorts +
+			inputSorts +
+			outputSorts,
+		SortProvider::boolSort
+	);
+}
+
+SortPointer functionBodySort(FunctionDefinition const& _function, ContractDefinition const* _contract)
+{
+	auto fSort = dynamic_pointer_cast<FunctionSort>(functionSort(_function, _contract));
+	solAssert(fSort, "");
+
+	auto smtSort = [](auto _var) { return smt::smtSortAbstractFunction(*_var->type()); };
+	return make_shared<FunctionSort>(
+		fSort->domain + applyMap(_function.localVariables(), smtSort),
+		SortProvider::boolSort
+	);
+}
+
+SortPointer arity0FunctionSort()
+{
+	return make_shared<FunctionSort>(
+		vector<SortPointer>(),
+		SortProvider::boolSort
+	);
+}
+
+/// Helpers
+
+vector<SortPointer> stateSorts(ContractDefinition const& _contract)
+{
+	return applyMap(
+		SMTEncoder::stateVariablesIncludingInheritedAndPrivate(_contract),
+		[](auto _var) { return smt::smtSortAbstractFunction(*_var->type()); }
+	);
+}
+
+}

--- a/libsolidity/formal/PredicateSort.h
+++ b/libsolidity/formal/PredicateSort.h
@@ -1,0 +1,82 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsolidity/formal/Predicate.h>
+
+#include <libsmtutil/Sorts.h>
+
+namespace solidity::frontend::smt
+{
+
+/**
+ * This file represents the specification for CHC predicate sorts.
+ * Types of predicates:
+ *
+ * 1. Interface
+ * The idle state of a contract. Signature:
+ * interface(stateVariables).
+ *
+ * 2. Nondet interface
+ * The nondeterminism behavior of a contract. Signature:
+ * nondet_interface(stateVariables, stateVariables').
+ *
+ * 3. Implicit constructor
+ * The implicit constructor of a contract, that is, without input parameters. Signature:
+ * implicit_constructor().
+ *
+ * 4. Constructor entry/summary
+ * The summary of an implicit constructor. Signature:
+ * constructor_summary(error, stateVariables').
+ *
+ * 5. Function entry/summary
+ * The entry point of a function definition. Signature:
+ * function_entry(error, stateVariables, inputVariables, stateVariables', inputVariables', outputVariables').
+ *
+ * 6. Function body
+ * Use for any predicate within a function. Signature:
+ * function_body(error, stateVariables, inputVariables, stateVariables', inputVariables', outputVariables', localVariables).
+ */
+
+/// @returns the interface predicate sort for _contract.
+smtutil::SortPointer interfaceSort(ContractDefinition const& _contract);
+
+/// @returns the nondeterminisc interface predicate sort for _contract.
+smtutil::SortPointer nondetInterfaceSort(ContractDefinition const& _contract);
+
+/// @returns the implicit constructor predicate sort.
+smtutil::SortPointer implicitConstructorSort();
+
+/// @returns the constructor entry/summary predicate sort for _contract.
+smtutil::SortPointer constructorSort(ContractDefinition const& _contract);
+
+/// @returns the function entry/summary predicate sort for _function contained in _contract.
+smtutil::SortPointer functionSort(FunctionDefinition const& _function, ContractDefinition const* _contract);
+
+/// @returns the function body predicate sort for _function contained in _contract.
+smtutil::SortPointer functionBodySort(FunctionDefinition const& _function, ContractDefinition const* _contract);
+
+/// @returns the sort of a predicate without parameters.
+smtutil::SortPointer arity0FunctionSort();
+
+/// Helpers
+
+std::vector<smtutil::SortPointer> stateSorts(ContractDefinition const& _contract) ;
+
+}


### PR DESCRIPTION
Depends on https://github.com/ethereum/solidity/pull/9731

This PR pulls sort management out of CHC. The new file is much easier to read, understand, and apply changes to.