### PR TITLE
[CLI] Fix --output-dir failure for paths with a trailing slash

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ Bugfixes:
  * SMTChecker: Fix false negative in modifier applied multiple times.
  * SMTChecker: Fix internal error in the BMC engine when inherited contract from a different source unit has private state variables.
  * SMTChecker: Fix internal error when ``array.push()`` is used as the LHS of an assignment.
+ * Command Line Interface: Fix write error when the directory passed to ``--output-dir`` ends with a slash.
  * SMTChecker: Fix CHC false positives when branches are used inside modifiers.
  * Code generator: Fix missing creation dependency tracking for abstract contracts.
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -730,12 +730,15 @@ map<string, Json::Value> CommandLineInterface::parseAstFromInput()
 void CommandLineInterface::createFile(string const& _fileName, string const& _data)
 {
 	namespace fs = boost::filesystem;
-	// create directory if not existent
-	fs::path p(m_args.at(g_argOutputDir).as<string>());
-	// Do not try creating the directory if the first item is . or ..
-	if (p.filename() != "." && p.filename() != "..")
-		fs::create_directories(p);
-	string pathName = (p / _fileName).string();
+
+	fs::path outputDir(m_args.at(g_argOutputDir).as<string>());
+
+	// NOTE: create_directories() raises an exception if the path consists solely of '.' or '..'
+	// (or equivalent such as './././.'). Paths like 'a/b/.' and 'a/b/..' are fine though.
+	// The simplest workaround is to use an absolute path.
+	fs::create_directories(fs::absolute(outputDir));
+
+	string pathName = (outputDir / _fileName).string();
 	if (fs::exists(pathName) && !m_args.count(g_strOverwrite))
 	{
 		serr() << "Refusing to overwrite existing file \"" << pathName << "\" (use --" << g_strOverwrite << " to force)." << endl;


### PR DESCRIPTION
Test contract (`/tmp/test.sol`):
```solidity
contract C {}
```

This is fine:
```bash
solc /tmp/test.sol --output-dir /tmp/a/b/c --bin
```
After running it, `/tmp/a/b/c` is created and contains `C.bin`.

But this fails:
```bash
solc /tmp/test.sol --output-dir /tmp/a/b/c/ --bin
```

Output:
```
Could not write to file "/tmp/a/b/c/C.bin".
```
The only difference is the trailing slash. No files or directories get created.

It was actually an ICE on 0.7.4 but the recent #10241 patched it up. Before that the output was:
```
Exception during output generation: /solidity/solc/CommandLineInterface.cpp(739): Throw in function void solidity::frontend::CommandLineInterface::createFile(const string&, const string&)
Dynamic exception type: boost::wrapexcept<solidity::util::FileError>
std::exception::what: FileError
[solidity::util::tag_comment*] = Could not write to file: /tmp/a/b/c/C.bin
```