### PR TITLE
Fix static arrays with dynamic elements not being treated as dynamic in returnParameterTypesWithoutDynamicTypes()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Code generator: Fix internal error on stripping dynamic types from return parameters on EVM versions without ``RETURNDATACOPY``.
  * Type Checker: Disallow ``virtual`` for modifiers in libraries.
  * Type Checker: Correct the warning for homonymous, but not shadowing declarations.
  * ViewPureChecker: Prevent visibility check on constructors.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3010,7 +3010,7 @@ TypePointers FunctionType::returnParameterTypesWithoutDynamicTypes() const
 		m_kind == Kind::BareStaticCall
 	)
 		for (auto& param: returnParameterTypes)
-			if (param->isDynamicallySized() && !param->dataStoredIn(DataLocation::Storage))
+			if (param->isDynamicallyEncoded() && !param->dataStoredIn(DataLocation::Storage))
 				param = TypeProvider::inaccessibleDynamic();
 
 	return returnParameterTypes;

--- a/test/libsolidity/semanticTests/various/skip_dynamic_types_for_static_arrays_with_dynamic_elements.sol
+++ b/test/libsolidity/semanticTests/various/skip_dynamic_types_for_static_arrays_with_dynamic_elements.sol
@@ -1,0 +1,23 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    struct S {
+        bool[] b;
+    }
+
+    function f() public returns (uint256, bool[][2] memory, S[2] memory, uint256) {
+        return (
+            5,
+            [new bool[](1), new bool[](2)],
+            [S(new bool[](2)), S(new bool[](5))],
+            6
+        );
+    }
+
+    function g() public returns (uint256, uint256) {
+        (uint256 a, , , uint256 b) = this.f();
+        return (a, b);
+    }
+}
+// ----
+// g() -> 5, 6


### PR DESCRIPTION
Fixes #9815.

The problem was simply was that `isDynamicallySized()` does not do a recursive check.