### PR TITLE
Rename AsmData* to AST*

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <libsolidity/analysis/ControlFlowBuilder.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
 using namespace solidity;

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -27,7 +27,7 @@
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <liblangutil/ErrorReporter.h>

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -23,7 +23,7 @@
 #include <libsolidity/interface/Version.h>
 
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/SemVerHandler.h>

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -28,7 +28,7 @@
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <liblangutil/ErrorReporter.h>
 

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -18,7 +18,7 @@
 
 #include <libsolidity/analysis/ViewPureChecker.h>
 #include <libsolidity/ast/ExperimentalFeatures.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <liblangutil/ErrorReporter.h>
 #include <libevmasm/SemanticInformation.h>

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -45,7 +45,7 @@
 
 namespace solidity::yul
 {
-// Forward-declaration to <yul/AsmData.h>
+// Forward-declaration to <yul/AST.h>
 struct Block;
 struct Dialect;
 }

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -26,8 +26,8 @@
 #include <libsolidity/ast/TypeProvider.h>
 
 #include <libyul/AsmJsonConverter.h>
-#include <libyul/AsmData.h>
 #include <libyul/AsmPrinter.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <libsolutil/JSON.h>

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -25,6 +25,7 @@
 
 #include <libyul/AsmJsonImporter.h>
 #include <libyul/AsmParser.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/backends/evm/EVMDialect.h>
 

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -32,6 +32,7 @@
 #include <libyul/AsmPrinter.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/AsmCodeGen.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/backends/evm/EVMMetrics.h>

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -31,7 +31,7 @@
 
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/AsmAnalysis.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/AsmCodeGen.h>
 #include <libyul/backends/evm/EVMMetrics.h>
 #include <libyul/backends/evm/EVMDialect.h>

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -35,7 +35,7 @@
 #include <libevmasm/GasMeter.h>
 
 #include <libyul/AsmPrinter.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/optimiser/ASTCopier.h>
 

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -60,6 +60,7 @@
 #include <libyul/AsmJsonConverter.h>
 #include <libyul/AssemblyStack.h>
 #include <libyul/AsmParser.h>
+#include <libyul/AST.h>
 
 #include <liblangutil/Scanner.h>
 #include <liblangutil/SemVerHandler.h>

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -25,6 +25,7 @@
 
 #include <libsolidity/interface/Version.h>
 #include <libyul/AsmParser.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Scanner.h>

--- a/libyul/AST.h
+++ b/libyul/AST.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
 
 #include <liblangutil/SourceLocation.h>

--- a/libyul/ASTForward.h
+++ b/libyul/ASTForward.h
@@ -28,6 +28,7 @@
 namespace solidity::yul
 {
 
+enum class LiteralKind;
 struct Literal;
 struct Label;
 struct Identifier;

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/AsmAnalysis.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/AsmScopeFiller.h>
 #include <libyul/AsmScope.h>
 #include <libyul/AsmAnalysisInfo.h>
@@ -667,4 +667,9 @@ bool AsmAnalyzer::validateInstructions(evmasm::Instruction _instr, SourceLocatio
 		return false;
 
 	return true;
+}
+
+bool AsmAnalyzer::validateInstructions(FunctionCall const& _functionCall)
+{
+	return validateInstructions(_functionCall.functionName.name.str(), _functionCall.functionName.location);
 }

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -26,7 +26,7 @@
 
 #include <libyul/Dialect.h>
 #include <libyul/AsmScope.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/backends/evm/AbstractAssembly.h>
 #include <libyul/backends/evm/EVMDialect.h>
@@ -114,10 +114,7 @@ private:
 
 	bool validateInstructions(evmasm::Instruction _instr, langutil::SourceLocation const& _location);
 	bool validateInstructions(std::string const& _instrIdentifier, langutil::SourceLocation const& _location);
-	bool validateInstructions(FunctionCall const& _functionCall)
-	{
-		return validateInstructions(_functionCall.functionName.name.str(), _functionCall.functionName.location);
-	}
+	bool validateInstructions(FunctionCall const& _functionCall);
 
 	yul::ExternalIdentifierAccess::Resolver m_resolver;
 	Scope* m_currentScope = nullptr;

--- a/libyul/AsmAnalysisInfo.h
+++ b/libyul/AsmAnalysisInfo.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <map>
 #include <memory>

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <libyul/AsmJsonConverter.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 #include <libsolutil/CommonData.h>
 

--- a/libyul/AsmJsonConverter.h
+++ b/libyul/AsmJsonConverter.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <liblangutil/SourceLocation.h>
 #include <json/json.h>
 #include <boost/variant.hpp>

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -23,8 +23,7 @@
  */
 
 #include <libyul/AsmJsonImporter.h>
-#include <libyul/AsmData.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 
 #include <liblangutil/Scanner.h>

--- a/libyul/AsmJsonImporter.h
+++ b/libyul/AsmJsonImporter.h
@@ -25,7 +25,7 @@
 
 #include <json/json.h>
 #include <liblangutil/SourceLocation.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <utility>
 

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <libyul/AsmParser.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 #include <liblangutil/Scanner.h>
 #include <liblangutil/ErrorReporter.h>

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <libyul/AsmData.h>
+#include <libyul/ASTForward.h>
 #include <libyul/Dialect.h>
 
 #include <liblangutil/SourceLocation.h>

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <libyul/AsmPrinter.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Dialect.h>
 

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/YulString.h>
 

--- a/libyul/AsmScopeFiller.cpp
+++ b/libyul/AsmScopeFiller.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/AsmScopeFiller.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/AsmScope.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/Exceptions.h>

--- a/libyul/AsmScopeFiller.h
+++ b/libyul/AsmScopeFiller.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <functional>
 #include <memory>

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -2,8 +2,8 @@ add_library(yul
 	AsmAnalysis.cpp
 	AsmAnalysis.h
 	AsmAnalysisInfo.h
-	AsmData.h
-	AsmDataForward.h
+	AST.h
+	ASTForward.h
 	AsmJsonConverter.h
 	AsmJsonConverter.cpp
 	AsmJsonImporter.h

--- a/libyul/CompilabilityChecker.h
+++ b/libyul/CompilabilityChecker.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <libyul/Dialect.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/Object.h>
 
 #include <map>

--- a/libyul/Dialect.cpp
+++ b/libyul/Dialect.cpp
@@ -20,7 +20,7 @@
  */
 
 #include <libyul/Dialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace solidity::yul;
 using namespace std;

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
 
 #include <libsolutil/Common.h>

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -22,6 +22,7 @@
 #include <libyul/ObjectParser.h>
 
 #include <libyul/AsmParser.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 
 #include <liblangutil/Token.h>

--- a/libyul/Utilities.cpp
+++ b/libyul/Utilities.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/Utilities.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 
 #include <libsolutil/CommonData.h>

--- a/libyul/Utilities.h
+++ b/libyul/Utilities.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <libsolutil/Common.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 namespace solidity::yul
 {

--- a/libyul/backends/evm/AsmCodeGen.cpp
+++ b/libyul/backends/evm/AsmCodeGen.cpp
@@ -21,8 +21,8 @@
 
 #include <libyul/backends/evm/AsmCodeGen.h>
 
-#include <libyul/AsmData.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AST.h>
 
 #include <libyul/backends/evm/AbstractAssembly.h>
 #include <libyul/backends/evm/EVMCodeTransform.h>

--- a/libyul/backends/evm/ConstantOptimiser.cpp
+++ b/libyul/backends/evm/ConstantOptimiser.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/backends/evm/EVMMetrics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 
 #include <libsolutil/CommonData.h>

--- a/libyul/backends/evm/ConstantOptimiser.h
+++ b/libyul/backends/evm/ConstantOptimiser.h
@@ -25,7 +25,7 @@
 #include <libyul/YulString.h>
 #include <libyul/Dialect.h>
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/ASTForward.h>
 
 #include <liblangutil/SourceLocation.h>
 

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 
 #include <liblangutil/Exceptions.h>

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -25,7 +25,7 @@
 
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/ASTWalker.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/AsmScope.h>
 
 #include <optional>

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -22,7 +22,7 @@
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Object.h>
 #include <libyul/Exceptions.h>
 #include <libyul/AsmParser.h>

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -24,7 +24,7 @@
 #include <libyul/Dialect.h>
 
 #include <libyul/backends/evm/AbstractAssembly.h>
-#include <libyul/AsmData.h>
+#include <libyul/ASTForward.h>
 #include <liblangutil/EVMVersion.h>
 
 #include <map>

--- a/libyul/backends/evm/EVMMetrics.cpp
+++ b/libyul/backends/evm/EVMMetrics.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/backends/evm/EVMMetrics.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Utilities.h>
 #include <libyul/backends/evm/EVMDialect.h>

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -21,6 +21,7 @@
 
 #include <libyul/backends/evm/NoOutputAssembly.h>
 
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 
 #include <libevmasm/Instruction.h>

--- a/libyul/backends/wasm/EVMToEwasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEwasmTranslator.cpp
@@ -35,6 +35,7 @@
 #include <libyul/AsmParser.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AST.h>
 #include <libyul/Object.h>
 
 #include <liblangutil/ErrorReporter.h>

--- a/libyul/backends/wasm/EVMToEwasmTranslator.h
+++ b/libyul/backends/wasm/EVMToEwasmTranslator.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/Dialect.h>
 

--- a/libyul/backends/wasm/WasmCodeTransform.cpp
+++ b/libyul/backends/wasm/WasmCodeTransform.cpp
@@ -25,7 +25,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/Utilities.h>
 #include <libyul/Exceptions.h>

--- a/libyul/backends/wasm/WasmCodeTransform.h
+++ b/libyul/backends/wasm/WasmCodeTransform.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <libyul/backends/wasm/WasmAST.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/Dialect.h>
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/optimiser/TypeInfo.h>

--- a/libyul/backends/wasm/WasmDialect.cpp
+++ b/libyul/backends/wasm/WasmDialect.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/backends/wasm/WasmDialect.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 
 using namespace std;

--- a/libyul/backends/wasm/WordSizeTransform.cpp
+++ b/libyul/backends/wasm/WordSizeTransform.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/backends/wasm/WordSizeTransform.h>
 #include <libyul/Utilities.h>
 #include <libyul/Dialect.h>

--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/Exceptions.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/Common.h>
 

--- a/libyul/optimiser/ASTCopier.h
+++ b/libyul/optimiser/ASTCopier.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/YulString.h>
 

--- a/libyul/optimiser/ASTWalker.cpp
+++ b/libyul/optimiser/ASTWalker.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <boost/range/adaptor/reversed.hpp>
 

--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/Exceptions.h>
 #include <libyul/YulString.h>

--- a/libyul/optimiser/BlockFlattener.cpp
+++ b/libyul/optimiser/BlockFlattener.cpp
@@ -15,10 +15,13 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 // SPDX-License-Identifier: GPL-3.0
+
 #include <libyul/optimiser/BlockFlattener.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
+
 #include <libsolutil/Visitor.h>
 #include <libsolutil/CommonData.h>
+
 #include <functional>
 
 using namespace std;

--- a/libyul/optimiser/BlockHasher.cpp
+++ b/libyul/optimiser/BlockHasher.cpp
@@ -21,7 +21,9 @@
 
 #include <libyul/optimiser/BlockHasher.h>
 #include <libyul/optimiser/SyntacticalEquality.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
+
 #include <libsolutil/CommonData.h>
 
 using namespace std;

--- a/libyul/optimiser/BlockHasher.h
+++ b/libyul/optimiser/BlockHasher.h
@@ -21,9 +21,8 @@
 #pragma once
 
 #include <libyul/optimiser/ASTWalker.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
-#include <libyul/AsmData.h>
 
 namespace solidity::yul
 {

--- a/libyul/optimiser/CallGraphGenerator.cpp
+++ b/libyul/optimiser/CallGraphGenerator.cpp
@@ -19,7 +19,7 @@
  * Specific AST walker that generates the call graph.
  */
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/optimiser/CallGraphGenerator.h>
 
 #include <stack>

--- a/libyul/optimiser/CircularReferencesPruner.cpp
+++ b/libyul/optimiser/CircularReferencesPruner.cpp
@@ -19,7 +19,7 @@
 
 #include <libyul/optimiser/CallGraphGenerator.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/Algorithms.h>
 

--- a/libyul/optimiser/CommonSubexpressionEliminator.cpp
+++ b/libyul/optimiser/CommonSubexpressionEliminator.cpp
@@ -27,7 +27,7 @@
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/SideEffects.h>
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 
 using namespace std;

--- a/libyul/optimiser/ConditionalSimplifier.cpp
+++ b/libyul/optimiser/ConditionalSimplifier.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 #include <libyul/optimiser/ConditionalSimplifier.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 #include <libyul/optimiser/NameCollector.h>
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/ConditionalSimplifier.h
+++ b/libyul/optimiser/ConditionalSimplifier.h
@@ -19,6 +19,7 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/OptimiserStep.h>
+#include <libyul/ASTForward.h>
 #include <libyul/Dialect.h>
 #include <libsolutil/Common.h>
 

--- a/libyul/optimiser/ConditionalUnsimplifier.cpp
+++ b/libyul/optimiser/ConditionalUnsimplifier.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 #include <libyul/optimiser/ConditionalUnsimplifier.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 #include <libyul/optimiser/NameCollector.h>
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/ControlFlowSimplifier.cpp
+++ b/libyul/optimiser/ControlFlowSimplifier.cpp
@@ -19,7 +19,7 @@
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/OptimiserStep.h>
 #include <libyul/optimiser/TypeInfo.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 #include <libyul/Dialect.h>
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -24,8 +24,8 @@
 
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/Semantics.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <libsolutil/CommonData.h>
@@ -38,7 +38,6 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::yul;
-
 
 void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 {

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -26,7 +26,7 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/KnowledgeBase.h>
 #include <libyul/YulString.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h> // Needed for m_zero below.
 #include <libyul/SideEffects.h>
 
 // TODO avoid

--- a/libyul/optimiser/DeadCodeEliminator.cpp
+++ b/libyul/optimiser/DeadCodeEliminator.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/DeadCodeEliminator.h>
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/OptimiserStep.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libevmasm/SemanticInformation.h>
 #include <libevmasm/AssemblyItem.h>

--- a/libyul/optimiser/Disambiguator.cpp
+++ b/libyul/optimiser/Disambiguator.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/Disambiguator.h>
 
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/AsmScope.h>
 #include <libyul/Dialect.h>
 

--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/optimiser/NameDispenser.h>

--- a/libyul/optimiser/EquivalentFunctionCombiner.cpp
+++ b/libyul/optimiser/EquivalentFunctionCombiner.cpp
@@ -20,7 +20,7 @@
  */
 
 #include <libyul/optimiser/EquivalentFunctionCombiner.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libsolutil/CommonData.h>
 
 using namespace std;

--- a/libyul/optimiser/EquivalentFunctionCombiner.h
+++ b/libyul/optimiser/EquivalentFunctionCombiner.h
@@ -23,7 +23,7 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/EquivalentFunctionDetector.h>
 #include <libyul/optimiser/OptimiserStep.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 namespace solidity::yul
 {

--- a/libyul/optimiser/EquivalentFunctionDetector.cpp
+++ b/libyul/optimiser/EquivalentFunctionDetector.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/EquivalentFunctionDetector.h>
 #include <libyul/optimiser/SyntacticalEquality.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/optimiser/Metrics.h>
 
 using namespace std;

--- a/libyul/optimiser/EquivalentFunctionDetector.h
+++ b/libyul/optimiser/EquivalentFunctionDetector.h
@@ -22,7 +22,7 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/BlockHasher.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 namespace solidity::yul
 {

--- a/libyul/optimiser/ExpressionInliner.cpp
+++ b/libyul/optimiser/ExpressionInliner.cpp
@@ -28,7 +28,7 @@
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/OptimiserStep.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/ExpressionInliner.h
+++ b/libyul/optimiser/ExpressionInliner.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <libyul/optimiser/ASTWalker.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <optional>
 #include <set>

--- a/libyul/optimiser/ExpressionJoiner.cpp
+++ b/libyul/optimiser/ExpressionJoiner.cpp
@@ -25,7 +25,7 @@
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/libyul/optimiser/ExpressionJoiner.h
+++ b/libyul/optimiser/ExpressionJoiner.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 
 #include <map>
@@ -31,7 +31,6 @@ namespace solidity::yul
 
 class NameCollector;
 struct OptimiserStepContext;
-
 
 /**
  * Optimiser component that modifies an AST in place, turning sequences

--- a/libyul/optimiser/ExpressionSimplifier.cpp
+++ b/libyul/optimiser/ExpressionSimplifier.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/optimiser/SimplificationRules.h>
 #include <libyul/optimiser/OptimiserStep.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/ExpressionSimplifier.h
+++ b/libyul/optimiser/ExpressionSimplifier.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/optimiser/DataFlowAnalyzer.h>
 

--- a/libyul/optimiser/ExpressionSplitter.cpp
+++ b/libyul/optimiser/ExpressionSplitter.cpp
@@ -26,7 +26,7 @@
 #include <libyul/optimiser/OptimiserStep.h>
 #include <libyul/optimiser/TypeInfo.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/ExpressionSplitter.h
+++ b/libyul/optimiser/ExpressionSplitter.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/NameDispenser.h>

--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -18,7 +18,8 @@
 
 #include <libyul/optimiser/ForLoopConditionIntoBody.h>
 #include <libyul/optimiser/OptimiserStep.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
+
 #include <libsolutil/CommonData.h>
 
 using namespace std;

--- a/libyul/optimiser/ForLoopConditionOutOfBody.cpp
+++ b/libyul/optimiser/ForLoopConditionOutOfBody.cpp
@@ -18,8 +18,9 @@
 
 #include <libyul/optimiser/ForLoopConditionOutOfBody.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
+
 #include <libsolutil/CommonData.h>
 
 using namespace std;

--- a/libyul/optimiser/ForLoopInitRewriter.cpp
+++ b/libyul/optimiser/ForLoopInitRewriter.cpp
@@ -16,8 +16,10 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 #include <libyul/optimiser/ForLoopInitRewriter.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
+
 #include <libsolutil/CommonData.h>
+
 #include <functional>
 
 using namespace std;

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -30,7 +30,7 @@
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/CallGraphGenerator.h>
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/FullInliner.h
+++ b/libyul/optimiser/FullInliner.h
@@ -20,7 +20,7 @@
  */
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/optimiser/ASTWalker.h>

--- a/libyul/optimiser/FunctionCallFinder.cpp
+++ b/libyul/optimiser/FunctionCallFinder.cpp
@@ -16,7 +16,7 @@
 */
 
 #include <libyul/optimiser/FunctionCallFinder.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/FunctionGrouper.cpp
+++ b/libyul/optimiser/FunctionGrouper.cpp
@@ -22,7 +22,7 @@
 
 #include <libyul/optimiser/FunctionGrouper.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <boost/range/algorithm_ext/erase.hpp>
 

--- a/libyul/optimiser/FunctionGrouper.h
+++ b/libyul/optimiser/FunctionGrouper.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 namespace solidity::yul
 {

--- a/libyul/optimiser/FunctionHoister.cpp
+++ b/libyul/optimiser/FunctionHoister.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/optimiser/FunctionHoister.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/libyul/optimiser/FunctionHoister.h
+++ b/libyul/optimiser/FunctionHoister.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 
 namespace solidity::yul

--- a/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
+++ b/libyul/optimiser/InlinableExpressionFunctionFinder.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/InlinableExpressionFunctionFinder.h>
 
 #include <libyul/optimiser/OptimizerUtilities.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/InlinableExpressionFunctionFinder.h
+++ b/libyul/optimiser/InlinableExpressionFunctionFinder.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 
 #include <set>

--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/optimiser/KnowledgeBase.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 #include <libyul/optimiser/SimplificationRules.h>
 #include <libyul/optimiser/DataFlowAnalyzer.h>

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -21,8 +21,9 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
+
 #include <map>
 
 namespace solidity::yul

--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -26,7 +26,7 @@
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/CallGraphGenerator.h>
 #include <libyul/SideEffects.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/LoopInvariantCodeMotion.cpp
+++ b/libyul/optimiser/LoopInvariantCodeMotion.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/SSAValueTracker.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libsolutil/CommonData.h>
 
 #include <utility>

--- a/libyul/optimiser/MainFunction.cpp
+++ b/libyul/optimiser/MainFunction.cpp
@@ -25,7 +25,7 @@
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/Exceptions.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/libyul/optimiser/MainFunction.h
+++ b/libyul/optimiser/MainFunction.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 namespace solidity::yul
 {

--- a/libyul/optimiser/Metrics.cpp
+++ b/libyul/optimiser/Metrics.cpp
@@ -20,7 +20,7 @@
 
 #include <libyul/optimiser/Metrics.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Utilities.h>
 #include <libyul/backends/evm/EVMDialect.h>

--- a/libyul/optimiser/NameCollector.cpp
+++ b/libyul/optimiser/NameCollector.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/NameDispenser.cpp
+++ b/libyul/optimiser/NameDispenser.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/YulString.h>
 

--- a/libyul/optimiser/NameDispenser.h
+++ b/libyul/optimiser/NameDispenser.h
@@ -20,7 +20,7 @@
  */
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libyul/YulString.h>
 

--- a/libyul/optimiser/NameDisplacer.cpp
+++ b/libyul/optimiser/NameDisplacer.cpp
@@ -21,8 +21,7 @@
 
 #include <libyul/optimiser/NameDisplacer.h>
 
-#include <libyul/AsmData.h>
-
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/NameSimplifier.cpp
+++ b/libyul/optimiser/NameSimplifier.cpp
@@ -17,7 +17,7 @@
 
 #include <libyul/optimiser/NameSimplifier.h>
 #include <libyul/optimiser/NameCollector.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
 

--- a/libyul/optimiser/NameSimplifier.h
+++ b/libyul/optimiser/NameSimplifier.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/YulString.h>
 #include <libyul/optimiser/OptimiserStep.h>

--- a/libyul/optimiser/OptimizerUtilities.cpp
+++ b/libyul/optimiser/OptimizerUtilities.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/OptimizerUtilities.h>
 
 #include <libyul/Dialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <liblangutil/Token.h>
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/OptimizerUtilities.h
+++ b/libyul/optimiser/OptimizerUtilities.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <libsolutil/Common.h>
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/Dialect.h>
 #include <libyul/YulString.h>
 

--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -19,7 +19,7 @@
 
 #include <libyul/optimiser/SSAValueTracker.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 #include <libyul/Dialect.h>
 

--- a/libyul/optimiser/RedundantAssignEliminator.cpp
+++ b/libyul/optimiser/RedundantAssignEliminator.cpp
@@ -23,7 +23,7 @@
 #include <libyul/optimiser/RedundantAssignEliminator.h>
 
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/libyul/optimiser/RedundantAssignEliminator.h
+++ b/libyul/optimiser/RedundantAssignEliminator.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/OptimiserStep.h>
 

--- a/libyul/optimiser/Rematerialiser.cpp
+++ b/libyul/optimiser/Rematerialiser.cpp
@@ -24,7 +24,7 @@
 #include <libyul/optimiser/ASTCopier.h>
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/SSAReverser.cpp
+++ b/libyul/optimiser/SSAReverser.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 #include <libyul/optimiser/SSAReverser.h>
 #include <libyul/optimiser/Metrics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libsolutil/CommonData.h>
 
 #include <variant>

--- a/libyul/optimiser/SSATransform.cpp
+++ b/libyul/optimiser/SSATransform.cpp
@@ -24,7 +24,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 #include <libyul/optimiser/NameDispenser.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/libyul/optimiser/SSATransform.h
+++ b/libyul/optimiser/SSATransform.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/OptimiserStep.h>
 

--- a/libyul/optimiser/SSAValueTracker.cpp
+++ b/libyul/optimiser/SSAValueTracker.cpp
@@ -22,7 +22,7 @@
 
 #include <libyul/optimiser/SSAValueTracker.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/SSAValueTracker.h
+++ b/libyul/optimiser/SSAValueTracker.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <libyul/optimiser/ASTWalker.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h> // Needed for m_zero below.
 
 #include <map>
 #include <set>

--- a/libyul/optimiser/Semantics.cpp
+++ b/libyul/optimiser/Semantics.cpp
@@ -22,7 +22,7 @@
 #include <libyul/optimiser/Semantics.h>
 
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/backends/evm/EVMDialect.h>
 

--- a/libyul/optimiser/Semantics.h
+++ b/libyul/optimiser/Semantics.h
@@ -24,7 +24,7 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/SideEffects.h>
 #include <libyul/optimiser/CallGraphGenerator.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <set>
 

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -26,7 +26,7 @@
 #include <libyul/optimiser/SyntacticalEquality.h>
 #include <libyul/optimiser/DataFlowAnalyzer.h>
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 
 #include <libevmasm/RuleList.h>

--- a/libyul/optimiser/SimplificationRules.h
+++ b/libyul/optimiser/SimplificationRules.h
@@ -23,12 +23,13 @@
 
 #include <libevmasm/SimplificationRule.h>
 
-#include <libyul/AsmDataForward.h>
-#include <libyul/AsmData.h>
+#include <libyul/ASTForward.h>
+#include <libyul/YulString.h>
 
 #include <libsolutil/CommonData.h>
 
 #include <liblangutil/EVMVersion.h>
+#include <liblangutil/SourceLocation.h>
 
 #include <boost/noncopyable.hpp>
 

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -30,7 +30,7 @@
 
 #include <libyul/CompilabilityChecker.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/StackCompressor.h
+++ b/libyul/optimiser/StackCompressor.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <libyul/Object.h>
+
 #include <memory>
 
 namespace solidity::yul

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -21,7 +21,7 @@
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/optimiser/StackToMemoryMover.h>
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Object.h>

--- a/libyul/optimiser/StackToMemoryMover.cpp
+++ b/libyul/optimiser/StackToMemoryMover.cpp
@@ -18,7 +18,7 @@
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/Visitor.h>

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 #include <libyul/optimiser/StructuralSimplifier.h>
 #include <libyul/optimiser/Semantics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 #include <libsolutil/CommonData.h>
 #include <libsolutil/Visitor.h>

--- a/libyul/optimiser/Substitution.cpp
+++ b/libyul/optimiser/Substitution.cpp
@@ -21,7 +21,7 @@
 
 #include <libyul/optimiser/Substitution.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -63,8 +63,8 @@
 #include <libyul/backends/evm/ConstantOptimiser.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/AsmData.h>
 #include <libyul/AsmPrinter.h>
+#include <libyul/AST.h>
 #include <libyul/Object.h>
 
 #include <libyul/backends/wasm/WasmDialect.h>

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
 #include <libyul/optimiser/OptimiserStep.h>
 #include <libyul/optimiser/NameDispenser.h>

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -21,7 +21,7 @@
 #include <libyul/optimiser/SyntacticalEquality.h>
 
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Utilities.h>
 
 #include <libsolutil/CommonData.h>

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
 
 #include <map>

--- a/libyul/optimiser/TypeInfo.cpp
+++ b/libyul/optimiser/TypeInfo.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/optimiser/NameCollector.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 
 #include <libsolutil/Visitor.h>

--- a/libyul/optimiser/TypeInfo.h
+++ b/libyul/optimiser/TypeInfo.h
@@ -20,7 +20,7 @@
  */
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/YulString.h>
 
 #include <vector>

--- a/libyul/optimiser/UnusedFunctionParameterPruner.cpp
+++ b/libyul/optimiser/UnusedFunctionParameterPruner.cpp
@@ -27,7 +27,7 @@
 #include <libyul/optimiser/NameDisplacer.h>
 #include <libyul/optimiser/NameDispenser.h>
 #include <libyul/YulString.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/libyul/optimiser/UnusedFunctionsCommon.h
+++ b/libyul/optimiser/UnusedFunctionsCommon.h
@@ -19,7 +19,7 @@
 
 #include <libyul/optimiser/Metrics.h>
 #include <libyul/optimiser/NameDispenser.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/Exceptions.h>
 

--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -25,7 +25,7 @@
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
 #include <libyul/Exceptions.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/SideEffects.h>
 

--- a/libyul/optimiser/VarDeclInitializer.cpp
+++ b/libyul/optimiser/VarDeclInitializer.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <libyul/optimiser/VarDeclInitializer.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/Visitor.h>

--- a/libyul/optimiser/VarDeclInitializer.h
+++ b/libyul/optimiser/VarDeclInitializer.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/OptimiserStep.h>
 

--- a/libyul/optimiser/VarNameCleaner.cpp
+++ b/libyul/optimiser/VarNameCleaner.cpp
@@ -18,7 +18,7 @@
 
 #include <libyul/optimiser/VarNameCleaner.h>
 #include <libyul/optimiser/OptimizerUtilities.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 
 #include <algorithm>

--- a/libyul/optimiser/VarNameCleaner.h
+++ b/libyul/optimiser/VarNameCleaner.h
@@ -19,7 +19,7 @@
 #pragma once
 
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/YulString.h>
 #include <libyul/optimiser/OptimiserStep.h>

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -30,6 +30,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/AssemblyStack.h>
+#include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/backends/wasm/WasmDialect.h>
 

--- a/test/libyul/EwasmTranslationTest.cpp
+++ b/test/libyul/EwasmTranslationTest.cpp
@@ -28,6 +28,7 @@
 #include <libyul/AsmParser.h>
 #include <libyul/AssemblyStack.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AST.h>
 #include <libyul/Object.h>
 
 #include <liblangutil/ErrorReporter.h>

--- a/test/libyul/Inliner.cpp
+++ b/test/libyul/Inliner.cpp
@@ -28,7 +28,7 @@
 #include <libyul/optimiser/FunctionHoister.h>
 #include <libyul/optimiser/FunctionGrouper.h>
 #include <libyul/AsmPrinter.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/libyul/Metrics.cpp
+++ b/test/libyul/Metrics.cpp
@@ -23,7 +23,7 @@
 #include <test/libyul/Common.h>
 
 #include <libyul/optimiser/Metrics.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -28,6 +28,7 @@
 #include <libyul/AsmPrinter.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <liblangutil/Scanner.h>
 #include <liblangutil/ErrorReporter.h>

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -24,7 +24,7 @@
 #include <test/tools/yulInterpreter/Interpreter.h>
 
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libevmasm/Instruction.h>
 

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.h
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libsolutil/CommonData.h>
 

--- a/test/tools/yulInterpreter/EwasmBuiltinInterpreter.cpp
+++ b/test/tools/yulInterpreter/EwasmBuiltinInterpreter.cpp
@@ -24,7 +24,7 @@
 #include <test/tools/yulInterpreter/Interpreter.h>
 
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <libevmasm/Instruction.h>
 

--- a/test/tools/yulInterpreter/EwasmBuiltinInterpreter.h
+++ b/test/tools/yulInterpreter/EwasmBuiltinInterpreter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmDataForward.h>
+#include <libyul/ASTForward.h>
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/FixedHash.h>

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -24,7 +24,7 @@
 #include <test/tools/yulInterpreter/EVMInstructionInterpreter.h>
 #include <test/tools/yulInterpreter/EwasmBuiltinInterpreter.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/Dialect.h>
 #include <libyul/Utilities.h>
 #include <libyul/backends/evm/EVMDialect.h>

--- a/test/tools/yulInterpreter/Interpreter.h
+++ b/test/tools/yulInterpreter/Interpreter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libyul/AsmData.h>
+#include <libyul/ASTForward.h>
 #include <libyul/optimiser/ASTWalker.h>
 
 #include <libsolutil/FixedHash.h>

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -26,7 +26,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libsolidity/parsing/Parser.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/Object.h>

--- a/test/yulPhaser/Program.cpp
+++ b/test/yulPhaser/Program.cpp
@@ -24,7 +24,6 @@
 #include <libyul/optimiser/BlockFlattener.h>
 #include <libyul/optimiser/Metrics.h>
 #include <libyul/optimiser/StructuralSimplifier.h>
-#include <libyul/AsmData.h>
 
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/JSON.h>

--- a/tools/solidityUpgrade/Upgrade050.cpp
+++ b/tools/solidityUpgrade/Upgrade050.cpp
@@ -20,7 +20,7 @@
 
 #include <libsolidity/analysis/OverrideChecker.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <regex>
 

--- a/tools/solidityUpgrade/Upgrade060.cpp
+++ b/tools/solidityUpgrade/Upgrade060.cpp
@@ -20,7 +20,7 @@
 
 #include <libsolidity/analysis/OverrideChecker.h>
 
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <regex>
 

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -27,6 +27,7 @@
 #include <libyul/AsmJsonConverter.h>
 #include <libyul/AsmParser.h>
 #include <libyul/AsmPrinter.h>
+#include <libyul/AST.h>
 #include <libyul/ObjectParser.h>
 #include <libyul/YulString.h>
 #include <libyul/backends/evm/EVMDialect.h>

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <libyul/optimiser/NameDispenser.h>
-#include <libyul/AsmData.h>
+#include <libyul/AST.h>
 
 #include <liblangutil/Exceptions.h>
 


### PR DESCRIPTION
Also attempt to only include ASTForward where appropriate.

So for a long while I hoped we can get rid of the "asm" notion since we moved everything under `libyul`, but it hasn't happened yet. This PR blew up because I thought why not also try to use the forward declaration more, which turned into a feat itself.

I'm not totally convinced it is worth doing all the renaming, but I'm more in favour of renaming `AsmData` to `AST` as it reflects its behaviour much better, and it s good counterpart to `Object` and `libsolidity/AST.h`