### PR TITLE
[SMTChecker] Fix counterexample state reporting

### DIFF
--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -189,7 +189,7 @@ string Predicate::formatSummaryCall(vector<string> const& _args) const
 vector<string> Predicate::summaryStateValues(vector<string> const& _args) const
 {
 	/// The signature of a function summary predicate is: summary(error, this, txData, preBlockchainState, preStateVars, preInputVars, postBlockchainState, postStateVars, postInputVars, outputVars).
-	/// The signature of an implicit constructor summary predicate is: summary(error, this, txData, postBlockchainState, postStateVars).
+	/// The signature of an implicit constructor summary predicate is: summary(error, this, txData, preBlockSchainState, postBlockchainState, postStateVars).
 	/// Here we are interested in postStateVars.
 
 	auto stateVars = stateVariables();
@@ -204,7 +204,7 @@ vector<string> Predicate::summaryStateValues(vector<string> const& _args) const
 	}
 	else if (programContract())
 	{
-		stateFirst = _args.begin() + 4;
+		stateFirst = _args.begin() + 5;
 		stateLast = stateFirst + static_cast<int>(stateVars->size());
 	}
 	else


### PR DESCRIPTION
Missed that in https://github.com/ethereum/solidity/pull/10014.

Without this PR, the counterexamples are reported wrong:

```
pragma experimental SMTChecker;
contract D {
    uint x = 0;
    uint y = x - 1;
}  
```

```
Warning: CHC: Underflow (resulting value less than 0) happens here.
 --> a.sol:4:11:
  |
4 | 	uint y = x - 1;
  | 	         ^^^^^
Note: 
Counterexample:
x = (state_type ((as const (Array Int Int)) 0)), y = 0

Transaction trace:
constructor()
```
Since the index is wrong, it's reporting the balances as the wanted state variable.

With the PR it goes back to normal:
```
Warning: CHC: Underflow (resulting value less than 0) happens here.
 --> a.sol:4:11:
  |
4 | 	uint y = x - 1;
  | 	         ^^^^^
Note: 
Counterexample:
x = 0, y = 115792089237316195423570985008687907853269984665640564039457584007913129639935

Transaction trace:
constructor()
```