### PR TITLE
Replace "pragma experimental ABIEncoderV2" in tests where appropriate

### DIFF
--- a/test/libsolidity/semanticTests/enums/enum_with_256_members.sol
+++ b/test/libsolidity/semanticTests/enums/enum_with_256_members.sol
@@ -1,5 +1,4 @@
-pragma experimental ABIEncoderV2;
-
+pragma abicoder v2;
 enum E {
     E000, E001, E002, E003, E004, E005, E006, E007, E008, E009,
     E010, E011, E012, E013, E014, E015, E016, E017, E018, E019,

--- a/test/libsolidity/semanticTests/types/mapping_enum_key_library_v2.sol
+++ b/test/libsolidity/semanticTests/types/mapping_enum_key_library_v2.sol
@@ -1,4 +1,4 @@
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 enum E { A, B, C }
 library L {

--- a/test/libsolidity/semanticTests/types/mapping_enum_key_v2.sol
+++ b/test/libsolidity/semanticTests/types/mapping_enum_key_v2.sol
@@ -1,4 +1,4 @@
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 enum E { A, B, C }
 contract test {
     mapping(E => uint8) table;

--- a/test/libsolidity/smtCheckerTests/special/abi_decode_memory_v2.sol
+++ b/test/libsolidity/smtCheckerTests/special/abi_decode_memory_v2.sol
@@ -1,5 +1,5 @@
 pragma experimental SMTChecker;
-pragma experimental "ABIEncoderV2";
+pragma abicoder v2;
 
 contract C {
 	struct S { uint x; uint[] b; }
@@ -8,9 +8,9 @@ contract C {
 	}
 }
 // ----
-// Warning 8364: (231-237): Assertion checker does not yet implement type type(uint256[] memory)
-// Warning 8364: (231-240): Assertion checker does not yet implement type type(uint256[] memory[2] memory)
-// Warning 8364: (221-222): Assertion checker does not yet implement type type(struct C.S storage pointer)
-// Warning 8364: (231-237): Assertion checker does not yet implement type type(uint256[] memory)
-// Warning 8364: (231-240): Assertion checker does not yet implement type type(uint256[] memory[2] memory)
-// Warning 8364: (221-222): Assertion checker does not yet implement type type(struct C.S storage pointer)
+// Warning 8364: (215-221): Assertion checker does not yet implement type type(uint256[] memory)
+// Warning 8364: (215-224): Assertion checker does not yet implement type type(uint256[] memory[2] memory)
+// Warning 8364: (205-206): Assertion checker does not yet implement type type(struct C.S storage pointer)
+// Warning 8364: (215-221): Assertion checker does not yet implement type type(uint256[] memory)
+// Warning 8364: (215-224): Assertion checker does not yet implement type type(uint256[] memory[2] memory)
+// Warning 8364: (205-206): Assertion checker does not yet implement type type(struct C.S storage pointer)

--- a/test/libsolidity/smtCheckerTests/special/abi_decode_memory_v2_value_types.sol
+++ b/test/libsolidity/smtCheckerTests/special/abi_decode_memory_v2_value_types.sol
@@ -1,5 +1,5 @@
 pragma experimental SMTChecker;
-pragma experimental "ABIEncoderV2";
+pragma abicoder v2;
 
 contract C {
 	function f(bytes memory data) public pure {
@@ -9,5 +9,5 @@ contract C {
 	}
 }
 // ----
-// Warning 2072: (139-146): Unused local variable.
-// Warning 2072: (194-201): Unused local variable.
+// Warning 2072: (123-130): Unused local variable.
+// Warning 2072: (178-185): Unused local variable.

--- a/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse.sol
@@ -1,4 +1,4 @@
 pragma abicoder v1;
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 // ----
-// SyntaxError 8273: (20-53): ABI coder v1 has already been selected through "pragma abicoder v1".
+// SyntaxError 3845: (20-39): ABI coder has already been selected for this source unit.

--- a/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse_experimental.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse_experimental.sol
@@ -1,0 +1,4 @@
+pragma abicoder v1;
+pragma experimental ABIEncoderV2;
+// ----
+// SyntaxError 8273: (20-53): ABI coder v1 has already been selected through "pragma abicoder v1".

--- a/test/libsolidity/syntaxTests/abiEncoder/select_v1_quoted_string.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/select_v1_quoted_string.sol
@@ -1,0 +1,1 @@
+pragma abicoder "v1";

--- a/test/libsolidity/syntaxTests/abiEncoder/select_v2_quoted_string.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/select_v2_quoted_string.sol
@@ -1,0 +1,1 @@
+pragma abicoder "v2";

--- a/test/libsolidity/syntaxTests/metaTypes/super_name.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/super_name.sol
@@ -1,4 +1,4 @@
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 function compareStrings(string memory s1, string memory s2) returns (bool) {
     return keccak256(abi.encodePacked(s1)) == keccak256(abi.encodePacked(s2));
@@ -50,4 +50,4 @@ contract D is B, C {
     }
 }
 // ----
-// TypeError 4259: (440-445): Invalid type for argument in the function call. A contract type or an integer type is required, but type(contract super B) provided.
+// TypeError 4259: (426-431): Invalid type for argument in the function call. A contract type or an integer type is required, but type(contract super B) provided.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_memory_v2.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_memory_v2.sol
@@ -1,5 +1,4 @@
-pragma experimental "ABIEncoderV2";
-
+pragma abicoder v2;
 contract C {
   struct S { uint x; uint[] b; }
   function f() public pure returns (S memory, bytes memory, uint[][2] memory) {


### PR DESCRIPTION
And add a few tests for "pragma abicoder".

Pulled out of #10643