### PR TITLE
Top level exception handlers in solc and yulrun

### DIFF
--- a/solc/main.cpp
+++ b/solc/main.cpp
@@ -53,22 +53,28 @@ static void setDefaultOrCLocale()
 
 int main(int argc, char** argv)
 {
-	setDefaultOrCLocale();
-	solidity::frontend::CommandLineInterface cli;
-	if (!cli.parseArguments(argc, argv))
-		return 1;
-	if (!cli.processInput())
-		return 1;
-	bool success = false;
 	try
 	{
-		success = cli.actOnInput();
-	}
-	catch (boost::exception const& _exception)
-	{
-		cerr << "Exception during output generation: " << boost::diagnostic_information(_exception) << endl;
-		success = false;
-	}
+		setDefaultOrCLocale();
+		solidity::frontend::CommandLineInterface cli;
+		if (!cli.parseArguments(argc, argv) || !cli.processInput() || !cli.actOnInput())
+			return 1;
 
-	return success ? 0 : 1;
+		return 0;
+	}
+	catch (boost::exception const& exception)
+	{
+		cerr << "Uncaught exception: " << boost::diagnostic_information(exception) << endl;
+		return 1;
+	}
+	catch (std::exception const& exception)
+	{
+		cerr << "Uncaught exception" << (exception.what() ? ": " + string(exception.what()) : ".") << endl;
+		return 1;
+	}
+	catch (...)
+	{
+		cerr << "Uncaught exception. No message provided." << endl;
+		return 1;
+	}
 }

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -104,7 +104,7 @@ void interpret(string const& _source)
 
 }
 
-int main(int argc, char** argv)
+int run(int _argc, char** _argv)
 {
 	po::options_description options(
 		R"(yulrun, the Yul interpreter.
@@ -123,7 +123,7 @@ Allowed options)",
 	po::variables_map arguments;
 	try
 	{
-		po::command_line_parser cmdLineParser(argc, argv);
+		po::command_line_parser cmdLineParser(_argc, _argv);
 		cmdLineParser.options(options).positional(filesPositions);
 		po::store(cmdLineParser.run(), arguments);
 	}
@@ -158,4 +158,27 @@ Allowed options)",
 	}
 
 	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	try
+	{
+		return run(argc, argv);
+	}
+	catch (boost::exception const& exception)
+	{
+		cerr << "Uncaught exception: " << boost::diagnostic_information(exception) << endl;
+		return 1;
+	}
+	catch (std::exception const& exception)
+	{
+		cerr << "Uncaught exception" << (exception.what() ? ": " + string(exception.what()) : ".") << endl;
+		return 1;
+	}
+	catch (...)
+	{
+		cerr << "Uncaught exception. No message provided." << endl;
+		return 1;
+	}
 }


### PR DESCRIPTION
We have nothing catching stray exceptions at the top level so the executables crash without any useful debugging info when one happens. And they sometimes do (see e.g. #10241, #10296, #10293).