### PR TITLE
Remove obsolete eoan and add new groovy from the PPA release script.

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -57,7 +57,7 @@ packagename=solc
 
 static_build_distribution=focal
 
-DISTRIBUTIONS="bionic eoan focal"
+DISTRIBUTIONS="bionic focal"
 
 if is_release
 then

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -57,7 +57,7 @@ packagename=solc
 
 static_build_distribution=focal
 
-DISTRIBUTIONS="bionic focal"
+DISTRIBUTIONS="bionic focal groovy"
 
 if is_release
 then


### PR DESCRIPTION
Updating the static Z3 PPA build, I just noticed that launchpad will no longer accept eoan uploads, so before we forget, we can remove it from the release PPA script as well right now.