### PR TITLE
[SMTChecker] Fix ICE when using >>>

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1627,7 +1627,8 @@ smtutil::Expression SMTEncoder::bitwiseOperation(
 			result = bvLeft << bvRight;
 			break;
 		case Token::SHR:
-			solAssert(false, "");
+			result = bvLeft >> bvRight;
+			break;
 		case Token::SAR:
 			result = isSigned ?
 				smtutil::Expression::ashr(bvLeft, bvRight) :

--- a/test/libsolidity/smtCheckerTests/operators/shifts/shr_unused.sol
+++ b/test/libsolidity/smtCheckerTests/operators/shifts/shr_unused.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	function f() public pure {
+		fixed x;
+		assert(x >>> 6 == 0);
+	}
+}
+// ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.


### PR DESCRIPTION
Fixes #10106

Just added result to be `bvLeft >> bvRight`. Other option is to ignore it completely and set result to `0`, but anyway if it is not used, don't think it should make any difference

I think changelog entry is not needed here as well