### PR TITLE
Fix overload resolution with named arguments when order differs from declaration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Bugfixes:
  * Type Checker: Disallow ``virtual`` for modifiers in libraries.
  * ViewPureChecker: Prevent visibility check on constructors.
  * Type system: Fix internal error on implicit conversion of contract instance to the type of its ``super``.
+ * Type system: Fix named parameters in overloaded function and event calls being matched incorrectly if the order differs from the declaration.
 
 ### 0.7.1 (2020-09-02)
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3485,12 +3485,12 @@ bool FunctionType::canTakeArguments(
 
 		size_t matchedNames = 0;
 
-		for (auto const& argName: _arguments.names)
-			for (size_t i = 0; i < paramNames.size(); i++)
-				if (*argName == paramNames[i])
+		for (size_t a = 0; a < _arguments.names.size(); a++)
+			for (size_t p = 0; p < paramNames.size(); p++)
+				if (*_arguments.names[a] == paramNames[p])
 				{
 					matchedNames++;
-					if (!_arguments.types[i]->isImplicitlyConvertibleTo(*paramTypes[i]))
+					if (!_arguments.types[a]->isImplicitlyConvertibleTo(*paramTypes[p]))
 						return false;
 				}
 

--- a/test/libsolidity/syntaxTests/events/event_named_arguments_in_any_order.sol
+++ b/test/libsolidity/syntaxTests/events/event_named_arguments_in_any_order.sol
@@ -1,0 +1,13 @@
+contract C {
+    event e(uint u, string s, bool b);
+
+    function call() public {
+        emit e({s: "abc", u: 1,     b: true});
+        emit e({s: "abc", b: true,  u: 1});
+        emit e({u: 1,     s: "abc", b: true});
+        emit e({b: true,  s: "abc", u: 1});
+        emit e({u: 1,     b: true,  s: "abc"});
+        emit e({b: true,  u: 1,     s: "abc"});
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/events/event_overload_named_arguments_ambiguous.sol
+++ b/test/libsolidity/syntaxTests/events/event_overload_named_arguments_ambiguous.sol
@@ -1,0 +1,10 @@
+contract C {
+    event e(uint u, string s);
+    event e(string s, uint u);
+
+    function call() public {
+        emit e({u: 2, s: "abc"});
+    }
+}
+// ----
+// TypeError 4487: (118-119): No unique declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/events/event_overload_named_arguments_ambiguous_implicit_conversion.sol
+++ b/test/libsolidity/syntaxTests/events/event_overload_named_arguments_ambiguous_implicit_conversion.sol
@@ -1,0 +1,10 @@
+contract C {
+    event e(uint u, string s);
+    event e(bytes s, int u);
+
+    function call() public {
+        emit e({u: 2, s: "abc"});
+    }
+}
+// ----
+// TypeError 4487: (116-117): No unique declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/events/event_overload_named_arguments_in_any_order.sol
+++ b/test/libsolidity/syntaxTests/events/event_overload_named_arguments_in_any_order.sol
@@ -1,0 +1,14 @@
+contract C {
+    event e(uint u, string s, bool b);
+    event e(uint u, uint s, uint b);
+
+    function call() public {
+        emit e({s: "abc", u: 1,     b: true});
+        emit e({s: "abc", b: true,  u: 1});
+        emit e({u: 1,     s: "abc", b: true});
+        emit e({b: true,  s: "abc", u: 1});
+        emit e({u: 1,     b: true,  s: "abc"});
+        emit e({b: true,  u: 1,     s: "abc"});
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/events/event_overload_named_arguments_wrong_types.sol
+++ b/test/libsolidity/syntaxTests/events/event_overload_named_arguments_wrong_types.sol
@@ -1,0 +1,10 @@
+contract C {
+    event e(uint u, string s);
+    event e(string s, uint u);
+
+    function call() public {
+        emit e({s: 2, u: "abc"});
+    }
+}
+// ----
+// TypeError 9322: (118-119): No matching declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_in_any_order.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_in_any_order.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f(uint u, string memory s, bool b) internal {}
+
+    function call() public {
+        f({s: "abc", u: 1,     b: true});
+        f({s: "abc", b: true,  u: 1});
+        f({u: 1,     s: "abc", b: true});
+        f({b: true,  s: "abc", u: 1});
+        f({u: 1,     b: true,  s: "abc"});
+        f({b: true,  u: 1,     s: "abc"});
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_ambiguous.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_ambiguous.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f(uint x, string memory y, bool z) internal {}
+    function f(string memory y, uint x, bool z) internal {}
+    function f(bool z, string memory y, uint x) internal {}
+
+    function call() internal {
+        f({x: 1, y: "abc", z: true});
+    }
+}
+// ----
+// TypeError 4487: (233-234): No unique declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_ambiguous_implicit_conversion.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_ambiguous_implicit_conversion.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f(uint x, string memory y) internal {}
+    function f(bytes memory y, int x) internal {}
+
+    function call() internal {
+        f({x: 1, y: "abc"});
+    }
+}
+// ----
+// TypeError 4487: (155-156): No unique declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_right_names_wrong_order.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_right_names_wrong_order.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f(uint x, string memory y, bool z) internal {}
+    function f(uint x, uint y, uint z) internal {}
+
+    function call() internal {
+        f({y: 1, x: "abc", z: true});
+    }
+}
+// ----
+// TypeError 9322: (164-165): No matching declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_wrong_names.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_failing_wrong_names.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f(uint x, string memory y, bool z) internal {}
+    function f(uint x, uint y, uint z) internal {}
+
+    function call() internal {
+        f({a: 1, b: "abc", c: true});
+    }
+}
+// ----
+// TypeError 9322: (164-165): No matching declaration found after argument-dependent lookup.

--- a/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_in_any_order.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/named_arguments_overload_in_any_order.sol
@@ -1,0 +1,14 @@
+contract C {
+    function f(uint u, string memory s, bool b) internal {}
+    function f(uint u, uint s, uint b) internal {}
+
+    function call() public {
+        f({s: "abc", u: 1,     b: true});
+        f({s: "abc", b: true,  u: 1});
+        f({u: 1,     s: "abc", b: true});
+        f({b: true,  s: "abc", u: 1});
+        f({u: 1,     b: true,  s: "abc"});
+        f({b: true,  u: 1,     s: "abc"});
+    }
+}
+// ----


### PR DESCRIPTION
Fixes #9752.