### PR TITLE
Bump docker images for z3 4.8.10

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -29,12 +29,12 @@
 #   make version=2.0.12 build
 #
 FROM emscripten/emsdk:2.0.12 AS base
-LABEL version="3"
+LABEL version="4"
 
 ADD emscripten.jam /usr/src
 RUN set -ex; \
 	cd /usr/src; \
-	git clone https://github.com/Z3Prover/z3.git -b z3-4.8.9 --depth 1 ; \
+	git clone https://github.com/Z3Prover/z3.git -b z3-4.8.10 --depth 1 ; \
 	cd z3; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang as base
-LABEL version="7"
+LABEL version="8"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -60,7 +60,7 @@ RUN set -ex; \
 
 # Z3
 RUN set -ex; \
-    git clone --depth 1 -b z3-4.8.9 https://github.com/Z3Prover/z3.git \
+    git clone --depth 1 -b z3-4.8.10 https://github.com/Z3Prover/z3.git \
     /usr/src/z3; \
     cd /usr/src/z3; \
     mkdir build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="4"
+LABEL version="5"
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="4"
+LABEL version="5"
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Once the images are built, their hashes will be used by the PR that updates the tests.