### PR TITLE
Mark msg.sender and tx.origin as nonpayable in docs

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -77,11 +77,11 @@ Block and Transaction Properties
 - ``block.timestamp`` (``uint``): current block timestamp as seconds since unix epoch
 - ``gasleft() returns (uint256)``: remaining gas
 - ``msg.data`` (``bytes calldata``): complete calldata
-- ``msg.sender`` (``address payable``): sender of the message (current call)
+- ``msg.sender`` (``address``): sender of the message (current call)
 - ``msg.sig`` (``bytes4``): first four bytes of the calldata (i.e. function identifier)
 - ``msg.value`` (``uint``): number of wei sent with the message
 - ``tx.gasprice`` (``uint``): gas price of the transaction
-- ``tx.origin`` (``address payable``): sender of the transaction (full call chain)
+- ``tx.origin`` (``address``): sender of the transaction (full call chain)
 
 .. note::
     The values of all members of ``msg``, including ``msg.sender`` and


### PR DESCRIPTION
I just noticed that the documentation was never updated to indicate that `msg.sender` and `tx.origin` are now `address` rather than `address payable`.  Obviously that's a simple matter to fix so I figured I'd just submit a PR for it. :)  Thanks!