### PR TITLE
[SMTChecker] Creating Verification targets in two stages.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@ Bugfixes:
  * SMTChecker: Fix internal error on conversion from string literal to byte.
  * SMTChecker: Fix internal error when using tuples of rational literals inside the conditional operator.
  * SMTChecker: Fix internal error when assigning state variable via contract's name.
+ * SMTChecker: Fix incorrect counterexamples reported by the CHC engine.
+ * SMTChecker: Fix false negative in modifier applied multiple times.
  * Code generator: Fix missing creation dependency tracking for abstract contracts.
 
 

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -620,32 +620,46 @@ types.
 
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >=0.5.0;
+    pragma experimental ABIEncoderV2;
     pragma experimental SMTChecker;
     // This will report a warning
 
     contract Aliasing
     {
-        uint[] array;
+        uint[] array1;
+        uint[][] array2;
         function f(
             uint[] memory a,
             uint[] memory b,
             uint[][] memory c,
             uint[] storage d
-        ) internal view {
-            require(array[0] == 42);
-            require(a[0] == 2);
-            require(c[0][0] == 2);
-            require(d[0] == 2);
+        ) internal {
+            array1[0] = 42;
+            a[0] = 2;
+            c[0][0] = 2;
             b[0] = 1;
             // Erasing knowledge about memory references should not
             // erase knowledge about state variables.
-            assert(array[0] == 42);
+            assert(array1[0] == 42);
+            // However, an assignment to a storage reference will erase
+            // storage knowledge accordingly.
+            d[0] = 2;
+            // Fails as false positive because of the assignment above.
+            assert(array1[0] == 42);
             // Fails because `a == b` is possible.
             assert(a[0] == 2);
             // Fails because `c[i] == b` is possible.
             assert(c[0][0] == 2);
             assert(d[0] == 2);
             assert(b[0] == 1);
+        }
+        function g(
+            uint[] memory a,
+            uint[] memory b,
+            uint[][] memory c,
+            uint x
+        ) public {
+            f(a, b, c, array2[x]);
         }
     }
 

--- a/libsolidity/formal/EncodingContext.cpp
+++ b/libsolidity/formal/EncodingContext.cpp
@@ -33,7 +33,6 @@ EncodingContext::EncodingContext():
 void EncodingContext::reset()
 {
 	resetAllVariables();
-	resetUniqueId();
 	m_expressions.clear();
 	m_globalContext.clear();
 	m_state.reset();

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_1.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_1.sol
@@ -8,4 +8,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (82-89): CHC: Empty array "pop" detected here.
+// Warning 2529: (82-89): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_2.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_2.sol
@@ -8,4 +8,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (82-89): CHC: Empty array "pop" detected here.
+// Warning 2529: (82-89): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_3.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_3.sol
@@ -8,5 +8,5 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (82-89): CHC: Empty array "pop" detected here.
-// Warning 2529: (93-100): CHC: Empty array "pop" detected here.
+// Warning 2529: (82-89): CHC: Empty array "pop" happens here.
+// Warning 2529: (93-100): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_4.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_4.sol
@@ -8,4 +8,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (94-101): CHC: Empty array "pop" detected here.
+// Warning 2529: (94-101): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_5.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_5.sol
@@ -11,4 +11,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (122-129): CHC: Empty array "pop" detected here.
+// Warning 2529: (122-129): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_6.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_6.sol
@@ -11,4 +11,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (127-134): CHC: Empty array "pop" detected here.
+// Warning 2529: (127-134): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_pop_length_8.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_pop_length_8.sol
@@ -13,4 +13,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (82-89): CHC: Empty array "pop" detected here.
+// Warning 2529: (82-89): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_1_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_1_unsafe.sol
@@ -7,4 +7,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (82-89): CHC: Empty array "pop" detected here.
+// Warning 2529: (82-89): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_2d_unsafe.sol
@@ -9,4 +9,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (111-121): CHC: Empty array "pop" detected here.
+// Warning 2529: (111-121): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_constructor_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_constructor_unsafe.sol
@@ -7,4 +7,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (76-83): CHC: Empty array "pop" detected here.
+// Warning 2529: (76-83): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/pop_loop_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/pop_loop_unsafe.sol
@@ -11,4 +11,4 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (150-157): CHC: Empty array "pop" detected here.
+// Warning 2529: (150-157): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/functions/constructor_hierarchy_4.sol
+++ b/test/libsolidity/smtCheckerTests/functions/constructor_hierarchy_4.sol
@@ -18,6 +18,6 @@ contract A is B {
 	}
 }
 // ----
-// Warning 4984: (198-203): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 4984: (207-212): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
+// Warning 4984: (198-203): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 4984: (230-235): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/functions/constructor_state_value_parameter.sol
+++ b/test/libsolidity/smtCheckerTests/functions/constructor_state_value_parameter.sol
@@ -13,5 +13,5 @@ contract C {
 	}
 }
 // ----
-// Warning 4984: (115-120): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 6328: (162-176): CHC: Assertion violation happens here.
+// Warning 4984: (115-120): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/imports/imported_fail_1.sol
+++ b/test/libsolidity/smtCheckerTests/imports/imported_fail_1.sol
@@ -21,4 +21,5 @@ contract B is A {
 	}
 }
 // ----
+// Warning 6328: (B.sol:71-85): CHC: Assertion violation happens here.
 // Warning 6328: (C.sol:103-117): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_1_false_positive.sol
@@ -15,4 +15,6 @@ contract C
 }
 // ----
 // Warning 4984: (176-181): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
+// Warning 6328: (296-309): CHC: Assertion violation might happen here.
 // Warning 2661: (176-181): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
+// Warning 4661: (296-309): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_memory.sol
@@ -16,5 +16,7 @@ contract LoopFor2 {
 	}
 }
 // ----
+// Warning 4984: (252-257): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
+// Warning 4984: (232-238): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
 // Warning 6328: (373-392): CHC: Assertion violation happens here.
 // Warning 6328: (396-415): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_memory_storage.sol
@@ -20,3 +20,5 @@ contract LoopFor2 {
 // ====
 // SMTSolvers: z3
 // ----
+// Warning 4984: (245-250): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
+// Warning 4984: (225-231): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_memory.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_memory.sol
@@ -19,4 +19,6 @@ contract LoopFor2 {
 	}
 }
 // ----
+// Warning 4984: (236-241): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
+// Warning 4984: (216-222): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
 // Warning 6328: (363-382): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_array_assignment_storage_storage.sol
@@ -19,5 +19,7 @@ contract LoopFor2 {
 	}
 }
 // ----
+// Warning 4984: (237-242): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
+// Warning 4984: (217-223): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
 // Warning 6328: (341-360): CHC: Assertion violation happens here.
 // Warning 6328: (364-383): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
@@ -14,12 +14,12 @@ contract LoopFor2 {
 			c[i] = b[i];
 			++i;
 		}
-		assert(b[0] == c[0]);
+		//assert(b[0] == c[0]); // Removed because of Spacer's nondeterminism
 		assert(a[0] == 900);
 		assert(b[0] == 900);
 	}
 }
 // ----
 // Warning 4984: (229-234): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
-// Warning 6328: (290-309): CHC: Assertion violation happens here.
-// Warning 6328: (313-332): CHC: Assertion violation happens here.
+// Warning 6328: (338-357): CHC: Assertion violation happens here.
+// Warning 6328: (361-380): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_two_invocations_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_two_invocations_2.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C
+{
+	uint x;
+
+	modifier m {
+		require(x == 0);
+		_;
+		x = x + 1;
+		assert(x <= 2);
+	}
+
+	function f() m m public {
+		x = x + 1;
+	}
+}
+// ----
+// Warning 6328: (109-123): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/operators/slice_default_end.sol
+++ b/test/libsolidity/smtCheckerTests/operators/slice_default_end.sol
@@ -7,14 +7,10 @@ contract C {
 		require(b[b.length - 1] == 0xaa);
 		assert(bytes(b[10:]).length == 20);
 		assert(bytes(b[10:])[0] == 0xff);
-		assert(bytes(b[10:])[5] == 0xff);
+		//assert(bytes(b[10:])[5] == 0xff); // Removed because of Spacer's nondeterminism
 		assert(bytes(b[10:])[19] == 0xaa);
 	}
 }
 // ----
 // Warning 6328: (221-253): CHC: Assertion violation might happen here.
-// Warning 6328: (257-289): CHC: Assertion violation might happen here.
-// Warning 6328: (293-326): CHC: Assertion violation might happen here.
 // Warning 4661: (221-253): BMC: Assertion violation happens here.
-// Warning 4661: (257-289): BMC: Assertion violation happens here.
-// Warning 4661: (293-326): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/overflow_sum.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/overflow_sum.sol
@@ -14,5 +14,6 @@ contract C
 	}
 }
 // ----
+// Warning 4984: (109-116): CHC: Overflow (resulting value larger than 255) happens here.
 // Warning 4984: (154-159): CHC: Overflow (resulting value larger than 255) happens here.
 // Warning 4984: (185-192): CHC: Overflow (resulting value larger than 255) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/safe_add_1.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/safe_add_1.sol
@@ -7,3 +7,5 @@ contract C
 		return x + y;
 	}
 }
+// ----
+// Warning 4984: (115-120): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/safe_add_2.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/safe_add_2.sol
@@ -8,3 +8,5 @@ contract C
 		return z;
 	}
 }
+// ----
+// Warning 4984: (116-121): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/signed_guard_sum_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_guard_sum_overflow.sol
@@ -8,4 +8,5 @@ contract C  {
 }
 // ----
 // Warning 3944: (111-116): CHC: Underflow (resulting value less than -57896044618658097711785492504343953926634992332820282019728792003956564819968) happens here.
+// Warning 4984: (111-116): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.
 // Warning 3944: (133-138): CHC: Underflow (resulting value less than -57896044618658097711785492504343953926634992332820282019728792003956564819968) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/unsigned_guard_sum_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/unsigned_guard_sum_overflow.sol
@@ -6,3 +6,5 @@ contract C  {
 		return x + y;
 	}
 }
+// ----
+// Warning 4984: (114-119): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/special/many.sol
+++ b/test/libsolidity/smtCheckerTests/special/many.sol
@@ -15,12 +15,12 @@ contract C
 	}
 }
 // ----
-// Warning 4984: (311-316): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 6328: (79-115): CHC: Assertion violation happens here.
 // Warning 6328: (119-161): CHC: Assertion violation happens here.
 // Warning 6328: (165-204): CHC: Assertion violation happens here.
 // Warning 6328: (208-240): CHC: Assertion violation happens here.
 // Warning 6328: (244-275): CHC: Assertion violation happens here.
+// Warning 4984: (311-316): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 6328: (304-332): CHC: Assertion violation happens here.
 // Warning 6328: (336-364): CHC: Assertion violation happens here.
 // Warning 6328: (368-391): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/types/function_type_external_address.sol
+++ b/test/libsolidity/smtCheckerTests/types/function_type_external_address.sol
@@ -7,4 +7,3 @@ contract C {
 }
 // ----
 // Warning 7650: (128-137): Assertion checker does not yet support this expression.
-// Warning 4661: (141-155): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/types/struct/struct_state_var_array_pop_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/struct/struct_state_var_array_pop_1.sol
@@ -21,5 +21,5 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (121-130): CHC: Empty array "pop" detected here.
+// Warning 2529: (121-130): CHC: Empty array "pop" happens here.
 // Warning 6328: (230-254): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/types/struct/struct_state_var_array_pop_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/struct/struct_state_var_array_pop_2.sol
@@ -18,5 +18,5 @@ contract C {
 	}
 }
 // ----
-// Warning 2529: (133-142): CHC: Empty array "pop" detected here.
+// Warning 2529: (133-142): CHC: Empty array "pop" happens here.
 // Warning 6328: (189-213): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/types/tuple_array_pop_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_array_pop_1.sol
@@ -4,4 +4,4 @@ contract C {
 	function f() public { (a).pop();}
 }
 // ----
-// Warning 2529: (78-87): CHC: Empty array "pop" detected here.
+// Warning 2529: (78-87): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/types/tuple_array_pop_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_array_pop_2.sol
@@ -4,4 +4,4 @@ contract C {
 	function f() public { (((((a))))).pop();}
 }
 // ----
-// Warning 2529: (78-95): CHC: Empty array "pop" detected here.
+// Warning 2529: (78-95): CHC: Empty array "pop" happens here.

--- a/test/libsolidity/smtCheckerTests/types/tuple_declarations_function_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_declarations_function_2.sol
@@ -15,4 +15,3 @@ contract C
 	}
 }
 // ----
-// Warning 4984: (152-157): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.


### PR DESCRIPTION
In order to remember the values of variables at the place of error for CEX reporting and to correctly consider all potential errors for all external functions, all verification targets are now created in two stages (similarly as Assert targets have been so far). 

This removes some problems, like #10087, #10034 and also spurious overflows in internal functions.
On the other hand, with the new encoding Spacer is no longer able to solve some targets in examples with loop.