### PR TITLE
Bytecode comparison via CLI interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -925,13 +925,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: build
-      - run: scripts/bytecodecompare/storebytecode.sh && cp -v report.txt bytecode-report-ubuntu.txt
+      - run: mkdir test-cases/
+      - run: cd test-cases && ../scripts/isolate_tests.py ../test/
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json && mv -v report.txt ../bytecode-report-ubuntu-json.txt
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface cli && mv -v report.txt ../bytecode-report-ubuntu-cli.txt
       - store_artifacts:
-          path: report.txt
+          path: bytecode-report-ubuntu-json.txt
+      - store_artifacts:
+          path: bytecode-report-ubuntu-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-ubuntu.txt
+            - bytecode-report-ubuntu-json.txt
+            - bytecode-report-ubuntu-cli.txt
 
   b_bytecode_osx:
     macos:
@@ -942,13 +948,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: scripts/bytecodecompare/storebytecode.sh && cp -v report.txt bytecode-report-osx.txt
+      - run: mkdir test-cases/
+      - run: cd test-cases && ../scripts/isolate_tests.py ../test/
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json && mv -v report.txt ../bytecode-report-osx-json.txt
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface cli && mv -v report.txt ../bytecode-report-osx-cli.txt
       - store_artifacts:
-          path: report.txt
+          path: bytecode-report-osx-json.txt
+      - store_artifacts:
+          path: bytecode-report-osx-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-osx.txt
+            - bytecode-report-osx-json.txt
+            - bytecode-report-osx-cli.txt
 
   b_bytecode_win:
     executor:
@@ -961,15 +973,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: build
-      - run: python scripts\isolate_tests.py test\
-      - run: python scripts\bytecodecompare\prepare_report.py build\solc\Release\solc.exe
-      - run: cp report.txt bytecode-report-windows.txt
+      - run: mkdir test-cases\
+      - run: cd test-cases\ && python ..\scripts\isolate_tests.py ..\test\
+      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface standard-json && move report.txt ..\bytecode-report-windows-json.txt
+      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface cli && move report.txt ..\bytecode-report-windows-cli.txt
       - store_artifacts:
-          path: report.txt
+          path: bytecode-report-windows-json.txt
+      - store_artifacts:
+          path: bytecode-report-windows-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-windows.txt
+            - bytecode-report-windows-json.txt
+            - bytecode-report-windows-cli.txt
 
   b_bytecode_ems:
     docker:
@@ -980,9 +996,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: emscripten_build/libsolc
-      - run: scripts/bytecodecompare/storebytecode.sh && cp -v report.txt bytecode-report-emscripten.txt
+      - run: scripts/bytecodecompare/storebytecode.sh && mv -v report.txt bytecode-report-emscripten.txt
       - store_artifacts:
-          path: report.txt
+          path: bytecode-report-emscripten.txt
       - persist_to_workspace:
           root: .
           paths:
@@ -994,7 +1010,15 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: diff --report-identical-files --from-file bytecode-report-emscripten.txt bytecode-report-ubuntu.txt bytecode-report-osx.txt bytecode-report-windows.txt
+      - run: |
+          diff --report-identical-files --from-file \
+            bytecode-report-emscripten.txt \
+            bytecode-report-ubuntu-json.txt \
+            bytecode-report-ubuntu-cli.txt \
+            bytecode-report-osx-json.txt \
+            bytecode-report-osx-cli.txt \
+            bytecode-report-windows-json.txt \
+            bytecode-report-windows-cli.txt
 
 workflows:
   version: 2

--- a/test/scripts/fixtures/code_generation_error_cli_output.txt
+++ b/test/scripts/fixtures/code_generation_error_cli_output.txt
@@ -1,0 +1,8 @@
+Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+--> test_1c3426238b8296745d8d8bd0ff995ab65a51992b568dc7c5ce73c3f59b107825_no_assignments_sol.sol
+
+Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.0;"
+--> test_1c3426238b8296745d8d8bd0ff995ab65a51992b568dc7c5ce73c3f59b107825_no_assignments_sol.sol
+
+Error: Some immutables were read from but never assigned, possibly because of optimization.
+

--- a/test/scripts/fixtures/code_generation_error_json_output.json
+++ b/test/scripts/fixtures/code_generation_error_json_output.json
@@ -1,0 +1,50 @@
+{
+    "contracts": {
+        "syntaxTests/immutable/no_assignments.sol": {
+            "C": {
+                "metadata": "{\"compiler\":{\"version\":\"0.8.0+commit.c7dfd78e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"f\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"syntaxTests/immutable/no_assignments.sol\":\"C\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[]},\"sources\":{\"syntaxTests/immutable/no_assignments.sol\":{\"keccak256\":\"0xbafaec265150d52cd293787144247b1a0a782adf3cb89296fb4f0eb05dc25739\",\"urls\":[\"bzz-raw://7c01dbb8146347c8cf62469d57a0e290f7ef1b871426d86d995315160db665c0\",\"dweb:/ipfs/QmPrYtxVbFCFeXwnhcHoBgbg546EqMzQCT5kK7wLc3rat8\"]}},\"version\":1}"
+            }
+        }
+    },
+    "errors": [
+        {
+            "component": "general",
+            "errorCode": "1878",
+            "formattedMessage": "Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing \"SPDX-License-Identifier: <SPDX-License>\" to each source file. Use \"SPDX-License-Identifier: UNLICENSED\" for non-open-source code. Please see https://spdx.org for more information.\n--> syntaxTests/immutable/no_assignments.sol\n\n",
+            "message": "SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing \"SPDX-License-Identifier: <SPDX-License>\" to each source file. Use \"SPDX-License-Identifier: UNLICENSED\" for non-open-source code. Please see https://spdx.org for more information.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": -1,
+                "file": "syntaxTests/immutable/no_assignments.sol",
+                "start": -1
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
+            "errorCode": "3420",
+            "formattedMessage": "Warning: Source file does not specify required compiler version! Consider adding \"pragma solidity ^0.8.0;\"\n--> syntaxTests/immutable/no_assignments.sol\n\n",
+            "message": "Source file does not specify required compiler version! Consider adding \"pragma solidity ^0.8.0;\"",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": -1,
+                "file": "syntaxTests/immutable/no_assignments.sol",
+                "start": -1
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
+            "errorCode": "1284",
+            "formattedMessage": "CodeGenerationError: Some immutables were read from but never assigned, possibly because of optimization.\n\n",
+            "message": "Some immutables were read from but never assigned, possibly because of optimization.",
+            "severity": "error",
+            "type": "CodeGenerationError"
+        }
+    ],
+    "sources": {
+        "syntaxTests/immutable/no_assignments.sol": {
+            "id": 0
+        }
+    }
+}

--- a/test/scripts/fixtures/library_inherited2_sol_cli_output.txt
+++ b/test/scripts/fixtures/library_inherited2_sol_cli_output.txt
@@ -1,0 +1,24 @@
+Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+--> syntaxTests/scoping/library_inherited2.sol
+
+Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.0;"
+--> syntaxTests/scoping/library_inherited2.sol
+
+
+======= syntaxTests/scoping/library_inherited2.sol:A =======
+Binary:
+6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066735822122086e727f29d40b264a19bbfcad38d64493dca4bab5dbba8c82ffdaae389d2bba064736f6c63430008000033
+Metadata:
+{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"A"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}
+
+======= syntaxTests/scoping/library_inherited2.sol:B =======
+Binary:
+608060405234801561001057600080fd5b506101cc806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630423a13214610030575b600080fd5b61004a6004803603810190610045919061009d565b610060565b60405161005791906100d5565b60405180910390f35b600061006b82610072565b9050919050565b6000602a8261008191906100f0565b9050919050565b6000813590506100978161017f565b92915050565b6000602082840312156100af57600080fd5b60006100bd84828501610088565b91505092915050565b6100cf81610146565b82525050565b60006020820190506100ea60008301846100c6565b92915050565b60006100fb82610146565b915061010683610146565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0382111561013b5761013a610150565b5b828201905092915050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b61018881610146565b811461019357600080fd5b5056fea2646970667358221220104c345633313efe410492448844d96d78452c3044ce126b5e041b7fbeaa790064736f6c63430008000033
+Metadata:
+{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"uint256","name":"value","type":"uint256"}],"name":"bar","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"B"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}
+
+======= syntaxTests/scoping/library_inherited2.sol:Lib =======
+Binary:
+60566050600b82828239805160001a6073146043577f4e487b7100000000000000000000000000000000000000000000000000000000600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212207f9515e2263fa71a7984707e2aefd82241fac15c497386ca798b526f14f8ba6664736f6c63430008000033
+Metadata:
+{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"Lib"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}

--- a/test/scripts/fixtures/stack_too_deep_cli_output.txt
+++ b/test/scripts/fixtures/stack_too_deep_cli_output.txt
@@ -1,0 +1,2 @@
+Compiler error: Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.
+

--- a/test/scripts/fixtures/stack_too_deep_json_output.json
+++ b/test/scripts/fixtures/stack_too_deep_json_output.json
@@ -1,0 +1,23 @@
+{
+    "contracts": {
+        "syntaxTests/tupleAssignments/large_component_count.sol": {
+            "C": {
+                "metadata": "{\"compiler\":{\"version\":\"0.8.0+commit.c7dfd78e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"f\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"g\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"syntaxTests/tupleAssignments/large_component_count.sol\":\"C\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"syntaxTests/tupleAssignments/large_component_count.sol\":{\"keccak256\":\"0xb5478857c30ab2e7cf6b0fdcad0fdc70f4715129a7dd3f3f1dda5b3892a83846\",\"urls\":[\"bzz-raw://abc14e4a2a61618b712c4ac3ba0cab07d9214d0637af78aa7648e3d2f89eb725\",\"dweb:/ipfs/QmTqrQzwWbZgdAck6ma9xY3sL1mGiw61Nsg36P21mZdxLG\"]}},\"version\":1}"
+            }
+        }
+    },
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "CompilerError: Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.\n\n",
+            "message": "Compiler error (/solidity/libyul/backends/evm/AsmCodeGen.cpp:248):Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.",
+            "severity": "error",
+            "type": "CompilerError"
+        }
+    ],
+    "sources": {
+        "syntaxTests/tupleAssignments/large_component_count.sol": {
+            "id": 0
+        }
+    }
+}

--- a/test/scripts/fixtures/unimplemented_feature_cli_output.txt
+++ b/test/scripts/fixtures/unimplemented_feature_cli_output.txt
@@ -1,0 +1,5 @@
+Unimplemented feature:
+/solidity/libsolidity/codegen/CompilerUtils.cpp(771): Throw in function void solidity::frontend::CompilerUtils::convertType(const solidity::frontend::Type&, const solidity::frontend::Type&, bool, bool, bool)
+Dynamic exception type: boost::wrapexcept<solidity::langutil::UnimplementedFeatureError>
+std::exception::what: Not yet implemented - FixedPointType.
+[solidity::util::tag_comment*] = Not yet implemented - FixedPointType.

--- a/test/scripts/fixtures/unimplemented_feature_json_output.json
+++ b/test/scripts/fixtures/unimplemented_feature_json_output.json
@@ -1,0 +1,23 @@
+{
+    "contracts": {
+        "syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol": {
+            "test": {
+                "metadata": "{\"compiler\":{\"version\":\"0.8.0+commit.c7dfd78e\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"f\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol\":\"test\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol\":{\"keccak256\":\"0x44b85b2db00441b574d40d11a6be684517d4312de0f6ef0550e02aea33e2a05f\",\"urls\":[\"bzz-raw://c7a9416a8634c5bd1451742f09d633acab37a6e0db1441d0bb7ea4e8f4af214b\",\"dweb:/ipfs/QmZNMQcZu9wnD6sFH2c7PymZReYeroBXDyKkJ5YEhWtCjc\"]}},\"version\":1}"
+            }
+        }
+    },
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "UnimplementedFeatureError: Not yet implemented - FixedPointType.\n\n",
+            "message": "Unimplemented feature (/solidity/libsolidity/codegen/CompilerUtils.cpp:771):Not yet implemented - FixedPointType.",
+            "severity": "error",
+            "type": "UnimplementedFeatureError"
+        }
+    ],
+    "sources": {
+        "syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol": {
+            "id": 0
+        }
+    }
+}

--- a/test/scripts/fixtures/unknown_pragma_sol_cli_output.txt
+++ b/test/scripts/fixtures/unknown_pragma_sol_cli_output.txt
@@ -1,0 +1,11 @@
+Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
+--> syntaxTests/pragma/unknown_pragma.sol
+
+Error: Unknown pragma "thisdoesntexist"
+--> syntaxTests/pragma/unknown_pragma.sol:1:1:
+|
+1 | pragma thisdoesntexist;
+| ^^^^^^^^^^^^^^^^^^^^^^^
+
+Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.0;"
+--> syntaxTests/pragma/unknown_pragma.sol

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -3,13 +3,14 @@
 import json
 import unittest
 from pathlib import Path
+from textwrap import dedent
 
 from unittest_helpers import FIXTURE_DIR, LIBSOLIDITY_TEST_DIR, load_fixture, load_libsolidity_test_case
 
 # NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
-from bytecodecompare.prepare_report import FileReport, ContractReport
-from bytecodecompare.prepare_report import load_source, parse_standard_json_output, prepare_compiler_input
+from bytecodecompare.prepare_report import CompilerInterface, FileReport, ContractReport
+from bytecodecompare.prepare_report import load_source, parse_cli_output, parse_standard_json_output, prepare_compiler_input
 # pragma pylint: enable=import-error
 
 
@@ -20,16 +21,24 @@ SMT_CONTRACT_WITH_LF_NEWLINES_SOL_PATH = FIXTURE_DIR / 'smt_contract_with_lf_new
 SMT_CONTRACT_WITH_CRLF_NEWLINES_SOL_PATH = FIXTURE_DIR / 'smt_contract_with_crlf_newlines.sol'
 SMT_CONTRACT_WITH_CR_NEWLINES_SOL_PATH = FIXTURE_DIR / 'smt_contract_with_cr_newlines.sol'
 SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH = FIXTURE_DIR / 'smt_contract_with_mixed_newlines.sol'
+SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_CODE = load_fixture(SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH)
 
 SYNTAX_SMOKE_TEST_SOL_PATH = LIBSOLIDITY_TEST_DIR / 'syntaxTests/smoke_test.sol'
 SYNTAX_SMOKE_TEST_SOL_CODE = load_libsolidity_test_case(SYNTAX_SMOKE_TEST_SOL_PATH)
 
 LIBRARY_INHERITED2_SOL_JSON_OUTPUT = load_fixture('library_inherited2_sol_json_output.json')
+LIBRARY_INHERITED2_SOL_CLI_OUTPUT = load_fixture('library_inherited2_sol_cli_output.txt')
 
 UNKNOWN_PRAGMA_SOL_JSON_OUTPUT = load_fixture('unknown_pragma_sol_json_output.json')
+UNKNOWN_PRAGMA_SOL_CLI_OUTPUT = load_fixture('unknown_pragma_sol_cli_output.txt')
 
 
-class TestPrepareReport_FileReport(unittest.TestCase):
+class PrepareReportTestBase(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = 10000
+
+
+class TestFileReport(PrepareReportTestBase):
     def test_format_report(self):
         report = FileReport(
             file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
@@ -79,10 +88,7 @@ class TestPrepareReport_FileReport(unittest.TestCase):
         self.assertEqual(report.format_report(), '')
 
 
-class TestPrepareReport(unittest.TestCase):
-    def setUp(self):
-        self.maxDiff = 10000
-
+class TestLoadSource(PrepareReportTestBase):
     def test_load_source(self):
         self.assertEqual(load_source(SMT_SMOKE_TEST_SOL_PATH), SMT_SMOKE_TEST_SOL_CODE)
 
@@ -126,7 +132,9 @@ class TestPrepareReport(unittest.TestCase):
 
         self.assertEqual(load_source(SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH), expected_output)
 
-    def test_prepare_compiler_input(self):
+
+class TestPrepareCompilerInput(PrepareReportTestBase):
+    def test_prepare_compiler_input_should_work_with_standard_json_interface(self):
         expected_compiler_input = {
             'language': 'Solidity',
             'sources': {
@@ -143,12 +151,27 @@ class TestPrepareReport(unittest.TestCase):
             Path('solc'),
             SMT_SMOKE_TEST_SOL_PATH,
             optimize=True,
+            interface=CompilerInterface.STANDARD_JSON,
         )
 
         self.assertEqual(command_line, ['solc', '--standard-json'])
         self.assertEqual(json.loads(compiler_input), expected_compiler_input)
 
-    def test_prepare_compiler_input_preserves_newlines(self):
+    def test_prepare_compiler_input_should_work_with_cli_interface(self):
+        (command_line, compiler_input) = prepare_compiler_input(
+            Path('solc'),
+            SMT_SMOKE_TEST_SOL_PATH,
+            optimize=True,
+            interface=CompilerInterface.CLI,
+        )
+
+        self.assertEqual(
+            command_line,
+            ['solc', str(SMT_SMOKE_TEST_SOL_PATH), '--bin', '--metadata', '--model-checker-engine', 'none', '--optimize']
+        )
+        self.assertEqual(compiler_input, SMT_SMOKE_TEST_SOL_CODE)
+
+    def test_prepare_compiler_input_for_json_preserves_newlines(self):
         expected_compiler_input = {
             'language': 'Solidity',
             'sources': {
@@ -171,11 +194,24 @@ class TestPrepareReport(unittest.TestCase):
             Path('solc'),
             SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH,
             optimize=True,
+            interface=CompilerInterface.STANDARD_JSON,
         )
 
         self.assertEqual(command_line, ['solc', '--standard-json'])
         self.assertEqual(json.loads(compiler_input), expected_compiler_input)
 
+    def test_prepare_compiler_input_for_cli_preserves_newlines(self):
+        (_command_line, compiler_input) = prepare_compiler_input(
+            Path('solc'),
+            SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH,
+            optimize=True,
+            interface=CompilerInterface.CLI,
+        )
+
+        self.assertEqual(compiler_input, SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_CODE)
+
+
+class TestParseStandardJSONOutput(PrepareReportTestBase):
     def test_parse_standard_json_output(self):
         expected_report = FileReport(
             file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
@@ -257,3 +293,88 @@ class TestPrepareReport(unittest.TestCase):
         )
 
         self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
+
+
+class TestParseCLIOutput(PrepareReportTestBase):
+    def test_parse_cli_output(self):
+        expected_report = FileReport(
+            file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+            contract_reports=[
+                # pragma pylint: disable=line-too-long
+                ContractReport(
+                    contract_name='A',
+                    file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+                    bytecode='6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066735822122086e727f29d40b264a19bbfcad38d64493dca4bab5dbba8c82ffdaae389d2bba064736f6c63430008000033',
+                    metadata='{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"A"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}',
+                ),
+                ContractReport(
+                    contract_name='B',
+                    file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+                    bytecode='608060405234801561001057600080fd5b506101cc806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630423a13214610030575b600080fd5b61004a6004803603810190610045919061009d565b610060565b60405161005791906100d5565b60405180910390f35b600061006b82610072565b9050919050565b6000602a8261008191906100f0565b9050919050565b6000813590506100978161017f565b92915050565b6000602082840312156100af57600080fd5b60006100bd84828501610088565b91505092915050565b6100cf81610146565b82525050565b60006020820190506100ea60008301846100c6565b92915050565b60006100fb82610146565b915061010683610146565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0382111561013b5761013a610150565b5b828201905092915050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b61018881610146565b811461019357600080fd5b5056fea2646970667358221220104c345633313efe410492448844d96d78452c3044ce126b5e041b7fbeaa790064736f6c63430008000033',
+                    metadata='{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"uint256","name":"value","type":"uint256"}],"name":"bar","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"B"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}',
+                ),
+                ContractReport(
+                    contract_name='Lib',
+                    file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+                    bytecode='60566050600b82828239805160001a6073146043577f4e487b7100000000000000000000000000000000000000000000000000000000600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212207f9515e2263fa71a7984707e2aefd82241fac15c497386ca798b526f14f8ba6664736f6c63430008000033',
+                    metadata='{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"Lib"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}',
+                ),
+                # pragma pylint: enable=line-too-long
+            ]
+        )
+
+        report = parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), LIBRARY_INHERITED2_SOL_CLI_OUTPUT)
+        self.assertEqual(report, expected_report)
+
+    def test_parse_cli_output_should_report_error_on_compiler_errors(self):
+        expected_report = FileReport(file_name=Path('syntaxTests/pragma/unknown_pragma.sol'), contract_reports=None)
+
+        report = parse_cli_output(Path('syntaxTests/pragma/unknown_pragma.sol'), UNKNOWN_PRAGMA_SOL_CLI_OUTPUT)
+        self.assertEqual(report, expected_report)
+
+    def test_parse_cli_output_should_report_error_on_empty_output(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_cli_output(Path('file.sol'), ''), expected_report)
+
+    def test_parse_cli_output_should_report_missing_bytecode_and_metadata(self):
+        compiler_output = dedent("""\
+            ======= syntaxTests/scoping/library_inherited2.sol:A =======
+            ======= syntaxTests/scoping/library_inherited2.sol:B =======
+            608060405234801561001057600080fd5b506101cc806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630423a13214610030575b600080fd5b61004a6004803603810190610045919061009d565b610060565b60405161005791906100d5565b60405180910390f35b600061006b82610072565b9050919050565b6000602a8261008191906100f0565b9050919050565b6000813590506100978161017f565b92915050565b6000602082840312156100af57600080fd5b60006100bd84828501610088565b91505092915050565b6100cf81610146565b82525050565b60006020820190506100ea60008301846100c6565b92915050565b60006100fb82610146565b915061010683610146565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0382111561013b5761013a610150565b5b828201905092915050565b6000819050919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b61018881610146565b811461019357600080fd5b5056fea2646970667358221220104c345633313efe410492448844d96d78452c3044ce126b5e041b7fbeaa790064736f6c63430008000033
+            Metadata:
+            {"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"uint256","name":"value","type":"uint256"}],"name":"bar","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"B"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}
+
+            ======= syntaxTests/scoping/library_inherited2.sol:Lib =======
+            Binary:
+            60566050600b82828239805160001a6073146043577f4e487b7100000000000000000000000000000000000000000000000000000000600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212207f9515e2263fa71a7984707e2aefd82241fac15c497386ca798b526f14f8ba6664736f6c63430008000033
+            Metadata:
+        """)
+
+        expected_report = FileReport(
+            file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+            contract_reports=[
+                ContractReport(
+                    contract_name='A',
+                    file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+                    bytecode=None,
+                    metadata=None,
+                ),
+                # pragma pylint: disable=line-too-long
+                ContractReport(
+                    contract_name='B',
+                    file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+                    bytecode=None,
+                    metadata='{"compiler":{"version":"0.8.0+commit.c7dfd78e"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"uint256","name":"value","type":"uint256"}],"name":"bar","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"pure","type":"function"}],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"syntaxTests/scoping/library_inherited2.sol":"B"},"evmVersion":"istanbul","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"syntaxTests/scoping/library_inherited2.sol":{"keccak256":"0xd0619f00638fdfea187368965615dbd599fead93dd14b6558725e85ec7011d96","urls":["bzz-raw://ec7af066be66a223f0d25ba3bf9ba6dc103e1a57531a66a38a5ca2b6ce172f55","dweb:/ipfs/QmW1NrqQNhnY1Tkgr3Z9oM8buCGLUJCJVCDTVejJTT5Vet"]}},"version":1}',
+                ),
+                ContractReport(
+                    contract_name='Lib',
+                    file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
+                    bytecode='60566050600b82828239805160001a6073146043577f4e487b7100000000000000000000000000000000000000000000000000000000600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600080fdfea26469706673582212207f9515e2263fa71a7984707e2aefd82241fac15c497386ca798b526f14f8ba6664736f6c63430008000033',
+                    metadata=None,
+                ),
+                # pragma pylint: enable=line-too-long
+            ]
+        )
+
+        self.assertEqual(parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), compiler_output), expected_report)

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -32,6 +32,15 @@ LIBRARY_INHERITED2_SOL_CLI_OUTPUT = load_fixture('library_inherited2_sol_cli_out
 UNKNOWN_PRAGMA_SOL_JSON_OUTPUT = load_fixture('unknown_pragma_sol_json_output.json')
 UNKNOWN_PRAGMA_SOL_CLI_OUTPUT = load_fixture('unknown_pragma_sol_cli_output.txt')
 
+UNIMPLEMENTED_FEATURE_JSON_OUTPUT = load_fixture('unimplemented_feature_json_output.json')
+UNIMPLEMENTED_FEATURE_CLI_OUTPUT = load_fixture('unimplemented_feature_cli_output.txt')
+
+STACK_TOO_DEEP_JSON_OUTPUT = load_fixture('stack_too_deep_json_output.json')
+STACK_TOO_DEEP_CLI_OUTPUT = load_fixture('stack_too_deep_cli_output.txt')
+
+CODE_GENERATION_ERROR_JSON_OUTPUT = load_fixture('code_generation_error_json_output.json')
+CODE_GENERATION_ERROR_CLI_OUTPUT = load_fixture('code_generation_error_cli_output.txt')
+
 
 class PrepareReportTestBase(unittest.TestCase):
     def setUp(self):
@@ -294,6 +303,21 @@ class TestParseStandardJSONOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
 
+    def test_parse_standard_json_output_should_report_error_on_unimplemented_feature_error(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_standard_json_output(Path('file.sol'), UNIMPLEMENTED_FEATURE_JSON_OUTPUT), expected_report)
+
+    def test_parse_standard_json_output_should_report_error_on_stack_too_deep_error(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_standard_json_output(Path('file.sol'), STACK_TOO_DEEP_JSON_OUTPUT), expected_report)
+
+    def test_parse_standard_json_output_should_report_error_on_code_generation_error(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_standard_json_output(Path('file.sol'), CODE_GENERATION_ERROR_JSON_OUTPUT), expected_report)
+
 
 class TestParseCLIOutput(PrepareReportTestBase):
     def test_parse_cli_output(self):
@@ -378,3 +402,18 @@ class TestParseCLIOutput(PrepareReportTestBase):
         )
 
         self.assertEqual(parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), compiler_output), expected_report)
+
+    def test_parse_cli_output_should_report_error_on_unimplemented_feature_error(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_cli_output(Path('file.sol'), UNIMPLEMENTED_FEATURE_CLI_OUTPUT), expected_report)
+
+    def test_parse_cli_output_should_report_error_on_stack_too_deep_error(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_cli_output(Path('file.sol'), STACK_TOO_DEEP_CLI_OUTPUT), expected_report)
+
+    def test_parse_cli_output_should_report_error_on_code_generation_error(self):
+        expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
+
+        self.assertEqual(parse_cli_output(Path('file.sol'), CODE_GENERATION_ERROR_CLI_OUTPUT), expected_report)


### PR DESCRIPTION
Fixes #4698.

~**Depends on #10819. Don't merge until that PR is merged!**.~ It's on `develop` now.

This PR adds `--interface` option to `prepare_report.py` to allow selecting between doing the compilation via Standard JSON or via the ordinary CLI interface.

It also modifies the existing CI jobs to create both versions of the report to make sure they're identical.