### PR TITLE
Add storage load/store functions to Yul dialect.

### DIFF
--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -74,6 +74,8 @@ struct Dialect: boost::noncopyable
 
 	virtual BuiltinFunction const* memoryStoreFunction(YulString /* _type */) const { return nullptr; }
 	virtual BuiltinFunction const* memoryLoadFunction(YulString /* _type */) const { return nullptr; }
+	virtual BuiltinFunction const* storageStoreFunction(YulString /* _type */) const { return nullptr; }
+	virtual BuiltinFunction const* storageLoadFunction(YulString /* _type */) const { return nullptr; }
 
 	/// Check whether the given type is legal for the given literal value.
 	/// Should only be called if the type exists in the dialect at all.

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -75,6 +75,8 @@ struct EVMDialect: public Dialect
 	BuiltinFunctionForEVM const* booleanNegationFunction() const override { return builtin("iszero"_yulstring); }
 	BuiltinFunctionForEVM const* memoryStoreFunction(YulString /*_type*/) const override { return builtin("mstore"_yulstring); }
 	BuiltinFunctionForEVM const* memoryLoadFunction(YulString /*_type*/) const override { return builtin("mload"_yulstring); }
+	BuiltinFunctionForEVM const* storageStoreFunction(YulString /*_type*/) const override { return builtin("sstore"_yulstring); }
+	BuiltinFunctionForEVM const* storageLoadFunction(YulString /*_type*/) const override { return builtin("sload"_yulstring); }
 
 	static EVMDialect const& strictAssemblyForEVM(langutil::EVMVersion _version);
 	static EVMDialect const& strictAssemblyForEVMObjects(langutil::EVMVersion _version);

--- a/libyul/optimiser/LoadResolver.h
+++ b/libyul/optimiser/LoadResolver.h
@@ -24,13 +24,9 @@
 
 #include <libyul/optimiser/DataFlowAnalyzer.h>
 #include <libyul/optimiser/OptimiserStep.h>
-#include <libevmasm/Instruction.h>
 
 namespace solidity::yul
 {
-
-struct EVMDialect;
-struct BuiltinFunctionForEVM;
 
 /**
  * Optimisation stage that replaces expressions of type ``sload(x)`` and ``mload(x)`` by the value
@@ -63,7 +59,7 @@ protected:
 
 	void tryResolve(
 		Expression& _e,
-		evmasm::Instruction _instruction,
+		StoreLoadLocation _location,
 		std::vector<Expression> const& _arguments
 	);
 


### PR DESCRIPTION
@chriseth is this about the amount you want to have extracted here: https://github.com/ethereum/solidity/pull/10467#discussion_r534035494 ?
Or are the casted-enum-index-lookups into the member arrays already a bit over the top? If so I can dial it down a bit:-)...