### PR TITLE
[yul-phaser] Make phaser tests less brittle

### DIFF
--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -120,6 +120,15 @@ BOOST_AUTO_TEST_CASE(constructor_should_allow_duplicate_steps)
 	BOOST_TEST(Chromosome("ttfuf").genes() == "ttfuf");
 }
 
+BOOST_AUTO_TEST_CASE(constructor_should_allow_genes_that_do_not_correspond_to_any_step)
+{
+	assert(OptimiserSuite::stepAbbreviationToNameMap().count('.') == 0);
+	assert(OptimiserSuite::stepAbbreviationToNameMap().count('b') == 0);
+
+	BOOST_TEST(Chromosome(".").genes() == ".");
+	BOOST_TEST(Chromosome("a..abatbb").genes() == "a..abatbb");
+}
+
 BOOST_AUTO_TEST_CASE(output_operator_should_create_concise_and_unambiguous_string_representation)
 {
 	vector<string> allSteps;

--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -73,8 +73,8 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_return_different_chromosome_each_time)
 BOOST_AUTO_TEST_CASE(makeRandom_should_use_every_possible_step_with_the_same_probability)
 {
 	SimulationRNG::reset(1);
-	constexpr int samplesPerStep = 100;
-	constexpr double relativeTolerance = 0.01;
+	constexpr int samplesPerStep = 500;
+	constexpr double relativeTolerance = 0.02;
 
 	map<string, size_t> stepIndices = enumerateOptmisationSteps();
 	auto chromosome = Chromosome::makeRandom(stepIndices.size() * samplesPerStep);
@@ -149,8 +149,8 @@ BOOST_AUTO_TEST_CASE(optimisationSteps_should_translate_chromosomes_genes_to_opt
 BOOST_AUTO_TEST_CASE(randomOptimisationStep_should_return_each_step_with_same_probability)
 {
 	SimulationRNG::reset(1);
-	constexpr int samplesPerStep = 100;
-	constexpr double relativeTolerance = 0.01;
+	constexpr int samplesPerStep = 500;
+	constexpr double relativeTolerance = 0.02;
 
 	map<string, size_t> stepIndices = enumerateOptmisationSteps();
 	vector<size_t> samples;

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -67,6 +67,11 @@ string const& Chromosome::randomOptimisationStep()
 	return stepNames[SimulationRNG::uniformInt(0, stepNames.size() - 1)];
 }
 
+char Chromosome::randomGene()
+{
+	return OptimiserSuite::stepNameToAbbreviationMap().at(randomOptimisationStep());
+}
+
 string Chromosome::stepsToGenes(vector<string> const& _optimisationSteps)
 {
 	string genes;

--- a/tools/yulPhaser/Chromosome.h
+++ b/tools/yulPhaser/Chromosome.h
@@ -44,6 +44,8 @@ public:
 	explicit Chromosome(std::vector<std::string> _optimisationSteps):
 		m_genes(stepsToGenes(_optimisationSteps)) {}
 	explicit Chromosome(std::string _genes):
+		// NOTE: We don't validate the genes - they're only checked at the point of conversion to
+		// actual optimisation steps names. This is very convenient in mutation tests.
 		m_genes(std::move(_genes)) {}
 	static Chromosome makeRandom(size_t _length);
 
@@ -58,6 +60,7 @@ public:
 	bool operator!=(Chromosome const& _other) const { return !(*this == _other); }
 
 	static std::string const& randomOptimisationStep();
+	static char randomGene();
 	static std::string stepsToGenes(std::vector<std::string> const& _optimisationSteps);
 	static std::vector<std::string> genesToSteps(std::string const& _genes);
 

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -36,15 +36,15 @@ function<Mutation> phaser::geneRandomisation(double _chance)
 {
 	return [=](Chromosome const& _chromosome)
 	{
-		vector<string> optimisationSteps;
-		for (auto const& step: _chromosome.optimisationSteps())
-			optimisationSteps.push_back(
+		string genes;
+		for (char gene: _chromosome.genes())
+			genes.push_back(
 				SimulationRNG::bernoulliTrial(_chance) ?
-				Chromosome::randomOptimisationStep() :
-				step
+				Chromosome::randomGene() :
+				gene
 			);
 
-		return Chromosome(move(optimisationSteps));
+		return Chromosome(move(genes));
 	};
 }
 
@@ -52,12 +52,12 @@ function<Mutation> phaser::geneDeletion(double _chance)
 {
 	return [=](Chromosome const& _chromosome)
 	{
-		vector<string> optimisationSteps;
-		for (auto const& step: _chromosome.optimisationSteps())
+		string genes;
+		for (char gene: _chromosome.genes())
 			if (!SimulationRNG::bernoulliTrial(_chance))
-				optimisationSteps.push_back(step);
+				genes.push_back(gene);
 
-		return Chromosome(move(optimisationSteps));
+		return Chromosome(move(genes));
 	};
 }
 
@@ -65,19 +65,19 @@ function<Mutation> phaser::geneAddition(double _chance)
 {
 	return [=](Chromosome const& _chromosome)
 	{
-		vector<string> optimisationSteps;
+		string genes;
 
 		if (SimulationRNG::bernoulliTrial(_chance))
-			optimisationSteps.push_back(Chromosome::randomOptimisationStep());
+			genes.push_back(Chromosome::randomGene());
 
-		for (auto const& step: _chromosome.optimisationSteps())
+		for (char gene: _chromosome.genes())
 		{
-			optimisationSteps.push_back(step);
+			genes.push_back(gene);
 			if (SimulationRNG::bernoulliTrial(_chance))
-				optimisationSteps.push_back(Chromosome::randomOptimisationStep());
+				genes.push_back(Chromosome::randomGene());
 		}
 
-		return Chromosome(move(optimisationSteps));
+		return Chromosome(move(genes));
 	};
 }
 


### PR DESCRIPTION
This PR replaces three mutation tests that had the expected random results hard-coded for a given seed. The new tests just check the expected value and variance of the random effects of mutations.

Another change are the increased tolerance and number of samples in two chromosome tests that also check variance and expected value. @chriseth reported that they tend do break easily. That's because the original tolerances and sample numbers are deliberately low to make them fast.

This change makes phaser tests take about 1.5 seconds, which is a lot compared to ~0.25 previously, but practically nothing compared to the runtime of other tests.

EDIT: Depends on #9783 (sorry for not mentioning it earlier!). 