### PR TITLE
Fix bytecode replacement in command-line tests not detecting all bytecode segments between linker references

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -118,7 +118,7 @@ function test_solc_behaviour()
         # Remove bytecode (but not linker references).
         sed -i.bak -E -e 's/(\"object\":\")[0-9a-f]+([^"]*\")/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
         sed -i.bak -E -e 's/(\"object\":\"[^"]+\$__)[0-9a-f]+(\")/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
-        sed -i.bak -E -e 's/(__\$[0-9a-f]{34}\$__)[0-9a-f]+(__\$[0-9a-f]{34}\$__)/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
+        sed -i.bak -E -e 's/([0-9a-f]{34}\$__)[0-9a-f]+(__\$[0-9a-f]{17})/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
 
         # Replace escaped newlines by actual newlines for readability
         sed -i.bak -E -e 's/\\n/\'$'\n/g' "$stdout_path"
@@ -137,7 +137,7 @@ function test_solc_behaviour()
         # 64697066735822 = hex encoding of 0x64 'i' 'p' 'f' 's' 0x58 0x22
         # 64736f6c63     = hex encoding of 0x64 's' 'o' 'l' 'c'
         sed -i.bak -E -e 's/[0-9a-f]*64697066735822[0-9a-f]+64736f6c63[0-9a-f]+/<BYTECODE REMOVED>/g' "$stdout_path"
-        sed -i.bak -E -e 's/(__\$[0-9a-f]{34}\$__)[0-9a-f]+(__\$[0-9a-f]{34}\$__)/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
+        sed -i.bak -E -e 's/([0-9a-f]{17}\$__)[0-9a-f]+(__\$[0-9a-f]{17})/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
         sed -i.bak -E -e 's/[0-9a-f]+((__\$[0-9a-f]{34}\$__)*<BYTECODE REMOVED>)/<BYTECODE REMOVED>\1/g' "$stdout_path"
 
         # Remove trailing empty lines. Needs a line break to make OSX sed happy.


### PR DESCRIPTION
A trivial issue I did not notice in #10225 because there is no test with more than two unresolved references.

The global regex matches whole link references on both sides of the bytecode wchich results in this (shortened for readability):
```
0123__$abcd$__4567__$efab$_8901__$cdef$__2345
```
being replaced with
```
<BYTECODE REMOVED>__$abcd$__<BYTECODE REMOVED>__$efab$_8901__$cdef$__<BYTECODE REMOVED>
```
rather than with:
```
<BYTECODE REMOVED>__$abcd$__<BYTECODE REMOVED>__$efab$_<BYTECODE REMOVED>__$cdef$__<BYTECODE REMOVED>
```

It leaves out every other piece of bytecode because `sed` does not find overlapping matches. The fix is to match only half of the link reference.