### PR TITLE
[SMTChecker] Remove assert that is not true for compound assignment with right shift

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1975,12 +1975,6 @@ smtutil::Expression SMTEncoder::compoundAssignment(Assignment const& _assignment
 
 	auto decl = identifierToVariable(_assignment.leftHandSide());
 
-	TypePointer commonType = Type::commonType(
-		_assignment.leftHandSide().annotation().type,
-		_assignment.rightHandSide().annotation().type
-	);
-	solAssert(commonType == _assignment.annotation().type, "");
-
 	if (compoundToBitwise.count(op))
 		return bitwiseOperation(
 			compoundToBitwise.at(op),

--- a/test/libsolidity/smtCheckerTests/operators/compound_assignment_right_shift.sol
+++ b/test/libsolidity/smtCheckerTests/operators/compound_assignment_right_shift.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	function f(int a, uint b) public view {
+		a >>= tx.gasprice;
+		require(a == 16 && b == 2);
+		a >>= b;
+		assert(a == 4); // should hold
+	}
+}
+// ----


### PR DESCRIPTION
An assert has been introduced in #10380, that, however, does not hold for compound assignment with right shift where LHS is a `signed int` and RHS is `unsigned int` with the same number of bits. In that case, there is no common type which violates this `assert` even though it is not a problem for the compiler.

Fixes #10473.
Fixes #10522.
