### PR TITLE
Silence remaining shellcheck warnings and remove ignore list

### DIFF
--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -41,6 +41,7 @@ REPODIR="$(realpath "$(dirname "$0")/..")"
 IFS=" " read -r -a BOOST_TEST_ARGS <<< "$BOOST_TEST_ARGS"
 IFS=" " read -r -a SOLTEST_FLAGS <<< "$SOLTEST_FLAGS"
 
+# shellcheck source=scripts/common.sh
 source "${REPODIR}/scripts/common.sh"
 # Test result output directory (CircleCI is reading test results from here)
 mkdir -p test_results

--- a/scripts/ASTImportTest.sh
+++ b/scripts/ASTImportTest.sh
@@ -25,7 +25,7 @@ FAILED=0
 UNCOMPILABLE=0
 TESTED=0
 
-if [ "$(ls | wc -l)" -ne 0 ]; then
+if [[ "$(find . -maxdepth 0 -type d -empty)" == "" ]]; then
     echo "Test directory not empty. Skipping!"
     exit 1
 fi
@@ -86,7 +86,8 @@ WORKINGDIR=$PWD
 # boost_filesystem_bug specifically tests a local fix for a boost::filesystem
 # bug. Since the test involves a malformed path, there is no point in running
 # AST tests on it. See https://github.com/boostorg/filesystem/issues/176
-for solfile in $(find "$SYNTAXTESTS_DIR" "$ASTJSONTESTS_DIR" -name *.sol -and -not -name "boost_filesystem_bug.sol")
+# shellcheck disable=SC2044
+for solfile in $(find "$SYNTAXTESTS_DIR" "$ASTJSONTESTS_DIR" -name "*.sol" -and -not -name "boost_filesystem_bug.sol")
 do
     echo -n "."
     # create a temporary sub-directory

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -48,6 +48,7 @@ TMPDIR=$(mktemp -d)
         cp "$REPO_ROOT/emscripten_build/libsolc/soljson.js" solc-js/
         cp "$REPO_ROOT/scripts/bytecodecompare/prepare_report.js" .
         echo "Running the compiler..."
+        # shellcheck disable=SC2035
         ./prepare_report.js *.sol > report.txt
         echo "Finished running the compiler."
     else

--- a/scripts/chk_shellscripts/chk_shellscripts.sh
+++ b/scripts/chk_shellscripts/chk_shellscripts.sh
@@ -4,16 +4,8 @@ set -eu
 
 REPO_ROOT="$(dirname "$0")"/../..
 REPO_ROOT=$(realpath "${REPO_ROOT}")
-IGNORE_FILENAME="ignore.txt"
-IGNORE_FILE="${REPO_ROOT}/scripts/chk_shellscripts/${IGNORE_FILENAME}"
 
-FOUND_FILES_TMP=$(mktemp)
-IGNORE_FILES_TMP=$(mktemp)
-trap 'rm -f ${FOUND_FILES_TMP} ; rm -f ${IGNORE_FILES_TMP}' EXIT
-
-sort < "${IGNORE_FILE}" >"${IGNORE_FILES_TMP}"
 cd "${REPO_ROOT}"
-find . -type f -name "*.sh" | sort >"${FOUND_FILES_TMP}"
 
 SHELLCHECK=${SHELLCHECK:-"$(command -v -- shellcheck)"}
 if [ ! -f "${SHELLCHECK}" ]; then
@@ -21,7 +13,5 @@ if [ ! -f "${SHELLCHECK}" ]; then
     exit 1
 fi
 
-FILES=$(join -v2 "${IGNORE_FILES_TMP}" "${FOUND_FILES_TMP}")
-
-# shellcheck disable=SC2086
-"${SHELLCHECK}" ${FILES[*]}
+mapfile -t FILES < <(find . -type f -name "*.sh")
+"${SHELLCHECK}" "${FILES[@]}"

--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -205,6 +205,7 @@ sed -i -e "s/UNRELEASED/${distribution}/" -e s/urgency=medium/urgency=low/ ../*.
 (
 cd ..
 orig="${packagename}_${debversion}.orig.tar.gz"
+# shellcheck disable=SC2012
 orig_size=$(ls -l "$orig" | cut -d ' ' -f 5)
 orig_sha1=$(sha1sum $orig | cut -d ' ' -f 1)
 orig_sha256=$(sha256sum $orig | cut -d ' ' -f 1)
@@ -214,6 +215,7 @@ if wget --quiet -O $orig-tmp "$ppafilesurl/$orig"
 then
     echo "[WARN] Original tarball found in Ubuntu archive, using it instead"
     mv $orig-tmp $orig
+    # shellcheck disable=SC2012
     new_size=$(ls -l ./*.orig.tar.gz | cut -d ' ' -f 5)
     new_sha1=$(sha1sum $orig | cut -d ' ' -f 1)
     new_sha256=$(sha256sum $orig | cut -d ' ' -f 1)

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -29,7 +29,9 @@ set -e
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
+# shellcheck source=scripts/common.sh
 source "${REPO_ROOT}/scripts/common.sh"
+# shellcheck source=scripts/common_cmdline.sh
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
 
 developmentVersion=$("$REPO_ROOT/scripts/get_version.sh")

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -40,7 +40,9 @@ function versionGreater()
 {
     v1=$1
     v2=$2
+    # shellcheck disable=SC2206
     ver1=( ${v1//./ } )
+    # shellcheck disable=SC2206
     ver2=( ${v2//./ } )
 
     if (( "${ver1[0]}" > "${ver2[0]}" ))

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -175,6 +175,7 @@ case $(uname -s) in
 
             Debian*|Raspbian)
                 #Debian
+                # shellcheck disable=SC1091
                 . /etc/os-release
                 install_z3=""
                 case $VERSION_ID in
@@ -354,7 +355,10 @@ case $(uname -s) in
 #------------------------------------------------------------------------------
             CentOS*)
                 echo "Attention: CentOS 7 is currently not supported!";
+                # FIXME: read -p and [[ ]] are bash features but our shebang says we're using sh
+                # shellcheck disable=SC2039
                 read -p "This script will heavily modify your system in order to allow for compilation of Solidity. Are you sure? [Y/N]" -n 1 -r
+                # shellcheck disable=SC2039
                 if [[ $REPLY =~ ^[Yy]$ ]]; then
                     # Make Sure we have the EPEL repos
                     sudo yum -y install epel-release

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -265,6 +265,7 @@ fi
 (
 cd ..
 orig="${packagename}_${debversion}.orig.tar.gz"
+# shellcheck disable=SC2012
 orig_size=$(ls -l "$orig" | cut -d ' ' -f 5)
 orig_sha1=$(sha1sum "$orig" | cut -d ' ' -f 1)
 orig_sha256=$(sha256sum "$orig" | cut -d ' ' -f 1)
@@ -274,6 +275,7 @@ if wget --quiet -O "$orig-tmp" "$ppafilesurl/$orig"
 then
     echo "[WARN] Original tarball found in Ubuntu archive, using it instead"
     mv "$orig-tmp" "$orig"
+    # shellcheck disable=SC2012
     new_size=$(ls -l ./*.orig.tar.gz | cut -d ' ' -f 5)
     new_sha1=$(sha1sum "$orig" | cut -d ' ' -f 1)
     new_sha256=$(sha256sum "$orig" | cut -d ' ' -f 1)

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -32,6 +32,7 @@ REPO_ROOT="$(dirname "$0")/.."
 SOLIDITY_BUILD_DIR="${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}"
 IFS=" " read -r -a SMT_FLAGS <<< "$SMT_FLAGS"
 
+# shellcheck source=scripts/common.sh
 source "${REPO_ROOT}/scripts/common.sh"
 
 WORKDIR=$(mktemp -d)

--- a/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
+++ b/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
@@ -190,6 +190,7 @@ echo "Extract bytecode comparison scripts from v0.6.1..."
 cd /root/project
 git checkout v0.6.1 --quiet
 cp scripts/bytecodecompare/storebytecode.sh /tmp
+# shellcheck disable=SC2016
 sed -i -e 's/rm -rf "\$TMPDIR"/cp "\$TMPDIR"\/report.txt \/tmp\/report.txt ; rm -rf "\$TMPDIR"/' /tmp/storebytecode.sh
 sed -i -e 's/REPO_ROOT=.*/REPO_ROOT=\/src/' /tmp/storebytecode.sh
 export SOLC_EMSCRIPTEN="On"

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -32,7 +32,9 @@ set -e
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
+# shellcheck source=scripts/common.sh
 source "${REPO_ROOT}/scripts/common.sh"
+# shellcheck source=scripts/common_cmdline.sh
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
 
 (( $# <= 1 )) || { printError "Too many arguments"; exit 1; }

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -126,6 +126,7 @@ function test_solc_behaviour()
     local stdout_path; stdout_path=$(mktemp)
     local stderr_path; stderr_path=$(mktemp)
 
+    # shellcheck disable=SC2064
     trap "rm -f $stdout_path $stderr_path" EXIT
 
     if [[ "$exit_code_expected" = "" ]]; then exit_code_expected="0"; fi
@@ -146,10 +147,13 @@ function test_solc_behaviour()
 
         # Remove bytecode (but not linker references).
         sed -i.bak -E -e 's/(\"object\":\")[0-9a-f]+([^"]*\")/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
+        # shellcheck disable=SC2016
         sed -i.bak -E -e 's/(\"object\":\"[^"]+\$__)[0-9a-f]+(\")/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
+        # shellcheck disable=SC2016
         sed -i.bak -E -e 's/([0-9a-f]{34}\$__)[0-9a-f]+(__\$[0-9a-f]{17})/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
 
         # Replace escaped newlines by actual newlines for readability
+        # shellcheck disable=SC1003
         sed -i.bak -E -e 's/\\n/\'$'\n/g' "$stdout_path"
         rm "$stdout_path.bak"
     else
@@ -166,7 +170,9 @@ function test_solc_behaviour()
         # 64697066735822 = hex encoding of 0x64 'i' 'p' 'f' 's' 0x58 0x22
         # 64736f6c63     = hex encoding of 0x64 's' 'o' 'l' 'c'
         sed -i.bak -E -e 's/[0-9a-f]*64697066735822[0-9a-f]+64736f6c63[0-9a-f]+/<BYTECODE REMOVED>/g' "$stdout_path"
+        # shellcheck disable=SC2016
         sed -i.bak -E -e 's/([0-9a-f]{17}\$__)[0-9a-f]+(__\$[0-9a-f]{17})/\1<BYTECODE REMOVED>\2/g' "$stdout_path"
+        # shellcheck disable=SC2016
         sed -i.bak -E -e 's/[0-9a-f]+((__\$[0-9a-f]{34}\$__)*<BYTECODE REMOVED>)/<BYTECODE REMOVED>\1/g' "$stdout_path"
 
         # Remove trailing empty lines. Needs a line break to make OSX sed happy.


### PR DESCRIPTION
~Depends on #10586. It will remain a draft until all PRs below are merged.~ It's on `develop` now.

This is the last batch and mostly just disables warnings where shellcheck is overzealous or doing it properly is not worth the extra effort.

It also removes the whole ignorelist mechanism from our scripts. I think that going forward it's better to add specific local ignores in scripts instead of having the whole script ignored.