### PR TITLE
Fix line endings in Unicode diretion override tests

### DIFF
--- a/test/libsolidity/syntaxTests/comments/unicode_direction_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/unicode_direction_override_1.sol
@@ -7,4 +7,4 @@ contract TimelockUpgrade {
 }
 
 // ----
-// ParserError 8936: (128-139): Mismatching directional override markers in comment or string literal.
+// ParserError 8936: (124-135): Mismatching directional override markers in comment or string literal.


### PR DESCRIPTION
One of the tests added in #10326 has Windows line endings. We probably have some line-ending conversion that kicks in only on non-CRLF platforms because the source locations in error messages end up being different on Windows because of this.

### Details
See [this failed run or t_win](https://app.circleci.com/pipelines/github/ethereum/solidity/11835/workflows/1c77d549-1b36-4544-8896-80c305309d32/jobs/561666):

```
ASSERTION FAILURE:
- file   : boostTest.cpp
- line   : 125
- message: Test expectation mismatch.
Expected result:
  ParserError 8936: (128-139): Mismatching directional override markers in comment or string literal.
Obtained result:
  ParserError 8936: (124-135): Mismatching directional override markers in comment or string literal.
```