### PR TITLE
[SMTChecker] Decrease rlimit

### DIFF
--- a/libsmtutil/Z3Interface.h
+++ b/libsmtutil/Z3Interface.h
@@ -49,7 +49,7 @@ public:
 
 	// Z3 "basic resources" limit.
 	// This is used to make the runs more deterministic and platform/machine independent.
-	static int const resourceLimit = 12500000;
+	static int const resourceLimit = 1000000;
 
 private:
 	void declareFunction(std::string const& _name, Sort const& _sort);

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
@@ -22,5 +22,7 @@ contract LoopFor2 {
 }
 // ----
 // Warning 1218: (229-234): Error trying to invoke SMT solver.
+// Warning 1218: (296-316): Error trying to invoke SMT solver.
 // Warning 6328: (320-339): Assertion violation happens here.
 // Warning 6328: (343-362): Assertion violation happens here.
+// Warning 4661: (296-316): Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_int_1.sol
+++ b/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_int_1.sol
@@ -9,3 +9,4 @@ contract C {
     }
 }
 // ----
+// Warning 1218: (174-212): Error trying to invoke SMT solver.

--- a/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_uint_1.sol
+++ b/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_uint_1.sol
@@ -9,3 +9,4 @@ contract C {
     }
 }
 // ----
+// Warning 1218: (166-183): Error trying to invoke SMT solver.

--- a/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_uint_2.sol
+++ b/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_uint_2.sol
@@ -11,4 +11,5 @@ contract C {
     }
 }
 // ----
-// Warning 6328: (173-192): Assertion violation happens here.
+// Warning 1218: (173-192): Error trying to invoke SMT solver.
+// Warning 7812: (173-192): Assertion violation might happen here.

--- a/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_uint_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/compound_bitwise_or_uint_3.sol
@@ -10,3 +10,5 @@ contract C {
     }
 }
 // ----
+// Warning 1218: (157-172): Error trying to invoke SMT solver.
+// Warning 7812: (157-172): Assertion violation might happen here.


### PR DESCRIPTION
This decreases the total time to run the smt tests to 2 min (2:10 locally on my machine), and not that many tests are affected, so I think it's ok to do it.