### PR TITLE
Refactor stack to memory mover in preparation of moving function arguments.

### DIFF
--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -126,7 +126,7 @@ void OptimiserSuite::run(
 	{
 		yulAssert(_meter, "");
 		ConstantOptimiser{*dialect, *_meter}(ast);
-		if (dialect->providesObjectAccess())
+		if (dialect->providesObjectAccess() && _optimizeStackAllocation)
 			StackLimitEvader::run(suite.m_context, _object, CompilabilityChecker{
 				_dialect,
 				_object,


### PR DESCRIPTION
Some refactoring in preparation of https://github.com/ethereum/solidity/pull/10015.

The only real change is to only run the step when stack optimizations are enabled (since otherwise the transformation is unsound anyways).