### PR TITLE
Added expression conversion rule for mod(mul(x,y),z) -> mulmod(x,y,z) and equivalent for addmod(x,y,z)

### DIFF
--- a/libevmasm/RuleList.h
+++ b/libevmasm/RuleList.h
@@ -99,6 +99,8 @@ std::vector<SimplificationRule<Pattern>> simplificationRuleListPart1(
 		}},
 		{Builtins::ADDMOD(A, B, C), [=]{ return C.d() == 0 ? 0 : Word((bigint(A.d()) + bigint(B.d())) % C.d()); }},
 		{Builtins::MULMOD(A, B, C), [=]{ return C.d() == 0 ? 0 : Word((bigint(A.d()) * bigint(B.d())) % C.d()); }},
+        {Builtins::MOD(ADD(A, B), C), [=]{ return ADDMOD(A, B, C); }},
+        {Builtins::MOD(MUL(A, B), C), [=]{ return MULMOD(A,B,C); }},
 		{Builtins::SIGNEXTEND(A, B), [=]() -> Word {
 			if (A.d() >= Pattern::WordSize / 8 - 1)
 				return B.d();


### PR DESCRIPTION
This is in reference to issue #10688 

I added two rules to the Rules.h file to allow mod(mul(x,y),z) to be converted to mulmod(x,y,z) and
also for mod(add(x,y,),z) to be converted to addmod(x,y,z)