### PR TITLE
Move for loop conditons and split expressions during StackToMemoryMover (reversing afterwards).

### DIFF
--- a/libyul/optimiser/ExpressionJoiner.cpp
+++ b/libyul/optimiser/ExpressionJoiner.cpp
@@ -40,6 +40,17 @@ void ExpressionJoiner::run(OptimiserStepContext&, Block& _ast)
 	ExpressionJoiner{_ast}(_ast);
 }
 
+void ExpressionJoiner::runUntilStabilized(OptimiserStepContext&, Block& _ast)
+{
+	while (true)
+	{
+		ExpressionJoiner expressionJoiner{_ast};
+		expressionJoiner(_ast);
+		if (!expressionJoiner.m_expressionWasJoined)
+			break;
+	}
+}
+
 
 void ExpressionJoiner::operator()(FunctionCall& _funCall)
 {
@@ -74,6 +85,7 @@ void ExpressionJoiner::visit(Expression& _e)
 			*latestStatement() = Block();
 
 			decrementLatestStatementPointer();
+			m_expressionWasJoined = true;
 		}
 	}
 	else

--- a/libyul/optimiser/ExpressionJoiner.h
+++ b/libyul/optimiser/ExpressionJoiner.h
@@ -74,6 +74,7 @@ class ExpressionJoiner: public ASTModifier
 public:
 	static constexpr char const* name{"ExpressionJoiner"};
 	static void run(OptimiserStepContext&, Block& _ast);
+	static void runUntilStabilized(OptimiserStepContext&, Block& _ast);
 
 private:
 	explicit ExpressionJoiner(Block& _ast);
@@ -92,9 +93,10 @@ private:
 	bool isLatestStatementVarDeclJoinable(Identifier const& _identifier);
 
 private:
-	Block* m_currentBlock = nullptr;		///< Pointer to current block holding the statement being visited.
+	Block* m_currentBlock = nullptr;			///< Pointer to current block holding the statement being visited.
 	size_t m_latestStatementInBlock = 0;		///< Offset to m_currentBlock's statements of the last visited statement.
 	std::map<YulString, size_t> m_references;	///< Holds reference counts to all variable declarations in current block.
+	bool m_expressionWasJoined = false;			///< True, if any expression was joined during the visit.
 };
 
 }

--- a/libyul/optimiser/StackToMemoryMover.cpp
+++ b/libyul/optimiser/StackToMemoryMover.cpp
@@ -63,6 +63,12 @@ void StackToMemoryMover::run(
 	Block& _block
 )
 {
+	if (!_numRequiredSlots)
+	{
+		yulAssert(_memorySlots.empty(), "");
+		return;
+	}
+
 	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&_context.dialect);
 	yulAssert(
 		evmDialect && evmDialect->providesObjectAccess(),

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/connected.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/connected.yul
@@ -29,31 +29,32 @@
 //     {
 //         a := 21
 //         mstore(0x60, 1)
-//         let b_1, a_2, $c_3 := z()
-//         mstore(0x60, $c_3)
-//         a := a_2
-//         b := b_1
+//         let b_8, a_9, $c_10 := z()
+//         mstore(0x60, $c_10)
+//         a := a_9
+//         b := b_8
 //     }
 //     function f() -> x
 //     {
-//         mstore(0x20, 0)
+//         let $x2_11
+//         mstore(0x20, $x2_11)
 //         mstore(0x20, 42)
-//         let $x3_4, $x4_5 := g()
-//         mstore(0x00, $x4_5)
-//         mstore(0x40, $x3_4)
+//         let $x3_13, $x4_14 := g()
+//         mstore(0x00, $x4_14)
+//         mstore(0x40, $x3_13)
 //         x := mul(add(mload(0x20), mload(0x40)), h(mload(0x00)))
 //         sstore(mload(0x40), mload(0x00))
 //     }
 //     function h(v) -> a_1
 //     {
-//         let x_2_6, $z_7, y_8 := z()
-//         mstore(0x60, $z_7)
-//         let y := y_8
-//         let x_2 := x_2_6
-//         let a_1_9, $z_10, v_11 := z()
-//         mstore(0x60, $z_10)
-//         v := v_11
-//         a_1 := a_1_9
+//         let x_2_15, $z_16, y_17 := z()
+//         mstore(0x60, $z_16)
+//         let y := y_17
+//         let x_2 := x_2_15
+//         let a_1_18, $z_19, v_20 := z()
+//         mstore(0x60, $z_19)
+//         v := v_20
+//         a_1 := a_1_18
 //     }
 //     function z() -> a_3, b_4, c
 //     { mstore(0x80, 0) }

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/stub.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/stub.yul
@@ -30,52 +30,53 @@
 //     mstore(0x40, memoryguard(0x80))
 //     function f()
 //     {
-//         mstore(0x40, 0)
+//         let $fx_8
+//         mstore(0x40, $fx_8)
 //         mstore(0x60, 42)
 //         sstore(mload(0x40), mload(0x60))
 //         mstore(0x40, 21)
 //     }
 //     function g(gx)
 //     {
-//         let $gx_1, $gy_2 := tuple2()
-//         mstore(0x40, $gy_2)
-//         mstore(0x60, $gx_1)
+//         let $gx_11, $gy_12 := tuple2()
+//         mstore(0x40, $gy_12)
+//         mstore(0x60, $gx_11)
 //         {
-//             let $gx_3, $gy_4 := tuple2()
-//             mstore(0x40, $gy_4)
-//             mstore(0x60, $gx_3)
+//             let $gx_13, $gy_14 := tuple2()
+//             mstore(0x40, $gy_14)
+//             mstore(0x60, $gx_13)
 //         }
 //         {
-//             let $gx_5, gx_6 := tuple2()
-//             mstore(0x60, $gx_5)
-//             gx := gx_6
+//             let $gx_15, gx_16 := tuple2()
+//             mstore(0x60, $gx_15)
+//             gx := gx_16
 //         }
 //         {
-//             let gx_7, $gy_8 := tuple2()
-//             mstore(0x40, $gy_8)
-//             gx := gx_7
+//             let gx_17, $gy_18 := tuple2()
+//             mstore(0x40, $gy_18)
+//             gx := gx_17
 //         }
 //     }
 //     function h(hx, hy, hz, hw)
 //     {
-//         let $hx_9, $hy_10, $hz_11, $hw_12 := tuple4()
-//         mstore(0x00, $hw_12)
-//         mstore(0x60, $hz_11)
-//         mstore(0x40, $hy_10)
-//         mstore(0x20, $hx_9)
+//         let $hx_19, $hy_20, $hz_21, $hw_22 := tuple4()
+//         mstore(0x00, $hw_22)
+//         mstore(0x60, $hz_21)
+//         mstore(0x40, $hy_20)
+//         mstore(0x20, $hx_19)
 //         {
-//             let hx_13, $hy_14, hz_15, $hw_16 := tuple4()
-//             mstore(0x00, $hw_16)
-//             mstore(0x40, $hy_14)
-//             hz := hz_15
-//             hx := hx_13
+//             let hx_23, $hy_24, hz_25, $hw_26 := tuple4()
+//             mstore(0x00, $hw_26)
+//             mstore(0x40, $hy_24)
+//             hz := hz_25
+//             hx := hx_23
 //         }
 //         {
-//             let $hx_17, $hy_18, hz_19, hw_20 := tuple4()
-//             mstore(0x40, $hy_18)
-//             mstore(0x20, $hx_17)
-//             hw := hw_20
-//             hz := hz_19
+//             let $hx_27, $hy_28, hz_29, hw_30 := tuple4()
+//             mstore(0x40, $hy_28)
+//             mstore(0x20, $hx_27)
+//             hw := hw_30
+//             hz := hz_29
 //         }
 //     }
 //     function tuple2() -> a, b


### PR DESCRIPTION
Depends on https://github.com/ethereum/solidity/pull/9962 (which depends on https://github.com/ethereum/solidity/pull/9961 which depends on https://github.com/ethereum/solidity/pull/9960).

This one needs some thought.

The reason for doing this, is that in the next step, function definitions will be rewritten (moving arguments/return parameters to memory), which requires rewriting function calls - and that's only possible in split form.

But first of all I'm not sure, if we shouldn't generally run the ExpressionJoiner until it stabilizes instead of only once.

And secondly, we need to make sure that the combination ``ForLoopConditionIntoBody`` + ``ExpressionSplitter`` before and ``ExpressionJoiner`` + ``ForLoopConditionOutOfBody`` after is invariant with respect to stack slot requirements.
- Moving the for loop condition should be fine - whatever is accessible in the condition should be accessible in an if in the beginning of the body and vice versa.
- ``ExpressionSplitter`` and ``ExpressionJoiner`` should not change the stack layout at all, if I'm thinking about them correctly (they just exchange implicit spots on stack with explicitly named slots, i.e. local variables). But maybe good, if someone confirm that that's true.

Nicely, the test expectations are identical, except for higher variable indices.

Putting this into draft mode until https://github.com/ethereum/solidity/pull/9962 is merged.