### PR TITLE
Arbitrary input file extensions in command-line tests

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -242,6 +242,9 @@ printTask "Running general commandline tests..."
     do
         printTask " - ${tdir}"
 
+        # Strip trailing slash from $tdir. `find` on MacOS X won't strip it and will produce double slashes.
+        tdir=$(basename "${tdir}")
+
         if [ -e "${tdir}/input.json" ]
         then
             inputFile=""
@@ -250,17 +253,17 @@ printTask "Running general commandline tests..."
             stdoutExpectationFile="${tdir}/output.json"
             args="--standard-json "$(cat ${tdir}/args 2>/dev/null || true)
         else
-            if [[ -e "${tdir}input.yul" && -e "${tdir}input.sol" ]]
+            if [[ -e "${tdir}/input.yul" && -e "${tdir}/input.sol" ]]
             then
                 printError "Ambiguous input. Found both input.sol and input.yul."
                 exit 1
             fi
 
-            if [ -e "${tdir}input.yul" ]
+            if [ -e "${tdir}/input.yul" ]
             then
-                inputFile="${tdir}input.yul"
+                inputFile="${tdir}/input.yul"
             else
-                inputFile="${tdir}input.sol"
+                inputFile="${tdir}/input.sol"
             fi
             stdin=""
             stdout="$(cat ${tdir}/output 2>/dev/null || true)"

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -240,6 +240,8 @@ printTask "Running general commandline tests..."
     cd "$REPO_ROOT"/test/cmdlineTests/
     for tdir in */
     do
+        printTask " - ${tdir}"
+
         if [ -e "${tdir}/input.json" ]
         then
             inputFile=""
@@ -268,7 +270,6 @@ printTask "Running general commandline tests..."
         exitCode=$(cat ${tdir}/exit 2>/dev/null || true)
         err="$(cat ${tdir}/err 2>/dev/null || true)"
         stderrExpectationFile="${tdir}/err"
-        printTask " - ${tdir}"
         test_solc_behaviour "$inputFile" \
                             "$args" \
                             "$stdin" \


### PR DESCRIPTION
Related to #10215.

Currently the command-line tests explicitly check for `input.sol`, `input.yul` or `input.json`. This PR changes that so any extension except for `.json` is allowed and is assumed to be non-JSON input.

The primary motivation behind this PR was adding command-line tests for `--link` option which expects `.bin` files. In the end that didn't work out because linker does not play well with command-line tests (it modifies input in place) but I think that this change is useful on its own too.