### PR TITLE
[SMTChecker] Fix internal error when increment/decrement is applied on a result of push().

### DIFF
--- a/test/libsolidity/smtCheckerTests/operators/unary_add_array_push_1.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_add_array_push_1.sol
@@ -1,0 +1,13 @@
+pragma experimental SMTChecker;
+contract C {
+	uint[] x;
+	function f() public {
+		require(x.length == 0);
+		++x.push();
+		assert(x.length == 1);
+		assert(x[0] == 1); // should hold
+		assert(x[0] == 42); // should fail
+	}
+}
+// ----
+// Warning 6328: (182-200): CHC: Assertion violation happens here.\nCounterexample:\nx = [1]\n\n\n\nTransaction trace:\nconstructor()\nState: x = []\nf()

--- a/test/libsolidity/smtCheckerTests/operators/unary_add_array_push_2.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_add_array_push_2.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+
+contract C {
+	struct S {
+		int[][] d;
+	}
+	S[] data;
+	function f() public {
+		++data[1].d[3].push();
+	}
+}


### PR DESCRIPTION
Fixes #9744.