### PR TITLE
Allow using zero in patterns passed to isoltest --test

### DIFF
--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -77,7 +77,7 @@ bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 
 void IsolTestOptions::validate() const
 {
-	static std::string filterString{"[a-zA-Z1-9_/*]*"};
+	static std::string filterString{"[a-zA-Z0-9_/*]*"};
 	static std::regex filterExpression{filterString};
 	assertThrow(
 		regex_match(testFilter, filterExpression),


### PR DESCRIPTION
Is there a reason for disallowing zeros or was this just a bug?

After this change a command like
```bash
isoltest --test=syntaxTests/nameAndTypeResolution/044_*
```
no longer results in
```
Invalid test unit filter - can only contain '[a-zA-Z1-9_/*]*: syntaxTests/nameAndTypeResolution/044_*
```
but runs `syntaxTests/nameAndTypeResolution/044_returning_multi_dimensional_arrays_new_abi.sol` instead.