### PR TITLE
Fix Visual Studio compilation error (add missing include <optional>)

### DIFF
--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
It seems that `<optional>` is included implicitly in other cases (e.g. my `g++` is happy with `#include <map>` instead).