### PR TITLE
Testing: Add ens contracts to compilation tests. Contract source

### DIFF
--- a/test/compilationTests/ens/Deed.sol
+++ b/test/compilationTests/ens/Deed.sol
@@ -1,0 +1,16 @@
+pragma solidity >=0.0;
+
+interface Deed {
+
+    function setOwner(address payable newOwner) external;
+    function setRegistrar(address newRegistrar) external;
+    function setBalance(uint newValue, bool throwOnFailure) external;
+    function closeDeed(uint refundRatio) external;
+    function destroyDeed() external;
+
+    function owner() external view returns (address);
+    function previousOwner() external view returns (address);
+    function value() external view returns (uint);
+    function creationDate() external view returns (uint);
+
+}

--- a/test/compilationTests/ens/DeedImplementation.sol
+++ b/test/compilationTests/ens/DeedImplementation.sol
@@ -1,0 +1,120 @@
+pragma solidity>=0.0;
+
+import "./Deed.sol";
+
+/**
+ * @title Deed to hold ether in exchange for ownership of a node
+ * @dev The deed can be controlled only by the registrar and can only send ether back to the owner.
+ */
+contract DeedImplementation is Deed {
+
+    address payable constant burn = address(0xdead);
+
+    address payable private _owner;
+    address private _previousOwner;
+    address private _registrar;
+
+    uint private _creationDate;
+    uint private _value;
+
+    bool active;
+
+    event OwnerChanged(address newOwner);
+    event DeedClosed();
+
+    modifier onlyRegistrar {
+        require(msg.sender == _registrar);
+        _;
+    }
+
+    modifier onlyActive {
+        require(active);
+        _;
+    }
+
+    /// Solidity upgrade: Warning on ignored constructor
+    /// visibility.
+    constructor(address payable initialOwner) public payable {
+        _owner = initialOwner;
+        _registrar = msg.sender;
+        /// Solidity upgrade: `now` changed to `block.timestamp`
+        _creationDate = block.timestamp;
+        active = true;
+        _value = msg.value;
+    }
+
+    /// Solidity upgrade: Function missing override specifier
+    function setOwner(address payable newOwner) override external onlyRegistrar {
+        require(newOwner != address(0x0));
+        _previousOwner = _owner;  // This allows contracts to check who sent them the ownership
+        _owner = newOwner;
+        emit OwnerChanged(newOwner);
+    }
+
+    /// Solidity upgrade: Function missing override specifier
+    function setRegistrar(address newRegistrar) override external onlyRegistrar {
+        _registrar = newRegistrar;
+    }
+
+    /// Solidity upgrade: Function missing override specifier
+    function setBalance(uint newValue, bool throwOnFailure) override external onlyRegistrar onlyActive {
+        // Check if it has enough balance to set the value
+        require(_value >= newValue);
+        _value = newValue;
+        // Send the difference to the owner
+        require(_owner.send(address(this).balance - newValue) || !throwOnFailure);
+    }
+
+    /**
+     * @dev Close a deed and refund a specified fraction of the bid value
+     *
+     * @param refundRatio The amount*1/1000 to refund
+     */
+    /// Solidity upgrade: Function missing override specifier
+    function closeDeed(uint refundRatio) override external onlyRegistrar onlyActive {
+        active = false;
+        require(burn.send(((1000 - refundRatio) * address(this).balance)/1000));
+        emit DeedClosed();
+        _destroyDeed();
+    }
+
+    /**
+     * @dev Close a deed and refund a specified fraction of the bid value
+     */
+    /// Solidity upgrade: Function missing override specifier
+    function destroyDeed() override external {
+        _destroyDeed();
+    }
+
+    /// Solidity upgrade: Function missing override identifier
+    function owner() override external view returns (address) {
+        return _owner;
+    }
+
+    /// Solidity upgrade: Function missing override identifier
+    function previousOwner() override external view returns (address) {
+        return _previousOwner;
+    }
+
+    /// Solidity upgrade: Function missing override specifier
+    function value() override external view returns (uint) {
+        return _value;
+    }
+
+    /// Solidity upgrade: Function missing override specifier
+    function creationDate() override external view returns (uint) {
+        /// Solidity upgrade: Missing return statement
+        return _creationDate;
+    }
+
+    function _destroyDeed() internal {
+        require(!active);
+
+        // Instead of selfdestruct(owner), invoke owner fallback function to allow
+        // owner to log an event if desired; but owner should also be aware that
+        // its fallback function can also be invoked by setBalance
+        if (_owner.send(address(this).balance)) {
+            selfdestruct(burn);
+        }
+    }
+}

--- a/test/compilationTests/ens/ENS.sol
+++ b/test/compilationTests/ens/ENS.sol
@@ -1,0 +1,32 @@
+pragma solidity >=0.0;
+
+interface ENS {
+
+    // Logged when the owner of a node assigns a new owner to a subnode.
+    event NewOwner(bytes32 indexed node, bytes32 indexed label, address owner);
+
+    // Logged when the owner of a node transfers ownership to a new account.
+    event Transfer(bytes32 indexed node, address owner);
+
+    // Logged when the resolver for a node changes.
+    event NewResolver(bytes32 indexed node, address resolver);
+
+    // Logged when the TTL of a node changes
+    event NewTTL(bytes32 indexed node, uint64 ttl);
+
+    // Logged when an operator is added or removed.
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function setRecord(bytes32 node, address owner, address resolver, uint64 ttl) external;
+    function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) external;
+    function setSubnodeOwner(bytes32 node, bytes32 label, address owner) external returns(bytes32);
+    function setResolver(bytes32 node, address resolver) external;
+    function setOwner(bytes32 node, address owner) external;
+    function setTTL(bytes32 node, uint64 ttl) external;
+    function setApprovalForAll(address operator, bool approved) external;
+    function owner(bytes32 node) external view returns (address);
+    function resolver(bytes32 node) external view returns (address);
+    function ttl(bytes32 node) external view returns (uint64);
+    function recordExists(bytes32 node) external view returns (bool);
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+}

--- a/test/compilationTests/ens/ENSRegistry.sol
+++ b/test/compilationTests/ens/ENSRegistry.sol
@@ -1,0 +1,190 @@
+pragma solidity >=0.0;
+
+import "./ENS.sol";
+
+/**
+ * The ENS registry contract.
+ */
+contract ENSRegistry is ENS {
+
+    struct Record {
+        address owner;
+        address resolver;
+        uint64 ttl;
+    }
+
+    mapping (bytes32 => Record) records;
+    mapping (address => mapping(address => bool)) operators;
+
+    // Permits modifications only by the owner of the specified node.
+    modifier authorised(bytes32 node) {
+        address owner = records[node].owner;
+        require(owner == msg.sender || operators[owner][msg.sender]);
+        _;
+    }
+
+    /**
+     * @dev Constructs a new ENS registrar.
+     */
+    constructor() public {
+        records[0x0].owner = msg.sender;
+    }
+
+    /**
+     * @dev Sets the record for a node.
+     * @param node The node to update.
+     * @param owner The address of the new owner.
+     * @param resolver The address of the resolver.
+     * @param ttl The TTL in seconds.
+     */
+    /// Solidity: Missing override specifier
+    function setRecord(bytes32 node, address owner, address resolver, uint64 ttl) override external {
+        setOwner(node, owner);
+        _setResolverAndTTL(node, resolver, ttl);
+    }
+
+    /**
+     * @dev Sets the record for a subnode.
+     * @param node The parent node.
+     * @param label The hash of the label specifying the subnode.
+     * @param owner The address of the new owner.
+     * @param resolver The address of the resolver.
+     * @param ttl The TTL in seconds.
+     */
+    /// Solidity: Missing override specifier
+    function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) override external {
+        bytes32 subnode = setSubnodeOwner(node, label, owner);
+        _setResolverAndTTL(subnode, resolver, ttl);
+    }
+
+    /**
+     * @dev Transfers ownership of a node to a new address. May only be called by the current owner of the node.
+     * @param node The node to transfer ownership of.
+     * @param owner The address of the new owner.
+     */
+    /// Solidity: Missing override specifier
+    function setOwner(bytes32 node, address owner) override public authorised(node) {
+        _setOwner(node, owner);
+        emit Transfer(node, owner);
+    }
+
+    /**
+     * @dev Transfers ownership of a subnode keccak256(node, label) to a new address. May only be called by the owner of the parent node.
+     * @param node The parent node.
+     * @param label The hash of the label specifying the subnode.
+     * @param owner The address of the new owner.
+     */
+    /// Solidity: Missing override specifier
+    function setSubnodeOwner(bytes32 node, bytes32 label, address owner) override public authorised(node) returns(bytes32) {
+        bytes32 subnode = keccak256(abi.encodePacked(node, label));
+        _setOwner(subnode, owner);
+        emit NewOwner(node, label, owner);
+        return subnode;
+    }
+
+    /**
+     * @dev Sets the resolver address for the specified node.
+     * @param node The node to update.
+     * @param resolver The address of the resolver.
+     */
+    /// Solidity: Missing override specifier
+    function setResolver(bytes32 node, address resolver) override public authorised(node) {
+        emit NewResolver(node, resolver);
+        records[node].resolver = resolver;
+    }
+
+    /**
+     * @dev Sets the TTL for the specified node.
+     * @param node The node to update.
+     * @param ttl The TTL in seconds.
+     */
+    /// Solidity: Missing override specifier
+    function setTTL(bytes32 node, uint64 ttl) override public authorised(node) {
+        emit NewTTL(node, ttl);
+        records[node].ttl = ttl;
+    }
+
+    /**
+     * @dev Enable or disable approval for a third party ("operator") to manage
+     *  all of `msg.sender`'s ENS records. Emits the ApprovalForAll event.
+     * @param operator Address to add to the set of authorized operators.
+     * @param approved True if the operator is approved, false to revoke approval.
+     */
+    /// Solidity: Missing override specifier
+    function setApprovalForAll(address operator, bool approved) override external {
+        operators[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    /**
+     * @dev Returns the address that owns the specified node.
+     * @param node The specified node.
+     * @return address of the owner.
+     */
+    /// Solidity: Missing override and virtual specifiers
+    function owner(bytes32 node) override virtual public view returns (address) {
+        address addr = records[node].owner;
+        if (addr == address(this)) {
+            return address(0x0);
+        }
+
+        return addr;
+    }
+
+    /**
+     * @dev Returns the address of the resolver for the specified node.
+     * @param node The specified node.
+     * @return address of the resolver.
+     */
+    /// Solidity: Missing override and virtual specifiers
+    function resolver(bytes32 node) override virtual public view returns (address) {
+        return records[node].resolver;
+    }
+
+    /**
+     * @dev Returns the TTL of a node, and any records associated with it.
+     * @param node The specified node.
+     * @return ttl of the node.
+     */
+    /// Solidity: Missing override and virtual specifiers
+    function ttl(bytes32 node) override virtual public view returns (uint64) {
+        return records[node].ttl;
+    }
+
+    /**
+     * @dev Returns whether a record has been imported to the registry.
+     * @param node The specified node.
+     * @return Bool if record exists
+     */
+    /// Solidity: Missing override specifier
+    function recordExists(bytes32 node) override public view returns (bool) {
+        return records[node].owner != address(0x0);
+    }
+
+    /**
+     * @dev Query if an address is an authorized operator for another address.
+     * @param owner The address that owns the records.
+     * @param operator The address that acts on behalf of the owner.
+     * @return True if `operator` is an approved operator for `owner`, false otherwise.
+     */
+    /// Solidity: Missing override specifier
+    function isApprovedForAll(address owner, address operator) override external view returns (bool) {
+        return operators[owner][operator];
+    }
+
+    function _setOwner(bytes32 node, address owner) virtual internal {
+        records[node].owner = owner;
+    }
+
+    function _setResolverAndTTL(bytes32 node, address resolver, uint64 ttl) internal {
+        if(resolver != records[node].resolver) {
+            records[node].resolver = resolver;
+            emit NewResolver(node, resolver);
+        }
+
+        if(ttl != records[node].ttl) {
+            records[node].ttl = ttl;
+            emit NewTTL(node, ttl);
+        }
+    }
+}

--- a/test/compilationTests/ens/ENSRegistryWithFallback.sol
+++ b/test/compilationTests/ens/ENSRegistryWithFallback.sol
@@ -1,0 +1,70 @@
+pragma solidity >=0.0;
+
+import "./ENS.sol";
+import "./ENSRegistry.sol";
+
+/**
+ * The ENS registry contract.
+ */
+contract ENSRegistryWithFallback is ENSRegistry {
+
+    ENS public old;
+
+    /**
+     * @dev Constructs a new ENS registrar.
+     */
+    constructor(ENS _old) public ENSRegistry() {
+        old = _old;
+    }
+
+    /**
+     * @dev Returns the address of the resolver for the specified node.
+     * @param node The specified node.
+     * @return address of the resolver.
+     */
+    /// Solidity: Missing override specifier
+    function resolver(bytes32 node) override public view returns (address) {
+        if (!recordExists(node)) {
+            return old.resolver(node);
+        }
+
+        return super.resolver(node);
+    }
+
+    /**
+     * @dev Returns the address that owns the specified node.
+     * @param node The specified node.
+     * @return address of the owner.
+     */
+    /// Solidity: Missing override specifier
+    function owner(bytes32 node) override public view returns (address) {
+        if (!recordExists(node)) {
+            return old.owner(node);
+        }
+
+        return super.owner(node);
+    }
+
+    /**
+     * @dev Returns the TTL of a node, and any records associated with it.
+     * @param node The specified node.
+     * @return ttl of the node.
+     */
+    /// Solidity: Missing override specifier
+    function ttl(bytes32 node) override public view returns (uint64) {
+        if (!recordExists(node)) {
+            return old.ttl(node);
+        }
+
+        return super.ttl(node);
+    }
+
+    function _setOwner(bytes32 node, address owner) override internal {
+        address addr = owner;
+        if (addr == address(0x0)) {
+            addr = address(this);
+        }
+
+        super._setOwner(node, addr);
+    }
+}

--- a/test/compilationTests/ens/FIFSRegistrar.sol
+++ b/test/compilationTests/ens/FIFSRegistrar.sol
@@ -1,0 +1,36 @@
+pragma solidity >=0.0;
+
+import "./ENS.sol";
+
+/**
+ * A registrar that allocates subdomains to the first person to claim them.
+ */
+contract FIFSRegistrar {
+    ENS ens;
+    bytes32 rootNode;
+
+    modifier only_owner(bytes32 label) {
+        address currentOwner = ens.owner(keccak256(abi.encodePacked(rootNode, label)));
+        require(currentOwner == address(0x0) || currentOwner == msg.sender);
+        _;
+    }
+
+    /**
+     * Constructor.
+     * @param ensAddr The address of the ENS registry.
+     * @param node The node that this registrar administers.
+     */
+    constructor(ENS ensAddr, bytes32 node) public {
+        ens = ensAddr;
+        rootNode = node;
+    }
+
+    /**
+     * Register a name, or change the owner of an existing registration.
+     * @param label The hash of the label to register.
+     * @param owner The address of the new owner.
+     */
+    function register(bytes32 label, address owner) public only_owner(label) {
+        ens.setSubnodeOwner(rootNode, label, owner);
+    }
+}

--- a/test/compilationTests/ens/HashRegistrar.sol
+++ b/test/compilationTests/ens/HashRegistrar.sol
@@ -1,0 +1,559 @@
+pragma solidity >=0.0;
+
+
+/*
+
+Temporary Hash Registrar
+========================
+
+This is a simplified version of a hash registrar. It is purporsefully limited:
+names cannot be six letters or shorter, new auctions will stop after 4 years.
+
+The plan is to test the basic features and then move to a new contract in at most
+2 years, when some sort of renewal mechanism will be enabled.
+*/
+
+
+import "./ENS.sol";
+import "./DeedImplementation.sol";
+import "./Registrar.sol";
+
+/**
+ * @title Registrar
+ * @dev The registrar handles the auction process for each subnode of the node it owns.
+ */
+contract HashRegistrar is Registrar {
+    ENS public ens;
+    bytes32 public rootNode;
+
+    mapping (bytes32 => Entry) _entries;
+    mapping (address => mapping (bytes32 => Deed)) public sealedBids;
+
+    uint32 constant totalAuctionLength = 5 days;
+    uint32 constant revealPeriod = 48 hours;
+    uint32 public constant launchLength = 8 weeks;
+
+    uint constant minPrice = 0.01 ether;
+    uint public registryStarted;
+
+    struct Entry {
+        Deed deed;
+        uint registrationDate;
+        uint value;
+        uint highestBid;
+    }
+
+    modifier inState(bytes32 _hash, Mode _state) {
+        require(state(_hash) == _state);
+        _;
+    }
+
+    modifier onlyOwner(bytes32 _hash) {
+        require(state(_hash) == Mode.Owned && msg.sender == _entries[_hash].deed.owner());
+        _;
+    }
+
+    modifier registryOpen() {
+        require(block.timestamp >= registryStarted && block.timestamp <= registryStarted + (365 * 4) * 1 days && ens.owner(rootNode) == address(this));
+        _;
+    }
+
+    /**
+     * @dev Constructs a new Registrar, with the provided address as the owner of the root node.
+     *
+     * @param _ens The address of the ENS
+     * @param _rootNode The hash of the rootnode.
+     */
+    constructor(ENS _ens, bytes32 _rootNode, uint _startDate) public {
+        ens = _ens;
+        rootNode = _rootNode;
+        registryStarted = _startDate > 0 ? _startDate : block.timestamp;
+    }
+
+    /**
+     * @dev Start an auction for an available hash
+     *
+     * @param _hash The hash to start an auction on
+     */
+    /// Solidity: Missing override specifier
+    function startAuction(bytes32 _hash) override external {
+        _startAuction(_hash);
+    }
+
+    /**
+     * @dev Start multiple auctions for better anonymity
+     *
+     * Anyone can start an auction by sending an array of hashes that they want to bid for.
+     * Arrays are sent so that someone can open up an auction for X dummy hashes when they
+     * are only really interested in bidding for one. This will increase the cost for an
+     * attacker to simply bid blindly on all new auctions. Dummy auctions that are
+     * open but not bid on are closed after a week.
+     *
+     * @param _hashes An array of hashes, at least one of which you presumably want to bid on
+     */
+    /// Solidity: Missing override specifier
+    function startAuctions(bytes32[] calldata _hashes) override external {
+        _startAuctions(_hashes);
+    }
+
+    /**
+     * @dev Submit a new sealed bid on a desired hash in a blind auction
+     *
+     * Bids are sent by sending a message to the main contract with a hash and an amount. The hash
+     * contains information about the bid, including the bidded hash, the bid amount, and a random
+     * salt. Bids are not tied to any one auction until they are revealed. The value of the bid
+     * itself can be masqueraded by sending more than the value of your actual bid. This is
+     * followed by a 48h reveal period. Bids revealed after this period will be burned and the ether unrecoverable.
+     * Since this is an auction, it is expected that most public hashes, like known domains and common dictionary
+     * words, will have multiple bidders pushing the price up.
+     *
+     * @param sealedBid A sealedBid, created by the shaBid function
+     */
+    /// Solidity: Missing override specifier
+    function newBid(bytes32 sealedBid) override external payable {
+        _newBid(sealedBid);
+    }
+
+    /**
+     * @dev Start a set of auctions and bid on one of them
+     *
+     * This method functions identically to calling `startAuctions` followed by `newBid`,
+     * but all in one transaction.
+     *
+     * @param hashes A list of hashes to start auctions on.
+     * @param sealedBid A sealed bid for one of the auctions.
+     */
+    /// Solidity: Missing override specifier
+    function startAuctionsAndBid(bytes32[] calldata hashes, bytes32 sealedBid) override external payable {
+        _startAuctions(hashes);
+        _newBid(sealedBid);
+    }
+
+    /**
+     * @dev Submit the properties of a bid to reveal them
+     *
+     * @param _hash The node in the sealedBid
+     * @param _value The bid amount in the sealedBid
+     * @param _salt The sale in the sealedBid
+     */
+    /// Solidity: Missing override specifier
+    function unsealBid(bytes32 _hash, uint _value, bytes32 _salt) override external {
+        bytes32 seal = shaBid(_hash, msg.sender, _value, _salt);
+        Deed bid = sealedBids[msg.sender][seal];
+        require(address(bid) != address(0x0));
+
+        sealedBids[msg.sender][seal] = Deed(address(0x0));
+        Entry storage h = _entries[_hash];
+        uint value = min(_value, bid.value());
+        bid.setBalance(value, true);
+
+        Mode auctionState = state(_hash);
+        if (auctionState == Mode.Owned) {
+            // Too late! Bidder loses their bid. Gets 0.5% back.
+            bid.closeDeed(5);
+            emit BidRevealed(_hash, msg.sender, value, 1);
+        } else if (auctionState != Mode.Reveal) {
+            // Invalid phase
+            revert();
+        } else if (value < minPrice || bid.creationDate() > h.registrationDate - revealPeriod) {
+            // Bid too low or too late, refund 99.5%
+            bid.closeDeed(995);
+            emit BidRevealed(_hash, msg.sender, value, 0);
+        } else if (value > h.highestBid) {
+            // New winner
+            // Cancel the other bid, refund 99.5%
+            if (address(h.deed) != address(0x0)) {
+                Deed previousWinner = h.deed;
+                previousWinner.closeDeed(995);
+            }
+
+            // Set new winner
+            // Per the rules of a vickery auction, the value becomes the previous highestBid
+            h.value = h.highestBid;  // will be zero if there's only 1 bidder
+            h.highestBid = value;
+            h.deed = bid;
+            emit BidRevealed(_hash, msg.sender, value, 2);
+        } else if (value > h.value) {
+            // Not winner, but affects second place
+            h.value = value;
+            bid.closeDeed(995);
+            emit BidRevealed(_hash, msg.sender, value, 3);
+        } else {
+            // Bid doesn't affect auction
+            bid.closeDeed(995);
+            emit BidRevealed(_hash, msg.sender, value, 4);
+        }
+    }
+
+    /**
+     * @dev Cancel a bid
+     *
+     * @param seal The value returned by the shaBid function
+     */
+    /// Solidity: Missing override specifier
+    function cancelBid(address bidder, bytes32 seal) override external {
+        Deed bid = sealedBids[bidder][seal];
+
+        // If a sole bidder does not `unsealBid` in time, they have a few more days
+        // where they can call `startAuction` (again) and then `unsealBid` during
+        // the revealPeriod to get back their bid value.
+        // For simplicity, they should call `startAuction` within
+        // 9 days (2 weeks - totalAuctionLength), otherwise their bid will be
+        // cancellable by anyone.
+        require(address(bid) != address(0x0) && block.timestamp >= bid.creationDate() + totalAuctionLength + 2 weeks);
+
+        // Send the canceller 0.5% of the bid, and burn the rest.
+        bid.setOwner(msg.sender);
+        bid.closeDeed(5);
+        sealedBids[bidder][seal] = Deed(0);
+        emit BidRevealed(seal, bidder, 0, 5);
+    }
+
+    /**
+     * @dev Finalize an auction after the registration date has passed
+     *
+     * @param _hash The hash of the name the auction is for
+     */
+    /// Solidity: Missing override specifier
+    function finalizeAuction(bytes32 _hash) override external onlyOwner(_hash) {
+        Entry storage h = _entries[_hash];
+
+        // Handles the case when there's only a single bidder (h.value is zero)
+        h.value = max(h.value, minPrice);
+        h.deed.setBalance(h.value, true);
+
+        trySetSubnodeOwner(_hash, h.deed.owner());
+        emit HashRegistered(_hash, h.deed.owner(), h.value, h.registrationDate);
+    }
+
+    /**
+     * @dev The owner of a domain may transfer it to someone else at any time.
+     *
+     * @param _hash The node to transfer
+     * @param newOwner The address to transfer ownership to
+     */
+    /// Solidity: Missing override specifier
+    function transfer(bytes32 _hash, address payable newOwner) override external onlyOwner(_hash) {
+        require(newOwner != address(0x0));
+
+        Entry storage h = _entries[_hash];
+        h.deed.setOwner(newOwner);
+        trySetSubnodeOwner(_hash, newOwner);
+    }
+
+    /**
+     * @dev After some time, or if we're no longer the registrar, the owner can release
+     *      the name and get their ether back.
+     *
+     * @param _hash The node to release
+     */
+    /// Solidity: Missing override specifier
+    function releaseDeed(bytes32 _hash) override external onlyOwner(_hash) {
+        Entry storage h = _entries[_hash];
+        Deed deedContract = h.deed;
+
+        require(block.timestamp >= h.registrationDate + 365 days || ens.owner(rootNode) != address(this));
+
+        h.value = 0;
+        h.highestBid = 0;
+        h.deed = Deed(0);
+
+        _tryEraseSingleNode(_hash);
+        deedContract.closeDeed(1000);
+        emit HashReleased(_hash, h.value);
+    }
+
+    /**
+     * @dev Submit a name 6 characters long or less. If it has been registered,
+     *      the submitter will earn 50% of the deed value.
+     *
+     * We are purposefully handicapping the simplified registrar as a way
+     * to force it into being restructured in a few years.
+     *
+     * @param unhashedName An invalid name to search for in the registry.
+     */
+    /// Solidity: Missing override specifier
+    function invalidateName(string calldata unhashedName)
+        override
+        external
+        inState(keccak256(abi.encode(unhashedName)), Mode.Owned)
+    {
+        require(strlen(unhashedName) <= 6);
+        bytes32 hash = keccak256(abi.encode(unhashedName));
+
+        Entry storage h = _entries[hash];
+
+        _tryEraseSingleNode(hash);
+
+        if (address(h.deed) != address(0x0)) {
+            // Reward the discoverer with 50% of the deed
+            // The previous owner gets 50%
+            h.value = max(h.value, minPrice);
+            h.deed.setBalance(h.value/2, false);
+            h.deed.setOwner(msg.sender);
+            h.deed.closeDeed(1000);
+        }
+
+        emit HashInvalidated(hash, unhashedName, h.value, h.registrationDate);
+
+        h.value = 0;
+        h.highestBid = 0;
+        h.deed = Deed(0);
+    }
+
+    /**
+     * @dev Allows anyone to delete the owner and resolver records for a (subdomain of) a
+     *      name that is not currently owned in the registrar. If passing, eg, 'foo.bar.eth',
+     *      the owner and resolver fields on 'foo.bar.eth' and 'bar.eth' will all be cleared.
+     *
+     * @param labels A series of label hashes identifying the name to zero out, rooted at the
+     *        registrar's root. Must contain at least one element. For instance, to zero
+     *        'foo.bar.eth' on a registrar that owns '.eth', pass an array containing
+     *        [keccak256('foo'), keccak256('bar')].
+     */
+    /// Solidity: Missing override specifier
+    function eraseNode(bytes32[] calldata labels) override external {
+        require(labels.length != 0);
+        require(state(labels[labels.length - 1]) != Mode.Owned);
+
+        _eraseNodeHierarchy(labels.length - 1, labels, rootNode);
+    }
+
+    /**
+     * @dev Transfers the deed to the current registrar, if different from this one.
+     *
+     * Used during the upgrade process to a permanent registrar.
+     *
+     * @param _hash The name hash to transfer.
+     */
+    /// Solidity: Missing override specifier
+    function transferRegistrars(bytes32 _hash) override external onlyOwner(_hash) {
+        address registrar = ens.owner(rootNode);
+        require(registrar != address(this));
+
+        // Migrate the deed
+        Entry storage h = _entries[_hash];
+        h.deed.setRegistrar(registrar);
+
+        // Call the new registrar to accept the transfer
+        Registrar(registrar).acceptRegistrarTransfer(_hash, h.deed, h.registrationDate);
+
+        // Zero out the Entry
+        h.deed = Deed(0);
+        h.registrationDate = 0;
+        h.value = 0;
+        h.highestBid = 0;
+    }
+
+    /**
+     * @dev Accepts a transfer from a previous registrar; stubbed out here since there
+     *      is no previous registrar implementing this interface.
+     *
+     * @param hash The sha3 hash of the label to transfer.
+     * @param deed The Deed object for the name being transferred in.
+     * @param registrationDate The date at which the name was originally registered.
+     */
+    /// Solidity: Missing override specifier
+    function acceptRegistrarTransfer(bytes32 hash, Deed deed, uint registrationDate) override external {
+        hash; deed; registrationDate; // Don't warn about unused variables
+    }
+
+    /// Solidity: Missing override specifier
+    function entries(bytes32 _hash) override external view returns (Mode, address, uint, uint, uint) {
+        Entry storage h = _entries[_hash];
+        return (state(_hash), address(h.deed), h.registrationDate, h.value, h.highestBid);
+    }
+
+    // State transitions for names:
+    //   Open -> Auction (startAuction)
+    //   Auction -> Reveal
+    //   Reveal -> Owned
+    //   Reveal -> Open (if nobody bid)
+    //   Owned -> Open (releaseDeed or invalidateName)
+    /// Solidity: Missing override specifier
+    function state(bytes32 _hash) override public view returns (Mode) {
+        Entry storage entry = _entries[_hash];
+
+        if (!isAllowed(_hash, block.timestamp)) {
+            return Mode.NotYetAvailable;
+        } else if (block.timestamp < entry.registrationDate) {
+            if (block.timestamp < entry.registrationDate - revealPeriod) {
+                return Mode.Auction;
+            } else {
+                return Mode.Reveal;
+            }
+        } else {
+            if (entry.highestBid == 0) {
+                return Mode.Open;
+            } else {
+                return Mode.Owned;
+            }
+        }
+    }
+
+    /**
+     * @dev Determines if a name is available for registration yet
+     *
+     * Each name will be assigned a random date in which its auction
+     * can be started, from 0 to 8 weeks
+     *
+     * @param _hash The hash to start an auction on
+     * @param _timestamp The timestamp to query about
+     */
+    function isAllowed(bytes32 _hash, uint _timestamp) public view returns (bool allowed) {
+        return _timestamp > getAllowedTime(_hash);
+    }
+
+    /**
+     * @dev Returns available date for hash
+     *
+     * The available time from the `registryStarted` for a hash is proportional
+     * to its numeric value.
+     *
+     * @param _hash The hash to start an auction on
+     */
+    function getAllowedTime(bytes32 _hash) public view returns (uint) {
+        return registryStarted + ((launchLength * (uint(_hash) >> 128)) >> 128);
+        // Right shift operator: a >> b == a / 2**b
+    }
+
+    /**
+     * @dev Hash the values required for a secret bid
+     *
+     * @param hash The node corresponding to the desired namehash
+     * @param value The bid amount
+     * @param salt A random value to ensure secrecy of the bid
+     * @return The hash of the bid values
+     */
+    function shaBid(bytes32 hash, address owner, uint value, bytes32 salt) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(hash, owner, value, salt));
+    }
+
+    function _tryEraseSingleNode(bytes32 label) internal {
+        if (ens.owner(rootNode) == address(this)) {
+            ens.setSubnodeOwner(rootNode, label, address(this));
+            bytes32 node = keccak256(abi.encodePacked(rootNode, label));
+            ens.setResolver(node, address(0x0));
+            ens.setOwner(node, address(0x0));
+        }
+    }
+
+    function _startAuction(bytes32 _hash) internal registryOpen() {
+        Mode mode = state(_hash);
+        if (mode == Mode.Auction) return;
+        require(mode == Mode.Open);
+
+        Entry storage newAuction = _entries[_hash];
+        newAuction.registrationDate = block.timestamp + totalAuctionLength;
+        newAuction.value = 0;
+        newAuction.highestBid = 0;
+        emit AuctionStarted(_hash, newAuction.registrationDate);
+    }
+
+    function _startAuctions(bytes32[] memory _hashes) internal {
+        for (uint i = 0; i < _hashes.length; i ++) {
+            _startAuction(_hashes[i]);
+        }
+    }
+
+    function _newBid(bytes32 sealedBid) internal {
+        require(address(sealedBids[msg.sender][sealedBid]) == address(0x0));
+        require(msg.value >= minPrice);
+
+        // Creates a new hash contract with the owner
+        Deed bid = (new DeedImplementation){value: msg.value}(msg.sender);
+        sealedBids[msg.sender][sealedBid] = bid;
+        emit NewBid(sealedBid, msg.sender, msg.value);
+    }
+
+    function _eraseNodeHierarchy(uint idx, bytes32[] memory labels, bytes32 node) internal {
+        // Take ownership of the node
+        ens.setSubnodeOwner(node, labels[idx], address(this));
+        node = keccak256(abi.encodePacked(node, labels[idx]));
+
+        // Recurse if there are more labels
+        if (idx > 0) {
+            _eraseNodeHierarchy(idx - 1, labels, node);
+        }
+
+        // Erase the resolver and owner records
+        ens.setResolver(node, address(0x0));
+        ens.setOwner(node, address(0x0));
+    }
+
+    /**
+     * @dev Assign the owner in ENS, if we're still the registrar
+     *
+     * @param _hash hash to change owner
+     * @param _newOwner new owner to transfer to
+     */
+    function trySetSubnodeOwner(bytes32 _hash, address _newOwner) internal {
+        if (ens.owner(rootNode) == address(this))
+            ens.setSubnodeOwner(rootNode, _hash, _newOwner);
+    }
+
+    /**
+     * @dev Returns the maximum of two unsigned integers
+     *
+     * @param a A number to compare
+     * @param b A number to compare
+     * @return The maximum of two unsigned integers
+     */
+    function max(uint a, uint b) internal pure returns (uint) {
+        if (a > b)
+            return a;
+        else
+            return b;
+    }
+
+    /**
+     * @dev Returns the minimum of two unsigned integers
+     *
+     * @param a A number to compare
+     * @param b A number to compare
+     * @return The minimum of two unsigned integers
+     */
+    function min(uint a, uint b) internal pure returns (uint) {
+        if (a < b)
+            return a;
+        else
+            return b;
+    }
+
+    /**
+     * @dev Returns the length of a given string
+     *
+     * @param s The string to measure the length of
+     * @return The length of the input string
+     */
+    function strlen(string memory s) internal pure returns (uint) {
+        s; // Don't warn about unused variables
+        // Starting here means the LSB will be the byte we care about
+        uint ptr;
+        uint end;
+        assembly {
+            ptr := add(s, 1)
+            end := add(mload(s), ptr)
+        }
+        uint len = 0;
+        for (len; ptr < end; len++) {
+            uint8 b;
+            assembly { b := and(mload(ptr), 0xFF) }
+            if (b < 0x80) {
+                ptr += 1;
+            } else if (b < 0xE0) {
+                ptr += 2;
+            } else if (b < 0xF0) {
+                ptr += 3;
+            } else if (b < 0xF8) {
+                ptr += 4;
+            } else if (b < 0xFC) {
+                ptr += 5;
+            } else {
+                ptr += 6;
+            }
+        }
+        return len;
+    }
+
+}

--- a/test/compilationTests/ens/LICENSE
+++ b/test/compilationTests/ens/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2018, True Names Limited
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/compilationTests/ens/README.md
+++ b/test/compilationTests/ens/README.md
@@ -1,0 +1,2 @@
+Original source: https://github.com/ensdomains/ens
+Commit hash: 2a6785c3b5fc27269eb3bb18b9d1245d1f01d6c8

--- a/test/compilationTests/ens/Registrar.sol
+++ b/test/compilationTests/ens/Registrar.sol
@@ -1,0 +1,31 @@
+pragma solidity >=0.0;
+
+import "./Deed.sol";
+
+interface Registrar {
+
+    enum Mode { Open, Auction, Owned, Forbidden, Reveal, NotYetAvailable }
+
+    event AuctionStarted(bytes32 indexed hash, uint registrationDate);
+    event NewBid(bytes32 indexed hash, address indexed bidder, uint deposit);
+    event BidRevealed(bytes32 indexed hash, address indexed owner, uint value, uint8 status);
+    event HashRegistered(bytes32 indexed hash, address indexed owner, uint value, uint registrationDate);
+    event HashReleased(bytes32 indexed hash, uint value);
+    event HashInvalidated(bytes32 indexed hash, string indexed name, uint value, uint registrationDate);
+
+    function state(bytes32 _hash) external view returns (Mode);
+    function startAuction(bytes32 _hash) external;
+    function startAuctions(bytes32[] calldata _hashes) external;
+    function newBid(bytes32 sealedBid) external payable;
+    function startAuctionsAndBid(bytes32[] calldata hashes, bytes32 sealedBid) external payable;
+    function unsealBid(bytes32 _hash, uint _value, bytes32 _salt) external;
+    function cancelBid(address bidder, bytes32 seal) external;
+    function finalizeAuction(bytes32 _hash) external;
+    function transfer(bytes32 _hash, address payable newOwner) external;
+    function releaseDeed(bytes32 _hash) external;
+    function invalidateName(string calldata unhashedName) external;
+    function eraseNode(bytes32[] calldata labels) external;
+    function transferRegistrars(bytes32 _hash) external;
+    function acceptRegistrarTransfer(bytes32 hash, Deed deed, uint registrationDate) external;
+    function entries(bytes32 _hash) external view returns (Mode, address, uint, uint, uint);
+}

--- a/test/compilationTests/ens/ReverseRegistrar.sol
+++ b/test/compilationTests/ens/ReverseRegistrar.sol
@@ -1,0 +1,125 @@
+pragma solidity >=0.0;
+
+import "./ENS.sol";
+
+/// Solidity: Missing abstract specifier
+abstract contract NameResolver {
+    /// Solidity: Missing virtual specifier
+    function setName(bytes32 node, string memory name) public virtual;
+}
+
+/// Solidity: Missing abstract specifier
+abstract contract ReverseRegistrar {
+    // namehash('addr.reverse')
+    bytes32 public constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+
+    ENS public ens;
+    NameResolver public defaultResolver;
+
+    /**
+     * @dev Constructor
+     * @param ensAddr The address of the ENS registry.
+     * @param resolverAddr The address of the default reverse resolver.
+     */
+    /// Solidity: Abstract contracts cannot have public constructors
+    constructor(ENS ensAddr, NameResolver resolverAddr) {
+        ens = ensAddr;
+        defaultResolver = resolverAddr;
+
+        // Assign ownership of the reverse record to our deployer
+        ReverseRegistrar oldRegistrar = ReverseRegistrar(ens.owner(ADDR_REVERSE_NODE));
+        if (address(oldRegistrar) != address(0x0)) {
+            oldRegistrar.claim(msg.sender);
+        }
+    }
+
+    /**
+     * @dev Transfers ownership of the reverse ENS record associated with the
+     *      calling account.
+     * @param owner The address to set as the owner of the reverse record in ENS.
+     * @return The ENS node hash of the reverse record.
+     */
+    function claim(address owner) public returns (bytes32) {
+        return claimWithResolver(owner, address(0x0));
+    }
+
+    /**
+     * @dev Transfers ownership of the reverse ENS record associated with the
+     *      calling account.
+     * @param owner The address to set as the owner of the reverse record in ENS.
+     * @param resolver The address of the resolver to set; 0 to leave unchanged.
+     * @return The ENS node hash of the reverse record.
+     */
+    function claimWithResolver(address owner, address resolver) public returns (bytes32) {
+        bytes32 label = sha3HexAddress(msg.sender);
+        bytes32 node = keccak256(abi.encodePacked(ADDR_REVERSE_NODE, label));
+        address currentOwner = ens.owner(node);
+
+        // Update the resolver if required
+        if (resolver != address(0x0) && resolver != ens.resolver(node)) {
+            // Transfer the name to us first if it's not already
+            if (currentOwner != address(this)) {
+                ens.setSubnodeOwner(ADDR_REVERSE_NODE, label, address(this));
+                currentOwner = address(this);
+            }
+            ens.setResolver(node, resolver);
+        }
+
+        // Update the owner if required
+        if (currentOwner != owner) {
+            ens.setSubnodeOwner(ADDR_REVERSE_NODE, label, owner);
+        }
+
+        return node;
+    }
+
+    /**
+     * @dev Sets the `name()` record for the reverse ENS record associated with
+     * the calling account. First updates the resolver to the default reverse
+     * resolver if necessary.
+     * @param name The name to set for this address.
+     * @return The ENS node hash of the reverse record.
+     */
+    function setName(string memory name) public returns (bytes32) {
+        bytes32 node = claimWithResolver(address(this), address(defaultResolver));
+        defaultResolver.setName(node, name);
+        return node;
+    }
+
+    /**
+     * @dev Returns the node hash for a given account's reverse records.
+     * @param addr The address to hash
+     * @return The ENS node hash.
+     */
+    function node(address addr) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(ADDR_REVERSE_NODE, sha3HexAddress(addr)));
+    }
+
+    /**
+     * @dev An optimised function to compute the sha3 of the lower-case
+     *      hexadecimal representation of an Ethereum address.
+     * @param addr The address to hash
+     * /// Solidity: Missing return parameter name after return
+     * /// Natspec tag
+     * @return ret The SHA3 hash of the lower-case hexadecimal encoding of the
+     *         input address.
+     */
+    function sha3HexAddress(address addr) private pure returns (bytes32 ret) {
+        addr;
+        ret; // Stop warning us about unused variables
+        assembly {
+            let lookup := 0x3031323334353637383961626364656600000000000000000000000000000000
+
+            for { let i := 40 } gt(i, 0) { } {
+                i := sub(i, 1)
+                mstore8(i, byte(and(addr, 0xf), lookup))
+                addr := div(addr, 0x10)
+                i := sub(i, 1)
+                mstore8(i, byte(and(addr, 0xf), lookup))
+                addr := div(addr, 0x10)
+            }
+
+            ret := keccak256(0, 40)
+        }
+    }
+}


### PR DESCRIPTION
adapted from https://github.com/ensdomains/ens, commit hash
2a6785c3b5fc27269eb3bb18b9d1245d1f01d6c8

Changes done to remove errors
  - Add override specifiers when implicitly overriding an interface function
  - Add virtual specifier when virtualising an overridden interface function
  - Replace `now` by `block.timestamp`
  - Remove `public` specifier from abstract contract constructor
  - Add Natspec return parameter name following a return Natspec tag
  - Make contracts without function implementation abstract and add virtual specifier to unimplemented function(s)