### PR TITLE
Assume input.sol by default in command-line tests (restores old behavior) (reopened)

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -261,12 +261,6 @@ printTask "Running general commandline tests..."
 
         inputFiles="$(find "${tdir}" -name 'input.*' -type f -exec printf "%s\n" "{}" \;)"
         inputCount="$(echo "${inputFiles}" | wc -l)"
-        if (( ${inputCount} == 0 ))
-        then
-            printError "No input files found."
-            exit 1
-        fi
-
         if (( ${inputCount} > 1 ))
         then
             printError "Ambiguous input. Found input files in multiple formats:"
@@ -276,6 +270,11 @@ printTask "Running general commandline tests..."
 
         # Use printf to get rid of the trailing newline
         inputFile=$(printf "%s" "${inputFiles}")
+
+        # If no files specified, assume input.sol as the default
+        if [ -z "${inputFile}" ]; then
+            inputFile="${tdir}/input.sol"
+        fi
 
         if [ "${inputFile}" = "${tdir}/input.json" ]
         then


### PR DESCRIPTION
*Resubmitting #10249 because github thought it got merged when I swapped the order with #10248 and won't let me reopen it. The content is exactly the same but it's now directly on develop.*

> Restores the old behavior of `cmdlineTests.sh` in case where there are no input files. In #10248 I made it report an error but this broke the assumptions made in #10199.
>
> I don't think it's a good default but command-line tests are broken on `develop` because of this. It's at least no worse than it was before and works as a quick fix.