### PR TITLE
Fix ICE caused by storage parameters with nested mappings in libraries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 ### 0.7.4 (unreleased)
 
+Important Bugfixes:
+
+
+Compiler Features:
+
+
+Bugfixes:
+ * Type Checker: Fix internal compiler error caused by storage parameters with nested mappings in libraries.
+
 
 ### 0.7.3 (2020-10-07)
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -599,8 +599,13 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 	if (auto referenceType = dynamic_cast<ReferenceType const*>(varType))
 	{
 		auto result = referenceType->validForLocation(referenceType->location());
-		if (result && (_variable.isConstructorParameter() || _variable.isPublicCallableParameter()))
-			result = referenceType->validForLocation(DataLocation::CallData);
+		if (result)
+		{
+			bool isLibraryStorageParameter = (_variable.isLibraryFunctionParameter() && referenceType->location() == DataLocation::Storage);
+			bool callDataCheckRequired = ((_variable.isConstructorParameter() || _variable.isPublicCallableParameter()) && !isLibraryStorageParameter);
+			if (callDataCheckRequired)
+				result = referenceType->validForLocation(DataLocation::CallData);
+		}
 		if (!result)
 		{
 			solAssert(!result.message().empty(), "Expected detailed error message");

--- a/test/libsolidity/syntaxTests/types/mapping/contract_storage_parameter_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/contract_storage_parameter_with_mapping.sol
@@ -1,0 +1,6 @@
+struct S { mapping(uint => uint)[2] a; }
+contract C {
+    function f(S storage s) public {}
+}
+// ----
+// TypeError 6651: (69-80): Data location must be "memory" or "calldata" for parameter in function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/library_storage_parameter_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_storage_parameter_with_mapping.sol
@@ -1,0 +1,4 @@
+struct S { mapping(uint => uint)[2] a; }
+library L {
+    function f(S storage s) public {}
+}

--- a/test/libsolidity/syntaxTests/types/mapping/library_storage_parameter_with_nested_mapping.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/library_storage_parameter_with_nested_mapping.sol
@@ -1,0 +1,5 @@
+library Test {
+    struct Nested { mapping(uint => uint)[2][] a; }
+    struct X { Nested n; }
+    function f(X storage x) public {}
+}


### PR DESCRIPTION
Fixes #9957 .

Alternatively we could wait for PR #9746, it fixes the issue too. (So I was puzzled for some time why I cannot reproduce the error locally :).)
 