### PR TITLE
Asmanalysis: Add test case that demonstrates bug

### DIFF
--- a/test/libyul/yulSyntaxTests/builtin_function_literal.yul
+++ b/test/libyul/yulSyntaxTests/builtin_function_literal.yul
@@ -1,0 +1,7 @@
+{
+  datasize(x,1)
+}
+// ----
+// TypeError 7000: (4-12): Function expects 1 arguments but got 2.
+// TypeError 9114: (4-12): Function expects direct literals as arguments.
+// DeclarationError 8198: (13-14): Identifier not found.


### PR DESCRIPTION
This PR adds test case that was missing in the already merged #10611 

The bug happens because
  - literalArguments for `datasize(x,1)` is non null
  - size of literalArguments is `1`
  - size of function call arguments is `2`
  - so, in the second iteration, `literalArguments->at(1)` leads to an out of bounds read that #10611 already fixed

This PR simply adds the missing test case