### PR TITLE
External tests: Add ENS contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,7 +829,7 @@ jobs:
           name: External GnosisSafe compilation
           command: |
             export COMPILE_ONLY=1
-            test/externalTests/gnosis.sh /tmp/workspace/soljson.js || test/externalTests/gnosis.sh /tmp/workspace/soljson.js
+            test/externalTests/gnosis.sh /tmp/workspace/soljson.js
 
   t_ems_test_ext_gnosis:
     docker:
@@ -860,7 +860,7 @@ jobs:
           name: External Zeppelin compilation
           command: |
             export COMPILE_ONLY=1
-            test/externalTests/zeppelin.sh /tmp/workspace/soljson.js || test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
+            test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
 
   t_ems_test_ext_zeppelin:
     docker:
@@ -895,7 +895,7 @@ jobs:
           name: External ColonyNetworks compilation
           command: |
             export COMPILE_ONLY=1
-            test/externalTests/colony.sh /tmp/workspace/soljson.js || test/externalTests/colony.sh /tmp/workspace/soljson.js
+            test/externalTests/colony.sh /tmp/workspace/soljson.js
 
   t_ems_test_ext_colony:
     docker:
@@ -916,6 +916,25 @@ jobs:
             test/externalTests/colony.sh /tmp/workspace/soljson.js || test/externalTests/colony.sh /tmp/workspace/soljson.js
       - run: *gitter_notify_failure
       - run: *gitter_notify_success
+
+  t_ems_compile_ext_ens:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Install test dependencies
+          command: |
+            sudo apt-get -qy install lsof
+      - run:
+          name: External Ens compilation
+          command: |
+            export COMPILE_ONLY=1
+            test/externalTests/ens.sh /tmp/workspace/soljson.js
 
   b_win: &b_win
     executor:
@@ -1101,6 +1120,7 @@ workflows:
       - t_ems_compile_ext_colony: *workflow_emscripten
       - t_ems_compile_ext_gnosis: *workflow_emscripten
       - t_ems_compile_ext_zeppelin: *workflow_emscripten
+      - t_ems_compile_ext_ens: *workflow_emscripten
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-#------------------------------------------------------------------------------
-# Bash script to run external Solidity tests.
-#
-# Argument: Path to soljson.js to test.
-#
-# Requires npm, networking access and git to download the tests.
-#
 # ------------------------------------------------------------------------------
 # This file is part of solidity.
 #
@@ -23,29 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with solidity.  If not, see <http://www.gnu.org/licenses/>
 #
-# (c) 2016 solidity contributors.
+# (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
-
-set -e
-
-if [ ! -f "$1" ]
-then
-  echo "Usage: $0 <path to soljson.js>"
-  exit 1
-fi
-
-SOLJSON="$1"
-REPO_ROOT="$(dirname "$0")"
-
+# shellcheck disable=SC1091
 source scripts/common.sh
+# shellcheck disable=SC1091
 source test/externalTests/common.sh
 
-printTask "Running external tests..."
+verify_input "$1"
+export SOLJSON="$1"
 
-$REPO_ROOT/externalTests/zeppelin.sh "$SOLJSON"
-$REPO_ROOT/externalTests/gnosis.sh "$SOLJSON"
-$REPO_ROOT/externalTests/colony.sh "$SOLJSON"
-$REPO_ROOT/externalTests/ens.sh "$SOLJSON"
+function install_fn { npm install; }
+function compile_fn { npx truffle compile; }
+function test_fn { npm run test; }
 
-# Disabled temporarily as it needs to be updated to latest Truffle first.
-#test_truffle Gnosis https://github.com/axic/pm-contracts.git solidity-050
+function ens_test
+{
+    export OPTIMIZER_LEVEL=1
+    export CONFIG="truffle-config.js"
+
+    truffle_setup https://github.com/solidity-external-tests/ens.git upgrade-0.8.0
+    run_install install_fn
+
+    truffle_run_test compile_fn test_fn
+}
+
+external_test Ens ens_test


### PR DESCRIPTION
As part of extending work for https://github.com/ethereum/solidity/issues/10328, this PR adds ENS contracts as an external test