### PR TITLE
Implemented ``type(address).min`` and ``type(address).max``

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ### 0.7.2 (unreleased)
 
 Language Features:
-
+ * Implemented ``type(address).min`` and ``type(address).max`` that returns ``0`` and ``2**160 - 1`` respectively.
 
 Compiler Features:
  * Export compiler-generated utility sources via standard-json or combined-json.

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -121,8 +121,8 @@ Global Variables
 - ``type(C).creationCode`` (``bytes memory``): creation bytecode of the given contract, see :ref:`Type Information<meta-type>`.
 - ``type(C).runtimeCode`` (``bytes memory``): runtime bytecode of the given contract, see :ref:`Type Information<meta-type>`.
 - ``type(I).interfaceId`` (``bytes4``): value containing the EIP-165 interface identifier of the given interface, see :ref:`Type Information<meta-type>`.
-- ``type(T).min`` (``T``): the minimum value representable by the integer type ``T``, see :ref:`Type Information<meta-type>`.
-- ``type(T).max`` (``T``): the maximum value representable by the integer type ``T``, see :ref:`Type Information<meta-type>`.
+- ``type(T).min`` (``T``): the minimum value representable by an integer or an address type ``T``, see :ref:`Type Information<meta-type>`.
+- ``type(T).max`` (``T``): the maximum value representable by an integer or an address type ``T``, see :ref:`Type Information<meta-type>`.
 
 .. note::
     Do not rely on ``block.timestamp`` or ``blockhash`` as a source of randomness,

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -40,7 +40,7 @@ Operators:
 * Shift operators: ``<<`` (left shift), ``>>`` (right shift)
 * Arithmetic operators: ``+``, ``-``, unary ``-``, ``*``, ``/``, ``%`` (modulo), ``**`` (exponentiation)
 
-For an integer type ``X``, you can use ``type(X).min`` and ``type(X).max`` to
+For an integer or an address type ``X``, you can use ``type(X).min`` and ``type(X).max`` to
 access the minimum and maximum value representable by the type.
 
 .. warning::

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -301,7 +301,7 @@ Type Information
 
 The expression ``type(X)`` can be used to retrieve information about the type
 ``X``. Currently, there is limited support for this feature (``X`` can be either
-a contract or an integer type) but it might be expanded in the future.
+a contract, an integer or an address type) but it might be expanded in the future.
 
 The following properties are available for a contract type ``C``:
 
@@ -334,7 +334,7 @@ for an interface type ``I``:
     interface identifier of the given interface ``I``. This identifier is defined as the ``XOR`` of all
     function selectors defined within the interface itself - excluding all inherited functions.
 
-The following properties are available for an integer type ``T``:
+The following properties are available for an integer or an address type ``T``:
 
 ``type(T).min``
     The smallest value representable by type ``T``.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -245,7 +245,8 @@ TypePointers TypeChecker::typeCheckMetaTypeFunctionAndRetrieveReturnType(Functio
 		Type::Category typeCategory = typeTypePtr->actualType()->category();
 		if (
 			typeCategory != Type::Category::Contract &&
-			typeCategory != Type::Category::Integer
+			typeCategory != Type::Category::Integer &&
+			typeCategory != Type::Category::Address
 		)
 			wrongType = true;
 	}
@@ -258,7 +259,7 @@ TypePointers TypeChecker::typeCheckMetaTypeFunctionAndRetrieveReturnType(Functio
 			4259_error,
 			arguments.front()->location(),
 			"Invalid type for argument in the function call. "
-			"A contract type or an integer type is required, but " +
+			"A contract type, an integer type or an address type is required, but " +
 			type(*arguments.front())->toString(true) + " provided."
 		);
 		return {};

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -561,9 +561,10 @@ MagicType const* TypeProvider::meta(Type const* _type)
 	solAssert(
 		_type && (
 			_type->category() == Type::Category::Contract ||
-			_type->category() == Type::Category::Integer
+			_type->category() == Type::Category::Integer ||
+			_type->category() == Type::Category::Address
 		),
-		"Only contracts or integer types supported for now."
+		"Only contract, integer, or address types supported for now."
 	);
 	return createAndGet<MagicType>(_type);
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -4057,9 +4057,10 @@ MemberList::MemberMap MagicType::nativeMembers(ASTNode const*) const
 		solAssert(
 			m_typeArgument && (
 					m_typeArgument->category() == Type::Category::Contract ||
-					m_typeArgument->category() == Type::Category::Integer
+					m_typeArgument->category() == Type::Category::Integer ||
+					m_typeArgument->category() == Type::Category::Address
 			),
-			"Only contracts or integer types supported for now"
+			"Only contract, integer or address types supported for now"
 		);
 
 		if (m_typeArgument->category() == Type::Category::Contract)
@@ -4083,6 +4084,14 @@ MemberList::MemberMap MagicType::nativeMembers(ASTNode const*) const
 			return MemberList::MemberMap({
 				{"min", integerTypePointer},
 				{"max", integerTypePointer},
+			});
+		}
+		else if (m_typeArgument->category() == Type::Category::Address)
+		{
+			auto addressTypePointer = dynamic_cast<AddressType const*>(m_typeArgument);
+			return MemberList::MemberMap({
+				{"min", addressTypePointer},
+				{"max", addressTypePointer},
 			});
 		}
 	}

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -1603,12 +1603,26 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		else if (member == "min" || member == "max")
 		{
 			MagicType const* arg = dynamic_cast<MagicType const*>(_memberAccess.expression().annotation().type);
-			IntegerType const* integerType = dynamic_cast<IntegerType const*>(arg->typeArgument());
+			Type const* typePointer = arg->typeArgument();
 
-			if (member == "min")
-				m_context << integerType->min();
+			if (auto integerType = dynamic_cast<IntegerType const*>(typePointer))
+			{
+				if (member == "min")
+					m_context << integerType->min();
+				else
+					m_context << integerType->max();
+			}
+			else if (dynamic_cast<AddressType const*>(typePointer))
+			{
+				auto integerType = IntegerType(160, IntegerType::Modifier::Unsigned);
+
+				if (member == "min")
+					m_context << integerType.min();
+				else
+					m_context << integerType.max();
+			}
 			else
-				m_context << integerType->max();
+				solAssert(false, "");
 		}
 		else if ((set<string>{"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "decode"}).count(member))
 		{

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1650,12 +1650,25 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 		else if (member == "min" || member == "max")
 		{
 			MagicType const* arg = dynamic_cast<MagicType const*>(_memberAccess.expression().annotation().type);
-			IntegerType const* integerType = dynamic_cast<IntegerType const*>(arg->typeArgument());
+			Type const* typePointer = arg->typeArgument();
 
-			if (member == "min")
-				define(_memberAccess) << formatNumber(integerType->min()) << "\n";
+			if (auto integerType = dynamic_cast<IntegerType const*>(typePointer))
+			{
+				if (member == "min")
+					define(_memberAccess) << formatNumber(integerType->min()) << "\n";
+				else
+					define(_memberAccess) << formatNumber(integerType->max()) << "\n";
+			}
+			else if (dynamic_cast<AddressType const*>(typePointer))
+			{
+				auto integerType = IntegerType(160, IntegerType::Modifier::Unsigned);
+				if (member == "min")
+					define(_memberAccess) << formatNumber(integerType.min()) << "\n";
+				else
+					define(_memberAccess) << formatNumber(integerType.max()) << "\n";
+			}
 			else
-				define(_memberAccess) << formatNumber(integerType->max()) << "\n";
+				solAssert(false, "");
 		}
 		else if (set<string>{"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "decode"}.count(member))
 		{

--- a/test/libsolidity/semanticTests/address/type_min_max.sol
+++ b/test/libsolidity/semanticTests/address/type_min_max.sol
@@ -1,0 +1,16 @@
+contract test {
+
+	function address_min_max() public pure returns (bool) {
+		address a = type(address).min;
+		require(a == address(0));
+
+		address b = type(address).max;
+		require(b == address(2**160 - 1));
+
+		return true;
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// address_min_max() -> true

--- a/test/libsolidity/syntaxTests/metaTypes/address.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/address.sol
@@ -1,0 +1,8 @@
+contract Test {
+    function basic() public pure {
+        address a = type(address).min;
+        a;
+        address b = type(address).max;
+        b;
+    }
+}

--- a/test/libsolidity/syntaxTests/metaTypes/typeRecursive.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/typeRecursive.sol
@@ -4,5 +4,5 @@ contract Test {
     }
 }
 // ----
-// TypeError 4259: (65-75): Invalid type for argument in the function call. A contract type or an integer type is required, but type(contract Test) provided.
-// TypeError 4259: (60-76): Invalid type for argument in the function call. A contract type or an integer type is required, but tuple() provided.
+// TypeError 4259: (65-75): Invalid type for argument in the function call. A contract type, an integer type or an address type is required, but type(contract Test) provided.
+// TypeError 4259: (60-76): Invalid type for argument in the function call. A contract type, an integer type or an address type is required, but tuple() provided.

--- a/test/libsolidity/syntaxTests/metaTypes/unsupportedArgForType.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/unsupportedArgForType.sol
@@ -6,4 +6,4 @@ contract Test {
     }
 }
 // ----
-// TypeError 4259: (154-155): Invalid type for argument in the function call. A contract type or an integer type is required, but type(struct Test.S) provided.
+// TypeError 4259: (154-155): Invalid type for argument in the function call. A contract type, an integer type or an address type is required, but type(struct Test.S) provided.


### PR DESCRIPTION
Since we are disallowing `address(-1)` it makes sense to implement `type(address).min` and `type(address).max`.