### PR TITLE
Running external tests nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,9 +847,6 @@ jobs:
           name: External GnosisSafe tests
           command: |
             test/externalTests/gnosis.sh /tmp/workspace/soljson.js
-      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
-      #- run: *gitter_notify_failure
-      #- run: *gitter_notify_success
 
   t_ems_compile_ext_gnosis_v2:
     docker:
@@ -880,9 +877,6 @@ jobs:
           name: External GnosisSafe v2 tests
           command: |
             test/externalTests/gnosis-v2.sh /tmp/workspace/soljson.js
-      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
-      #- run: *gitter_notify_failure
-      #- run: *gitter_notify_success
 
   t_ems_compile_ext_zeppelin:
     docker:
@@ -912,9 +906,6 @@ jobs:
           name: External Zeppelin tests
           command: |
             test/externalTests/zeppelin.sh /tmp/workspace/soljson.js
-      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
-      #- run: *gitter_notify_failure
-      #- run: *gitter_notify_success
 
   t_ems_compile_ext_colony:
     docker:
@@ -952,9 +943,8 @@ jobs:
           name: External ColonyNetworks tests
           command: |
             test/externalTests/colony.sh /tmp/workspace/soljson.js
-      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
-      #- run: *gitter_notify_failure
-      #- run: *gitter_notify_success
+      - run: *gitter_notify_failure
+      - run: *gitter_notify_success
 
   t_ems_compile_ext_ens:
     docker:
@@ -994,9 +984,6 @@ jobs:
           name: External Ens compilation
           command: |
             test/externalTests/ens.sh /tmp/workspace/soljson.js
-      # TODO: Re-enable notifications once this is running nightly rather than as a PR check
-      #- run: *gitter_notify_failure
-      #- run: *gitter_notify_success
 
   b_win: &b_win
     executor:
@@ -1176,7 +1163,7 @@ workflows:
       - t_ubu_release_cli: *workflow_ubuntu2004_release
       - t_ubu_release_soltest: *workflow_ubuntu2004_release
 
-      # Emscripten build and selected tests
+      # Emscripten build and tests that take 15 minutes or less
       - b_ems: *workflow_trigger_on_tags
       - t_ems_solcjs: *workflow_emscripten
       - t_ems_compile_ext_colony: *workflow_emscripten
@@ -1184,7 +1171,6 @@ workflows:
       - t_ems_compile_ext_gnosis_v2: *workflow_emscripten
       - t_ems_compile_ext_zeppelin: *workflow_emscripten
       - t_ems_compile_ext_ens: *workflow_emscripten
-      - t_ems_test_ext_colony: *workflow_emscripten
       # FIXME: Gnosis tests are pretty flaky right now. They often fail on CircleCI due to random ProviderError
       # and there are also other less frequent problems. See https://github.com/gnosis/safe-contracts/issues/216.
       #- t_ems_test_ext_gnosis: *workflow_emscripten
@@ -1244,3 +1230,7 @@ workflows:
       - t_ubu_asan_constantinople: *workflow_ubuntu2004_asan
       - t_ubu_asan_constantinople_clang: *workflow_ubuntu2004_asan_clang
       - t_ubu_asan_cli: *workflow_ubuntu2004_asan
+
+      # Emscripten build and tests that take more than 15 minutes to execute
+      - b_ems: *workflow_trigger_on_tags
+      - t_ems_test_ext_colony: *workflow_emscripten


### PR DESCRIPTION
Fixes #10397.

**This PR depends on #10429 and should be merged after it.**

This is just cleanup after #10429:
- Converts the external test jobs from PR checks to nightly jobs.
- Re-enables gitter notifications which are too spammy in PR checks but useful for nightly jobs.
- ~Switches back to the usual branches from `solidity-external-tests`. #10429 was made to run on branches suffixed with `_new` (e.g. `develop_070_new`) to avoid breaking tests on `develop` in the meantime.~ EDIT: This is now a separate PR: #10500.