### PR TITLE
Replace the inconsistent use of u160/Address/h160 with h160 only

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1471,7 +1471,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		solAssert(!functionType->gasSet(), "");
 		solAssert(!functionType->bound(), "");
 
-		static map<FunctionType::Kind, std::tuple<u160, size_t>> precompiles = {
+		static map<FunctionType::Kind, std::tuple<unsigned, size_t>> precompiles = {
 			{FunctionType::Kind::ECRecover, std::make_tuple(1, 0)},
 			{FunctionType::Kind::SHA256, std::make_tuple(2, 0)},
 			{FunctionType::Kind::RIPEMD160, std::make_tuple(3, 12)},

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -209,7 +209,7 @@ evmc::result EVMHost::call(evmc_message const& _message) noexcept
 	{
 		// TODO this is not the right formula
 		// TODO is the nonce incremented on failure, too?
-		Address createAddress(keccak256(
+		h160 createAddress(keccak256(
 			bytes(begin(message.sender.bytes), end(message.sender.bytes)) +
 			asBytes(to_string(sender.nonce++))
 		));
@@ -218,7 +218,7 @@ evmc::result EVMHost::call(evmc_message const& _message) noexcept
 	}
 	else if (message.kind == EVMC_CREATE2)
 	{
-		Address createAddress(keccak256(
+		h160 createAddress(keccak256(
 			bytes(1, 0xff) +
 			bytes(begin(message.sender.bytes), end(message.sender.bytes)) +
 			bytes(begin(message.create2_salt.bytes), end(message.create2_salt.bytes)) +
@@ -292,12 +292,12 @@ evmc::bytes32 EVMHost::get_block_hash(int64_t _number) const noexcept
 	return convertToEVMC(u256("0x3737373737373737373737373737373737373737373737373737373737373737") + _number);
 }
 
-Address EVMHost::convertFromEVMC(evmc::address const& _addr)
+h160 EVMHost::convertFromEVMC(evmc::address const& _addr)
 {
-	return Address(bytes(begin(_addr.bytes), end(_addr.bytes)));
+	return h160(bytes(begin(_addr.bytes), end(_addr.bytes)));
 }
 
-evmc::address EVMHost::convertToEVMC(Address const& _addr)
+evmc::address EVMHost::convertToEVMC(h160 const& _addr)
 {
 	evmc::address a;
 	for (size_t i = 0; i < 20; ++i)

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -160,7 +160,7 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 	if (_isCreation)
 	{
 		message.kind = EVMC_CREATE;
-		message.destination = EVMHost::convertToEVMC(Address{});
+		message.destination = EVMHost::convertToEVMC(h160{});
 	}
 	else
 	{
@@ -186,7 +186,7 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 	}
 }
 
-void ExecutionFramework::sendEther(Address const& _addr, u256 const& _amount)
+void ExecutionFramework::sendEther(h160 const& _addr, u256 const& _amount)
 {
 	m_evmcHost->newBlock();
 
@@ -219,12 +219,12 @@ size_t ExecutionFramework::blockTimestamp(u256 _block)
 		return static_cast<size_t>((currentTimestamp() / blockNumber()) * _block);
 }
 
-Address ExecutionFramework::account(size_t _idx)
+h160 ExecutionFramework::account(size_t _idx)
 {
-	return Address(h256(u256{"0x1212121212121212121212121212120000000012"} + _idx * 0x1000), Address::AlignRight);
+	return h160(h256(u256{"0x1212121212121212121212121212120000000012"} + _idx * 0x1000), h160::AlignRight);
 }
 
-bool ExecutionFramework::addressHasCode(Address const& _addr)
+bool ExecutionFramework::addressHasCode(h160 const& _addr)
 {
 	return m_evmcHost->get_code_size(EVMHost::convertToEVMC(_addr)) != 0;
 }
@@ -244,7 +244,7 @@ h256 ExecutionFramework::logTopic(size_t _logIdx, size_t _topicIdx) const
 	return EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(_logIdx).topics.at(_topicIdx));
 }
 
-Address ExecutionFramework::logAddress(size_t _logIdx) const
+h160 ExecutionFramework::logAddress(size_t _logIdx) const
 {
 	return EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(_logIdx).creator);
 }
@@ -257,12 +257,12 @@ bytes ExecutionFramework::logData(size_t _logIdx) const
 	return {data.begin(), data.end()};
 }
 
-u256 ExecutionFramework::balanceAt(Address const& _addr)
+u256 ExecutionFramework::balanceAt(h160 const& _addr)
 {
 	return u256(EVMHost::convertFromEVMC(m_evmcHost->get_balance(EVMHost::convertToEVMC(_addr))));
 }
 
-bool ExecutionFramework::storageEmpty(Address const& _addr)
+bool ExecutionFramework::storageEmpty(h160 const& _addr)
 {
 	const auto it = m_evmcHost->accounts.find(EVMHost::convertToEVMC(_addr));
 	if (it != m_evmcHost->accounts.end())

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -41,9 +41,6 @@
 namespace solidity::test
 {
 using rational = boost::rational<bigint>;
-/// An Ethereum address: 20 bytes.
-/// @NOTE This is not endian-specific; it's just a bunch of bytes.
-using Address = util::h160;
 
 // The ether and gwei denominations; here for ease of use where needed within code.
 static const u256 gwei = u256(1) << 9;
@@ -62,7 +59,7 @@ public:
 		u256 const& _value = 0,
 		std::string const& _contractName = "",
 		bytes const& _arguments = {},
-		std::map<std::string, Address> const& _libraryAddresses = {}
+		std::map<std::string, util::h160> const& _libraryAddresses = {}
 	) = 0;
 
 	bytes const& compileAndRun(
@@ -70,7 +67,7 @@ public:
 		u256 const& _value = 0,
 		std::string const& _contractName = "",
 		bytes const& _arguments = {},
-		std::map<std::string, Address> const& _libraryAddresses = {}
+		std::map<std::string, util::h160> const& _libraryAddresses = {}
 	)
 	{
 		compileAndRunWithoutCheck(
@@ -176,6 +173,7 @@ public:
 		return encode(u256((value.numerator() << fractionalBits) / value.denominator()));
 	}
 	static bytes encode(util::h256 const& _value) { return _value.asBytes(); }
+	static bytes encode(util::h160 const& _value) { return encode(util::h256(_value, util::h256::AlignRight)); }
 	static bytes encode(bytes const& _value, bool _padLeft = true)
 	{
 		bytes padding = bytes((32 - _value.size() % 32) % 32, 0);
@@ -258,21 +256,21 @@ protected:
 	void reset();
 
 	void sendMessage(bytes const& _data, bool _isCreation, u256 const& _value = 0);
-	void sendEther(Address const& _to, u256 const& _value);
+	void sendEther(util::h160 const& _to, u256 const& _value);
 	size_t currentTimestamp();
 	size_t blockTimestamp(u256 _number);
 
 	/// @returns the (potentially newly created) _ith address.
-	Address account(size_t _i);
+	util::h160 account(size_t _i);
 
-	u256 balanceAt(Address const& _addr);
-	bool storageEmpty(Address const& _addr);
-	bool addressHasCode(Address const& _addr);
+	u256 balanceAt(util::h160 const& _addr);
+	bool storageEmpty(util::h160 const& _addr);
+	bool addressHasCode(util::h160 const& _addr);
 
 	size_t numLogs() const;
 	size_t numLogTopics(size_t _logIdx) const;
 	util::h256 logTopic(size_t _logIdx, size_t _topicIdx) const;
-	Address logAddress(size_t _logIdx) const;
+	util::h160 logAddress(size_t _logIdx) const;
 	bytes logData(size_t _logIdx) const;
 
 	langutil::EVMVersion m_evmVersion;
@@ -285,8 +283,8 @@ protected:
 	std::vector<boost::filesystem::path> m_vmPaths;
 
 	bool m_transactionSuccessful = true;
-	Address m_sender = account(0);
-	Address m_contractAddress;
+	util::h160 m_sender = account(0);
+	util::h160 m_contractAddress;
 	u256 const m_gasPrice = 10 * gwei;
 	u256 const m_gas = 100000000;
 	bytes m_output;

--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -239,27 +239,27 @@ protected:
 		{
 			callString("reserve", _name);
 		}
-		u160 owner(string const& _name)
+		h160 owner(string const& _name)
 		{
 			return callStringReturnsAddress("owner", _name);
 		}
-		void setAddress(string const& _name, u160 const& _address, bool _primary)
+		void setAddress(string const& _name, h160 const& _address, bool _primary)
 		{
 			callStringAddressBool("setAddress", _name, _address, _primary);
 		}
-		u160 addr(string const& _name)
+		h160 addr(string const& _name)
 		{
 			return callStringReturnsAddress("addr", _name);
 		}
-		string name(u160 const& _addr)
+		string name(h160 const& _addr)
 		{
 			return callAddressReturnsString("name", _addr);
 		}
-		void setSubRegistrar(string const& _name, u160 const& _address)
+		void setSubRegistrar(string const& _name, h160 const& _address)
 		{
 			callStringAddress("setSubRegistrar", _name, _address);
 		}
-		u160 subRegistrar(string const& _name)
+		h160 subRegistrar(string const& _name)
 		{
 			return callStringReturnsAddress("subRegistrar", _name);
 		}
@@ -271,7 +271,7 @@ protected:
 		{
 			return callStringReturnsBytes32("content", _name);
 		}
-		void transfer(string const& _name, u160 const& _target)
+		void transfer(string const& _name, h160 const& _target)
 		{
 			return callStringAddress("transfer", _name, _target);
 		}
@@ -304,12 +304,12 @@ BOOST_AUTO_TEST_CASE(reserve)
 
 	// should not work
 	registrar.reserve("");
-	BOOST_CHECK_EQUAL(registrar.owner(""), u160(0));
+	BOOST_CHECK_EQUAL(registrar.owner(""), h160{});
 
 	for (auto const& name: names)
 	{
 		registrar.reserve(name);
-		BOOST_CHECK_EQUAL(registrar.owner(name), u160(m_sender));
+		BOOST_CHECK_EQUAL(registrar.owner(name), m_sender);
 	}
 }
 
@@ -346,20 +346,20 @@ BOOST_AUTO_TEST_CASE(properties)
 		// setting by sender works
 		registrar.reserve(name);
 		BOOST_CHECK_EQUAL(registrar.owner(name), sender);
-		registrar.setAddress(name, addr, true);
-		BOOST_CHECK_EQUAL(registrar.addr(name), u160(addr));
-		registrar.setSubRegistrar(name, addr + 20);
-		BOOST_CHECK_EQUAL(registrar.subRegistrar(name), u160(addr + 20));
+		registrar.setAddress(name, h160(addr), true);
+		BOOST_CHECK_EQUAL(registrar.addr(name), h160(addr));
+		registrar.setSubRegistrar(name, h160(addr + 20));
+		BOOST_CHECK_EQUAL(registrar.subRegistrar(name), h160(addr + 20));
 		registrar.setContent(name, h256(u256(addr + 90)));
 		BOOST_CHECK_EQUAL(registrar.content(name), h256(u256(addr + 90)));
 
 		// but not by someone else
 		m_sender = account(count - 1);
 		BOOST_CHECK_EQUAL(registrar.owner(name), sender);
-		registrar.setAddress(name, addr + 1, true);
-		BOOST_CHECK_EQUAL(registrar.addr(name), u160(addr));
-		registrar.setSubRegistrar(name, addr + 20 + 1);
-		BOOST_CHECK_EQUAL(registrar.subRegistrar(name), u160(addr + 20));
+		registrar.setAddress(name, h160(addr + 1), true);
+		BOOST_CHECK_EQUAL(registrar.addr(name), h160(addr));
+		registrar.setSubRegistrar(name, h160(addr + 20 + 1));
+		BOOST_CHECK_EQUAL(registrar.subRegistrar(name), h160(addr + 20));
 		registrar.setContent(name, h256(u256(addr + 90 + 1)));
 		BOOST_CHECK_EQUAL(registrar.content(name), h256(u256(addr + 90)));
 		count++;
@@ -373,8 +373,8 @@ BOOST_AUTO_TEST_CASE(transfer)
 	RegistrarInterface registrar(*this);
 	registrar.reserve(name);
 	registrar.setContent(name, h256(u256(123)));
-	registrar.transfer(name, u160(555));
-	BOOST_CHECK_EQUAL(registrar.owner(name), u160(555));
+	registrar.transfer(name, h160(555));
+	BOOST_CHECK_EQUAL(registrar.owner(name), h160(555));
 	BOOST_CHECK_EQUAL(registrar.content(name), h256(u256(123)));
 }
 
@@ -386,9 +386,9 @@ BOOST_AUTO_TEST_CASE(disown)
 	RegistrarInterface registrar(*this);
 	registrar.reserve(name);
 	registrar.setContent(name, h256(u256(123)));
-	registrar.setAddress(name, u160(124), true);
-	registrar.setSubRegistrar(name, u160(125));
-	BOOST_CHECK_EQUAL(registrar.name(u160(124)), name);
+	registrar.setAddress(name, h160(124), true);
+	registrar.setSubRegistrar(name, h160(125));
+	BOOST_CHECK_EQUAL(registrar.name(h160(124)), name);
 
 	// someone else tries disowning
 	sendEther(account(1), u256(10) * ether);
@@ -398,11 +398,11 @@ BOOST_AUTO_TEST_CASE(disown)
 
 	m_sender = account(0);
 	registrar.disown(name);
-	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
-	BOOST_CHECK_EQUAL(registrar.addr(name), 0);
-	BOOST_CHECK_EQUAL(registrar.subRegistrar(name), 0);
+	BOOST_CHECK_EQUAL(registrar.owner(name), h160());
+	BOOST_CHECK_EQUAL(registrar.addr(name), h160());
+	BOOST_CHECK_EQUAL(registrar.subRegistrar(name), h160());
 	BOOST_CHECK_EQUAL(registrar.content(name), h256());
-	BOOST_CHECK_EQUAL(registrar.name(u160(124)), "");
+	BOOST_CHECK_EQUAL(registrar.name(h160(124)), "");
 }
 
 BOOST_AUTO_TEST_CASE(auction_simple)
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(auction_simple)
 	// initiate auction
 	registrar.setNextValue(8);
 	registrar.reserve(name);
-	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
+	BOOST_CHECK_EQUAL(registrar.owner(name), h160());
 	// "wait" until auction end
 
 	m_evmcHost->tx_context.block_timestamp += m_biddingTime + 10;
@@ -435,7 +435,7 @@ BOOST_AUTO_TEST_CASE(auction_bidding)
 	// initiate auction
 	registrar.setNextValue(8);
 	registrar.reserve(name);
-	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
+	BOOST_CHECK_EQUAL(registrar.owner(name), h160());
 	// overbid self
 	m_evmcHost->tx_context.block_timestamp = startTime + m_biddingTime - 10;
 	registrar.setNextValue(12);
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(auction_bidding)
 	m_evmcHost->tx_context.block_timestamp = startTime + 2 * m_biddingTime - 50;
 	registrar.setNextValue(13);
 	registrar.reserve(name);
-	BOOST_CHECK_EQUAL(registrar.owner(name), 0);
+	BOOST_CHECK_EQUAL(registrar.owner(name), h160());
 	// end auction by first bidder (which is not highest) trying to overbid again (too late)
 	m_sender = account(0);
 	m_evmcHost->tx_context.block_timestamp = startTime + 4 * m_biddingTime;

--- a/test/contracts/ContractInterface.h
+++ b/test/contracts/ContractInterface.h
@@ -47,12 +47,12 @@ protected:
 		BOOST_CHECK(call(_name + "(string)", u256(0x20), _arg.length(), _arg).empty());
 	}
 
-	void callStringAddress(std::string const& _name, std::string const& _arg1, u160 const& _arg2)
+	void callStringAddress(std::string const& _name, std::string const& _arg1, util::h160 const& _arg2)
 	{
 		BOOST_CHECK(call(_name + "(string,address)", u256(0x40), _arg2, _arg1.length(), _arg1).empty());
 	}
 
-	void callStringAddressBool(std::string const& _name, std::string const& _arg1, u160 const& _arg2, bool _arg3)
+	void callStringAddressBool(std::string const& _name, std::string const& _arg1, util::h160 const& _arg2, bool _arg3)
 	{
 		BOOST_CHECK(call(_name + "(string,address,bool)", u256(0x60), _arg2, _arg3, _arg1.length(), _arg1).empty());
 	}
@@ -62,15 +62,16 @@ protected:
 		BOOST_CHECK(call(_name + "(string,bytes32)", u256(0x40), _arg2, _arg1.length(), _arg1).empty());
 	}
 
-	u160 callStringReturnsAddress(std::string const& _name, std::string const& _arg)
+	util::h160 callStringReturnsAddress(std::string const& _name, std::string const& _arg)
 	{
 		bytes const& ret = call(_name + "(string)", u256(0x20), _arg.length(), _arg);
 		BOOST_REQUIRE(ret.size() == 0x20);
 		BOOST_CHECK(std::count(ret.begin(), ret.begin() + 12, 0) == 12);
-		return u160(u256(util::h256(ret)));
+		bytes const addr{ret.begin() + 12, ret.end()};
+		return util::h160(addr);
 	}
 
-	std::string callAddressReturnsString(std::string const& _name, u160 const& _arg)
+	std::string callAddressReturnsString(std::string const& _name, util::h160 const& _arg)
 	{
 		bytesConstRef const ret(&call(_name + "(address)", _arg));
 		BOOST_REQUIRE(ret.size() >= 0x40);

--- a/test/contracts/FixedFeeRegistrar.cpp
+++ b/test/contracts/FixedFeeRegistrar.cpp
@@ -160,11 +160,11 @@ BOOST_AUTO_TEST_CASE(reserve)
 	deployRegistrar();
 	string name[] = {"abc", "def", "ghi"};
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee, encodeDyn(name[0])) == encodeArgs());
-	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name[0])) == encodeArgs(h256(account(0), h256::AlignRight)));
+	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name[0])) == encodeArgs(account(0)));
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee + 1, encodeDyn(name[1])) == encodeArgs());
-	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name[1])) == encodeArgs(h256(account(0), h256::AlignRight)));
+	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name[1])) == encodeArgs(account(0)));
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee - 1, encodeDyn(name[2])) == encodeArgs());
-	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name[2])) == encodeArgs(h256{}));
+	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name[2])) == encodeArgs(h160{}));
 }
 
 BOOST_AUTO_TEST_CASE(double_reserve)
@@ -173,12 +173,12 @@ BOOST_AUTO_TEST_CASE(double_reserve)
 	deployRegistrar();
 	string name = "abc";
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee, encodeDyn(name)) == encodeArgs());
-	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(h256(account(0), h256::AlignRight)));
+	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(account(0)));
 
 	sendEther(account(1), 100 * ether);
 	m_sender = account(1);
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee, encodeDyn(name)) == encodeArgs());
-	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(h256(account(0), h256::AlignRight)));
+	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(account(0)));
 }
 
 BOOST_AUTO_TEST_CASE(properties)
@@ -194,10 +194,10 @@ BOOST_AUTO_TEST_CASE(properties)
 		m_sender = account(0);
 		sendEther(account(count), 100 * ether);
 		m_sender = account(count);
-		Address owner = m_sender;
+		h160 owner = m_sender;
 		// setting by sender works
 		BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee, encodeDyn(name)) == encodeArgs());
-		BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(h256(owner, h256::AlignRight)));
+		BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(owner));
 		BOOST_CHECK(callContractFunction("setAddr(string,address)", u256(0x40), u256(addr), u256(name.length()), name) == encodeArgs());
 		BOOST_CHECK(callContractFunction("addr(string)", encodeDyn(name)) == encodeArgs(addr));
 		BOOST_CHECK(callContractFunction("setSubRegistrar(string,address)", u256(0x40), addr + 20, u256(name.length()), name) == encodeArgs());
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(properties)
 		m_sender = account(0);
 		sendEther(account(count), 100 * ether);
 		m_sender = account(count);
-		BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(h256(owner, h256::AlignRight)));
+		BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(owner));
 		BOOST_CHECK(callContractFunction("setAddr(string,address)", u256(0x40), addr + 1, u256(name.length()), name) == encodeArgs());
 		BOOST_CHECK(callContractFunction("addr(string)", encodeDyn(name)) == encodeArgs(addr));
 		BOOST_CHECK(callContractFunction("setSubRegistrar(string,address)", u256(0x40), addr + 20 + 1, u256(name.length()), name) == encodeArgs());
@@ -225,10 +225,10 @@ BOOST_AUTO_TEST_CASE(transfer)
 	deployRegistrar();
 	string name = "abc";
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee, encodeDyn(name)) == encodeArgs());
-	BOOST_CHECK(callContractFunction("setContent(string,bytes32)", u256(0x40), h256(account(0), h256::AlignRight), u256(name.length()), name) == encodeArgs());
+	BOOST_CHECK(callContractFunction("setContent(string,bytes32)", u256(0x40), account(0), u256(name.length()), name) == encodeArgs());
 	BOOST_CHECK(callContractFunction("transfer(string,address)", u256(0x40), u256(555), u256(name.length()), name) == encodeArgs());
 	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(u256(555)));
-	BOOST_CHECK(callContractFunction("content(string)", encodeDyn(name)) == encodeArgs(h256(account(0), h256::AlignRight)));
+	BOOST_CHECK(callContractFunction("content(string)", encodeDyn(name)) == encodeArgs(account(0)));
 }
 
 BOOST_AUTO_TEST_CASE(disown)
@@ -236,13 +236,13 @@ BOOST_AUTO_TEST_CASE(disown)
 	deployRegistrar();
 	string name = "abc";
 	BOOST_REQUIRE(callContractFunctionWithValue("reserve(string)", m_fee, encodeDyn(name)) == encodeArgs());
-	BOOST_CHECK(callContractFunction("setContent(string,bytes32)", u256(0x40), h256(account(0), h256::AlignRight), u256(name.length()), name) == encodeArgs());
+	BOOST_CHECK(callContractFunction("setContent(string,bytes32)", u256(0x40), account(0), u256(name.length()), name) == encodeArgs());
 	BOOST_CHECK(callContractFunction("setAddr(string,address)", u256(0x40), u256(124), u256(name.length()), name) == encodeArgs());
 	BOOST_CHECK(callContractFunction("setSubRegistrar(string,address)", u256(0x40), u256(125), u256(name.length()), name) == encodeArgs());
 
-	BOOST_CHECK_EQUAL(balanceAt(Address(0x124)), 0);
+	BOOST_CHECK_EQUAL(balanceAt(h160(0x124)), 0);
 	BOOST_CHECK(callContractFunction("disown(string,address)", u256(0x40), u256(0x124), name.size(), name) == encodeArgs());
-	BOOST_CHECK_EQUAL(balanceAt(Address(0x124)), m_fee);
+	BOOST_CHECK_EQUAL(balanceAt(h160(0x124)), m_fee);
 
 	BOOST_CHECK(callContractFunction("owner(string)", encodeDyn(name)) == encodeArgs(u256(0)));
 	BOOST_CHECK(callContractFunction("content(string)", encodeDyn(name)) == encodeArgs(u256(0)));

--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -445,7 +445,7 @@ class WalletTestFramework: public SolidityExecutionFramework
 protected:
 	void deployWallet(
 		u256 const& _value = 0,
-		vector<u256> const& _owners = vector<u256>{},
+		vector<h160> const& _owners = vector<h160>{},
 		u256 _required = 1,
 		u256 _dailyLimit = 0
 	)
@@ -467,7 +467,7 @@ BOOST_FIXTURE_TEST_SUITE(SolidityWallet, WalletTestFramework)
 BOOST_AUTO_TEST_CASE(creation)
 {
 	deployWallet(200);
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(m_sender, h256::AlignRight)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", m_sender) == encodeArgs(true));
 	bool v2 = solidity::test::CommonOptions::get().useABIEncoderV2;
 	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(~0)) == (v2 ? encodeArgs() : encodeArgs(false)));
 }
@@ -475,34 +475,34 @@ BOOST_AUTO_TEST_CASE(creation)
 BOOST_AUTO_TEST_CASE(add_owners)
 {
 	deployWallet(200);
-	Address originalOwner = m_sender;
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs(true));
+	h160 originalOwner = m_sender;
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(1)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", account(1)) == encodeArgs(true));
 	// now let the new owner add someone
 	sendEther(account(1), 10 * ether);
 	m_sender = account(1);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x13)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x13)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x13)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x13)) == encodeArgs(true));
 	// and check that a non-owner cannot add a new owner
 	m_sender = account(0);
 	sendEther(account(2), 10 * ether);
 	m_sender = account(2);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x20)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x20)) == encodeArgs(false));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x20)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x20)) == encodeArgs(false));
 	// finally check that all the owners are there
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(originalOwner, h256::AlignRight)) == encodeArgs(true));
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs(true));
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x13)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", originalOwner) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", account(1)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x13)) == encodeArgs(true));
 }
 
 BOOST_AUTO_TEST_CASE(change_owners)
 {
 	deployWallet(200);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x12)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x12)) == encodeArgs(true));
-	BOOST_REQUIRE(callContractFunction("changeOwner(address,address)", h256(0x12), h256(0x13)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x12)) == encodeArgs(false));
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x13)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x12)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x12)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("changeOwner(address,address)", h160(0x12), h160(0x13)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x12)) == encodeArgs(false));
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x13)) == encodeArgs(true));
 }
 
 BOOST_AUTO_TEST_CASE(remove_owner)
@@ -511,43 +511,43 @@ BOOST_AUTO_TEST_CASE(remove_owner)
 	// add 10 owners
 	for (unsigned i = 0; i < 10; ++i)
 	{
-		BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x12 + i)) == encodeArgs());
-		BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x12 + i)) == encodeArgs(true));
+		BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x12 + i)) == encodeArgs());
+		BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x12 + i)) == encodeArgs(true));
 	}
 	// check they are there again
 	for (unsigned i = 0; i < 10; ++i)
-		BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x12 + i)) == encodeArgs(true));
+		BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x12 + i)) == encodeArgs(true));
 	// remove the odd owners
 	for (unsigned i = 0; i < 10; ++i)
 		if (i % 2 == 1)
-			BOOST_REQUIRE(callContractFunction("removeOwner(address)", h256(0x12 + i)) == encodeArgs());
+			BOOST_REQUIRE(callContractFunction("removeOwner(address)", h160(0x12 + i)) == encodeArgs());
 	// check the result
 	for (unsigned i = 0; i < 10; ++i)
-		BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x12 + i)) == encodeArgs(i % 2 == 0));
+		BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x12 + i)) == encodeArgs(i % 2 == 0));
 	// add them again
 	for (unsigned i = 0; i < 10; ++i)
 		if (i % 2 == 1)
-			BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x12 + i)) == encodeArgs());
+			BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x12 + i)) == encodeArgs());
 	// check everyone is there
 	for (unsigned i = 0; i < 10; ++i)
-		BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x12 + i)) == encodeArgs(true));
+		BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x12 + i)) == encodeArgs(true));
 }
 
 BOOST_AUTO_TEST_CASE(initial_owners)
 {
-	vector<u256> owners{
-		u256("0x00000000000000000000000042c56279432962a17176998a4747d1b4d6ed4367"),
-		u256("0x000000000000000000000000d4d4669f5ba9f4c27d38ef02a358c339b5560c47"),
-		u256("0x000000000000000000000000e6716f9544a56c530d868e4bfbacb172315bdead"),
-		u256("0x000000000000000000000000775e18be7a50a0abb8a4e82b1bd697d79f31fe04"),
-		u256("0x000000000000000000000000f4dd5c3794f1fd0cdc0327a83aa472609c806e99"),
-		u256("0x0000000000000000000000004c9113886af165b2de069d6e99430647e94a9fff"),
-		u256("0x0000000000000000000000003fb1cd2cd96c6d5c0b5eb3322d807b34482481d4")
+	vector<h160> owners{
+		h160("0x42c56279432962a17176998a4747d1b4d6ed4367"),
+		h160("0xd4d4669f5ba9f4c27d38ef02a358c339b5560c47"),
+		h160("0xe6716f9544a56c530d868e4bfbacb172315bdead"),
+		h160("0x775e18be7a50a0abb8a4e82b1bd697d79f31fe04"),
+		h160("0xf4dd5c3794f1fd0cdc0327a83aa472609c806e99"),
+		h160("0x4c9113886af165b2de069d6e99430647e94a9fff"),
+		h160("0x3fb1cd2cd96c6d5c0b5eb3322d807b34482481d4")
 	};
 	deployWallet(0, owners, 4, 2);
 	BOOST_CHECK(callContractFunction("m_numOwners()") == encodeArgs(u256(8)));
-	BOOST_CHECK(callContractFunction("isOwner(address)", h256(m_sender, h256::AlignRight)) == encodeArgs(true));
-	for (u256 const& owner: owners)
+	BOOST_CHECK(callContractFunction("isOwner(address)", m_sender) == encodeArgs(true));
+	for (h160 const& owner: owners)
 	{
 		BOOST_CHECK(callContractFunction("isOwner(address)", owner) == encodeArgs(true));
 	}
@@ -556,17 +556,17 @@ BOOST_AUTO_TEST_CASE(initial_owners)
 BOOST_AUTO_TEST_CASE(multisig_value_transfer)
 {
 	deployWallet(200);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(2), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(3), h256::AlignRight)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(1)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(2)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(3)) == encodeArgs());
 	// 4 owners, set required to 3
 	BOOST_REQUIRE(callContractFunction("changeRequirement(uint256)", u256(3)) == encodeArgs());
-	Address destination = Address("0x5c6d6026d3fb35cd7175fd0054ae8df50d8f8b41");
+	h160 destination = h160("0x5c6d6026d3fb35cd7175fd0054ae8df50d8f8b41");
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
 	m_sender = account(0);
 	sendEther(account(1), 10 * ether);
 	m_sender = account(1);
-	auto ophash = callContractFunction("execute(address,uint256,bytes)", h256(destination, h256::AlignRight), 100, 0x60, 0x00);
+	auto ophash = callContractFunction("execute(address,uint256,bytes)", destination, 100, 0x60, 0x00);
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
 	m_sender = account(0);
 	sendEther(account(2), 10 * ether);
@@ -584,52 +584,52 @@ BOOST_AUTO_TEST_CASE(multisig_value_transfer)
 BOOST_AUTO_TEST_CASE(revoke_addOwner)
 {
 	deployWallet();
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(2), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(3), h256::AlignRight)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(1)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(2)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(3)) == encodeArgs());
 	// 4 owners, set required to 3
 	BOOST_REQUIRE(callContractFunction("changeRequirement(uint256)", u256(3)) == encodeArgs());
 	// add a new owner
-	Address deployer = m_sender;
+	h160 deployer = m_sender;
 	h256 opHash = util::keccak256(FixedHash<4>(util::keccak256("addOwner(address)")).asBytes() + h256(0x33).asBytes());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x33)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x33)) == encodeArgs(false));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x33)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x33)) == encodeArgs(false));
 	m_sender = account(0);
 	sendEther(account(1), 10 * ether);
 	m_sender = account(1);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x33)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x33)) == encodeArgs(false));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x33)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x33)) == encodeArgs(false));
 	// revoke one confirmation
 	m_sender = deployer;
 	BOOST_REQUIRE(callContractFunction("revoke(bytes32)", opHash) == encodeArgs());
 	m_sender = account(0);
 	sendEther(account(2), 10 * ether);
 	m_sender = account(2);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x33)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x33)) == encodeArgs(false));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x33)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x33)) == encodeArgs(false));
 	m_sender = account(0);
 	sendEther(account(3), 10 * ether);
 	m_sender = account(3);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(0x33)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("isOwner(address)", h256(0x33)) == encodeArgs(true));
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", h160(0x33)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("isOwner(address)", h160(0x33)) == encodeArgs(true));
 }
 
 BOOST_AUTO_TEST_CASE(revoke_transaction)
 {
 	deployWallet(200);
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(2), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(3), h256::AlignRight)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(1)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(2)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(3)) == encodeArgs());
 	// 4 owners, set required to 3
 	BOOST_REQUIRE(callContractFunction("changeRequirement(uint256)", u256(3)) == encodeArgs());
 	// create a transaction
-	Address deployer = m_sender;
-	Address destination = Address("0x5c6d6026d3fb35cd7175fd0054ae8df50d8f8b41");
+	h160 deployer = m_sender;
+	h160 destination = h160("0x5c6d6026d3fb35cd7175fd0054ae8df50d8f8b41");
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
 	m_sender = account(0);
 	sendEther(account(1), 10 * ether);
 	m_sender = account(1);
-	auto opHash = callContractFunction("execute(address,uint256,bytes)", h256(destination, h256::AlignRight), 100, 0x60, 0x00);
+	auto opHash = callContractFunction("execute(address,uint256,bytes)", destination, 100, 0x60, 0x00);
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
 	m_sender = account(0);
 	sendEther(account(2), 10 * ether);
@@ -655,21 +655,21 @@ BOOST_AUTO_TEST_CASE(daylimit)
 {
 	deployWallet(200);
 	BOOST_REQUIRE(callContractFunction("m_dailyLimit()") == encodeArgs(u256(0)));
-	BOOST_REQUIRE(callContractFunction("setDailyLimit(uint256)", h256(100)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("setDailyLimit(uint256)", u256(100)) == encodeArgs());
 	BOOST_REQUIRE(callContractFunction("m_dailyLimit()") == encodeArgs(u256(100)));
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(1), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(2), h256::AlignRight)) == encodeArgs());
-	BOOST_REQUIRE(callContractFunction("addOwner(address)", h256(account(3), h256::AlignRight)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(1)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(2)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("addOwner(address)", account(3)) == encodeArgs());
 	// 4 owners, set required to 3
 	BOOST_REQUIRE(callContractFunction("changeRequirement(uint256)", u256(3)) == encodeArgs());
 
 	// try to send tx over daylimit
-	Address destination = Address("0x5c6d6026d3fb35cd7175fd0054ae8df50d8f8b41");
+	h160 destination = h160("0x5c6d6026d3fb35cd7175fd0054ae8df50d8f8b41");
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
 	sendEther(account(1), 10 * ether);
 	m_sender = account(1);
 	BOOST_REQUIRE(
-		callContractFunction("execute(address,uint256,bytes)", h256(destination, h256::AlignRight), 150, 0x60, 0x00) !=
+		callContractFunction("execute(address,uint256,bytes)", destination, 150, 0x60, 0x00) !=
 		encodeArgs(u256(0))
 	);
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
@@ -678,7 +678,7 @@ BOOST_AUTO_TEST_CASE(daylimit)
 	sendEther(account(4), 10 * ether);
 	m_sender = account(4);
 	BOOST_REQUIRE(
-		callContractFunction("execute(address,uint256,bytes)", h256(destination, h256::AlignRight), 90, 0x60, 0x00) ==
+		callContractFunction("execute(address,uint256,bytes)", destination, 90, 0x60, 0x00) ==
 		encodeArgs(u256(0))
 	);
 	BOOST_CHECK_EQUAL(balanceAt(destination), 0);
@@ -686,7 +686,7 @@ BOOST_AUTO_TEST_CASE(daylimit)
 	m_sender = account(0);
 	sendEther(account(1), 10 * ether);
 	BOOST_REQUIRE(
-		callContractFunction("execute(address,uint256,bytes)", h256(destination, h256::AlignRight), 90, 0x60, 0x00) ==
+		callContractFunction("execute(address,uint256,bytes)", destination, 90, 0x60, 0x00) ==
 		encodeArgs(u256(0))
 	);
 	BOOST_CHECK_EQUAL(balanceAt(destination), 90);
@@ -696,7 +696,7 @@ BOOST_AUTO_TEST_CASE(daylimit_constructor)
 {
 	deployWallet(200, {}, 1, 20);
 	BOOST_REQUIRE(callContractFunction("m_dailyLimit()") == encodeArgs(u256(20)));
-	BOOST_REQUIRE(callContractFunction("setDailyLimit(uint256)", h256(30)) == encodeArgs());
+	BOOST_REQUIRE(callContractFunction("setDailyLimit(uint256)", u256(30)) == encodeArgs());
 	BOOST_REQUIRE(callContractFunction("m_dailyLimit()") == encodeArgs(u256(30)));
 }
 

--- a/test/libsolidity/ABIDecoderTests.cpp
+++ b/test/libsolidity/ABIDecoderTests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(value_types)
 		compileAndRun(sourceCode);
 		ABI_CHECK(callContractFunction(
 			"f(uint256,uint16,uint24,int24,bytes3,bool,address)",
-			1, 2, 3, 4, string("abc"), true, u160(m_contractAddress)
+			1, 2, 3, 4, string("abc"), true, m_contractAddress
 		), encodeArgs(u256(20)));
 	)
 }
@@ -408,7 +408,7 @@ BOOST_AUTO_TEST_CASE(complex_struct)
 			0x40,
 			0x100,
 			// S s1[0]
-			u256(u160(m_contractAddress)),
+			m_contractAddress,
 			0x40,
 			// T s1[0].t
 			1, // length
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(complex_struct)
 			0x21, 2, 0x22,
 			0, 0, 0
 		);
-		ABI_CHECK(callContractFunction(sig, args), encodeArgs(7, u256(u160(m_contractAddress)), 8, 2, 0x1234, 3, 2, 0x22));
+		ABI_CHECK(callContractFunction(sig, args), encodeArgs(7, m_contractAddress, 8, 2, 0x1234, 3, 2, 0x22));
 		// invalid enum value
 		args.data()[0x20 * 28] = 3;
 		ABI_CHECK(callContractFunction(sig, args), encodeArgs());

--- a/test/libsolidity/ABIEncoderTests.cpp
+++ b/test/libsolidity/ABIEncoderTests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(value_types)
 		compileAndRun(sourceCode);
 		callContractFunction("f()");
 		REQUIRE_LOG_DATA(encodeArgs(
-			10, u256(65534), u256(0x121212), u256(-1), string("\x1b\xab\xab"), true, u160(u256(-5))
+			10, u256(65534), u256(0x121212), u256(-1), string("\x1b\xab\xab"), true, h160("fffffffffffffffffffffffffffffffffffffffb")
 		));
 	)
 }
@@ -273,7 +273,11 @@ BOOST_AUTO_TEST_CASE(storage_array)
 	BOTH_ENCODERS(
 		compileAndRun(sourceCode);
 		callContractFunction("f()");
-		REQUIRE_LOG_DATA(encodeArgs(u160(-1), u160(-2), u160(-3)));
+		REQUIRE_LOG_DATA(encodeArgs(
+			h160("ffffffffffffffffffffffffffffffffffffffff"),
+			h160("fffffffffffffffffffffffffffffffffffffffe"),
+			h160("fffffffffffffffffffffffffffffffffffffffd")
+		));
 	)
 }
 
@@ -294,7 +298,13 @@ BOOST_AUTO_TEST_CASE(storage_array_dyn)
 	BOTH_ENCODERS(
 		compileAndRun(sourceCode);
 		callContractFunction("f()");
-		REQUIRE_LOG_DATA(encodeArgs(0x20, 3, u160(1), u160(2), u160(3)));
+		REQUIRE_LOG_DATA(encodeArgs(
+			0x20,
+			3,
+			h160("0000000000000000000000000000000000000001"),
+			h160("0000000000000000000000000000000000000002"),
+			h160("0000000000000000000000000000000000000003")
+		));
 	)
 }
 
@@ -488,7 +498,7 @@ BOOST_AUTO_TEST_CASE(structs2)
 			0x40,
 			0x100,
 			// S s1[0]
-			u256(u160(m_contractAddress)),
+			m_contractAddress,
 			0x40,
 			// T s1[0].t
 			1, // length

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(blockchain)
 			}
 		}
 	)";
-	m_evmcHost->tx_context.block_coinbase = EVMHost::convertToEVMC(Address("0x1212121212121212121212121212121212121212"));
+	m_evmcHost->tx_context.block_coinbase = EVMHost::convertToEVMC(h160("0x1212121212121212121212121212121212121212"));
 	m_evmcHost->newBlock();
 	m_evmcHost->newBlock();
 	m_evmcHost->newBlock();
@@ -851,7 +851,7 @@ BOOST_AUTO_TEST_CASE(send_ether)
 
 		u256 amount(250);
 		compileAndRun(sourceCode, amount + 1);
-		u160 address(23);
+		h160 address(23);
 		ABI_CHECK(callContractFunction("a(address,uint256)", address, amount), encodeArgs(1));
 		BOOST_CHECK_EQUAL(balanceAt(address), amount);
 	)
@@ -884,11 +884,11 @@ BOOST_AUTO_TEST_CASE(transfer_ether)
 		DISABLE_EWASM_TESTRUN()
 
 		compileAndRun(sourceCode, 0, "B");
-		u160 const nonPayableRecipient = m_contractAddress;
+		h160 const nonPayableRecipient = m_contractAddress;
 		compileAndRun(sourceCode, 0, "C");
-		u160 const oogRecipient = m_contractAddress;
+		h160 const oogRecipient = m_contractAddress;
 		compileAndRun(sourceCode, 20, "A");
-		u160 payableRecipient(23);
+		h160 payableRecipient(23);
 		ABI_CHECK(callContractFunction("a(address,uint256)", payableRecipient, 10), encodeArgs(10));
 		BOOST_CHECK_EQUAL(balanceAt(payableRecipient), 10);
 		BOOST_CHECK_EQUAL(balanceAt(m_contractAddress), 10);
@@ -1061,7 +1061,7 @@ BOOST_AUTO_TEST_CASE(selfdestruct)
 		}
 	)";
 	u256 amount(130);
-	u160 address(23);
+	h160 address(23);
 	ALSO_VIA_YUL(
 		DISABLE_EWASM_TESTRUN()
 
@@ -1290,7 +1290,7 @@ BOOST_AUTO_TEST_CASE(inter_contract_calls)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
@@ -1321,7 +1321,7 @@ BOOST_AUTO_TEST_CASE(inter_contract_calls_with_complex_parameters)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
@@ -1353,7 +1353,7 @@ BOOST_AUTO_TEST_CASE(inter_contract_calls_accessing_this)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
@@ -1385,7 +1385,7 @@ BOOST_AUTO_TEST_CASE(calls_to_this)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
@@ -1420,7 +1420,7 @@ BOOST_AUTO_TEST_CASE(inter_contract_calls_with_local_vars)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
@@ -1451,7 +1451,7 @@ BOOST_AUTO_TEST_CASE(fixed_bytes_in_calls)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
@@ -1749,7 +1749,7 @@ BOOST_AUTO_TEST_CASE(events_with_same_name)
 			}
 		}
 	)";
-	u160 const c_loggedAddress = m_contractAddress;
+	h160 const c_loggedAddress = m_contractAddress;
 
 	ALSO_VIA_YUL(
 		DISABLE_EWASM_TESTRUN()
@@ -1812,7 +1812,7 @@ BOOST_AUTO_TEST_CASE(events_with_same_name_inherited_emit)
 			}
 		}
 	)";
-	u160 const c_loggedAddress = m_contractAddress;
+	h160 const c_loggedAddress = m_contractAddress;
 
 	ALSO_VIA_YUL(
 		DISABLE_EWASM_TESTRUN()
@@ -1907,7 +1907,7 @@ BOOST_AUTO_TEST_CASE(event_lots_of_data)
 		callContractFunctionWithValue("deposit(bytes32)", value, id);
 		BOOST_REQUIRE_EQUAL(numLogs(), 1);
 		BOOST_CHECK_EQUAL(logAddress(0), m_contractAddress);
-		BOOST_CHECK(logData(0) == encodeArgs((u160)m_sender, id, value, true));
+		BOOST_CHECK(logData(0) == encodeArgs(m_sender, id, value, true));
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 1);
 		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("Deposit(address,bytes32,uint256,bool)")));
 	)
@@ -2300,7 +2300,7 @@ BOOST_AUTO_TEST_CASE(generic_call)
 			}
 	)**";
 	compileAndRun(sourceCode, 0, "receiver");
-	u160 const c_receiverAddress = m_contractAddress;
+	h160 const c_receiverAddress = m_contractAddress;
 	compileAndRun(sourceCode, 50, "sender");
 	BOOST_REQUIRE(callContractFunction("doSend(address)", c_receiverAddress) == encodeArgs(23));
 	BOOST_CHECK_EQUAL(balanceAt(m_contractAddress), 50 - 2);
@@ -2335,13 +2335,13 @@ BOOST_AUTO_TEST_CASE(generic_delegatecall)
 		string source = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n" + string(sourceCode);
 
 		compileAndRun(source, 0, "Receiver");
-		u160 const c_receiverAddress = m_contractAddress;
+		h160 const c_receiverAddress = m_contractAddress;
 		compileAndRun(source, 50, "Sender");
-		u160 const c_senderAddress = m_contractAddress;
+		h160 const c_senderAddress = m_contractAddress;
 		BOOST_CHECK(m_sender != c_senderAddress); // just for sanity
 		ABI_CHECK(callContractFunctionWithValue("doSend(address)", 11, c_receiverAddress), encodeArgs());
 		ABI_CHECK(callContractFunction("received()"), encodeArgs(u256(23)));
-		ABI_CHECK(callContractFunction("sender()"), encodeArgs(u160(m_sender)));
+		ABI_CHECK(callContractFunction("sender()"), encodeArgs(m_sender));
 		ABI_CHECK(callContractFunction("value()"), encodeArgs(u256(11)));
 		m_contractAddress = c_receiverAddress;
 		ABI_CHECK(callContractFunction("received()"), encodeArgs(u256(0)));
@@ -2387,7 +2387,7 @@ BOOST_AUTO_TEST_CASE(generic_staticcall)
 				}
 		)**";
 		compileAndRun(sourceCode, 0, "A");
-		u160 const c_addressA = m_contractAddress;
+		h160 const c_addressA = m_contractAddress;
 		compileAndRun(sourceCode, 0, "C");
 		ABI_CHECK(callContractFunction("f(address)", c_addressA), encodeArgs(true, 0x40, 0x20, 23));
 		ABI_CHECK(callContractFunction("g(address)", c_addressA), encodeArgs(true, 0x40, 0x20, 23 + 42));
@@ -2409,9 +2409,9 @@ BOOST_AUTO_TEST_CASE(library_call_in_homestead)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs());
-	ABI_CHECK(callContractFunction("sender()"), encodeArgs(u160(m_sender)));
+	ABI_CHECK(callContractFunction("sender()"), encodeArgs(m_sender));
 }
 
 BOOST_AUTO_TEST_CASE(library_call_protection)
@@ -2437,13 +2437,13 @@ BOOST_AUTO_TEST_CASE(library_call_protection)
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
 	ABI_CHECK(callContractFunction("np(Lib.S storage)", 0), encodeArgs());
-	ABI_CHECK(callContractFunction("v(Lib.S storage)", 0), encodeArgs(u160(m_sender)));
+	ABI_CHECK(callContractFunction("v(Lib.S storage)", 0), encodeArgs(m_sender));
 	ABI_CHECK(callContractFunction("pu()"), encodeArgs(2));
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("s()"), encodeArgs(0));
-	ABI_CHECK(callContractFunction("np()"), encodeArgs(u160(m_sender)));
+	ABI_CHECK(callContractFunction("np()"), encodeArgs(m_sender));
 	ABI_CHECK(callContractFunction("s()"), encodeArgs(3));
-	ABI_CHECK(callContractFunction("v()"), encodeArgs(u160(m_sender)));
+	ABI_CHECK(callContractFunction("v()"), encodeArgs(m_sender));
 	ABI_CHECK(callContractFunction("pu()"), encodeArgs(2));
 }
 
@@ -2467,7 +2467,7 @@ BOOST_AUTO_TEST_CASE(library_staticcall_delegatecall)
 		 }
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(1));
 }
 
@@ -2709,7 +2709,7 @@ BOOST_AUTO_TEST_CASE(struct_referencing)
 	compileAndRun(sourceCode, 0, "L");
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(0, 3));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(4));
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{ {"L", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{ {"L", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(1));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(2));
 	ABI_CHECK(callContractFunction("h()"), encodeArgs(0, 5));
@@ -2755,7 +2755,7 @@ BOOST_AUTO_TEST_CASE(enum_referencing)
 	compileAndRun(sourceCode, 0, "L");
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(1));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(3));
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"L", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"L", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(3));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(3));
 	ABI_CHECK(callContractFunction("h()"), encodeArgs(1));
@@ -2982,7 +2982,7 @@ BOOST_AUTO_TEST_CASE(failing_send)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Helper");
-	u160 const c_helperAddress = m_contractAddress;
+	h160 const c_helperAddress = m_contractAddress;
 	compileAndRun(sourceCode, 20, "Main");
 	BOOST_REQUIRE(callContractFunction("callHelper(address)", c_helperAddress) == encodeArgs(true, 20));
 }
@@ -3587,7 +3587,7 @@ BOOST_AUTO_TEST_CASE(library_call)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(33)), encodeArgs(u256(33) * 9));
 }
 
@@ -3602,7 +3602,7 @@ BOOST_AUTO_TEST_CASE(library_function_external)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(bytes)", u256(0x20), u256(5), "abcde"), encodeArgs("c"));
 }
 
@@ -3619,7 +3619,7 @@ BOOST_AUTO_TEST_CASE(library_stray_values)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(33)), encodeArgs(u256(42)));
 }
 
@@ -3649,7 +3649,7 @@ BOOST_AUTO_TEST_CASE(internal_types_in_library)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(4), u256(17)));
 }
 
@@ -3680,7 +3680,7 @@ BOOST_AUTO_TEST_CASE(mapping_arguments_in_library)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("set(uint256,uint256)", u256(1), u256(42)), encodeArgs(u256(0)));
 	ABI_CHECK(callContractFunction("set(uint256,uint256)", u256(2), u256(84)), encodeArgs(u256(0)));
 	ABI_CHECK(callContractFunction("set(uint256,uint256)", u256(21), u256(7)), encodeArgs(u256(0)));
@@ -3728,7 +3728,7 @@ BOOST_AUTO_TEST_CASE(mapping_returns_in_library)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("set(bool,uint256,uint256)", true, u256(1), u256(42)), encodeArgs(u256(0)));
 	ABI_CHECK(callContractFunction("set(bool,uint256,uint256)", true, u256(2), u256(84)), encodeArgs(u256(0)));
 	ABI_CHECK(callContractFunction("set(bool,uint256,uint256)", true, u256(21), u256(7)), encodeArgs(u256(0)));
@@ -3804,7 +3804,7 @@ BOOST_AUTO_TEST_CASE(mapping_returns_in_library_named)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(0), u256(42), u256(0), u256(0), u256(21), u256(84)));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(u256(0), u256(42), u256(0), u256(0), u256(21), u256(17)));
 }
@@ -3832,7 +3832,7 @@ BOOST_AUTO_TEST_CASE(using_library_mappings_public)
 			}
 		)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(1), u256(0), u256(42), u256(23), u256(0), u256(99)));
 }
 
@@ -3867,7 +3867,7 @@ BOOST_AUTO_TEST_CASE(using_library_mappings_external)
 	{
 		string prefix = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n";
 		compileAndRun(prefix + libSourceCode, 0, "Lib");
-		compileAndRun(prefix + sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+		compileAndRun(prefix + sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 		ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(2), u256(0), u256(84), u256(46), u256(0), u256(198)));
 	}
 }
@@ -3893,7 +3893,7 @@ BOOST_AUTO_TEST_CASE(using_library_mappings_return)
 			}
 		)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(1), u256(0), u256(42), u256(23), u256(0), u256(99)));
 }
 
@@ -3921,7 +3921,7 @@ BOOST_AUTO_TEST_CASE(using_library_structs)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Lib");
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"Lib", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"Lib", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(7), u256(8)));
 }
 
@@ -4079,10 +4079,10 @@ BOOST_AUTO_TEST_CASE(reject_ether_sent_to_library)
 	compileAndRun(sourceCode, 10, "c");
 	BOOST_CHECK_EQUAL(balanceAt(m_contractAddress), 10);
 	BOOST_CHECK_EQUAL(balanceAt(libraryAddress), 0);
-	ABI_CHECK(callContractFunction("f(address)", encodeArgs(u160(libraryAddress))), encodeArgs(false));
+	ABI_CHECK(callContractFunction("f(address)", encodeArgs(libraryAddress)), encodeArgs(false));
 	BOOST_CHECK_EQUAL(balanceAt(m_contractAddress), 10);
 	BOOST_CHECK_EQUAL(balanceAt(libraryAddress), 0);
-	ABI_CHECK(callContractFunction("f(address)", encodeArgs(u160(m_contractAddress))), encodeArgs(true));
+	ABI_CHECK(callContractFunction("f(address)", encodeArgs(m_contractAddress)), encodeArgs(true));
 	BOOST_CHECK_EQUAL(balanceAt(m_contractAddress), 10);
 	BOOST_CHECK_EQUAL(balanceAt(libraryAddress), 0);
 }
@@ -4126,7 +4126,7 @@ BOOST_AUTO_TEST_CASE(using_for_function_on_int)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "D");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"D", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"D", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(9)), encodeArgs(u256(2 * 9)));
 }
 
@@ -4144,7 +4144,7 @@ BOOST_AUTO_TEST_CASE(using_for_function_on_struct)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "D");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"D", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"D", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(7)), encodeArgs(u256(3 * 7)));
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(u256(3 * 7)));
 }
@@ -4167,7 +4167,7 @@ BOOST_AUTO_TEST_CASE(using_for_overload)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "D");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"D", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"D", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(7)), encodeArgs(u256(6 * 7)));
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(u256(6 * 7)));
 }
@@ -4186,7 +4186,7 @@ BOOST_AUTO_TEST_CASE(using_for_by_name)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "D");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"D", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"D", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(7)), encodeArgs(u256(6 * 7)));
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(u256(6 * 7)));
 }
@@ -4206,7 +4206,7 @@ BOOST_AUTO_TEST_CASE(bound_function_in_function)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "L");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"L", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"L", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(7)));
 }
 
@@ -4224,7 +4224,7 @@ BOOST_AUTO_TEST_CASE(bound_function_in_var)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "D");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"D", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"D", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f(uint256)", u256(7)), encodeArgs(u256(6 * 7)));
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(u256(6 * 7)));
 }
@@ -4247,7 +4247,7 @@ BOOST_AUTO_TEST_CASE(bound_function_to_string)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "D");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"D", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"D", m_contractAddress}});
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(3)));
 	ABI_CHECK(callContractFunction("g()"), encodeArgs(u256(3)));
 }
@@ -4399,9 +4399,9 @@ BOOST_AUTO_TEST_CASE(mutex)
 		}
 	)";
 	compileAndRun(sourceCode, 500, "Fund");
-	auto fund = m_contractAddress;
+	h160 const fund = m_contractAddress;
 	BOOST_CHECK_EQUAL(balanceAt(fund), 500);
-	compileAndRun(sourceCode, 0, "Attacker", encodeArgs(u160(fund)));
+	compileAndRun(sourceCode, 0, "Attacker", encodeArgs(fund));
 	ABI_CHECK(callContractFunction("setProtected(bool)", true), encodeArgs());
 	ABI_CHECK(callContractFunction("attack()"), encodeArgs());
 	BOOST_CHECK_EQUAL(balanceAt(fund), 500);
@@ -4445,7 +4445,7 @@ BOOST_AUTO_TEST_CASE(payable_function_calls_library)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "L");
-	compileAndRun(sourceCode, 0, "C", bytes(), map<string, Address>{{"L", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{"L", m_contractAddress}});
 	ABI_CHECK(callContractFunctionWithValue("f()", 27), encodeArgs(u256(7)));
 }
 
@@ -4497,7 +4497,7 @@ BOOST_AUTO_TEST_CASE(mem_resize_is_not_paid_at_call)
 	)";
 
 	compileAndRun(sourceCode, 0, "C");
-	u160 cAddr = m_contractAddress;
+	h160 const cAddr = m_contractAddress;
 	compileAndRun(sourceCode, 0, "D");
 	ABI_CHECK(callContractFunction("f(address)", cAddr), encodeArgs(u256(7)));
 }
@@ -4911,7 +4911,7 @@ BOOST_AUTO_TEST_CASE(interface_contract)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "A");
-	u160 const recipient = m_contractAddress;
+	h160 const recipient = m_contractAddress;
 	compileAndRun(sourceCode, 0, "C");
 	ABI_CHECK(callContractFunction("f(address)", recipient), encodeArgs(true));
 }
@@ -5730,7 +5730,7 @@ BOOST_AUTO_TEST_CASE(event_wrong_abi_name)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "ClientReceipt", bytes());
-	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, Address>{{"ClientReceipt", m_contractAddress}});
+	compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{"ClientReceipt", m_contractAddress}});
 
 	callContractFunction("f()");
 	BOOST_REQUIRE_EQUAL(numLogs(), 1);

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -119,8 +119,8 @@ protected:
 	u256 m_gasUsedNonOptimized;
 	bytes m_nonOptimizedBytecode;
 	bytes m_optimizedBytecode;
-	Address m_optimizedContract;
-	Address m_nonOptimizedContract;
+	h160 m_optimizedContract;
+	h160 m_nonOptimizedContract;
 };
 
 BOOST_FIXTURE_TEST_SUITE(SolidityOptimizer, OptimizerTestFramework)


### PR DESCRIPTION
Part of #7794.

Prior to this change tests used a mixture of h160/u160/Address and various ways to pad/truncate.

Should squash before merging.