### PR TITLE
[Sol->Yul] Implementing missing array push

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -212,8 +212,10 @@ public:
 	std::string storageArrayPopFunction(ArrayType const& _type);
 
 	/// @returns the name of a function that pushes an element to a storage array
+/// @param _fromType represents the type of the element being pushed.
+/// If _fromType is ReferenceType the function will perform deep copy.
 	/// signature: (array, value)
-	std::string storageArrayPushFunction(ArrayType const& _type);
+	std::string storageArrayPushFunction(ArrayType const& _type, TypePointer _fromType = nullptr);
 
 	/// @returns the name of a function that pushes the base type's zero element to a storage array and returns storage slot and offset of the added element.
 	/// signature: (array) -> slot, offset
@@ -483,7 +485,7 @@ public:
 	std::string externalCodeFunction();
 
 private:
-	/// @returns function that copies struct to storage
+/// @returns the name of a function that copies a struct from calldata or memory to storage
 	/// signature: (slot, value) ->
 	std::string copyStructToStorageFunction(StructType const& _from, StructType const& _to);
 

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -483,6 +483,10 @@ public:
 	std::string externalCodeFunction();
 
 private:
+	/// @returns function that copies struct to storage
+	/// signature: (slot, value) ->
+	std::string copyStructToStorageFunction(StructType const& _from, StructType const& _to);
+
 	/// Special case of conversion functions - handles all array conversions.
 	std::string arrayConversionFunction(ArrayType const& _from, ArrayType const& _to);
 

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1316,9 +1316,13 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		}
 		else
 		{
-			IRVariable argument = convert(*arguments.front(), *arrayType.baseType());
+			IRVariable argument =
+				arrayType.baseType()->isValueType() ?
+				convert(*arguments.front(), *arrayType.baseType()) :
+				*arguments.front();
+
 			m_code <<
-				m_utils.storageArrayPushFunction(arrayType) <<
+				m_utils.storageArrayPushFunction(arrayType, &argument.type()) <<
 				"(" <<
 				IRVariable(_functionCall.expression()).commaSeparatedList() <<
 				", " <<

--- a/test/libsolidity/semanticTests/array/push/array_push_nested_from_calldata.sol
+++ b/test/libsolidity/semanticTests/array/push/array_push_nested_from_calldata.sol
@@ -1,0 +1,16 @@
+contract C {
+    uint8 b = 23;
+    uint120[][] s;
+    uint8 a = 17;
+    function f(uint120[] calldata c) public returns(uint120) {
+        s.push(c);
+        assert(s.length == 1);
+        assert(s[0].length == c.length);
+        assert(s[0].length > 0);
+        return s[0][0];
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint120[]): 0x20, 3, 1, 2, 3 -> 1

--- a/test/libsolidity/semanticTests/array/push/array_push_nested_from_memory.sol
+++ b/test/libsolidity/semanticTests/array/push/array_push_nested_from_memory.sol
@@ -1,0 +1,19 @@
+contract C {
+    uint8 b = 23;
+    uint120[][] s;
+    uint8 a = 17;
+    function f() public returns(uint120) {
+        delete s;
+        uint120[] memory m = new uint120[](3);
+        m[0] = 1;
+        s.push(m);
+        assert(s.length == 1);
+        assert(s[0].length == m.length);
+        assert(s[0].length > 0);
+        return s[0][0];
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 1

--- a/test/libsolidity/semanticTests/array/push/array_push_struct.sol
+++ b/test/libsolidity/semanticTests/array/push/array_push_struct.sol
@@ -18,6 +18,7 @@ contract c {
         return (data[0].a, data[0].b, data[0].c[2], data[0].d[2]);
     }
 }
-
+// ====
+// compileViaYul: also
 // ----
 // test() -> 2, 3, 4, 5

--- a/test/libsolidity/semanticTests/array/push/array_push_struct_from_calldata.sol
+++ b/test/libsolidity/semanticTests/array/push/array_push_struct_from_calldata.sol
@@ -1,0 +1,20 @@
+pragma abicoder v2;
+
+contract c {
+    struct S {
+        uint16 a;
+        uint16 b;
+        uint16[3] c;
+        uint16[] d;
+    }
+    S[] data;
+
+    function test(S calldata c) public returns (uint16, uint16, uint16, uint16) {
+        data.push(c);
+        return (data[0].a, data[0].b, data[0].c[2], data[0].d[2]);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// test((uint16, uint16, uint16[3], uint16[])): 0x20, 2, 3, 0, 0, 4, 0xC0, 4, 0, 0, 5, 0, 0 -> 2, 3, 4, 5


### PR DESCRIPTION
This PR implemnents
- small refactor (creating `copyStructToStorageFunction` as it is quite big)
- array push with struct argument coming from calldata or memory
- nested array push with argument coming from calldata or memory

It is easier to review commit by commit, as majority of changes are from refactoring commit (first one)