### PR TITLE
[SMTChecker] Small refactoring

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -561,8 +561,7 @@ void BMC::internalOrExternalFunctionCall(FunctionCall const& _funCall)
 	else
 	{
 		m_externalFunctionCallHappened = true;
-		resetStateVariables();
-		resetStorageReferences();
+		resetStorageVariables();
 	}
 }
 
@@ -622,11 +621,6 @@ pair<smtutil::Expression, smtutil::Expression> BMC::arithmeticOperation(
 		&_expression
 	);
 	return values;
-}
-
-void BMC::resetStorageReferences()
-{
-	m_context.resetVariables([&](VariableDeclaration const& _variable) { return _variable.hasReferenceOrMappingType(); });
 }
 
 void BMC::reset()

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -162,7 +162,7 @@ bool BMC::visit(FunctionDefinition const& _function)
 	{
 		reset();
 		initFunction(_function);
-		m_context.addAssertion(m_context.state().txTypeConstraints() && m_context.state().txFunctionConstraints(_function));
+		m_context.addAssertion(state().txTypeConstraints() && state().txFunctionConstraints(_function));
 		resetStateVariables();
 	}
 
@@ -440,7 +440,7 @@ void BMC::endVisit(FunctionCall const& _funCall)
 	{
 		auto value = _funCall.arguments().front();
 		solAssert(value, "");
-		smtutil::Expression thisBalance = m_context.state().balance();
+		smtutil::Expression thisBalance = state().balance();
 
 		addVerificationTarget(
 			VerificationTargetType::Balance,

--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -123,7 +123,6 @@ private:
 		Expression const& _expression
 	) override;
 
-	void resetStorageReferences();
 	void reset();
 
 	std::pair<std::vector<smtutil::Expression>, std::vector<std::string>> modelExpressions();

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -880,8 +880,7 @@ void CHC::resetContractAnalysis()
 
 void CHC::eraseKnowledge()
 {
-	resetStateVariables();
-	m_context.resetVariables([&](VariableDeclaration const& _variable) { return _variable.hasReferenceOrMappingType(); });
+	resetStorageVariables();
 }
 
 void CHC::clearIndices(ContractDefinition const* _contract, FunctionDefinition const* _function)

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -1691,11 +1691,6 @@ unsigned CHC::newErrorId()
 	return errorId;
 }
 
-SymbolicState& CHC::state()
-{
-	return m_context.state();
-}
-
 SymbolicIntVariable& CHC::errorFlag()
 {
 	return state().errorFlag();

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -258,7 +258,6 @@ private:
 	/// it into m_errorIds.
 	unsigned newErrorId();
 
-	smt::SymbolicState& state();
 	smt::SymbolicIntVariable& errorFlag();
 	//@}
 

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -424,6 +424,8 @@ protected:
 
 	/// Stores the context of the encoding.
 	smt::EncodingContext& m_context;
+
+	smt::SymbolicState& state();
 };
 
 }

--- a/test/libsolidity/smtCheckerTests/types/address_call.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_call.sol
@@ -20,8 +20,8 @@ contract C
 // ----
 // Warning 2072: (224-240): Unused local variable.
 // Warning 4588: (244-256): Assertion checker does not yet implement this type of function call.
-// Warning 6328: (260-275): CHC: Assertion violation happens here.
-// Warning 6328: (279-293): CHC: Assertion violation happens here.
-// Warning 6328: (297-316): CHC: Assertion violation happens here.
-// Warning 6328: (320-344): CHC: Assertion violation happens here.
+// Warning 6328: (260-275): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
+// Warning 6328: (279-293): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
+// Warning 6328: (297-316): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
+// Warning 6328: (320-344): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
 // Warning 4588: (244-256): Assertion checker does not yet implement this type of function call.

--- a/test/libsolidity/smtCheckerTests/types/address_delegatecall.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_delegatecall.sol
@@ -20,8 +20,8 @@ contract C
 // ----
 // Warning 2072: (224-240): Unused local variable.
 // Warning 4588: (244-264): Assertion checker does not yet implement this type of function call.
-// Warning 6328: (268-283): CHC: Assertion violation happens here.
-// Warning 6328: (287-301): CHC: Assertion violation happens here.
-// Warning 6328: (305-324): CHC: Assertion violation happens here.
-// Warning 6328: (328-352): CHC: Assertion violation happens here.
+// Warning 6328: (268-283): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
+// Warning 6328: (287-301): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
+// Warning 6328: (305-324): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
+// Warning 6328: (328-352): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0, data)
 // Warning 4588: (244-264): Assertion checker does not yet implement this type of function call.


### PR DESCRIPTION
This PR introduces 2 small refactoring changes:

- `CHC::state` that provides the shortcut to `m_context.state()`is lifted to the base class and is used wherever possible.
- `resetStorageVariables` can achieve the proper effect instead of combining `resetStateVariables` and `resetStorageReferences`