### PR TITLE
Deterministic function order in internal dispatch

### DIFF
--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -44,7 +44,20 @@ namespace solidity::frontend
 class YulUtilFunctions;
 class ABIFunctions;
 
-using InternalDispatchMap = std::map<YulArity, std::set<FunctionDefinition const*>>;
+struct AscendingFunctionIDCompare
+{
+	bool operator()(FunctionDefinition const* _f1, FunctionDefinition const* _f2) const
+	{
+		// NULLs always first.
+		if (_f1 != nullptr && _f2 != nullptr)
+			return _f1->id() < _f2->id();
+		else
+			return _f1 == nullptr;
+	}
+};
+
+using DispatchSet = std::set<FunctionDefinition const*, AscendingFunctionIDCompare>;
+using InternalDispatchMap = std::map<YulArity, DispatchSet>;
 
 /**
  * Class that contains contextual information during IR generation.
@@ -164,7 +177,7 @@ private:
 	/// The order and duplicates are irrelevant here (hence std::set rather than std::queue) as
 	/// long as the order of Yul functions in the generated code is deterministic and the same on
 	/// all platforms - which is a property guaranteed by MultiUseYulFunctionCollector.
-	std::set<FunctionDefinition const*> m_functionGenerationQueue;
+	DispatchSet m_functionGenerationQueue;
 
 	/// Collection of functions that need to be callable via internal dispatch.
 	/// Note that having a key with an empty set of functions is a valid situation. It means that


### PR DESCRIPTION
This adds a custom comparator to `std::set<FunctionDefinition const*>` to make the order depend on function ID rather than the layout of `FunctionDefinition` objects in memory.

This is not completely deterministic but good enough for now.
See https://gitter.im/ethereum/solidity-dev?at=5fc655b030c9c144c64f2202:
> I think sorting by function IDs (which at some later point do not have to be AST IDs) is a good solution
> AST IDs are somewhat determinsitic
> they do not depend on the memory layout of the machine the compiler runs on, as ast pointers do
> but they depend on whether or not some unused source files are supplied to the compiler
> so if you run `solc a.sol b.sol`, it can result in different bytecode than just running `solc b.sol`
> we should really try to avoid that, but it's not always possible
> at least I was not able to find a complete fix