### PR TITLE
[solc] Handle exceptions in AssemblyStack.translate() gracefully

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1883,8 +1883,29 @@ bool CommandLineInterface::assemble(
 
 		if (_language != yul::AssemblyStack::Language::Ewasm && _targetMachine == yul::AssemblyStack::Machine::Ewasm)
 		{
-			stack.translate(yul::AssemblyStack::Language::Ewasm);
-			stack.optimize();
+			try
+			{
+				stack.translate(yul::AssemblyStack::Language::Ewasm);
+				stack.optimize();
+			}
+			catch (Exception const& _exception)
+			{
+				serr() << "Exception in assembler: " << boost::diagnostic_information(_exception) << endl;
+				return false;
+			}
+			catch (std::exception const& _e)
+			{
+				serr() <<
+					"Unknown exception during compilation" <<
+					(_e.what() ? ": " + string(_e.what()) : ".") <<
+					endl;
+				return false;
+			}
+			catch (...)
+			{
+				serr() << "Unknown exception in assembler." << endl;
+				return false;
+			}
 
 			sout() << endl << "==========================" << endl;
 			sout() << endl << "Translated source:" << endl;


### PR DESCRIPTION
Easy way to crash this was a `yul::OptimizerException`:
```
{
function main() { }
}
```

With `solc --strict-assembly --machine ewasm --yul-dialect evm wasm-crash.yul` results in an exception:
```
Exception in assembler: /Users/alex/Projects/solidity/libyul/optimiser/MainFunction.cpp(43): Throw in function void solidity::yul::MainFunction::operator()(solidity::yul::Block &)
Dynamic exception type: boost::wrapexcept<solidity::yul::OptimizerException>
std::exception::what: 
[solidity::util::tag_comment*] = 
```