### PR TITLE
Fix typo modifier onlyowner using all lowercase instead of mixed case

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -560,7 +560,7 @@ Yes::
         return x + 1;
     }
 
-    function increment(uint x) public pure onlyowner returns (uint) {
+    function increment(uint x) public pure onlyOwner returns (uint) {
         return x + 1;
     }
 
@@ -596,7 +596,7 @@ Yes::
         return balanceOf[from];
     }
 
-    function shutdown() public onlyowner {
+    function shutdown() public onlyOwner {
         selfdestruct(owner);
     }
 
@@ -606,7 +606,7 @@ No::
         return balanceOf[from];
     }
 
-    function shutdown() onlyowner public {
+    function shutdown() onlyOwner public {
         selfdestruct(owner);
     }
 
@@ -663,7 +663,7 @@ Yes::
 
     function thisFunctionNameIsReallyLong(address x, address y, address z)
         public
-        onlyowner
+        onlyOwner
         priced
         returns (address)
     {
@@ -676,7 +676,7 @@ Yes::
         address z,
     )
         public
-        onlyowner
+        onlyOwner
         priced
         returns (address)
     {
@@ -687,21 +687,21 @@ No::
 
     function thisFunctionNameIsReallyLong(address x, address y, address z)
                                           public
-                                          onlyowner
+                                          onlyOwner
                                           priced
                                           returns (address) {
         doSomething();
     }
 
     function thisFunctionNameIsReallyLong(address x, address y, address z)
-        public onlyowner priced returns (address)
+        public onlyOwner priced returns (address)
     {
         doSomething();
     }
 
     function thisFunctionNameIsReallyLong(address x, address y, address z)
         public
-        onlyowner
+        onlyOwner
         priced
         returns (address) {
         doSomething();


### PR DESCRIPTION
Update the style guide to fix the modifier name `onlyowner` using lowercase where mixedCase is expected.