### PR TITLE
Simplify abstraction of Compiler/CompilerContext/CompilerStack

### DIFF
--- a/libsolidity/codegen/Compiler.h
+++ b/libsolidity/codegen/Compiler.h
@@ -51,28 +51,12 @@ public:
 	);
 	/// @returns Entire assembly.
 	evmasm::Assembly const& assembly() const { return m_context.assembly(); }
+	/// @returns Runtime assembly.
+	evmasm::Assembly const& runtimeAssembly() const { return m_context.assembly().sub(m_runtimeSub); }
 	/// @returns Entire assembly as a shared pointer to non-const.
 	std::shared_ptr<evmasm::Assembly> assemblyPtr() const { return m_context.assemblyPtr(); }
-	/// @returns Runtime assembly.
+	/// @returns Runtime assembly as a shared pointer.
 	std::shared_ptr<evmasm::Assembly> runtimeAssemblyPtr() const;
-	/// @returns The entire assembled object (with constructor).
-	evmasm::LinkerObject assembledObject() const { return m_context.assembledObject(); }
-	/// @returns Only the runtime object (without constructor).
-	evmasm::LinkerObject runtimeObject() const { return m_context.assembledRuntimeObject(m_runtimeSub); }
-	/// @arg _sourceCodes is the map of input files to source code strings
-	std::string assemblyString(StringMap const& _sourceCodes = StringMap()) const
-	{
-		return m_context.assemblyString(_sourceCodes);
-	}
-	/// @arg _sourceCodes is the map of input files to source code strings
-	Json::Value assemblyJSON(std::map<std::string, unsigned> const& _indices = std::map<std::string, unsigned>()) const
-	{
-		return m_context.assemblyJSON(_indices);
-	}
-	/// @returns Assembly items of the normal compiler context
-	evmasm::AssemblyItems const& assemblyItems() const { return m_context.assembly().items(); }
-	/// @returns Assembly items of the runtime compiler context
-	evmasm::AssemblyItems const& runtimeAssemblyItems() const { return m_context.assembly().sub(m_runtimeSub).items(); }
 
 	std::string generatedYulUtilityCode() const { return m_context.generatedYulUtilityCode(); }
 	std::string runtimeGeneratedYulUtilityCode() const { return m_runtimeContext.generatedYulUtilityCode(); }

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -548,13 +548,6 @@ void CompilerContext::optimizeYul(yul::Object& _object, yul::EVMDialect const& _
 #endif
 }
 
-LinkerObject const& CompilerContext::assembledObject() const
-{
-	LinkerObject const& object = m_asm->assemble();
-	solAssert(object.immutableReferences.empty(), "Leftover immutables.");
-	return object;
-}
-
 string CompilerContext::revertReasonIfDebug(string const& _message)
 {
 	return YulUtilFunctions::revertReasonIfDebug(m_revertStrings, _message);

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -287,21 +287,6 @@ public:
 	/// Should be avoided except when adding sub-assemblies.
 	std::shared_ptr<evmasm::Assembly> assemblyPtr() const { return m_asm; }
 
-	/// @arg _sourceCodes is the map of input files to source code strings
-	std::string assemblyString(StringMap const& _sourceCodes = StringMap()) const
-	{
-		return m_asm->assemblyString(_sourceCodes);
-	}
-
-	/// @arg _sourceCodes is the map of input files to source code strings
-	Json::Value assemblyJSON(std::map<std::string, unsigned> const& _indicies = std::map<std::string, unsigned>()) const
-	{
-		return m_asm->assemblyJSON(_indicies);
-	}
-
-	evmasm::LinkerObject const& assembledObject() const;
-	evmasm::LinkerObject const& assembledRuntimeObject(size_t _subIndex) const { return m_asm->sub(_subIndex).assemble(); }
-
 	/**
 	 * Helper class to pop the visited nodes stack when a scope closes
 	 */

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -358,6 +358,8 @@ private:
 	{
 		ContractDefinition const* contract = nullptr;
 		std::shared_ptr<Compiler> compiler;
+		std::shared_ptr<evmasm::Assembly> evmAssembly;
+		std::shared_ptr<evmasm::Assembly> evmRuntimeAssembly;
 		evmasm::LinkerObject object; ///< Deployment object (includes the runtime sub-object).
 		evmasm::LinkerObject runtimeObject; ///< Runtime object.
 		std::string yulIR; ///< Experimental Yul IR code.

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -91,7 +91,7 @@ evmasm::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 			);
 			compiler.compileContract(*contract, map<ContractDefinition const*, shared_ptr<Compiler const>>{}, bytes());
 
-			return compiler.runtimeAssemblyItems();
+			return compiler.runtimeAssembly().items();
 		}
 	BOOST_FAIL("No contract found in source.");
 	return AssemblyItems();

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -35,6 +35,7 @@
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/analysis/TypeChecker.h>
 #include <liblangutil/ErrorReporter.h>
+#include <libevmasm/LinkerObject.h>
 #include <test/Common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -160,7 +161,10 @@ bytes compileFirstExpression(
 				context << context.functionEntryLabel(dynamic_cast<FunctionDefinition const&>(
 					resolveDeclaration(*sourceUnit, function, resolver)
 				));
-			bytes instructions = context.assembledObject().bytecode;
+			BOOST_REQUIRE(context.assemblyPtr());
+			LinkerObject const& object = context.assemblyPtr()->assemble();
+			BOOST_REQUIRE(object.immutableReferences.empty());
+			bytes instructions = object.bytecode;
 			// debug
 			// cout << evmasm::disassemble(instructions) << endl;
 			return instructions;


### PR DESCRIPTION
Part of #10152.

Basically the motivation here was that if `AssemblyStack.assemble` can return the underlying evmasm object for the EVM case, then we can store the `evmAssembly` and `runtimeEvmAssembly` fields (just like the old codegen does in this PR) and all outputs using them will work.

Not sure we want to do that though, however some of the earlier commits in this PR are still useful to reduce indirection between `Compiler.h` and `CompilerContext.h`.

Let me know.