### PR TITLE
[SMTChecker] Analyzing external calls to `this`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
  * Command Line interface: Report proper error for each output file which could not be written. Previously an exception was thrown, and execution aborted, on the first error.
  * SMTChecker: Add division by zero checks in the CHC engine.
  * SMTChecker: Support ``selector`` for expressions with value known at compile-time.
+ * SMTChecker: More precise analysis of external calls using ``this``.
  * Command Line Interface: New option ``--model-checker-timeout`` sets a timeout in milliseconds for each individual query performed by the SMTChecker.
  * Standard JSON: New option ``modelCheckerSettings.timeout`` sets a timeout in milliseconds for each individual query performed by the SMTChecker.
  * Assembler: Perform linking in assembly mode when library addresses are provided.

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -96,20 +96,7 @@ bool BMC::shouldInlineFunctionCall(FunctionCall const& _funCall)
 
 	FunctionType const& funType = dynamic_cast<FunctionType const&>(*_funCall.expression().annotation().type);
 	if (funType.kind() == FunctionType::Kind::External)
-	{
-		auto memberAccess = dynamic_cast<MemberAccess const*>(&_funCall.expression());
-		if (!memberAccess)
-			return false;
-
-		auto identifier = dynamic_cast<Identifier const*>(&memberAccess->expression());
-		if (!(
-			identifier &&
-			identifier->name() == "this" &&
-			identifier->annotation().referencedDeclaration &&
-			dynamic_cast<MagicVariableDeclaration const*>(identifier->annotation().referencedDeclaration)
-		))
-			return false;
-	}
+		return isTrustedExternalCall(&_funCall.expression());
 	else if (funType.kind() != FunctionType::Kind::Internal)
 		return false;
 

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -88,6 +88,7 @@ private:
 	void visitAddMulMod(FunctionCall const& _funCall) override;
 	void internalFunctionCall(FunctionCall const& _funCall);
 	void externalFunctionCall(FunctionCall const& _funCall);
+	void externalFunctionCallToTrustedCode(FunctionCall const& _funCall);
 	void unknownFunctionCall(FunctionCall const& _funCall);
 	void makeArrayPopVerificationTarget(FunctionCall const& _arrayPop) override;
 	/// Creates underflow/overflow verification targets.

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -2391,6 +2391,19 @@ MemberAccess const* SMTEncoder::isEmptyPush(Expression const& _expr) const
 	return nullptr;
 }
 
+bool SMTEncoder::isTrustedExternalCall(Expression const* _expr) {
+	auto memberAccess = dynamic_cast<MemberAccess const*>(_expr);
+	if (!memberAccess)
+		return false;
+
+	auto identifier = dynamic_cast<Identifier const*>(&memberAccess->expression());
+	return identifier &&
+		identifier->name() == "this" &&
+		identifier->annotation().referencedDeclaration &&
+		dynamic_cast<MagicVariableDeclaration const*>(identifier->annotation().referencedDeclaration)
+	;
+}
+
 string SMTEncoder::extraComment()
 {
 	string extra;

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -295,6 +295,10 @@ protected:
 	/// otherwise nullptr.
 	MemberAccess const* isEmptyPush(Expression const& _expr) const;
 
+	/// @returns true if the given identifier is a contract which is known and trusted.
+	/// This means we don't have to abstract away effects of external function calls to this contract.
+	static bool isTrustedExternalCall(Expression const* _expr);
+
 	/// Creates symbolic expressions for the returned values
 	/// and set them as the components of the symbolic tuple.
 	void createReturnedExpressions(FunctionCall const& _funCall);

--- a/test/libsolidity/smtCheckerTests/functions/this_external_call.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_call.sol
@@ -9,9 +9,7 @@ contract C
 	function g(uint y) public {
 		require(y < 1000);
 		this.f(y);
-		// Fails as false positive because CHC does not support `this`.
 		assert(x < 1000);
 	}
 }
 // ----
-// Warning 6328: (227-243): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_call_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_call_2.sol
@@ -1,0 +1,16 @@
+pragma experimental SMTChecker;
+
+contract C {
+    uint a;
+    function f(uint x) public {
+        this.g(x);
+        assert(a == x);
+        assert(a != 42);
+    }
+
+    function g(uint x) public {
+        a = x;
+    }
+}
+// ----
+// Warning 6328: (141-156): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_call_return.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_call_return.sol
@@ -10,9 +10,7 @@ contract C
 	function g(uint y) public {
 		require(y < 1000);
 		uint z = this.f(y);
-		// Fails as false positive because CHC does not support `this`.
 		assert(z < 1000);
 	}
 }
 // ----
-// Warning 6328: (263-279): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_call_sender.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_call_sender.sol
@@ -1,0 +1,28 @@
+pragma experimental SMTChecker;
+
+contract C {
+    address lastCaller;
+
+    constructor() {
+        lastCaller = msg.sender;
+    }
+
+    modifier log {
+        lastCaller = msg.sender;
+        _;
+    }
+
+    function test() log public {
+        assert(lastCaller == msg.sender);
+        this.g();
+        assert(lastCaller == address(this));
+        assert(lastCaller == msg.sender);
+        assert(lastCaller == address(0));
+    }
+
+    function g() log public {
+    }
+}
+// ----
+// Warning 6328: (347-379): CHC: Assertion violation happens here.
+// Warning 6328: (389-421): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_call_tx_origin.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_call_tx_origin.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+
+contract C {
+
+	function test() view public {
+		require(address(this) != tx.origin);
+		assert(!this.g());
+	}
+
+	function g() view public returns (bool) {
+		return msg.sender == tx.origin;
+	}
+}
+// ----

--- a/test/libsolidity/smtCheckerTests/functions/this_external_getter_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_getter_1.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint public x;
+
+	function f() public view {
+		uint y = this.x();
+		assert(y == x); // This fails as false positive because of lack of support for external getters.
+	}
+}
+// ----
+// Warning 6328: (114-128): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_getter_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_getter_2.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C {
+	mapping (uint => uint) public map;
+
+	function f() public view {
+		uint y = this.map(2);
+		assert(y == map[2]); // This fails as false positive because of lack of support for external getters.
+	}
+}
+// ----
+// Warning 6328: (137-156): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_getter_3.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_getter_3.sol
@@ -1,0 +1,12 @@
+pragma experimental SMTChecker;
+
+contract C {
+	mapping (uint => mapping (uint => uint)) public map;
+
+	function f() public view {
+		uint y = this.map(2, 3);
+		assert(y == map[2][3]); // This fails as false positive because of lack of support for external getters.
+	}
+}
+// ----
+// Warning 6328: (158-180): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/functions/this_state.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_state.sol
@@ -6,7 +6,6 @@ contract C
     function g() public {
 		x = 0;
         this.h();
-		// Fails as false positive because CHC does not support `this`.
 		assert(x == 2);
     }
     function h() public {
@@ -14,4 +13,3 @@ contract C
     }
 }
 // ----
-// Warning 6328: (186-200): CHC: Assertion violation happens here.


### PR DESCRIPTION
This PR resolves #9385.
External calls to `this` can be analyzed in a similar manner as internal calls, since we know and can trust the code of the called function.
The difference is that such external call creates a new transaction and this needs to be incorporated in the encoding.