### PR TITLE
Add missing check for nested dynamic arrays in abi.encode()/decode() functions in ABIEncoderV1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Compiler Features:
 
 Bugfixes:
  * Code generator: Fix internal error on stripping dynamic types from return parameters on EVM versions without ``RETURNDATACOPY``.
+ * Type Checker: Add missing check against nested dynamic arrays in ABI encoding functions when ABIEncoderV2 is disabled.
  * Type Checker: Disallow ``virtual`` for modifiers in libraries.
  * Type Checker: Correct the warning for homonymous, but not shadowing declarations.
  * ViewPureChecker: Prevent visibility check on constructors.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -404,10 +404,16 @@ TypePointer Type::fullEncodingType(bool _inLibraryCall, bool _encoderV2, bool) c
 		return encodingType;
 	TypePointer baseType = encodingType;
 	while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType))
+	{
 		baseType = arrayType->baseType();
-	if (dynamic_cast<StructType const*>(baseType))
-		if (!_encoderV2)
+
+		auto const* baseArrayType = dynamic_cast<ArrayType const*>(baseType);
+		if (!_encoderV2 && baseArrayType && baseArrayType->isDynamicallySized())
 			return nullptr;
+	}
+	if (!_encoderV2 && dynamic_cast<StructType const*>(baseType))
+		return nullptr;
+
 	return encodingType;
 }
 

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_nested_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_nested_dynamic_array.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        abi.encodePacked([new uint[](5), new uint[](7)]);
+    }
+}
+// ----
+// TypeError 9578: (69-99): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_nested_dynamic_array_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_nested_dynamic_array_v2.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function f() public pure {
+        abi.encodePacked([new uint[](5), new uint[](7)]);
+    }
+}
+// ----
+// TypeError 9578: (104-134): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_nested_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_nested_dynamic_array.sol
@@ -1,0 +1,7 @@
+contract C {
+    function test() public pure {
+        abi.encode([new uint[](5), new uint[](7)]);
+    }
+}
+// ----
+// TypeError 2056: (66-96): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_nested_dynamic_array_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_nested_dynamic_array_v2.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function f() public pure {
+        abi.encode([new uint[](5), new uint[](7)]);
+    }
+}
+// ----
+// Warning 6133: (87-129): Statement has no effect.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nested_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nested_dynamic_array.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        abi.decode("1234", (uint[][3]));
+    }
+}
+// ----
+// TypeError 9611: (72-81): Decoding type uint256[] memory[3] memory not supported.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nested_dynamic_array_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nested_dynamic_array_v2.sol
@@ -1,0 +1,9 @@
+pragma experimental ABIEncoderV2;
+
+contract C {
+    function f() public pure {
+        abi.decode("1234", (uint[][3]));
+    }
+}
+// ----
+// Warning 6133: (87-118): Statement has no effect.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_struct.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_struct.sol
@@ -1,0 +1,11 @@
+struct S {
+    uint x;
+}
+
+contract C {
+    function f() public pure {
+        abi.decode("1234", (S));
+    }
+}
+// ----
+// TypeError 9611: (98-99): Decoding type struct S memory not supported.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_struct_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_struct_v2.sol
@@ -1,0 +1,13 @@
+pragma experimental ABIEncoderV2;
+
+struct S {
+    uint x;
+}
+
+contract C {
+    function f() public pure {
+        abi.decode("1234", (S));
+    }
+}
+// ----
+// Warning 6133: (113-136): Statement has no effect.


### PR DESCRIPTION
Related to #9835.

Nested dynamic arrays passed to `abi.encode()` and `abi.decode()` are not detected as unsupported when not using ABI encoder v2 but the compiler fails down the line on an `UnimplementedError` instead. A proper compilation error is reported only for structs. This PR makes changes this so that they're both handled the same way.

The fix makes `Type::fullEncodingType()` consistent with what `TypeChecker::typeSupportedByOldABIEncoder()` returns for ABI v1.

Type checks affected by this change:
https://github.com/ethereum/solidity/blob/d8520b0af00dd3acfee7d5af98dade2cac1c4118/libsolidity/analysis/TypeChecker.cpp#L196-L201
https://github.com/ethereum/solidity/blob/d8520b0af00dd3acfee7d5af98dade2cac1c4118/libsolidity/analysis/TypeChecker.cpp#L1940-L1955