### PR TITLE
Fix command for stripping version pragmas in external tests

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -104,7 +104,7 @@ function replace_version_pragmas
     # Replace fixed-version pragmas (part of Consensys best practice).
     # Include all directories to also cover node dependencies.
     printLog "Replacing fixed-version pragmas..."
-    find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -e 's/pragma solidity [\^0-9\.]*/pragma solidity >=0.0/'
+    find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -E -e 's/pragma solidity [^;]+;/pragma solidity >=0.0;/'
 }
 
 function replace_libsolc_call


### PR DESCRIPTION
The current command only works with pragmas that do not contain operators.

For example for this input:
```solidity
pragma solidity >=0.5.8 <0.8.0;
```
it produces this:
```solidity
pragma solidity >=0.0>=0.5.8 <0.8.0;
```

I think it does not break the tests only because we have manually updated the pragmas in our external tests repo.