### PR TITLE
Ensure empty arrays are not visited and fix formatting issues

### DIFF
--- a/test/tools/ossfuzz/protoToAbiV2.h
+++ b/test/tools/ossfuzz/protoToAbiV2.h
@@ -748,6 +748,9 @@ private:
 		std::ostringstream stream;
 		void startStruct()
 		{
+			if (index >= 1)
+				stream << ",";
+			index = 0;
 			stream << "(";
 		}
 		void endStruct()
@@ -756,11 +759,15 @@ private:
 		}
 		void startArray()
 		{
+			if (index >= 1)
+				stream << ",";
+			index = 0;
 			stream << "[";
 		}
 		void endArray()
 		{
 			stream << "]";
+			index++;
 		}
 		void appendValue(std::string& _value);
 	};
@@ -793,6 +800,7 @@ private:
 	unsigned m_structCounter;
 	unsigned m_structStart;
 	ValueStream m_valueStream;
+	bool m_forcedVisit = false;
 };
 
 /// Returns a valid value (as a string) for a given type.


### PR DESCRIPTION
The following bugs are fixed by this PR

1. When visiting emtpy (zero length) arrays of struct type, encoded value is not altered beyond `[]`
2. When formatting value across struct types of another composite type (e.g., struct type) ensure that a comma is placed between the two types
3. When formatting value for a composite type involving an empty array `[]`, treat the empty array as a single element so that a comma is placed on subsequent elements