### PR TITLE
Fix inheritance bug in CHC cex

### DIFF
--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -937,9 +937,9 @@ SortPointer CHC::sort(ASTNode const* _node)
 	return functionBodySort(*m_currentFunction, m_currentContract, state());
 }
 
-Predicate const* CHC::createSymbolicBlock(SortPointer _sort, string const& _name, PredicateType _predType, ASTNode const* _node)
+Predicate const* CHC::createSymbolicBlock(SortPointer _sort, string const& _name, PredicateType _predType, ASTNode const* _node, ContractDefinition const* _contractContext)
 {
-	auto const* block = Predicate::create(_sort, _name, _predType, m_context, _node);
+	auto const* block = Predicate::create(_sort, _name, _predType, m_context, _node, _contractContext);
 	m_interface->registerRelation(block->functor());
 	return block;
 }
@@ -1082,7 +1082,8 @@ Predicate const* CHC::createBlock(ASTNode const* _node, PredicateType _predType,
 		sort(_node),
 		"block_" + uniquePrefix() + "_" + _prefix + predicateName(_node),
 		_predType,
-		_node
+		_node,
+		m_currentContract
 	);
 
 	solAssert(m_currentFunction, "");
@@ -1095,7 +1096,8 @@ Predicate const* CHC::createSummaryBlock(FunctionDefinition const& _function, Co
 		functionSort(_function, &_contract, state()),
 		"summary_" + uniquePrefix() + "_" + predicateName(&_function, &_contract),
 		_type,
-		&_function
+		&_function,
+		&_contract
 	);
 }
 
@@ -1105,6 +1107,7 @@ Predicate const* CHC::createConstructorBlock(ContractDefinition const& _contract
 		constructorSort(_contract, state()),
 		_prefix + "_" + contractSuffix(_contract) + "_" + uniquePrefix(),
 		PredicateType::ConstructorSummary,
+		&_contract,
 		&_contract
 	);
 }

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -126,7 +126,7 @@ private:
 	/// Predicate helpers.
 	//@{
 	/// @returns a new block of given _sort and _name.
-	Predicate const* createSymbolicBlock(smtutil::SortPointer _sort, std::string const& _name, PredicateType _predType, ASTNode const* _node = nullptr);
+	Predicate const* createSymbolicBlock(smtutil::SortPointer _sort, std::string const& _name, PredicateType _predType, ASTNode const* _node = nullptr, ContractDefinition const* _contractContext = nullptr);
 
 	/// Creates summary predicates for all functions of all contracts
 	/// in a given _source.

--- a/libsolidity/formal/Predicate.h
+++ b/libsolidity/formal/Predicate.h
@@ -55,13 +55,15 @@ public:
 		std::string _name,
 		PredicateType _type,
 		smt::EncodingContext& _context,
-		ASTNode const* _node = nullptr
+		ASTNode const* _node = nullptr,
+		ContractDefinition const* _contractContext = nullptr
 	);
 
 	Predicate(
 		smt::SymbolicFunctionVariable&& _predicate,
 		PredicateType _type,
-		ASTNode const* _node = nullptr
+		ASTNode const* _node = nullptr,
+		ContractDefinition const* _contractContext = nullptr
 	);
 
 	/// Predicate should not be copiable.
@@ -165,6 +167,12 @@ private:
 	/// The ASTNode that this predicate represents.
 	/// nullptr if this predicate is not associated with a specific program AST node.
 	ASTNode const* m_node = nullptr;
+
+	/// The ContractDefinition that contains this predicate.
+	/// nullptr if this predicate is not associated with a specific contract.
+	/// This is unfortunately necessary because of virtual resolution for
+	/// function nodes.
+	ContractDefinition const* m_contractContext = nullptr;
 
 	/// Maps the name of the predicate to the actual Predicate.
 	/// Used in counterexample generation.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_1.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_1.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+
+contract B {
+	uint x;
+	function f() public view {
+		assert(x == 0);
+	}
+}
+
+contract C is B {
+	uint y;
+	function g() public {
+		x = 1;
+		f();
+	}
+}
+// ----
+// Warning 6328: (85-99): CHC: Assertion violation happens here.\nCounterexample:\ny = 0, x = 1\n\nTransaction trace:\nC.constructor()\nState: y = 0, x = 0\nC.g()\n    B.f() -- internal call\nState: y = 0, x = 1\nB.f()

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_2.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_2.sol
@@ -1,0 +1,25 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() internal view {
+		assert(x == 0);
+	}
+}
+
+contract B is A {
+	uint a;
+	uint b;
+}
+
+contract C is B {
+	uint y;
+	uint z;
+	uint w;
+	function g() public {
+		x = 1;
+		f();
+	}
+}
+// ----
+// Warning 6328: (87-101): CHC: Assertion violation happens here.\nCounterexample:\ny = 0, z = 0, w = 0, a = 0, b = 0, x = 1\n\nTransaction trace:\nC.constructor()\nState: y = 0, z = 0, w = 0, a = 0, b = 0, x = 0\nC.g()\n    A.f() -- internal call


### PR DESCRIPTION
The added tests used to throw because the wrong scope contract was taken into account,