### PR TITLE
[SMTChecker] Adding support for reporting values of structs in CEX in CHC engine

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Compiler Features:
  * SMTChecker: Support struct constructor.
  * SMTChecker: Support getters.
  * SMTChecker: Support early returns in the CHC engine.
+ * SMTChecker: Report struct values in counterexamples from CHC engine.
  * Standard-Json: Properly filter the requested output artifacts.
 
 Bugfixes:


### PR DESCRIPTION
This PR improves the reporting of counter-examples in the CHC engine.
The proposed format for a `struct` variable `s` is:
`s = {m1: v1, m2: v2, ...}`
where `m1, m2, ...` are names of the members of the struct and `v1, v2, ...` are their respective values in the CEX.

If there is a problem for obtaining a value for some member, that the value will be an empty string.

This deals with the issue #9660, but only for the CHC engine.