### PR TITLE
Force even more semantic tests for the IR

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -63,7 +63,7 @@ SemanticTest::SemanticTest(string const& _filename, langutil::EVMVersion _evmVer
 		m_runWithYul = false;
 		m_runWithoutYul = true;
 		// Do not try to run via yul if explicitly denied.
-		m_enforceViaYul = false;
+		//m_enforceViaYul = false;
 	}
 	else if (choice == "default")
 	{

--- a/test/libsolidity/semanticTests/revertStrings/function_entry_checks_v1_abiv2.sol
+++ b/test/libsolidity/semanticTests/revertStrings/function_entry_checks_v1_abiv2.sol
@@ -4,7 +4,7 @@ contract C {
 }
 // ====
 // EVMVersion: >=byzantium
-// compileViaYul: false
+// compileViaYul: also
 // revertStrings: debug
 // ----
 // t(uint256) -> FAILURE, hex"08c379a0", 0x20, 34, "ABI decoding: tuple data too sho", "rt"

--- a/test/libsolidity/semanticTests/structs/struct_memory_to_storage_function_ptr.sol
+++ b/test/libsolidity/semanticTests/structs/struct_memory_to_storage_function_ptr.sol
@@ -28,6 +28,6 @@ contract C {
 }
 
 // ====
-// compileViaYul: false
+// compileViaYul: also
 // ----
 // f() -> 42, 23, 34, 42, 42

--- a/test/libsolidity/semanticTests/structs/struct_storage_to_memory_function_ptr.sol
+++ b/test/libsolidity/semanticTests/structs/struct_storage_to_memory_function_ptr.sol
@@ -27,6 +27,6 @@ contract C {
 }
 
 // ====
-// compileViaYul: false
+// compileViaYul: also
 // ----
 // f() -> 42, 23, 34, 42, 42


### PR DESCRIPTION
The modifiers ones are likely correctly disabled, as some semantic differences are present. We should however verify these tests one by one.