### PR TITLE
Replace ABIEncoderV1Only with checking for pragma

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -97,12 +97,9 @@ SemanticTest::SemanticTest(
 
 	if (!solidity::test::CommonOptions::get().useABIEncoderV1)
 	{
-		for (auto const& [filename,source]: m_reader.sources().sources)
-			if (source.find("pragma abicoder v1;") != string::npos)
-			{
-				m_shouldRun = false;
-				break;
-			}
+		// If the top level sources requires ABICoder v1 we can not run it.
+		if (m_sources.sources[m_sources.mainSourceFile].find("pragma abicoder v1;") != string::npos)
+			m_shouldRun = false;
 	}
 
 	auto revertStrings = revertStringsFromString(m_reader.stringSetting("revertStrings", "default"));

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -90,7 +90,6 @@ private:
 	bool m_testCaseWantsLegacyRun = true;
 	bool m_enforceViaYul = false;
 	bool m_enforceCompileToEwasm = false;
-	bool m_runWithABIEncoderV1Only = false;
 	bool m_allowNonExistingFunctions = false;
 	bool m_canEnableYulRun = false;
 	bool m_canEnableEwasmRun = false;

--- a/test/libsolidity/semanticTests/abiEncoderV1/abi_encode_empty_string.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV1/abi_encode_empty_string.sol
@@ -21,7 +21,6 @@ contract C {
 }
 
 // ====
-// ABIEncoderV1Only: true
 // compileViaYul: false
 // ----
 // f1() -> 0x20, 0x40, 0x20, 0

--- a/test/libsolidity/semanticTests/abiEncoderV1/bool_out_of_bounds.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV1/bool_out_of_bounds.sol
@@ -3,7 +3,7 @@ contract C {
 	function f(bool b) public pure returns (bool) { return b; }
 }
 // ====
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // f(bool): true -> true
 // f(bool): false -> false

--- a/test/libsolidity/semanticTests/abiEncoderV1/cleanup/cleanup.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV1/cleanup/cleanup.sol
@@ -6,7 +6,7 @@ contract C {
     }
 }
 // ====
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // f(uint16,int16,address,bytes3,bool): 1, 2, 3, "a", true -> 1, 2, 3, "a", true
 // f(uint16,int16,address,bytes3,bool): 0xffffff, 0x1ffff, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, "abcd", 1 -> 0xffff, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffffffffffff, "abc", true

--- a/test/libsolidity/semanticTests/abiEncoderV1/enums.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV1/enums.sol
@@ -6,7 +6,7 @@ contract C {
     }
 }
 // ====
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // f(uint8): 0 -> 0
 // f(uint8): 1 -> 1

--- a/test/libsolidity/semanticTests/abiencodedecode/contract_array_v1.sol
+++ b/test/libsolidity/semanticTests/abiencodedecode/contract_array_v1.sol
@@ -1,3 +1,4 @@
+pragma abicoder v1;
 contract C {
   function f(bytes calldata x) public returns (C[] memory) {
     return abi.decode(x, (C[]));

--- a/test/libsolidity/semanticTests/arithmetics/checked_add_v1.sol
+++ b/test/libsolidity/semanticTests/arithmetics/checked_add_v1.sol
@@ -6,7 +6,7 @@ contract C {
     }
 }
 // ====
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // f(uint16,uint16): 65534, 0 -> 0xfffe
 // f(uint16,uint16): 65536, 0 -> 0x00

--- a/test/libsolidity/semanticTests/cleanup/bool_conversion_v1.sol
+++ b/test/libsolidity/semanticTests/cleanup/bool_conversion_v1.sol
@@ -10,7 +10,7 @@ contract C {
     }
 }
 // ====
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // f(bool): 0x0 -> 0x0
 // f(bool): 0x1 -> 0x1

--- a/test/libsolidity/semanticTests/cleanup/cleanup_address_types_v1.sol
+++ b/test/libsolidity/semanticTests/cleanup/cleanup_address_types_v1.sol
@@ -12,7 +12,7 @@ contract C {
     }
 }
 // ====
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // f(address): 0xffff1234567890123456789012345678901234567890 -> 0x0 # We input longer data on purpose.#
 // g(address): 0xffff1234567890123456789012345678901234567890 -> 0x0

--- a/test/libsolidity/semanticTests/cleanup/cleanup_bytes_types_v1.sol
+++ b/test/libsolidity/semanticTests/cleanup/cleanup_bytes_types_v1.sol
@@ -8,7 +8,5 @@ contract C {
         return 0;
     }
 }
-// ====
-// ABIEncoderV1Only: true
 // ----
 // f(bytes2,uint16): "abc", 0x40102 -> 0x0 # We input longer data on purpose. #

--- a/test/libsolidity/semanticTests/operators/shifts/shift_right_garbled_signed_v1.sol
+++ b/test/libsolidity/semanticTests/operators/shifts/shift_right_garbled_signed_v1.sol
@@ -16,8 +16,6 @@ contract C {
         return a >> b;
     }
 }
-// ====
-// ABIEncoderV1Only: true
 // ----
 // f(int8,uint8): 0x00, 0x03 -> 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
 // f(int8,uint8): 0x00, 0x04 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/test/libsolidity/semanticTests/operators/shifts/shift_right_garbled_v1.sol
+++ b/test/libsolidity/semanticTests/operators/shifts/shift_right_garbled_v1.sol
@@ -8,8 +8,6 @@ contract C {
         return a >> b;
     }
 }
-// ====
-// ABIEncoderV1Only: true
 // ----
 // f(uint8,uint8): 0x00, 0x04 -> 0x0f
 // f(uint8,uint8): 0x00, 0x1004 -> 0x0f

--- a/test/libsolidity/semanticTests/operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol
+++ b/test/libsolidity/semanticTests/operators/shifts/shift_right_negative_lvalue_signextend_int16_v1.sol
@@ -4,8 +4,6 @@ contract C {
         return a >> b;
     }
 }
-// ====
-// ABIEncoderV1Only: true
 // ----
 // f(int16,uint16): 0xff99, 0x00 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff99
 // f(int16,uint16): 0xff99, 0x01 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc

--- a/test/libsolidity/semanticTests/operators/shifts/shift_right_negative_lvalue_signextend_int32_v1.sol
+++ b/test/libsolidity/semanticTests/operators/shifts/shift_right_negative_lvalue_signextend_int32_v1.sol
@@ -4,8 +4,6 @@ contract C {
         return a >> b;
     }
 }
-// ====
-// ABIEncoderV1Only: true
 // ----
 // f(int32,uint32): 0xffffff99, 0x00 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff99
 // f(int32,uint32): 0xffffff99, 0x01 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc

--- a/test/libsolidity/semanticTests/operators/shifts/shift_right_negative_lvalue_signextend_int8_v1.sol
+++ b/test/libsolidity/semanticTests/operators/shifts/shift_right_negative_lvalue_signextend_int8_v1.sol
@@ -4,8 +4,6 @@ contract C {
         return a >> b;
     }
 }
-// ====
-// ABIEncoderV1Only: true
 // ----
 // f(int8,uint8): 0x99, 0x00 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff99
 // f(int8,uint8): 0x99, 0x01 -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc

--- a/test/libsolidity/semanticTests/revertStrings/calldata_too_short_v1.sol
+++ b/test/libsolidity/semanticTests/revertStrings/calldata_too_short_v1.sol
@@ -7,6 +7,5 @@ contract C {
 // ====
 // EVMVersion: >=byzantium
 // revertStrings: debug
-// ABIEncoderV1Only: true
 // ----
 // d(bytes): 0x20, 0x01, 0x0000000000000000000000000000000000000000000000000000000000000000 -> FAILURE, hex"08c379a0", 0x20, 18, "Calldata too short"

--- a/test/libsolidity/semanticTests/revertStrings/empty_v1.sol
+++ b/test/libsolidity/semanticTests/revertStrings/empty_v1.sol
@@ -8,7 +8,6 @@ contract C {
 	}
 }
 // ====
-// ABIEncoderV1Only: true
 // EVMVersion: >=byzantium
 // compileViaYul: false
 // revertStrings: debug

--- a/test/libsolidity/semanticTests/revertStrings/enum_v1.sol
+++ b/test/libsolidity/semanticTests/revertStrings/enum_v1.sol
@@ -8,6 +8,5 @@ contract C {
 // ====
 // EVMVersion: >=byzantium
 // revertStrings: debug
-// ABIEncoderV1Only: true
 // ----
 // f(uint8[]): 0x20, 2, 3, 3 -> FAILURE, hex"08c379a0", 0x20, 17, "Enum out of range"

--- a/test/libsolidity/semanticTests/revertStrings/invalid_abi_decoding_calldata_v1.sol
+++ b/test/libsolidity/semanticTests/revertStrings/invalid_abi_decoding_calldata_v1.sol
@@ -7,7 +7,6 @@ contract C {
 // ====
 // EVMVersion: >=byzantium
 // revertStrings: debug
-// ABIEncoderV1Only: true
 // ----
 // d(bytes): 0x20, 0x20, 0x0000000000000000000000000000000000000000000000000000000000000000 -> 0
 // d(bytes): 0x100, 0x20, 0x0000000000000000000000000000000000000000000000000000000000000000 -> FAILURE, hex"08c379a0", 0x20, 43, "ABI calldata decoding: invalid h", "ead pointer"

--- a/test/libsolidity/semanticTests/revertStrings/invalid_abi_decoding_memory_v1.sol
+++ b/test/libsolidity/semanticTests/revertStrings/invalid_abi_decoding_memory_v1.sol
@@ -15,7 +15,6 @@ contract C {
 // ====
 // EVMVersion: >=byzantium
 // revertStrings: debug
-// ABIEncoderV1Only: true
 // ----
 // f(uint256,uint256,uint256): 0, 0x200, 0x60 -> FAILURE, hex"08c379a0", 0x20, 39, "ABI memory decoding: invalid dat", "a start"
 // f(uint256,uint256,uint256): 0, 0x20, 0x60 -> FAILURE, hex"08c379a0", 0x20, 40, "ABI memory decoding: invalid dat", "a length"

--- a/test/libsolidity/semanticTests/types/mapping_enum_key_getter_v1.sol
+++ b/test/libsolidity/semanticTests/types/mapping_enum_key_getter_v1.sol
@@ -10,7 +10,6 @@ contract test {
     }
 }
 // ====
-// ABIEncoderV1Only: true
 // EVMVersion: >=byzantium
 // ----
 // table(uint8): 0 -> 0

--- a/test/libsolidity/semanticTests/types/mapping_enum_key_library_v1.sol
+++ b/test/libsolidity/semanticTests/types/mapping_enum_key_library_v1.sol
@@ -19,7 +19,7 @@ contract test {
 }
 // ====
 // EVMVersion: >=byzantium
-// ABIEncoderV1Only: true
+// compileViaYul: false
 // ----
 // library: L
 // get(uint8): 0 -> 0

--- a/test/libsolidity/semanticTests/types/mapping_enum_key_v1.sol
+++ b/test/libsolidity/semanticTests/types/mapping_enum_key_v1.sol
@@ -11,7 +11,6 @@ contract test {
 }
 // ====
 // EVMVersion: >=byzantium
-// ABIEncoderV1Only: true
 // compileViaYul: false
 // ----
 // get(uint8): 0 -> 0


### PR DESCRIPTION
Depends on #10795

In short: any file **requiring** the abicoder V1 implicitly requires the old codegen, given the IR switches on abicoder V2 unconditionally. This PR therefore replaces the `ABIEncoderV1Only` setting with the v1 pragma and `compileViaYul: false`.

Also removed some stray experimental or unneeded abicoder v2 pragmas. (There are still 351 of them remaining.)D