### PR TITLE
Special case for development version in doc pragma checker

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -24,10 +24,12 @@ then
     export TERM="${TERM:-xterm}"
     function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
     function printError() { >&2 echo "$(tput setaf 1)$1$(tput setaf 7)"; }
+    function printWarning() { >&2 echo "$(tput setaf 11)$1$(tput setaf 7)"; }
     function printLog() { echo "$(tput setaf 3)$1$(tput setaf 7)"; }
 else
     function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
     function printError() { >&2 echo "$(tput setaf 1)$1$(tput sgr0)"; }
+    function printWarning() { >&2 echo "$(tput setaf 11)$1$(tput sgr0)"; }
     function printLog() { echo "$(tput setaf 3)$1$(tput sgr0)"; }
 fi
 

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -56,7 +56,7 @@ function versionGreater()
 
 function versionEqual()
 {
-    if [ "$1" == "$2" ]
+    if [[ "$1" == "$2" ]]
     then
         return 0
     fi
@@ -112,14 +112,14 @@ function findMinimalVersion()
         then
             version="$ver"
             break
-        elif ([ $greater == false ]) && versionEqual "$ver" "$pragmaVersion"
+        elif [[ "$greater" == false ]] && versionEqual "$ver" "$pragmaVersion"
         then
             version="$ver"
             break
         fi
     done
 
-    if [ -z "$version" ]
+    if [[ "$version" == "" ]]
     then
         if [[ "$greater" = true && "$pragmaVersion" =~ 99 ]]
         then
@@ -163,7 +163,7 @@ SOLTMPDIR=$(mktemp -d)
         opts="$opts -o"
 
         findMinimalVersion $f
-        if [ -z "$version" ]
+        if [[ "$version" == "" ]]
         then
             continue
         fi

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -121,13 +121,8 @@ function findMinimalVersion()
 
     if [[ "$version" == "" ]]
     then
-        if [[ "$greater" = true && "$pragmaVersion" =~ 99 ]]
-        then
-            printError "Skipping version check for pragma: $pragmaVersion"
-        else
-            printError "No release $sign$pragmaVersion was listed in available releases!"
-            exit 1
-        fi
+        printError "No release ${sign}${pragmaVersion} was listed in available releases!"
+        exit 1
     fi
 }
 

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -32,6 +32,8 @@ SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 source "${REPO_ROOT}/scripts/common.sh"
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
 
+developmentVersion=$("$REPO_ROOT/scripts/get_version.sh")
+
 function versionGreater()
 {
     v1=$1
@@ -104,7 +106,7 @@ function findMinimalVersion()
     fi
 
     version=""
-    for ver in "${allVersions[@]}"
+    for ver in "${allVersions[@]}" "$developmentVersion"
     do
         if versionGreater "$ver" "$pragmaVersion"
         then
@@ -163,6 +165,11 @@ SOLTMPDIR=$(mktemp -d)
         findMinimalVersion $f
         if [ -z "$version" ]
         then
+            continue
+        fi
+        if [[ "$version" == "$developmentVersion" ]]
+        then
+            printWarning "Skipping unreleased development version $developmentVersion"
             continue
         fi
 


### PR DESCRIPTION
This solves the problem raised in https://github.com/ethereum/solidity/pull/10682#discussion_r547279182.

Now the script no longer fails if the earliest version supported by a code snippet is the one we're building right now. It does not run that version though - it's possible but with some complications - I'd have to choose one of platforms to depend on and pass the executable through the workspace in CI.

I have removed the hack that makes it ignore versions ending with `.99` as it should not be necessary now.