### PR TITLE
Fix YulUtilFunctions::negateNumberWrappingFunction

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3765,7 +3765,7 @@ string YulUtilFunctions::negateNumberWrappingFunction(Type const& _type)
 	return m_functionCollector.createFunction(functionName, [&]() {
 		return Whiskers(R"(
 			function <functionName>(value) -> ret {
-				value := <cleanupFunction>(sub(0, value)))
+				ret := <cleanupFunction>(sub(0, value))
 			}
 		)")
 		("functionName", functionName)

--- a/test/libsolidity/semanticTests/various/flipping_sign_tests.sol
+++ b/test/libsolidity/semanticTests/various/flipping_sign_tests.sol
@@ -6,5 +6,7 @@ contract test {
     }
 }
 
+// ====
+// compileViaYul: also
 // ----
 // f() -> true


### PR DESCRIPTION
Fixes `flipping_sign_tests` found by #10235, which was miscompiled as:
```
            function negate_t_int256(value) -> ret {
            value := cleanup_t_int256(sub(0, value)))
        }
```

e.g. missing the closing `}` which broke the entire yul.