### PR TITLE
Enable IR generation for syntax tests

### DIFF
--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -76,6 +76,7 @@ void SyntaxTest::setupCompiler()
 		OptimiserSettings::full() :
 		OptimiserSettings::minimal()
 	);
+	compiler().enableIRGeneration();
 }
 
 void SyntaxTest::parseAndAnalyze()
@@ -148,4 +149,3 @@ void SyntaxTest::filterObtainedErrors()
 		});
 	}
 }
-


### PR DESCRIPTION
This PR is to only collect all the failing tests. Will close this.