### PR TITLE
Update emscripten docker image to be based on emscripten 2.0.12 and boost 1.75.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ parameters:
     default: "solbuildpackpusher/solidity-buildpack-deps@sha256:8cbbb722b7f919264d73f61cb79cd555469f6f1d3d153b1c848a60b391faee39"
   emscripten-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-2
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:23dad3b34deae8107c8551804ef299f6a89c23ed506e8118fac151e2bdc9018c"
+    # solbuildpackpusher/solidity-buildpack-deps:emscripten-3
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:e92ff672095ae31ea62ee9f4c6b552890f08c03a650d2a694609cb4385a17615"
 
 orbs:
   win: circleci/windows@2.2.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
  * Possibility to use ``catch Panic(uint code)`` to catch a panic failure from an external call.
 
 Compiler Features:
+ * Build system: Update the soljson.js build to emscripten 2.0.12 and boost 1.75.0.
  * Optimizer: Add rule to replace ``iszero(sub(x,y))`` by ``eq(x,y)``.
  * Parser: Report meaningful error if parsing a version pragma failed.
  * SMTChecker: Support ABI functions as uninterpreted functions.

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -150,7 +150,8 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s WASM_ASYNC_COMPILATION=0")
 			# Output a single js file with the wasm binary embedded as base64 string.
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s SINGLE_FILE=1")
-
+			# Allow new functions to be added to the wasm module via addFunction.
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s ALLOW_TABLE_GROWTH=1")
 			# Disable warnings about not being pure asm.js due to memory growth.
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-almost-asm")
 		endif()

--- a/cmake/toolchains/emscripten.cmake
+++ b/cmake/toolchains/emscripten.cmake
@@ -1,2 +1,0 @@
-include("${CMAKE_CURRENT_LIST_DIR}/default.cmake")
-include("$ENV{EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake")

--- a/libsolc/CMakeLists.txt
+++ b/libsolc/CMakeLists.txt
@@ -2,7 +2,7 @@ if (EMSCRIPTEN)
 	# Specify which functions to export in soljson.js.
 	# Note that additional Emscripten-generated methods needed by solc-js are
 	# defined to be exported in cmake/EthCompilerSettings.cmake.
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s EXPORTED_FUNCTIONS='[\"_solidity_license\",\"_solidity_version\",\"_solidity_compile\",\"_solidity_alloc\",\"_solidity_free\",\"_solidity_reset\"]' -s RESERVED_FUNCTION_POINTERS=20")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s EXPORTED_FUNCTIONS='[\"_solidity_license\",\"_solidity_version\",\"_solidity_compile\",\"_solidity_alloc\",\"_solidity_free\",\"_solidity_reset\"]'")
 	add_executable(soljson libsolc.cpp libsolc.h)
 	target_link_libraries(soljson PRIVATE solidity)
 else()

--- a/libsolutil/SwarmHash.cpp
+++ b/libsolutil/SwarmHash.cpp
@@ -29,7 +29,7 @@ using namespace solidity::util;
 namespace
 {
 
-bytes toLittleEndian(size_t _size)
+bytes toLittleEndian(uint64_t _size)
 {
 	bytes encoded(8);
 	for (size_t i = 0; i < 8; ++i)

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,5 +35,5 @@ else
 fi
 
 docker run -v $(pwd):/root/project -w /root/project \
-    solbuildpackpusher/solidity-buildpack-deps@sha256:23dad3b34deae8107c8551804ef299f6a89c23ed506e8118fac151e2bdc9018c\
+    solbuildpackpusher/solidity-buildpack-deps@sha256:e92ff672095ae31ea62ee9f4c6b552890f08c03a650d2a694609cb4385a17615 \
     ./scripts/ci/build_emscripten.sh $BUILD_DIR

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -56,8 +56,7 @@ fi
 
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
-cmake \
-  -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/emscripten.cmake \
+emcmake cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DBoost_USE_STATIC_LIBS=1 \
   -DBoost_USE_STATIC_RUNTIME=1 \

--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -26,10 +26,10 @@
 # contains a Makefile in the docker/ subdirectory that can be used to create the
 # required base image using:
 #
-#   make version=1.39.15 build
+#   make version=2.0.12 build
 #
-FROM emscripten/emsdk:1.39.15 AS base
-LABEL version="2"
+FROM emscripten/emsdk:2.0.12 AS base
+LABEL version="3"
 
 ADD emscripten.jam /usr/src
 RUN set -ex; \
@@ -40,7 +40,7 @@ RUN set -ex; \
 	cd build; \
 	emcmake cmake \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
-		-DCMAKE_INSTALL_PREFIX=/emsdk/emscripten/sdk/system/ \
+		-DCMAKE_INSTALL_PREFIX=/emsdk/upstream/emscripten/system \
 		-DZ3_BUILD_LIBZ3_SHARED=OFF \
 		-DZ3_ENABLE_EXAMPLE_TARGETS=OFF \
 		-DZ3_BUILD_TEST_EXECUTABLES=OFF \
@@ -48,20 +48,19 @@ RUN set -ex; \
 		-DZ3_SINGLE_THREADED=ON \
 		-DCMAKE_CXX_FLAGS="-s DISABLE_EXCEPTION_CATCHING=0" \
 		..; \
-	make; make install; \
+	make ; make install; \
 	rm -r /usr/src/z3; \
 	cd /usr/src; \
-	wget -q 'https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
-	test "$(sha256sum boost.tar.bz2)" = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402  boost.tar.bz2"; \
+	wget -q 'https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2' -O boost.tar.bz2; \
+	test "$(sha256sum boost.tar.bz2)" = "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb  boost.tar.bz2"; \
 	tar -xf boost.tar.bz2; \
 	rm boost.tar.bz2; \
-	cd boost_1_73_0; \
+	cd boost_1_75_0; \
 	mv ../emscripten.jam .; \
 	./bootstrap.sh; \
 	echo "using emscripten : : em++ ;" >> project-config.jam ; \
 	./b2 toolset=emscripten link=static variant=release threading=single runtime-link=static \
 		--with-system --with-filesystem --with-test --with-program_options \
 		cxxflags="-s DISABLE_EXCEPTION_CATCHING=0 -Wno-unused-local-typedef -Wno-variadic-macros -Wno-c99-extensions -Wno-all" \
-	       --prefix=/emsdk/emscripten/sdk/system install; \
-	rm -r /usr/src/boost_1_73_0
-
+	       --prefix=/emsdk/upstream/emscripten/system install; \
+	rm -r /usr/src/boost_1_75_0

--- a/scripts/docker/buildpack-deps/emscripten.jam
+++ b/scripts/docker/buildpack-deps/emscripten.jam
@@ -79,10 +79,10 @@ rule init ( version ? : command * : options * )
   # @todo this seems to be the right way, but this is a list somehow
   toolset.add-requirements <toolset>emscripten:<testing.launcher>node ;
 
-  toolset.flags emscripten.compile STDHDRS $(condition) : /emsdk/emscripten/sdk/system/include ;
-  toolset.flags emscripten.link STDLIBPATH $(condition) : /emsdk/emscripten/sdk/system/lib ;
-  toolset.flags emscripten AR $(condition) : /emsdk/emscripten/sdk/emar ;
-  toolset.flags emscripten RANLIB $(condition) : /emsdk/emscripten/sdk/emranlib ;
+  toolset.flags emscripten.compile STDHDRS $(condition) : /emsdk/upstream/emscripten/system/include ;
+  toolset.flags emscripten.link STDLIBPATH $(condition) : /emsdk/upstream/emscripten/system/lib ;
+  toolset.flags emscripten AR $(condition) : /emsdk/upstream/emscripten/emar ;
+  toolset.flags emscripten RANLIB $(condition) : /emsdk/upstream/emscripten/emranlib ;
 }
 
 type.set-generated-target-suffix EXE : <toolset>emscripten : js ;


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10747