### PR TITLE
[SMTChecker] Support all type casts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Compiler Features:
  * SMTChecker: Support ``addmod`` and ``mulmod``.
  * SMTChecker: Support array slices.
+ * SMTChecker: Support type conversions.
  * Optimizer: Optimize ``exp`` when base is -1.
  * Code generator: Implemented events with function type as one of its indexed parameters.
  * General: Option to stop compilation after parsing stage. Can be used with ``solc --stop-after parsing``

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -65,8 +65,11 @@ bool isNonRecursiveStruct(frontend::Type const& _type);
 std::pair<bool, std::shared_ptr<SymbolicVariable>> newSymbolicVariable(frontend::Type const& _type, std::string const& _uniqueName, EncodingContext& _context);
 
 smtutil::Expression minValue(frontend::IntegerType const& _type);
+smtutil::Expression minValue(frontend::TypePointer _type);
 smtutil::Expression maxValue(frontend::IntegerType const& _type);
+smtutil::Expression maxValue(frontend::TypePointer _type);
 smtutil::Expression zeroValue(frontend::TypePointer const& _type);
+bool isSigned(frontend::TypePointer const& _type);
 
 std::pair<unsigned, bool> typeBvSizeAndSignedness(frontend::TypePointer const& type);
 

--- a/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
+++ b/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
@@ -83,6 +83,5 @@ contract InternalCall {
 // Warning 2018: (1144-1206): Function state mutability can be restricted to pure
 // Warning 2018: (1212-1274): Function state mutability can be restricted to pure
 // Warning 2018: (1280-1342): Function state mutability can be restricted to pure
-// Warning 5084: (782-813): Type conversion is not yet fully supported and might yield false positives.
 // Warning 4588: (771-814): Assertion checker does not yet implement this type of function call.
 // Warning 5729: (1403-1408): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/complex/warn_on_typecast.sol
+++ b/test/libsolidity/smtCheckerTests/complex/warn_on_typecast.sol
@@ -5,4 +5,3 @@ contract C {
     }
 }
 // ----
-// Warning 5084: (106-114): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_and_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_and_fixed_bytes.sol
@@ -5,4 +5,3 @@ contract C {
   }
 }
 // ----
-// Warning 5084: (101-109): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_not_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_not_fixed_bytes.sol
@@ -5,4 +5,3 @@ contract C {
   }
 }
 // ----
-// Warning 5084: (102-112): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_or_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_or_fixed_bytes.sol
@@ -5,5 +5,3 @@ contract C {
   }
 }
 // ----
-// Warning 5084: (101-111): Type conversion is not yet fully supported and might yield false positives.
-// Warning 5084: (115-125): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_rational_1.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_rational_1.sol
@@ -3,10 +3,8 @@ pragma experimental SMTChecker;
 contract C {
 	function f() public pure {
 		uint x = uint(~1);
-		// This assertion fails because type conversion is still unsupported.
 		assert(x == 2**256 - 2);
 		assert(~1 == -2);
 	}
 }
 // ----
-// Warning 6328: (169-192): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/operators/fixed_point_add.sol
+++ b/test/libsolidity/smtCheckerTests/operators/fixed_point_add.sol
@@ -6,6 +6,3 @@ contract test {
 }
 // ----
 // Warning 2072: (80-88): Unused local variable.
-// Warning 4984: (91-112): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
-// Warning 5084: (91-100): Type conversion is not yet fully supported and might yield false positives.
-// Warning 5084: (103-112): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_different_size_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_different_size_1.sol
@@ -7,20 +7,10 @@ contract C
 		uint32 b = uint16(a); // b will be 0x00001234
 		assert(b == 0x1234);
 		uint32 c = uint32(bytes4(a)); // c will be 0x12340000
-		// This fails because right padding is not supported.
 		assert(c == 0x12340000);
 		uint8 d = uint8(uint16(a)); // d will be 0x34
-		// False positive since truncating is not supported yet.
 		assert(d == 0x34);
 		uint8 e = uint8(bytes1(a)); // e will be 0x12
-		// False positive since truncating is not supported yet.
 		assert(e == 0x12);
 	}
 }
-// ----
-// Warning 6328: (280-303): CHC: Assertion violation happens here.
-// Warning 6328: (414-431): CHC: Assertion violation happens here.
-// Warning 6328: (542-559): CHC: Assertion violation happens here.
-// Warning 5084: (186-195): Type conversion is not yet fully supported and might yield false positives.
-// Warning 5084: (317-333): Type conversion is not yet fully supported and might yield false positives.
-// Warning 5084: (451-460): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_1.sol
@@ -9,4 +9,3 @@ contract C
 	}
 }
 // ----
-// Warning 5084: (94-103): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_2.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_2.sol
@@ -10,4 +10,3 @@ contract C
 	}
 }
 // ----
-// Warning 5084: (108-117): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_2_fail.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_2_fail.sol
@@ -10,4 +10,3 @@ contract C
 }
 // ----
 // Warning 6328: (149-163): CHC: Assertion violation happens here.
-// Warning 5084: (108-117): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_3.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_3.sol
@@ -12,6 +12,4 @@ contract C
 	}
 }
 // ----
-// Warning 6328: (207-230): CHC: Assertion violation happens here.
 // Warning 6328: (273-287): CHC: Assertion violation happens here.
-// Warning 5084: (108-117): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_smaller_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_smaller_1.sol
@@ -9,4 +9,3 @@ contract C
 	}
 }
 // ----
-// Warning 5084: (94-102): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_smaller_2.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_smaller_2.sol
@@ -5,10 +5,6 @@ contract C
 	function f() public pure {
 		uint32 a = 0x12345678;
 		uint16 b = uint16(a); // b will be 0x5678 now
-		// False positive since truncation is not supported yet.
 		assert(b == 0x5678);
 	}
 }
-// ----
-// Warning 6328: (208-227): CHC: Assertion violation happens here.
-// Warning 5084: (112-121): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_smaller_3.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_smaller_3.sol
@@ -5,10 +5,6 @@ contract C
 	function f() public pure {
 		bytes2 a = 0x1234;
 		bytes1 b = bytes1(a); // b will be 0x12
-		// False positive since truncation is not supported yet.
 		assert(b == 0x12);
 	}
 }
-// ----
-// Warning 6328: (198-215): CHC: Assertion violation happens here.
-// Warning 5084: (108-117): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/downcast.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/downcast.sol
@@ -1,0 +1,48 @@
+pragma experimental SMTChecker;
+
+contract C {
+	function f1() public pure {
+		// signed <- signed
+		int8 z = int8(-1);
+		assert(z == -1);
+		z = int8(0xf0ff);
+		assert(z == -1);
+		z = int8(0xcafecafef0ff);
+		assert(z == -1);
+		z = int8(0xcafecafe);
+		assert(z == -2);
+		z = int8(255);
+		assert(z == -1);
+
+		// unsigned <= unsigned
+		uint8 x = uint8(uint16(-1));
+		assert(x == 255);
+		x = uint8(uint256(-1));
+		assert(x == 255);
+
+		// signed <- unsigned
+		int8 y = int8(uint16(-1));
+		assert(y == -1);
+		y = int8(uint16(100));
+		assert(y == 100);
+		y = int8(uint16(200));
+		assert(y == -56);
+
+		// unsigned <- signed
+		uint8 v = uint8(int16(-1));
+		assert(v == 255);
+		v = uint8(int16(300));
+		assert(v == 44);
+		v = uint8(int16(200));
+		assert(v == 200);
+
+		// fixed bytes
+		bytes2 b = bytes2(bytes4(0xcafeffff));
+		assert(b == 0xcafe);
+		b = bytes2(bytes4(bytes8(0xaaaabbbbccccdddd)));
+		assert(b == 0xaaaa);
+		b = bytes2(bytes8(0xaaaabbbbccccdddd));
+		assert(b == 0xaaaa);
+	}
+}
+// ----

--- a/test/libsolidity/smtCheckerTests/typecast/enum_from_uint.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/enum_from_uint.sol
@@ -10,6 +10,4 @@ contract C
 	}
 }
 // ----
-// Warning 6328: (140-160): CHC: Assertion violation happens here.
 // Warning 8364: (132-133): Assertion checker does not yet implement type type(enum C.D)
-// Warning 5084: (132-136): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/enum_to_uint_max_value.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/enum_to_uint_max_value.sol
@@ -9,4 +9,3 @@ contract C
 	}
 }
 // ----
-// Warning 5084: (113-121): Type conversion is not yet fully supported and might yield false positives.

--- a/test/libsolidity/smtCheckerTests/typecast/number_literal.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/number_literal.sol
@@ -1,0 +1,31 @@
+pragma experimental SMTChecker;
+
+contract C {
+  function f() public pure {
+    uint x = 1234;
+    uint y = 0;
+    assert(x != y);
+    assert(x == uint(1234));
+    assert(y == uint(0));
+  }
+  function g() public pure {
+    uint a = uint(0);
+    uint b = uint(-1);
+    uint c = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    int d = -1;
+    uint e = uint(d);
+    assert(a != b);
+    assert(b == c);
+    assert(b == e);
+  }
+  function h() public pure {
+    uint32 a = uint32(0);
+    uint32 b = uint32(-1);
+    uint32 c = 4294967295;
+    int32 d = -1;
+    uint32 e = uint32(d);
+    assert(a != b);
+    assert(b == c);
+    assert(b == e);
+  }
+}

--- a/test/libsolidity/smtCheckerTests/typecast/same_size.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/same_size.sol
@@ -1,0 +1,74 @@
+pragma experimental SMTChecker;
+
+abstract contract D {}
+
+enum E {A, B}
+
+contract C {
+	function f1() public pure {
+		// signed <- unsigned
+		int8 x = int8(uint8(200));
+		assert(x == -56);
+		int256 y = int256(uint256(2**255 + 10));
+		assert(y == -(2**255) + 10);
+		int256 z = int256(2**255 + 10);
+		assert(z == -(2**255) + 10);
+		int256 t = int256(bytes32(uint256(200)));
+		assert(t == 200);
+		int256 v = int256(bytes32(uint256(2**255 + 10)));
+		assert(v == -(2**255) + 10);
+		int160 a = int160(address(-1));
+		assert(a == -1);
+		int160 b = int160(address(2**159 + 10));
+		assert(b == -(2**159) + 10);
+		D d;
+		int160 e = int160(address(d));
+		assert(e == 0);
+	}
+
+	function f2() public pure {
+		// unsigned <- signed
+		uint8 x = uint8(int8(100));
+		assert(x == 100);
+		uint8 y = uint8(int8(200));
+		assert(y == 200);
+		uint8 z = uint8(int8(-100));
+		assert(z == 156);
+		uint8 t = uint8(int8(-200));
+		assert(t == 56);
+		uint256 v = uint256(int256(-200));
+		assert(v == 2**256 - 200);
+		uint256 w = uint256(-2);
+		assert(w == 2**256 - 2);
+		bytes4 b = bytes4(uint32(-2));
+		assert(uint32(b) == uint32(2**32 - 2));
+		address a = address(-1);
+		assert(uint160(a) == uint160(2**160 - 1));
+		address c = address(0);
+		assert(uint160(c) == 0);
+		D d;
+		address e = address(d);
+		assert(uint160(e) == 0);
+		E f = E(1);
+		assert(uint(f) == 1);
+	}
+
+	function f3() public pure {
+		// unsigned <- unsigned
+		uint8 x = uint8(bytes1(uint8(100)));
+		assert(x == 100);
+		address a = address(0);
+		assert(a == address(uint160(0)));
+		D d;
+		assert(a == address(d));
+	}
+
+	function f4() public pure {
+		// signed <- signed
+		int8 x = -10;
+		int8 y = int8(x);
+		assert(y == -10);
+	}
+}
+// ----
+// Warning 8364: (1304-1305): Assertion checker does not yet implement type type(enum E)

--- a/test/libsolidity/smtCheckerTests/typecast/upcast.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/upcast.sol
@@ -1,0 +1,70 @@
+pragma experimental SMTChecker;
+
+abstract contract D {}
+
+contract C {
+	function f1() public pure {
+		// unsigned <- signed
+		uint16 x = uint16(-1);
+		assert(x == 65535);
+		int8 i = int8(-1);
+		assert(i == -1);
+		x = uint16(int8(-1));
+		assert(x == 65535);
+		x = uint16(int16(i));
+		assert(x == 65535);
+		uint z = uint(i);
+		assert(z == 2**256 - 1);
+	}
+
+	function f2() public pure {
+		// signed <- unsigned
+		int16 y = int16(uint8(65535));
+		assert(y == 255);
+		int z = int(uint8(-1));
+		assert(z == 255);
+		z = int(uint8(255));
+		assert(z == 255);
+	}
+
+	function f3() public pure {
+		// signed <- signed
+		int16 y = int16(int8(65535));
+		assert(y == -1);
+		int z = int(int8(-1));
+		assert(z == -1);
+		z = int(int8(255));
+		assert(z == -1);
+		z = int(int16(5000));
+		assert(z == 5000);
+	}
+
+	function f4() public pure {
+		// unsigned <- unsigned
+		uint x = uint(uint8(-1));
+		assert(x == 255);
+		x = uint(uint16(-1));
+		assert(x == 65535);
+		x = uint(uint16(5000));
+		assert(x == 5000);
+		uint16 y = uint16(-1);
+		assert(y == 65535);
+		y = uint16(uint8(-1));
+		assert(y == 255);
+		address a = address(uint8(0));
+		assert(a == address(0));
+		D d = D(uint8(0));
+		assert(a == address(d));
+		bytes2 b1 = 0xcafe;
+		bytes4 b2 = bytes4(b1);
+		assert(b2 == 0xcafe0000);
+		bytes16 b3 = bytes16(b1);
+		assert(b3 == 0xcafe0000000000000000000000000000);
+		bytes4 b4 = bytes4(uint32(0xcafe));
+		assert(b4 == 0x0000cafe);
+		bytes4 b5 = bytes4(uint32(0xcafe0000));
+		assert(b5 == 0xcafe0000);
+	}
+}
+// ----
+// Warning 8364: (1144-1145): Assertion checker does not yet implement type type(contract D)


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9789
Fixes https://github.com/ethereum/solidity/issues/5795
Replaces https://github.com/ethereum/solidity/pull/9808

The implementation is a bit verbose but it's clear and explicit in the typecast behavior.
It will be simplified a lot in 0.8.0 when oversized/not fitting casts are disallowed.

Missing:
- [x] FixedBytes downcast