### PR TITLE
[yul-phaser] Fix slow tests for classic genetic algorithm

### DIFF
--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -47,25 +47,25 @@ using namespace solidity::util;
 namespace solidity::phaser::test
 {
 
+vector<string> const ChrOmOsoMeSteps{
+	ConditionalSimplifier::name,
+	FunctionHoister::name,
+	RedundantAssignEliminator::name,
+	ForLoopConditionOutOfBody::name,
+	Rematerialiser::name,
+	ForLoopConditionOutOfBody::name,
+	ExpressionSimplifier::name,
+	ForLoopInitRewriter::name,
+	LoopInvariantCodeMotion::name,
+	ExpressionInliner::name
+};
+
 BOOST_AUTO_TEST_SUITE(Phaser, *boost::unit_test::label("nooptions"))
 BOOST_AUTO_TEST_SUITE(ChromosomeTest)
 
 BOOST_AUTO_TEST_CASE(constructor_should_convert_from_string_to_optimisation_steps)
 {
-	vector<string> expectedSteps{
-		ConditionalSimplifier::name,
-		FunctionHoister::name,
-		RedundantAssignEliminator::name,
-		ForLoopConditionOutOfBody::name,
-		Rematerialiser::name,
-		ForLoopConditionOutOfBody::name,
-		ExpressionSimplifier::name,
-		ForLoopInitRewriter::name,
-		LoopInvariantCodeMotion::name,
-		ExpressionInliner::name
-	};
-
-	BOOST_TEST(Chromosome("ChrOmOsoMe").optimisationSteps() == expectedSteps);
+	BOOST_TEST(Chromosome("ChrOmOsoMe").optimisationSteps() == ChrOmOsoMeSteps);
 }
 
 BOOST_AUTO_TEST_CASE(makeRandom_should_return_different_chromosome_each_time)
@@ -149,6 +149,18 @@ BOOST_AUTO_TEST_CASE(randomOptimisationStep_should_return_each_step_with_same_pr
 
 	BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
 	BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
+}
+
+BOOST_AUTO_TEST_CASE(stepsToGenes_should_translate_optimisation_step_names_to_abbreviations)
+{
+	BOOST_TEST(Chromosome::stepsToGenes({}) == "");
+	BOOST_TEST(Chromosome::stepsToGenes(ChrOmOsoMeSteps) == "ChrOmOsoMe");
+}
+
+BOOST_AUTO_TEST_CASE(genesToSteps_should_translate_optimisation_step_abbreviations_to_names)
+{
+	BOOST_TEST(Chromosome::genesToSteps("") == vector<string>{});
+	BOOST_TEST(Chromosome::genesToSteps("ChrOmOsoMe") == ChrOmOsoMeSteps);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -63,11 +63,6 @@ vector<string> const ChrOmOsoMeSteps{
 BOOST_AUTO_TEST_SUITE(Phaser, *boost::unit_test::label("nooptions"))
 BOOST_AUTO_TEST_SUITE(ChromosomeTest)
 
-BOOST_AUTO_TEST_CASE(constructor_should_convert_from_string_to_optimisation_steps)
-{
-	BOOST_TEST(Chromosome("ChrOmOsoMe").optimisationSteps() == ChrOmOsoMeSteps);
-}
-
 BOOST_AUTO_TEST_CASE(makeRandom_should_return_different_chromosome_each_time)
 {
 	SimulationRNG::reset(1);
@@ -95,6 +90,11 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_use_every_possible_step_with_the_same_pro
 	BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
 }
 
+BOOST_AUTO_TEST_CASE(constructor_should_store_genes)
+{
+	BOOST_TEST(Chromosome("ChrOmOsoMe").genes() == "ChrOmOsoMe");
+}
+
 BOOST_AUTO_TEST_CASE(constructor_should_store_optimisation_steps)
 {
 	vector<string> steps = {
@@ -102,9 +102,8 @@ BOOST_AUTO_TEST_CASE(constructor_should_store_optimisation_steps)
 		BlockFlattener::name,
 		UnusedPruner::name,
 	};
-	Chromosome chromosome(steps);
 
-	BOOST_TEST(steps == chromosome.optimisationSteps());
+	BOOST_TEST(Chromosome(steps).genes() == "tfu");
 }
 
 BOOST_AUTO_TEST_CASE(constructor_should_allow_duplicate_steps)
@@ -116,9 +115,9 @@ BOOST_AUTO_TEST_CASE(constructor_should_allow_duplicate_steps)
 		UnusedPruner::name,
 		BlockFlattener::name,
 	};
-	Chromosome chromosome(steps);
 
-	BOOST_TEST(steps == chromosome.optimisationSteps());
+	BOOST_TEST(Chromosome(steps).genes() == "ttfuf");
+	BOOST_TEST(Chromosome("ttfuf").genes() == "ttfuf");
 }
 
 BOOST_AUTO_TEST_CASE(output_operator_should_create_concise_and_unambiguous_string_representation)
@@ -131,6 +130,11 @@ BOOST_AUTO_TEST_CASE(output_operator_should_create_concise_and_unambiguous_strin
 	BOOST_TEST(chromosome.length() == allSteps.size());
 	BOOST_TEST(chromosome.optimisationSteps() == allSteps);
 	BOOST_TEST(toString(chromosome) == "flcCUnDvejsxIOoighTLMNrmVatpud");
+}
+
+BOOST_AUTO_TEST_CASE(optimisationSteps_should_translate_chromosomes_genes_to_optimisation_step_names)
+{
+	BOOST_TEST(Chromosome("ChrOmOsoMe").optimisationSteps() == ChrOmOsoMeSteps);
 }
 
 BOOST_AUTO_TEST_CASE(randomOptimisationStep_should_return_each_step_with_same_probability)

--- a/test/yulPhaser/GeneticAlgorithms.cpp
+++ b/test/yulPhaser/GeneticAlgorithms.cpp
@@ -213,8 +213,7 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_generate_individuals_in_the_crossove
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(ClassicGeneticAlgorithmTest)
 
-// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_proportional_to_fitness, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_proportional_to_fitness, ClassicGeneticAlgorithmFixture)
 {
 	constexpr double relativeTolerance = 0.1;
 	constexpr size_t populationSize = 1000;
@@ -255,8 +254,7 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_individuals_with_probability_
 	BOOST_TEST(abs(meanSquaredError(newFitness, expectedValue) - variance) < variance * relativeTolerance);
 }
 
-// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_only_individuals_existing_in_the_original_population, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_select_only_individuals_existing_in_the_original_population, ClassicGeneticAlgorithmFixture)
 {
 	constexpr size_t populationSize = 1000;
 	auto population = Population::makeRandom(m_fitnessMetric, populationSize, 1, 10);
@@ -300,8 +298,7 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_crossover, ClassicGeneticAlgorith
 	BOOST_TEST(totalCrossed >= 2);
 }
 
-// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithmFixture)
 {
 	m_options.mutationChance = 0.6;
 	ClassicGeneticAlgorithm algorithm(m_options);
@@ -330,8 +327,7 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_mutation, ClassicGeneticAlgorithm
 	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
 }
 
-// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithmFixture)
 {
 	m_options.deletionChance = 0.6;
 	ClassicGeneticAlgorithm algorithm(m_options);
@@ -360,8 +356,7 @@ BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_deletion, ClassicGeneticAlgorithm
 	BOOST_TEST(abs(meanSquaredError(bernoulliTrials, expectedValue) - variance) < variance * relativeTolerance);
 }
 
-// FIXME: This test runs *very* slowly (tens of seconds). Investigate, fix and re-enable.
-BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_addition, ClassicGeneticAlgorithmFixture, *boost::unit_test::disabled())
+BOOST_FIXTURE_TEST_CASE(runNextRound_should_do_addition, ClassicGeneticAlgorithmFixture)
 {
 	m_options.additionChance = 0.6;
 	ClassicGeneticAlgorithm algorithm(m_options);

--- a/test/yulPhaser/Mutations.cpp
+++ b/test/yulPhaser/Mutations.cpp
@@ -218,10 +218,11 @@ BOOST_AUTO_TEST_CASE(alternativeMutations_should_always_choose_second_mutation_i
 BOOST_AUTO_TEST_CASE(mutationSequence_should_apply_all_mutations)
 {
 	Chromosome chromosome("aaaaa");
+	vector<string> steps = Chromosome::genesToSteps("gfc");
 	function<Mutation> mutation = mutationSequence({
-		geneSubstitution(3, Chromosome("g").optimisationSteps()[0]),
-		geneSubstitution(2, Chromosome("f").optimisationSteps()[0]),
-		geneSubstitution(1, Chromosome("c").optimisationSteps()[0]),
+		geneSubstitution(3, steps[0]),
+		geneSubstitution(2, steps[1]),
+		geneSubstitution(1, steps[2]),
 	});
 
 	BOOST_TEST(mutation(chromosome) == Chromosome("acfga"));
@@ -230,11 +231,12 @@ BOOST_AUTO_TEST_CASE(mutationSequence_should_apply_all_mutations)
 BOOST_AUTO_TEST_CASE(mutationSequence_apply_mutations_in_the_order_they_are_given)
 {
 	Chromosome chromosome("aa");
+	vector<string> steps = Chromosome::genesToSteps("gcfo");
 	function<Mutation> mutation = mutationSequence({
-		geneSubstitution(0, Chromosome("g").optimisationSteps()[0]),
-		geneSubstitution(1, Chromosome("c").optimisationSteps()[0]),
-		geneSubstitution(0, Chromosome("f").optimisationSteps()[0]),
-		geneSubstitution(1, Chromosome("o").optimisationSteps()[0]),
+		geneSubstitution(0, steps[0]),
+		geneSubstitution(1, steps[1]),
+		geneSubstitution(0, steps[2]),
+		geneSubstitution(1, steps[3]),
 	});
 
 	BOOST_TEST(mutation(chromosome) == Chromosome("fo"));

--- a/test/yulPhaser/Mutations.cpp
+++ b/test/yulPhaser/Mutations.cpp
@@ -24,6 +24,7 @@
 #include <libsolutil/CommonIO.h>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -117,12 +118,7 @@ BOOST_AUTO_TEST_CASE(geneAddition_should_be_able_to_insert_before_first_position
 
 	Chromosome mutatedChromosome = mutation(chromosome);
 	BOOST_TEST(mutatedChromosome.length() > chromosome.length());
-
-	vector<string> suffix(
-		mutatedChromosome.optimisationSteps().end() - static_cast<ptrdiff_t>(chromosome.length()),
-		mutatedChromosome.optimisationSteps().end()
-	);
-	BOOST_TEST(suffix == chromosome.optimisationSteps());
+	BOOST_TEST(boost::ends_with(mutatedChromosome.genes(), chromosome.genes()));
 }
 
 BOOST_AUTO_TEST_CASE(geneAddition_should_be_able_to_insert_after_last_position)
@@ -133,12 +129,7 @@ BOOST_AUTO_TEST_CASE(geneAddition_should_be_able_to_insert_after_last_position)
 
 	Chromosome mutatedChromosome = mutation(chromosome);
 	BOOST_TEST(mutatedChromosome.length() > chromosome.length());
-
-	vector<string> prefix(
-		mutatedChromosome.optimisationSteps().begin(),
-		mutatedChromosome.optimisationSteps().begin() + static_cast<ptrdiff_t>(chromosome.length())
-	);
-	BOOST_TEST(prefix == chromosome.optimisationSteps());
+	BOOST_TEST(boost::starts_with(mutatedChromosome.genes(), chromosome.genes()));
 }
 
 BOOST_AUTO_TEST_CASE(geneAddition_should_return_identical_chromosome_if_probability_is_zero)

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(build_should_apply_prefix)
 	CharStream nestedSource("{{{let x:= 1}}}", "");
 	Program nestedProgram = get<Program>(Program::load(nestedSource));
 	Program flatProgram = get<Program>(Program::load(nestedSource));
-	flatProgram.optimise(Chromosome("f").optimisationSteps());
+	flatProgram.optimise(Chromosome::genesToSteps("f"));
 	assert(toString(nestedProgram) != toString(flatProgram));
 
 	{

--- a/test/yulPhaser/ProgramCache.cpp
+++ b/test/yulPhaser/ProgramCache.cpp
@@ -53,7 +53,7 @@ protected:
 	Program optimisedProgram(Program _program, string _abbreviatedOptimisationSteps) const
 	{
 		Program result = move(_program);
-		result.optimise(Chromosome(_abbreviatedOptimisationSteps).optimisationSteps());
+		result.optimise(Chromosome::genesToSteps(_abbreviatedOptimisationSteps));
 		return result;
 	}
 

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -37,12 +37,6 @@ ostream& operator<<(ostream& _stream, Chromosome const& _chromosome);
 
 }
 
-Chromosome::Chromosome(string const& _optimisationSteps)
-{
-	for (char abbreviation: _optimisationSteps)
-		m_optimisationSteps.push_back(OptimiserSuite::stepAbbreviationToNameMap().at(abbreviation));
-}
-
 Chromosome Chromosome::makeRandom(size_t _length)
 {
 	vector<string> steps;
@@ -54,10 +48,7 @@ Chromosome Chromosome::makeRandom(size_t _length)
 
 ostream& phaser::operator<<(ostream& _stream, Chromosome const& _chromosome)
 {
-	for (auto const& stepName: _chromosome.m_optimisationSteps)
-		_stream << OptimiserSuite::stepNameToAbbreviationMap().at(stepName);
-
-	return _stream;
+	return _stream << Chromosome::stepsToGenes(_chromosome.m_optimisationSteps);
 }
 
 vector<string> Chromosome::allStepNames()
@@ -74,4 +65,22 @@ string const& Chromosome::randomOptimisationStep()
 	static vector<string> stepNames = allStepNames();
 
 	return stepNames[SimulationRNG::uniformInt(0, stepNames.size() - 1)];
+}
+
+string Chromosome::stepsToGenes(vector<string> const& _optimisationSteps)
+{
+	string genes;
+	for (string const& stepName: _optimisationSteps)
+		genes.push_back(OptimiserSuite::stepNameToAbbreviationMap().at(stepName));
+
+	return genes;
+}
+
+vector<string> Chromosome::genesToSteps(string const& _genes)
+{
+	vector<string> steps;
+	for (char abbreviation: _genes)
+		steps.push_back(OptimiserSuite::stepAbbreviationToNameMap().at(abbreviation));
+
+	return steps;
 }

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -48,7 +48,7 @@ Chromosome Chromosome::makeRandom(size_t _length)
 
 ostream& phaser::operator<<(ostream& _stream, Chromosome const& _chromosome)
 {
-	return _stream << Chromosome::stepsToGenes(_chromosome.m_optimisationSteps);
+	return _stream << _chromosome.m_genes;
 }
 
 vector<string> Chromosome::allStepNames()

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -42,17 +42,19 @@ class Chromosome
 public:
 	Chromosome() = default;
 	explicit Chromosome(std::vector<std::string> _optimisationSteps):
-		m_optimisationSteps(std::move(_optimisationSteps)) {}
-	explicit Chromosome(std::string const& _genes):
-		m_optimisationSteps(genesToSteps(_genes)) {}
+		m_genes(stepsToGenes(_optimisationSteps)) {}
+	explicit Chromosome(std::string _genes):
+		m_genes(std::move(_genes)) {}
 	static Chromosome makeRandom(size_t _length);
 
-	size_t length() const { return m_optimisationSteps.size(); }
-	std::vector<std::string> const& optimisationSteps() const { return m_optimisationSteps; }
+	size_t length() const { return m_genes.size(); }
+	std::string const& genes() const { return m_genes; }
+
+	std::vector<std::string> optimisationSteps() const { return genesToSteps(m_genes); }
 
 	friend std::ostream& operator<<(std::ostream& _stream, Chromosome const& _chromosome);
 
-	bool operator==(Chromosome const& _other) const { return m_optimisationSteps == _other.m_optimisationSteps; }
+	bool operator==(Chromosome const& _other) const { return m_genes == _other.m_genes; }
 	bool operator!=(Chromosome const& _other) const { return !(*this == _other); }
 
 	static std::string const& randomOptimisationStep();
@@ -62,7 +64,7 @@ public:
 private:
 	static std::vector<std::string> allStepNames();
 
-	std::vector<std::string> m_optimisationSteps;
+	std::string m_genes;
 };
 
 }

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -43,7 +43,8 @@ public:
 	Chromosome() = default;
 	explicit Chromosome(std::vector<std::string> _optimisationSteps):
 		m_optimisationSteps(std::move(_optimisationSteps)) {}
-	explicit Chromosome(std::string const& _optimisationSteps);
+	explicit Chromosome(std::string const& _genes):
+		m_optimisationSteps(genesToSteps(_genes)) {}
 	static Chromosome makeRandom(size_t _length);
 
 	size_t length() const { return m_optimisationSteps.size(); }
@@ -55,6 +56,8 @@ public:
 	bool operator!=(Chromosome const& _other) const { return !(*this == _other); }
 
 	static std::string const& randomOptimisationStep();
+	static std::string stepsToGenes(std::vector<std::string> const& _optimisationSteps);
+	static std::vector<std::string> genesToSteps(std::string const& _genes);
 
 private:
 	static std::vector<std::string> allStepNames();

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -120,19 +120,14 @@ ChromosomePair fixedPointSwap(
 	assert(_crossoverPoint <= _chromosome1.length());
 	assert(_crossoverPoint <= _chromosome2.length());
 
-	auto begin1 = _chromosome1.optimisationSteps().begin();
-	auto begin2 = _chromosome2.optimisationSteps().begin();
-	auto end1 = _chromosome1.optimisationSteps().end();
-	auto end2 = _chromosome2.optimisationSteps().end();
-
 	return {
 		Chromosome(
-			vector<string>(begin1, begin1 + static_cast<ptrdiff_t>(_crossoverPoint)) +
-			vector<string>(begin2 + static_cast<ptrdiff_t>(_crossoverPoint), end2)
+			_chromosome1.genes().substr(0, _crossoverPoint) +
+			_chromosome2.genes().substr(_crossoverPoint, _chromosome2.length() - _crossoverPoint)
 		),
 		Chromosome(
-			vector<string>(begin2, begin2 + static_cast<ptrdiff_t>(_crossoverPoint)) +
-			vector<string>(begin1 + static_cast<ptrdiff_t>(_crossoverPoint), end1)
+			_chromosome2.genes().substr(0, _crossoverPoint) +
+			_chromosome1.genes().substr(_crossoverPoint, _chromosome1.length() - _crossoverPoint)
 		),
 	};
 }
@@ -197,24 +192,19 @@ ChromosomePair fixedTwoPointSwap(
 	assert(_crossoverPoint2 <= _chromosome1.length());
 	assert(_crossoverPoint2 <= _chromosome2.length());
 
-	auto lowPoint = static_cast<ptrdiff_t>(min(_crossoverPoint1, _crossoverPoint2));
-	auto highPoint = static_cast<ptrdiff_t>(max(_crossoverPoint1, _crossoverPoint2));
-
-	auto begin1 = _chromosome1.optimisationSteps().begin();
-	auto begin2 = _chromosome2.optimisationSteps().begin();
-	auto end1 = _chromosome1.optimisationSteps().end();
-	auto end2 = _chromosome2.optimisationSteps().end();
+	size_t lowPoint = min(_crossoverPoint1, _crossoverPoint2);
+	size_t highPoint = max(_crossoverPoint1, _crossoverPoint2);
 
 	return {
 		Chromosome(
-			vector<string>(begin1, begin1 + lowPoint) +
-			vector<string>(begin2 + lowPoint, begin2 + highPoint) +
-			vector<string>(begin1 + highPoint, end1)
+			_chromosome1.genes().substr(0, lowPoint) +
+			_chromosome2.genes().substr(lowPoint, highPoint - lowPoint) +
+			_chromosome1.genes().substr(highPoint, _chromosome1.length() - highPoint)
 		),
 		Chromosome(
-			vector<string>(begin2, begin2 + lowPoint) +
-			vector<string>(begin1 + lowPoint, begin1 + highPoint) +
-			vector<string>(begin2 + highPoint, end2)
+			_chromosome2.genes().substr(0, lowPoint) +
+			_chromosome1.genes().substr(lowPoint, highPoint - lowPoint) +
+			_chromosome2.genes().substr(highPoint, _chromosome2.length() - highPoint)
 		),
 	};
 }
@@ -258,42 +248,37 @@ namespace
 
 ChromosomePair uniformSwap(Chromosome const& _chromosome1, Chromosome const& _chromosome2, double _swapChance)
 {
-	vector<string> steps1;
-	vector<string> steps2;
+	string steps1;
+	string steps2;
 
 	size_t minLength = min(_chromosome1.length(), _chromosome2.length());
 	for (size_t i = 0; i < minLength; ++i)
 		if (SimulationRNG::bernoulliTrial(_swapChance))
 		{
-			steps1.push_back(_chromosome2.optimisationSteps()[i]);
-			steps2.push_back(_chromosome1.optimisationSteps()[i]);
+			steps1.push_back(_chromosome2.genes()[i]);
+			steps2.push_back(_chromosome1.genes()[i]);
 		}
 		else
 		{
-			steps1.push_back(_chromosome1.optimisationSteps()[i]);
-			steps2.push_back(_chromosome2.optimisationSteps()[i]);
+			steps1.push_back(_chromosome1.genes()[i]);
+			steps2.push_back(_chromosome2.genes()[i]);
 		}
-
-	auto begin1 = _chromosome1.optimisationSteps().begin();
-	auto begin2 = _chromosome2.optimisationSteps().begin();
-	auto end1 = _chromosome1.optimisationSteps().end();
-	auto end2 = _chromosome2.optimisationSteps().end();
 
 	bool swapTail = SimulationRNG::bernoulliTrial(_swapChance);
 	if (_chromosome1.length() > minLength)
 	{
 		if (swapTail)
-			steps2.insert(steps2.end(), begin1 + static_cast<ptrdiff_t>(minLength), end1);
+			steps2 += _chromosome1.genes().substr(minLength, _chromosome1.length() - minLength);
 		else
-			steps1.insert(steps1.end(), begin1 + static_cast<ptrdiff_t>(minLength), end1);
+			steps1 += _chromosome1.genes().substr(minLength, _chromosome1.length() - minLength);
 	}
 
 	if (_chromosome2.length() > minLength)
 	{
 		if (swapTail)
-			steps1.insert(steps1.end(), begin2 + static_cast<ptrdiff_t>(minLength), end2);
+			steps1 += _chromosome2.genes().substr(minLength, _chromosome2.length() - minLength);
 		else
-			steps2.insert(steps2.end(), begin2 + static_cast<ptrdiff_t>(minLength), end2);
+			steps2 += _chromosome2.genes().substr(minLength, _chromosome2.length() - minLength);
 	}
 
 	return {Chromosome(steps1), Chromosome(steps2)};

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -54,7 +54,7 @@ bool phaser::isFitter(Individual const& a, Individual const& b)
 	return (
 		(a.fitness < b.fitness) ||
 		(a.fitness == b.fitness && a.chromosome.length() < b.chromosome.length()) ||
-		(a.fitness == b.fitness && a.chromosome.length() == b.chromosome.length() && toString(a.chromosome) < toString(b.chromosome))
+		(a.fitness == b.fitness && a.chromosome.length() == b.chromosome.length() && a.chromosome.genes() < b.chromosome.genes())
 	);
 }
 


### PR DESCRIPTION
Fixes #9343 and re-enables the disabled tests.

Turns out that the thing that was slowing tests was my last-minute change to `isFitter()` function to make chromosome comparisons deterministic. The change was a lexicographic comparison if length and fitness of both chromosomes were the same. The worst case scenario for this is a huge population of many long identical chromosomes - and that's exactly the case in the affected tests. The comparison was not very heavy on its own but still much heavier than iterating over a string and it's a very common operation. It involved iterating over the chromosome and looking up every step name in a map.

My fix is a refactor suggested at some point by @chriseth - making `Chromosome` store the string of abbreviations rather than a vector of optimisation step names. This way the string conversion is now basically free.

The re-enabled tests are now back to running in ~1 second (down from ~70 seconds before refactoring).