### PR TITLE
[BREAKING] Update external tests for 0.8.0

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -33,12 +33,12 @@ function colony_test
     OPTIMIZER_LEVEL=3
     CONFIG="truffle.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_070_new
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_080_new
     run_install "$SOLJSON" install_fn
 
     cd lib
     rm -Rf dappsys
-    git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_070 dappsys
+    git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_080 dappsys
     cd ..
 
     truffle_run_test "$SOLJSON" compile_fn test_fn

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -33,7 +33,7 @@ function ens_test
     export OPTIMIZER_LEVEL=1
     export CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/ens.git upgrade-0.8.0
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/ens.git master_080
 
     # Use latest Truffle. Older versions crash on the output from 0.8.0.
     force_truffle_version ^5.1.55

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -33,9 +33,9 @@ function gnosis_safe_test
     OPTIMIZER_LEVEL=2
     CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git v2_070
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git v2_080
 
-    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070_new|g' package.json
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080_new|g' package.json
     sed -i -E 's|"@gnosis.pm/util-contracts": "[^"]+"|"@gnosis.pm/util-contracts": "github:solidity-external-tests/util-contracts#solc-7"|g' package.json
 
     # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -30,7 +30,7 @@ function test_fn { npm test; }
 
 function gnosis_safe_test
 {
-    OPTIMIZER_LEVEL=1
+    OPTIMIZER_LEVEL=2
     CONFIG="truffle-config.js"
 
     truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git v2_070

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -30,7 +30,7 @@ function test_fn { npm test; }
 
 function gnosis_safe_test
 {
-    OPTIMIZER_LEVEL=1
+    OPTIMIZER_LEVEL=2
     CONFIG="truffle-config.js"
 
     truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_070_new

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -33,9 +33,9 @@ function gnosis_safe_test
     OPTIMIZER_LEVEL=2
     CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_070_new
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_080_new
 
-    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070_new|g' package.json
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080_new|g' package.json
 
     # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
     rm -f package-lock.json

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -33,7 +33,7 @@ function zeppelin_test
     OPTIMIZER_LEVEL=1
     CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/openzeppelin-contracts.git master_070
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/openzeppelin-contracts.git master_080
     run_install "$SOLJSON" install_fn
 
     truffle_run_test "$SOLJSON" compile_fn test_fn


### PR DESCRIPTION
~**This PR depends on #10429 and should be merged after it and after `develop` is then merged into `breaking`.**~
~Currently this PR includes copies of all commits from #10429 and #10464 because those PRs are not on `breaking` yet. I'm going to rebase it and remove the copies once  they're merged.~
This is on breaking now and ready for review + merge.

An integral part of this PR is the update of `solidity-external-tests` repos. All changes are pretty minor updates over the `070` variants (mostly cherry-picked from @hrkrshnn's commits). The big ones were all in #10429.
- [Gnosis v1: `development_080_new`](https://github.com/solidity-external-tests/safe-contracts/tree/development_080_new) (depends on [mock-contract `master_080_new`](https://github.com/solidity-external-tests/mock-contract/tree/master_080_new))
- [Gnosis v2: `v2_080_new`](https://github.com/solidity-external-tests/safe-contracts/tree/v2_080) (depends on [mock-contract `master_080_new`](https://github.com/solidity-external-tests/mock-contract/tree/master_080_new) and the new [util-contracts](https://github.com/solidity-external-tests/util-contracts) that I have forked into `solidity-external-contracts`)
- [OpenZeppelin: `master_080`](https://github.com/solidity-external-tests/openzeppelin-contracts/tree/master_080)
- [Colony: `develop_080_new`](https://github.com/solidity-external-tests/colonyNetwork/tree/develop_080_new) (depends on [dappsys `master_080`](https://github.com/solidity-external-tests/dappsys-monolithic/tree/master_080))
- [ENS: `master_080`](https://github.com/solidity-external-tests/ens/tree/master_080)