### PR TITLE
Support .offset and .length for dynamic calldata arrays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Language Features:
  * Ability to select the abi coder using ``pragma abicoder v1`` and ``pragma abicoder v2``.
+ * Inline Assembly: Use ``.offset`` and ``.length`` for calldata variables of dynamic array type to access their calldata offset and length (number of elements). Both of them can also be assigned to.
  * Immutable variables with literal number values are considered pure.
 
 Compiler Features:
@@ -33,6 +34,9 @@ Bugfixes:
  * Code generator: Fix missing creation dependency tracking for abstract contracts.
  * NatSpec: Fix internal error when inheriting return parameter documentation but the parameter names differ between base and inherited.
  * Standard JSON: Fix library addresses specified in ``libraries`` being used for linking even if the file names do not match.
+
+AST Changes:
+ * New member ``suffix`` for inline assembly identifiers. Currently supported values are ``"slot"``, ``"offset"`` and ``"length"`` to access the components of a Solidity variable.
 
 
 ### 0.7.4 (2020-10-19)

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -135,6 +135,10 @@ inside that slot. To retrieve the slot pointed to by the variable ``x``, you
 use ``x.slot``, and to retrieve the byte-offset you use ``x.offset``.
 Using ``x`` itself will result in an error.
 
+For dynamic calldata arrays, you can access
+their calldata offset (in bytes) and length (number of elements) using ``x.offset`` and ``x.length``.
+Both expressions can also be assigned to.
+
 Local Solidity variables are available for assignments, for example:
 
 .. code::

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -215,22 +215,21 @@ void ReferencesResolver::operator()(yul::FunctionDefinition const& _function)
 
 void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 {
-	bool isSlot = boost::algorithm::ends_with(_identifier.name.str(), ".slot");
-	bool isOffset = boost::algorithm::ends_with(_identifier.name.str(), ".offset");
+	static set<string> suffixes{"slot", "offset", "length"};
+	string suffix;
+	for (string const& s: suffixes)
+		if (boost::algorithm::ends_with(_identifier.name.str(), "." + s))
+			suffix = s;
 
 	// Could also use `pathFromCurrentScope`, split by '.'
 	auto declarations = m_resolver.nameFromCurrentScope(_identifier.name.str());
-	if (isSlot || isOffset)
+	if (!suffix.empty())
 	{
 		// special mode to access storage variables
 		if (!declarations.empty())
 			// the special identifier exists itself, we should not allow that.
 			return;
-		string realName = _identifier.name.str().substr(0, _identifier.name.str().size() - (
-			isSlot ?
-			string(".slot").size() :
-			string(".offset").size()
-		));
+		string realName = _identifier.name.str().substr(0, _identifier.name.str().size() - suffix.size() - 1);
 		solAssert(!realName.empty(), "Empty name.");
 		declarations = m_resolver.nameFromCurrentScope(realName);
 		if (!declarations.empty())
@@ -255,7 +254,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 			m_errorReporter.declarationError(
 				9467_error,
 				_identifier.location,
-				"Identifier not found. Use ``.slot`` and ``.offset`` to access storage variables."
+				"Identifier not found. Use \".slot\" and \".offset\" to access storage variables."
 			);
 		return;
 	}
@@ -270,8 +269,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 			return;
 		}
 
-	m_yulAnnotation->externalReferences[&_identifier].isSlot = isSlot;
-	m_yulAnnotation->externalReferences[&_identifier].isOffset = isOffset;
+	m_yulAnnotation->externalReferences[&_identifier].suffix = move(suffix);
 	m_yulAnnotation->externalReferences[&_identifier].declaration = declarations.front();
 }
 

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -198,8 +198,8 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 	struct ExternalIdentifierInfo
 	{
 		Declaration const* declaration = nullptr;
-		bool isSlot = false; ///< Whether the storage slot of a variable is queried.
-		bool isOffset = false; ///< Whether the intra-slot offset of a storage variable is queried.
+		/// Suffix used, one of "slot", "offset", "length" or empty.
+		std::string suffix;
 		size_t valueSize = size_t(-1);
 	};
 

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -224,8 +224,10 @@ Json::Value ASTJsonConverter::inlineAssemblyIdentifierToJson(pair<yul::Identifie
 	Json::Value tuple(Json::objectValue);
 	tuple["src"] = sourceLocationToString(_info.first->location);
 	tuple["declaration"] = idOrNull(_info.second.declaration);
-	tuple["isSlot"] = Json::Value(_info.second.isSlot);
-	tuple["isOffset"] = Json::Value(_info.second.isOffset);
+	tuple["isSlot"] = Json::Value(_info.second.suffix == "slot");
+	tuple["isOffset"] = Json::Value(_info.second.suffix == "offset");
+	if (!_info.second.suffix.empty())
+		tuple["suffix"] = Json::Value(_info.second.suffix);
 	tuple["valueSize"] = Json::Value(Json::LargestUInt(_info.second.valueSize));
 	return tuple;
 }

--- a/test/libsolidity/ASTJSON/assembly/slot_offset.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset.json
@@ -180,6 +180,7 @@
                     "isOffset": true,
                     "isSlot": false,
                     "src": "106:8:1",
+                    "suffix": "offset",
                     "valueSize": 1
                   },
                   {
@@ -187,6 +188,7 @@
                     "isOffset": false,
                     "isSlot": true,
                     "src": "128:6:1",
+                    "suffix": "slot",
                     "valueSize": 1
                   }
                 ],

--- a/test/libsolidity/ASTJSON/assembly/slot_offset_legacy.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset_legacy.json
@@ -168,6 +168,7 @@
                         "isOffset": true,
                         "isSlot": false,
                         "src": "106:8:1",
+                        "suffix": "offset",
                         "valueSize": 1
                       },
                       {
@@ -175,6 +176,7 @@
                         "isOffset": false,
                         "isSlot": true,
                         "src": "128:6:1",
+                        "suffix": "slot",
                         "valueSize": 1
                       }
                     ],

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_array_assign.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_array_assign.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(uint[2][] calldata x) public returns (uint[2][] memory r) {
+        assembly { x.offset := 0x44 x.length := 2 }
+        r = x;
+    }
+}
+// ----
+// f(uint256[2][]): 0x0, 1, 8, 7, 6, 5 -> 0x20, 2, 8, 7, 6, 5

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_array_read.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_array_read.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f(uint[2][] calldata x) public returns (uint o, uint l, uint s) {
+        assembly { l := x.length o := x.offset }
+        uint[2] calldata t = x[1];
+        // statically-sized arrays only use one slot, so we read directly.
+        assembly { s := t }
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256[2][]): 0x20, 2, 1, 2, 3, 4 -> 0x44, 2, 0x84

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_assign.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_assign.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f(bytes calldata x) public returns (bytes memory) {
+        assembly { x.offset := 1 x.length := 3 }
+        return x;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(bytes): 0x20, 0, 0 -> 0x20, 3, 0x5754f80000000000000000000000000000000000000000000000000000000000

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_assign_from_nowhere.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_assign_from_nowhere.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure returns (bytes calldata x) {
+        assembly { x.offset := 0 x.length := 4 }
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 0x20, 4, 0x26121ff000000000000000000000000000000000000000000000000000000000

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_length_read.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_length_read.sol
@@ -1,0 +1,18 @@
+contract C {
+    function lenBytesRead(bytes calldata x) public returns (uint l) {
+        assembly { l := x.length }
+    }
+
+    function lenStringRead(string calldata x) public returns (uint l) {
+        assembly { l := x.length }
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// lenBytesRead(bytes): 0x20, 4, "abcd" -> 4
+// lenBytesRead(bytes): 0x20, 0, "abcd" -> 0x00
+// lenBytesRead(bytes): 0x20, 0x21, "abcd", "ef" -> 33
+// lenStringRead(string): 0x20, 4, "abcd" -> 4
+// lenStringRead(string): 0x20, 0, "abcd" -> 0x00
+// lenStringRead(string): 0x20, 0x21, "abcd", "ef" -> 33

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_offset_read.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_offset_read.sol
@@ -1,0 +1,19 @@
+contract C {
+    function f(bytes calldata x) public returns (uint r) {
+        assembly { r := x.offset }
+    }
+
+    function f(uint, bytes calldata x, uint) public returns (uint r, uint v) {
+        assembly {
+            r := x.offset
+            v := x.length
+        }
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(bytes): 0x20, 0, 0 -> 0x44
+// f(bytes): 0x22, 0, 0, 0 -> 0x46
+// f(uint256,bytes,uint256): 7, 0x60, 8, 2, 0 -> 0x84, 2
+// f(uint256,bytes,uint256): 0, 0, 0 -> 0x24, 0x00

--- a/test/libsolidity/semanticTests/inlineAssembly/calldata_offset_read_write.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/calldata_offset_read_write.sol
@@ -1,0 +1,18 @@
+contract C {
+    function f(uint, bytes calldata x, uint) public returns (uint r, uint v) {
+        assembly {
+            x.offset := 8
+            x.length := 20
+        }
+        assembly {
+            r := x.offset
+            v := x.length
+        }
+    }
+}
+
+// ====
+// compileViaYul: also
+// ----
+// f(uint256,bytes,uint256): 7, 0x60, 8, 2, 0 -> 8, 0x14
+// f(uint256,bytes,uint256): 0, 0, 0 -> 8, 0x14

--- a/test/libsolidity/semanticTests/inlineAssembly/slot_access.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/slot_access.sol
@@ -25,6 +25,8 @@ contract C {
         return data().a;
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // get() -> 0
 // mappingAccess(uint256): 1 -> 0, 0

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_array.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_array.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(uint[] calldata bytesAsCalldata) external {
+        assembly {
+            let x := bytesAsCalldata
+        }
+    }
+}
+// ----
+// TypeError 1397: (112-127): Call data elements cannot be accessed directly. Use ".offset" and ".length" to access the calldata offset and length of this array and then use "calldatacopy".

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_array_offset.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_array_offset.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(uint[] calldata bytesAsCalldata) external pure {
+        assembly {
+            let x := bytesAsCalldata.offset
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_slot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_slot.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(bytes calldata bytesAsCalldata) external {
+        assembly {
+            let x := bytesAsCalldata.slot
+        }
+    }
+}
+// ----
+// TypeError 1536: (111-131): Calldata variables only support ".offset" and ".length".

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_variables.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/calldata_variables.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2370: (111-126): Call data elements cannot be accessed directly. Copy to a local variable first or use "calldataload" or "calldatacopy" with manually determined offsets and sizes.
+// TypeError 1397: (111-126): Call data elements cannot be accessed directly. Use ".offset" and ".length" to access the calldata offset and length of this array and then use "calldatacopy".

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/storage_assignment.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/storage_assignment.sol
@@ -7,4 +7,4 @@ contract test {
     }
 }
 // ----
-// TypeError 1408: (89-90): Only local variables are supported. To access storage variables, use the .slot and .offset suffixes.
+// TypeError 1408: (89-90): Only local variables are supported. To access storage variables, use the ".slot" and ".offset" suffixes.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/storage_assignment_in_modifier.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/storage_assignment_in_modifier.sol
@@ -10,4 +10,4 @@ contract test {
     }
 }
 // ----
-// TypeError 1408: (80-81): Only local variables are supported. To access storage variables, use the .slot and .offset suffixes.
+// TypeError 1408: (80-81): Only local variables are supported. To access storage variables, use the ".slot" and ".offset" suffixes.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/storage_nonslot.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/storage_nonslot.sol
@@ -1,0 +1,12 @@
+contract test {
+    uint x = 1;
+    function f() public {
+        assembly {
+            let t := x.length
+            x.length := 2
+        }
+    }
+}
+// ----
+// TypeError 4656: (98-106): State variables only support ".slot" and ".offset".
+// TypeError 4656: (119-127): State variables only support ".slot" and ".offset".

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/unbalanced_two_stack_load.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/unbalanced_two_stack_load.sol
@@ -5,4 +5,4 @@ contract c {
     }
 }
 // ----
-// TypeError 1408: (75-76): Only local variables are supported. To access storage variables, use the .slot and .offset suffixes.
+// TypeError 1408: (75-76): Only local variables are supported. To access storage variables, use the ".slot" and ".offset" suffixes.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference.sol
@@ -8,4 +8,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9068: (118-119): You have to use the .slot or .offset suffix to access storage reference variables.
+// TypeError 9068: (118-119): You have to use the ".slot" or ".offset" suffix to access storage reference variables.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_old.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_old.sol
@@ -9,5 +9,5 @@ contract C {
     }
 }
 // ----
-// DeclarationError 9467: (118-124): Identifier not found. Use ``.slot`` and ``.offset`` to access storage variables.
-// DeclarationError 9467: (142-150): Identifier not found. Use ``.slot`` and ``.offset`` to access storage variables.
+// DeclarationError 9467: (118-124): Identifier not found. Use ".slot" and ".offset" to access storage variables.
+// DeclarationError 9467: (142-150): Identifier not found. Use ".slot" and ".offset" to access storage variables.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 7944: (84-90): The suffixes .offset and .slot can only be used on storage variables.
+// TypeError 7944: (84-90): The suffixes ".offset", ".slot" and ".length" can only be used with variables.

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_memory.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_memory.sol
@@ -9,5 +9,5 @@ contract C {
     }
 }
 // ----
-// TypeError 3622: (117-123): The suffixes .offset and .slot can only be used on storage variables.
-// TypeError 3622: (141-149): The suffixes .offset and .slot can only be used on storage variables.
+// TypeError 3622: (117-123): The suffix ".slot" is not supported by this variable or type.
+// TypeError 3622: (141-149): The suffix ".offset" is not supported by this variable or type.

--- a/test/libsolidity/syntaxTests/inlineAssembly/two_stack_slot_access.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/two_stack_slot_access.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f() pure external {
+        function() external two_stack_slots;
+        assembly {
+            let x :=  two_stack_slots
+        }
+    }
+}
+// ----
+// TypeError 9857: (132-147): Only types that use one stack slot are supported.


### PR DESCRIPTION
Fixes #9762 
fixes https://github.com/ethereum/solidity/issues/8917

This also fixes a bug in sol->yul about assigning to `.slot`.