### PR TITLE
Build solidity-upgrade and yul-phaser statically on static PPA builds.

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -75,7 +75,7 @@ if [ $distribution = STATIC ]
 then
     pparepo=ethereum-static
     SMTDEPENDENCY=""
-    CMAKE_OPTIONS="-DSOLC_LINK_STATIC=On"
+    CMAKE_OPTIONS="-DSOLC_LINK_STATIC=On -DCMAKE_EXE_LINKER_FLAGS=-static"
 else
     if is_release
     then


### PR DESCRIPTION
For the record: this is what I'm doing to fix https://github.com/ethereum/solidity/issues/10644
The issue being that ``solidity-upgrade`` and ``yul-phaser`` are not built statically, but only ``solc`` - but we package all of them, s.t. the entire package will depend on old glibc.
It'd be nicer to do this per-cmake-target depending on ``SOLC_LINK_STATIC`` instead, but this also works and maybe we should merge this, s.t. this doesn't happen on the next release again - even though we might want to do it more nicely later.