### PR TITLE
Abiv2 isabelle: Add fuzzer test harness skeleton and update CMake

### DIFF
--- a/test/tools/ossfuzz/AbiV2IsabelleFuzzer.cpp
+++ b/test/tools/ossfuzz/AbiV2IsabelleFuzzer.cpp
@@ -1,0 +1,37 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <test/tools/ossfuzz/abiV2FuzzerCommon.h>
+
+#include <test/tools/ossfuzz/protoToAbiV2.h>
+
+#include <src/libfuzzer/libfuzzer_macro.h>
+#include <abicoder.hpp>
+
+using namespace solidity::test::abiv2fuzzer;
+using namespace solidity::test;
+using namespace std;
+
+static constexpr size_t abiCoderHeapSize = 1024 * 512;
+
+DEFINE_PROTO_FUZZER(Contract const&)
+{
+	abicoder::ABICoder coder(abiCoderHeapSize);
+	auto [encodeStatus, encodedData] = coder.encode("bool", "true");
+	solAssert(encodeStatus, "Isabelle abicoder fuzzer: Encoding failed");
+	return;
+}

--- a/test/tools/ossfuzz/CMakeLists.txt
+++ b/test/tools/ossfuzz/CMakeLists.txt
@@ -21,7 +21,7 @@ if (OSSFUZZ)
     )
 
     add_custom_target(ossfuzz_abiv2)
-    add_dependencies(ossfuzz_abiv2 abiv2_proto_ossfuzz)
+    add_dependencies(ossfuzz_abiv2 abiv2_proto_ossfuzz abiv2_isabelle_ossfuzz)
 endif()
 
 if (OSSFUZZ)
@@ -134,6 +134,28 @@ if (OSSFUZZ)
     )
     set_target_properties(abiv2_proto_ossfuzz PROPERTIES LINK_FLAGS ${LIB_FUZZING_ENGINE})
     target_compile_options(abiv2_proto_ossfuzz PUBLIC ${COMPILE_OPTIONS} -Wno-sign-conversion)
+
+    add_executable(abiv2_isabelle_ossfuzz
+            ../../EVMHost.cpp
+            AbiV2IsabelleFuzzer.cpp
+            abiV2FuzzerCommon.cpp
+            protoToAbiV2.cpp
+            abiV2Proto.pb.cc
+    )
+    target_include_directories(abiv2_isabelle_ossfuzz PRIVATE
+            /usr/include/libprotobuf-mutator
+    )
+    target_link_libraries(abiv2_isabelle_ossfuzz PRIVATE solidity
+            evmc
+            evmone-standalone
+            protobuf-mutator-libfuzzer.a
+            protobuf-mutator.a
+            protobuf.a
+            abicoder
+            gmp
+    )
+    set_target_properties(abiv2_isabelle_ossfuzz PROPERTIES LINK_FLAGS ${LIB_FUZZING_ENGINE})
+    target_compile_options(abiv2_isabelle_ossfuzz PUBLIC ${COMPILE_OPTIONS} -Wno-sign-conversion)
 
     add_executable(sol_proto_ossfuzz
             solProtoFuzzer.cpp


### PR DESCRIPTION
This PR adds a dummy test harness for the upcoming abiv2 isabelle fuzzer and tests whether the docker changes related to libabicoder and gmp actually work (true if the ossfuzz build CI passes).