### PR TITLE
[scripts/install_deps.sh] support MacOS Big Sur

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -93,9 +93,12 @@ case $(uname -s) in
             10.15)
                 echo "Installing solidity dependencies on macOS 10.15 Catalina."
                 ;;
+            11.0 | 11.1)
+                echo "Installing solidity dependencies on macOS 11.0 / 11.1 Big Sur."
+                ;;
             *)
                 echo "Unsupported macOS version."
-                echo "We only support Mavericks, Yosemite, El Capitan, Sierra, High Sierra, Mojave, and Catalina."
+                echo "We only support Mavericks, Yosemite, El Capitan, Sierra, High Sierra, Mojave, Catalina, and Big Sur."
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
Update `scripts/install_deps.sh` to support `MacOS Big Sur`.

I have verified it in the following computers:

> Mac mini (2018) - MacOS Big Sur 11.1
>
> MacBook Pro (13-inch, 2019) - MacOS Big Sur 11.0

Thanks for your review!