### PR TITLE
Restore original external test branches

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -33,7 +33,7 @@ function colony_test
     OPTIMIZER_LEVEL=3
     CONFIG="truffle.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_070_new
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_070
     run_install "$SOLJSON" install_fn
 
     cd lib

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -33,7 +33,7 @@ function ens_test
     export OPTIMIZER_LEVEL=1
     export CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/ens.git upgrade-0.8.0
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/ens.git master_070
 
     # Use latest Truffle. Older versions crash on the output from 0.8.0.
     force_truffle_version ^5.1.55

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -35,8 +35,8 @@ function gnosis_safe_test
 
     truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git v2_070
 
-    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070_new|g' package.json
-    sed -i -E 's|"@gnosis.pm/util-contracts": "[^"]+"|"@gnosis.pm/util-contracts": "github:solidity-external-tests/util-contracts#solc-7"|g' package.json
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070|g' package.json
+    sed -i -E 's|"@gnosis.pm/util-contracts": "[^"]+"|"@gnosis.pm/util-contracts": "github:solidity-external-tests/util-contracts#solc-7_070"|g' package.json
 
     # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
     rm -f package-lock.json

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -33,9 +33,9 @@ function gnosis_safe_test
     OPTIMIZER_LEVEL=1
     CONFIG="truffle-config.js"
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_070_new
+    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_070
 
-    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070_new|g' package.json
+    sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_070|g' package.json
 
     # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
     rm -f package-lock.json


### PR DESCRIPTION
~**This PR depends on #10429 and should be merged after it.**~ (done)
~**Also, please don't merge until branches in `solidity-external-tests` are updated**.~ (done)

This is just cleanup that could not be made a part of #10429. The base PR is running on branches suffixed with `_new` (e.g. `develop_070_new`) to avoid breaking tests on `develop`. This one is meant to switch back to the original branches after we update them to match the `_new` ones.