### PR TITLE
Replace links to readthedocs.io with ones using the new domain

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -4,7 +4,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -4,7 +4,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # Configuration Environment Variables:

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -4,7 +4,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contribution Guidelines
 
-Please see our contribution guidelines in [the Solidity documentation](https://solidity.readthedocs.io/en/latest/contributing.html).
+Please see our contribution guidelines in [the Solidity documentation](https://docs.soliditylang.org/en/latest/contributing.html).
 
 Thank you for your help!

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ number [to indicate this fast pace of change](https://semver.org/#spec-item-4).
 ## Build and Install
 
 Instructions about how to build and install the Solidity compiler can be
-found in the [Solidity documentation](https://solidity.readthedocs.io/en/latest/installing-solidity.html#building-from-source).
+found in the [Solidity documentation](https://docs.soliditylang.org/en/latest/installing-solidity.html#building-from-source).
 
 
 ## Example
@@ -49,20 +49,20 @@ contract HelloWorld {
 To get started with Solidity, you can use [Remix](https://remix.ethereum.org/), which is a
 browser-based IDE. Here are some example contracts:
 
-1. [Voting](https://solidity.readthedocs.io/en/latest/solidity-by-example.html#voting)
-2. [Blind Auction](https://solidity.readthedocs.io/en/latest/solidity-by-example.html#blind-auction)
-3. [Safe remote purchase](https://solidity.readthedocs.io/en/latest/solidity-by-example.html#safe-remote-purchase)
-4. [Micropayment Channel](https://solidity.readthedocs.io/en/latest/solidity-by-example.html#micropayment-channel)
+1. [Voting](https://docs.soliditylang.org/en/latest/solidity-by-example.html#voting)
+2. [Blind Auction](https://docs.soliditylang.org/en/latest/solidity-by-example.html#blind-auction)
+3. [Safe remote purchase](https://docs.soliditylang.org/en/latest/solidity-by-example.html#safe-remote-purchase)
+4. [Micropayment Channel](https://docs.soliditylang.org/en/latest/solidity-by-example.html#micropayment-channel)
 
 ## Documentation
 
-The Solidity documentation is hosted at [Read the docs](https://solidity.readthedocs.io).
+The Solidity documentation is hosted at [Read the docs](https://docs.soliditylang.org).
 
 ## Development
 
 Solidity is still under development. Contributions are always welcome!
 Please follow the
-[Developers Guide](https://solidity.readthedocs.io/en/latest/contributing.html)
+[Developers Guide](https://docs.soliditylang.org/en/latest/contributing.html)
 if you want to help.
 
 You can find our current feature and bug priorities for forthcoming

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,5 +48,5 @@ The Solidity team maintains the following JSON-formatted lists of patched securi
 
 [1]: https://bounty.ethereum.org/
 [2]: https://bounty.ethereum.org/#rules
-[3]: https://solidity.readthedocs.io/en/develop/bugs.html
+[3]: https://docs.soliditylang.org/en/develop/bugs.html
 [4]: https://github.com/ethereum/solidity/blob/develop/docs/bugs_by_version.json

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -441,7 +441,7 @@ Output Description
           // If the language used has no contract names, this field should equal to an empty string.
           "ContractName": {
             // The Ethereum Contract ABI. If empty, it is represented as an empty array.
-            // See https://solidity.readthedocs.io/en/develop/abi-spec.html
+            // See https://docs.soliditylang.org/en/develop/abi-spec.html
             "abi": [],
             // See the Metadata Output documentation (serialised JSON string)
             "metadata": "{...}",

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3255,7 +3255,7 @@ void TypeChecker::endVisit(Literal const& _literal)
 				_literal.location(),
 				msg +
 				" If this is not used as an address, please prepend '00'. " +
-				"For more information please see https://solidity.readthedocs.io/en/develop/types.html#address-literals"
+				"For more information please see https://docs.soliditylang.org/en/develop/types.html#address-literals"
 			);
 	}
 

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 /**
- * Utilities to handle the Contract ABI (https://solidity.readthedocs.io/en/develop/abi-spec.html)
+ * Utilities to handle the Contract ABI (https://docs.soliditylang.org/en/develop/abi-spec.html)
  */
 
 #include <libsolidity/interface/ABI.h>

--- a/libsolidity/interface/ABI.h
+++ b/libsolidity/interface/ABI.h
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 /**
- * Utilities to handle the Contract ABI (https://solidity.readthedocs.io/en/develop/abi-spec.html)
+ * Utilities to handle the Contract ABI (https://docs.soliditylang.org/en/develop/abi-spec.html)
  */
 
 #pragma once

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -5,7 +5,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -11,7 +11,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-# http://solidity.readthedocs.io/
+# https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -5,7 +5,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/get_nightly_version.sh
+++ b/scripts/get_nightly_version.sh
@@ -6,7 +6,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -5,7 +5,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -37,7 +37,7 @@ REM for those packages.
 REM
 REM The documentation for solidity is hosted at:
 REM
-REM http://solidity.readthedocs.org
+REM https://docs.soliditylang.org
 REM
 REM ---------------------------------------------------------------------------
 REM This file is part of solidity.

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -6,7 +6,7 @@
 #
 # This is an "infrastucture-as-code" alternative to the manual build
 # instructions pages which we previously maintained at:
-# http://solidity.readthedocs.io/en/latest/installing-solidity.html
+# https://docs.soliditylang.org/en/latest/installing-solidity.html
 #
 # The aim of this script is to simplify things down to the following basic
 # flow for all supported operating systems:
@@ -23,7 +23,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-# http://solidity.readthedocs.io/
+# https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.
@@ -179,7 +179,7 @@ case $(uname -s) in
                         #wheezy
                         echo "Installing solidity dependencies on Debian Wheezy (7.x)."
                         echo "ERROR - 'install_deps.sh' doesn't have Debian Wheezy support yet."
-                        echo "See http://solidity.readthedocs.io/en/latest/installing-solidity.html for manual instructions."
+                        echo "See https://docs.soliditylang.org/en/latest/installing-solidity.html for manual instructions."
                         echo "If you would like to get 'install_deps.sh' working for Debian Wheezy, that would be fantastic."
                         echo "Drop us a message at https://gitter.im/ethereum/solidity-dev."
                         echo "See also https://github.com/ethereum/webthree-umbrella/issues/495 where we are working through Alpine support."
@@ -254,7 +254,7 @@ case $(uname -s) in
                 #openSUSE
                 echo "Installing solidity dependencies on openSUSE."
                 echo "ERROR - 'install_deps.sh' doesn't have openSUSE support yet."
-                echo "See http://solidity.readthedocs.io/en/latest/installing-solidity.html for manual instructions."
+                echo "See https://docs.soliditylang.org/en/latest/installing-solidity.html for manual instructions."
                 echo "If you would like to get 'install_deps.sh' working for openSUSE, that would be fantastic."
                 echo "See https://github.com/ethereum/webthree-umbrella/issues/552."
                 exit 1
@@ -311,7 +311,7 @@ case $(uname -s) in
                         #do not try anything for betsy.
                         echo "Linux Mint Betsy is not supported at the moment as it runs off of Debian."
                         echo "We only support Sylvia, Sonya, Serena, Sarah, Rosa, Rafaela, Rebecca, and Qiana."
-                        echo "See http://solidity.readthedocs.io/en/latest/installing-solidity.html for manual instructions."
+                        echo "See https://docs.soliditylang.org/en/latest/installing-solidity.html for manual instructions."
                         echo "If you would like to get your distro working, that would be fantastic."
                         echo "Drop us a message at https://gitter.im/ethereum/solidity-dev."
                         exit 1
@@ -396,7 +396,7 @@ case $(uname -s) in
 
                 #other Linux
                 echo "ERROR - Unsupported or unidentified Linux distro."
-                echo "See http://solidity.readthedocs.io/en/latest/installing-solidity.html for manual instructions."
+                echo "See https://docs.soliditylang.org/en/latest/installing-solidity.html for manual instructions."
                 echo "If you would like to get your distro working, that would be fantastic."
                 echo "Drop us a message at https://gitter.im/ethereum/solidity-dev."
                 exit 1
@@ -413,7 +413,7 @@ case $(uname -s) in
     *)
         #other
         echo "ERROR - Unsupported or unidentified operating system."
-        echo "See http://solidity.readthedocs.io/en/latest/installing-solidity.html for manual instructions."
+        echo "See https://docs.soliditylang.org/en/latest/installing-solidity.html for manual instructions."
         echo "If you would like to get your operating system working, that would be fantastic."
         echo "Drop us a message at https://gitter.im/ethereum/solidity-dev."
         ;;

--- a/scripts/release.bat
+++ b/scripts/release.bat
@@ -5,7 +5,7 @@ REM Batch file for implementing release flow for solidity for Windows.
 REM
 REM The documentation for solidity is hosted at:
 REM
-REM     https://solidity.readthedocs.org
+REM     https://docs.soliditylang.org
 REM
 REM ---------------------------------------------------------------------------
 REM This file is part of solidity.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/test_emscripten.sh
+++ b/scripts/test_emscripten.sh
@@ -5,7 +5,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -5,7 +5,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/scripts/yul_coverage.sh
+++ b/scripts/yul_coverage.sh
@@ -30,7 +30,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -5,7 +5,7 @@
 #
 # The documentation for solidity is hosted at:
 #
-#     https://solidity.readthedocs.org
+#     https://docs.soliditylang.org
 #
 # ------------------------------------------------------------------------------
 # This file is part of solidity.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/406_invalid_address_checksum.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/406_invalid_address_checksum.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// SyntaxError 9429: (64-106): This looks like an address but has an invalid checksum. Correct checksummed address: "0xfA0bFc97E48458494Ccd857e1A85DC91F7F0046E". If this is not used as an address, please prepend '00'. For more information please see https://solidity.readthedocs.io/en/develop/types.html#address-literals
+// SyntaxError 9429: (64-106): This looks like an address but has an invalid checksum. Correct checksummed address: "0xfA0bFc97E48458494Ccd857e1A85DC91F7F0046E". If this is not used as an address, please prepend '00'. For more information please see https://docs.soliditylang.org/en/develop/types.html#address-literals

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/407_invalid_address_no_checksum.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/407_invalid_address_no_checksum.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// SyntaxError 9429: (64-106): This looks like an address but has an invalid checksum. Correct checksummed address: "0xfA0bFc97E48458494Ccd857e1A85DC91F7F0046E". If this is not used as an address, please prepend '00'. For more information please see https://solidity.readthedocs.io/en/develop/types.html#address-literals
+// SyntaxError 9429: (64-106): This looks like an address but has an invalid checksum. Correct checksummed address: "0xfA0bFc97E48458494Ccd857e1A85DC91F7F0046E". If this is not used as an address, please prepend '00'. For more information please see https://docs.soliditylang.org/en/develop/types.html#address-literals

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/408_invalid_address_length_short.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/408_invalid_address_length_short.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// SyntaxError 9429: (64-105): This looks like an address but is not exactly 40 hex digits. It is 39 hex digits. If this is not used as an address, please prepend '00'. For more information please see https://solidity.readthedocs.io/en/develop/types.html#address-literals
+// SyntaxError 9429: (64-105): This looks like an address but is not exactly 40 hex digits. It is 39 hex digits. If this is not used as an address, please prepend '00'. For more information please see https://docs.soliditylang.org/en/develop/types.html#address-literals

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/409_invalid_address_length_long.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/409_invalid_address_length_long.sol
@@ -5,4 +5,4 @@ contract C {
     }
 }
 // ----
-// SyntaxError 9429: (64-107): This looks like an address but is not exactly 40 hex digits. It is 41 hex digits. If this is not used as an address, please prepend '00'. For more information please see https://solidity.readthedocs.io/en/develop/types.html#address-literals
+// SyntaxError 9429: (64-107): This looks like an address but is not exactly 40 hex digits. It is 41 hex digits. If this is not used as an address, please prepend '00'. For more information please see https://docs.soliditylang.org/en/develop/types.html#address-literals


### PR DESCRIPTION
Note that links were changed in one of the error messages so tests are relevant. Please make sure they passed before merging this.