### PR TITLE
[isoltest] Add support for builtin functions.

### DIFF
--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -58,6 +58,7 @@ public:
 	/// Compiles and deploys currently held source.
 	/// Returns true if deployment was successful, false otherwise.
 	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments, std::map<std::string, solidity::test::Address> const& _libraries = {});
+
 private:
 	TestResult runTest(std::ostream& _stream, std::string const& _linePrefix, bool _formatted, bool _compileViaYul, bool _compileToEwasm);
 	SourceMap m_sources;
@@ -70,6 +71,7 @@ private:
 	bool m_runWithABIEncoderV1Only = false;
 	bool m_allowNonExistingFunctions = false;
 	bool m_compileViaYulCanBeSet = false;
+	std::map<std::string, Builtin> m_builtins{};
 };
 
 }

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -17,6 +17,8 @@
 #include <libsolutil/AnsiColorized.h>
 #include <libsolutil/CommonData.h>
 
+#include <test/ExecutionFramework.h>
+
 namespace solidity::frontend::test
 {
 
@@ -174,6 +176,8 @@ struct Parameter
 };
 using ParameterList = std::vector<Parameter>;
 
+struct FunctionCall;
+
 /**
  * Represents the expected result of a function call after it has been executed. This may be a single
  * return value or a comma-separated list of return values. It also contains the detected input
@@ -193,6 +197,7 @@ struct FunctionCallExpectations
 	/// A Comment that can be attached to the expectations,
 	/// that is retained and can be displayed.
 	std::string comment;
+
 	/// ABI encoded `bytes` of parsed expected return values. It is checked
 	/// against the actual result of a function call when used in test framework.
 	bytes rawBytes() const
@@ -286,12 +291,16 @@ struct FunctionCall
 		/// Marks a library deployment call.
 		Library,
 		/// Check that the storage of the current contract is empty or non-empty.
-		Storage
+		Storage,
+		/// Call to a builtin.
+		Builtin
 	};
 	Kind kind = Kind::Regular;
 	/// Marks this function call as "short-handed", meaning
 	/// no `->` declared.
 	bool omitsArrow = true;
 };
+
+using Builtin = std::function<std::optional<bytes>(FunctionCall const&)>;
 
 }

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <libsolutil/CommonData.h>
 #include <liblangutil/Exceptions.h>
+#include <libsolutil/CommonData.h>
 #include <test/libsolidity/util/SoltestTypes.h>
 
 #include <iosfwd>
@@ -52,7 +52,7 @@ class TestFileParser
 public:
 	/// Constructor that takes an input stream \param _stream to operate on
 	/// and creates the internal scanner.
-	TestFileParser(std::istream& _stream): m_scanner(_stream) {}
+	explicit TestFileParser(std::istream& _stream, std::map<std::string, Builtin> const& _builtins): m_scanner(_stream), m_builtins(_builtins) {}
 
 	/// Parses function calls blockwise and returns a list of function calls found.
 	/// Throws an exception if a function call cannot be parsed because of its
@@ -177,12 +177,18 @@ private:
 	/// Parses the current string literal.
 	std::string parseString();
 
+	/// Checks whether a builtin function with the given signature exist.
+	/// @returns true, if builtin found, false otherwise
+	bool isBuiltinFunction(std::string const& signature);
+
 	/// A scanner instance
 	Scanner m_scanner;
 
 	/// The current line number. Incremented when Token::Newline (//) is found and
 	/// used to enhance parser error messages.
 	size_t m_lineNumber = 0;
+
+	std::map<std::string, Builtin> const& m_builtins;
 };
 
 }

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -45,7 +45,7 @@ namespace
 vector<FunctionCall> parse(string const& _source)
 {
 	istringstream stream{_source, ios_base::out};
-	TestFileParser parser{stream};
+	TestFileParser parser{stream, {}};
 	return parser.parseFunctionCalls(0);
 }
 


### PR DESCRIPTION
I extracted the builtin part from #10728. I think it is easier to review it as a separated PR. Probably we get this merged before #10728 is done.

Main motivation for this was to have an easy way to plugin new commands into isoltest, without touching the parser. This should simplify the extension of new expectation commands.

- [X] No need to specify function signature for builtin calls.
- [X] Simplified failure creation for builtins.
- [X] User defined expectation update mechanism.
  - [X] Initial working version.
  - [X] Remove Logging specific stuff.

After discussion with @christeth I removed the support to have builtin functions on the expectation side.
```
// functionCallSide -> expectationSide
```