### PR TITLE
Remove the option for forcing ABIv2 from external tests

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -41,7 +41,7 @@ function colony_test
     git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_060 dappsys
     cd ..
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn "NO-FORCE-ABI-V2"
+    truffle_run_test "$SOLJSON" compile_fn test_fn
 }
 
 external_test ColonyNetworks colony_test

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -40,7 +40,7 @@ function ens_test
 
     run_install "$SOLJSON" install_fn
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn "NO-FORCE-ABI-V2"
+    truffle_run_test "$SOLJSON" compile_fn test_fn
 }
 
 external_test Ens ens_test

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -43,7 +43,7 @@ function gnosis_safe_test
     run_install "$SOLJSON" install_fn
     replace_libsolc_call
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn "NO-FORCE-ABI-V2"
+    truffle_run_test "$SOLJSON" compile_fn test_fn
 }
 
 external_test Gnosis-Safe gnosis_safe_test

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -36,7 +36,7 @@ function zeppelin_test
     truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/openzeppelin-contracts.git upgrade-0.7.0
     run_install "$SOLJSON" install_fn
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn "NO-FORCE-ABI-V2"
+    truffle_run_test "$SOLJSON" compile_fn test_fn
 }
 
 external_test Zeppelin zeppelin_test


### PR DESCRIPTION
The flag is no longer used by any of the scripts and only causes conflicts with the PR that turns on ABIEncoderV2 by default on `breaking` (https://github.com/ethereum/solidity/pull/10336/commits/a5e0d84e6a19c95ba8a8943d52591217dddfa10c).