### PR TITLE
[isoltest] Add support for events.

### DIFF
--- a/liblangutil/Common.h
+++ b/liblangutil/Common.h
@@ -45,6 +45,11 @@ inline bool isIdentifierPart(char c)
 	return isIdentifierStart(c) || isDecimalDigit(c);
 }
 
+inline bool isIdentifierPartWithDot(char c)
+{
+	return isIdentifierPart(c) || c == '.';
+}
+
 inline int hexValue(char c)
 {
 	if (c >= '0' && c <= '9')

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -51,6 +51,25 @@ class ExecutionFramework
 {
 
 public:
+	/// LOG record.
+	struct log_record
+	{
+		/// The address of the account which created the log.
+		util::h160 creator;
+
+		/// The data attached to the log.
+		bytes data;
+
+		/// The log topics.
+		std::vector<util::h256> topics;
+
+		/// Equal operator.
+		bool operator==(const log_record& other) const noexcept
+		{
+			return creator == other.creator && data == other.data && topics == other.topics;
+		}
+	};
+
 	ExecutionFramework();
 	ExecutionFramework(langutil::EVMVersion _evmVersion, std::vector<boost::filesystem::path> const& _vmPaths);
 	virtual ~ExecutionFramework() = default;
@@ -276,6 +295,22 @@ protected:
 	util::h256 logTopic(size_t _logIdx, size_t _topicIdx) const;
 	util::h160 logAddress(size_t _logIdx) const;
 	bytes logData(size_t _logIdx) const;
+
+	std::vector<log_record> recordedLogs() {
+		std::vector<log_record> logs{};
+		for (size_t logIdx = 0; logIdx < numLogs(); ++logIdx)
+		{
+			log_record record;
+			const auto& data = m_evmcHost->recorded_logs.at(logIdx).data;
+			record.data = bytes{data.begin(), data.end()};
+			record.creator = EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(logIdx).creator);
+			for (size_t topicIdx = 0; topicIdx < numLogTopics(logIdx); ++topicIdx) {
+				record.topics.emplace_back(EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(logIdx).topics.at(topicIdx)));
+			}
+			logs.emplace_back(record);
+		}
+		return logs;
+	}
 
 	langutil::EVMVersion m_evmVersion;
 	solidity::frontend::RevertStrings m_revertStrings = solidity::frontend::RevertStrings::Default;

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -51,9 +51,9 @@ class ExecutionFramework
 {
 
 public:
-	/// LOG record.
 	struct log_record
 	{
+		size_t index;
 		/// The address of the account which created the log.
 		util::h160 creator;
 
@@ -302,6 +302,7 @@ protected:
 		{
 			log_record record;
 			const auto& data = m_evmcHost->recorded_logs.at(logIdx).data;
+			record.index = logIdx;
 			record.data = bytes{data.begin(), data.end()};
 			record.creator = EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(logIdx).creator);
 			for (size_t topicIdx = 0; topicIdx < numLogTopics(logIdx); ++topicIdx) {

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -234,7 +234,19 @@ TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _line
 					);
 				}
 
-				bool outputMismatch = (output != test.call().expectations.rawBytes());
+				bytes expectationOutput;
+				if (test.call().expectations.builtin)
+				{
+					std::vector<string> builtinPath;
+					boost::split(builtinPath, test.call().expectations.builtin->signature, boost::is_any_of("."));
+					assert(builtinPath.size() == 2);
+					auto builtin = m_builtins[builtinPath.front()][builtinPath.back()];
+					expectationOutput = builtin(*test.call().expectations.builtin);
+				}
+				else
+					expectationOutput = test.call().expectations.rawBytes();
+
+				bool outputMismatch = (output != expectationOutput);
 				if (test.call().kind == FunctionCall::Kind::Builtin)
 				{
 					if (outputMismatch)

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -271,7 +271,10 @@ TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _line
 
 					if (m_transactionSuccessful != !test.call().expectations.failure || outputMismatch)
 						success = false;
-					success = checkLogs(test);
+
+					if (success)
+						success = checkLogs(test);
+
 					test.setFailure(!m_transactionSuccessful);
 				}
 
@@ -450,10 +453,10 @@ bool SemanticTest::checkLogs(TestFunctionCall& _call)
 
 		// Finally we update the consumed logs within the producer.
 		for (auto& logIdx: m_touchedLogs[&producer->call()])
-			producer->consumedLogs().insert(logIdx);
+			producer->consumedLogIndexes().insert(logIdx);
 
 		// It is ok if some builtins consumed log events.
-		return producer->consumedLogs().size() >= producer->logs().size();
+		return producer->consumedLogIndexes().size() >= producer->logs().size();
 	}
 	return true;
 }

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -58,7 +58,15 @@ public:
 	/// Compiles and deploys currently held source.
 	/// Returns true if deployment was successful, false otherwise.
 	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments, std::map<std::string, solidity::test::Address> const& _libraries = {});
+
 private:
+	// logs builtins.
+	bytes numLogs(FunctionCall const& call);
+	bytes numLogTopics(FunctionCall const& call);
+	bytes logTopic(FunctionCall const& call);
+	bytes logAddress(FunctionCall const& call);
+	bytes logData(FunctionCall const& call);
+
 	TestResult runTest(std::ostream& _stream, std::string const& _linePrefix, bool _formatted, bool _compileViaYul, bool _compileToEwasm);
 	SourceMap m_sources;
 	std::size_t m_lineOffset;
@@ -70,6 +78,7 @@ private:
 	bool m_runWithABIEncoderV1Only = false;
 	bool m_allowNonExistingFunctions = false;
 	bool m_compileViaYulCanBeSet = false;
+	BuiltinFunctions m_builtins;
 };
 
 }

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -60,12 +60,19 @@ public:
 	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments, std::map<std::string, solidity::test::Address> const& _libraries = {});
 
 private:
+	bool checkLogs(TestFunctionCall& _call);
+
 	// logs builtins.
 	bytes numLogs(FunctionCall const& call);
 	bytes numLogTopics(FunctionCall const& call);
 	bytes logTopic(FunctionCall const& call);
 	bytes logAddress(FunctionCall const& call);
 	bytes logData(FunctionCall const& call);
+	bytes expectEvent(FunctionCall const& call);
+	void touchLog(FunctionCall const& call, size_t _logIdx)
+	{
+		m_touchedLogs[&call].insert(_logIdx);
+	}
 
 	TestResult runTest(std::ostream& _stream, std::string const& _linePrefix, bool _formatted, bool _compileViaYul, bool _compileToEwasm);
 	SourceMap m_sources;
@@ -79,6 +86,7 @@ private:
 	bool m_allowNonExistingFunctions = false;
 	bool m_compileViaYulCanBeSet = false;
 	BuiltinFunctions m_builtins;
+	std::map<FunctionCall const*, std::set<size_t>> m_touchedLogs;
 };
 
 }

--- a/test/libsolidity/semanticTests/builtins/smoke.sol
+++ b/test/libsolidity/semanticTests/builtins/smoke.sol
@@ -1,0 +1,10 @@
+contract ClientReceipt {
+}
+// ====
+// compileViaYul: also
+// ----
+// logs.numLogs() -> logs.numLogs()
+// logs.logAddress(uint256): 0 -> logs.logAddress(uint256): 0
+// logs.logData(uint256): 0 -> logs.logData(uint256): 0
+// logs.numLogTopics(uint256): 0 -> logs.numLogTopics(uint256): 0
+// logs.logTopic(uint256,uint256): 0, 0 -> logs.logTopic(uint256,uint256): 0, 0

--- a/test/libsolidity/semanticTests/events/event_emit.sol
+++ b/test/libsolidity/semanticTests/events/event_emit.sol
@@ -1,17 +1,25 @@
 contract ClientReceipt {
-    event Deposit(address indexed _from, bytes32 indexed _id, uint _value);
+    event D(address indexed _from, bytes32 indexed _id, uint _value);
+    event D2(address indexed _from, bytes32 indexed _id, uint _value) anonymous;
+    event D3(address _from, bytes32 indexed _id, uint _value);
     function deposit(bytes32 _id) public payable {
-        emit Deposit(msg.sender, _id, msg.value);
+        emit D(msg.sender, _id, msg.value);
+        emit D2(msg.sender, _id, msg.value);
+        emit D3(msg.sender, _id, msg.value);
+    }
+    function deposit2(bytes32 _id) public payable {
+        emit D(msg.sender, _id, msg.value);
     }
 }
+
+// logs.expectEvent(uint256,string): 0, "D(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 18
+
+// deposit2(bytes32), 18 wei: 0x1234 ->
+// deposit(bytes32), 18 wei: 0x1234 ->
 // ====
-// compileViaYul: also
+// compileViaYul: false
 // ----
 // deposit(bytes32), 18 wei: 0x1234 ->
-// logs.numLogs() -> 1
-// logs.logAddress(uint256): 0 -> 0x0fdd67305928fcac8d213d1e47bfa6165cd0b87b
-// logs.logData(uint256): 0 -> 0x12
-// logs.numLogTopics(uint256): 0 -> 3
-// logs.logTopic(uint256,uint256): 0, 0 -> 0x19dacbf83c5de6658e14cbf7bcae5c15eca2eedecf1c66fbca928e4d351bea0f
-// logs.logTopic(uint256,uint256): 0, 1 -> 0x1212121212121212121212121212120000000012
-// logs.logTopic(uint256,uint256): 0, 2 -> 0x1234
+// logs.expectEvent(uint256,string): 0, "D(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 18
+// logs.expectEvent(uint256,string): 1, "D2(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 18
+// logs.expectEvent(uint256,string): 2, "D3(address,bytes32,uint256)" -> 0x1234, 0x1212121212121212121212121212120000000012, 0x12

--- a/test/libsolidity/semanticTests/events/event_emit.sol
+++ b/test/libsolidity/semanticTests/events/event_emit.sol
@@ -1,0 +1,17 @@
+contract ClientReceipt {
+    event Deposit(address indexed _from, bytes32 indexed _id, uint _value);
+    function deposit(bytes32 _id) public payable {
+        emit Deposit(msg.sender, _id, msg.value);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// deposit(bytes32), 18 wei: 0x1234 ->
+// logs.numLogs() -> 1
+// logs.logAddress(uint256): 0 -> 0x0fdd67305928fcac8d213d1e47bfa6165cd0b87b
+// logs.logData(uint256): 0 -> 0x12
+// logs.numLogTopics(uint256): 0 -> 3
+// logs.logTopic(uint256,uint256): 0, 0 -> 0x19dacbf83c5de6658e14cbf7bcae5c15eca2eedecf1c66fbca928e4d351bea0f
+// logs.logTopic(uint256,uint256): 0, 1 -> 0x1212121212121212121212121212120000000012
+// logs.logTopic(uint256,uint256): 0, 2 -> 0x1234

--- a/test/libsolidity/semanticTests/events/event_emit.sol
+++ b/test/libsolidity/semanticTests/events/event_emit.sol
@@ -2,17 +2,23 @@ contract ClientReceipt {
     event A(address _from, bytes32 _id, uint _value);
     event B(address _from, bytes32 _id, uint indexed _value) anonymous;
     event C(address _from, bytes32 indexed _id, uint _value);
-    function deposit(bytes32 _id) public payable {
+    function deposit(bytes32 _id) public payable returns(uint256) {
         emit A(msg.sender, _id, msg.value);
         emit B(msg.sender, _id, msg.value);
         emit C(msg.sender, _id, msg.value);
+
+        return  msg.value;
     }
 }
 
 // ====
 // compileViaYul: false
 // ----
-// deposit(bytes32), 18 wei: 0x1234 ->
-// logs.expectEvent(uint256,string): 0, "A(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 0x12
-// logs.expectEvent(uint256,string): 1, "" -> 0x12, 0x1212121212121212121212121212120000000012, 0x1234
-// logs.expectEvent(uint256,string): 2, "C(address,bytes32,uint256)" -> 0x1234, 0x1212121212121212121212121212120000000012, 0x12
+// deposit(bytes32), 28 wei: 0x1234 -> 0x1c
+// logs.expectEvent(uint256,string): 0, "A(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 0x1c
+// logs.expectEvent(uint256,string): 1, "" -> 0x1c, 0x1212121212121212121212121212120000000012, 0x1234
+// logs.expectEvent(uint256,string): 2, "C(address,bytes32,uint256)" -> 0x1234, 0x1212121212121212121212121212120000000012, 0x1c
+// deposit(bytes32), 23 wei: 0x1234 -> 0x17
+// logs.expectEvent(uint256,string): 0, "A(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 0x17
+// logs.expectEvent(uint256,string): 1, "" -> 0x17, 0x1212121212121212121212121212120000000012, 0x1234
+// logs.expectEvent(uint256,string): 2, "C(address,bytes32,uint256)" -> 0x1234, 0x1212121212121212121212121212120000000012, 0x17

--- a/test/libsolidity/semanticTests/events/event_emit.sol
+++ b/test/libsolidity/semanticTests/events/event_emit.sol
@@ -1,25 +1,18 @@
 contract ClientReceipt {
-    event D(address indexed _from, bytes32 indexed _id, uint _value);
-    event D2(address indexed _from, bytes32 indexed _id, uint _value) anonymous;
-    event D3(address _from, bytes32 indexed _id, uint _value);
+    event A(address _from, bytes32 _id, uint _value);
+    event B(address _from, bytes32 _id, uint indexed _value) anonymous;
+    event C(address _from, bytes32 indexed _id, uint _value);
     function deposit(bytes32 _id) public payable {
-        emit D(msg.sender, _id, msg.value);
-        emit D2(msg.sender, _id, msg.value);
-        emit D3(msg.sender, _id, msg.value);
-    }
-    function deposit2(bytes32 _id) public payable {
-        emit D(msg.sender, _id, msg.value);
+        emit A(msg.sender, _id, msg.value);
+        emit B(msg.sender, _id, msg.value);
+        emit C(msg.sender, _id, msg.value);
     }
 }
 
-// logs.expectEvent(uint256,string): 0, "D(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 18
-
-// deposit2(bytes32), 18 wei: 0x1234 ->
-// deposit(bytes32), 18 wei: 0x1234 ->
 // ====
 // compileViaYul: false
 // ----
 // deposit(bytes32), 18 wei: 0x1234 ->
-// logs.expectEvent(uint256,string): 0, "D(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 18
-// logs.expectEvent(uint256,string): 1, "D2(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 18
-// logs.expectEvent(uint256,string): 2, "D3(address,bytes32,uint256)" -> 0x1234, 0x1212121212121212121212121212120000000012, 0x12
+// logs.expectEvent(uint256,string): 0, "A(address,bytes32,uint256)" -> 0x1212121212121212121212121212120000000012, 0x1234, 0x12
+// logs.expectEvent(uint256,string): 1, "" -> 0x12, 0x1212121212121212121212121212120000000012, 0x1234
+// logs.expectEvent(uint256,string): 2, "C(address,bytes32,uint256)" -> 0x1234, 0x1212121212121212121212121212120000000012, 0x12

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -176,6 +176,8 @@ struct Parameter
 };
 using ParameterList = std::vector<Parameter>;
 
+struct FunctionCall;
+
 /**
  * Represents the expected result of a function call after it has been executed. This may be a single
  * return value or a comma-separated list of return values. It also contains the detected input
@@ -195,6 +197,9 @@ struct FunctionCallExpectations
 	/// A Comment that can be attached to the expectations,
 	/// that is retained and can be displayed.
 	std::string comment;
+	/// An expectation can also be defined by a builtin function.
+	std::unique_ptr<FunctionCall> builtin;
+
 	/// ABI encoded `bytes` of parsed expected return values. It is checked
 	/// against the actual result of a function call when used in test framework.
 	bytes rawBytes() const
@@ -298,6 +303,7 @@ struct FunctionCall
 	bool omitsArrow = true;
 };
 
-using BuiltinFunctions = std::map<std::string, std::map<std::string, std::function<bytes(FunctionCall const&)>>>;
+using BuiltinFunction = std::function<bytes(FunctionCall const&)>;
+using BuiltinFunctions = std::map<std::string, std::map<std::string, BuiltinFunction>>;
 
 }

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -198,7 +198,7 @@ struct FunctionCallExpectations
 	/// that is retained and can be displayed.
 	std::string comment;
 	/// An expectation can also be defined by a builtin function.
-	std::unique_ptr<FunctionCall> builtin;
+	std::shared_ptr<FunctionCall> builtin;
 
 	/// ABI encoded `bytes` of parsed expected return values. It is checked
 	/// against the actual result of a function call when used in test framework.

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -17,6 +17,8 @@
 #include <libsolutil/AnsiColorized.h>
 #include <libsolutil/CommonData.h>
 
+#include <test/ExecutionFramework.h>
+
 namespace solidity::frontend::test
 {
 
@@ -286,12 +288,16 @@ struct FunctionCall
 		/// Marks a library deployment call.
 		Library,
 		/// Check that the storage of the current contract is empty or non-empty.
-		Storage
+		Storage,
+		/// Call to a builtin.
+		Builtin
 	};
 	Kind kind = Kind::Regular;
 	/// Marks this function call as "short-handed", meaning
 	/// no `->` declared.
 	bool omitsArrow = true;
 };
+
+using BuiltinFunctions = std::map<std::string, std::map<std::string, std::function<bytes(FunctionCall const&)>>>;
 
 }

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -177,6 +177,10 @@ private:
 	/// Parses the current string literal.
 	std::string parseString();
 
+	/// Checks whether a builtin function with the given signature exist.
+	/// This function will throw an TestParserError exception, if not.
+	void checkBuiltinFunction(std::string const& signature);
+
 	/// A scanner instance
 	Scanner m_scanner;
 

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -52,7 +52,7 @@ class TestFileParser
 public:
 	/// Constructor that takes an input stream \param _stream to operate on
 	/// and creates the internal scanner.
-	TestFileParser(std::istream& _stream): m_scanner(_stream) {}
+	explicit TestFileParser(std::istream& _stream, BuiltinFunctions* _builtins = nullptr): m_scanner(_stream), m_builtins(_builtins) {}
 
 	/// Parses function calls blockwise and returns a list of function calls found.
 	/// Throws an exception if a function call cannot be parsed because of its
@@ -183,6 +183,8 @@ private:
 	/// The current line number. Incremented when Token::Newline (//) is found and
 	/// used to enhance parser error messages.
 	size_t m_lineNumber = 0;
+
+	BuiltinFunctions* m_builtins{nullptr};
 };
 
 }

--- a/test/libsolidity/util/TestFunctionCall.h
+++ b/test/libsolidity/util/TestFunctionCall.h
@@ -16,6 +16,7 @@
 
 #include <test/libsolidity/util/TestFileParser.h>
 #include <test/libsolidity/util/SoltestErrors.h>
+#include <test/ExecutionFramework.h>
 
 #include <liblangutil/Exceptions.h>
 #include <libsolutil/AnsiColorized.h>
@@ -27,6 +28,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace solidity::frontend::test
@@ -80,6 +82,26 @@ public:
 	void setFailure(const bool _failure) { m_failure = _failure; }
 	void setRawBytes(const bytes _rawBytes) { m_rawBytes = _rawBytes; }
 	void setContractABI(Json::Value _contractABI) { m_contractABI = std::move(_contractABI); }
+	std::vector<solidity::test::ExecutionFramework::log_record> logs()
+	{
+		return m_rawLogs;
+	}
+	void setLogs(std::vector<solidity::test::ExecutionFramework::log_record> _logs)
+	{
+		m_rawLogs = std::move(_logs);
+	}
+	std::set<size_t>& consumedLogs()
+	{
+		return m_consumedLogs;
+	}
+	void setPreviousCall(TestFunctionCall* _call)
+	{
+		m_previousCall = _call;
+	}
+	TestFunctionCall* previousCall()
+	{
+		return m_previousCall;
+	}
 
 private:
 	/// Tries to format the given `bytes`, applying the detected ABI types that have be set for each parameter.
@@ -124,6 +146,10 @@ private:
 	FunctionCall m_call;
 	/// Result of the actual call been made.
 	bytes m_rawBytes = bytes{};
+	/// Logs created by the actual call.
+	std::vector<solidity::test::ExecutionFramework::log_record> m_rawLogs{};
+	std::set<size_t> m_consumedLogs;
+
 	/// Transaction status of the actual call. False in case of a REVERT or any other failure.
 	bool m_failure = true;
 	/// JSON object which holds the contract ABI and that is used to set the output formatting
@@ -131,6 +157,8 @@ private:
 	Json::Value m_contractABI;
 	/// Flags that the test failed because the called function is not known to exist on the contract.
 	bool m_calledNonExistingFunction = false;
+
+	TestFunctionCall* m_previousCall = nullptr;
 };
 
 }

--- a/test/libsolidity/util/TestFunctionCallTests.cpp
+++ b/test/libsolidity/util/TestFunctionCallTests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_singleline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_singleline_signed_encoding)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_multiline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter result{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{result}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{result}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(format_multiple_unsigned_singleline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param, param}, string{}};
 	FunctionCall call{"f(uint8, uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(format_signed_singleline)
 	bytes expectedBytes = toBigEndian(u256{-1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "-1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(int8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(format_hex_singleline)
 	bytes expectedBytes = result + bytes(32 - result.size(), 0);
 	ABIType abiType{ABIType::Hex, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "0x31", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bytes32)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(format_hex_string_singleline)
 	bytes expectedBytes = fromHex("4200ef");
 	ABIType abiType{ABIType::HexString, ABIType::AlignLeft, 3};
 	Parameter param{expectedBytes, "hex\"4200ef\"", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(string)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(format_bool_true_singleline)
 	bytes expectedBytes = toBigEndian(u256{true});
 	ABIType abiType{ABIType::Boolean, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "true", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(format_bool_false_singleline)
 	bytes expectedBytes = toBigEndian(u256{false});
 	ABIType abiType{ABIType::Boolean, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "false", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(format_bool_left_singleline)
 	bytes expectedBytes = toBigEndian(u256{false});
 	ABIType abiType{ABIType::Boolean, ABIType::AlignLeft, 32};
 	Parameter param{expectedBytes, "left(false)", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(format_hex_number_right_singleline)
 	bytes expectedBytes = result + bytes(32 - result.size(), 0);
 	ABIType abiType{ABIType::Hex, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "right(0x42)", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(format_empty_byte_range)
 	bytes expectedBytes;
 	ABIType abiType{ABIType::None, ABIType::AlignNone, 0};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{}, string{}};
 	FunctionCall call{"f()", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(format_failure_singleline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{}, true, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{}, true, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;


### PR DESCRIPTION
Depends on #10867.

Fixes #6902.

- [X] support for builtin functions.
  - [X] basic builtin functions.
  - [X] basic support to enable usage of builtin functions within expectations.
- [x] implementation of all event specific builtin functions.

- [x] add implicit check for events.
- [x] support automatic expectation generation (easily readable), if events where found but not checked for.

- [ ] add useful builtins that can be used within expectations. (e.g. `contract.address`, `utils.keccak256`) - maybe this should be done in another PR
- [ ] add  log specific expectation builtins e.g. `logs.sender`.
- [ ] move event specific tests from `SolidityEndToEndTests` to semantic tests.