### PR TITLE
Fix commit date command for CI builds on macOS

### DIFF
--- a/.circleci/build_win.ps1
+++ b/.circleci/build_win.ps1
@@ -6,6 +6,14 @@ if ("$Env:FORCE_RELEASE" -Or "$Env:CIRCLE_TAG") {
 	New-Item prerelease.txt -type file
 	Write-Host "Building release version."
 }
+else {
+	# Use last commit date rather than build date to avoid ending up with builds for
+	# different platforms having different version strings (and therefore producing different bytecode)
+	# if the CI is triggered just before midnight.
+	$last_commit_timestamp = git log -1 --date=unix --format=%ad HEAD
+	$last_commit_date = (Get-Date -Date "1970-01-01 00:00:00Z").toUniversalTime().addSeconds($last_commit_timestamp).ToString("yyyy.M.d")
+	-join("ci.", $last_commit_date) | out-file -encoding ascii prerelease.txt
+}
 
 mkdir build
 cd build

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -12,8 +12,7 @@ else
     # Use last commit date rather than build date to avoid ending up with builds for
     # different platforms having different version strings (and therefore producing different bytecode)
     # if the CI is triggered just before midnight.
-    last_commit_timestamp=$(git log -1 --date=iso --format=%ad HEAD)
-    date -d "$last_commit_timestamp" -u "+ci.%Y.%-m.%-d" >prerelease.txt
+    TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="ci.%cd" >prerelease.txt
 fi
 
 if [ -n "$CIRCLE_SHA1" ]

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -47,11 +47,16 @@ cd $WORKSPACE
 # shellcheck disable=SC2166
 if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]
 then
-  echo -n >prerelease.txt
+	echo -n >prerelease.txt
+else
+	# Use last commit date rather than build date to avoid ending up with builds for
+	# different platforms having different version strings (and therefore producing different bytecode)
+	# if the CI is triggered just before midnight.
+	TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="ci.%cd" >prerelease.txt
 fi
 if [ -n "$CIRCLE_SHA1" ]
 then
-  echo -n "$CIRCLE_SHA1" >commit_hash.txt
+	echo -n "$CIRCLE_SHA1" >commit_hash.txt
 fi
 
 mkdir -p $BUILD_DIR


### PR DESCRIPTION
Turns out BSD date has different options than the one on Linux so #10771 is broken on macOS. This PR makes it portable.