### PR TITLE
[SMTChecker] Refactoring common functionality

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -351,11 +351,8 @@ bool BMC::visit(TryStatement const& _tryStatement)
 	solAssert(externalCall && externalCall->annotation().tryCall, "");
 
 	externalCall->accept(*this);
-	auto callExpr = expr(*externalCall);
 	if (_tryStatement.successClause()->parameters())
-		tryCatchAssignment(
-			_tryStatement.successClause()->parameters()->parameters(), *m_context.expression(*externalCall)
-		);
+		expressionToTupleAssignment(_tryStatement.successClause()->parameters()->parameters(), *externalCall);
 
 	smtutil::Expression clauseId = m_context.newVariable("clause_choice_" + to_string(m_context.newUniqueId()), smtutil::SortProvider::uintSort);
 	auto const& clauses = _tryStatement.clauses();

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -567,9 +567,8 @@ bool CHC::visit(TryStatement const& _tryStatement)
 	// Only now visit the actual call to record its effects and connect to the success clause.
 	endVisit(*externalCall);
 	if (_tryStatement.successClause()->parameters())
-		tryCatchAssignment(
-			_tryStatement.successClause()->parameters()->parameters(), *m_context.expression(*externalCall)
-		);
+		expressionToTupleAssignment(_tryStatement.successClause()->parameters()->parameters(), *externalCall);
+
 	connectBlocks(m_currentBlock, predicate(*clauseBlocks[0]));
 
 	for (size_t i = 0; i < clauses.size(); ++i)

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -238,8 +238,8 @@ protected:
 	void tupleAssignment(Expression const& _left, Expression const& _right);
 	/// Computes the right hand side of a compound assignment.
 	smtutil::Expression compoundAssignment(Assignment const& _assignment);
-	/// Handles assignment of the result of external call in try statement to the parameters of success clause
-	void tryCatchAssignment(std::vector<std::shared_ptr<VariableDeclaration>> const& _variables, smt::SymbolicVariable const& rhs);
+	/// Handles assignment of an expression to a tuple of variables.
+	void expressionToTupleAssignment(std::vector<std::shared_ptr<VariableDeclaration>> const& _variables, Expression const& _rhs);
 
 	/// Maps a variable to an SSA index.
 	using VariableIndices = std::unordered_map<VariableDeclaration const*, int>;

--- a/test/libsolidity/smtCheckerTests/function_selector/function_types_sig.sol
+++ b/test/libsolidity/smtCheckerTests/function_selector/function_types_sig.sol
@@ -24,10 +24,8 @@ contract C {
     }
 }
 // ----
-// Warning 6031: (261-267): Internal error: Expression undefined for SMT solver.
 // Warning 7650: (284-296): Assertion checker does not yet support this expression.
 // Warning 6328: (470-495): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.check()\n  C.f() -- internal call\n  C.g() -- internal call
 // Warning 6328: (540-565): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.check()\n  C.f() -- internal call\n  C.g() -- internal call\n  C.i() -- internal call\n  C.i() -- internal call
-// Warning 6031: (261-267): Internal error: Expression undefined for SMT solver.
 // Warning 7650: (284-296): Assertion checker does not yet support this expression.
 // Warning 7650: (284-296): Assertion checker does not yet support this expression.


### PR DESCRIPTION
Refactoring common functionality from `tryCatchAssignment` and `endVisit(VariableDeclarationStatement const&)`.