### PR TITLE
[SMTChecker] Fix buggy virtual and super

### DIFF
--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -74,7 +74,13 @@ public:
 	std::vector<std::string> unhandledQueries() { return m_interface->unhandledQueries(); }
 
 	/// @returns true if _funCall should be inlined, otherwise false.
-	static bool shouldInlineFunctionCall(FunctionCall const& _funCall, ContractDefinition const* _contract);
+	/// @param _scopeContract The contract that contains the current function being analyzed.
+	/// @param _contextContract The most derived contract, currently being analyzed.
+	static bool shouldInlineFunctionCall(
+		FunctionCall const& _funCall,
+		ContractDefinition const* _scopeContract,
+		ContractDefinition const* _contextContract
+	);
 
 private:
 	/// AST visitors.

--- a/libsolidity/formal/VariableUsage.cpp
+++ b/libsolidity/formal/VariableUsage.cpp
@@ -60,11 +60,9 @@ void VariableUsage::endVisit(IndexAccess const& _indexAccess)
 
 void VariableUsage::endVisit(FunctionCall const& _funCall)
 {
-	if (m_inlineFunctionCalls(_funCall, m_currentContract))
-		if (
-			auto [funDef, contextContract] = SMTEncoder::functionCallToDefinition(_funCall, m_currentContract);
-			funDef
-		)
+	auto scopeContract = m_currentFunction->annotation().contract;
+	if (m_inlineFunctionCalls(_funCall, scopeContract, m_currentContract))
+		if (auto funDef = SMTEncoder::functionCallToDefinition(_funCall, scopeContract, m_currentContract))
 			if (find(m_callStack.begin(), m_callStack.end(), funDef) == m_callStack.end())
 				funDef->accept(*this);
 }

--- a/libsolidity/formal/VariableUsage.h
+++ b/libsolidity/formal/VariableUsage.h
@@ -36,9 +36,10 @@ public:
 	std::set<VariableDeclaration const*> touchedVariables(ASTNode const& _node, std::vector<CallableDeclaration const*> const& _outerCallstack);
 
 	/// Sets whether to inline function calls.
-	void setFunctionInlining(std::function<bool(FunctionCall const&, ContractDefinition const*)> _inlineFunctionCalls) { m_inlineFunctionCalls = _inlineFunctionCalls; }
+	void setFunctionInlining(std::function<bool(FunctionCall const&, ContractDefinition const*, ContractDefinition const*)> _inlineFunctionCalls) { m_inlineFunctionCalls = _inlineFunctionCalls; }
 
 	void setCurrentContract(ContractDefinition const& _contract) { m_currentContract = &_contract; }
+	void setCurrentFunction(FunctionDefinition const& _function) { m_currentFunction = &_function; }
 
 private:
 	void endVisit(Identifier const& _node) override;
@@ -56,8 +57,9 @@ private:
 	std::vector<CallableDeclaration const*> m_callStack;
 	CallableDeclaration const* m_lastCall = nullptr;
 	ContractDefinition const* m_currentContract = nullptr;
+	FunctionDefinition const* m_currentFunction = nullptr;
 
-	std::function<bool(FunctionCall const&, ContractDefinition const*)> m_inlineFunctionCalls = [](FunctionCall const&, ContractDefinition const*) { return false; };
+	std::function<bool(FunctionCall const&, ContractDefinition const*, ContractDefinition const*)> m_inlineFunctionCalls = [](FunctionCall const&, ContractDefinition const*, ContractDefinition const*) { return false; };
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/imports/import_base.sol
+++ b/test/libsolidity/smtCheckerTests/imports/import_base.sol
@@ -20,9 +20,9 @@ contract Der is Base {
 // ====
 // SMTIgnoreCex: yes
 // ----
+// Warning 4984: (base:100-103): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
 // Warning 4984: (der:101-109): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
 // Warning 6328: (der:113-126): CHC: Assertion violation happens here.
-// Warning 4984: (base:100-103): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
+// Warning 2661: (base:100-103): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 2661: (base:100-103): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 2661: (der:101-109): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
-// Warning 2661: (base:100-103): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_3.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_3.sol
@@ -1,0 +1,31 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() internal virtual {
+		v();
+		assert(x == 0); // should fail
+		assert(x == 2); // should hold
+	}
+	function v() internal virtual {
+		x = 0;
+	}
+}
+
+contract B is A {
+	function f() internal virtual override {
+		super.f();
+	}
+}
+
+contract C is B {
+	function g() public {
+		x = 1;
+		f();
+	}
+	function v() internal override {
+		x = 2;
+	}
+}
+// ----
+// Warning 6328: (97-111): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    B.f() -- internal call\n        A.f() -- internal call\n            C.v() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_4.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_4.sol
@@ -1,0 +1,38 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() internal virtual {
+		v();
+		assert(x == 0); // should fail
+		assert(x == 2); // should hold
+	}
+	function v() internal virtual {
+		x = 0;
+	}
+}
+contract A1 is A {
+	function f() internal virtual override {
+		super.f();
+	}
+}
+contract B is A {
+	function f() internal virtual override {
+		super.f();
+	}
+}
+
+contract C is B, A1 {
+	function g() public {
+		x = 1;
+		f();
+	}
+	function f() internal override(B, A1) {
+		super.f();
+	}
+	function v() internal override {
+		x = 2;
+	}
+}
+// ----
+// Warning 6328: (97-111): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    C.f() -- internal call\n        A1.f() -- internal call\n            B.f() -- internal call\n                A.f() -- internal call\n                    C.v() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_5.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_5.sol
@@ -1,0 +1,32 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() internal virtual {
+		v();
+		assert(x == 0); // should hold
+		assert(x == 2); // should fail
+	}
+	function v() internal virtual {
+		x = 0;
+	}
+}
+
+contract B is A {
+	function f() internal virtual override {
+		super.f();
+	}
+}
+
+contract C is B {
+	function g() public {
+		x = 1;
+		f();
+	}
+	function v() internal override {
+		x = 2;
+		super.v();
+	}
+}
+// ----
+// Warning 6328: (130-144): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    B.f() -- internal call\n        A.f() -- internal call\n            C.v() -- internal call\n                A.v() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_6.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_6.sol
@@ -1,0 +1,34 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() internal virtual {
+		v();
+		assert(x == 2); // should hold
+	}
+	function v() internal virtual {
+		x = 0;
+	}
+	function g() public virtual {
+		v();
+		assert(x == 2); // should fail
+	}
+}
+
+contract B is A {
+	function f() internal virtual override {
+		super.f();
+	}
+}
+
+contract C is B {
+	function g() public override {
+		x = 1;
+		f();
+	}
+	function v() internal override {
+		x = 2;
+	}
+}
+// ----
+// Warning 6328: (216-230): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nA.constructor()\nState: x = 0\nA.g()\n    A.v() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_7.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_7.sol
@@ -1,0 +1,25 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() internal {
+		v();
+		assert(x == 0); // should fail
+		assert(x == 2); // should hold
+	}
+	function v() internal virtual {
+		x = 0;
+	}
+}
+
+contract C is A {
+	function g() public {
+		x = 1;
+		f();
+	}
+	function v() internal override {
+		x = 2;
+	}
+}
+// ----
+// Warning 6328: (89-103): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    A.f() -- internal call\n        C.v() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_8.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_8.sol
@@ -1,0 +1,18 @@
+pragma experimental SMTChecker;
+
+abstract contract A {
+	uint x;
+	function f() public view {
+		assert(x == 2);
+	}
+}
+
+contract C is  A {
+	function g() public {
+		x = 2;
+		f();
+		x = 0;
+	}
+}
+// ----
+// Warning 6328: (94-108): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nA.constructor()\nState: x = 0\nA.f()

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_9.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_9.sol
@@ -1,0 +1,32 @@
+pragma experimental SMTChecker;
+
+contract A {
+	uint x;
+	function f() public virtual {
+		v();
+		assert(x == 0); // should fail when C is the most derived contract
+		assert(x == 2); // should fail when A is the most derived contract
+	}
+	function v() internal virtual {
+		x = 0;
+	}
+}
+
+contract B is A {
+	function f() public virtual override {
+		super.f();
+	}
+}
+
+contract C is B {
+	function g() public {
+		x = 1;
+		f();
+	}
+	function v() internal override {
+		x = 2;
+	}
+}
+// ----
+// Warning 6328: (164-178): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nA.constructor()\nState: x = 0\nA.f()\n    A.v() -- internal call
+// Warning 6328: (95-109): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nB.f()\n    A.f() -- internal call\n        C.v() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/diamond_super_1.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/diamond_super_1.sol
@@ -1,0 +1,31 @@
+pragma experimental SMTChecker;
+contract A {
+	function f() public virtual returns (uint256 r) {
+		return 1;
+	}
+}
+
+
+contract B is A {
+	function f() public virtual override returns (uint256 r) {
+		return super.f() + 2;
+	}
+}
+
+
+contract C is A {
+	function f() public virtual override returns (uint256 r) {
+		return super.f() + 4;
+	}
+}
+
+
+contract D is B, C {
+	function f() public override(B, C) returns (uint256 r) {
+		r = super.f() + 8;
+		assert(r == 15); // should hold
+		assert(r == 13); // should fail
+	}
+}
+// ----
+// Warning 6328: (469-484): CHC: Assertion violation happens here.\nCounterexample:\n\nr = 15\n\nTransaction trace:\nD.constructor()\nD.f()\n    C.f() -- internal call\n        B.f() -- internal call\n            A.f() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/diamond_super_2.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/diamond_super_2.sol
@@ -1,0 +1,33 @@
+pragma experimental SMTChecker;
+contract A {
+	function f() public virtual returns (uint256 r) {
+		return 1;
+	}
+}
+
+
+contract B is A {
+	function f() public virtual override returns (uint256 r) {
+		return super.f() + 2;
+	}
+}
+
+
+contract C is A {
+	function f() public virtual override returns (uint256 r) {
+		return 2 * (super.f() + 4);
+	}
+}
+
+
+contract D is B, C {
+	function f() public override(B, C) returns (uint256 r) {
+		r = super.f() + 8;
+		assert(r == 22); // should hold
+		assert(r == 20); // should fail
+		assert(r == 18); // should fail
+	}
+}
+// ----
+// Warning 6328: (475-490): CHC: Assertion violation happens here.\nCounterexample:\n\nr = 22\n\nTransaction trace:\nD.constructor()\nD.f()\n    C.f() -- internal call\n        B.f() -- internal call\n            A.f() -- internal call
+// Warning 6328: (509-524): CHC: Assertion violation happens here.\nCounterexample:\n\nr = 22\n\nTransaction trace:\nD.constructor()\nD.f()\n    C.f() -- internal call\n        B.f() -- internal call\n            A.f() -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/diamond_super_3.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/diamond_super_3.sol
@@ -1,0 +1,35 @@
+pragma experimental SMTChecker;
+
+contract A {
+	int public x;
+	function f() public virtual {
+		x = 1;
+	}
+}
+
+contract B is A {
+	function f() public virtual override {
+		super.f();
+		x += 100;
+	}
+}
+
+contract C is B {
+	function f() public virtual override {
+		super.f();
+		x += 10;
+	}
+}
+
+contract D is B {
+}
+
+contract E is C,D {
+	function f() public override(C,B) {
+		super.f();
+		assert(x == 111); // should hold
+		assert(x == 13); // should fail
+	}
+}
+// ----
+// Warning 6328: (412-427): CHC: Assertion violation happens here.\nCounterexample:\nx = 111\n\nTransaction trace:\nE.constructor()\nState: x = 0\nE.f()\n    C.f() -- internal call\n        B.f() -- internal call\n            A.f() -- internal call


### PR DESCRIPTION
Virtual and super resolution were not taking the correct contracts into account.
To support that properly in CHC we need a full CFG encoding of every function of every base contract to also be part of the most derived contract. Now, `SMTEncoder::contractFunctions` (1) returns the functions of a contract including inherited functions, after override resolution, and `SMTEncoder::contractFunctionsWithoutVirtual` (2) returns ALL the functions of ALL base contracts. Only functions in (1) can be an entry point for the most derived contract.