### PR TITLE
JSON indentation rules in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,6 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
-[*.{txt,cmake}]
+[*.{txt,cmake,json}]
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
I noticed that we don't have rules defined for JSON.

Looks like in command-line tests it's either a tab or 1 space per level. The latter is completely unreadable to me when I have to see what is nested where so I suggest tabs.