### PR TITLE
Backwards compatibility for bytecode comparison

### DIFF
--- a/scripts/bytecodecompare/prepare_report.js
+++ b/scripts/bytecodecompare/prepare_report.js
@@ -16,6 +16,13 @@ function loadSource(sourceFileName, stripSMTPragmas)
     return source
 }
 
+function cleanString(string)
+{
+    if (string !== undefined)
+        string = string.trim()
+    return (string !== '' ? string : undefined)
+}
+
 
 let stripSMTPragmas = false
 let firstFileArgumentIndex = 2
@@ -78,10 +85,15 @@ for (const optimize of [false, true])
                         let bytecode = '<NO BYTECODE>'
                         let metadata = '<NO METADATA>'
 
-                        if ('evm' in contractResults && 'bytecode' in contractResults['evm'] && 'object' in contractResults['evm']['bytecode'])
-                            bytecode = contractResults.evm.bytecode.object
+                        if (
+                            'evm' in contractResults &&
+                            'bytecode' in contractResults['evm'] &&
+                            'object' in contractResults['evm']['bytecode'] &&
+                            cleanString(contractResults.evm.bytecode.object) !== undefined
+                        )
+                            bytecode = cleanString(contractResults.evm.bytecode.object)
 
-                        if ('metadata' in contractResults)
+                        if ('metadata' in contractResults && cleanString(contractResults.metadata) !== undefined)
                             metadata = contractResults.metadata
 
                         console.log(filename + ':' + contractName + ' ' + bytecode)

--- a/scripts/bytecodecompare/prepare_report.js
+++ b/scripts/bytecodecompare/prepare_report.js
@@ -4,23 +4,46 @@ const fs = require('fs')
 
 const compiler = require('./solc-js/wrapper.js')(require('./solc-js/soljson.js'))
 
+
+function loadSource(sourceFileName, stripSMTPragmas)
+{
+    source = fs.readFileSync(sourceFileName).toString()
+
+    if (stripSMTPragmas)
+        // NOTE: replace() with string parameter replaces only the first occurrence.
+        return source.replace('pragma experimental SMTChecker;', '');
+
+    return source
+}
+
+
+let stripSMTPragmas = false
+let firstFileArgumentIndex = 2
+
+if (process.argv.length >= 3 && process.argv[2] === '--strip-smt-pragmas')
+{
+    stripSMTPragmas = true
+    firstFileArgumentIndex = 3
+}
+
 for (const optimize of [false, true])
 {
-    for (const filename of process.argv.slice(2))
+    for (const filename of process.argv.slice(firstFileArgumentIndex))
     {
         if (filename !== undefined)
         {
-            const input = {
+            let input = {
                 language: 'Solidity',
                 sources: {
-                    [filename]: {content: fs.readFileSync(filename).toString()}
+                    [filename]: {content: loadSource(filename, stripSMTPragmas)}
                 },
                 settings: {
                     optimizer: {enabled: optimize},
-                    outputSelection: {'*': {'*': ['evm.bytecode.object', 'metadata']}},
-                    "modelChecker": {"engine": "none"}
+                    outputSelection: {'*': {'*': ['evm.bytecode.object', 'metadata']}}
                 }
             }
+            if (!stripSMTPragmas)
+                input['settings']['modelChecker'] = {engine: 'none'}
 
             const result = JSON.parse(compiler.compile(JSON.stringify(input)))
 

--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -13,9 +13,9 @@ from tempfile import TemporaryDirectory
 from typing import List, Optional, Tuple, Union
 
 
-CONTRACT_SEPARATOR_PATTERN = re.compile(r'^======= (?P<file_name>.+):(?P<contract_name>[^:]+) =======$', re.MULTILINE)
-BYTECODE_REGEX = re.compile(r'^Binary:\n(?P<bytecode>.*)$', re.MULTILINE)
-METADATA_REGEX = re.compile(r'^Metadata:\n(?P<metadata>\{.*\})$', re.MULTILINE)
+CONTRACT_SEPARATOR_PATTERN = re.compile(r'^ *======= +(?:(?P<file_name>.+) *:)? *(?P<contract_name>[^:]+) +======= *$', re.MULTILINE)
+BYTECODE_REGEX = re.compile(r'^ *Binary: *\n(?P<bytecode>.*[0-9a-f$_]+.*)$', re.MULTILINE)
+METADATA_REGEX = re.compile(r'^ *Metadata: *\n *(?P<metadata>\{.*\}) *$', re.MULTILINE)
 
 
 class CompilerInterface(Enum):
@@ -32,7 +32,7 @@ class SMTUse(Enum):
 @dataclass(frozen=True)
 class ContractReport:
     contract_name: str
-    file_name: Path
+    file_name: Optional[Path]
     bytecode: Optional[str]
     metadata: Optional[str]
 
@@ -72,6 +72,11 @@ def load_source(path: Union[Path, str], smt_use: SMTUse) -> str:
     return file_content
 
 
+def clean_string(value: Optional[str]) -> Optional[str]:
+    value = value.strip() if value is not None else None
+    return value if value != '' else None
+
+
 def parse_standard_json_output(source_file_name: Path, standard_json_output: str) -> FileReport:
     decoded_json_output = json.loads(standard_json_output.strip())
 
@@ -98,8 +103,8 @@ def parse_standard_json_output(source_file_name: Path, standard_json_output: str
             file_report.contract_reports.append(ContractReport(
                 contract_name=contract_name,
                 file_name=Path(file_name),
-                bytecode=contract_results.get('evm', {}).get('bytecode', {}).get('object'),
-                metadata=contract_results.get('metadata'),
+                bytecode=clean_string(contract_results.get('evm', {}).get('bytecode', {}).get('object')),
+                metadata=clean_string(contract_results.get('metadata')),
             ))
 
     return file_report
@@ -122,10 +127,10 @@ def parse_cli_output(source_file_name: Path, cli_output: str) -> FileReport:
 
         assert file_report.contract_reports is not None
         file_report.contract_reports.append(ContractReport(
-            contract_name=contract_name,
-            file_name=Path(file_name),
-            bytecode=bytecode_match['bytecode'] if bytecode_match is not None else None,
-            metadata=metadata_match['metadata'] if metadata_match is not None else None,
+            contract_name=contract_name.strip(),
+            file_name=Path(file_name.strip()) if file_name is not None else None,
+            bytecode=clean_string(bytecode_match['bytecode'] if bytecode_match is not None else None),
+            metadata=clean_string(metadata_match['metadata'] if metadata_match is not None else None),
         ))
 
     return file_report

--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -23,6 +23,12 @@ class CompilerInterface(Enum):
     STANDARD_JSON = 'standard-json'
 
 
+class SMTUse(Enum):
+    PRESERVE = 'preserve'
+    DISABLE = 'disable'
+    STRIP_PRAGMAS = 'strip-pragmas'
+
+
 @dataclass(frozen=True)
 class ContractReport:
     contract_name: str
@@ -54,11 +60,14 @@ class FileReport:
         return report
 
 
-def load_source(path: Union[Path, str]) -> str:
+def load_source(path: Union[Path, str], smt_use: SMTUse) -> str:
     # NOTE: newline='' disables newline conversion.
     # We want the file exactly as is because changing even a single byte in the source affects metadata.
     with open(path, mode='r', encoding='utf8', newline='') as source_file:
         file_content = source_file.read()
+
+    if smt_use == SMTUse.STRIP_PRAGMAS:
+        return file_content.replace('pragma experimental SMTChecker;', '', 1)
 
     return file_content
 
@@ -126,33 +135,37 @@ def prepare_compiler_input(
     compiler_path: Path,
     source_file_name: Path,
     optimize: bool,
-    interface: CompilerInterface
+    interface: CompilerInterface,
+    smt_use: SMTUse,
 ) -> Tuple[List[str], str]:
-
     if interface == CompilerInterface.STANDARD_JSON:
         json_input: dict = {
             'language': 'Solidity',
             'sources': {
-                str(source_file_name): {'content': load_source(source_file_name)}
+                str(source_file_name): {'content': load_source(source_file_name, smt_use)}
             },
             'settings': {
                 'optimizer': {'enabled': optimize},
                 'outputSelection': {'*': {'*': ['evm.bytecode.object', 'metadata']}},
-                'modelChecker': {'engine': 'none'},
             }
         }
+
+        if smt_use == SMTUse.DISABLE:
+            json_input['settings']['modelChecker'] = {'engine': 'none'}
 
         command_line = [str(compiler_path), '--standard-json']
         compiler_input = json.dumps(json_input)
     else:
         assert interface == CompilerInterface.CLI
 
-        compiler_options = [str(source_file_name), '--bin', '--metadata', '--model-checker-engine', 'none']
+        compiler_options = [str(source_file_name), '--bin', '--metadata']
         if optimize:
             compiler_options.append('--optimize')
+        if smt_use == SMTUse.DISABLE:
+            compiler_options += ['--model-checker-engine', 'none']
 
         command_line = [str(compiler_path)] + compiler_options
-        compiler_input = load_source(source_file_name)
+        compiler_input = load_source(source_file_name, smt_use)
 
     return (command_line, compiler_input)
 
@@ -162,6 +175,7 @@ def run_compiler(
     source_file_name: Path,
     optimize: bool,
     interface: CompilerInterface,
+    smt_use: SMTUse,
     tmp_dir: Path,
 ) -> FileReport:
 
@@ -170,7 +184,8 @@ def run_compiler(
             compiler_path,
             Path(source_file_name.name),
             optimize,
-            interface
+            interface,
+            smt_use,
         )
 
         process = subprocess.run(
@@ -190,7 +205,8 @@ def run_compiler(
             compiler_path.absolute(),
             Path(source_file_name.name),
             optimize,
-            interface
+            interface,
+            smt_use,
         )
 
         # Create a copy that we can use directly with the CLI interface
@@ -211,13 +227,20 @@ def run_compiler(
         return parse_cli_output(Path(source_file_name), process.stdout)
 
 
-def generate_report(source_file_names: List[str], compiler_path: Path, interface: CompilerInterface):
+def generate_report(source_file_names: List[str], compiler_path: Path, interface: CompilerInterface, smt_use: SMTUse):
     with open('report.txt', mode='w', encoding='utf8', newline='\n') as report_file:
         for optimize in [False, True]:
             with TemporaryDirectory(prefix='prepare_report-') as tmp_dir:
                 for source_file_name in sorted(source_file_names):
                     try:
-                        report = run_compiler(compiler_path, Path(source_file_name), optimize, interface, Path(tmp_dir))
+                        report = run_compiler(
+                            compiler_path,
+                            Path(source_file_name),
+                            optimize,
+                            interface,
+                            smt_use,
+                            Path(tmp_dir),
+                        )
                         report_file.write(report.format_report())
                     except subprocess.CalledProcessError as exception:
                         print(
@@ -250,7 +273,14 @@ def commandline_parser() -> ArgumentParser:
         dest='interface',
         default=CompilerInterface.STANDARD_JSON.value,
         choices=[c.value for c in CompilerInterface],
-        help="Compiler interface to use."
+        help="Compiler interface to use.",
+    )
+    parser.add_argument(
+        '--smt-use',
+        dest='smt_use',
+        default=SMTUse.DISABLE.value,
+        choices=[s.value for s in SMTUse],
+        help="What to do about contracts that use the experimental SMT checker."
     )
     return parser;
 
@@ -261,4 +291,5 @@ if __name__ == "__main__":
         glob("*.sol"),
         Path(options.compiler_path),
         CompilerInterface(options.interface),
+        SMTUse(options.smt_use),
     )

--- a/test/scripts/fixtures/solc_0.4.0_cli_output.txt
+++ b/test/scripts/fixtures/solc_0.4.0_cli_output.txt
@@ -1,0 +1,8 @@
+contract.sol:1:1: Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.4.0;".
+contract C {}
+^
+Spanning multiple lines.
+
+======= C =======
+Binary:
+6060604052600c8060106000396000f360606040526008565b600256

--- a/test/scripts/fixtures/solc_0.4.8_cli_output.txt
+++ b/test/scripts/fixtures/solc_0.4.8_cli_output.txt
@@ -1,0 +1,10 @@
+contract.sol:1:1: Warning: Source file does not specify required compiler version!Consider adding "pragma solidity ^0.4.8
+contract C {}
+^
+Spanning multiple lines.
+
+======= C =======
+Binary:
+6060604052346000575b60358060166000396000f30060606040525b60005600a165627a7a72305820ccf9337430b4c4f7d6ad41efb10a94411a2af6a9f173ef52daeadd31f4bf11890029
+Metadata:
+{"compiler":{"version":"0.4.8+commit.60cc1668.mod.Darwin.appleclang"},"language":"Solidity","output":{"abi":[],"devdoc":{"methods":{}},"userdoc":{"methods":{}}},"settings":{"compilationTarget":{"contract.sol":"C"},"libraries":{},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"contract.sol":{"keccak256":"0xbe86d3681a198587296ad6d4a834606197e1a8f8944922c501631b04e21eeba2","urls":["bzzr://af16957d3d86013309d64d3cc572d007b1d8b08a821f2ff366840deb54a78524"]}},"version":1}

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -173,6 +173,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             Path('solc'),
             SMT_SMOKE_TEST_SOL_PATH,
             optimize=True,
+            force_no_optimize_yul=False,
             interface=CompilerInterface.STANDARD_JSON,
             smt_use=SMTUse.DISABLE,
         )
@@ -185,6 +186,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             Path('solc'),
             SMT_SMOKE_TEST_SOL_PATH,
             optimize=True,
+            force_no_optimize_yul=False,
             interface=CompilerInterface.CLI,
             smt_use=SMTUse.DISABLE,
         )
@@ -218,6 +220,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             Path('solc'),
             SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH,
             optimize=True,
+            force_no_optimize_yul=False,
             interface=CompilerInterface.STANDARD_JSON,
             smt_use=SMTUse.DISABLE,
         )
@@ -230,11 +233,28 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             Path('solc'),
             SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH,
             optimize=True,
+            force_no_optimize_yul=True,
             interface=CompilerInterface.CLI,
             smt_use=SMTUse.DISABLE,
         )
 
         self.assertEqual(compiler_input, SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_CODE)
+
+    def test_prepare_compiler_input_for_cli_should_handle_force_no_optimize_yul_flag(self):
+        (command_line, compiler_input) = prepare_compiler_input(
+            Path('solc'),
+            SMT_SMOKE_TEST_SOL_PATH,
+            optimize=False,
+            force_no_optimize_yul=True,
+            interface=CompilerInterface.CLI,
+            smt_use=SMTUse.DISABLE,
+        )
+
+        self.assertEqual(
+            command_line,
+            ['solc', str(SMT_SMOKE_TEST_SOL_PATH), '--bin', '--metadata', '--no-optimize-yul', '--model-checker-engine', 'none'],
+        )
+        self.assertEqual(compiler_input, SMT_SMOKE_TEST_SOL_CODE)
 
 
 class TestParseStandardJSONOutput(PrepareReportTestBase):
@@ -506,7 +526,9 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         expected_report = FileReport(
             file_name=Path('contract.sol'),
-            contract_reports=[ContractReport(contract_name='C', file_name=Path('contract.sol'), bytecode='60806040523480156', metadata='{  }')]
+            contract_reports=[
+                ContractReport(contract_name='C', file_name=Path('contract.sol'), bytecode='60806040523480156', metadata='{  }')
+            ]
         )
 
         self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -176,6 +176,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             force_no_optimize_yul=False,
             interface=CompilerInterface.STANDARD_JSON,
             smt_use=SMTUse.DISABLE,
+            metadata_option_supported=True,
         )
 
         self.assertEqual(command_line, ['solc', '--standard-json'])
@@ -189,6 +190,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             force_no_optimize_yul=False,
             interface=CompilerInterface.CLI,
             smt_use=SMTUse.DISABLE,
+            metadata_option_supported=True,
         )
 
         self.assertEqual(
@@ -223,6 +225,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             force_no_optimize_yul=False,
             interface=CompilerInterface.STANDARD_JSON,
             smt_use=SMTUse.DISABLE,
+            metadata_option_supported=True,
         )
 
         self.assertEqual(command_line, ['solc', '--standard-json'])
@@ -236,6 +239,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             force_no_optimize_yul=True,
             interface=CompilerInterface.CLI,
             smt_use=SMTUse.DISABLE,
+            metadata_option_supported=True,
         )
 
         self.assertEqual(compiler_input, SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_CODE)
@@ -248,11 +252,29 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
             force_no_optimize_yul=True,
             interface=CompilerInterface.CLI,
             smt_use=SMTUse.DISABLE,
+            metadata_option_supported=True,
         )
 
         self.assertEqual(
             command_line,
             ['solc', str(SMT_SMOKE_TEST_SOL_PATH), '--bin', '--metadata', '--no-optimize-yul', '--model-checker-engine', 'none'],
+        )
+        self.assertEqual(compiler_input, SMT_SMOKE_TEST_SOL_CODE)
+
+    def test_prepare_compiler_input_for_cli_should_not_use_metadata_option_if_not_supported(self):
+        (command_line, compiler_input) = prepare_compiler_input(
+            Path('solc'),
+            SMT_SMOKE_TEST_SOL_PATH,
+            optimize=True,
+            force_no_optimize_yul=False,
+            interface=CompilerInterface.CLI,
+            smt_use=SMTUse.PRESERVE,
+            metadata_option_supported=False,
+        )
+
+        self.assertEqual(
+            command_line,
+            ['solc', str(SMT_SMOKE_TEST_SOL_PATH), '--bin', '--optimize'],
         )
         self.assertEqual(compiler_input, SMT_SMOKE_TEST_SOL_CODE)
 

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -41,6 +41,9 @@ STACK_TOO_DEEP_CLI_OUTPUT = load_fixture('stack_too_deep_cli_output.txt')
 CODE_GENERATION_ERROR_JSON_OUTPUT = load_fixture('code_generation_error_json_output.json')
 CODE_GENERATION_ERROR_CLI_OUTPUT = load_fixture('code_generation_error_cli_output.txt')
 
+SOLC_0_4_0_CLI_OUTPUT = load_fixture('solc_0.4.0_cli_output.txt')
+SOLC_0_4_8_CLI_OUTPUT = load_fixture('solc_0.4.8_cli_output.txt')
+
 
 class PrepareReportTestBase(unittest.TestCase):
     def setUp(self):
@@ -334,6 +337,34 @@ class TestParseStandardJSONOutput(PrepareReportTestBase):
 
 
 class TestParseCLIOutput(PrepareReportTestBase):
+    def test_parse_standard_json_output_should_report_missing_if_value_is_just_whitespace(self):
+        compiler_output = dedent("""\
+            {
+                "contracts": {
+                    "contract.sol": {
+                        "A": {
+                            "evm": {"bytecode": {"object": ""}},
+                            "metadata": ""
+                        },
+                        "B": {
+                            "evm": {"bytecode": {"object": "  "}},
+                            "metadata": "  "
+                        }
+                    }
+                }
+            }
+        """)
+
+        expected_report = FileReport(
+            file_name=Path('contract.sol'),
+            contract_reports=[
+                ContractReport(contract_name='A', file_name=Path('contract.sol'), bytecode=None, metadata=None),
+                ContractReport(contract_name='B', file_name=Path('contract.sol'), bytecode=None, metadata=None),
+            ]
+        )
+
+        self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
+
     def test_parse_cli_output(self):
         expected_report = FileReport(
             file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
@@ -431,3 +462,107 @@ class TestParseCLIOutput(PrepareReportTestBase):
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_cli_output(Path('file.sol'), CODE_GENERATION_ERROR_CLI_OUTPUT), expected_report)
+
+    def test_parse_cli_output_should_handle_output_from_solc_0_4_0(self):
+        expected_report = FileReport(
+            file_name=Path('contract.sol'),
+            contract_reports=[
+                ContractReport(
+                    contract_name='C',
+                    file_name=None,
+                    bytecode='6060604052600c8060106000396000f360606040526008565b600256',
+                    metadata=None,
+                )
+            ]
+        )
+
+        self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_0_CLI_OUTPUT), expected_report)
+
+    def test_parse_cli_output_should_handle_output_from_solc_0_4_8(self):
+        expected_report = FileReport(
+            file_name=Path('contract.sol'),
+            contract_reports=[
+                # pragma pylint: disable=line-too-long
+                ContractReport(
+                    contract_name='C',
+                    file_name=None,
+                    bytecode='6060604052346000575b60358060166000396000f30060606040525b60005600a165627a7a72305820ccf9337430b4c4f7d6ad41efb10a94411a2af6a9f173ef52daeadd31f4bf11890029',
+                    metadata='{"compiler":{"version":"0.4.8+commit.60cc1668.mod.Darwin.appleclang"},"language":"Solidity","output":{"abi":[],"devdoc":{"methods":{}},"userdoc":{"methods":{}}},"settings":{"compilationTarget":{"contract.sol":"C"},"libraries":{},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"contract.sol":{"keccak256":"0xbe86d3681a198587296ad6d4a834606197e1a8f8944922c501631b04e21eeba2","urls":["bzzr://af16957d3d86013309d64d3cc572d007b1d8b08a821f2ff366840deb54a78524"]}},"version":1}',
+                )
+                # pragma pylint: enable=line-too-long
+            ]
+        )
+
+        self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_8_CLI_OUTPUT), expected_report)
+
+    def test_parse_cli_output_should_handle_leading_and_trailing_spaces(self):
+        compiler_output = (
+            ' =======  contract.sol : C  ======= \n'
+            ' Binary: \n'
+            ' 60806040523480156 \n'
+            ' Metadata: \n'
+            ' {  } \n'
+        )
+
+        expected_report = FileReport(
+            file_name=Path('contract.sol'),
+            contract_reports=[ContractReport(contract_name='C', file_name=Path('contract.sol'), bytecode='60806040523480156', metadata='{  }')]
+        )
+
+        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
+
+    def test_parse_cli_output_should_handle_empty_bytecode_and_metadata_lines(self):
+        compiler_output = dedent("""\
+            ======= contract.sol:C =======
+            Binary:
+            60806040523480156
+            Metadata:
+
+
+            ======= contract.sol:D =======
+            Binary:
+
+            Metadata:
+            {}
+
+
+            ======= contract.sol:E =======
+            Binary:
+
+            Metadata:
+
+
+        """)
+
+        expected_report = FileReport(
+            file_name=Path('contract.sol'),
+            contract_reports=[
+                ContractReport(contract_name='C', file_name=Path('contract.sol'), bytecode='60806040523480156', metadata=None),
+                ContractReport(contract_name='D', file_name=Path('contract.sol'), bytecode=None, metadata='{}'),
+                ContractReport(contract_name='E', file_name=Path('contract.sol'), bytecode=None, metadata=None),
+            ]
+        )
+
+        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
+
+    def test_parse_cli_output_should_handle_link_references_in_bytecode(self):
+        compiler_output = dedent("""\
+            ======= contract.sol:C =======
+            Binary:
+            73123456789012345678901234567890123456789073__$fb58009a6b1ecea3b9d99bedd645df4ec3$__5050
+            ======= contract.sol:D =======
+            Binary:
+            __$fb58009a6b1ecea3b9d99bedd645df4ec3$__
+        """)
+
+        # pragma pylint: disable=line-too-long
+        expected_report = FileReport(
+            file_name=Path('contract.sol'),
+            contract_reports=[
+                ContractReport(contract_name='C', file_name=Path('contract.sol'), bytecode='73123456789012345678901234567890123456789073__$fb58009a6b1ecea3b9d99bedd645df4ec3$__5050', metadata=None),
+                ContractReport(contract_name='D', file_name=Path('contract.sol'), bytecode='__$fb58009a6b1ecea3b9d99bedd645df4ec3$__', metadata=None),
+            ]
+        )
+        # pragma pylint: enable=line-too-long
+
+        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)


### PR DESCRIPTION
~Depends on #10676. Don't merge until that PR is merged!~ It's on `develop` now.

This is a set of workarounds for #10183, to make `prepare_report.py` and `prepare_report.js` work with older versions of the compiler:
- The option to disable SMT Checker only appeared in 0.7.6. Before that we need to fall back to stripping pragmas.
- Some versions have more whitespace in CLI output.
- On 0.6.0 and 0.6.1 Yul optimizer was enabled by default which results in different metadata.
- Before 0.4.6 the `--metadata` option was not supported. Up to 0.4.4 it was ignored but on 0.4.5 and 0.4.6 it cause an error so I added a step to detect that and prevent the script from using it.
- On 0.4.11 the emscripten builds of the compiler raise exceptions instead of reporting an error on some invalid input (specifically: extracted examples that are actually LLL, not Solidity). Now there's a try/catch block that handles this like all other errors.