### PR TITLE
Whitelist 'ether' in the spellchecker

### DIFF
--- a/scripts/codespell_whitelist.txt
+++ b/scripts/codespell_whitelist.txt
@@ -12,3 +12,4 @@ errorstring
 hist
 otion
 keypair
+ether


### PR DESCRIPTION
The spellchecker suddenly started to want to replace it with 'either`.