### PR TITLE
Unary minus is not implemented for fixed point type

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -453,6 +453,10 @@ bool ExpressionCompiler::visit(UnaryOperation const& _unaryOperation)
 		// unary add, so basically no-op
 		break;
 	case Token::Sub: // -
+		solUnimplementedAssert(
+			type.category() != Type::Category::FixedPoint,
+			"Not yet implemented - FixedPointType."
+		);
 		if (m_context.arithmetic() == Arithmetic::Checked)
 			m_context.callYulFunction(m_context.utilFunctions().negateNumberCheckedFunction(type), 1, 1);
 		else

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3484,6 +3484,7 @@ string YulUtilFunctions::forwardingRevertFunction()
 
 std::string YulUtilFunctions::decrementCheckedFunction(Type const& _type)
 {
+	solAssert(_type.category() == Type::Category::Integer, "");
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 
 	string const functionName = "decrement_" + _type.identifier();
@@ -3506,6 +3507,7 @@ std::string YulUtilFunctions::decrementCheckedFunction(Type const& _type)
 
 std::string YulUtilFunctions::decrementWrappingFunction(Type const& _type)
 {
+	solAssert(_type.category() == Type::Category::Integer, "");
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 
 	string const functionName = "decrement_wrapping_" + _type.identifier();
@@ -3524,6 +3526,7 @@ std::string YulUtilFunctions::decrementWrappingFunction(Type const& _type)
 
 std::string YulUtilFunctions::incrementCheckedFunction(Type const& _type)
 {
+	solAssert(_type.category() == Type::Category::Integer, "");
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 
 	string const functionName = "increment_" + _type.identifier();
@@ -3546,6 +3549,7 @@ std::string YulUtilFunctions::incrementCheckedFunction(Type const& _type)
 
 std::string YulUtilFunctions::incrementWrappingFunction(Type const& _type)
 {
+	solAssert(_type.category() == Type::Category::Integer, "");
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 
 	string const functionName = "increment_wrapping_" + _type.identifier();
@@ -3564,6 +3568,7 @@ std::string YulUtilFunctions::incrementWrappingFunction(Type const& _type)
 
 string YulUtilFunctions::negateNumberCheckedFunction(Type const& _type)
 {
+	solAssert(_type.category() == Type::Category::Integer, "");
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 	solAssert(type.isSigned(), "Expected signed type!");
 
@@ -3586,6 +3591,7 @@ string YulUtilFunctions::negateNumberCheckedFunction(Type const& _type)
 
 string YulUtilFunctions::negateNumberWrappingFunction(Type const& _type)
 {
+	solAssert(_type.category() == Type::Category::Integer, "");
 	IntegerType const& type = dynamic_cast<IntegerType const&>(_type);
 	solAssert(type.isSigned(), "Expected signed type!");
 


### PR DESCRIPTION
Closes #10256.

This only adds the necessary assertion. We could improve the type checker, but not sure it is worth it?