### PR TITLE
More informative assertion message on invalid conversions YulUtilFunctions::conversionFunction()

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2971,7 +2971,7 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 			break;
 		}
 		default:
-			solAssert(false, "");
+			solAssert(false, "Invalid conversion from " + _from.canonicalName() + " to " + _to.canonicalName());
 		}
 
 		solAssert(!body.empty(), _from.canonicalName() + " to " + _to.canonicalName());


### PR DESCRIPTION
A trivial change to include type names in the assertion message. I've been hitting this assertion a lot in #10230 and having the names in the message makes debugging much easier.