### PR TITLE
Conversion of calldata array slices to memory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
  * Code generator: Support copying dynamically encoded structs from calldata to memory.
  * Code generator: Support copying of nested arrays from calldata to memory.
+ * Code generator: Support conversion from calldata slices to memory and storage arrays.
  * The fallback function can now also have a single ``calldata`` argument (equaling ``msg.data``) and return ``bytes memory`` (which will not be ABI-encoded but returned as-is).
  * Wasm backend: Add ``i32.select`` and ``i64.select`` instructions.
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2074,7 +2074,11 @@ std::unique_ptr<ReferenceType> ArrayType::copyForLocation(DataLocation _location
 
 BoolResult ArraySliceType::isImplicitlyConvertibleTo(Type const& _other) const
 {
-	if (m_arrayType.location() == DataLocation::CallData && m_arrayType.isDynamicallySized() && m_arrayType == _other)
+	if (
+		m_arrayType.dataStoredIn(DataLocation::CallData) &&
+		m_arrayType.isDynamicallySized() &&
+		m_arrayType.isImplicitlyConvertibleTo(_other)
+	)
 		return true;
 	return (*this) == _other;
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2074,13 +2074,13 @@ std::unique_ptr<ReferenceType> ArrayType::copyForLocation(DataLocation _location
 
 BoolResult ArraySliceType::isImplicitlyConvertibleTo(Type const& _other) const
 {
-	if (
-		m_arrayType.dataStoredIn(DataLocation::CallData) &&
-		m_arrayType.isDynamicallySized() &&
-		m_arrayType.isImplicitlyConvertibleTo(_other)
-	)
-		return true;
-	return (*this) == _other;
+	return
+		(*this) == _other ||
+		(
+			m_arrayType.dataStoredIn(DataLocation::CallData) &&
+			m_arrayType.isDynamicallySized() &&
+			m_arrayType.isImplicitlyConvertibleTo(_other)
+		);
 }
 
 string ArraySliceType::richIdentifier() const

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1051,11 +1051,11 @@ void CompilerUtils::convertType(
 	case Type::Category::ArraySlice:
 	{
 		auto& typeOnStack = dynamic_cast<ArraySliceType const&>(_typeOnStack);
-		solUnimplementedAssert(
-			_targetType.dataStoredIn(DataLocation::CallData),
-			"Conversion from calldata slices to memory not yet implemented."
-		);
-		solAssert(_targetType == typeOnStack.arrayType(), "");
+		solAssert(_targetType.category() == Type::Category::Array, "");
+		auto const& targetArrayType = dynamic_cast<ArrayType const&>(_targetType);
+		solAssert(targetArrayType == *typeOnStack.arrayType().copyForLocation(targetArrayType.location(), false), "");
+		if (!_targetType.dataStoredIn(DataLocation::CallData))
+			return convertType(typeOnStack.arrayType(), _targetType);
 		solUnimplementedAssert(
 			typeOnStack.arrayType().location() == DataLocation::CallData &&
 			typeOnStack.arrayType().isDynamicallySized() &&

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1050,18 +1050,18 @@ void CompilerUtils::convertType(
 	}
 	case Type::Category::ArraySlice:
 	{
-		auto& typeOnStack = dynamic_cast<ArraySliceType const&>(_typeOnStack);
 		solAssert(_targetType.category() == Type::Category::Array, "");
+		auto& typeOnStack = dynamic_cast<ArraySliceType const&>(_typeOnStack);
 		auto const& targetArrayType = dynamic_cast<ArrayType const&>(_targetType);
-		solAssert(targetArrayType == *typeOnStack.arrayType().copyForLocation(targetArrayType.location(), false), "");
-		if (!_targetType.dataStoredIn(DataLocation::CallData))
-			return convertType(typeOnStack.arrayType(), _targetType);
-		solUnimplementedAssert(
-			typeOnStack.arrayType().location() == DataLocation::CallData &&
+		solAssert(typeOnStack.arrayType().isImplicitlyConvertibleTo(targetArrayType), "");
+		solAssert(
+			typeOnStack.arrayType().dataStoredIn(DataLocation::CallData) &&
 			typeOnStack.arrayType().isDynamicallySized() &&
 			!typeOnStack.arrayType().baseType()->isDynamicallyEncoded(),
 			""
 		);
+		if (!_targetType.dataStoredIn(DataLocation::CallData))
+			return convertType(typeOnStack.arrayType(), _targetType);
 		break;
 	}
 	case Type::Category::Struct:

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2852,14 +2852,17 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 		solAssert(_from.dataStoredIn(DataLocation::CallData), "");
 		solAssert(_to.category() == Type::Category::Array, "");
 
-		ArraySliceType const& fromType = dynamic_cast<ArraySliceType const&>(_from);
-		ArrayType const& targetType = dynamic_cast<ArrayType const&>(_to);
+		auto const& fromType = dynamic_cast<ArraySliceType const&>(_from);
+		auto const& targetType = dynamic_cast<ArrayType const&>(_to);
 
 		solAssert(!fromType.arrayType().baseType()->isDynamicallyEncoded(), "");
 		solAssert(
 			*fromType.arrayType().baseType() == *targetType.baseType(),
 			"Converting arrays of different type is not possible"
 		);
+
+		if (!targetType.dataStoredIn(DataLocation::CallData))
+			return arrayConversionFunction(fromType.arrayType(), targetType);
 
 		string const functionName =
 			"convert_" +

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2848,17 +2848,16 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 	}
 	else if (_from.category() == Type::Category::ArraySlice)
 	{
-		solAssert(_from.isDynamicallySized(), "");
-		solAssert(_from.dataStoredIn(DataLocation::CallData), "");
 		solAssert(_to.category() == Type::Category::Array, "");
-
 		auto const& fromType = dynamic_cast<ArraySliceType const&>(_from);
 		auto const& targetType = dynamic_cast<ArrayType const&>(_to);
 
-		solAssert(!fromType.arrayType().baseType()->isDynamicallyEncoded(), "");
+		solAssert(fromType.arrayType().isImplicitlyConvertibleTo(targetType), "");
 		solAssert(
-			*fromType.arrayType().baseType() == *targetType.baseType(),
-			"Converting arrays of different type is not possible"
+			fromType.arrayType().dataStoredIn(DataLocation::CallData) &&
+			fromType.arrayType().isDynamicallySized() &&
+			!fromType.arrayType().baseType()->isDynamicallyEncoded(),
+			""
 		);
 
 		if (!targetType.dataStoredIn(DataLocation::CallData))

--- a/test/libsolidity/semanticTests/array/calldata_array_as_argument_internal_function.sol
+++ b/test/libsolidity/semanticTests/array/calldata_array_as_argument_internal_function.sol
@@ -1,0 +1,19 @@
+pragma abicoder v2;
+contract Test {
+    function f(uint256[] calldata c) internal returns (uint a, uint b) {
+        return (c.length, c[0]);
+    }
+
+    function g(uint256[] calldata c) external returns (uint a, uint b) {
+        return f(c);
+    }
+
+    function h(uint256[] calldata c, uint start, uint end) external returns (uint a, uint b) {
+        return f(c[start: end]);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// g(uint256[]): 0x20, 4, 1, 2, 3, 4 -> 4, 1
+// h(uint256[], uint256, uint256): 0x60, 1, 3, 4, 1, 2, 3, 4 -> 2, 2

--- a/test/libsolidity/semanticTests/array/slices/array_slice_calldata_as_argument_of_external_calls.sol
+++ b/test/libsolidity/semanticTests/array/slices/array_slice_calldata_as_argument_of_external_calls.sol
@@ -1,0 +1,39 @@
+contract C {
+    function f1(bytes calldata c1, uint256 s, uint256 e, bytes calldata c2) public returns (bool) {
+        return keccak256(c1[s:e]) == keccak256(c2);
+    }
+
+    function f2(bytes calldata c, uint256 s) public returns (uint256, bytes memory) {
+        return abi.decode(c[s:], (uint256, bytes));
+    }
+
+    function f3(bytes calldata c1, uint256 s, uint256 e, bytes calldata c2) public returns (bool) {
+        bytes memory a = abi.encode(c1[s:e]);
+        bytes memory b = abi.encode(c2);
+        if (a.length != b.length) { return false; }
+        for (uint256 i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) { return false; }
+        }
+        return true;
+    }
+
+    function f4(bytes calldata c1, uint256 s, uint256 e, bytes calldata c2) public returns (bool) {
+        bytes memory a = abi.encodePacked(c1[s:e]);
+        bytes memory b = abi.encodePacked(c2);
+        if (a.length != b.length) { return false; }
+        for (uint256 i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) { return false; }
+        }
+        return true;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f1(bytes,uint256,uint256,bytes): 0x80, 1, 5, 0xC0, 8, "abcdefgh", 4, "bcde" -> true
+// f1(bytes,uint256,uint256,bytes): 0x80, 1, 5, 0xC0, 8, "abcdefgh", 4, "bcdf" -> false
+// f2(bytes,uint256): 0x40, 0, 0x80, 0x21, 0x40, 0x7, "abcdefg" -> 0x21, 0x40, 0x7, "abcdefg"
+// f3(bytes,uint256,uint256,bytes): 0x80, 1, 5, 0xC0, 8, "abcdefgh", 4, "bcde" -> true
+// f3(bytes,uint256,uint256,bytes): 0x80, 1, 5, 0xC0, 8, "abcdefgh", 4, "bcdf" -> false
+// f4(bytes,uint256,uint256,bytes): 0x80, 1, 5, 0xC0, 8, "abcdefgh", 4, "bcde" -> true
+// f4(bytes,uint256,uint256,bytes): 0x80, 1, 5, 0xC0, 8, "abcdefgh", 4, "bcdf" -> false

--- a/test/libsolidity/semanticTests/array/slices/array_slice_calldata_to_calldata.sol
+++ b/test/libsolidity/semanticTests/array/slices/array_slice_calldata_to_calldata.sol
@@ -1,0 +1,27 @@
+pragma abicoder v2;
+
+contract C {
+    struct S {
+        uint128 p1;
+        uint256[3] a;
+        uint32 p2;
+    }
+    function f(S[] calldata c) internal returns (S[] memory) {
+        return c;
+    }
+    function g(S[] calldata c, uint256 s, uint256 e) public returns (S[] memory) {
+        return f(c[s:e]);
+    }
+
+    function f1(uint256[3][] calldata c) internal returns (uint256[3][] memory) {
+        return c;
+    }
+    function g1(uint256[3][] calldata c, uint256 s, uint256 e) public returns (uint256[3][] memory) {
+        return f1(c[s:e]);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// g((uint128, uint256[3], uint32)[], uint256, uint256): 0x60, 1, 3, 4, 55, 1, 2, 3, 66, 66, 2, 3, 4, 77, 77, 3, 4, 5, 88, 88, 4, 5, 6, 99 -> 0x20, 2, 66, 2, 3, 4, 77, 77, 3, 4, 5, 88
+// g1(uint256[3][], uint256, uint256): 0x60, 1, 3, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 -> 0x20, 2, 4, 5, 6, 7, 8, 9

--- a/test/libsolidity/semanticTests/array/slices/array_slice_calldata_to_memory.sol
+++ b/test/libsolidity/semanticTests/array/slices/array_slice_calldata_to_memory.sol
@@ -1,0 +1,29 @@
+contract C {
+    function f(int[] calldata b, uint256 start, uint256 end) public returns (int) {
+        int[] memory m = b[start:end];
+        uint len = end - start;
+        assert(len == m.length);
+        for (uint i = 0; i < len; i++) {
+            assert(b[start:end][i] == m[i]);
+        }
+        return [b[start:end]][0][0];
+    }
+
+    function g(int[] calldata b, uint256 start, uint256 end) public returns (int[] memory) {
+        return b[start:end];
+    }
+
+    function h1(int[] memory b) internal returns (int[] memory) {
+        return b;
+    }
+
+    function h(int[] calldata b, uint256 start, uint256 end) public returns (int[] memory) {
+        return h1(b[start:end]);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(int256[], uint256, uint256): 0x60, 1, 3, 4, 1, 2, 3, 4 -> 2
+// g(int256[], uint256, uint256): 0x60, 1, 3, 4, 1, 2, 3, 4 -> 0x20, 2, 2, 3
+// h(int256[], uint256, uint256): 0x60, 1, 3, 4, 1, 2, 3, 4 -> 0x20, 2, 2, 3

--- a/test/libsolidity/semanticTests/array/slices/array_slice_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/slices/array_slice_calldata_to_storage.sol
@@ -1,0 +1,16 @@
+contract C {
+    int[] s;
+    function f(int[] calldata b, uint256 start, uint256 end) public returns (int) {
+        s = b[start:end];
+        uint len = end - start;
+        assert(len == s.length);
+        for (uint i = 0; i < len; i++) {
+            assert(b[start:end][i] == s[i]);
+        }
+        return s[0];
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(int256[], uint256, uint256): 0x60, 1, 3, 4, 1, 2, 3, 4 -> 2

--- a/test/libsolidity/syntaxTests/array/slice/assign_to_storage.sol
+++ b/test/libsolidity/syntaxTests/array/slice/assign_to_storage.sol
@@ -5,4 +5,3 @@ contract c {
   }
 }
 // ----
-// TypeError 7407: (63-74): Type bytes calldata slice is not implicitly convertible to expected type bytes storage ref.

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_convert_to_memory.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_convert_to_memory.sol
@@ -1,7 +1,5 @@
 contract C {
-    function f(bytes calldata x) external {
-        bytes memory y = x[1:2];
+    function f(bytes calldata x) external pure returns (bytes memory) {
+        return x[1:2];
     }
 }
-// ----
-// TypeError 9574: (65-88): Type bytes calldata slice is not implicitly convertible to expected type bytes memory.

--- a/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_forward.sol
+++ b/test/libsolidity/syntaxTests/array/slice/calldata_dynamic_forward.sol
@@ -4,4 +4,3 @@ contract C {
     }
 }
 // ----
-// TypeError 9553: (79-85): Invalid type for argument in function call. Invalid implicit conversion from bytes calldata slice to bytes memory requested.


### PR DESCRIPTION
Fixes #8991 for both old codegen and IR.

Test coverage for array slices is not great, so I guess will need to add more tests here