### PR TITLE
[SMTChecker] Adding test witnessing that SMTChecker no longer crashes when producing CEX with arrays

### DIFF
--- a/test/libsolidity/smtCheckerTests/overflow/overflow_mul_cex_with_array.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/overflow_mul_cex_with_array.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+
+contract C {
+	function f(bytes calldata x, uint y) external pure {
+		x[8][0];
+		x[8][5*y];
+	}
+}
+// ----
+// Warning 4984: (118-121): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.


### PR DESCRIPTION
This PR adds a testcase that was crashing previously, see #10502, contract 2.
The problem was fixed in #10510 which revealed the problem already in our test suite.