### PR TITLE
Commit date in CI build version strings

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -5,10 +5,20 @@ ROOTDIR="$(dirname "$0")/../.."
 cd "${ROOTDIR}"
 
 # shellcheck disable=SC2166
-if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" -o -n "$FORCE_RELEASE" ]; then echo -n >prerelease.txt; fi
+if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" -o -n "$FORCE_RELEASE" ]
+then
+    echo -n "" >prerelease.txt
+else
+    # Use last commit date rather than build date to avoid ending up with builds for
+    # different platforms having different version strings (and therefore producing different bytecode)
+    # if the CI is triggered just before midnight.
+    last_commit_timestamp=$(git log -1 --date=iso --format=%ad HEAD)
+    date -d "$last_commit_timestamp" -u "+ci.%Y.%-m.%-d" >prerelease.txt
+fi
+
 if [ -n "$CIRCLE_SHA1" ]
 then
-  echo -n "$CIRCLE_SHA1" >commit_hash.txt
+    echo -n "$CIRCLE_SHA1" >commit_hash.txt
 fi
 
 mkdir -p build


### PR DESCRIPTION
Using build date results in bytecode mismatch if different executables end up being built on different dates, which happens suprisingly often. I can list at least 3 recent instances of this that happened either when someone pushed code just before midnight or when failed build jobs were restarted not on the same day: https://github.com/ethereum/solidity/pull/9555#issuecomment-735759352, https://github.com/ethereum/solidity/pull/10753#issuecomment-760047855, https://github.com/ethereum/solidity/pull/10582#issuecomment-744300819.

This PR switches to using commit date. Which could sometimes be a lot earlier than the build date but I don't think it matters in CI. But just to be safe, I'm changing the `develop` prefix in version string to `ci` in CI builds.