### PR TITLE
[SMTChecker] Do not report warning when encountered a Type identifier.

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -857,11 +857,8 @@ void SMTEncoder::endVisit(Identifier const& _identifier)
 		defineExpr(_identifier, m_context.state().thisAddress());
 		m_uninterpretedTerms.insert(&_identifier);
 	}
-	// Ignore struct type identifiers in struct constructor calls
-	else if (
-		auto typetype = dynamic_cast<TypeType const*>(_identifier.annotation().type);
-		typetype && typetype->actualType()->category() == Type::Category::Struct
-	)
+	// Ignore type identifiers
+	else if (dynamic_cast<TypeType const*>(_identifier.annotation().type))
 		return;
 	// Ignore the builtin abi, it is handled in FunctionCall.
 	// TODO: ignore MagicType in general (abi, block, msg, tx, type)

--- a/test/libsolidity/smtCheckerTests/functions/functions_library_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_library_1.sol
@@ -17,5 +17,3 @@ contract C
 	}
 }
 // ----
-// Warning 8364: (228-229): Assertion checker does not yet implement type type(library L)
-// Warning 8364: (228-229): Assertion checker does not yet implement type type(library L)

--- a/test/libsolidity/smtCheckerTests/functions/functions_library_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_library_1_fail.sol
@@ -17,6 +17,4 @@ contract C
 	}
 }
 // ----
-// Warning 8364: (228-229): Assertion checker does not yet implement type type(library L)
 // Warning 6328: (245-261): CHC: Assertion violation happens here.
-// Warning 8364: (228-229): Assertion checker does not yet implement type type(library L)

--- a/test/libsolidity/smtCheckerTests/functions/library_after_contract.sol
+++ b/test/libsolidity/smtCheckerTests/functions/library_after_contract.sol
@@ -15,5 +15,3 @@ library L {
 
 // ----
 // Warning 2018: (131-190): Function state mutability can be restricted to pure
-// Warning 8364: (86-87): Assertion checker does not yet implement type type(library L)
-// Warning 8364: (86-87): Assertion checker does not yet implement type type(library L)

--- a/test/libsolidity/smtCheckerTests/functions/library_constant.sol
+++ b/test/libsolidity/smtCheckerTests/functions/library_constant.sol
@@ -19,8 +19,6 @@ contract C {
 	}
 }
 // ----
-// Warning 8364: (300-302): Assertion checker does not yet implement type type(library l1)
 // Warning 6328: (136-155): CHC: Assertion violation happens here.
 // Warning 4984: (229-234): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 4984: (327-332): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
-// Warning 8364: (300-302): Assertion checker does not yet implement type type(library l1)

--- a/test/libsolidity/smtCheckerTests/imports/import_library.sol
+++ b/test/libsolidity/smtCheckerTests/imports/import_library.sol
@@ -15,6 +15,4 @@ library L {
 	}
 }
 // ----
-// Warning 8364: (c:104-105): Assertion checker does not yet implement type type(library L)
 // Warning 6328: (c:113-126): CHC: Assertion violation happens here.
-// Warning 8364: (c:104-105): Assertion checker does not yet implement type type(library L)

--- a/test/libsolidity/smtCheckerTests/operators/function_call_named_arguments.sol
+++ b/test/libsolidity/smtCheckerTests/operators/function_call_named_arguments.sol
@@ -29,6 +29,4 @@ contract C {
 	}
 }
 // ----
-// Warning 8364: (360-361): Assertion checker does not yet implement type type(library L)
 // Warning 6328: (507-521): CHC: Assertion violation happens here.
-// Warning 8364: (360-361): Assertion checker does not yet implement type type(library L)

--- a/test/libsolidity/smtCheckerTests/typecast/enum_from_uint.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/enum_from_uint.sol
@@ -10,5 +10,3 @@ contract C
 	}
 }
 // ----
-// Warning 8364: (132-133): Assertion checker does not yet implement type type(enum C.D)
-// Warning 8364: (132-133): Assertion checker does not yet implement type type(enum C.D)

--- a/test/libsolidity/smtCheckerTests/typecast/same_size.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/same_size.sol
@@ -71,5 +71,3 @@ contract C {
 	}
 }
 // ----
-// Warning 8364: (1304-1305): Assertion checker does not yet implement type type(enum E)
-// Warning 8364: (1304-1305): Assertion checker does not yet implement type type(enum E)

--- a/test/libsolidity/smtCheckerTests/typecast/upcast.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/upcast.sol
@@ -67,5 +67,3 @@ contract C {
 	}
 }
 // ----
-// Warning 8364: (1144-1145): Assertion checker does not yet implement type type(contract D)
-// Warning 8364: (1144-1145): Assertion checker does not yet implement type type(contract D)


### PR DESCRIPTION
Continuing the discussion from #10360, it seems there is no reasoning for SMTChecker to issue a warning when it encounters `Type` identifiers like name of a contract, library or enum. The operations where these identifiers occur are supported by SMTChecker now.

Fixes https://github.com/ethereum/solidity/issues/10141