### PR TITLE
Use Bash arrays for argument lists in shell scripts

### DIFF
--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -38,6 +38,9 @@ OPTIMIZE=${OPTIMIZE:-"0"}
 EVM=${EVM:-"invalid"}
 REPODIR="$(realpath "$(dirname "$0")/..")"
 
+IFS=" " read -r -a BOOST_TEST_ARGS <<< "$BOOST_TEST_ARGS"
+IFS=" " read -r -a SOLTEST_FLAGS <<< "$SOLTEST_FLAGS"
+
 source "${REPODIR}/scripts/common.sh"
 # Test result output directory (CircleCI is reading test results from here)
 mkdir -p test_results
@@ -53,11 +56,12 @@ get_logfile_basename() {
     echo -ne "${filename}"
 }
 
-BOOST_TEST_ARGS="--color_output=no --show_progress=yes --logger=JUNIT,error,test_results/`get_logfile_basename`.xml ${BOOST_TEST_ARGS}"
-SOLTEST_ARGS="--evm-version=$EVM $SOLTEST_FLAGS"
-test "${OPTIMIZE}" = "1" && SOLTEST_ARGS="${SOLTEST_ARGS} --optimize"
-test "${ABI_ENCODER_V1}" = "1" && SOLTEST_ARGS="${SOLTEST_ARGS} --abiencoderv1"
+BOOST_TEST_ARGS=("--color_output=no" "--show_progress=yes" "--logger=JUNIT,error,test_results/`get_logfile_basename`.xml" "${BOOST_TEST_ARGS[@]}")
+SOLTEST_ARGS=("--evm-version=$EVM" "${SOLTEST_FLAGS[@]}")
 
-echo "Running ${REPODIR}/build/test/soltest ${BOOST_TEST_ARGS} -- ${SOLTEST_ARGS}"
+test "${OPTIMIZE}" = "1" && SOLTEST_ARGS+=(--optimize)
+test "${ABI_ENCODER_V1}" = "1" && SOLTEST_ARGS+=(--abiencoderv1)
 
-"${REPODIR}/build/test/soltest" ${BOOST_TEST_ARGS} -- ${SOLTEST_ARGS}
+echo "Running ${REPODIR}/build/test/soltest ${BOOST_TEST_ARGS[*]} -- ${SOLTEST_ARGS[*]}"
+
+"${REPODIR}/build/test/soltest" "${BOOST_TEST_ARGS[@]}" -- "${SOLTEST_ARGS[@]}"

--- a/scripts/ASTImportTest.sh
+++ b/scripts/ASTImportTest.sh
@@ -37,10 +37,13 @@ fi
 # $1 name of the file to be exported and imported
 # $2 any files needed to do so that might be in parent directories
 function testImportExportEquivalence {
-    if $SOLC "$1" $2 > /dev/null 2>&1
+    local nth_input_file="$1"
+    IFS=" " read -r -a all_input_files <<< "$2"
+
+    if $SOLC "$nth_input_file" "${all_input_files[@]}" > /dev/null 2>&1
     then
         # save exported json as expected result (silently)
-        $SOLC --combined-json ast,compact-format --pretty-json "$1" $2 > expected.json 2> /dev/null
+        $SOLC --combined-json ast,compact-format --pretty-json "$nth_input_file" "${all_input_files[@]}" > expected.json 2> /dev/null
         # import it, and export it again as obtained result (silently)
         $SOLC --import-ast --combined-json ast,compact-format --pretty-json expected.json > obtained.json 2> /dev/null
         if [ $? -ne 0 ]

--- a/scripts/chk_shellscripts/ignore.txt
+++ b/scripts/chk_shellscripts/ignore.txt
@@ -1,5 +1,4 @@
 ./test/cmdlineTests.sh
-./scripts/soltest.sh
 ./scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
 ./scripts/wasm-rebuild/docker-scripts/rebuild_current.sh
 ./scripts/wasm-rebuild/docker-scripts/genbytecode.sh

--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -18,8 +18,8 @@
 # (c) 2016-2019 solidity contributors.
 # ------------------------------------------------------------------------------
 
-FULLARGS="--optimize --ignore-missing --combined-json abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
-OLDARGS="--optimize --combined-json abi,asm,ast,bin,bin-runtime,devdoc,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc"
+FULLARGS=(--optimize --ignore-missing --combined-json "abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
+OLDARGS=(--optimize --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
 function compileFull()
 {
     local expected_exit_code=0
@@ -37,23 +37,23 @@ function compileFull()
         expect_output=2
         shift;
     fi
-    local args=$FULLARGS
+    local args=("${FULLARGS[@]}")
     if [[ $1 = '-v' ]]; then
         if (echo "$2" | grep -Po '(?<=0.4.)\d+' >/dev/null); then
             patch=$(echo "$2" | grep -Po '(?<=0.4.)\d+')
             if (( patch < 22 )); then
-                args=$OLDARGS
+                args=("${OLDARGS[@]}")
             fi
         fi
         shift 2
     fi
 
-    local files="$*"
+    local files=("$@")
 
     local stderr_path=$(mktemp)
 
     set +e
-    "$SOLC" ${args} ${files} >/dev/null 2>"$stderr_path"
+    "$SOLC" "${args[@]}" "${files[@]}" >/dev/null 2>"$stderr_path"
     local exit_code=$?
     local errors=$(grep -v -E 'Warning: This is a pre-release compiler version|Warning: Experimental features are turned on|pragma experimental ABIEncoderV2|^ +--> |^ +\||^[0-9]+ +\|' < "$stderr_path")
     set -e
@@ -70,7 +70,7 @@ function compileFull()
         printError "Was failure: $exit_code"
         echo "$errors"
         printError "While calling:"
-        echo "\"$SOLC\" $args $files"
+        echo "\"$SOLC\" ${args[*]} ${files[*]}"
         printError "Inside directory:"
         pwd
         false

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -145,17 +145,17 @@ SOLTMPDIR=$(mktemp -d)
         fi
         echo "$f"
 
-        opts=''
+        opts=()
         # We expect errors if explicitly stated, or if imports
         # are used (in the style guide)
         if ( ! grep -E "This will not compile after" "$f" >/dev/null && \
             grep -E "This will not compile|import \"" "$f" >/dev/null )
         then
-            opts="-e"
+            opts=(-e)
         fi
 
         # ignore warnings in this case
-        opts="$opts -o"
+        opts+=(-o)
 
         findMinimalVersion "$f"
         if [[ "$version" == "" ]]
@@ -168,7 +168,7 @@ SOLTMPDIR=$(mktemp -d)
             continue
         fi
 
-        opts="$opts -v $version"
+        opts+=(-v "$version")
 
         solc_bin="solc-$version"
         echo "$solc_bin"
@@ -188,7 +188,7 @@ SOLTMPDIR=$(mktemp -d)
         chmod a+x solc
 
         SOLC="$SOLTMPDIR/solc"
-        compileFull $opts "$SOLTMPDIR/$f"
+        compileFull "${opts[@]}" "$SOLTMPDIR/$f"
     done
 )
 rm -rf "$SOLTMPDIR"

--- a/scripts/soltest.sh
+++ b/scripts/soltest.sh
@@ -4,8 +4,8 @@ set -e
 REPO_ROOT="$(dirname "$0")"/..
 USE_DEBUGGER=0
 DEBUGGER="gdb --args"
-BOOST_OPTIONS=
-SOLTEST_OPTIONS=
+BOOST_OPTIONS=()
+SOLTEST_OPTIONS=()
 SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 
 usage() {
@@ -41,7 +41,7 @@ do
 			;;
 		--boost-options)
 			shift
-			BOOST_OPTIONS="${BOOST_OPTIONS} $1"
+			BOOST_OPTIONS+=("$1")
 			;;
 		--help)
 			usage
@@ -49,13 +49,13 @@ do
 			;;
 		--run_test | -t )
 			shift
-			BOOST_OPTIONS="${BOOST_OPTIONS} -t $1"
+			BOOST_OPTIONS+=(-t "$1")
 			;;
 		--show-progress | -p)
-			BOOST_OPTIONS="${BOOST_OPTIONS} $1"
+			BOOST_OPTIONS+=("$1")
 			;;
 		*)
-			SOLTEST_OPTIONS="${SOLTEST_OPTIONS} $1"
+			SOLTEST_OPTIONS+=("$1")
 			;;
 	esac
 	shift
@@ -64,4 +64,4 @@ if [ "$USE_DEBUGGER" -ne "0" ]; then
 	DEBUG_PREFIX=${DEBUGGER}
 fi
 
-exec ${DEBUG_PREFIX} "${SOLIDITY_BUILD_DIR}/test/soltest" ${BOOST_OPTIONS} -- --testpath "${REPO_ROOT}/test" ${SOLTEST_OPTIONS}
+exec ${DEBUG_PREFIX} "${SOLIDITY_BUILD_DIR}/test/soltest" "${BOOST_OPTIONS[@]}" -- --testpath "${REPO_ROOT}/test" "${SOLTEST_OPTIONS[@]}"

--- a/scripts/soltest.sh
+++ b/scripts/soltest.sh
@@ -60,8 +60,12 @@ do
 	esac
 	shift
 done
-if [ "$USE_DEBUGGER" -ne "0" ]; then
-	DEBUG_PREFIX=${DEBUGGER}
-fi
 
-exec ${DEBUG_PREFIX} "${SOLIDITY_BUILD_DIR}/test/soltest" "${BOOST_OPTIONS[@]}" -- --testpath "${REPO_ROOT}/test" "${SOLTEST_OPTIONS[@]}"
+SOLTEST_COMMAND=("${SOLIDITY_BUILD_DIR}/test/soltest" "${BOOST_OPTIONS[@]}" -- --testpath "${REPO_ROOT}/test" "${SOLTEST_OPTIONS[@]}")
+
+if [ "$USE_DEBUGGER" -ne "0" ]; then
+	# shellcheck disable=SC2086
+	exec ${DEBUGGER} "${SOLTEST_COMMAND[@]}"
+else
+	exec "${SOLTEST_COMMAND[@]}"
+fi

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -30,6 +30,7 @@ set -e
 
 REPO_ROOT="$(dirname "$0")/.."
 SOLIDITY_BUILD_DIR="${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}"
+IFS=" " read -r -a SMT_FLAGS <<< "$SMT_FLAGS"
 
 source "${REPO_ROOT}/scripts/common.sh"
 
@@ -100,21 +101,21 @@ do
         fi
         for abiv1 in $FORCE_ABIV1_RUNS
         do
-            force_abiv1_flag=""
+            force_abiv1_flag=()
             if [[ "$abiv1" == "yes" ]]
             then
-                force_abiv1_flag="--abiencoderv1"
+                force_abiv1_flag=(--abiencoderv1)
             fi
-            printTask "--> Running tests using $optimize --evm-version $vm $force_abiv1_flag..."
+            printTask "--> Running tests using $optimize --evm-version $vm ${force_abiv1_flag[*]}..."
 
-            log=""
+            log=()
             if [ -n "$log_directory" ]
             then
                 if [ -n "$optimize" ]
                 then
-                    log=--logger=JUNIT,error,$log_directory/opt_$vm.xml
+                    log+=("--logger=JUNIT,error,$log_directory/opt_$vm.xml")
                 else
-                    log=--logger=JUNIT,error,$log_directory/noopt_$vm.xml
+                    log+=("--logger=JUNIT,error,$log_directory/noopt_$vm.xml")
                 fi
             fi
 
@@ -122,7 +123,7 @@ do
             [ "${vm}" = "byzantium" ] && [ "${optimize}" = "" ] && EWASM_ARGS="--ewasm"
 
             set +e
-            "${SOLIDITY_BUILD_DIR}"/test/soltest --show-progress $log -- ${EWASM_ARGS} --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" $SMT_FLAGS $force_abiv1_flag
+            "${SOLIDITY_BUILD_DIR}"/test/soltest --show-progress "${log[@]}" -- ${EWASM_ARGS} --testpath "$REPO_ROOT"/test "$optimize" --evm-version "$vm" "${SMT_FLAGS[@]}" "${force_abiv1_flag[@]}"
 
             if test "0" -ne "$?"; then
                 exit 1


### PR DESCRIPTION
Depends on #10585.

This PR fixes shellcheck warnings about missing quotes in cases where they can contain spaces and are unquoted on purpose (to rely on Bash word splitting behavior). The solution is to use Bash arrays.