### PR TITLE
Upgrade bytecode comparison container to node.js 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1046,7 +1046,7 @@ jobs:
 
   b_bytecode_ems:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     environment:
       SOLC_EMSCRIPTEN: "On"
     steps:


### PR DESCRIPTION
Originally a part of #10429 but it's unrelated other than by the fact that both PRs update node.js versions of some containers. And it's small enough that it would easily go unnoticed there. I'm making a separate PR to get this properly reviewed.

Are there any reasons for keeping it on an ancient node.js version?