### PR TITLE
Always run the FunctionHoister as part of the optimizer Suite.

### DIFF
--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -101,9 +101,9 @@ void OptimiserSuite::run(
 
 	OptimiserSuite suite(_dialect, reservedIdentifiers, Debug::None, ast);
 
-	// Some steps depend on properties ensured by FunctionHoister, FunctionGrouper and
+	// Some steps depend on properties ensured by FunctionHoister, BlockFlattener, FunctionGrouper and
 	// ForLoopInitRewriter. Run them first to be able to run arbitrary sequences safely.
-	suite.runSequence("fgo", ast);
+	suite.runSequence("hfgo", ast);
 
 	// Now the user-supplied part
 	suite.runSequence(_optimisationSequence, ast);


### PR DESCRIPTION
The comment claimed it runs the ``FunctionHoister`` already, but it did run the ``BlockFlattener`` instead.

Came up in https://github.com/ethereum/solidity/pull/9973.