### PR TITLE
Refactor SMT cex graph

### DIFF
--- a/libsmtutil/CHCSolverInterface.h
+++ b/libsmtutil/CHCSolverInterface.h
@@ -44,9 +44,7 @@ public:
 	/// Needs to bound all vars as universally quantified.
 	virtual void addRule(Expression const& _expr, std::string const& _name) = 0;
 
-	/// first: predicate name
-	/// second: predicate arguments
-	using CexNode = std::pair<std::string, std::vector<std::string>>;
+	using CexNode = Expression;
 	struct CexGraph
 	{
 		std::map<unsigned, CexNode> nodes;

--- a/libsmtutil/Z3CHCInterface.cpp
+++ b/libsmtutil/Z3CHCInterface.cpp
@@ -161,7 +161,7 @@ CHCSolverInterface::CexGraph Z3CHCInterface::cexGraph(z3::expr const& _proof)
 	proofStack.push(_proof.arg(0));
 
 	auto const& root = proofStack.top();
-	graph.nodes[root.id()] = {name(fact(root)), arguments(fact(root))};
+	graph.nodes.emplace(root.id(), m_z3Interface->fromZ3Expr(fact(root)));
 
 	set<unsigned> visited;
 	visited.insert(root.id());
@@ -186,7 +186,7 @@ CHCSolverInterface::CexGraph Z3CHCInterface::cexGraph(z3::expr const& _proof)
 
 				if (!graph.nodes.count(child.id()))
 				{
-					graph.nodes[child.id()] = {name(fact(child)), arguments(fact(child))};
+					graph.nodes.emplace(child.id(), m_z3Interface->fromZ3Expr(fact(child)));
 					graph.edges[child.id()] = {};
 				}
 

--- a/libsmtutil/Z3Interface.h
+++ b/libsmtutil/Z3Interface.h
@@ -41,6 +41,7 @@ public:
 	std::pair<CheckResult, std::vector<std::string>> check(std::vector<Expression> const& _expressionsToEvaluate) override;
 
 	z3::expr toZ3Expr(Expression const& _expr);
+	smtutil::Expression fromZ3Expr(z3::expr const& _expr);
 
 	std::map<std::string, z3::expr> constants() const { return m_constants; }
 	std::map<std::string, z3::func_decl> functions() const { return m_functions; }
@@ -56,6 +57,8 @@ private:
 
 	z3::sort z3Sort(Sort const& _sort);
 	z3::sort_vector z3Sort(std::vector<SortPointer> const& _sorts);
+	smtutil::SortPointer fromZ3Sort(z3::sort const& _sort);
+	std::vector<smtutil::SortPointer> fromZ3Sort(z3::sort_vector const& _sorts);
 
 	z3::context m_context;
 	z3::solver m_solver;

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -1306,7 +1306,7 @@ optional<string> CHC::generateCounterexample(CHCSolverInterface::CexGraph const&
 {
 	optional<unsigned> rootId;
 	for (auto const& [id, node]: _graph.nodes)
-		if (node.first == _root)
+		if (node.name == _root)
 		{
 			rootId = id;
 			break;
@@ -1330,18 +1330,18 @@ optional<string> CHC::generateCounterexample(CHCSolverInterface::CexGraph const&
 		if (edges.size() == 2)
 		{
 			interfaceId = edges.at(1);
-			if (!Predicate::predicate(_graph.nodes.at(summaryId).first)->isSummary())
+			if (!Predicate::predicate(_graph.nodes.at(summaryId).name)->isSummary())
 				swap(summaryId, *interfaceId);
-			auto interfacePredicate = Predicate::predicate(_graph.nodes.at(*interfaceId).first);
+			auto interfacePredicate = Predicate::predicate(_graph.nodes.at(*interfaceId).name);
 			solAssert(interfacePredicate && interfacePredicate->isInterface(), "");
 		}
 		/// The children are unordered, so we need to check which is the summary and
 		/// which is the interface.
 
-		Predicate const* summaryPredicate = Predicate::predicate(_graph.nodes.at(summaryId).first);
+		Predicate const* summaryPredicate = Predicate::predicate(_graph.nodes.at(summaryId).name);
 		solAssert(summaryPredicate && summaryPredicate->isSummary(), "");
 		/// At this point property 2 from the function description is verified for this node.
-		auto summaryArgs = _graph.nodes.at(summaryId).second;
+		vector<smtutil::Expression> summaryArgs = _graph.nodes.at(summaryId).arguments;
 
 		FunctionDefinition const* calledFun = summaryPredicate->programFunction();
 		ContractDefinition const* calledContract = summaryPredicate->programContract();
@@ -1387,7 +1387,7 @@ optional<string> CHC::generateCounterexample(CHCSolverInterface::CexGraph const&
 		/// or stop.
 		if (interfaceId)
 		{
-			Predicate const* interfacePredicate = Predicate::predicate(_graph.nodes.at(*interfaceId).first);
+			Predicate const* interfacePredicate = Predicate::predicate(_graph.nodes.at(*interfaceId).name);
 			solAssert(interfacePredicate && interfacePredicate->isInterface(), "");
 			node = *interfaceId;
 		}
@@ -1403,7 +1403,14 @@ string CHC::cex2dot(CHCSolverInterface::CexGraph const& _cex)
 	string dot = "digraph {\n";
 
 	auto pred = [&](CHCSolverInterface::CexNode const& _node) {
-		return "\"" + _node.first + "(" + boost::algorithm::join(_node.second, ", ") + ")\"";
+		vector<string> args = applyMap(
+			_node.arguments,
+			[&](auto const& arg) {
+				solAssert(arg.arguments.empty(), "");
+				return arg.name;
+			}
+		);
+		return "\"" + _node.name + "(" + boost::algorithm::join(args, ", ") + ")\"";
 	};
 
 	for (auto const& [u, vs]: _cex.edges)

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -203,7 +203,7 @@ private:
 
 	/// @returns a set of pairs _var = _value separated by _separator.
 	template <typename T>
-	std::string formatVariableModel(std::vector<T> const& _variables, std::vector<std::string> const& _values, std::string const& _separator) const
+	std::string formatVariableModel(std::vector<T> const& _variables, std::vector<std::optional<std::string>> const& _values, std::string const& _separator) const
 	{
 		solAssert(_variables.size() == _values.size(), "");
 
@@ -212,7 +212,10 @@ private:
 		{
 			auto var = _variables.at(i);
 			if (var && var->type()->isValueType())
-				assignments.emplace_back(var->name() + " = " + _values.at(i));
+			{
+				solAssert(_values.at(i), "");
+				assignments.emplace_back(var->name() + " = " + *_values.at(i));
+			}
 		}
 
 		return boost::algorithm::join(assignments, _separator);

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -107,21 +107,27 @@ public:
 
 	/// @returns a formatted string representing a call to this predicate
 	/// with _args.
-	std::string formatSummaryCall(std::vector<std::string> const& _args) const;
+	std::string formatSummaryCall(std::vector<smtutil::Expression> const& _args) const;
 
 	/// @returns the values of the state variables from _args at the point
 	/// where this summary was reached.
-	std::vector<std::string> summaryStateValues(std::vector<std::string> const& _args) const;
+	std::vector<std::optional<std::string>> summaryStateValues(std::vector<smtutil::Expression> const& _args) const;
 
 	/// @returns the values of the function input variables from _args at the point
 	/// where this summary was reached.
-	std::vector<std::string> summaryPostInputValues(std::vector<std::string> const& _args) const;
+	std::vector<std::optional<std::string>> summaryPostInputValues(std::vector<smtutil::Expression> const& _args) const;
 
 	/// @returns the values of the function output variables from _args at the point
 	/// where this summary was reached.
-	std::vector<std::string> summaryPostOutputValues(std::vector<std::string> const& _args) const;
+	std::vector<std::optional<std::string>> summaryPostOutputValues(std::vector<smtutil::Expression> const& _args) const;
 
 private:
+	/// @returns the formatted version of the given SMT expressions. Those expressions must be SMT constants.
+	std::vector<std::optional<std::string>> formatExpressions(std::vector<smtutil::Expression> const& _exprs, std::vector<TypePointer> const& _types) const;
+
+	/// @returns a string representation of the SMT expression based on a Solidity type.
+	std::optional<std::string> expressionToString(smtutil::Expression const& _expr, TypePointer _type) const;
+
 	/// The actual SMT expression.
 	smt::SymbolicFunctionVariable m_predicate;
 


### PR DESCRIPTION
Currently the cex graph builder in Z3CHCInterface uses strings directly from the model. This is not ideal since we'd need to parse smtlib2 to report counterexamples for arrays and structs, for example.
This PR then:
- Changes the cex graph builder to use `smtutil::Expression` instead of direct strings, which requires a translator back from `z3::expr` to `smtutil::Expression`. The translator doesn't need to be as complete as `Z3Interface::toZ3Expr`, it only needs to support the expressions that are used by z3/Spacer to described the counterexamples.
- Adds a function that formats `smtutil::Expression` nicely, based on the Solidity type. Since this is a refactoring PR, the result should be the same as before: only value types are reported. But the Solidity type is needed to decode certain SMT expressions, such as tuples.