### PR TITLE
[SMTChecker] Adding a dummy frame to the call stack for the implicit constructor

### DIFF
--- a/test/libsolidity/smtCheckerTests/bmc_coverage/assert_in_constructor.sol
+++ b/test/libsolidity/smtCheckerTests/bmc_coverage/assert_in_constructor.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x = initX();
+
+	function initX() internal pure returns (uint) {
+		return 42;
+	}
+}
+
+contract D is C {
+	uint y;
+
+	constructor() {
+		assert(x == 42);
+		y = x;
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----

--- a/test/libsolidity/smtCheckerTests/bmc_coverage/implicit_constructor_with_function_calls.sol
+++ b/test/libsolidity/smtCheckerTests/bmc_coverage/implicit_constructor_with_function_calls.sol
@@ -1,0 +1,19 @@
+pragma experimental SMTChecker;
+
+contract C {
+	uint x = initX();
+	uint y = initY();
+
+    function initX() internal pure returns (uint) {
+		return 42;
+	}
+
+	function initY() internal view returns (uint) {
+		assert(x == 42);
+		return x;
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Warning 4661: (205-220): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/bmc_coverage/math.sol
+++ b/test/libsolidity/smtCheckerTests/bmc_coverage/math.sol
@@ -22,4 +22,4 @@ contract C {
 // Warning 4144: (217-222): BMC: Underflow (resulting value less than 0) happens here.
 // Warning 2661: (293-298): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 3046: (369-374): BMC: Division by zero happens here.
-// Warning 6084: (68-73): BMC: Underflow (resulting value less than 0) happens here.
+// Warning 4144: (68-73): BMC: Underflow (resulting value less than 0) happens here.


### PR DESCRIPTION
Resolves #10306 

Functions called as part of state variable initialization (implicit constructor) should not be treated as functions on top of the call stack (root function) in the BMC analysis. 
For this reason we add a dummy frame on top of the call stack before analyzing the implicit constructor.