### PR TITLE
Fix checks for code snippets embedded in docs

### DIFF
--- a/docs/contracts/constant-state-variables.rst
+++ b/docs/contracts/constant-state-variables.rst
@@ -30,7 +30,7 @@ Not all types for constants and immutables are implemented at this time. The onl
 ::
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >0.7.2;
+    pragma solidity >=0.7.4;
 
     uint constant X = 32**22 + 8;
 

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -83,7 +83,7 @@ registering with a username and password, all you need is an Ethereum keypair.
 ::
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >0.5.99 <0.8.0;
+    pragma solidity >=0.7.0 <0.8.0;
 
     contract Coin {
         // The keyword "public" makes variables

--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -49,7 +49,7 @@ The following example shows a contract and a function using all available tags.
 .. code:: Solidity
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >0.6.10 <0.8.0;
+    pragma solidity >=0.6.12 <0.8.0;
 
     /// @title A simulator for trees
     /// @author Larry A. Gardner

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1071,6 +1071,10 @@ No::
 
 and in ``Congress.sol``::
 
+    // SPDX-License-Identifier: GPL-3.0
+    pragma solidity ^0.7.0;
+
+
     import "./owned.sol";
 
 

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -243,7 +243,7 @@ individual elements:
 ::
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >=0.4.0 <0.8.0;
+    pragma solidity >=0.4.16 <0.8.0;
 
     contract C {
         function f() public pure {

--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -71,7 +71,7 @@ function compileFull()
         printError "Was failure: $exit_code"
         echo "$errors"
         printError "While calling:"
-        echo "\"$SOLC\" $ARGS $files"
+        echo "\"$SOLC\" $args $files"
         printError "Inside directory:"
         pwd
         false

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -108,7 +108,7 @@ function findMinimalVersion()
     do
         if versionGreater "$ver" "$pragmaVersion"
         then
-            minVersion="$ver"
+            version="$ver"
             break
         elif ([ $greater == false ]) && versionEqual "$ver" "$pragmaVersion"
         then

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -117,7 +117,7 @@ function findMinimalVersion()
         fi
     done
 
-    if [ -z version ]
+    if [ -z "$version" ]
     then
         printError "No release $sign$pragmaVersion was listed in available releases!"
     fi

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -65,7 +65,7 @@ function getAllAvailableVersions()
 {
     allVersions=()
     local allListedVersions=( $(
-        wget -q -O- https://ethereum.github.io/solc-bin/bin/list.txt |
+        wget -q -O- https://binaries.soliditylang.org/bin/list.txt |
         grep -Po '(?<=soljson-v)\d+.\d+.\d+(?=\+commit)' |
         sort -V
     ) )

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -120,6 +120,7 @@ function findMinimalVersion()
     if [ -z "$version" ]
     then
         printError "No release $sign$pragmaVersion was listed in available releases!"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
While fixing shellcheck warnings in scripts I discovered a combination of several bugs in the script for validating code snippets in docs. This was making these checks ineffective in many cases and there were a few snippets that slipped through with wrong version pragmas due to this.