### PR TITLE
Make sure lValueOfOrdinaryAssignment does not have an undefined value.

### DIFF
--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -254,7 +254,7 @@ struct ExpressionAnnotation: ASTAnnotation
 	/// Whether the expression is an lvalue that is only assigned.
 	/// Would be false for --, ++, delete, +=, -=, ....
 	/// Only relevant if isLvalue == true
-	bool lValueOfOrdinaryAssignment;
+	bool lValueOfOrdinaryAssignment = false;
 
 	/// Types and - if given - names of arguments if the expr. is a function
 	/// that is called, used for overload resolution


### PR DESCRIPTION
I just had another look at https://github.com/ethereum/solidity/pull/9953/, because it came up as solving an issue in 0.7.2 in the gitter channel and saw this... documenting that it's only valid under some circumstances is one thing, but POD members should *always* be initialized either way, otherwise one always risks situations with undefined behaviour.