### PR TITLE
StackLimitEvader: Track unreachable variables globally instead of per function.

### DIFF
--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -66,14 +66,13 @@ struct MemoryOffsetAllocator
 		if (unreachableVariables.count(_function))
 		{
 			yulAssert(!slotAllocations.count(_function), "");
-			auto& assignedSlots = slotAllocations[_function];
 			for (YulString variable: unreachableVariables.at(_function))
 				if (variable.empty())
 				{
 					// TODO: Too many function arguments or return parameters.
 				}
 				else
-					assignedSlots[variable] = requiredSlots++;
+					slotAllocations[variable] = requiredSlots++;
 		}
 
 		return slotsRequiredForFunction[_function] = requiredSlots;
@@ -82,7 +81,7 @@ struct MemoryOffsetAllocator
 	map<YulString, set<YulString>> const& unreachableVariables;
 	map<YulString, set<YulString>> const& callGraph;
 
-	map<YulString, map<YulString, uint64_t>> slotAllocations{};
+	map<YulString, uint64_t> slotAllocations{};
 	map<YulString, uint64_t> slotsRequiredForFunction{};
 };
 

--- a/libyul/optimiser/StackToMemoryMover.h
+++ b/libyul/optimiser/StackToMemoryMover.h
@@ -90,7 +90,7 @@ public:
 	static void run(
 		OptimiserStepContext& _context,
 		u256 _reservedMemory,
-		std::map<YulString, std::map<YulString, uint64_t>> const& _memorySlots,
+		std::map<YulString, uint64_t> const& _memorySlots,
 		uint64_t _numRequiredSlots,
 		Block& _block
 	);
@@ -103,7 +103,7 @@ private:
 	StackToMemoryMover(
 		OptimiserStepContext& _context,
 		u256 _reservedMemory,
-		std::map<YulString, std::map<YulString, uint64_t>> const& _memorySlots,
+		std::map<YulString, uint64_t> const& _memorySlots,
 		uint64_t _numRequiredSlots
 	);
 
@@ -112,10 +112,9 @@ private:
 
 	OptimiserStepContext& m_context;
 	u256 m_reservedMemory;
-	std::map<YulString, std::map<YulString, uint64_t>> const& m_memorySlots;
+	std::map<YulString, uint64_t> const& m_memorySlots;
 	uint64_t m_numRequiredSlots = 0;
 	NameDispenser& m_nameDispenser;
-	std::map<YulString, uint64_t> const* m_currentFunctionMemorySlots = nullptr;
 };
 
 }


### PR DESCRIPTION
First part of a series of PRs moving towards moving function arguments (I'll do this in very small steps this time ;-)).

Since the Yul sources are disambiguated, i.e. all variables have globally unique names, unreachables can be tracked globally.

This will result in the ``StackToMemoryMover`` walking through functions without unreachable variables (doing nothing), but it simplifies things, especially down the road.
