### PR TITLE
Unused return parameter pruner

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Compiler Features:
  * SMTChecker: Support named arguments in function calls.
+ * Yul Optimizer: Prune return parameters of functions that are unused at callsite.
 
 
 ### 0.7.5 (2020-11-18)

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -45,6 +45,7 @@ struct OptimiserSettings
 			"xarulrul"                 // Prune a bit more in SSA
 			"xarrcL"                   // Turn into SSA again and simplify
 			"gvif"                     // Run full inliner
+			"xaTPrci"                  // Prune unused return values and inline
 			"CTUcarrLsTOtfDncarrIulc"  // SSA plus simplify
 		"]"
 		"jmuljuljul VcTOcul jmulN";     // Make source short and pretty

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -93,10 +93,8 @@ template <class T>
 inline std::vector<T> operator+(std::vector<T>&& _a, std::vector<T>&& _b)
 {
 	std::vector<T> ret(std::move(_a));
-	if (&_a == &_b)
-		ret += ret;
-	else
-		ret += std::move(_b);
+	assert(&_a != &_b);
+	ret += std::move(_b);
 	return ret;
 }
 

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -178,6 +178,8 @@ add_library(yul
 	optimiser/TypeInfo.h
 	optimiser/UnusedFunctionParameterPruner.cpp
 	optimiser/UnusedFunctionParameterPruner.h
+	optimiser/UnusedFunctionReturnParameterPruner.cpp
+	optimiser/UnusedFunctionReturnParameterPruner.h
 	optimiser/UnusedFunctionsCommon.h
 	optimiser/UnusedPruner.cpp
 	optimiser/UnusedPruner.h

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -44,6 +44,7 @@
 #include <libyul/optimiser/ReasoningBasedSimplifier.h>
 #include <libyul/optimiser/Rematerialiser.h>
 #include <libyul/optimiser/UnusedFunctionParameterPruner.h>
+#include <libyul/optimiser/UnusedFunctionReturnParameterPruner.h>
 #include <libyul/optimiser/UnusedPruner.h>
 #include <libyul/optimiser/ExpressionSimplifier.h>
 #include <libyul/optimiser/CommonSubexpressionEliminator.h>
@@ -199,6 +200,7 @@ map<string, unique_ptr<OptimiserStep>> const& OptimiserSuite::allSteps()
 			SSATransform,
 			StructuralSimplifier,
 			UnusedFunctionParameterPruner,
+			UnusedFunctionReturnParameterPruner,
 			UnusedPruner,
 			VarDeclInitializer
 		>();
@@ -209,37 +211,38 @@ map<string, unique_ptr<OptimiserStep>> const& OptimiserSuite::allSteps()
 map<string, char> const& OptimiserSuite::stepNameToAbbreviationMap()
 {
 	static map<string, char> lookupTable{
-		{BlockFlattener::name,                'f'},
-		{CircularReferencesPruner::name,      'l'},
-		{CommonSubexpressionEliminator::name, 'c'},
-		{ConditionalSimplifier::name,         'C'},
-		{ConditionalUnsimplifier::name,       'U'},
-		{ControlFlowSimplifier::name,         'n'},
-		{DeadCodeEliminator::name,            'D'},
-		{EquivalentFunctionCombiner::name,    'v'},
-		{ExpressionInliner::name,             'e'},
-		{ExpressionJoiner::name,              'j'},
-		{ExpressionSimplifier::name,          's'},
-		{ExpressionSplitter::name,            'x'},
-		{ForLoopConditionIntoBody::name,      'I'},
-		{ForLoopConditionOutOfBody::name,     'O'},
-		{ForLoopInitRewriter::name,           'o'},
-		{FullInliner::name,                   'i'},
-		{FunctionGrouper::name,               'g'},
-		{FunctionHoister::name,               'h'},
-		{LiteralRematerialiser::name,         'T'},
-		{LoadResolver::name,                  'L'},
-		{LoopInvariantCodeMotion::name,       'M'},
-		{NameSimplifier::name,                'N'},
-		{ReasoningBasedSimplifier::name,      'R'},
-		{RedundantAssignEliminator::name,     'r'},
-		{Rematerialiser::name,                'm'},
-		{SSAReverser::name,                   'V'},
-		{SSATransform::name,                  'a'},
-		{StructuralSimplifier::name,          't'},
-		{UnusedFunctionParameterPruner::name, 'p'},
-		{UnusedPruner::name,                  'u'},
-		{VarDeclInitializer::name,            'd'},
+		{BlockFlattener::name,                      'f'},
+		{CircularReferencesPruner::name,            'l'},
+		{CommonSubexpressionEliminator::name,       'c'},
+		{ConditionalSimplifier::name,               'C'},
+		{ConditionalUnsimplifier::name,             'U'},
+		{ControlFlowSimplifier::name,               'n'},
+		{DeadCodeEliminator::name,                  'D'},
+		{EquivalentFunctionCombiner::name,          'v'},
+		{ExpressionInliner::name,                   'e'},
+		{ExpressionJoiner::name,                    'j'},
+		{ExpressionSimplifier::name,                's'},
+		{ExpressionSplitter::name,                  'x'},
+		{ForLoopConditionIntoBody::name,            'I'},
+		{ForLoopConditionOutOfBody::name,           'O'},
+		{ForLoopInitRewriter::name,                 'o'},
+		{FullInliner::name,                         'i'},
+		{FunctionGrouper::name,                     'g'},
+		{FunctionHoister::name,                     'h'},
+		{LiteralRematerialiser::name,               'T'},
+		{LoadResolver::name,                        'L'},
+		{LoopInvariantCodeMotion::name,             'M'},
+		{NameSimplifier::name,                      'N'},
+		{ReasoningBasedSimplifier::name,            'R'},
+		{RedundantAssignEliminator::name,           'r'},
+		{Rematerialiser::name,                      'm'},
+		{SSAReverser::name,                         'V'},
+		{SSATransform::name,                        'a'},
+		{StructuralSimplifier::name,                't'},
+		{UnusedFunctionParameterPruner::name,       'p'},
+		{UnusedFunctionReturnParameterPruner::name, 'P'},
+		{UnusedPruner::name,                        'u'},
+		{VarDeclInitializer::name,                  'd'},
 	};
 	yulAssert(lookupTable.size() == allSteps().size(), "");
 	yulAssert((

--- a/libyul/optimiser/UnusedFunctionReturnParameterPruner.cpp
+++ b/libyul/optimiser/UnusedFunctionReturnParameterPruner.cpp
@@ -1,0 +1,270 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libyul/optimiser/UnusedFunctionReturnParameterPruner.h>
+#include <libyul/optimiser/UnusedFunctionsCommon.h>
+#include <libyul/optimiser/NameCollector.h>
+#include <libyul/optimiser/NameDisplacer.h>
+#include <libyul/optimiser/ASTWalker.h>
+
+#include <libyul/AsmDataForward.h>
+#include <libyul/AsmData.h>
+#include <libyul/Dialect.h>
+
+#include <libsolutil/CommonData.h>
+#include <variant>
+
+using namespace std;
+using namespace solidity::util;
+using namespace solidity::yul;
+using namespace solidity::langutil;
+using namespace solidity::yul::unusedFunctionsCommon;
+
+namespace
+{
+
+/**
+ * A helper class that removes expressions of the form `pop(a)` where a is an identifier. Generally,
+ * pop can be the discard function.
+ */
+class PopRemover: public ASTModifier
+{
+public:
+	using ASTModifier::operator();
+	void operator()(Block& _block) override;
+
+	static void removePop(Block& _ast, Dialect const& _dialect);
+private:
+	explicit PopRemover(Dialect const& _dialect): m_dialect(_dialect)
+	{}
+	Dialect const& m_dialect;
+};
+
+void PopRemover::operator()(Block& _block)
+{
+	iterateReplacing(_block.statements, [&](Statement& _s) -> optional<vector<Statement>> {
+		if (holds_alternative<ExpressionStatement>(_s))
+			if (
+				auto& expressionStatement = get<ExpressionStatement>(_s);
+				holds_alternative<FunctionCall>(expressionStatement.expression)
+			)
+			{
+				FunctionCall& f = get<FunctionCall>(expressionStatement.expression);
+				if (f.functionName.name == m_dialect.discardFunction(m_dialect.boolType)->name)
+					if (holds_alternative<Identifier>(f.arguments[0]))
+						return vector<Statement>{};
+			}
+
+		return nullopt;
+	});
+}
+
+void PopRemover::removePop(Block& _ast, Dialect const& _dialect)
+{
+	PopRemover p{_dialect};
+	p(_ast);
+}
+
+}
+
+/**
+ * Step 1 of UnusedFunctionReturnParameterPruner: Find functions whose return parameters are not
+ * used in the code, i.e.,
+ *
+ * Look at all VariableDeclaration `let x_1, ..., x_i, ..., x_n := f(y_1, ..., y_m)` and check if
+ * `x_i` is unused. If all function calls to `f` has its i-th return parameter unused, we will mark
+ * its i-th index so that it can be removed in later steps.
+ */
+class FindFunctionsWithUnusedReturns: public ASTWalker
+{
+public:
+	using ASTWalker::operator();
+	void operator()(VariableDeclaration const& _v) override;
+	void operator()(FunctionCall const& _v) override;
+
+	/// Returns a map with function name as key and vector of bools such that if the index `i` of the
+	/// vector is false, then the function's `i`-th return parameter is unused at *all* callsites.
+	static map<YulString, vector<bool>> functions(
+		Dialect const& _dialect,
+		map<YulString, size_t> _references,
+		Block& _block
+	);
+
+private:
+	explicit FindFunctionsWithUnusedReturns(
+		Dialect const& _dialect,
+		map<YulString, size_t> const& _references
+	):
+		m_references(_references),
+		m_dialect(_dialect)
+	{
+	}
+	/// Function name and a boolean mask, where `false` at index `i` indicates that the function
+	/// return-parameter at index `i` in `FunctionDefinition::parameter` is unused at every function
+	/// call-site.
+	map<YulString, vector<bool>> m_unusedReturnParameter;
+	/// A count of all references to all Declarations.
+	map<YulString, size_t> const& m_references;
+	/// Functions whose return parameters are all used.
+	set<YulString> m_usedFunctions;
+	Dialect const& m_dialect;
+};
+
+// Find functions whose return parameters are unused. Assuming that the code is in SSA form and that
+// ForLoopConditionIntoBody, ExpressionSplitter were run, all FunctionCalls with at least one return
+// value will have the form `let x_1, ..., x_n := f(y_1, ..., y_m)`
+void FindFunctionsWithUnusedReturns::operator()(VariableDeclaration const& _v)
+{
+	if (holds_alternative<FunctionCall>(*_v.value))
+	{
+		FunctionCall const& function = get<FunctionCall>(*_v.value);
+		YulString const& name = function.functionName.name;
+
+		// We avoid visiting `operator()(FunctionCall const&)` on purpose.
+		walkVector(function.arguments);
+
+		if (m_dialect.builtin(name))
+			return;
+
+		if (!m_unusedReturnParameter.count(name))
+			m_unusedReturnParameter[name].resize(_v.variables.size(), false);
+
+		for (size_t i = 0; i < _v.variables.size(); ++i)
+			if (m_references.count(_v.variables[i].name))
+				m_unusedReturnParameter.at(name)[i] = true;
+	}
+}
+
+void FindFunctionsWithUnusedReturns::operator()(FunctionCall const& _f)
+{
+	// Any function that can reach here is added to the "do-not-prune" list. Ideally, with the
+	// correct pre-requisites, no function (with at least one return parameter) will visit here.
+	// However, we have to do this to guarantee correctness for 'all' optimization sequences.
+	m_usedFunctions.insert(_f.functionName.name);
+	walkVector(_f.arguments);
+}
+
+map<YulString, vector<bool>> FindFunctionsWithUnusedReturns::functions(
+	Dialect const& _dialect,
+	map<YulString, size_t> _references,
+	Block& _block
+)
+{
+	FindFunctionsWithUnusedReturns find{_dialect, _references};
+	find(_block);
+
+	map<YulString, vector<bool>> functions;
+
+	for (auto const& [name, mask]: find.m_unusedReturnParameter)
+		if (
+			!find.m_usedFunctions.count(name) &&
+			any_of(mask.begin(), mask.end(), [](bool _b) { return !_b; })
+		)
+			functions[name] = mask;
+
+	return functions;
+}
+
+void UnusedFunctionReturnParameterPruner::run(OptimiserStepContext& _context, Block& _ast)
+{
+	PopRemover::removePop(_ast, _context.dialect);
+
+	map<YulString, size_t> references = ReferencesCounter::countReferences(_ast);
+	map<YulString, vector<bool>> functions = FindFunctionsWithUnusedReturns::functions(_context.dialect, references, _ast);
+
+	set<YulString> simpleFunctions;
+	for (auto const& s: _ast.statements)
+		if (holds_alternative<FunctionDefinition>(s))
+		{
+			FunctionDefinition const& f = get<FunctionDefinition>(s);
+			if (tooSimpleToBePruned(f))
+				simpleFunctions.insert(f.name);
+		}
+
+	set<YulString> functionNamesToFree = util::keys(functions) - simpleFunctions;
+
+	// Step 2 of UnusedFunctionReturnParameterPruner: Renames the function and replaces all references to
+	// the function, say `f`, by its new name, say `f_1`.
+	NameDisplacer replace{_context.dispenser, functionNamesToFree};
+	replace(_ast);
+
+	// Inverse-Map of the above translations. In the above example, this will store an element with
+	// key `f_1` and value `f`.
+	std::map<YulString, YulString> newToOriginalNames = invertMap(replace.translations());
+
+	// Step 3 of UnusedFunctionReturnParameterPruner: introduce a new function in the block with body of
+	// the old one. Replace the body of the old one with a function call to the new one with reduced
+	// parameters.
+	//
+	// For example: introduce a new 'linking' function `f` with the same the body as `f_1`, but with
+	// reduced return parameters, e.g., if `y` is unused at all callsites in the following
+	// definition: `function f() -> y { y := 1 }`. We create a linking function `f_1` whose body
+	// calls to `f`, i.e., `f_1(x) -> y { y := f() }`.
+	//
+	// Note that all parameter names of the linking function has to be renamed to avoid conflict.
+	iterateReplacing(_ast.statements, [&](Statement& _s) -> optional<vector<Statement>> {
+		if (holds_alternative<FunctionDefinition>(_s))
+		{
+			// The original function except that it has a new name (e.g., `f_1`)
+			FunctionDefinition& originalFunction = get<FunctionDefinition>(_s);
+			if (newToOriginalNames.count(originalFunction.name))
+			{
+				YulString linkingFunctionName = originalFunction.name;
+				YulString originalFunctionName = newToOriginalNames.at(linkingFunctionName);
+				pair<vector<bool>, vector<bool>> used =	{
+					vector<bool>(originalFunction.parameters.size(), true),
+					functions.at(originalFunctionName)
+				};
+
+				FunctionDefinition linkingFunction = createLinkingFunction(
+					originalFunction,
+					used,
+					originalFunctionName,
+					linkingFunctionName,
+					_context.dispenser
+				);
+
+				originalFunction.name = originalFunctionName;
+				auto missingVariables = filter(
+					originalFunction.returnVariables,
+					applyMap(used.second, [](bool _b) {return !_b;})
+				);
+				originalFunction.returnVariables =
+					filter(originalFunction.returnVariables, used.second);
+				// Return variables that are pruned can still be used inside the function body.
+				// Therefore, a extra `let missingVariables` needs to be added at the beginning of
+				// the function body.
+				vector<Statement> missingVariableDeclarations =
+					applyMap(missingVariables, [&](auto& _v) -> Statement {
+						return VariableDeclaration{
+							originalFunction.location,
+							vector<TypedName>{_v},
+							nullptr
+						};
+					});
+
+				originalFunction.body.statements =
+					move(missingVariableDeclarations) + move(originalFunction.body.statements);
+
+				return make_vector<Statement>(move(originalFunction), move(linkingFunction));
+			}
+		}
+
+		return nullopt;
+	});
+
+}

--- a/libyul/optimiser/UnusedFunctionReturnParameterPruner.h
+++ b/libyul/optimiser/UnusedFunctionReturnParameterPruner.h
@@ -1,0 +1,70 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/optimiser/OptimiserStep.h>
+
+namespace solidity::yul
+{
+
+/**
+ * UnusedFunctionReturnParameterPruner: Optimiser step that removes unused return parameters at function callsite.
+ *
+ * If a parameter is unused, like `z` and correspondingly `x` in the following snippet:
+ *
+ * {
+ *    let z := f(sload(1), sload(2))
+ *    function f(a,b) -> x { x := div(a,b) }
+ * }
+ *
+ * We remove the parameter and create a new "linking" function `f2` as follows:
+ *
+ * function f(a,b) {
+ *   let x
+ *   x := div(a,b)
+ * }
+ *
+ * function f2(a,b) -> x { x := f(a,b) }
+ *
+ * and replace all references to `f` by `f2`.
+ * The inliner should be run afterwards to make sure that all references to `f2` are replaced by
+ * `f`.
+ *
+ * Prerequisites: Disambiguator, FunctionHoister, SSATransform, ExpressionSplitter
+ *
+ * Only Disambiguator and FunctionHoister are needed for correctness.
+ *
+ * Ideally, we want all function calls to appear in the code in the following form:
+ * `let x_1, ..., x_n = f(y_1, ..., y_m)`.
+ *
+ * ExpressionSplitter can reduce expressions into the above form. SSATransform allows us to realize
+ * that the variable `x` is unused in the following example:
+ *
+ *   let x := f()
+ *   x := 1
+ *
+ * Note that ForLoopConditionIntoBody and ForLoopInitRewriter are prerequisites for ExpressionSplitter and SSATransform.
+ */
+struct UnusedFunctionReturnParameterPruner
+{
+	static constexpr char const* name{"UnusedFunctionReturnParameterPruner"};
+	static void run(OptimiserStepContext& _context, Block& _ast);
+};
+
+}

--- a/libyul/optimiser/UnusedFunctionsCommon.h
+++ b/libyul/optimiser/UnusedFunctionsCommon.h
@@ -48,12 +48,12 @@ std::vector<T> filter(std::vector<T> const& _vec, std::vector<bool> const& _mask
 
 /// Returns true if applying UnusedFunctionParameterPruner is not helpful or redundant because the
 /// inliner will be able to handle it anyway.
-bool tooSimpleToBePruned(FunctionDefinition const& _f)
+inline bool tooSimpleToBePruned(FunctionDefinition const& _f)
 {
 	return _f.body.statements.size() <= 1 && CodeSize::codeSize(_f.body) <= 1;
 }
 
-FunctionDefinition createLinkingFunction(
+inline FunctionDefinition createLinkingFunction(
 	FunctionDefinition const& _original,
 	std::pair<std::vector<bool>, std::vector<bool>> const& _usedParametersAndReturns,
 	YulString const& _originalFunctionName,

--- a/test/cmdlineTests/evm_to_wasm_break/output
+++ b/test/cmdlineTests/evm_to_wasm_break/output
@@ -43,7 +43,7 @@ object "object" {
                 x_7 := x_11
             }
             {
-                let _5, _6, _7, _8 := iszero_169_788(_1, _1, _1, lt_171(x_4, x_5, x_6, x_7, _1, _1, _1, 10))
+                let _5, _6, _7, _8 := iszero_169_864(_1, _1, _1, lt_171(x_4, x_5, x_6, x_7, _1, _1, _1, 10))
                 if i32.eqz(i64.eqz(i64.or(i64.or(_5, _6), i64.or(_7, _8)))) { break }
                 if i32.eqz(i64.eqz(i64.or(_3, i64.or(_1, eq(x_4, x_5, x_6, x_7, _1, _1, _1, 2))))) { break }
                 if i32.eqz(i64.eqz(i64.or(_3, i64.or(_1, eq(x_4, x_5, x_6, x_7, _1, _1, _1, 4))))) { continue }
@@ -67,7 +67,7 @@ object "object" {
             let r1_1, carry_2 := add_carry(x1, y1, carry_1)
             r1 := r1_1
         }
-        function iszero_169_788(x1, x2, x3, x4) -> r1, r2, r3, r4
+        function iszero_169_864(x1, x2, x3, x4) -> r1, r2, r3, r4
         {
             r4 := i64.extend_i32_u(i64.eqz(i64.or(i64.or(x1, x2), i64.or(x3, x4))))
         }
@@ -206,7 +206,7 @@ Text representation:
                 (br_if $label__3 (i32.eqz (i32.eqz (local.get $_4))))
                 (block $label__4
                     (block
-                        (local.set $_5 (call $iszero_169_788 (local.get $_1) (local.get $_1) (local.get $_1) (call $lt_171 (local.get $x_4) (local.get $x_5) (local.get $x_6) (local.get $x_7) (local.get $_1) (local.get $_1) (local.get $_1) (i64.const 10))))
+                        (local.set $_5 (call $iszero_169_864 (local.get $_1) (local.get $_1) (local.get $_1) (call $lt_171 (local.get $x_4) (local.get $x_5) (local.get $x_6) (local.get $x_7) (local.get $_1) (local.get $_1) (local.get $_1) (i64.const 10))))
                         (local.set $_6 (global.get $global_))
                         (local.set $_7 (global.get $global__1))
                         (local.set $_8 (global.get $global__2))
@@ -310,7 +310,7 @@ Text representation:
     (local.get $r1)
 )
 
-(func $iszero_169_788
+(func $iszero_169_864
     (param $x1 i64)
     (param $x2 i64)
     (param $x3 i64)

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -1396,11 +1396,11 @@ BOOST_AUTO_TEST_CASE(use_stack_optimization)
 	BOOST_REQUIRE(contract["evm"]["bytecode"]["object"].isString());
 	BOOST_CHECK(contract["evm"]["bytecode"]["object"].asString().length() > 20);
 
-	// Now disable stack optimizations and UnusedFunctionParameterPruner (p)
-	// results in "stack too deep"
+	// Now disable stack optimizations, UnusedFunctionParameterPruner (p) and
+	// UnusedFunctionReturnParameterPruner (P). Results in "stack too deep"
 	string optimiserSteps = OptimiserSettings::DefaultYulOptimiserSteps;
 	optimiserSteps.erase(
-		remove_if(optimiserSteps.begin(), optimiserSteps.end(), [](char ch) { return ch == 'p'; }),
+		remove_if(optimiserSteps.begin(), optimiserSteps.end(), [](char ch) { return ch == 'p' || ch == 'P'; }),
 		optimiserSteps.end()
 	);
 	parsedInput["settings"]["optimizer"]["details"]["yulDetails"]["stackAllocation"] = false;

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -51,6 +51,7 @@
 #include <libyul/optimiser/Rematerialiser.h>
 #include <libyul/optimiser/ExpressionSimplifier.h>
 #include <libyul/optimiser/UnusedFunctionParameterPruner.h>
+#include <libyul/optimiser/UnusedFunctionReturnParameterPruner.h>
 #include <libyul/optimiser/UnusedPruner.h>
 #include <libyul/optimiser/ExpressionJoiner.h>
 #include <libyul/optimiser/OptimiserStep.h>
@@ -263,6 +264,12 @@ TestCase::TestResult YulOptimizerTest::run(ostream& _stream, string const& _line
 		FunctionHoister::run(*m_context, *m_object->code);
 		LiteralRematerialiser::run(*m_context, *m_object->code);
 		UnusedFunctionParameterPruner::run(*m_context, *m_object->code);
+	}
+	else if (m_optimizerStep == "unusedFunctionReturnParameterPruner")
+	{
+		disambiguate();
+		FunctionHoister::run(*m_context, *m_object->code);
+		UnusedFunctionReturnParameterPruner::run(*m_context, *m_object->code);
 	}
 	else if (m_optimizerStep == "unusedPruner")
 	{

--- a/test/libyul/yulOptimizerTests/fullSuite/abi2.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/abi2.yul
@@ -1085,7 +1085,7 @@
 //         sstore(x1, x0)
 //         sstore(x3, x2)
 //         sstore(1, x4)
-//         pop(abi_encode_bytes32_t_address_t_uint256_t_bytes32_t_enum$_Operation_t_uint256_t_uint256_t_uint256_t_address_t_address_t_uint(mload(30), mload(31), mload(32), mload(33), mload(34), mload(35), mload(36), mload(37), mload(38), mload(39), mload(40), mload(41)))
+//         abi_encode_bytes32_t_address_t_uint256_t_bytes32_t_enum$_Operation_t_uint256_t_uint256_t_uint256_t_address_t_address_t_uint_461(mload(30), mload(31), mload(32), mload(33), mload(34), mload(35), mload(36), mload(37), mload(38), mload(39), mload(40), mload(41))
 //     }
 //     function abi_decode_addresst_uint256t_bytes_calldatat_enum$_Operation(headStart, dataEnd) -> value0, value1, value2, value3, value4
 //     {
@@ -1106,9 +1106,8 @@
 //         if iszero(lt(_3, 3)) { revert(value4, value4) }
 //         value4 := _3
 //     }
-//     function abi_encode_bytes32_t_address_t_uint256_t_bytes32_t_enum$_Operation_t_uint256_t_uint256_t_uint256_t_address_t_address_t_uint(headStart, value10, value9, value8, value7, value6, value5, value4, value3, value2, value1, value0) -> tail
+//     function abi_encode_bytes32_t_address_t_uint256_t_bytes32_t_enum$_Operation_t_uint256_t_uint256_t_uint256_t_address_t_address_t_uint_461(headStart, value10, value9, value8, value7, value6, value5, value4, value3, value2, value1, value0)
 //     {
-//         tail := add(headStart, 352)
 //         mstore(headStart, value0)
 //         let _1 := sub(shl(160, 1), 1)
 //         mstore(add(headStart, 32), and(value1, _1))

--- a/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParameterPruner_loop.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParameterPruner_loop.yul
@@ -1,0 +1,34 @@
+// A test to see if loop condition is properly split
+{
+    let b := f()
+    // Return value of f is used in for loop condition. So f cannot be rewritten,
+    // unless LoopConditionIntoBody and ExpressionSplitter is run.
+    for {let a := 1} iszero(sub(f(), a)) {a := add(a, 1)}
+    {}
+    function f() -> x
+    {
+        x := sload(1)
+        sstore(x, x)
+        if calldataload(0) { leave }
+    }
+}
+// ----
+// step: fullSuite
+//
+// {
+//     {
+//         pop(f())
+//         let a := 1
+//         let a_1 := a
+//         for { } true { a_1 := add(a_1, a) }
+//         {
+//             if iszero(iszero(sub(f(), a_1))) { break }
+//         }
+//     }
+//     function f() -> x
+//     {
+//         x := sload(1)
+//         sstore(x, x)
+//         if calldataload(0) { leave }
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParameterPruner_pop.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParameterPruner_pop.yul
@@ -1,0 +1,30 @@
+// A test to see if UnusedFunctionReturnParameterPruner can deal with pop
+// Expression splitter converts `pop(f(a))` into
+// {
+//   let z := f(a)
+//   pop(z)
+// }
+// Unless `pop(z)` is removed, `f` cannot be rewritten.
+{
+    let a := sload(1)
+    pop(f(a))
+    function f(x) -> y
+    {
+      if iszero(calldataload(0)) { leave }
+      sstore(x, x)
+      y := sload(x)
+    }
+}
+// ----
+// step: fullSuite
+//
+// {
+//     { pop(f_17(sload(1))) }
+//     function f(x)
+//     {
+//         if iszero(calldataload(0)) { leave }
+//         sstore(x, x)
+//     }
+//     function f_17(x) -> y
+//     { f(x) }
+// }

--- a/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParameterPruner_simple.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParameterPruner_simple.yul
@@ -1,0 +1,22 @@
+{
+    let c, d := f(calldataload(0), calldataload(1))
+    sstore(c, 1)
+    function f(x, y) -> a, b
+    {
+        // to prevent the function getting inlined
+        if iszero(calldataload(0)) {leave}
+        a := sload(x)
+        b := sload(y)
+    }
+}
+// ----
+// step: fullSuite
+//
+// {
+//     { sstore(f(calldataload(0)), 1) }
+//     function f(x) -> a
+//     {
+//         if iszero(calldataload(a)) { leave }
+//         a := sload(x)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParamterPruner_recursion.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionReturnParamterPruner_recursion.yul
@@ -1,0 +1,30 @@
+{
+    // second return paramter is unused
+    let j, k, l := f(1, 2, 3)
+    sstore(0, j)
+    sstore(1, l)
+    function f(a, b, c) -> x, y, z
+    {
+        // second return parameter is unused
+        let x_1, y_1, z_1 := f(1, 2, 3)
+        x := x_1
+        z := z_1
+        x := add(x, 1)
+    }
+}
+// ----
+// step: fullSuite
+//
+// {
+//     {
+//         let x, z := f()
+//         sstore(0, x)
+//         sstore(1, z)
+//     }
+//     function f() -> x, z
+//     {
+//         let x_1, z_1 := f()
+//         z := z_1
+//         x := add(x_1, 1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/all_return_unused.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/all_return_unused.yul
@@ -1,0 +1,26 @@
+{
+    let a, b, c := f(sload(0))
+    function f(d) -> x, y, z
+    {
+       y := mload(d)
+       z := mload(2)
+       sstore(y, z)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let a, b, c := f_1(sload(0))
+//     function f(d)
+//     {
+//         let x
+//         let y
+//         let z
+//         y := mload(d)
+//         z := mload(2)
+//         sstore(y, z)
+//     }
+//     function f_1(d_2) -> x_3, y_4, z_5
+//     { f(d_2) }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/all_return_used.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/all_return_used.yul
@@ -1,0 +1,30 @@
+// A test where the function should not be rewritten, since each parameter is used eventually.
+{
+    let a, b, c := f(sload(0))
+    sstore(a, 0)
+    let a1, b1, c1 := f(sload(2))
+    sstore(b1, 0)
+    let a2, b2, c3 := f(sload(3))
+    sstore(c3, 0)
+    function f(d) -> x, y, z
+    {
+       y := mload(d)
+       z := mload(2)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let a, b, c := f(sload(0))
+//     sstore(a, 0)
+//     let a1, b1, c1 := f(sload(2))
+//     sstore(b1, 0)
+//     let a2, b2, c3 := f(sload(3))
+//     sstore(c3, 0)
+//     function f(d) -> x, y, z
+//     {
+//         y := mload(d)
+//         z := mload(2)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/multiple_return.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/multiple_return.yul
@@ -1,0 +1,26 @@
+{
+    // b and c are unused
+    let a, b, c := f(sload(0))
+    sstore(a, 0)
+    function f(d) -> x, y, z
+    {
+       y := mload(d)
+       z := mload(2)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let a, b, c := f_1(sload(0))
+//     sstore(a, 0)
+//     function f(d) -> x
+//     {
+//         let y
+//         let z
+//         y := mload(d)
+//         z := mload(2)
+//     }
+//     function f_1(d_2) -> x_3, y_4, z_5
+//     { x_3 := f(d_2) }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/pop.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/pop.yul
@@ -1,0 +1,32 @@
+// A test to see if the optimization step can deal with pop
+// Expression splitter converts `pop(f(a))` into
+// {
+//   let z := f(a)
+//   pop(z)
+// }
+// Unless `pop(z)` is removed, `f` cannot be rewritten.
+{
+    let a := sload(1)
+    let z := f(a)
+    pop(z)
+    function f(x) -> y
+    {
+      sstore(x, x)
+      y := sload(x)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let a := sload(1)
+//     let z := f_1(a)
+//     function f(x)
+//     {
+//         let y
+//         sstore(x, x)
+//         y := sload(x)
+//     }
+//     function f_1(x_2) -> y_3
+//     { f(x_2) }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/should_not_prune.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/should_not_prune.yul
@@ -1,0 +1,20 @@
+// An example where the return parameter of the function should not be pruned
+{
+    function f() -> y {
+        y := sload(1)
+    }
+
+    // return value is unused here
+    let x := f()
+    // return value is used here, so f cannot be pruned.
+    sstore(1, f())
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let x := f()
+//     sstore(1, f())
+//     function f() -> y
+//     { y := sload(1) }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/simple.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/simple.yul
@@ -1,0 +1,24 @@
+{
+    let c, d := f(1, 2)
+    sstore(c, 1)
+    function f(x, y) -> a, b
+    {
+        a := sload(x)
+        b := sload(y)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let c, d := f_1(1, 2)
+//     sstore(c, 1)
+//     function f(x, y) -> a
+//     {
+//         let b
+//         a := sload(x)
+//         b := sload(y)
+//     }
+//     function f_1(x_2, y_3) -> a_4, b_5
+//     { a_4 := f(x_2, y_3) }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/smoke.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/smoke.yul
@@ -1,0 +1,5 @@
+{ }
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// { }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/tricky_unused.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/tricky_unused.yul
@@ -1,0 +1,38 @@
+{
+    // The third and the last return value is unused
+    let a, b, c, d, e := f(sload(0))
+    sstore(a, b)
+    let a1, b1, c1, d1, e1 := f(sload(1))
+    sstore(a1, d1)
+    let a2, b2, c2, d2, e2 := f(sload(2))
+    sstore(d2, b2)
+    function f(a_1) -> v, w, x, y, z
+    {
+       w := mload(a_1)
+       y := mload(w)
+       z := mload(y)
+       sstore(y, z)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let a, b, c, d, e := f_1(sload(0))
+//     sstore(a, b)
+//     let a1, b1, c1, d1, e1 := f_1(sload(1))
+//     sstore(a1, d1)
+//     let a2, b2, c2, d2, e2 := f_1(sload(2))
+//     sstore(d2, b2)
+//     function f(a_1) -> v, w, y
+//     {
+//         let x
+//         let z
+//         w := mload(a_1)
+//         y := mload(w)
+//         z := mload(y)
+//         sstore(y, z)
+//     }
+//     function f_1(a_1_2) -> v_3, w_4, x_5, y_6, z_7
+//     { v_3, w_4, y_6 := f(a_1_2) }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/tricky_used.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/tricky_used.yul
@@ -1,0 +1,22 @@
+{
+    let a := f()
+    // Return value of f is used here. So f cannot be rewritten.
+    sstore(sload(f()), 2)
+    function f() -> x
+    {
+        x := sload(1)
+        sstore(x, x)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let a := f()
+//     sstore(sload(f()), 2)
+//     function f() -> x
+//     {
+//         x := sload(1)
+//         sstore(x, x)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/tricky_used_loop.yul
+++ b/test/libyul/yulOptimizerTests/unusedFunctionReturnParameterPruner/tricky_used_loop.yul
@@ -1,0 +1,25 @@
+// A test to see if loop condition is properly split
+{
+    let b := f()
+    // Return value of f is used in for loop condition. So f cannot be rewritten.
+    for {let a := 1} iszero(sub(f(), a)) {a := add(a, 1)}
+    {}
+    function f() -> x
+    {
+        x := sload(1)
+        sstore(x, x)
+    }
+}
+// ----
+// step: unusedFunctionReturnParameterPruner
+//
+// {
+//     let b := f()
+//     for { let a := 1 } iszero(sub(f(), a)) { a := add(a, 1) }
+//     { }
+//     function f() -> x
+//     {
+//         x := sload(1)
+//         sstore(x, x)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedPruner/pop_function.yul
+++ b/test/libyul/yulOptimizerTests/unusedPruner/pop_function.yul
@@ -1,0 +1,15 @@
+{
+	let a := f()
+	pop(a)
+	function f() -> y {
+		sstore(1, sload(1))
+	}
+}
+// ----
+// step: unusedPruner
+//
+// {
+//     pop(f())
+//     function f() -> y
+//     { sstore(1, sload(1)) }
+// }


### PR DESCRIPTION
Optimization rule that rewrites functions whose return parameters are not used at callsite.

TODO
1. [ ] Tests in fullsuite
2. [ ] Figure out how to deal with the pop case.
3. [ ] Figure out a good sequence.