### PR TITLE
[Sol->Yul] Implement function modifiers.

### DIFF
--- a/docs/ir/ir-breaking-changes.rst
+++ b/docs/ir/ir-breaking-changes.rst
@@ -34,6 +34,27 @@ Consequently, if the padding space within a struct is used to store data (e.g. i
 
 We have the same behavior for implicit delete, for example when array of structs is shortened.
 
+ * Function modifiers are implemented in a slightly different way regarding function parameters.
+   This especially has an effect if the placeholder ``_;`` is evaluated multiple times in a modifier.
+   In the old code generator, each function parameter has a fixed slot on the stack. If the function
+   is run multiple times because ``_;`` is used multiple times or used in a loop, then a change to the
+   function parameter's value is visible in the next execution of the function.
+   The new code generator implements modifiers using actual functions and passes function parameters on.
+   This means that multiple executions of a function will get the same values for the parameters.
+
+::
+    // SPDX-License-Identifier: GPL-3.0
+    pragma solidity >=0.7.0;
+    contract C {
+        function f(uint a) public pure mod() returns (uint r) {
+            r = a++;
+        }
+        modifier mod() { _; _; }
+    }
+
+If you execute ``f(0)`` in the old code generator, it will return ``2``, while
+it will return ``1`` when using the new code generator.
+
  * The order of contract initialization has changed in case of inheritance.
 
 The order used to be:

--- a/libsolidity/codegen/ir/Common.cpp
+++ b/libsolidity/codegen/ir/Common.cpp
@@ -32,16 +32,30 @@ YulArity YulArity::fromType(FunctionType const& _functionType)
 		TupleType(_functionType.returnParameterTypes()).sizeOnStack()
 	};
 }
+
 string IRNames::function(FunctionDefinition const& _function)
 {
-	// @TODO previously, we had to distinguish creation context and runtime context,
-	// but since we do not work with jump positions anymore, this should not be a problem, right?
 	return "fun_" + _function.name() + "_" + to_string(_function.id());
 }
 
 string IRNames::function(VariableDeclaration const& _varDecl)
 {
 	return "getter_fun_" + _varDecl.name() + "_" + to_string(_varDecl.id());
+}
+
+string IRNames::modifierInvocation(ModifierInvocation const& _modifierInvocation)
+{
+	// This uses the ID of the modifier invocation because it has to be unique
+	// for each invocation.
+	solAssert(!_modifierInvocation.name().path().empty(), "");
+	string const& modifierName = _modifierInvocation.name().path().back();
+	solAssert(!modifierName.empty(), "");
+	return "modifier_" + modifierName + "_" + to_string(_modifierInvocation.id());
+}
+
+string IRNames::functionWithModifierInner(FunctionDefinition const& _function)
+{
+	return "fun_" + _function.name() + "_" + to_string(_function.id()) + "_inner";
 }
 
 string IRNames::creationObject(ContractDefinition const& _contract)

--- a/libsolidity/codegen/ir/Common.h
+++ b/libsolidity/codegen/ir/Common.h
@@ -49,6 +49,8 @@ struct IRNames
 {
 	static std::string function(FunctionDefinition const& _function);
 	static std::string function(VariableDeclaration const& _varDecl);
+	static std::string modifierInvocation(ModifierInvocation const& _modifierInvocation);
+	static std::string functionWithModifierInner(FunctionDefinition const& _function);
 	static std::string creationObject(ContractDefinition const& _contract);
 	static std::string runtimeObject(ContractDefinition const& _contract);
 	static std::string internalDispatch(YulArity const& _arity);

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -80,6 +80,11 @@ IRVariable const& IRGenerationContext::localVariable(VariableDeclaration const& 
 	return m_localVariables.at(&_varDecl);
 }
 
+void IRGenerationContext::resetLocalVariables()
+{
+	m_localVariables.clear();
+}
+
 void IRGenerationContext::registerImmutableVariable(VariableDeclaration const& _variable)
 {
 	solAssert(_variable.immutable(), "Attempted to register a non-immutable variable as immutable.");

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -97,6 +97,7 @@ public:
 	IRVariable const& addLocalVariable(VariableDeclaration const& _varDecl);
 	bool isLocalVariable(VariableDeclaration const& _varDecl) const { return m_localVariables.count(&_varDecl); }
 	IRVariable const& localVariable(VariableDeclaration const& _varDecl);
+	void resetLocalVariables();
 
 	/// Registers an immutable variable of the contract.
 	/// Should only be called at construction time.

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -249,10 +249,10 @@ string IRGenerator::generateFunction(FunctionDefinition const& _function)
 {
 	string functionName = IRNames::function(_function);
 	return m_context.functionCollector().createFunction(functionName, [&]() {
-		solUnimplementedAssert(_function.modifiers().empty(), "Modifiers not implemented yet.");
+		m_context.resetLocalVariables();
 		Whiskers t(R"(
 			function <functionName>(<params>)<?+retParams> -> <retParams></+retParams> {
-				<initReturnVariables>
+				<retInit>
 				<body>
 			}
 		)");
@@ -268,8 +268,137 @@ string IRGenerator::generateFunction(FunctionDefinition const& _function)
 			retParams += m_context.addLocalVariable(*varDecl).stackSlots();
 			retInit += generateInitialAssignment(*varDecl);
 		}
+
 		t("retParams", joinHumanReadable(retParams));
-		t("initReturnVariables", retInit);
+		t("retInit", retInit);
+
+		if (_function.modifiers().empty())
+			t("body", generate(_function.body()));
+		else
+		{
+			for (size_t i = 0; i < _function.modifiers().size(); ++i)
+			{
+				ModifierInvocation const& modifier = *_function.modifiers().at(i);
+				string next =
+					i + 1 < _function.modifiers().size() ?
+					IRNames::modifierInvocation(*_function.modifiers().at(i + 1)) :
+					IRNames::functionWithModifierInner(_function);
+				generateModifier(modifier, _function, next);
+			}
+			t("body",
+				(retParams.empty() ? string{} : joinHumanReadable(retParams) + " := ") +
+				IRNames::modifierInvocation(*_function.modifiers().at(0)) +
+				"(" +
+				joinHumanReadable(retParams + params) +
+				")"
+			);
+			// Now generate the actual inner function.
+			generateFunctionWithModifierInner(_function);
+		}
+		return t.render();
+	});
+}
+
+string IRGenerator::generateModifier(
+	ModifierInvocation const& _modifierInvocation,
+	FunctionDefinition const& _function,
+	string const& _nextFunction
+)
+{
+	string functionName = IRNames::modifierInvocation(_modifierInvocation);
+	return m_context.functionCollector().createFunction(functionName, [&]() {
+		m_context.resetLocalVariables();
+		Whiskers t(R"(
+			function <functionName>(<params>)<?+retParams> -> <retParams></+retParams> {
+				<assignRetParams>
+				<evalArgs>
+				<body>
+			}
+		)");
+		t("functionName", functionName);
+		vector<string> retParamsIn;
+		for (auto const& varDecl: _function.returnParameters())
+			retParamsIn += IRVariable(*varDecl).stackSlots();
+		vector<string> params = retParamsIn;
+		for (auto const& varDecl: _function.parameters())
+			params += m_context.addLocalVariable(*varDecl).stackSlots();
+		t("params", joinHumanReadable(params));
+		vector<string> retParams;
+		string assignRetParams;
+		for (size_t i = 0; i < retParamsIn.size(); ++i)
+		{
+			retParams.emplace_back(m_context.newYulVariable());
+			assignRetParams += retParams.back() + " := " + retParamsIn[i] + "\n";
+		}
+		t("retParams", joinHumanReadable(retParams));
+		t("assignRetParams", assignRetParams);
+
+		solAssert(*_modifierInvocation.name().annotation().requiredLookup == VirtualLookup::Virtual, "");
+
+		ModifierDefinition const& modifier = dynamic_cast<ModifierDefinition const&>(
+			*_modifierInvocation.name().annotation().referencedDeclaration
+		).resolveVirtual(m_context.mostDerivedContract());
+
+		solAssert(
+			modifier.parameters().empty() ==
+			(!_modifierInvocation.arguments() || _modifierInvocation.arguments()->empty()),
+			""
+		);
+		IRGeneratorForStatements expressionEvaluator(m_context, m_utils);
+		if (_modifierInvocation.arguments())
+			for (size_t i = 0; i < _modifierInvocation.arguments()->size(); i++)
+			{
+				IRVariable argument = expressionEvaluator.evaluateExpression(
+					*_modifierInvocation.arguments()->at(i),
+					*modifier.parameters()[i]->annotation().type
+				);
+				expressionEvaluator.define(
+					m_context.addLocalVariable(*modifier.parameters()[i]),
+					argument
+				);
+			}
+
+		t("evalArgs", expressionEvaluator.code());
+		IRGeneratorForStatements generator(m_context, m_utils, [&]() {
+			string ret = joinHumanReadable(retParams);
+			return
+				(ret.empty() ? "" : ret + " := ") +
+				_nextFunction + "(" + joinHumanReadable(params) + ")\n";
+		});
+		generator.generate(modifier.body());
+		t("body", generator.code());
+		return t.render();
+	});
+}
+
+string IRGenerator::generateFunctionWithModifierInner(FunctionDefinition const& _function)
+{
+	string functionName = IRNames::functionWithModifierInner(_function);
+	return m_context.functionCollector().createFunction(functionName, [&]() {
+		m_context.resetLocalVariables();
+		Whiskers t(R"(
+			function <functionName>(<params>)<?+retParams> -> <retParams></+retParams> {
+				<assignRetParams>
+				<body>
+			}
+		)");
+		t("functionName", functionName);
+		vector<string> retParams;
+		vector<string> retParamsIn;
+		for (auto const& varDecl: _function.returnParameters())
+			retParams += m_context.addLocalVariable(*varDecl).stackSlots();
+		string assignRetParams;
+		for (size_t i = 0; i < retParams.size(); ++i)
+		{
+			retParamsIn.emplace_back(m_context.newYulVariable());
+			assignRetParams += retParams.back() + " := " + retParamsIn[i] + "\n";
+		}
+		vector<string> params = retParamsIn;
+		for (auto const& varDecl: _function.parameters())
+			params += m_context.addLocalVariable(*varDecl).stackSlots();
+		t("params", joinHumanReadable(params));
+		t("retParams", joinHumanReadable(retParams));
+		t("assignRetParams", assignRetParams);
 		t("body", generate(_function.body()));
 		return t.render();
 	});
@@ -510,6 +639,7 @@ string IRGenerator::initStateVariables(ContractDefinition const& _contract)
 
 void IRGenerator::generateImplicitConstructors(ContractDefinition const& _contract)
 {
+	// TODO reset local variables somewhere here.
 	auto listAllParams = [&](
 		map<ContractDefinition const*, vector<string>> const& baseParams) -> vector<string>
 	{

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -73,6 +73,12 @@ private:
 	InternalDispatchMap generateInternalDispatchFunctions();
 	/// Generates code for and returns the name of the function.
 	std::string generateFunction(FunctionDefinition const& _function);
+	std::string generateModifier(
+		ModifierInvocation const& _modifierInvocation,
+		FunctionDefinition const& _function,
+		std::string const& _nextFunction
+	);
+	std::string generateFunctionWithModifierInner(FunctionDefinition const& _function);
 	/// Generates a getter for the given declaration and returns its name
 	std::string generateGetter(VariableDeclaration const& _varDecl);
 

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -581,6 +581,12 @@ bool IRGeneratorForStatements::visit(IfStatement const& _ifStatement)
 	return false;
 }
 
+void IRGeneratorForStatements::endVisit(PlaceholderStatement const&)
+{
+	solAssert(m_placeholderCallback, "");
+	m_code << m_placeholderCallback();
+}
+
 bool IRGeneratorForStatements::visit(ForStatement const& _forStatement)
 {
 	setLocation(_forStatement);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -40,8 +40,13 @@ class YulUtilFunctions;
 class IRGeneratorForStatements: public ASTConstVisitor
 {
 public:
-	IRGeneratorForStatements(IRGenerationContext& _context, YulUtilFunctions& _utils):
+	IRGeneratorForStatements(
+		IRGenerationContext& _context,
+		YulUtilFunctions& _utils,
+		std::function<std::string()> _placeholderCallback = {}
+	):
 		m_context(_context),
+		m_placeholderCallback(std::move(_placeholderCallback)),
 		m_utils(_utils)
 	{}
 
@@ -58,6 +63,9 @@ public:
 	/// Calculates expression's value and returns variable where it was stored
 	IRVariable evaluateExpression(Expression const& _expression, Type const& _to);
 
+	/// Defines @a _var using the value of @a _value while performing type conversions, if required.
+	void define(IRVariable const& _var, IRVariable const& _value) { declareAssign(_var, _value, true); }
+
 	/// @returns the name of a function that computes the value of the given constant
 	/// and also generates the function.
 	std::string constantValueFunction(VariableDeclaration const& _constant);
@@ -66,6 +74,7 @@ public:
 	bool visit(Conditional const& _conditional) override;
 	bool visit(Assignment const& _assignment) override;
 	bool visit(TupleExpression const& _tuple) override;
+	void endVisit(PlaceholderStatement const& _placeholder) override;
 	bool visit(Block const& _block) override;
 	void endVisit(Block const& _block) override;
 	bool visit(IfStatement const& _ifStatement) override;
@@ -135,8 +144,7 @@ private:
 	/// @returns an output stream that can be used to define @a _var using a function call or
 	/// single stack slot expression.
 	std::ostream& define(IRVariable const& _var);
-	/// Defines @a _var using the value of @a _value while performing type conversions, if required.
-	void define(IRVariable const& _var, IRVariable const& _value) { declareAssign(_var, _value, true); }
+
 	/// Assigns @a _var to the value of @a _value while performing type conversions, if required.
 	void assign(IRVariable const& _var, IRVariable const& _value) { declareAssign(_var, _value, false); }
 	/// Declares variable @a _var.
@@ -189,6 +197,7 @@ private:
 
 	std::ostringstream m_code;
 	IRGenerationContext& m_context;
+	std::function<std::string()> m_placeholderCallback;
 	YulUtilFunctions& m_utils;
 	std::optional<IRLValue> m_currentLValue;
 	langutil::SourceLocation m_currentLocation;

--- a/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_modifier_used_in_v1_contract.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_modifier_used_in_v1_contract.sol
@@ -34,5 +34,7 @@ contract C is B {
         return (x, y);
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // test() -> 5, 10

--- a/test/libsolidity/semanticTests/arithmetics/checked_modifier_called_by_unchecked.sol
+++ b/test/libsolidity/semanticTests/arithmetics/checked_modifier_called_by_unchecked.sol
@@ -8,6 +8,8 @@ contract C {
         return b + c;
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // f(uint16,uint16,uint16): 0xe000, 0xe500, 2 -> 58626
 // f(uint16,uint16,uint16): 0x1000, 0xe500, 0xe000 -> FAILURE, hex"4e487b71", 0x11

--- a/test/libsolidity/semanticTests/inlineAssembly/inline_assembly_in_modifiers.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/inline_assembly_in_modifiers.sol
@@ -28,6 +28,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f() -> true
 // g() -> FAILURE

--- a/test/libsolidity/semanticTests/modifiers/break_in_modifier.sol
+++ b/test/libsolidity/semanticTests/modifiers/break_in_modifier.sol
@@ -14,6 +14,8 @@ contract C {
         x = t;
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // x() -> 0
 // f() ->

--- a/test/libsolidity/semanticTests/modifiers/continue_in_modifier.sol
+++ b/test/libsolidity/semanticTests/modifiers/continue_in_modifier.sol
@@ -14,6 +14,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // x() -> 0
 // f() ->

--- a/test/libsolidity/semanticTests/modifiers/evaluation_order.sol
+++ b/test/libsolidity/semanticTests/modifiers/evaluation_order.sol
@@ -1,0 +1,22 @@
+contract A { constructor(uint) {} }
+contract B { constructor(uint) {} }
+contract C { constructor(uint) {} }
+
+contract D is A, B, C {
+    uint[] x;
+    constructor() m2(f(1)) B(f(2)) m1(f(3)) C(f(4)) m3(f(5)) A(f(6)) {
+        f(7);
+    }
+
+    function query() public view returns (uint[] memory) { return x; }
+
+    modifier m1(uint) { _; }
+    modifier m2(uint) { _; }
+    modifier m3(uint) { _; }
+
+    function f(uint y) internal returns (uint) { x.push(y); return 0; }
+}
+// ====
+// compileViaYul: also
+// ----
+// query() -> 0x20, 7, 4, 2, 6, 1, 3, 5, 7

--- a/test/libsolidity/semanticTests/modifiers/function_modifier.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier.sol
@@ -8,6 +8,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // getOne() -> 0
 // getOne(), 1 wei -> 1

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_calling_functions_in_creation_context.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_calling_functions_in_creation_context.sol
@@ -45,5 +45,7 @@ contract C is A {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // getData() -> 0x4300

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_empty.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_empty.sol
@@ -13,5 +13,7 @@ contract C is A {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f() -> false

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_for_constructor.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_for_constructor.sol
@@ -22,6 +22,7 @@ contract C is A {
         _;
     }
 }
-
+// ====
+// compileViaYul: also
 // ----
 // getData() -> 6

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_library.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_library.sol
@@ -24,5 +24,7 @@ contract Test {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f() -> 0x202

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_library_inheritance.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_library_inheritance.sol
@@ -30,5 +30,7 @@ contract Test {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f() -> 0x202

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_local_variables.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_local_variables.sol
@@ -14,6 +14,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f(bool): true -> 0
 // f(bool): false -> 3

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_loop_viair.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_loop_viair.sol
@@ -9,6 +9,6 @@ contract C {
     }
 }
 // ====
-// compileViaYul: false
+// compileViaYul: true
 // ----
-// f() -> 10
+// f() -> 1

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation.sol
@@ -8,7 +8,8 @@ contract C {
         r += 1;
     }
 }
-
+// ====
+// compileViaYul: false
 // ----
 // f(bool): false -> 1
 // f(bool): true -> 2

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation_viair.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_multi_invocation_viair.sol
@@ -1,5 +1,3 @@
-// Note that return sets the return variable and jumps to the end of the current function or
-// modifier code block.
 contract C {
     modifier repeat(bool twice) {
         if (twice) _;
@@ -8,11 +6,10 @@ contract C {
 
     function f(bool twice) public repeat(twice) returns (uint256 r) {
         r += 1;
-        return r;
     }
 }
 // ====
-// compileViaYul: false
+// compileViaYul: true
 // ----
 // f(bool): false -> 1
-// f(bool): true -> 2
+// f(bool): true -> 1

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_multiple_times.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_multiple_times.sol
@@ -10,6 +10,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f(uint256): 3 -> 10
 // a() -> 10

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_multiple_times_local_vars.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_multiple_times_local_vars.sol
@@ -13,6 +13,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f(uint256): 3 -> 10
 // a() -> 0

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_overriding.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_overriding.sol
@@ -15,5 +15,7 @@ contract C is A {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f() -> false

--- a/test/libsolidity/semanticTests/modifiers/modifier_init_return.sol
+++ b/test/libsolidity/semanticTests/modifiers/modifier_init_return.sol
@@ -8,6 +8,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f(uint256): 9 -> 0x00, 0x00, 0x00, 0x00, 0x00
 // f(uint256): 10 -> 0x00, 0x00, 3, 0x00, 0x00

--- a/test/libsolidity/semanticTests/modifiers/modifier_init_return.sol
+++ b/test/libsolidity/semanticTests/modifiers/modifier_init_return.sol
@@ -1,0 +1,13 @@
+contract C {
+    modifier m(bool condition) {
+        if (condition) _;
+    }
+
+    function f(uint x) public m(x >= 10) returns (uint[5] memory r) {
+        r[2] = 3;
+    }
+}
+
+// ----
+// f(uint256): 9 -> 0x00, 0x00, 0x00, 0x00, 0x00
+// f(uint256): 10 -> 0x00, 0x00, 3, 0x00, 0x00

--- a/test/libsolidity/semanticTests/modifiers/return_does_not_skip_modifier.sol
+++ b/test/libsolidity/semanticTests/modifiers/return_does_not_skip_modifier.sol
@@ -10,6 +10,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // x() -> 0
 // f() -> 2

--- a/test/libsolidity/semanticTests/modifiers/return_in_modifier.sol
+++ b/test/libsolidity/semanticTests/modifiers/return_in_modifier.sol
@@ -14,6 +14,8 @@ contract C {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // x() -> 0
 // f() ->

--- a/test/libsolidity/semanticTests/modifiers/stacked_return_with_modifiers.sol
+++ b/test/libsolidity/semanticTests/modifiers/stacked_return_with_modifiers.sol
@@ -15,6 +15,8 @@ contract C {
         }
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // x() -> 0
 // f() -> 42

--- a/test/libsolidity/semanticTests/payable/no_nonpayable_circumvention_by_modifier.sol
+++ b/test/libsolidity/semanticTests/payable/no_nonpayable_circumvention_by_modifier.sol
@@ -13,6 +13,8 @@ contract C {
         return address(this).balance;
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // f(), 27 wei -> FAILURE
 // balance() -> 0

--- a/test/libsolidity/semanticTests/various/multi_modifiers.sol
+++ b/test/libsolidity/semanticTests/various/multi_modifiers.sol
@@ -16,6 +16,8 @@ contract C {
         x += 3;
     }
 }
+// ====
+// compileViaYul: also
 // ----
 // f1() ->
 // x() -> 0x08


### PR DESCRIPTION
Fixes #10413.

This PR implements modifiers in a slightly different way than the old code generator.
Each modifier is wrapped into its own function and there is an "inner" function containing the actual function code (if the function has modifiers).

The generated code roughly has the following format:

```
function f(x, y) -> z {
  z := mod_m(x, y)
}
function mod_m(x, y) -> z {
  if gt(x, 2) {
    z := f_inner(x, y)
  }
}
function f_inner(x, y) -> z {
  z:= add(x, y)
}
```

In the old code generator, function parameters and return variables have a fixed place on the stack and modifier code is copied into the function. The main difference now is cases where the actual function is included multiple times (either by using `_` inside a loop or by using multiple `_` per modifier). In the old code generator, the function parameters would reference the same stack slots and would live on until after the function including modifiers exits. This means using `_a++` on a parameter would have an effect on the second time the function's body is included.

```
contract c {
  modifier m() { for (uint i = 0; i < 10; i++) _; }
  function f(uint a) m returns (x) { x = ++a; }
}
```

In the old codegen, the above code would return `10` while in the new one it returns `1`.


One problem that is not yet solved by this PR is that of how to initialize return variables. If we return memory structures, they have to be initialized at all times. The proper way would be to initialize them at the very outer function and pass them in through the call chain, but this causes a rather high variable pressure.

TODO:
 - [x]  more tests
 - [x]  document differences
 - [x] solve return variable init problem