### PR TITLE
[SMTChecker] Refactor cex loop

### DIFF
--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -207,6 +207,14 @@ private:
 
 	std::optional<std::string> generateCounterexample(smtutil::CHCSolverInterface::CexGraph const& _graph, std::string const& _root);
 
+	/// @returns a call graph for function summaries in the counterexample graph.
+	/// The returned map also contains a key _root, whose value are the
+	/// summaries called by _root.
+	std::map<unsigned, std::vector<unsigned>> summaryCalls(
+		smtutil::CHCSolverInterface::CexGraph const& _graph,
+		unsigned _root
+	);
+
 	/// @returns a set of pairs _var = _value separated by _separator.
 	template <typename T>
 	std::string formatVariableModel(std::vector<T> const& _variables, std::vector<std::optional<std::string>> const& _values, std::string const& _separator) const

--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -144,6 +144,11 @@ bool Predicate::isSummary() const
 	return m_type == PredicateType::ConstructorSummary || m_type == PredicateType::FunctionSummary;
 }
 
+bool Predicate::isConstructorSummary() const
+{
+	return m_type == PredicateType::ConstructorSummary;
+}
+
 bool Predicate::isInterface() const
 {
 	return m_type == PredicateType::Interface;

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -98,6 +98,9 @@ public:
 	/// @returns true if this predicate represents a summary.
 	bool isSummary() const;
 
+	/// @returns true if this predicate represents a constructor summary.
+	bool isConstructorSummary() const;
+
 	/// @returns true if this predicate represents an interface.
 	bool isInterface() const;
 


### PR DESCRIPTION
We build a summary call graph using a BFS that looks for predicates of type Summary. The BFS visit order guarantees the reverse order of called txs

Done in preparation for internal calls reported in cex