### PR TITLE
StackToMemoryMover: encapsulate memory offset tracking into its own class.

### DIFF
--- a/libyul/optimiser/StackToMemoryMover.h
+++ b/libyul/optimiser/StackToMemoryMover.h
@@ -100,20 +100,32 @@ public:
 	void operator()(Block& _block) override;
 	void visit(Expression& _expression) override;
 private:
+	class VariableMemoryOffsetTracker
+	{
+	public:
+		VariableMemoryOffsetTracker(
+			u256 _reservedMemory,
+			std::map<YulString, uint64_t> const& _memorySlots,
+			uint64_t _numRequiredSlots
+		): m_reservedMemory(_reservedMemory), m_memorySlots(_memorySlots), m_numRequiredSlots(_numRequiredSlots)
+		{}
+
+		/// @returns a YulString containing the memory offset to be assigned to @a _variable as number literal
+		/// or std::nullopt if the variable should not be moved.
+		std::optional<YulString> operator()(YulString _variable) const;
+	private:
+		u256 m_reservedMemory;
+		std::map<YulString, uint64_t> const& m_memorySlots;
+		uint64_t m_numRequiredSlots = 0;
+	};
+
 	StackToMemoryMover(
 		OptimiserStepContext& _context,
-		u256 _reservedMemory,
-		std::map<YulString, uint64_t> const& _memorySlots,
-		uint64_t _numRequiredSlots
+		VariableMemoryOffsetTracker const& _memoryOffsetTracker
 	);
 
-	/// @returns a YulString containing the memory offset to be assigned to @a _variable as number literal.
-	YulString memoryOffset(YulString _variable);
-
 	OptimiserStepContext& m_context;
-	u256 m_reservedMemory;
-	std::map<YulString, uint64_t> const& m_memorySlots;
-	uint64_t m_numRequiredSlots = 0;
+	VariableMemoryOffsetTracker const& m_memoryOffsetTracker;
 	NameDispenser& m_nameDispenser;
 };
 


### PR DESCRIPTION
~~Depends on https://github.com/ethereum/solidity/pull/9960.~~

Subsequently, the ``StackToMemoryMover`` will be split up into multiple steps (rewriting assignments+declarations, rewriting function definitions, rewriting function calls and rewriting identifiers) and will probably internally have to call the expression splitter and joiner between them.
Tracking and assigning memory offsets to variables will be shared among those individual steps and is therefore extracted first.

~~Putting this in draft mode until https://github.com/ethereum/solidity/pull/9960 is merged.~~