### PR TITLE
buildpack-deps: Update hera and fix some issues.

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -57,7 +57,7 @@ then
   rm -f evmone-0.4.0-darwin-x86_64.tar.gz
 
   # hera
-  wget https://github.com/ewasm/hera/releases/download/v0.3.0/hera-0.3.0-darwin-x86_64.tar.gz
-  tar xzpf hera-0.3.0-darwin-x86_64.tar.gz -C /usr/local
+  wget https://github.com/ewasm/hera/releases/download/v0.3.1/hera-0.3.1-darwin-x86_64.tar.gz
+  tar xzpf hera-0.3.1-darwin-x86_64.tar.gz -C /usr/local
   rm -f hera-0.3.0-darwin-x86_64.tar.gz
 fi

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -61,5 +61,5 @@ docker push "${DOCKER_IMAGE_ID}-${VERSION}"
 
 REPO_DIGEST=$(docker inspect --format='{{.RepoDigests}}' "${DOCKER_IMAGE_ID}-${VERSION}")
 
-echo "::set-env name=DOCKER_IMAGE::${DOCKER_IMAGE_ID}-${VERSION}"
-echo "::set-env name=DOCKER_REPO_DIGEST::${REPO_DIGEST}"
+echo "DOCKER_IMAGE=${DOCKER_IMAGE_ID}-${VERSION}" >> "$GITHUB_ENV"
+echo "DOCKER_REPO_DIGEST=${REPO_DIGEST}" >> "$GITHUB_ENV"

--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -29,7 +29,7 @@
 #   make version=1.39.15 build
 #
 FROM emscripten/emsdk:1.39.15 AS base
-LABEL version="2"
+LABEL version="3"
 
 ADD emscripten.jam /usr/src
 RUN set -ex; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -108,7 +108,7 @@ RUN set -ex; \
 	cd hera; \
 	mkdir build; \
 	cd build; \
-	cmake -G Ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="/usr" ..; \
+	cmake -G Ninja -DHERA_DEBUGGING=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="/usr" ..; \
 	ninja; \
 	ninja install/strip; \
 	rm -rf /usr/src/hera

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang as base
-LABEL version="5"
+LABEL version="6"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -104,7 +104,7 @@ RUN set -ex; \
 # HERA
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.3.0" --recurse-submodules https://github.com/ewasm/hera.git; \
+	git clone --branch="v0.3.1" --recurse-submodules https://github.com/ewasm/hera.git; \
 	cd hera; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1804
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1804
@@ -95,7 +95,7 @@ RUN set -ex; \
 	cd hera; \
 	mkdir build; \
 	cd build; \
-	cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
+	cmake -G Ninja -DHERA_DEBUGGING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
 	ninja; \
 	ninja install/strip; \
 	rm -rf /usr/src/hera

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1804
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1804
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:bionic AS base
-LABEL version="3"
+LABEL version="4"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -89,17 +89,16 @@ RUN set -ex; \
 	rm -f $TGZFILE;
 
 # HERA
-ARG HERA_HASH="622663cb3bc1fa07213c6e1fe8070c5c259096e75039a46d014b2a3448b5cf44"
-ARG HERA_MAJOR="0"
-ARG HERA_MINOR="3"
-ARG HERA_MICRO="0"
 RUN set -ex; \
-	HERA_VERSION="$HERA_MAJOR.$HERA_MINOR.$HERA_MICRO"; \
-	TGZFILE="hera-$HERA_VERSION-linux-x86_64.tar.gz"; \
-	wget https://github.com/ewasm/hera/releases/download/v$HERA_VERSION/$TGZFILE; \
-	sha256sum $TGZFILE; \
-	tar xzpf $TGZFILE -C /usr; \
-	rm -f $TGZFILE;
+	cd /usr/src; \
+	git clone --branch="v0.3.1" --recurse-submodules https://github.com/ewasm/hera.git; \
+	cd hera; \
+	mkdir build; \
+	cd build; \
+	cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
+	ninja; \
+	ninja install/strip; \
+	rm -rf /usr/src/hera
 
 FROM base
 COPY --from=libraries /usr/lib /usr/lib

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="3"
+LABEL version="4"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -60,7 +60,7 @@ RUN set -ex; \
 # HERA
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.3.0" --recurse-submodules https://github.com/ewasm/hera.git; \
+	git clone --branch="v0.3.1" --recurse-submodules https://github.com/ewasm/hera.git; \
 	cd hera; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -64,7 +64,7 @@ RUN set -ex; \
 	cd hera; \
 	mkdir build; \
 	cd build; \
-	cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
+	cmake -G Ninja -DHERA_DEBUGGING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
 	ninja; \
 	ninja install/strip; \
 	rm -rf /usr/src/hera

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="3"
+LABEL version="4"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -62,7 +62,7 @@ RUN set -ex; \
 # HERA
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.3.0" --recurse-submodules https://github.com/ewasm/hera.git; \
+	git clone --branch="v0.3.1" --recurse-submodules https://github.com/ewasm/hera.git; \
 	cd hera; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -66,7 +66,7 @@ RUN set -ex; \
 	cd hera; \
 	mkdir build; \
 	cd build; \
-	cmake -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
+	cmake -G Ninja -DHERA_DEBUGGING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX="/usr" ..; \
 	ninja; \
 	ninja install/strip; \
 	rm -rf /usr/src/hera

--- a/test/Common.h
+++ b/test/Common.h
@@ -34,17 +34,17 @@ namespace solidity::test
 static constexpr auto evmoneFilename = "evmone.dll";
 static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.4.1/evmone-0.4.1-windows-amd64.zip";
 static constexpr auto heraFilename = "hera.dll";
-static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/archive/v0.3.0.tar.gz";
+static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/archive/v0.3.1.tar.gz";
 #elif defined(__APPLE__)
 static constexpr auto evmoneFilename = "libevmone.dylib";
 static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.4.1/evmone-0.4.1-darwin-x86_64.tar.gz";
 static constexpr auto heraFilename = "libhera.dylib";
-static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.3.0/hera-0.3.0-darwin-x86_64.tar.gz";
+static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.3.1/hera-0.3.1-darwin-x86_64.tar.gz";
 #else
 static constexpr auto evmoneFilename = "libevmone.so";
 static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.4.1/evmone-0.4.1-linux-x86_64.tar.gz";
 static constexpr auto heraFilename = "libhera.so";
-static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.3.0/hera-0.3.0-linux-x86_64.tar.gz";
+static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.3.1/hera-0.3.1-linux-x86_64.tar.gz";
 #endif
 
 struct ConfigException : public util::Exception {};


### PR DESCRIPTION
Replaced by #10425.

This PR was intended to just update hera to `v0.3.1`. Doing this some unrelated issues where identified & fixed:
- ~broken symlink `scripts/ci/buildpack-deps_test_emscripten.sh`: link was pointing to `../../scripts/travis-emscripten/build_emscripten.sh`~ (see #10338)
- due to a security vulnerability `set-env` got deprecated, update `scripts/ci/docker_upgrade.sh` to use [Environment Files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)