### PR TITLE
OverrideSpecifier: Check for null before dereferencing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Type Checker: Fix internal error when override specifier is not a contract.
  * SMTChecker: Fix missing type constraints on block and transaction variables in the deployment phase.
 
 

--- a/libsolidity/analysis/PostTypeChecker.cpp
+++ b/libsolidity/analysis/PostTypeChecker.cpp
@@ -225,13 +225,12 @@ struct OverrideSpecifierChecker: public PostTypeChecker::Checker
 			if (dynamic_cast<ContractDefinition const*>(decl))
 				continue;
 
-			TypeType const* actualTypeType = dynamic_cast<TypeType const*>(decl->type());
-
+			auto const* typeType = dynamic_cast<TypeType const*>(decl->type());
 			m_errorReporter.typeError(
 				9301_error,
 				override->location(),
 				"Expected contract but got " +
-				actualTypeType->actualType()->toString(true) +
+				(typeType ? typeType->actualType() : decl->type())->toString(true) +
 				"."
 			);
 		}

--- a/test/libsolidity/syntaxTests/inheritance/override/override_type_mismatch2.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_type_mismatch2.sol
@@ -1,0 +1,12 @@
+contract A {
+  function f() public virtual {}
+}
+contract B {
+  function g() public {}
+}
+contract C is A,B {
+  function f() public override (g) {}
+}
+
+// ----
+// TypeError 9301: (140-141): Expected contract but got function ().


### PR DESCRIPTION
fixes #10874