### PR TITLE
Checking experimental pragmas in the right source unit when compiling modifiers and inherited functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 
 Bugfixes:
  * Code generator: Fix internal compiler error when referencing members via module name but not using the reference.
+ * Code generator: Fix ``ABIEncoderV2`` pragma from the current module affecting inherited functions and applied modifiers.
  * Type Checker: Fix internal compiler error caused by storage parameters with nested mappings in libraries.
  * Name Resolver: Fix shadowing/same-name warnings for later declarations.
 

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -78,6 +78,7 @@ public:
 
 	/// Update currently enabled set of experimental features.
 	void setExperimentalFeatures(std::set<ExperimentalFeature> const& _features) { m_experimentalFeatures = _features; }
+	std::set<ExperimentalFeature> const& experimentalFeaturesActive() const { return m_experimentalFeatures; }
 	/// @returns true if the given feature is enabled.
 	bool experimentalFeatureActive(ExperimentalFeature _feature) const { return m_experimentalFeatures.count(_feature); }
 

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -1326,8 +1326,13 @@ void ContractCompiler::appendModifierOrFunctionCode()
 
 	if (codeBlock)
 	{
+		std::set<ExperimentalFeature> experimentalFeaturesOutside = m_context.experimentalFeaturesActive();
+		m_context.setExperimentalFeatures(codeBlock->sourceUnit().annotation().experimentalFeatures);
+
 		m_returnTags.emplace_back(m_context.newTag(), m_context.stackHeight());
 		codeBlock->accept(*this);
+
+		m_context.setExperimentalFeatures(experimentalFeaturesOutside);
 
 		solAssert(!m_returnTags.empty(), "");
 		m_context << m_returnTags.back().first;

--- a/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_function_inherited_in_v1_contract.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_function_inherited_in_v1_contract.sol
@@ -1,0 +1,32 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    uint a;
+    uint[2] b;
+    uint c;
+}
+
+contract A {
+    function get() public view returns (Data memory) {
+        return Data(5, [uint(66), 77], 8);
+    }
+}
+
+contract B {
+    function foo(A _a) public returns (uint) {
+        return _a.get().b[1];
+    }
+}
+==== Source: B ====
+import "A";
+
+contract C is B {
+    function test() public returns (uint) {
+        return foo(new A());
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// test() -> 77

--- a/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_modifier_used_in_v1_contract.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_modifier_used_in_v1_contract.sol
@@ -1,0 +1,38 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    uint value;
+}
+
+contract A {
+    function get() public view returns (Data memory) {
+        return Data(5);
+    }
+}
+
+contract B {
+    uint x = 10;
+    uint y = 10;
+
+    modifier updateStorage() {
+        A a = new A();
+        x = a.get().value;
+        _;
+        y = a.get().value;
+    }
+}
+==== Source: B ====
+import "A";
+
+contract C is B {
+    function test()
+        public
+        updateStorage
+        returns (uint, uint)
+    {
+        return (x, y);
+    }
+}
+// ----
+// test() -> 5, 10

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_modifier.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_modifier.sol
@@ -1,0 +1,27 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    bool flag;
+}
+
+contract A {
+    function get() public view returns (Data memory) {}
+}
+
+contract B {
+    modifier validate() {
+        A(0x00).get();
+        _;
+    }
+}
+==== Source: B ====
+import "A";
+
+contract C is B {
+    function foo()
+        public
+        validate()
+    {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_constructor_with_v2_modifier.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_constructor_with_v2_modifier.sol
@@ -1,0 +1,33 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    bool flag;
+}
+
+contract A {
+    function get() public view returns (Data memory) {}
+}
+
+contract B {
+    constructor() validate {
+        A(0x00).get();
+    }
+
+    modifier validate() {
+        A(0x00).get();
+        _;
+    }
+}
+
+==== Source: B ====
+import "A";
+
+contract C is B {}
+==== Source: C ====
+import "B";
+
+contract D is C {
+    constructor() validate B() validate C() validate {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_calling_v2_function.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_calling_v2_function.sol
@@ -1,0 +1,25 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    bool flag;
+}
+
+contract A {
+    function get() public view returns (Data memory) {}
+}
+
+contract B {
+    constructor() {
+        A(0x00).get();
+    }
+
+    function foo() public view {
+        A(0x00).get();
+    }
+}
+==== Source: B ====
+import "A";
+
+contract C is B {}
+// ----

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_emitting_v2_event.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_emitting_v2_event.sol
@@ -1,0 +1,21 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Item {
+    uint x;
+}
+
+library L {
+    event Ev(Item);
+}
+
+contract C {
+    function foo() public {
+        emit L.Ev(Item(1));
+    }
+}
+==== Source: B ====
+import "A";
+
+contract D is C {}
+// ----

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_modifier_overriding_v2_modifier.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_modifier_overriding_v2_modifier.sol
@@ -1,0 +1,29 @@
+==== Source: A ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    bool flag;
+}
+
+contract A {
+    function get() public view returns (Data memory) {}
+}
+
+contract B {
+    modifier validate() virtual {
+        A(0x00).get();
+        _;
+    }
+}
+
+==== Source: B ====
+import "A";
+
+contract C is B {
+    function foo() public pure validate {}
+
+    modifier validate() override {
+        _;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_v2_v1_modifier_mix.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_v2_v1_modifier_mix.sol
@@ -1,0 +1,52 @@
+==== Source: C ====
+import "X";
+import "V1A";
+import "V2A";
+import "V1B";
+
+contract C is V1A, V2A, V1B {
+    function foo()
+        public
+        modV1A
+        modV2A // There should be no error for modV2A (it uses ABIEncoderV2)
+        modV1B
+    {
+    }
+}
+==== Source: V1A ====
+import "X";
+
+contract V1A {
+    modifier modV1A() {
+        _;
+    }
+}
+==== Source: V1B ====
+import "X";
+
+contract V1B {
+    modifier modV1B() {
+        _;
+    }
+}
+==== Source: V2A ====
+pragma experimental ABIEncoderV2;
+import "X";
+
+contract V2A {
+    modifier modV2A() {
+        X(0x00).get();
+        _;
+    }
+}
+==== Source: X ====
+pragma experimental ABIEncoderV2;
+
+struct Data {
+    bool flag;
+}
+
+contract X {
+    function get() public view returns (Data memory) {}
+}
+// ----


### PR DESCRIPTION
Fixes #9969.

~Needs more tests. I haven't really tested it with experimental pragmas other than `ABIEncoderV2`.~
- Done. This does not really affect the SMTChecker pragma because it's not used in the codegen. And those two are the only experimental pragmas we have now (not counting those test pragmas prefixed with `_`).