### PR TITLE
[linker] Avoid spurious errors on stray underscores in --link input

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1786,14 +1786,14 @@ bool CommandLineInterface::link()
 				return false;
 			}
 
-			string name(it, it + placeholderSize);
-			if (librariesReplacements.count(name))
+			string foundPlaceholder(it, it + placeholderSize);
+			if (librariesReplacements.count(foundPlaceholder))
 			{
-				string hexStr(toHex(librariesReplacements.at(name).asBytes()));
+				string hexStr(toHex(librariesReplacements.at(foundPlaceholder).asBytes()));
 				copy(hexStr.begin(), hexStr.end(), it);
 			}
 			else
-				serr() << "Reference \"" << name << "\" in file \"" << src.first << "\" still unresolved." << endl;
+				serr() << "Reference \"" << foundPlaceholder << "\" in file \"" << src.first << "\" still unresolved." << endl;
 			it += placeholderSize;
 		}
 		// Remove hints for resolved libraries.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1780,9 +1780,14 @@ bool CommandLineInterface::link()
 		{
 			while (it != end && *it != '_') ++it;
 			if (it == end) break;
-			if (end - it < placeholderSize)
+			if (
+				end - it < placeholderSize ||
+				*(it + 1) != '_' ||
+				*(it + placeholderSize - 2) != '_' ||
+				*(it + placeholderSize - 1) != '_'
+			)
 			{
-				serr() << "Error in binary object file " << src.first << " at position " << (end - src.second.begin()) << endl;
+				serr() << "Error in binary object file " << src.first << " at position " << (it - src.second.begin()) << endl;
 				return false;
 			}
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -55,6 +55,7 @@
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/JSON.h>
 
+#include <algorithm>
 #include <memory>
 
 #include <boost/filesystem.hpp>
@@ -1788,6 +1789,7 @@ bool CommandLineInterface::link()
 			)
 			{
 				serr() << "Error in binary object file " << src.first << " at position " << (it - src.second.begin()) << endl;
+				serr() << '"' << string(it, it + min(placeholderSize, static_cast<int>(end - it))) << "\" is not a valid link reference." << endl;
 				return false;
 			}
 


### PR DESCRIPTION
Linker prints spurious errors if the `.bin` file contains stray underscores. Initially I thought it was a bug but turns out I was just passing the whole `--bin` output rather than only the binary through the linker. Still, the linker does not make too many assumptions about what's in the file and the fix is simple so I think it won' hurt to make it not print these errors. It handles the command-line output surprisingly well.

`input_with_underscores.sol`
```solidity
library L {
    function f() external {}
}

contract C {
    function foo() public {
        L.f();
    }
}
```
```bash
solc input_with_underscores.sol --bin > output.bin
solc output.bin --link --libraries input_with_underscores.sol:L:0x1234567890123456789012345678901234567890
```

Output:
```
Reference "_with_underscores.sol:C =======
Binary:
" in file "output.bin" still unresolved.
Reference "_with_underscores.sol:L

======= input_w" in file "output.bin" still unresolved.
Reference "_underscores.sol:L =======
Binary:
60aa6" in file "output.bin" still unresolved.
Linking completed.
```