### PR TITLE
Properly omit require revert strings in IR code generator if requested.

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1057,7 +1057,10 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		solAssert(arguments.size() > 0, "Expected at least one parameter for require/assert");
 		solAssert(arguments.size() <= 2, "Expected no more than two parameters for require/assert");
 
-		Type const* messageArgumentType = arguments.size() > 1 ? arguments[1]->annotation().type : nullptr;
+		Type const* messageArgumentType =
+			arguments.size() > 1 && m_context.revertStrings() != RevertStrings::Strip ?
+			arguments[1]->annotation().type :
+			nullptr;
 		string requireOrAssertFunction = m_utils.requireOrAssertFunction(
 			functionType->kind() == FunctionType::Kind::Assert,
 			messageArgumentType

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -5696,29 +5696,32 @@ BOOST_AUTO_TEST_CASE(strip_reason_strings)
 			}
 		}
 	)";
-	m_revertStrings = RevertStrings::Default;
-	compileAndRun(sourceCode, 0, "C");
+	ALSO_VIA_YUL(
+		DISABLE_EWASM_TESTRUN()
+		m_revertStrings = RevertStrings::Default;
+		compileAndRun(sourceCode, 0, "C");
 
-	if (
-		m_optimiserSettings == OptimiserSettings::minimal() ||
-		m_optimiserSettings == OptimiserSettings::none()
+		if (
+			m_optimiserSettings == OptimiserSettings::minimal() ||
+			m_optimiserSettings == OptimiserSettings::none()
+		)
+			// check that the reason string IS part of the binary.
+			BOOST_CHECK(toHex(m_output).find("736f6d6520726561736f6e") != std::string::npos);
+
+		m_revertStrings = RevertStrings::Strip;
+		compileAndRun(sourceCode, 0, "C");
+		// check that the reason string is NOT part of the binary.
+		BOOST_CHECK(toHex(m_output).find("736f6d6520726561736f6e") == std::string::npos);
+
+		ABI_CHECK(callContractFunction("f(bool)", true), encodeArgs(7));
+		ABI_CHECK(callContractFunction("f(bool)", false), encodeArgs());
+		ABI_CHECK(callContractFunction("g(bool)", true), encodeArgs(8));
+		ABI_CHECK(callContractFunction("g(bool)", false), encodeArgs());
+		ABI_CHECK(callContractFunction("f1(bool)", true), encodeArgs(9));
+		ABI_CHECK(callContractFunction("f1(bool)", false), encodeArgs());
+		ABI_CHECK(callContractFunction("g1(bool)", true), encodeArgs(10));
+		ABI_CHECK(callContractFunction("g1(bool)", false), encodeArgs());
 	)
-		// check that the reason string IS part of the binary.
-		BOOST_CHECK(toHex(m_output).find("736f6d6520726561736f6e") != std::string::npos);
-
-	m_revertStrings = RevertStrings::Strip;
-	compileAndRun(sourceCode, 0, "C");
-	// check that the reason string is NOT part of the binary.
-	BOOST_CHECK(toHex(m_output).find("736f6d6520726561736f6e") == std::string::npos);
-
-	ABI_CHECK(callContractFunction("f(bool)", true), encodeArgs(7));
-	ABI_CHECK(callContractFunction("f(bool)", false), encodeArgs());
-	ABI_CHECK(callContractFunction("g(bool)", true), encodeArgs(8));
-	ABI_CHECK(callContractFunction("g(bool)", false), encodeArgs());
-	ABI_CHECK(callContractFunction("f1(bool)", true), encodeArgs(9));
-	ABI_CHECK(callContractFunction("f1(bool)", false), encodeArgs());
-	ABI_CHECK(callContractFunction("g1(bool)", true), encodeArgs(10));
-	ABI_CHECK(callContractFunction("g1(bool)", false), encodeArgs());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/7451