### PR TITLE
[Docs] Updates Index/Home Page of Sol Docs / Adds "Getting Started"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,42 +26,58 @@ a 0.x version number `to indicate this fast pace of change <https://semver.org/#
 
 .. warning::
 
-  Solidity recently released the 0.6.x version that introduced a lot of breaking
-  changes. Make sure you read :doc:`the full list <060-breaking-changes>`.
+  Solidity recently released the 0.7.x version that introduced a lot of breaking
+  changes. Make sure you read :doc:`the full list <070-breaking-changes>`.
 
-Language Documentation
-----------------------
+Ideas for improving Solidity or this documentation are always welcome,
+read our :doc:`contributors guide <contributing>` for more details.
 
-If you are new to the concept of smart contracts we recommend you start with
-:ref:`an example smart contract <simple-smart-contract>` written
-in Solidity. When you are ready for more detail, we recommend you read the
-:doc:`"Solidity by Example" <solidity-by-example>` and
-"Language Description" sections to learn the core concepts of the language.
+Getting Started
+---------------
 
-For further reading, try :ref:`the basics of blockchains <blockchain-basics>`
-and details of the :ref:`Ethereum Virtual Machine <the-ethereum-virtual-machine>`.
+**1. Understand the Smart Contract Basics**
+
+If you are new to the concept of smart contracts we recommend you to get started by digging
+into the "Introduction to Smart Contracts" section, which covers:
+* :ref:`A simple example smart contract <simple-smart-contract>` written in Solidity.
+* :ref:`Blockchain Basics <blockchain-basics>`.
+* :ref:`The Ethereum Virtual Machine <the-ethereum-virtual-machine>`.
+
+**2. Get to Know Solidity**
+
+Once you are accustomed to the basics, we recommend you read the :doc:`"Solidity by Example" <solidity-by-example>`
+and “Language Description” sections to understand the core concepts of the language.
+
+**3. Install the Solidity Compiler**
+
+There are various ways to install the Solidity compiler,
+simply choose your preferred option and follow the steps outlined on the :ref:`installation page <installing-solidity>`.
 
 .. hint::
-  You can always try out code examples in your browser with the
+  You can try out code examples directly in your browser with the
   `Remix IDE <https://remix.ethereum.org>`_. Remix is a web browser based IDE
-  that allows you to write Solidity smart contracts, then deploy and run the
-  smart contracts. It can take a while to load, so please be patient.
+  that allows you to write, deploy and administer Solidity smart contracts, without
+  the need to install Solidity locally.
 
 .. warning::
     As humans write software, it can have bugs. You should follow established
-    software development best-practices when writing your smart contracts, this
+    software development best-practices when writing your smart contracts. This
     includes code review, testing, audits, and correctness proofs. Smart contract
     users are sometimes more confident with code than their authors, and
     blockchains and smart contracts have their own unique issues to
     watch out for, so before working on production code, make sure you read the
     :ref:`security_considerations` section.
 
-If you have any questions, you can try searching for answers or asking on the
-`Ethereum Stackexchange <https://ethereum.stackexchange.com/>`_, or
-our `gitter channel <https://gitter.im/ethereum/solidity/>`_.
+**4. Learn More**
 
-Ideas for improving Solidity or this documentation are always welcome,
-read our :doc:`contributors guide <contributing>` for more details.
+If you want to learn more about building decentralized applications on Ethereum, the
+`Ethereum Developer Resources <https://ethereum.org/en/developers/>`_
+can help you with further general documentation around Ethereum, and a wide selection of tutorials,
+tools and development frameworks.
+
+If you have any questions, you can try searching for answers or asking on the
+`Ethereum StackExchange <https://ethereum.stackexchange.com/>`_, or
+our `Gitter channel <https://gitter.im/ethereum/solidity/>`_.
 
 .. _translations:
 


### PR DESCRIPTION
- restructures content on docs "home" page
- adds "getting started" section, which mostly contains what was there before, restructured and at parts slightly reworded

closes #9475