### PR TITLE
[ewasm] Allow compiling Yul without "main"

### DIFF
--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -663,9 +663,11 @@ bytes BinaryTransform::globalSection(vector<wasm::GlobalVariableDeclaration> con
 
 bytes BinaryTransform::exportSection(map<string, size_t> const& _functionIDs)
 {
-	bytes result = lebEncode(2);
+	bool hasMain = _functionIDs.count("main");
+	bytes result = lebEncode(hasMain ? 2 : 1);
 	result += encodeName("memory") + toBytes(Export::Memory) + lebEncode(0);
-	result += encodeName("main") + toBytes(Export::Function) + lebEncode(_functionIDs.at("main"));
+	if (hasMain)
+		result += encodeName("main") + toBytes(Export::Function) + lebEncode(_functionIDs.at("main"));
 	return makeSection(Section::EXPORT, move(result));
 }
 

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -56,8 +56,13 @@ string TextTransform::run(wasm::Module const& _module)
 
 	// allocate one 64k page of memory and make it available to the Ethereum client
 	ret += "    (memory $memory (export \"memory\") 1)\n";
-	// export the main function
-	ret += "    (export \"main\" (func $main))\n";
+	for (auto const& f: _module.functions)
+		if (f.name == "main")
+		{
+			// export the main function
+			ret += "    (export \"main\" (func $main))\n";
+			break;
+		}
 
 	for (auto const& g: _module.globals)
 		ret += "    (global $" + g.variableName + " (mut " + encodeType(g.type) + ") (" + encodeType(g.type) + ".const 0))\n";


### PR DESCRIPTION
Prior to this we'd have
```
Unknown exception during compilation: map::at:  key not found
```

Not sure which is better, a) having an assert, b) or allowing Yul objects without `main`. I think b) is more correct in terms of Wasm, but not in terms of Ewasm.