### PR TITLE
Fix initial optimizer settings in external tests

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -23,11 +23,11 @@ if [ "$CIRCLECI" ]
 then
     export TERM="${TERM:-xterm}"
     function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput setaf 7)"; }
+    function printError() { >&2 echo "$(tput setaf 1)$1$(tput setaf 7)"; }
     function printLog() { echo "$(tput setaf 3)$1$(tput setaf 7)"; }
 else
     function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput sgr0)"; }
+    function printError() { >&2 echo "$(tput setaf 1)$1$(tput sgr0)"; }
     function printLog() { echo "$(tput setaf 3)$1$(tput sgr0)"; }
 fi
 

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -139,7 +139,7 @@ function force_solc
 
     printLog "Forcing solc version..."
     cat >> "$config_file" <<EOF
-module.exports['compilers'] = {solc: {version: "$dir/solc", settings: $(solc_settings "$OPTIMIZER_LEVEL" istanbul)}};
+module.exports['compilers'] = $(truffle_compiler_settings "${dir}/solc" "$level" "$evm_version");
 EOF
 }
 
@@ -159,7 +159,7 @@ function force_solc_settings
 
     # Forcing the settings should always work by just overwriting the solc object. Forcing them by using a
     # dedicated settings objects should only be the fallback.
-    echo "module.exports['compilers']['solc']['settings'] = $(solc_settings "$level" istanbul);" >> "$config_file"
+    echo "module.exports['compilers'] = $(truffle_compiler_settings "${DIR}/solc" "$level" "$evm_version");" >> "$config_file"
 }
 
 function verify_compiler_version
@@ -220,6 +220,22 @@ function optimizer_settings_for_level {
             exit 1
             ;;
     esac
+}
+
+function truffle_compiler_settings {
+    local solc_path="$1"
+    local level="$2"
+    local evm_version="$3"
+
+    echo "{"
+    echo "    solc: {"
+    echo "        version: \"${solc_path}\","
+    echo "        settings: {"
+    echo "            optimizer: $(optimizer_settings_for_level "$level"),"
+    echo "            evmVersion: \"${evm_version}\""
+    echo "        }"
+    echo "    }"
+    echo "}"
 }
 
 function truffle_run_test

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -158,7 +158,6 @@ function force_solc_settings
 
     # Forcing the settings should always work by just overwriting the solc object. Forcing them by using a
     # dedicated settings objects should only be the fallback.
-    echo "module.exports['solc'] = { optimizer: $settings, evmVersion: \"$evmVersion\" };" >> "$config_file"
     echo "module.exports['compilers']['solc']['settings'] = { optimizer: $settings, evmVersion: \"$evmVersion\" };" >> "$config_file"
 }
 

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -109,20 +109,6 @@ function replace_version_pragmas
     find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -E -e 's/pragma solidity [^;]+;/pragma solidity >=0.0;/'
 }
 
-function find_truffle_config
-{
-    local config_file="truffle.js"
-    local alt_config_file="truffle-config.js"
-
-    if [ ! -f "$config_file" ] && [ ! -f "$alt_config_file" ]; then
-        printError "No matching Truffle config found."
-    fi
-    if [ ! -f "$config_file" ]; then
-        config_file=alt_config_file
-    fi
-    echo "$config_file"
-}
-
 function force_solc_truffle_modules
 {
     # Replace solc package by v0.5.0 and then overwrite with current version.

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -139,7 +139,7 @@ function force_solc
 
     printLog "Forcing solc version..."
     cat >> "$config_file" <<EOF
-module.exports['compilers'] = {solc: {version: "$dir/solc"} };
+module.exports['compilers'] = {solc: {version: "$dir/solc", settings: $(solc_settings "$OPTIMIZER_LEVEL" istanbul)}};
 EOF
 }
 


### PR DESCRIPTION
Currently external test scripts rely on the `$OPTIMIZER_LEVEL` variable to set minimal options that the external project works with. This variable is only used just before running tests though. If the project runs contract compilation during JS package installation (as it happens in case of Gnosis, see https://github.com/ethereum/solidity/pull/10336#issuecomment-740106553), it's still using initial settings that do not set optimization level at all. This PR fixes fixes that by making the initial config use the lowest allowed optimization level.

The core of this PR is this change:
```patch
-module.exports['compilers'] = {solc: {version: "$dir/solc"} };
+module.exports['compilers'] = {solc: {version: "$dir/solc", settings: $(solc_settings "$OPTIMIZER_LEVEL" istanbul)}};
```
the rest is just a refactor to make that change easy without code duplication.