### PR TITLE
Mark string literals as not implicitly convertible to calldata arrays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
  * Type Checker: Correct the warning for homonymous, but not shadowing declarations.
  * ViewPureChecker: Prevent visibility check on constructors.
  * Type system: Fix internal error on implicit conversion of contract instance to the type of its ``super``.
+ * Type system: Fix internal error on implicit conversion of string literal to a calldata string.
  * Type system: Fix named parameters in overloaded function and event calls being matched incorrectly if the order differs from the declaration.
 
 ### 0.7.1 (2020-09-02)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1408,6 +1408,7 @@ BoolResult StringLiteralType::isImplicitlyConvertibleTo(Type const& _convertTo) 
 		return static_cast<size_t>(fixedBytes->numBytes()) >= m_value.size();
 	else if (auto arrayType = dynamic_cast<ArrayType const*>(&_convertTo))
 		return
+			arrayType->location() != DataLocation::CallData &&
 			arrayType->isByteArray() &&
 			!(arrayType->dataStoredIn(DataLocation::Storage) && arrayType->isPointer()) &&
 			!(arrayType->isString() && !util::validateUTF8(value()));

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_array_of_string_literals_to_calldata_string.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_array_of_string_literals_to_calldata_string.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function f() public pure returns(string[5] calldata) {
+        return ["h", "e", "l", "l", "o"];
+    }
+}
+// ----
+// TypeError 6359: (122-147): Return argument type string memory[5] memory is not implicitly convertible to expected type (type of first return variable) string calldata[5] calldata.

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_string_literal_to_calldata_string.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_string_literal_to_calldata_string.sol
@@ -1,0 +1,17 @@
+contract C {
+    function f1() public pure returns(string calldata) {
+        return "hello";
+    }
+
+    function f2() public pure returns(string calldata) {
+        return unicode"hello";
+    }
+
+    function f3() public pure returns(bytes calldata) {
+        return hex"68656c6c6f";
+    }
+}
+// ----
+// TypeError 6359: (85-92): Return argument type literal_string "hello" is not implicitly convertible to expected type (type of first return variable) string calldata.
+// TypeError 6359: (173-187): Return argument type literal_string "hello" is not implicitly convertible to expected type (type of first return variable) string calldata.
+// TypeError 6359: (267-282): Return argument type literal_string "hello" is not implicitly convertible to expected type (type of first return variable) bytes calldata.

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_string_literal_to_calldata_string_in_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_string_literal_to_calldata_string_in_function_parameter.sol
@@ -1,0 +1,14 @@
+contract C {
+    function g(string calldata _s) public {}
+    function h(bytes calldata _b) public {}
+
+    function f() public {
+        g("hello");
+        g(unicode"hello");
+        h(hex"68656c6c6f");
+    }
+}
+// ----
+// TypeError 9553: (139-146): Invalid type for argument in function call. Invalid implicit conversion from literal_string "hello" to string calldata requested.
+// TypeError 9553: (159-173): Invalid type for argument in function call. Invalid implicit conversion from literal_string "hello" to string calldata requested.
+// TypeError 9553: (186-201): Invalid type for argument in function call. Invalid implicit conversion from literal_string "hello" to bytes calldata requested.


### PR DESCRIPTION
Fixes #9803.
Fixes #9821.