### PR TITLE
Remove release and zip logic from appveyor config.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,6 @@ before_build:
 build_script:
     - msbuild solidity.sln /p:Configuration=%CONFIGURATION% /m:%NUMBER_OF_PROCESSORS% /v:minimal
     - cd %APPVEYOR_BUILD_FOLDER%
-    - scripts\release.bat %CONFIGURATION% 2017
     - ps: $bytecodedir = git show -s --format="%cd-%H" --date="format:%Y-%m-%d-%H-%M"
 
 test_script:
@@ -75,10 +74,6 @@ test_script:
         scripts\bytecodecompare\storebytecode.bat $Env:CONFIGURATION $bytecodedir
         }
     - cd %APPVEYOR_BUILD_FOLDER%\build\test\%CONFIGURATION%
-
-artifacts:
-    - path: solidity-windows.zip
-      name: solidity-windows-zip
 
 # This is the deploy target for Windows which generates ZIPs per commit.
 # We are in agreement that generating ZIPs per commit for the develop


### PR DESCRIPTION
Since we removed the release script, the appveyor run fails everywhere...
On the other hand, it will probably be superseded by the CircleCI run anyways, so we can also just disable it altogether (I think @chriseth would need to do that in the github settings, though, right?)

In any case, this PR should fix the test runs for now.