### PR TITLE
[BREAKING] Remove the \b, \f, \v escape sequences from the Scanner

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Breaking Changes:
  * Type System: Declarations with the name ``this``, ``super`` and ``_`` are disallowed, with the exception of public functions and events.
  * Type System: Disallow ``type(super)``.
  * Command Line Interface: JSON fields `abi`, `devdoc`, `userdoc` and `storage-layout` are now sub-objects rather than strings.
+ * Scanner: Remove support for the ``\b``, ``\f``, and ``\v`` escape sequences.
 
 Language Features:
  * Super constructors can now be called using the member notation e.g. ``M.C(123)``.

--- a/docs/080-breaking-changes.rst
+++ b/docs/080-breaking-changes.rst
@@ -88,6 +88,9 @@ New Restrictions
 * Declarations with the name ``this``, ``super`` and ``_`` are disallowed, with the exception of
   public functions and events.
 
+* Remove support for the ``\b``, ``\f``, and ``\v`` escape sequences in code.
+  They can still be inserted via hexadecimal escapes, e.g. ``\x08``, ``\x0c``, and ``\x0b``, respectively.
+
 Interface Changes
 =================
 

--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -184,7 +184,7 @@ fragment DoubleQuotedPrintable: [\u0020-\u0021\u0023-\u005B\u005D-\u007E];
   */
 fragment EscapeSequence:
 	'\\' (
-		['"\\bfnrtv\n\r]
+		['"\\nrt\n\r]
 		| 'u' HexCharacter HexCharacter HexCharacter HexCharacter
 		| 'x' HexCharacter HexCharacter
 	);

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -728,12 +728,6 @@ bool Scanner::scanEscape()
 	case '"':  // fall through
 	case '\\':
 		break;
-	case 'b':
-		c = '\b';
-		break;
-	case 'f':
-		c = '\f';
-		break;
 	case 'n':
 		c = '\n';
 		break;
@@ -742,9 +736,6 @@ bool Scanner::scanEscape()
 		break;
 	case 't':
 		c = '\t';
-		break;
-	case 'v':
-		c = '\v';
 		break;
 	case 'u':
 	{

--- a/test/liblangutil/Scanner.cpp
+++ b/test/liblangutil/Scanner.cpp
@@ -131,10 +131,29 @@ BOOST_AUTO_TEST_CASE(string_escapes)
 
 BOOST_AUTO_TEST_CASE(string_escapes_all)
 {
-	Scanner scanner(CharStream("  { \"a\\x61\\b\\f\\n\\r\\t\\v\"", ""));
+	Scanner scanner(CharStream("  { \"a\\x61\\n\\r\\t\"", ""));
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
-	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "aa\b\f\n\r\t\v");
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "aa\n\r\t");
+}
+
+BOOST_AUTO_TEST_CASE(string_escapes_legal_before_080)
+{
+	Scanner scanner(CharStream("  { \"a\\b", ""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalEscapeSequence);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "");
+	scanner.reset(CharStream("  { \"a\\f", ""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalEscapeSequence);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "");
+	scanner.reset(CharStream("  { \"a\\v", ""));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
+	BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
+	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalEscapeSequence);
+	BOOST_CHECK_EQUAL(scanner.currentLiteral(), "");
 }
 
 BOOST_AUTO_TEST_CASE(string_escapes_with_zero)

--- a/test/libsolidity/semanticTests/strings/string_escapes.sol
+++ b/test/libsolidity/semanticTests/strings/string_escapes.sol
@@ -1,0 +1,10 @@
+contract test {
+    function f() public pure returns (bytes32) {
+        bytes32 escapeCharacters = "\t\n\r\'\"\\";
+        return escapeCharacters;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 0x090a0d27225c0000000000000000000000000000000000000000000000000000

--- a/test/libsolidity/syntaxTests/string/invalid_legacy_escape.sol
+++ b/test/libsolidity/syntaxTests/string/invalid_legacy_escape.sol
@@ -1,7 +1,8 @@
 contract test {
     function f() public pure returns (bytes32) {
-        bytes32 escapeCharacters = "\n\r\'\"\\";
+        bytes32 escapeCharacters = "\t\b\f";
         return escapeCharacters;
     }
 }
 // ----
+// ParserError 8936: (100-105): Invalid escape sequence.


### PR DESCRIPTION
Fixes #9525.

Not sure what was the agreement on this, but it was in the implementation column.

@ekpyron since you have missed the meeting, but you added one of these characters to the grammar, I'd be curious about your opinion.