### PR TITLE
Small clean up on call stack section

### DIFF
--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -181,14 +181,13 @@ Sending and Receiving Ether
      contract. Again, the best practice here is to use a :ref:`"withdraw"
      pattern instead of a "send" pattern <withdrawal_pattern>`.
 
-Call stack Depth
+Call Stack Depth
 ================
 
 External function calls can fail any time because they exceed the maximum
 call stack of 1024. In such situations, Solidity throws an exception.
 Malicious actors might be able to force the call stack to a high value
-before they interact with your contract, by controlling the number of calls
-and local function variables on the stack.
+before they interact with your contract. Note that, since [Tangerine Whistle](https://eips.ethereum.org/EIPS/eip-608) hardfork, the [63/64 rule](https://eips.ethereum.org/EIPS/eip-150) makes call stack depth attack impractical. Also note that the call stack and the expression stack are unrelated, even though both have a size limit of 1024 stack slots.
 
 Note that ``.send()`` does **not** throw an exception if the call stack is
 depleted but rather returns ``false`` in that case. The low-level functions

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -185,7 +185,7 @@ Call Stack Depth
 ================
 
 External function calls can fail any time because they exceed the maximum
-call stack of 1024. In such situations, Solidity throws an exception.
+call stack size limit of 1024. In such situations, Solidity throws an exception.
 Malicious actors might be able to force the call stack to a high value
 before they interact with your contract. Note that, since [Tangerine Whistle](https://eips.ethereum.org/EIPS/eip-608) hardfork, the [63/64 rule](https://eips.ethereum.org/EIPS/eip-150) makes call stack depth attack impractical. Also note that the call stack and the expression stack are unrelated, even though both have a size limit of 1024 stack slots.
 

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -181,13 +181,14 @@ Sending and Receiving Ether
      contract. Again, the best practice here is to use a :ref:`"withdraw"
      pattern instead of a "send" pattern <withdrawal_pattern>`.
 
-Callstack Depth
-===============
+Call stack Depth
+================
 
 External function calls can fail any time because they exceed the maximum
 call stack of 1024. In such situations, Solidity throws an exception.
 Malicious actors might be able to force the call stack to a high value
-before they interact with your contract.
+before they interact with your contract, by controlling the number of calls
+and local function variables on the stack.
 
 Note that ``.send()`` does **not** throw an exception if the call stack is
 depleted but rather returns ``false`` in that case. The low-level functions

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -187,7 +187,7 @@ Call Stack Depth
 External function calls can fail any time because they exceed the maximum
 call stack size limit of 1024. In such situations, Solidity throws an exception.
 Malicious actors might be able to force the call stack to a high value
-before they interact with your contract. Note that, since [Tangerine Whistle](https://eips.ethereum.org/EIPS/eip-608) hardfork, the [63/64 rule](https://eips.ethereum.org/EIPS/eip-150) makes call stack depth attack impractical. Also note that the call stack and the expression stack are unrelated, even though both have a size limit of 1024 stack slots.
+before they interact with your contract. Note that, since `Tangerine Whistle <https://eips.ethereum.org/EIPS/eip-608>`_ hardfork, the `63/64 rule <https://eips.ethereum.org/EIPS/eip-150>`_ makes call stack depth attack impractical. Also note that the call stack and the expression stack are unrelated, even though both have a size limit of 1024 stack slots.
 
 Note that ``.send()`` does **not** throw an exception if the call stack is
 depleted but rather returns ``false`` in that case. The low-level functions


### PR DESCRIPTION
Spelling, clarified what items go to the call stack and how any attack is executed