### PR TITLE
Force ENS external test to use latest Truffle

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -85,9 +85,9 @@ function download_project
 
 function force_truffle_version
 {
-    local repo="$1"
+    local version="$1"
 
-    sed -i 's/"truffle":\s*".*"/"truffle": "^5.0.42"/g' package.json
+    sed -i 's/"truffle":\s*".*"/"truffle": "'"$version"'"/g' package.json
 }
 
 function truffle_setup

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -36,6 +36,10 @@ function ens_test
     export CONFIG="truffle-config.js"
 
     truffle_setup https://github.com/solidity-external-tests/ens.git upgrade-0.8.0
+
+    # Use latest Truffle. Older versions crash on the output from 0.8.0.
+    force_truffle_version ^5.1.55
+
     run_install install_fn
 
     truffle_run_test compile_fn test_fn

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -35,7 +35,7 @@ function gnosis_safe_test
 
     truffle_setup https://github.com/solidity-external-tests/safe-contracts.git development_070
 
-    force_truffle_version
+    force_truffle_version ^5.0.42
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070|g' package.json
     rm -f package-lock.json
     rm -rf node_modules/


### PR DESCRIPTION
This PR fixes broken ENS external tests on `breaking`. The cause is simply that ENS currently depends on Truffle 5.0.19 which crashes on the output from Solidity 0.8.0. Latest Truffle works fine.

### Truffle output
This is the Truffle output from [one of the failed `t_ems_compile_ext_ens` runs](https://app.circleci.com/pipelines/github/ethereum/solidity/10984/workflows/92ac85e5-7c19-4860-a907-e686edcd6832/jobs/529858):
```
TypeError: Cannot read property 'children' of undefined
    at orderABI (/tmp/tmp.A6TGvNsvW0/ext/node_modules/truffle/build/webpack:/packages/truffle-compile/index.js:287:18)
    at Object.keys.forEach.contract_name (/tmp/tmp.A6TGvNsvW0/ext/node_modules/truffle/build/webpack:/packages/truffle-compile/index.js:210:1)
    at Array.forEach (<anonymous>)
    at Object.keys.forEach.source_path (/tmp/tmp.A6TGvNsvW0/ext/node_modules/truffle/build/webpack:/packages/truffle-compile/index.js:180:1)
    at Array.forEach (<anonymous>)
    at supplier.load.then.solc (/tmp/tmp.A6TGvNsvW0/ext/node_modules/truffle/build/webpack:/packages/truffle-compile/index.js:177:1)
Truffle v5.0.19 (core: 5.0.19)
Node v10.23.0
```