### PR TITLE
Improve the Error class with a constructor for secondaryLocation 

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -715,8 +715,11 @@ LinkerObject const& Assembly::assemble() const
 
 	if (!immutableReferencesBySub.empty())
 		throw
-			langutil::Error(1284_error, langutil::Error::Type::CodeGenerationError) <<
-			util::errinfo_comment("Some immutables were read from but never assigned, possibly because of optimization.");
+			langutil::Error(
+				1284_error,
+				langutil::Error::Type::CodeGenerationError,
+				"Some immutables were read from but never assigned, possibly because of optimization."
+			);
 
 	if (!m_subs.empty() || !m_data.empty() || !m_auxiliaryData.empty())
 		// Append an INVALID here to help tests find miscompilation.

--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -67,12 +67,7 @@ void ErrorReporter::error(ErrorId _errorId, Error::Type _type, SourceLocation co
 	if (checkForExcessiveErrors(_type))
 		return;
 
-	auto err = make_shared<Error>(_errorId, _type);
-	*err <<
-		errinfo_sourceLocation(_location) <<
-		util::errinfo_comment(_description);
-
-	m_errorList.push_back(err);
+	m_errorList.push_back(make_shared<Error>(_errorId, _type, _description, _location));
 }
 
 void ErrorReporter::error(ErrorId _errorId, Error::Type _type, SourceLocation const& _location, SecondarySourceLocation const& _secondaryLocation, string const& _description)
@@ -80,13 +75,7 @@ void ErrorReporter::error(ErrorId _errorId, Error::Type _type, SourceLocation co
 	if (checkForExcessiveErrors(_type))
 		return;
 
-	auto err = make_shared<Error>(_errorId, _type);
-	*err <<
-		errinfo_sourceLocation(_location) <<
-		errinfo_secondarySourceLocation(_secondaryLocation) <<
-		util::errinfo_comment(_description);
-
-	m_errorList.push_back(err);
+	m_errorList.push_back(make_shared<Error>(_errorId, _type, _description, _location, _secondaryLocation));
 }
 
 bool ErrorReporter::hasExcessiveErrors() const
@@ -101,11 +90,7 @@ bool ErrorReporter::checkForExcessiveErrors(Error::Type _type)
 		m_warningCount++;
 
 		if (m_warningCount == c_maxWarningsAllowed)
-		{
-			auto err = make_shared<Error>(4591_error, Error::Type::Warning);
-			*err << util::errinfo_comment("There are more than 256 warnings. Ignoring the rest.");
-			m_errorList.push_back(err);
-		}
+			m_errorList.push_back(make_shared<Error>(4591_error, Error::Type::Warning, "There are more than 256 warnings. Ignoring the rest."));
 
 		if (m_warningCount >= c_maxWarningsAllowed)
 			return true;
@@ -116,9 +101,7 @@ bool ErrorReporter::checkForExcessiveErrors(Error::Type _type)
 
 		if (m_errorCount > c_maxErrorsAllowed)
 		{
-			auto err = make_shared<Error>(4013_error, Error::Type::Warning);
-			*err << util::errinfo_comment("There are more than 256 errors. Aborting.");
-			m_errorList.push_back(err);
+			m_errorList.push_back(make_shared<Error>(4013_error, Error::Type::Warning, "There are more than 256 errors. Aborting."));
 			BOOST_THROW_EXCEPTION(FatalError());
 		}
 	}

--- a/liblangutil/Exceptions.cpp
+++ b/liblangutil/Exceptions.cpp
@@ -27,7 +27,12 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 
-Error::Error(ErrorId _errorId, Type _type, SourceLocation const& _location, string const& _description):
+Error::Error(
+	ErrorId _errorId, Error::Type _type,
+	std::string const& _description,
+	SourceLocation const& _location,
+	SecondarySourceLocation const& _secondaryLocation
+):
 	m_errorId(_errorId),
 	m_type(_type)
 {
@@ -58,14 +63,8 @@ Error::Error(ErrorId _errorId, Type _type, SourceLocation const& _location, stri
 
 	if (_location.isValid())
 		*this << errinfo_sourceLocation(_location);
+	if (!_secondaryLocation.infos.empty())
+		*this << errinfo_secondarySourceLocation(_secondaryLocation);
 	if (!_description.empty())
 		*this << util::errinfo_comment(_description);
-}
-
-Error::Error(ErrorId _errorId, Error::Type _type, std::string const& _description, SourceLocation const& _location):
-	Error(_errorId, _type)
-{
-	if (_location.isValid())
-		*this << errinfo_sourceLocation(_location);
-	*this << util::errinfo_comment(_description);
 }

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -58,73 +58,6 @@ struct InvalidAstError: virtual util::Exception {};
 #define astAssert(CONDITION, DESCRIPTION) \
 	assertThrow(CONDITION, ::solidity::langutil::InvalidAstError, DESCRIPTION)
 
-/**
- * Unique identifiers are used to tag and track individual error cases.
- * They are passed as the first parameter of error reporting functions.
- * Suffix _error helps to find them in the sources.
- * The struct ErrorId prevents incidental calls like typeError(3141) instead of typeError(3141_error).
- * To create a new ID, one can add 0000_error and then run "python ./scripts/error_codes.py --fix"
- * from the root of the repo.
- */
-struct ErrorId
-{
-	unsigned long long error = 0;
-	bool operator==(ErrorId const& _rhs) const { return error == _rhs.error; }
-};
-constexpr ErrorId operator"" _error(unsigned long long _error) { return ErrorId{ _error }; }
-
-class Error: virtual public util::Exception
-{
-public:
-	enum class Type
-	{
-		CodeGenerationError,
-		DeclarationError,
-		DocstringParsingError,
-		ParserError,
-		TypeError,
-		SyntaxError,
-		Warning
-	};
-
-	Error(
-		ErrorId _errorId,
-		Type _type,
-		SourceLocation const& _location = SourceLocation(),
-		std::string const& _description = std::string()
-	);
-
-	Error(ErrorId _errorId, Type _type, std::string const& _description, SourceLocation const& _location = SourceLocation());
-
-	ErrorId errorId() const { return m_errorId; }
-	Type type() const { return m_type; }
-	std::string const& typeName() const { return m_typeName; }
-
-	/// helper functions
-	static Error const* containsErrorOfType(ErrorList const& _list, Error::Type _type)
-	{
-		for (auto e: _list)
-		{
-			if (e->type() == _type)
-				return e.get();
-		}
-		return nullptr;
-	}
-	static bool containsOnlyWarnings(ErrorList const& _list)
-	{
-		for (auto e: _list)
-		{
-			if (e->type() != Type::Warning)
-				return false;
-		}
-		return true;
-	}
-private:
-	ErrorId m_errorId;
-	Type m_type;
-	std::string m_typeName;
-};
-
 using errorSourceLocationInfo = std::pair<std::string, SourceLocation>;
 
 class SecondarySourceLocation
@@ -159,5 +92,80 @@ public:
 using errinfo_sourceLocation = boost::error_info<struct tag_sourceLocation, SourceLocation>;
 using errinfo_secondarySourceLocation = boost::error_info<struct tag_secondarySourceLocation, SecondarySourceLocation>;
 
+/**
+ * Unique identifiers are used to tag and track individual error cases.
+ * They are passed as the first parameter of error reporting functions.
+ * Suffix _error helps to find them in the sources.
+ * The struct ErrorId prevents incidental calls like typeError(3141) instead of typeError(3141_error).
+ * To create a new ID, one can add 0000_error and then run "python ./scripts/error_codes.py --fix"
+ * from the root of the repo.
+ */
+struct ErrorId
+{
+	unsigned long long error = 0;
+	bool operator==(ErrorId const& _rhs) const { return error == _rhs.error; }
+};
+constexpr ErrorId operator"" _error(unsigned long long _error) { return ErrorId{ _error }; }
+
+class Error: virtual public util::Exception
+{
+public:
+	enum class Type
+	{
+		CodeGenerationError,
+		DeclarationError,
+		DocstringParsingError,
+		ParserError,
+		TypeError,
+		SyntaxError,
+		Warning
+	};
+
+	// TODO: remove this
+	Error(
+		ErrorId _errorId,
+		Type _type,
+		SourceLocation const& _location = SourceLocation(),
+		std::string const& _description = std::string()
+	):
+		Error(_errorId, _type, _description, _location)
+	{}
+
+	Error(
+		ErrorId _errorId,
+		Type _type,
+		std::string const& _description,
+		SourceLocation const& _location = SourceLocation(),
+		SecondarySourceLocation const& _secondaryLocation = SecondarySourceLocation()
+	);
+
+	ErrorId errorId() const { return m_errorId; }
+	Type type() const { return m_type; }
+	std::string const& typeName() const { return m_typeName; }
+
+	/// helper functions
+	static Error const* containsErrorOfType(ErrorList const& _list, Error::Type _type)
+	{
+		for (auto e: _list)
+		{
+			if (e->type() == _type)
+				return e.get();
+		}
+		return nullptr;
+	}
+	static bool containsOnlyWarnings(ErrorList const& _list)
+	{
+		for (auto e: _list)
+		{
+			if (e->type() != Type::Warning)
+				return false;
+		}
+		return true;
+	}
+private:
+	ErrorId m_errorId;
+	Type m_type;
+	std::string m_typeName;
+};
 
 }


### PR DESCRIPTION
Part of #3819.

This is the first step, because it removes the external coupling on the features (`errinfo_*`) added by the exception class.

Should squash before merging.