### PR TITLE
Store test results on CircleCI's t_win for proper reporting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -949,6 +949,7 @@ jobs:
       - run:
           name: "Run soltest"
           command: .circleci/soltest.ps1
+      - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
 
   t_win_release:


### PR DESCRIPTION
Missed this when I wrote t_win... I think this will make CircleCI properly report errors on the windows test runs...