### PR TITLE
Fix ICE caused by const structs with mappings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Bugfixes:
  * SMTChecker: Fix false negatives when analyzing external function calls.
  * SMTChecker: Fix missing type constraints for block variables.
  * SMTChecker: Fix internal error on ``block.chainid``.
+ * Type Checker: Fix internal error caused by constant structs containing mappings.
  * Type System: Disallow implicit conversion from ``uintN`` to ``intM`` when ``M > N``, and by extension, explicit conversion between the same types is also disallowed.
 
 ### 0.8.0 (2020-12-16)

--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -412,6 +412,15 @@ void DeclarationTypeChecker::endVisit(VariableDeclaration const& _variable)
 		type = TypeProvider::withLocation(ref, typeLoc, isPointer);
 	}
 
+	if (_variable.isConstant() && !type->isValueType())
+	{
+		bool allowed = false;
+		if (auto arrayType = dynamic_cast<ArrayType const*>(type))
+			allowed = arrayType->isByteArray();
+		if (!allowed)
+			m_errorReporter.fatalDeclarationError(9259_error, _variable.location(), "Constants of non-value type not yet implemented.");
+	}
+
 	_variable.annotation().type = type;
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -519,15 +519,6 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 	}
 	if (_variable.isConstant())
 	{
-		if (!_variable.type()->isValueType())
-		{
-			bool allowed = false;
-			if (auto arrayType = dynamic_cast<ArrayType const*>(_variable.type()))
-				allowed = arrayType->isByteArray();
-			if (!allowed)
-				m_errorReporter.typeError(9259_error, _variable.location(), "Constants of non-value type not yet implemented.");
-		}
-
 		if (!_variable.value())
 			m_errorReporter.typeError(4266_error, _variable.location(), "Uninitialized \"constant\" variable.");
 		else if (!*_variable.value()->annotation().isPure)

--- a/test/libsolidity/syntaxTests/constantEvaluator/type_reference.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/type_reference.sol
@@ -1,3 +1,4 @@
 int[L] constant L = 6;
 // ----
 // TypeError 5462: (4-5): Invalid array length, expected integer literal or constant expression.
+// DeclarationError 9259: (0-21): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/constantEvaluator/type_reference_in_contract.sol
+++ b/test/libsolidity/syntaxTests/constantEvaluator/type_reference_in_contract.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // TypeError 5462: (21-22): Invalid array length, expected integer literal or constant expression.
+// DeclarationError 9259: (17-38): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/constants/mapping_constant.sol
+++ b/test/libsolidity/syntaxTests/constants/mapping_constant.sol
@@ -1,3 +1,3 @@
 mapping(uint => uint) constant b = b;
 // ----
-// TypeError 9259: (0-36): Constants of non-value type not yet implemented.
+// DeclarationError 9259: (0-36): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/constants/struct_constant.sol
+++ b/test/libsolidity/syntaxTests/constants/struct_constant.sol
@@ -1,5 +1,4 @@
 struct S { uint x; }
 S constant s;
 // ----
-// TypeError 9259: (21-33): Constants of non-value type not yet implemented.
-// TypeError 4266: (21-33): Uninitialized "constant" variable.
+// DeclarationError 9259: (21-33): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/iceRegressionTests/const_struct_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/const_struct_with_mapping.sol
@@ -1,0 +1,8 @@
+contract C {
+    struct S {
+        mapping(uint => uint) c;
+    }
+    S public constant e = 0x1212121212121212121212121212121212121212;
+}
+// ----
+// DeclarationError 9259: (71-135): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/105_constant_input_parameter.sol
@@ -3,3 +3,4 @@ contract test {
 }
 // ----
 // DeclarationError 1788: (31-55): The "constant" keyword can only be used for state variables or variables at file level.
+// DeclarationError 9259: (31-55): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/171_assignment_to_const_array_vars.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/171_assignment_to_const_array_vars.sol
@@ -2,4 +2,4 @@ contract C {
     uint[3] constant x = [uint(1), 2, 3];
 }
 // ----
-// TypeError 9259: (17-53): Constants of non-value type not yet implemented.
+// DeclarationError 9259: (17-53): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/173_constant_struct.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/173_constant_struct.sol
@@ -3,4 +3,4 @@ contract C {
     S constant x = S(5, new uint[](4));
 }
 // ----
-// TypeError 9259: (52-86): Constants of non-value type not yet implemented.
+// DeclarationError 9259: (52-86): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/constant_mapping.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/constant_mapping.sol
@@ -4,5 +4,4 @@ contract C {
     mapping(uint => uint) constant x;
 }
 // ----
-// TypeError 9259: (148-180): Constants of non-value type not yet implemented.
-// TypeError 4266: (148-180): Uninitialized "constant" variable.
+// DeclarationError 9259: (148-180): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/constant_nested_mapping.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/constant_nested_mapping.sol
@@ -1,0 +1,8 @@
+contract C {
+    struct S {
+        mapping(uint => uint) x;
+    }
+    S public constant c;
+}
+// ----
+// DeclarationError 9259: (71-90): Constants of non-value type not yet implemented.

--- a/test/libsolidity/syntaxTests/parsing/location_specifiers_for_params.sol
+++ b/test/libsolidity/syntaxTests/parsing/location_specifiers_for_params.sol
@@ -3,3 +3,4 @@ contract Foo {
 }
 // ----
 // DeclarationError 1788: (30-55): The "constant" keyword can only be used for state variables or variables at file level.
+// DeclarationError 9259: (30-55): Constants of non-value type not yet implemented.


### PR DESCRIPTION
Fixes #9951.

The issue was introduced in d41eaeba5686828b85279057f3a7da8be0f9a8f9, PR #9146,
https://github.com/ethereum/solidity/pull/9146/files#diff-07335c711d9742b9c53a75648c7ad55cL2295-L2298.

Basically, `if + continue` was replaced with `solAssert`, which crashes with constant structs containing mappings:

```
contract C {
    struct S {
        mapping(uint => uint) c;
    }
    S public constant e;
}
```

The comment in the old code claims that the old behavior was intended. I restored it, but not completely sure if it is the right way to go. Skipping struct members looks suspicious :).
