### PR TITLE
Yul indentation rules in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_size = 4
 indent_style = space
 indent_size = 4
 
-[*.sol]
+[*.{sol,yul}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
Similar to #10237.

I don't think any particular style is currently dominant in our `.yul` tests. There's a variety of styles: 2 spaces, 4 spaces and 1 tab; some files even mix multiple styles. But I think there's no good reason to have different indentation styles for `.sol` and `.yul` and the current rule for `.sol` is 4 spaces so I suggest we use that.

I'm aware that `.editorconfig` is not enforced but it's often used by editors/IDEs which is convenient. It also makes it more likely that the right indentation settings will be picked up automatically by tools people use.