### PR TITLE
Reuse CircleCI osx cache across branches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,12 +574,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+      # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
+      # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
       - run:
           name: Install build dependencies
           command: ./.circleci/osx_install_dependencies.sh
       - save_cache:
-          key: dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+          key: dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
           paths:
             - /usr/local/bin
             - /usr/local/sbin
@@ -603,7 +605,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - attach_workspace:
           at: build
       - run: *run_soltest
@@ -619,7 +621,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - attach_workspace:
           at: build
       - run: *run_cmdline_tests
@@ -902,14 +904,14 @@ jobs:
       - restore_cache:
           keys:
             - dependencies-win-{{ checksum "scripts/install_deps.ps1" }}
-      - run:
+      # DO NOT EDIT between here and save_cache, but rather edit .\scripts\install_deps.ps1
+      # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.                                    - run:
           name: "Installing dependencies"
-          command: if ( -not (Test-Path .\deps\boost) ) { .\scripts\install_deps.ps1 }
+          command: .\scripts\install_deps.ps1
       - save_cache:
           key: dependencies-win-{{ checksum "scripts/install_deps.ps1" }}
           paths:
-            - .\deps\boost
-            - .\deps\cmake
+            - .\deps
       - run:
           name: "Building solidity"
           command: .circleci/build_win.ps1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,12 +574,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - run:
           name: Install build dependencies
           command: ./.circleci/osx_install_dependencies.sh
       - save_cache:
-          key: dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+          key: dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
           paths:
             - /usr/local/bin
             - /usr/local/sbin
@@ -603,7 +603,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - attach_workspace:
           at: build
       - run: *run_soltest
@@ -619,7 +619,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ checksum ".circleci/config.yml" }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - attach_workspace:
           at: build
       - run: *run_cmdline_tests

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -1,18 +1,20 @@
-$ErrorActionPreference = "Stop"
+if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
+  $ErrorActionPreference = "Stop"
 
-# Needed for Invoke-WebRequest to work via CI.
-$progressPreference = "silentlyContinue"
+  # Needed for Invoke-WebRequest to work via CI.
+  $progressPreference = "silentlyContinue"
 
-New-Item -ItemType Directory -Force -Path "$PSScriptRoot\..\deps"
+  New-Item -ItemType Directory -Force -Path "$PSScriptRoot\..\deps"
 
-Invoke-WebRequest -URI "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-win64-x64.zip" -OutFile cmake.zip
-tar -xf cmake.zip
-mv cmake-3.18.2-win64-x64 "$PSScriptRoot\..\deps\cmake"
+  Invoke-WebRequest -URI "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-win64-x64.zip" -OutFile cmake.zip
+  tar -xf cmake.zip
+  mv cmake-3.18.2-win64-x64 "$PSScriptRoot\..\deps\cmake"
 
-Invoke-WebRequest -URI "https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip
-tar -xf boost.zip
-cd boost_1_74_0
-.\bootstrap.bat
-.\b2 -j4 -d0 link=static runtime-link=static variant=release threading=multi address-model=64 --with-filesystem --with-system --with-program_options --with-test --prefix="$PSScriptRoot\..\deps\boost" install
-if ( -not $? ) { throw "Error building boost." }
-cd ..
+  Invoke-WebRequest -URI "https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip
+  tar -xf boost.zip
+  cd boost_1_74_0
+  .\bootstrap.bat
+  .\b2 -j4 -d0 link=static runtime-link=static variant=release threading=multi address-model=64 --with-filesystem --with-system --with-program_options --with-test --prefix="$PSScriptRoot\..\deps\boost" install
+  if ( -not $? ) { throw "Error building boost." }
+  cd ..
+}


### PR DESCRIPTION
A cache per branch really doesn't help much. Arguably also ``{{ checksum ".circleci/config.yml" }}`` could be removed as well, but I kept it for now. What's really cached is the result of ``.circleci/osx_install_dependencies.sh``, so that checksum would be enough...