### PR TITLE
Deal with old clang compilers.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -65,11 +65,8 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 
 	# Additional GCC-specific compiler settings.
 	if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-
 		# Check that we've got GCC 8.0 or newer.
-		execute_process(
-			COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-		if (NOT (GCC_VERSION VERSION_GREATER 8.0 OR GCC_VERSION VERSION_EQUAL 8.0))
+		if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0))
 			message(FATAL_ERROR "${PROJECT_NAME} requires g++ 8.0 or greater.")
 		endif ()
 
@@ -78,6 +75,11 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 
 	# Additional Clang-specific compiler settings.
 	elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+		# Check that we've got clang 7.0 or newer.
+		if (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0))
+			message(FATAL_ERROR "${PROJECT_NAME} requires clang++ 7.0 or greater.")
+		endif ()
+
 		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
 			# Set stack size to 32MB - by default Apple's clang defines a stack size of 8MB.
 			# Normally 16MB is enough to run all tests, but it will exceed the stack, if -DSANITIZE=address is used.

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -164,11 +164,11 @@ void CHC::endVisit(ContractDefinition const& _contract)
 		if (base != &_contract)
 		{
 			m_callGraph[&_contract].insert(base);
-			vector<ASTPointer<Expression>> const& args = baseArgs.count(base) ? baseArgs.at(base) : decltype(args){};
 
 			auto baseConstructor = base->constructor();
-			if (baseConstructor && !args.empty())
+			if (baseConstructor && baseArgs.count(base))
 			{
+				vector<ASTPointer<Expression>> const& args = baseArgs.at(base);
 				auto const& params = baseConstructor->parameters();
 				solAssert(params.size() == args.size(), "");
 				for (unsigned i = 0; i < params.size(); ++i)


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10532.

The first PR fixes the ICE with clang 6 - but then again we actually dropped support, so the second commit actually checks that in cmake. But not sure, if that works as is for osx - CI will tell.

Ping @leonardoalt about the CHC change.