### PR TITLE
cmdlineTests.sh: Fix buggy calculation of the number of input files

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -256,11 +256,11 @@ printTask "Running general commandline tests..."
     do
         printTask " - ${tdir}"
 
-        # Strip trailing slash from $tdir. `find` on MacOS X won't strip it and will produce double slashes.
+        # Strip trailing slash from $tdir.
         tdir=$(basename "${tdir}")
 
-        inputFiles="$(find "${tdir}" -name 'input.*' -type f -exec printf "%s\n" "{}" \;)"
-        inputCount="$(echo "${inputFiles}" | wc -l)"
+        inputFiles="$(ls -1 ${tdir}/input.* 2> /dev/null || true)"
+        inputCount="$(echo ${inputFiles} | wc -w)"
         if (( ${inputCount} > 1 ))
         then
             printError "Ambiguous input. Found input files in multiple formats:"


### PR DESCRIPTION
**This PR is based on #10251. Please don't merge until that one is merged.**

Bugfix for #10233.

I used `echo "${inputFiles}"` which adds a newline and `wc` counts it as a line even if it's empty. This means that `inputCount` is always >= 1.