### PR TITLE
 Disallow certain implicit conversions between integer types.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * SMTChecker: Fix false negatives when analyzing external function calls.
  * SMTChecker: Fix missing type constraints for block variables.
  * SMTChecker: Fix internal error on ``block.chainid``.
+ * Type System: Disallow implicit conversion from ``uintN`` to ``intM`` when ``M > N``, and by extension, explicit conversion between the same types is also disallowed.
 
 ### 0.8.0 (2020-12-16)
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -508,12 +508,13 @@ BoolResult IntegerType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	if (_convertTo.category() == category())
 	{
 		IntegerType const& convertTo = dynamic_cast<IntegerType const&>(_convertTo);
-		if (convertTo.m_bits < m_bits)
+		// disallowing unsigned to signed conversion of different bits
+		if (isSigned() != convertTo.isSigned())
 			return false;
-		else if (isSigned())
-			return convertTo.isSigned();
+		else if (convertTo.m_bits < m_bits)
+			return false;
 		else
-			return !convertTo.isSigned() || convertTo.m_bits > m_bits;
+			return true;
 	}
 	else if (_convertTo.category() == Category::FixedPoint)
 	{

--- a/test/compilationTests/gnosis/Events/ScalarEvent.sol
+++ b/test/compilationTests/gnosis/Events/ScalarEvent.sol
@@ -61,7 +61,7 @@ contract ScalarEvent is Event {
             convertedWinningOutcome = OUTCOME_RANGE;
         // Map outcome to outcome range
         else
-            convertedWinningOutcome = uint24(uint(OUTCOME_RANGE * (outcome - lowerBound) / (upperBound - lowerBound)));
+            convertedWinningOutcome = uint24(uint(int(uint(OUTCOME_RANGE)) * (outcome - lowerBound) / (upperBound - lowerBound)));
         uint factorShort = OUTCOME_RANGE - convertedWinningOutcome;
         uint factorLong = OUTCOME_RANGE - factorShort;
         uint shortOutcomeTokenCount = outcomeTokens[SHORT].balanceOf(msg.sender);

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/010_type_conversion_for_comparison.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/010_type_conversion_for_comparison.sol
@@ -1,6 +1,6 @@
 contract test {
-    function f() public { uint32(2) == int64(2); }
+    function f() public { uint32(2) == uint64(2); }
 }
 // ----
-// Warning 6133: (42-63): Statement has no effect.
-// Warning 2018: (20-66): Function state mutability can be restricted to pure
+// Warning 6133: (42-64): Statement has no effect.
+// Warning 2018: (20-67): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/types/integer_implicit_err.sol
+++ b/test/libsolidity/syntaxTests/types/integer_implicit_err.sol
@@ -1,0 +1,13 @@
+contract C
+{
+    function f() public pure {
+        uint16 a = 1;
+        int32 b = a;
+
+        uint256 c = 10;
+        int8 d = c;
+    }
+}
+// ----
+// TypeError 9574: (74-85): Type uint16 is not implicitly convertible to expected type int32.
+// TypeError 9574: (120-130): Type uint256 is not implicitly convertible to expected type int8.

--- a/test/libsolidity/syntaxTests/types/strict_explicit.sol
+++ b/test/libsolidity/syntaxTests/types/strict_explicit.sol
@@ -37,6 +37,10 @@ contract C
 
         B n = B(address(uint160(uint(int(100)))));
         n;
+
+        uint8 o = 1;
+        int16 p = int16(o);
     }
 }
 // ----
+// TypeError 9640: (801-809): Explicit type conversion not allowed from "uint8" to "int16".


### PR DESCRIPTION
Disallow implicit conversion from ``uintN`` and ``intM`` when ``M > N``, and by extension, explicit
conversion between the same types are also disallowed.