### PR TITLE
Fix missing error when accessing unintialized variables. (backported to 0.7)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+### 0.7.7 (unreleased)
+
+Bugfixes:
+ * Control Flow Graph: Fix missing error caused by read from/write to uninitialized variables.
+
 ### 0.7.6 (2020-12-16)
 
 Language Features:

--- a/libsolidity/analysis/ControlFlowAnalyzer.cpp
+++ b/libsolidity/analysis/ControlFlowAnalyzer.cpp
@@ -110,8 +110,12 @@ void ControlFlowAnalyzer::checkUninitializedAccess(CFGNode const* _entry, CFGNod
 
 		// Propagate changes to all exits and queue them for traversal, if needed.
 		for (auto const& exit: currentNode->exits)
-			if (nodeInfos[exit].propagateFrom(nodeInfo))
+		{
+			bool exists = nodeInfos.find(exit) != nodeInfos.end();
+
+			if (nodeInfos[exit].propagateFrom(nodeInfo) || !exists)
 				nodesToTraverse.insert(exit);
+		}
 	}
 
 	auto const& exitInfo = nodeInfos[_exit];

--- a/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-for.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-for.sol
@@ -1,0 +1,9 @@
+contract Test {
+	function testFunc() external {
+		for (;;) {}
+		bytes storage b;
+		b[0] = 0x42;
+	}
+}
+// ----
+// TypeError 3464: (83-84): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-if.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-if.sol
@@ -1,0 +1,13 @@
+contract Test {
+
+  struct Sample { bool flag; }
+  Sample public s;
+
+   function testFunc() external {
+        if(true){}
+        Sample storage t;
+        t.flag=true;
+    }
+}
+// ----
+// TypeError 3464: (155-156): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-modifier.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-modifier.sol
@@ -1,0 +1,16 @@
+contract Test {
+
+  struct Sample { bool flag; }
+  Sample public s;
+
+  modifier checkAddr(address _a){
+      require(_a!=address(0));
+      _;
+  }
+  function testFunc(address _a) external checkAddr(_a) {
+        Sample storage t;
+        t.flag=true;
+    }
+}
+// ----
+// TypeError 3464: (237-238): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-require.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-require.sol
@@ -1,0 +1,9 @@
+contract Test {
+	function testFunc() external {
+		require(true);
+		bytes storage b;
+		b[0] = 0x42;
+	}
+}
+// ----
+// TypeError 3464: (86-87): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-while.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/uninitializedAccess/bug10821-while.sol
@@ -1,0 +1,9 @@
+contract Test {
+	function testFunc() external {
+		while (true) {}
+		bytes storage b;
+		b[0] = 0x42;
+	}
+}
+// ----
+// TypeError 3464: (87-88): This variable is of storage pointer type and can be accessed without prior assignment, which would lead to undefined behaviour.


### PR DESCRIPTION
fixes issue #10821 for 0.7