### PR TITLE
Enable the four semantic tests from `functionCall.inheritance` that now pass via Yul

### DIFF
--- a/test/libsolidity/semanticTests/functionCall/inheritance/call_base.sol
+++ b/test/libsolidity/semanticTests/functionCall/inheritance/call_base.sol
@@ -9,5 +9,7 @@ contract Child is Base {
 		return f(n);
 	}
 }
+// ====
+// compileViaYul: also
 // ----
 // g(uint256): 4 -> 8

--- a/test/libsolidity/semanticTests/functionCall/inheritance/call_base_base.sol
+++ b/test/libsolidity/semanticTests/functionCall/inheritance/call_base_base.sol
@@ -22,6 +22,8 @@ contract Child is Base {
 		return s(n);
 	}
 }
+// ====
+// compileViaYul: also
 // ----
 // g(uint256): 4 -> 12
 // h(uint256): 4 -> 16

--- a/test/libsolidity/semanticTests/functionCall/inheritance/call_base_base_explicit.sol
+++ b/test/libsolidity/semanticTests/functionCall/inheritance/call_base_base_explicit.sol
@@ -25,6 +25,8 @@ contract Child is Base {
 		return BaseBase.s(n);
 	}
 }
+// ====
+// compileViaYul: also
 // ----
 // g(uint256): 4 -> 8
 // k(uint256): 4 -> 16

--- a/test/libsolidity/semanticTests/functionCall/inheritance/call_base_explicit.sol
+++ b/test/libsolidity/semanticTests/functionCall/inheritance/call_base_explicit.sol
@@ -9,6 +9,7 @@ contract Child is Base {
 		return Base.f(n);
 	}
 }
+// ====
+// compileViaYul: also
 // ----
 // g(uint256): 4 -> 8
-


### PR DESCRIPTION
Looks like something overlooked in one of the recently merged PRs. Not sure which one.