### PR TITLE
Disallow creating libraries or arrays of libraries with new.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Bugfixes:
  * Code generator: Fix internal compiler error when referencing members via module name but not using the reference.
  * Code generator: Fix ``ABIEncoderV2`` pragma from the current module affecting inherited functions and applied modifiers.
  * Code generator: Use revert instead of invalid opcode for out-of-bounds array index access in getter.
+ * Type Checker: Disallow creating libraries and arrays of libraries with ``new``.
  * Type Checker: Fix internal compiler error caused by storage parameters with nested mappings in libraries.
  * Name Resolver: Fix shadowing/same-name warnings for later declarations.
  * Contract Level Checker: Add missing check against inheriting functions with ABIEncoderV2 return types in ABIEncoderV1 contracts.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2532,6 +2532,19 @@ void TypeChecker::endVisit(NewExpression const& _newExpression)
 	_newExpression.annotation().isConstant = false;
 	_newExpression.annotation().isLValue = false;
 
+	TypePointer baseType = type;
+	while (auto const* arrayType = dynamic_cast<ArrayType const*>(baseType))
+		baseType = arrayType->baseType();
+
+	if (auto const* contractType = dynamic_cast<ContractType const*>(baseType))
+		if (contractType->contractDefinition().isLibrary())
+		{
+			if (type == baseType)
+				m_errorReporter.fatalTypeError(8696_error, _newExpression.location(), "Cannot instantiate a library.");
+			else
+				m_errorReporter.fatalTypeError(4409_error, _newExpression.location(), "Cannot create arrays of libraries.");
+		}
+
 	if (auto contractName = dynamic_cast<UserDefinedTypeName const*>(&_newExpression.typeName()))
 	{
 		auto contract = dynamic_cast<ContractDefinition const*>(&dereference(*contractName));

--- a/test/libsolidity/syntaxTests/array/library_array.sol
+++ b/test/libsolidity/syntaxTests/array/library_array.sol
@@ -1,0 +1,8 @@
+library L {}
+contract C {
+  function f() public pure {
+    new L[](2);
+  }
+}
+// ----
+// TypeError 4409: (59-66): Cannot create arrays of libraries.

--- a/test/libsolidity/syntaxTests/functionCalls/new_library.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/new_library.sol
@@ -1,0 +1,8 @@
+library L {}
+contract C {
+  function f() public pure {
+    new L();
+  }
+}
+// ----
+// TypeError 8696: (59-64): Cannot instantiate a library.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/524_accept_library_creation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/524_accept_library_creation.sol
@@ -4,3 +4,5 @@ contract C {
         new L();
     }
 }
+// ----
+// TypeError 8696: (60-65): Cannot instantiate a library.


### PR DESCRIPTION
Am I missing something here or do we just have loads of library related bugs?
Here we even had a test for allowing this... but why? The only thing one could do would be
```
library L {}
contract C { function f() public returns (address) { return address(new L()); } }
```
...
That actually compiles and runs in remix returning... some address... but it's not supposed to is it, that's not a proper way to deploy a library, is it :-)?