### PR TITLE
ossfuzz: Remove antlr4 build deps

### DIFF
--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -5,17 +5,6 @@ ROOTDIR="/root/project"
 BUILDDIR="${ROOTDIR}/build"
 mkdir -p "${BUILDDIR}" && mkdir -p "$BUILDDIR/deps"
 
-ANTLRJAR="${ROOTDIR}/build/deps/antlr4.8.jar"
-ANTLRJAR_URI="https://www.antlr.org/download/antlr-4.8-complete.jar"
-
-download_antlr4()
-{
-  if [[ ! -e "${ANTLRJAR}" ]]
-  then
-    wget -O "${ANTLRJAR}" "${ANTLRJAR_URI}"
-  fi
-}
-
 generate_protobuf_bindings()
 {
   cd "${ROOTDIR}"/test/tools/ossfuzz
@@ -26,21 +15,6 @@ generate_protobuf_bindings()
   done
 }
 
-generate_antlr4_bindings()
-{
-  cd "${ROOTDIR}"
-  # Replace boolean with bool to suit c++ syntax
-  sed -i 's/boolean /bool /g' docs/grammar/Solidity.g4
-  # Generate antlr4 visitor/parser/lexer c++ bindings
-  java -jar "${ANTLRJAR}" -Dlanguage=Cpp \
-    -Xexact-output-dir -package solidity::test::fuzzer -o test/tools/ossfuzz \
-    -no-listener -visitor docs/grammar/SolidityLexer.g4 docs/grammar/Solidity.g4
-  # Delete unnecessary autogen files
-  rm -f "${ROOTDIR}"/test/tools/ossfuzz/Solidity*Visitor.cpp \
-    "${ROOTDIR}"/test/tools/ossfuzz/Solidity*.interp \
-    "${ROOTDIR}"/test/tools/ossfuzz/Solidity*.tokens
-}
-
 build_fuzzers()
 {
   cd "${BUILDDIR}"
@@ -49,7 +23,5 @@ build_fuzzers()
   make ossfuzz ossfuzz_proto ossfuzz_abiv2 -j 4
 }
 
-download_antlr4
 generate_protobuf_bindings
-generate_antlr4_bindings
 build_fuzzers

--- a/test/tools/ossfuzz/CMakeLists.txt
+++ b/test/tools/ossfuzz/CMakeLists.txt
@@ -27,30 +27,16 @@ if (OSSFUZZ)
             solc_opt_ossfuzz.cpp
             ../fuzzer_common.cpp
             ../../TestCaseReader.cpp
-            SolidityLexer.cpp
-            SolidityParser.cpp
     )
-    target_compile_options(solc_opt_ossfuzz
-            PUBLIC
-            ${COMPILE_OPTIONS} -Wno-extra-semi -Wno-unused-parameter
-    )
-    target_include_directories(solc_opt_ossfuzz PRIVATE /usr/include/antlr4-runtime)
-    target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm antlr4-runtime)
+    target_link_libraries(solc_opt_ossfuzz PRIVATE libsolc evmasm)
     set_target_properties(solc_opt_ossfuzz PROPERTIES LINK_FLAGS ${LIB_FUZZING_ENGINE})
 
     add_executable(solc_noopt_ossfuzz
             solc_noopt_ossfuzz.cpp
             ../fuzzer_common.cpp
             ../../TestCaseReader.cpp
-            SolidityLexer.cpp
-            SolidityParser.cpp
     )
-    target_compile_options(solc_noopt_ossfuzz
-            PUBLIC
-            ${COMPILE_OPTIONS} -Wno-extra-semi -Wno-unused-parameter
-    )
-    target_include_directories(solc_noopt_ossfuzz PRIVATE /usr/include/antlr4-runtime)
-    target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm antlr4-runtime)
+    target_link_libraries(solc_noopt_ossfuzz PRIVATE libsolc evmasm)
     set_target_properties(solc_noopt_ossfuzz PROPERTIES LINK_FLAGS ${LIB_FUZZING_ENGINE})
 
     add_executable(const_opt_ossfuzz const_opt_ossfuzz.cpp ../fuzzer_common.cpp)


### PR DESCRIPTION
Antlr dependency is no longer needed because the "grammar aware" solidity fuzzer will be written in C++ from scratch.

I will create a separate PR in order to remove antlr4 from ossfuzz docker image.