### PR TITLE
Disable SMT checker instead of stripping SMT pragmas in bytecode comparison

### DIFF
--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -8,13 +8,10 @@ import json
 SOLC_BIN = sys.argv[1]
 REPORT_FILE = open("report.txt", mode="w", encoding='utf8', newline='\n')
 
-def removeSMT(source):
-    return source.replace('pragma experimental SMTChecker;', '')
-
 for optimize in [False, True]:
     for f in sorted(glob.glob("*.sol")):
         sources = {}
-        sources[f] = {'content': removeSMT(open(f, mode='r', encoding='utf8').read())}
+        sources[f] = {'content': open(f, mode='r', encoding='utf8').read()}
         input_json = {
             'language': 'Solidity',
             'sources': sources,
@@ -23,6 +20,9 @@ for optimize in [False, True]:
                     'enabled': optimize
                 },
                 'outputSelection': {'*': {'*': ['evm.bytecode.object', 'metadata']}}
+            },
+            'modelCheckerSettings': {
+                "engine": 'none'
             }
         }
         args = [SOLC_BIN, '--standard-json']

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -57,11 +57,6 @@ var fs = require('fs')
 
 var compiler = require('./solc-js/wrapper.js')(require('./solc-js/soljson.js'))
 
-function removeSMT(source)
-{
-    return source.replace('pragma experimental SMTChecker;', '');
-}
-
 for (var optimize of [false, true])
 {
     for (var filename of process.argv.slice(2))
@@ -69,13 +64,16 @@ for (var optimize of [false, true])
         if (filename !== undefined)
         {
             var inputs = {}
-            inputs[filename] = { content: removeSMT(fs.readFileSync(filename).toString()) }
+            inputs[filename] = { content: fs.readFileSync(filename).toString() }
             var input = {
                 language: 'Solidity',
                 sources: inputs,
                 settings: {
                     optimizer: { enabled: optimize },
                     outputSelection: { '*': { '*': ['evm.bytecode.object', 'metadata'] } }
+                },
+                "modelCheckerSettings": {
+                    "engine": "none"
                 }
             }
             var result = JSON.parse(compiler.compile(JSON.stringify(input)))


### PR DESCRIPTION
#10036 added an option to disable SMT checker. I think we should use it in bytecode comparison instead of stripping the pragmas.

I tried to compare the reports before and after but there tons of differences due to file hashes being different with and without pragmas. So to get some confidence that this does not break anything, I ran it with SMT enabled. There were just a few differences and all of them were due to the compilation working without SMT:
```
test_e14a359d47b37a3adaf08fcee4596170b185aa9291f527565d0833b7464789bd_named_arguments_overload_in_any_order_sol.sol:C 608060405234801561001057600080fd5b5061018d806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c806328b5e32b14610030575b600080fd5b61003861003a565b005b61006260016040518060400160405280600381526020016261626360e81b815250600161012c565b61008a60016040518060400160405280600381526020016261626360e81b815250600161012c565b6100b260016040518060400160405280600381526020016261626360e81b815250600161012c565b6100da60016040518060400160405280600381526020016261626360e81b815250600161012c565b61010260016040518060400160405280600381526020016261626360e81b815250600161012c565b61012a60016040518060400160405280600381526020016261626360e81b815250600161012c565b565b50505056fea2646970667358221220a5e8f6bed7bfe35a233c455af36d045dbc05cdc74ab3799d14ed9dd4c3ddc8bb64736f6c637828302e372e362d646576656c6f702e323032302e31312e32302b636f6d6d69742e63386634363635330059
test_e14a359d47b37a3adaf08fcee4596170b185aa9291f527565d0833b7464789bd_named_arguments_overload_in_any_order_sol.sol:C {"compiler":{"version":"0.7.6-develop.2020.11.20+commit.c8f46653"},"language":"Solidity","output":{"abi":[{"inputs":[],"name":"call","outputs":[],"stateMutability":"nonpayable","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"test_e14a359d47b37a3adaf08fcee4596170b185aa9291f527565d0833b7464789bd_named_arguments_overload_in_any_order_sol.sol":"C"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":true,"runs":200},"remappings":[]},"sources":{"test_e14a359d47b37a3adaf08fcee4596170b185aa9291f527565d0833b7464789bd_named_arguments_overload_in_any_order_sol.sol":{"keccak256":"0xc1290951d471b27163ce45e7e8ec7dbe23cd375a36e53ab622612d051d9f8b97","urls":["bzz-raw://0c92435dec6b2f2e0e1aef0f7a1a4275f6dbd943e01c5bbf1194cceabe2c1d4b","dweb:/ipfs/QmcS5j3Hq1vNXu3bF3BDw9TRivEhzJBfEnuYHqqusW7D8m"]}},"version":1}
```
and failing with SMT:
```
test_e14a359d47b37a3adaf08fcee4596170b185aa9291f527565d0833b7464789bd_named_arguments_overload_in_any_order_sol.sol: ERROR
```

There are actually only 3 files where SMT checker makes the compilation fail:
- `function_call_named_arguments.sol`
- `named_arguments_in_any_order.sol`
- `named_arguments_overload_in_any_order.sol`

Also the report with pragmas stripped has exactly same size as one with SMT disabled which indicates that it's unlikely that one has a different number of errors than the other.