### PR TITLE
[SMTChecker] Small refactoring of assignments to provide a common low-level point for model checking engines to hook into.

### DIFF
--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -194,6 +194,10 @@ protected:
 		IntegerType const& _type
 	);
 
+	/// Handles the actual assertion of the new value to the encoding context.
+	/// Other assignment methods should use this one in the end.
+	void assignment(smt::SymbolicVariable& _symVar, smtutil::Expression const& _value);
+
 	void assignment(VariableDeclaration const& _variable, Expression const& _value);
 	/// Handles assignments to variables of different types.
 	void assignment(VariableDeclaration const& _variable, smtutil::Expression const& _value);


### PR DESCRIPTION
The goal of this PR is to provide a single point in the `SMTEncoder` that handles assigning a new value to a symbolic variable/expression. Such single point can be used by the model checking engines to hook into if they need to customize the behaviour. The plan is to use this in BMC engine to make the assignment conditional based on the path condition.