### PR TITLE
Fix and enable external tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1123,6 +1123,9 @@ workflows:
       - t_ems_compile_ext_gnosis: *workflow_emscripten
       - t_ems_compile_ext_zeppelin: *workflow_emscripten
       - t_ems_compile_ext_ens: *workflow_emscripten
+      - t_ems_test_ext_colony: *workflow_emscripten
+      - t_ems_test_ext_gnosis: *workflow_emscripten
+      - t_ems_test_ext_zeppelin: *workflow_emscripten
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -820,7 +820,7 @@ jobs:
 
   t_ems_compile_ext_gnosis:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     environment:
       TERM: xterm
     steps:
@@ -835,7 +835,8 @@ jobs:
 
   t_ems_test_ext_gnosis:
     docker:
-      - image: circleci/node:10
+      # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
+      - image: circleci/node:12
     environment:
       TERM: xterm
     steps:
@@ -852,7 +853,7 @@ jobs:
 
   t_ems_compile_ext_gnosis_v2:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     environment:
       TERM: xterm
     steps:
@@ -867,7 +868,8 @@ jobs:
 
   t_ems_test_ext_gnosis_v2:
     docker:
-      - image: circleci/node:10
+      # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
+      - image: circleci/node:12
     environment:
       TERM: xterm
     steps:
@@ -884,7 +886,7 @@ jobs:
 
   t_ems_compile_ext_zeppelin:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     environment:
       TERM: xterm
     steps:
@@ -899,7 +901,7 @@ jobs:
 
   t_ems_test_ext_zeppelin:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     environment:
       TERM: xterm
     steps:
@@ -916,7 +918,7 @@ jobs:
 
   t_ems_compile_ext_colony:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     environment:
       TERM: xterm
     steps:
@@ -935,7 +937,7 @@ jobs:
 
   t_ems_test_ext_colony:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     environment:
       TERM: xterm
     steps:
@@ -956,6 +958,7 @@ jobs:
 
   t_ems_compile_ext_ens:
     docker:
+      # NOTE: One of the dependencies (fsevents) fails to build its native extension on node.js 12+.
       - image: circleci/node:10
     environment:
       TERM: xterm
@@ -975,6 +978,7 @@ jobs:
 
   t_ems_test_ext_ens:
     docker:
+      # NOTE: One of the dependencies (fsevents) fails to build its native extension on node.js 12+.
       - image: circleci/node:10
     environment:
       TERM: xterm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -884,7 +884,7 @@ jobs:
 
   t_ems_compile_ext_colony:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     environment:
       TERM: xterm
     steps:
@@ -903,7 +903,7 @@ jobs:
 
   t_ems_test_ext_colony:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     environment:
       TERM: xterm
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -850,6 +850,38 @@ jobs:
       #- run: *gitter_notify_failure
       #- run: *gitter_notify_success
 
+  t_ems_compile_ext_gnosis_v2:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: External GnosisSafe v2 compilation
+          command: |
+            export COMPILE_ONLY=1
+            test/externalTests/gnosis-v2.sh /tmp/workspace/soljson.js
+
+  t_ems_test_ext_gnosis_v2:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: External GnosisSafe v2 tests
+          command: |
+            test/externalTests/gnosis-v2.sh /tmp/workspace/soljson.js
+      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
+      #- run: *gitter_notify_failure
+      #- run: *gitter_notify_success
+
   t_ems_compile_ext_zeppelin:
     docker:
       - image: circleci/node:10
@@ -1124,10 +1156,12 @@ workflows:
       - t_ems_solcjs: *workflow_emscripten
       - t_ems_compile_ext_colony: *workflow_emscripten
       - t_ems_compile_ext_gnosis: *workflow_emscripten
+      - t_ems_compile_ext_gnosis_v2: *workflow_emscripten
       - t_ems_compile_ext_zeppelin: *workflow_emscripten
       - t_ems_compile_ext_ens: *workflow_emscripten
       - t_ems_test_ext_colony: *workflow_emscripten
       - t_ems_test_ext_gnosis: *workflow_emscripten
+      - t_ems_test_ext_gnosis_v2: *workflow_emscripten
       - t_ems_test_ext_zeppelin: *workflow_emscripten
 
       # Windows build and tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1185,7 +1185,9 @@ workflows:
       - t_ems_compile_ext_zeppelin: *workflow_emscripten
       - t_ems_compile_ext_ens: *workflow_emscripten
       - t_ems_test_ext_colony: *workflow_emscripten
-      - t_ems_test_ext_gnosis: *workflow_emscripten
+      # FIXME: Gnosis tests are pretty flaky right now. They often fail on CircleCI due to random ProviderError
+      # and there are also other less frequent problems. See https://github.com/gnosis/safe-contracts/issues/216.
+      #- t_ems_test_ext_gnosis: *workflow_emscripten
       - t_ems_test_ext_gnosis_v2: *workflow_emscripten
       - t_ems_test_ext_zeppelin: *workflow_emscripten
       - t_ems_test_ext_ens: *workflow_emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -846,8 +846,9 @@ jobs:
           name: External GnosisSafe tests
           command: |
             test/externalTests/gnosis.sh /tmp/workspace/soljson.js || test/externalTests/gnosis.sh /tmp/workspace/soljson.js
-      - run: *gitter_notify_failure
-      - run: *gitter_notify_success
+      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
+      #- run: *gitter_notify_failure
+      #- run: *gitter_notify_success
 
   t_ems_compile_ext_zeppelin:
     docker:
@@ -877,8 +878,9 @@ jobs:
           name: External Zeppelin tests
           command: |
             test/externalTests/zeppelin.sh /tmp/workspace/soljson.js || test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
-      - run: *gitter_notify_failure
-      - run: *gitter_notify_success
+      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
+      #- run: *gitter_notify_failure
+      #- run: *gitter_notify_success
 
   t_ems_compile_ext_colony:
     docker:
@@ -916,8 +918,9 @@ jobs:
           name: External ColonyNetworks tests
           command: |
             test/externalTests/colony.sh /tmp/workspace/soljson.js || test/externalTests/colony.sh /tmp/workspace/soljson.js
-      - run: *gitter_notify_failure
-      - run: *gitter_notify_success
+      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
+      #- run: *gitter_notify_failure
+      #- run: *gitter_notify_success
 
   t_ems_compile_ext_ens:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -845,7 +845,7 @@ jobs:
       - run:
           name: External GnosisSafe tests
           command: |
-            test/externalTests/gnosis.sh /tmp/workspace/soljson.js || test/externalTests/gnosis.sh /tmp/workspace/soljson.js
+            test/externalTests/gnosis.sh /tmp/workspace/soljson.js
       # TODO: Re-enable notifications once this is running nightly rather than as a PR check
       #- run: *gitter_notify_failure
       #- run: *gitter_notify_success
@@ -877,7 +877,7 @@ jobs:
       - run:
           name: External Zeppelin tests
           command: |
-            test/externalTests/zeppelin.sh /tmp/workspace/soljson.js || test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
+            test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
       # TODO: Re-enable notifications once this is running nightly rather than as a PR check
       #- run: *gitter_notify_failure
       #- run: *gitter_notify_success
@@ -917,7 +917,7 @@ jobs:
       - run:
           name: External ColonyNetworks tests
           command: |
-            test/externalTests/colony.sh /tmp/workspace/soljson.js || test/externalTests/colony.sh /tmp/workspace/soljson.js
+            test/externalTests/colony.sh /tmp/workspace/soljson.js
       # TODO: Re-enable notifications once this is running nightly rather than as a PR check
       #- run: *gitter_notify_failure
       #- run: *gitter_notify_success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -973,6 +973,27 @@ jobs:
             export COMPILE_ONLY=1
             test/externalTests/ens.sh /tmp/workspace/soljson.js
 
+  t_ems_test_ext_ens:
+    docker:
+      - image: circleci/node:10
+    environment:
+      TERM: xterm
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Install test dependencies
+          command: |
+            sudo apt-get -qy install lsof
+      - run:
+          name: External Ens compilation
+          command: |
+            test/externalTests/ens.sh /tmp/workspace/soljson.js
+      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
+      #- run: *gitter_notify_failure
+      #- run: *gitter_notify_success
+
   b_win: &b_win
     executor:
       name: win/default
@@ -1163,6 +1184,7 @@ workflows:
       - t_ems_test_ext_gnosis: *workflow_emscripten
       - t_ems_test_ext_gnosis_v2: *workflow_emscripten
       - t_ems_test_ext_zeppelin: *workflow_emscripten
+      - t_ems_test_ext_ens: *workflow_emscripten
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags

--- a/test/externalTests.sh
+++ b/test/externalTests.sh
@@ -44,6 +44,7 @@ printTask "Running external tests..."
 
 "$REPO_ROOT/externalTests/zeppelin.sh" "$SOLJSON"
 "$REPO_ROOT/externalTests/gnosis.sh" "$SOLJSON"
+"$REPO_ROOT/externalTests/gnosis-v2.sh" "$SOLJSON"
 "$REPO_ROOT/externalTests/colony.sh" "$SOLJSON"
 "$REPO_ROOT/externalTests/ens.sh" "$SOLJSON"
 

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -33,12 +33,12 @@ function colony_test
     OPTIMIZER_LEVEL=3
     CONFIG="truffle.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_070
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_070_new
     run_install "$SOLJSON" install_fn
 
     cd lib
     rm -Rf dappsys
-    git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_060 dappsys
+    git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_070 dappsys
     cd ..
 
     truffle_run_test "$SOLJSON" compile_fn test_fn

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -135,6 +135,9 @@ function force_solc_truffle_modules
             rm -rf solc
             git clone --depth 1 -b master https://github.com/ethereum/solc-js.git solc
             cp "$1" solc/soljson.js
+
+            cd solc
+            npm install
         fi
     )
     done

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -109,13 +109,6 @@ function replace_version_pragmas
     find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -E -e 's/pragma solidity [^;]+;/pragma solidity >=0.0;/'
 }
 
-function replace_libsolc_call
-{
-    # Change "compileStandard" to "compile" (needed for pre-5.x Truffle)
-    printLog "Replacing libsolc compile call in Truffle..."
-    sed -i s/solc.compileStandard/solc.compile/ "node_modules/truffle/build/cli.bundled.js"
-}
-
 function find_truffle_config
 {
     local config_file="truffle.js"

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -38,6 +38,9 @@ function ens_test
     # Use latest Truffle. Older versions crash on the output from 0.8.0.
     force_truffle_version ^5.1.55
 
+    # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
+    rm -f package-lock.json
+
     run_install "$SOLJSON" install_fn
 
     truffle_run_test "$SOLJSON" compile_fn test_fn

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2020 solidity contributors.
+#------------------------------------------------------------------------------
+source scripts/common.sh
+source test/externalTests/common.sh
+
+verify_input "$1"
+SOLJSON="$1"
+
+function install_fn { npm install --package-lock; }
+function compile_fn { npx truffle compile; }
+function test_fn { npm test; }
+
+function gnosis_safe_test
+{
+    OPTIMIZER_LEVEL=1
+    CONFIG="truffle-config.js"
+
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git v2_070
+
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070_new|g' package.json
+    sed -i -E 's|"@gnosis.pm/util-contracts": "[^"]+"|"@gnosis.pm/util-contracts": "github:solidity-external-tests/util-contracts#solc-7"|g' package.json
+
+    # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
+    rm -f package-lock.json
+
+    run_install "$SOLJSON" install_fn
+
+    truffle_run_test "$SOLJSON" compile_fn test_fn
+}
+
+external_test Gnosis-Safe gnosis_safe_test

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -31,17 +31,16 @@ function test_fn { npm test; }
 function gnosis_safe_test
 {
     OPTIMIZER_LEVEL=1
-    CONFIG="truffle.js"
+    CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_070
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_070_new
 
-    force_truffle_version ^5.0.42
-    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070|g' package.json
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070_new|g' package.json
+
+    # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
     rm -f package-lock.json
-    rm -rf node_modules/
 
     run_install "$SOLJSON" install_fn
-    replace_libsolc_call
 
     truffle_run_test "$SOLJSON" compile_fn test_fn
 }

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -33,7 +33,7 @@ function zeppelin_test
     OPTIMIZER_LEVEL=1
     CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/openzeppelin-contracts.git upgrade-0.7.0
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/openzeppelin-contracts.git master_070
     run_install "$SOLJSON" install_fn
 
     truffle_run_test "$SOLJSON" compile_fn test_fn


### PR DESCRIPTION
Related to #10397 (though my PR currently enables them in PR checks rather than in the nightly run).

This PR enables actual test runs (in addition to the current compilation runs) for external projects from `solidity-external-tests`.

An integral part of this PR is the update of `solidity-external-tests` repos. Here are the links in case you want to take a look at my changes. In all cases I pulled the most recent changes from the main upstream branch, created a `070` variant (or `070_new` when `070` already existed), cherry-picked our older changes where possible and then fixed the remaining problems.
- [Gnosis v1: `development_070_new`](https://github.com/solidity-external-tests/safe-contracts/tree/development_070_new) (depends on [mock-contract `master_070_new`](https://github.com/solidity-external-tests/mock-contract/tree/master_070_new))
- [Gnosis v2: `v2_070_new`](https://github.com/solidity-external-tests/safe-contracts/tree/v2_070) (depends on [mock-contract `master_070_new`](https://github.com/solidity-external-tests/mock-contract/tree/master_070_new) and the new [util-contracts](https://github.com/solidity-external-tests/util-contracts) that I have forked into `solidity-external-contracts`)
- [OpenZeppelin: `master_070`](https://github.com/solidity-external-tests/openzeppelin-contracts/tree/master_070)
- [Colony: `develop_070_new`](https://github.com/solidity-external-tests/colonyNetwork/tree/develop_070_new) (depends on [dappsys `master_070`](https://github.com/solidity-external-tests/dappsys-monolithic/tree/master_070))

Status:
- [x] Colony
- [x] Gnosis v1 (compilation only; tests disabled due to `ProviderError`)
- [x] Gnosis v2
- [x] OpenZeppelin
- [x] ENS

**Note: Once this PR gets merged into `breaking` (as a part of the usual merge from `develop`) it needs to be immediately followed by merging #10465 into `breaking` too (and also #10465 will need a rebase before that). Otherwise tests on breaking won't succeed because they'll still be using the `070` branches from `solidity-external-tests`.**