### PR TITLE
Use committer date in CI build version strings on Windows

### DIFF
--- a/.circleci/build_win.ps1
+++ b/.circleci/build_win.ps1
@@ -10,7 +10,7 @@ else {
 	# Use last commit date rather than build date to avoid ending up with builds for
 	# different platforms having different version strings (and therefore producing different bytecode)
 	# if the CI is triggered just before midnight.
-	$last_commit_timestamp = git log -1 --date=unix --format=%ad HEAD
+	$last_commit_timestamp = git log -1 --date=unix --format=%cd HEAD
 	$last_commit_date = (Get-Date -Date "1970-01-01 00:00:00Z").toUniversalTime().addSeconds($last_commit_timestamp).ToString("yyyy.M.d")
 	-join("ci.", $last_commit_date) | out-file -encoding ascii prerelease.txt
 }


### PR DESCRIPTION
Related to #10771. Fixes #10772.

In #10772 I followed @ekpyron's suggestion and used git command with `%cm` format (rather than my initial `%am`) but then I had to revert to my original fix on Windows and then forgot to swtch to `%cm` in it too. This PR fixes that.

Of the two, I think that the committer date is preferable. The commit can change during rebase after all. Also the moment of the last rebase changes more often and is closer to the current time.