### PR TITLE
README describing the workflow around external tests and their repositories

### DIFF
--- a/test/externalTests/README.md
+++ b/test/externalTests/README.md
@@ -2,12 +2,12 @@
 This directory contains scripts for compiling some of the popular open-source projects using the
 current version of the compiler and running their test suites.
 
-Since projects often don't use the latest compiler, we keep a fork of each of these projects
+Since projects often do not use the latest compiler, we keep a fork of each of these projects
 at https://github.com/solidity-external-tests/. If changes are needed to make a project work with the
-latest version of the compiler, they're maintained as a branch on top if the upstream master branch.
+latest version of the compiler, they are maintained as a branch on top of the upstream master branch.
 This is especially important for testing our `breaking` branch because we can not realistically expect
 external projects to be instantly compatible with a compiler version that has not been released yet.
-It also isolates us from upstream changes to some degree - their changes won't affect our test suite
+It also isolates us from upstream changes to some degree - their changes will not affect our test suite
 until we explicitly pull them.
 
 ### Recommended workflow
@@ -22,7 +22,7 @@ until we explicitly pull them.
     `develop` and `breaking`. E.g. if the latest Solidity version is 0.7.5 and the main branch of the
     external project is called `master`, create `master_070` and `master_080`. This is where we will
     be adding our own commits. The one corresponding to the newer Solidity version should always be
-    on top on the older one. E.g. if a change is needed to keep the project
+    rebased on top of the older one. E.g. if a change is needed to keep the project
     compilable using Solidity 0.7.x, add it in `master_070` and rebase `master_080` on top of it.
     If it is only needed for the compiler from its `breaking` branch, add it only in `master_080`.
     - The fewer commits in these branches, the better. Ideally, any changes needed to make the compiler
@@ -47,7 +47,7 @@ until we explicitly pull them.
 3. Create new branches corresponding to the two versioned ones but suffixed with `_new`. E.g.
     `master_070_new` and `master_080_new`. Then rebase them so that they are on top of the updated
     main branch. This may require tweaking some of the commits to apply our fixes in new places.
-4. Create PRs on `deveop` and `breaking` in Solidity repo which modify the script to use the new
+4. Create PRs on `develop` and `breaking` in Solidity repo which modify the script to use the new
     branches instead of `master_070`/`master_080`. Tweak the new branches until external tests
     in CI pass in the PRs.
 5. Discard the PRs and move the original branches to the place where the `_new` ones are and remove
@@ -56,7 +56,7 @@ until we explicitly pull them.
 #### Changes needed after a breaking release of the compiler
 When a breaking version of the compiler gets released and becomes the most recent release, the scripts
 and the branches in the forks need to be updated:
-- In each fork create a branch corresponding to the new brekaing version. E.g. if the current
+- In each fork create a branch corresponding to the new breaking version. E.g. if the current
     branches are `master_070` and `master_080` the new one should be called `master_090`.
 - Leave the oldest (i.e. `master_070`) branch as is. We will not be updating it any more but there is no
     need to remove it.

--- a/test/externalTests/README.md
+++ b/test/externalTests/README.md
@@ -1,0 +1,66 @@
+## Solidity external tests
+This directory contains scripts for compiling some of the popular open-source projects using the
+current version of the compiler and running their test suites.
+
+Since projects often don't use the latest compiler, we keep a fork of each of these projects
+at https://github.com/solidity-external-tests/. If changes are needed to make a project work with the
+latest version of the compiler, they're maintained as a branch on top if the upstream master branch.
+This is especially important for testing our `breaking` branch because we can not realistically expect
+external projects to be instantly compatible with a compiler version that has not been released yet.
+It also isolates us from upstream changes to some degree - their changes won't affect our test suite
+until we explicitly pull them.
+
+### Recommended workflow
+
+#### Adding a new external project
+1. Create a fork of the upstream repository in https://github.com/solidity-external-tests/. If the
+    project consists of several repositories, fork them all.
+2. Remove all the branches except for main one (`master`, `develop`, `main`, etc). This branch is
+    going to be always kept up to date with the upstream repository and should not contain any extra
+    commits.
+3. Create two new versions of the main branch, representing versions of the compiler currently in
+    `develop` and `breaking`. E.g. if the latest Solidity version is 0.7.5 and the main branch of the
+    external project is called `master`, create `master_070` and `master_080`. This is where we will
+    be adding our own commits. The one corresponding to the newer Solidity version should always be
+    on top on the older one. E.g. if a change is needed to keep the project
+    compilable using Solidity 0.7.x, add it in `master_070` and rebase `master_080` on top of it.
+    If it is only needed for the compiler from its `breaking` branch, add it only in `master_080`.
+    - The fewer commits in these branches, the better. Ideally, any changes needed to make the compiler
+        work should be submitted upstream and the branches should just be tracking the upstream
+        one without any extra commits.
+4. Create a script for compiling/testing the project and put it in `test/externalTests/` in the
+    Solidity repository.
+    - The script should apply workarounds necessary to make the project actually use the compiler
+      binary it receives as a parameter and possibly apply some generic workarounds that should
+      work across different versions of the upstream project. Very specific workarounds that may
+      easily break with every upstream change are better done as commits in the fork.
+5. Add the script to `tests/externalTests.sh`.
+6. Add the test to CircleCI configuration. Make sure to add both a compilation-only run and one that
+    also executes the test suite. If the latter takes a significant amount of time (say, more
+    than 15 minutes) make it run nightly rather than on every PR.
+
+#### Pulling upstream changes into a fork
+1. Pull changes directly into the main branch in the fork. This should be straightforward thanks to
+    it not containing any of our customizations.
+2. If the update is straightforward and looks safe, go straight to point 5. Otherwise you need to
+    test it first.
+3. Create new branches corresponding to the two versioned ones but suffixed with `_new`. E.g.
+    `master_070_new` and `master_080_new`. Then rebase them so that they are on top of the updated
+    main branch. This may require tweaking some of the commits to apply our fixes in new places.
+4. Create PRs on `deveop` and `breaking` in Solidity repo which modify the script to use the new
+    branches instead of `master_070`/`master_080`. Tweak the new branches until external tests
+    in CI pass in the PRs.
+5. Discard the PRs and move the original branches to the place where the `_new` ones are and remove
+    the `_new` branches.
+
+#### Changes needed after a breaking release of the compiler
+When a breaking version of the compiler gets released and becomes the most recent release, the scripts
+and the branches in the forks need to be updated:
+- In each fork create a branch corresponding to the new brekaing version. E.g. if the current
+    branches are `master_070` and `master_080` the new one should be called `master_090`.
+- Leave the oldest (i.e. `master_070`) branch as is. We will not be updating it any more but there is no
+    need to remove it.
+- Update scripts on `develop` to now refer to the branch that used to be breaking (i.e. `master_080`)
+    and on `breaking` to refer to the newly added branch (i.e. `master_090`).
+    - Take care not to overwrite these changes when merging `develop` into breaking. Each branch
+        should always use the branches from the external repos that correspond to it.


### PR DESCRIPTION
Somewhat related to #10429 and all the chaos around updating branches in `solidity-external-tests`.

I decided to write down the recommended workflow since it's not all that obvious what can/should/must be done when updating these tests. Different people do it slightly differently and this way sometimes get in the way of each other. The current text describes how I think it should be done but it's also an opportunity to discuss it. I'll apply any changes that result from the discussion.

I'm not sure if a README in an obscure directory is the best place for it but I think it's not relevant enough to end-users to put it in the main docs. Someone tasked with updating these tests will probably manage to find it.