### PR TITLE
Fix badly placed comment in build_emscripten.sh

### DIFF
--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -34,7 +34,7 @@ else
     BUILD_DIR="$1"
 fi
 
+# solbuildpackpusher/solidity-buildpack-deps:emscripten-4
 docker run -v $(pwd):/root/project -w /root/project \
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-4
     solbuildpackpusher/solidity-buildpack-deps@sha256:434719d8104cab47712dd1f56f255994d04eb65b802c0d382790071c1a0c074b \
     ./scripts/ci/build_emscripten.sh $BUILD_DIR


### PR DESCRIPTION
Fixes a comment inserted in the wrong place in #10845. This broke today's nightly build in solc-bin.