### PR TITLE
Bump Z3 version in static Z3 PPA build to 4.8.9.

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -25,7 +25,7 @@ set -ev
 keyid=70D110489D66E2F6
 email=builds@ethereum.org
 packagename=libz3-static-dev
-version=4.8.8
+version=4.8.9
 
 DISTRIBUTIONS="bionic eoan focal"
 
@@ -80,7 +80,9 @@ Vcs-Browser: https://github.com/Z3Prover/z3
 
 Package: libz3-static-dev
 Section: libdevel
-Architecture: any-i386 any-amd64
+Architecture: any-amd64
+Breaks: libz3-dev
+Replaces: libz3-dev
 Multi-Arch: same
 Depends: \${shlibs:Depends}, \${misc:Depends}
 Description: theorem prover from Microsoft Research - development files (static library)

--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -27,7 +27,7 @@ email=builds@ethereum.org
 packagename=libz3-static-dev
 version=4.8.9
 
-DISTRIBUTIONS="bionic focal"
+DISTRIBUTIONS="bionic focal groovy"
 
 for distribution in $DISTRIBUTIONS
 do

--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -27,7 +27,7 @@ email=builds@ethereum.org
 packagename=libz3-static-dev
 version=4.8.9
 
-DISTRIBUTIONS="bionic eoan focal"
+DISTRIBUTIONS="bionic focal"
 
 for distribution in $DISTRIBUTIONS
 do


### PR DESCRIPTION
First step in a series of PRs to update the Z3 version everywhere.
I haven't run the script yet, so please ping me, once we're clear that we go through with this before the next release, then I'll run it and link the build status here :-).

Should be the last merged.
Depends on https://github.com/ethereum/solidity/pull/9797