### PR TITLE
More robust interactive mode in command-line tests

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -87,12 +87,16 @@ function ask_expectation_update
         then
             update_expectation "$newExpectation" "$expectationFile"
         else
+            local editor="${FCEDIT:-${VISUAL:-${EDITOR:-vi}}}"
+
             while true
             do
-                read -N 1 -p "(u)pdate expectation/(q)uit? "
+                read -N 1 -p "(e)dit/(u)pdate expectations/(s)kip/(q)uit? "
                 echo
                 case $REPLY in
+                    e*) "$editor" "$expectationFile"; break;;
                     u*) update_expectation "$newExpectation" "$expectationFile"; break;;
+                    s*) return;;
                     q*) exit 1;;
                 esac
             done


### PR DESCRIPTION
Depends on #10814.

Adds two more improvements:
- You can now skip the test or launch an editor to edit the expectation file, just like with isoltest.
- Mismatched exit code no longer unconditionally ends the script.
    - You can now choose to change the expectation or skip it, just like in other cases.
    - Without this change the autoupdate feature was not fully automatic because it stopped on invalid exit codes.
    - I think that the original intention for the unconditional exit might have been that in most cases we're testing the positive case and non-zero exit code indicates some serious problem. I usually test error conditions though and not being able to update the expectation is annoying.