### PR TITLE
Implemented a shortcut  for ``address.code.length`` that generates ``…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 Compiler Features:
  * Build system: Update the soljson.js build to emscripten 2.0.12 and boost 1.75.0.
+ * Code Generator: Reduce the cost of ``<address>.code.length`` by using ``extcodesize`` directly.
  * Command Line Interface: Allow "=" as separator between library name and address in ``--libraries`` commandline option.
  * Command Line Interface: New option ``--model-checker-targets`` allows specifying which targets should be checked. The valid options are ``all``, ``constantCondition``, ``underflow``, ``overflow``, ``divByZero``, ``balance``, ``assert``, ``popEmptyArray``, where the default is ``all``. Multiple targets can be chosen at the same time, separated by a comma without spaces: ``underflow,overflow,assert``.
  * Command Line Interface: Only accept the library address that is prefixed with "0x" in ``--libraries`` commandline option.

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -87,6 +87,7 @@ public:
 	bool visit(BinaryOperation const& _binOp) override;
 	void endVisit(FunctionCall const& _funCall) override;
 	void endVisit(FunctionCallOptions const& _funCallOptions) override;
+	bool visit(MemberAccess const& _memberAccess) override;
 	void endVisit(MemberAccess const& _memberAccess) override;
 	bool visit(InlineAssembly const& _inlineAsm) override;
 	void endVisit(IndexAccess const& _indexAccess) override;

--- a/test/libsolidity/semanticTests/various/code_length.sol
+++ b/test/libsolidity/semanticTests/various/code_length.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0
+contract C {
+    uint len1;
+    uint len2;
+    constructor() {
+        uint mem_ptr_before;
+        uint mem_ptr_after;
+
+        assembly {
+            mem_ptr_before := mload(64)
+        }
+
+        len1 = address(0).code.length;
+
+        assembly {
+            mem_ptr_after := mload(64)
+        }
+
+        // To check that no memory was allocated and written.
+        assert(mem_ptr_before == mem_ptr_after);
+
+        len2 = address(this).code.length;
+
+        // To check that no memory was allocated and written.
+        assembly {
+            mem_ptr_after := mload(64)
+        }
+
+        assert(mem_ptr_before == mem_ptr_after);
+
+    }
+
+    function f() public view returns (bool r1, bool r2) {
+        uint mem_ptr_before;
+        uint mem_ptr_after;
+
+        assembly {
+            mem_ptr_before := mload(64)
+        }
+
+        r1 = address(this).code.length > 50;
+
+        assembly {
+            mem_ptr_after := mload(64)
+        }
+
+        // To check that no memory was allocated and written.
+        assert(mem_ptr_before == mem_ptr_after);
+
+        address a = address(0);
+        r2 = a.code.length == 0;
+
+        // To check that no memory was allocated and written.
+        assembly {
+            mem_ptr_after := mload(64)
+        }
+
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// constructor()
+// f(): true, true -> true, true

--- a/test/libsolidity/semanticTests/various/code_length_contract_member.sol
+++ b/test/libsolidity/semanticTests/various/code_length_contract_member.sol
@@ -1,0 +1,17 @@
+// Test to see if type.code.length does extcodesize(type) only when type is an address.
+struct S {
+    bytes32 code;
+    bytes32 another;
+}
+
+contract C {
+    S s;
+
+    function f() public returns (uint, uint, bool) {
+        return (s.code.length, s.another.length, address(this).code.length > 50);
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 0x20, 0x20, true


### PR DESCRIPTION
…extcodesize(address)``.

Closes https://github.com/ethereum/solidity/issues/10778

For the Yul codegen, not sure what should be done. Is this supposed to be dealt by the optimizer?