### PR TITLE
Handle linkersymbol in yulInterpreter

### DIFF
--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -468,6 +468,8 @@ u256 EVMInstructionInterpreter::evalBuiltin(
 			);
 		return 0;
 	}
+	else if (fun == "linkersymbol")
+		assertThrow(false, YulException, "The bytecode is incomplete and contains unresolved link references.");
 	else
 		yulAssert(false, "Unknown builtin: " + fun);
 	return 0;


### PR DESCRIPTION
`yulInterpreter` is not handling `linkersymbol()` builtin. This crashes the executable.

Actually, I don't think we can do anything much if we encounter it because the bytecode is simply incomplete. The PR just replaces the assertion with a more generic exception that (in combination with #10295) should at least provide a better error message.

Does anyone has suggestions on how to handle it better?