### PR TITLE
Move standard-json "modelCheckerSettings" key to "settings.modelChecker".

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
  * SMTChecker: Support getters.
  * SMTChecker: Support named arguments in function calls.
  * SMTChecker: Support struct constructor.
+ * Standard-Json: Move the recently introduced ``modelCheckerSettings`` key to ``settings.modelChecker``.
  * Standard-Json: Properly filter the requested output artifacts.
 
 Bugfixes:

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -369,16 +369,16 @@ Input Description
             "MyContract": [ "abi", "evm.bytecode.opcodes" ]
           }
         },
-      },
-      "modelCheckerSettings":
-      {
-        // Choose which model checker engine to use: all (default), bmc, chc, none.
-        "engine": "chc",
-        // Timeout for each SMT query in milliseconds.
-        // If this option is not given, the SMTChecker will use a deterministic
-        // resource limit by default.
-        // A given timeout of 0 means no resource/time restrictions for any query.
-        "timeout": 20000
+        "modelChecker":
+        {
+          // Choose which model checker engine to use: all (default), bmc, chc, none.
+          "engine": "chc",
+          // Timeout for each SMT query in milliseconds.
+          // If this option is not given, the SMTChecker will use a deterministic
+          // resource limit by default.
+          // A given timeout of 0 means no resource/time restrictions for any query.
+          "timeout": 20000
+        }
       }
     }
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -409,7 +409,7 @@ std::optional<Json::Value> checkKeys(Json::Value const& _input, set<string> cons
 
 std::optional<Json::Value> checkRootKeys(Json::Value const& _input)
 {
-	static set<string> keys{"auxiliaryInput", "language", "modelCheckerSettings", "settings", "sources"};
+	static set<string> keys{"auxiliaryInput", "language", "settings", "sources"};
 	return checkKeys(_input, keys, "root");
 }
 
@@ -427,14 +427,14 @@ std::optional<Json::Value> checkAuxiliaryInputKeys(Json::Value const& _input)
 
 std::optional<Json::Value> checkSettingsKeys(Json::Value const& _input)
 {
-	static set<string> keys{"parserErrorRecovery", "debug", "evmVersion", "libraries", "metadata", "optimizer", "outputSelection", "remappings", "stopAfter", "viaIR"};
+	static set<string> keys{"parserErrorRecovery", "debug", "evmVersion", "libraries", "metadata", "modelChecker", "optimizer", "outputSelection", "remappings", "stopAfter", "viaIR"};
 	return checkKeys(_input, keys, "settings");
 }
 
 std::optional<Json::Value> checkModelCheckerSettingsKeys(Json::Value const& _input)
 {
 	static set<string> keys{"engine", "timeout"};
-	return checkKeys(_input, keys, "modelCheckerSettings");
+	return checkKeys(_input, keys, "modelChecker");
 }
 
 std::optional<Json::Value> checkOptimizerKeys(Json::Value const& _input)
@@ -892,7 +892,7 @@ std::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompiler:
 			"Requested output selection conflicts with \"settings.stopAfter\"."
 		);
 
-	Json::Value const& modelCheckerSettings = _input.get("modelCheckerSettings", Json::Value());
+	Json::Value const& modelCheckerSettings = settings.get("modelChecker", Json::Value());
 
 	if (auto result = checkModelCheckerSettingsKeys(modelCheckerSettings))
 		return *result;
@@ -900,7 +900,7 @@ std::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompiler:
 	if (modelCheckerSettings.isMember("engine"))
 	{
 		if (!modelCheckerSettings["engine"].isString())
-			return formatFatalError("JSONError", "modelCheckerSettings.engine must be a string.");
+			return formatFatalError("JSONError", "settings.modelChecker.engine must be a string.");
 		std::optional<ModelCheckerEngine> engine = ModelCheckerEngine::fromString(modelCheckerSettings["engine"].asString());
 		if (!engine)
 			return formatFatalError("JSONError", "Invalid model checker engine requested.");
@@ -910,7 +910,7 @@ std::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompiler:
 	if (modelCheckerSettings.isMember("timeout"))
 	{
 		if (!modelCheckerSettings["timeout"].isUInt())
-			return formatFatalError("JSONError", "modelCheckerSettings.timeout must be an unsigned integer.");
+			return formatFatalError("JSONError", "settings.modelChecker.timeout must be an unsigned integer.");
 		ret.modelCheckerSettings.timeout = modelCheckerSettings["timeout"].asUInt();
 	}
 

--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -19,10 +19,8 @@ for optimize in [False, True]:
                 'optimizer': {
                     'enabled': optimize
                 },
-                'outputSelection': {'*': {'*': ['evm.bytecode.object', 'metadata']}}
-            },
-            'modelCheckerSettings': {
-                "engine": 'none'
+                'outputSelection': {'*': {'*': ['evm.bytecode.object', 'metadata']}},
+                'modelChecker': { "engine": 'none' }
             }
         }
         args = [SOLC_BIN, '--standard-json']

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -66,10 +66,8 @@ for (var optimize of [false, true])
                 sources: inputs,
                 settings: {
                     optimizer: { enabled: optimize },
-                    outputSelection: { '*': { '*': ['evm.bytecode.object', 'metadata'] } }
-                },
-                "modelCheckerSettings": {
-                    "engine": "none"
+                    outputSelection: { '*': { '*': ['evm.bytecode.object', 'metadata'] } },
+                    "modelChecker": { "engine": "none" }
                 }
             }
             var result = JSON.parse(compiler.compile(JSON.stringify(input)))

--- a/test/cmdlineTests/standard_model_checker_engine_all/input.json
+++ b/test/cmdlineTests/standard_model_checker_engine_all/input.json
@@ -7,8 +7,11 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract C { function f(uint x) public pure { assert(x > 0); } }"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "all"
+		"modelChecker":
+		{
+			"engine": "all"
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_engine_bmc/input.json
+++ b/test/cmdlineTests/standard_model_checker_engine_bmc/input.json
@@ -7,8 +7,11 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract C { function f(uint x) public pure { assert(x > 0); } }"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "bmc"
+		"modelChecker":
+		{
+			"engine": "bmc"
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_engine_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_engine_chc/input.json
@@ -7,8 +7,11 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract C { function f(uint x) public pure { assert(x > 0); } }"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "chc"
+		"modelChecker":
+		{
+			"engine": "chc"
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_engine_none/input.json
+++ b/test/cmdlineTests/standard_model_checker_engine_none/input.json
@@ -7,8 +7,11 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract C { function f(uint x) public pure { assert(x > 0); } }"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "none"
+		"modelChecker":
+		{
+			"engine": "none"
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_timeout_all/input.json
+++ b/test/cmdlineTests/standard_model_checker_timeout_all/input.json
@@ -7,8 +7,11 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract test {\nfunction f(uint x, uint y, uint k) public pure {\nrequire(k > 0); require(x % k == 0); require(y % k == 0); uint r = mulmod(x, y, k); assert(r % k == 0);}}"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"timeout": 1000
+		"modelChecker":
+		{
+			"timeout": 1000
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_timeout_bmc/input.json
+++ b/test/cmdlineTests/standard_model_checker_timeout_bmc/input.json
@@ -7,9 +7,12 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract test {\nfunction f(uint x, uint y, uint k) public pure {\nrequire(k > 0); require(x % k == 0); require(y % k == 0); uint r = mulmod(x, y, k); assert(r % k == 0);}}"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "bmc",
-		"timeout": 1000
+		"modelChecker":
+		{
+			"engine": "bmc",
+			"timeout": 1000
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_timeout_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_timeout_chc/input.json
@@ -7,9 +7,12 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract test {\nfunction f(uint x, uint y, uint k) public pure {\nrequire(k > 0); require(x % k == 0); require(y % k == 0); uint r = mulmod(x, y, k); assert(r % k == 0);}}"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "chc",
-		"timeout": 1000
+		"modelChecker":
+		{
+			"engine": "chc",
+			"timeout": 1000
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_timeout_wrong_key/input.json
+++ b/test/cmdlineTests/standard_model_checker_timeout_wrong_key/input.json
@@ -7,9 +7,12 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract C { function f(uint x) public pure { assert(x > 0); } }"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"engine": "chc",
-		"atimeout": 1
+		"modelChecker":
+		{
+			"engine": "chc",
+			"atimeout": 1
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_timeout_wrong_value/input.json
+++ b/test/cmdlineTests/standard_model_checker_timeout_wrong_value/input.json
@@ -7,8 +7,11 @@
 			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma experimental SMTChecker;\ncontract C { function f(uint x) public pure { assert(x > 0); } }"
 		}
 	},
-	"modelCheckerSettings":
+	"settings":
 	{
-		"timeout": "asd"
+		"modelChecker":
+		{
+			"timeout": "asd"
+		}
 	}
 }

--- a/test/cmdlineTests/standard_model_checker_timeout_wrong_value/output.json
+++ b/test/cmdlineTests/standard_model_checker_timeout_wrong_value/output.json
@@ -1,1 +1,1 @@
-{"errors":[{"component":"general","formattedMessage":"modelCheckerSettings.timeout must be an unsigned integer.","message":"modelCheckerSettings.timeout must be an unsigned integer.","severity":"error","type":"JSONError"}]}
+{"errors":[{"component":"general","formattedMessage":"settings.modelChecker.timeout must be an unsigned integer.","message":"settings.modelChecker.timeout must be an unsigned integer.","severity":"error","type":"JSONError"}]}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10509.

Note that it wouldn't be a big deal to still accept ``modelCheckerSettings`` in 0.7, if ``settings.modelCheckerSettings`` isn't there (optionally with a warning, although *that* would take some doing, since ``StandardCompiler`` doesn't have a warning infrastructure), and only drop it for 0.8, in case we're worried about any tooling breaking/complaining.

Also we need to watch the bytecode comparison - should be fine, but I haven't checked locally.