### PR TITLE
[SMTChecker] Fix virtual modifier called statically

### DIFF
--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -77,6 +77,9 @@ public:
 	static std::vector<VariableDeclaration const*> localVariablesIncludingModifiers(FunctionDefinition const& _function, ContractDefinition const* _contract);
 	static std::vector<VariableDeclaration const*> modifiersVariables(FunctionDefinition const& _function, ContractDefinition const* _contract);
 
+	/// @returns the ModifierDefinition of a ModifierInvocation if possible, or nullptr.
+	static ModifierDefinition const* resolveModifierInvocation(ModifierInvocation const& _invocation, ContractDefinition const* _contract);
+
 	/// @returns the SourceUnit that contains _scopable.
 	static SourceUnit const* sourceUnitContaining(Scopable const& _scopable);
 

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_1.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_1.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract A {
+    modifier m virtual {
+      _;
+    }
+}
+contract C is A {
+    function f() public A.m returns (uint) {
+    }
+}

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_2.sol
@@ -1,0 +1,22 @@
+pragma experimental SMTChecker;
+contract A {
+	int x = 0;
+
+	modifier m virtual {
+		assert(x == 0); // should hold
+		assert(x == 42); // should fail
+		_;
+	}
+}
+contract C is A {
+
+	modifier m override {
+		assert(x == 1); // This assert is not reachable, should NOT be reported
+		_;
+	}
+
+	function f() public A.m returns (uint) {
+	}
+}
+// ----
+// Warning 6328: (115-130): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\n = 0\n\nTransaction trace:\nconstructor()\nState: x = 0\nf()


### PR DESCRIPTION
Fixes #10660.

This is a fix for a recent PR #10597.
Virtual modifiers require virtual resolution when they are called directly, using only the name: `m`.
However, when the name is qualified, using concrete contract type, the call is actually static: `A.m`.