### PR TITLE
Throw unimplemented assert for fixedpoint types early to help Fuzzer

### DIFF
--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -225,16 +225,20 @@ Type const* TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken const& 
 	case Token::BytesM:
 		return fixedBytes(m);
 	case Token::FixedMxN:
+		solUnimplemented("Not yet implemented - FixedPointType.");
 		return fixedPoint(m, n, FixedPointType::Modifier::Signed);
 	case Token::UFixedMxN:
+		solUnimplemented("Not yet implemented - FixedPointType.");
 		return fixedPoint(m, n, FixedPointType::Modifier::Unsigned);
 	case Token::Int:
 		return integer(256, IntegerType::Modifier::Signed);
 	case Token::UInt:
 		return integer(256, IntegerType::Modifier::Unsigned);
 	case Token::Fixed:
+		solUnimplemented("Not yet implemented - FixedPointType.");
 		return fixedPoint(128, 18, FixedPointType::Modifier::Signed);
 	case Token::UFixed:
+		solUnimplemented("Not yet implemented - FixedPointType.");
 		return fixedPoint(128, 18, FixedPointType::Modifier::Unsigned);
 	case Token::Address:
 	{

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -190,12 +190,15 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
     test_ids |= find_ids_in_cmdline_test_err(path.join(top_dir, "test", "cmdlineTests", "error_codes", "err"))
 
     # white list of ids which are not covered by tests
+    # pylint: disable=W0511
     white_ids = {
         "3805", # "This is a pre-release compiler version, please do not use it in production."
                 # The warning may or may not exist in a compiler build.
         "4591", # "There are more than 256 warnings. Ignoring the rest."
                 # Due to 3805, the warning lists look different for different compiler builds.
-        "1834"  # Unimplemented feature error, as we do not test it anymore via cmdLineTests
+        "1834",  # Unimplemented feature error, as we do not test it anymore via cmdLineTests
+        "4426",  # FIXME remove this when fixed point types gets implemented
+        "5107"   # FIXME remove this when fixed point types gets implemented
     }
     assert len(test_ids & white_ids) == 0, "The sets are not supposed to intersect"
     test_ids |= white_ids

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -55,25 +55,27 @@ BOOST_AUTO_TEST_CASE(byte_types)
 		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::BytesM, i, 0)) == *TypeProvider::fixedBytes(i));
 }
 
-BOOST_AUTO_TEST_CASE(fixed_types)
-{
-	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::Fixed, 0, 0)) == *TypeProvider::fixedPoint(128, 18, FixedPointType::Modifier::Signed));
-	for (unsigned i = 8; i <= 256; i += 8)
-	{
-		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 0)) == *TypeProvider::fixedPoint(i, 0, FixedPointType::Modifier::Signed));
-		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 2)) == *TypeProvider::fixedPoint(i, 2, FixedPointType::Modifier::Signed));
-	}
-}
+// FIXME when fixed point types get implemented
+// BOOST_AUTO_TEST_CASE(fixed_types)
+// {
+// 	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::Fixed, 0, 0)) == *TypeProvider::fixedPoint(128, 18, FixedPointType::Modifier::Signed));
+// 	for (unsigned i = 8; i <= 256; i += 8)
+// 	{
+// 		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 0)) == *TypeProvider::fixedPoint(i, 0, FixedPointType::Modifier::Signed));
+// 		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::FixedMxN, i, 2)) == *TypeProvider::fixedPoint(i, 2, FixedPointType::Modifier::Signed));
+// 	}
+// }
 
-BOOST_AUTO_TEST_CASE(ufixed_types)
-{
-	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixed, 0, 0)) == *TypeProvider::fixedPoint(128, 18, FixedPointType::Modifier::Unsigned));
-	for (unsigned i = 8; i <= 256; i += 8)
-	{
-		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 0)) == *TypeProvider::fixedPoint(i, 0, FixedPointType::Modifier::Unsigned));
-		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 2)) == *TypeProvider::fixedPoint(i, 2, FixedPointType::Modifier::Unsigned));
-	}
-}
+// FIXME when fixed point types get implemented
+// BOOST_AUTO_TEST_CASE(ufixed_types)
+// {
+// 	BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixed, 0, 0)) == *TypeProvider::fixedPoint(128, 18, FixedPointType::Modifier::Unsigned));
+// 	for (unsigned i = 8; i <= 256; i += 8)
+// 	{
+// 		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 0)) == *TypeProvider::fixedPoint(i, 0, FixedPointType::Modifier::Unsigned));
+// 		BOOST_CHECK(*TypeProvider::fromElementaryTypeName(ElementaryTypeNameToken(Token::UFixedMxN, i, 2)) == *TypeProvider::fixedPoint(i, 2, FixedPointType::Modifier::Unsigned));
+// 	}
+// }
 
 BOOST_AUTO_TEST_CASE(storage_layout_simple)
 {
@@ -151,8 +153,9 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("int128")->identifier(), "t_int128");
 	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("address")->identifier(), "t_address");
 	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("uint8")->identifier(), "t_uint8");
-	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("ufixed64x2")->identifier(), "t_ufixed64x2");
-	BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("fixed128x8")->identifier(), "t_fixed128x8");
+	// FIXME when fixed point types get implemented
+	// BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("ufixed64x2")->identifier(), "t_ufixed64x2");
+	// BOOST_CHECK_EQUAL(TypeProvider::fromElementaryTypeName("fixed128x8")->identifier(), "t_fixed128x8");
 	BOOST_CHECK_EQUAL(RationalNumberType(rational(7, 1)).identifier(), "t_rational_7_by_1");
 	BOOST_CHECK_EQUAL(RationalNumberType(rational(200, 77)).identifier(), "t_rational_200_by_77");
 	BOOST_CHECK_EQUAL(RationalNumberType(rational(2 * 200, 2 * 77)).identifier(), "t_rational_200_by_77");

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -80,22 +80,26 @@ void SyntaxTest::setupCompiler()
 
 void SyntaxTest::parseAndAnalyze()
 {
-	if (compiler().parse() && compiler().analyze())
+	if (compiler().parse())
+	{
 		try
 		{
-			if (!compiler().compile())
+			if (compiler().analyze())
 			{
-				ErrorList const& errors = compiler().errors();
-				auto codeGeneretionErrorCount = count_if(errors.cbegin(), errors.cend(), [](auto const& error) {
-					return error->type() == Error::Type::CodeGenerationError;
-				});
-				auto errorCount = count_if(errors.cbegin(), errors.cend(), [](auto const& error) {
-					return error->type() != Error::Type::Warning;
-				});
-				// failing compilation after successful analysis is a rare case,
-				// it assumes that errors contain exactly one error, and the error is of type Error::Type::CodeGenerationError
-				if (codeGeneretionErrorCount != 1 || errorCount != 1)
-					BOOST_THROW_EXCEPTION(runtime_error("Compilation failed even though analysis was successful."));
+				if (!compiler().compile())
+				{
+					ErrorList const& errors = compiler().errors();
+					auto codeGeneretionErrorCount = count_if(errors.cbegin(), errors.cend(), [](auto const& error) {
+						return error->type() == Error::Type::CodeGenerationError;
+					});
+					auto errorCount = count_if(errors.cbegin(), errors.cend(), [](auto const& error) {
+						return error->type() != Error::Type::Warning;
+					});
+					// failing compilation after successful analysis is a rare case,
+					// it assumes that errors contain exactly one error, and the error is of type Error::Type::CodeGenerationError
+					if (codeGeneretionErrorCount != 1 || errorCount != 1)
+						BOOST_THROW_EXCEPTION(runtime_error("Compilation failed even though analysis was successful."));
+				}
 			}
 		}
 		catch (UnimplementedFeatureError const& _e)
@@ -109,6 +113,7 @@ void SyntaxTest::parseAndAnalyze()
 				-1
 			});
 		}
+	}
 }
 
 void SyntaxTest::filterObtainedErrors()
@@ -148,4 +153,3 @@ void SyntaxTest::filterObtainedErrors()
 		});
 	}
 }
-

--- a/test/libsolidity/smtCheckerTests/file_level/free_function_4.sol
+++ b/test/libsolidity/smtCheckerTests/file_level/free_function_4.sol
@@ -3,6 +3,4 @@ function f()pure {
 	ufixed a = uint64(1) + ufixed(2);
 }
 // ----
-// Warning 2072: (52-60): Unused local variable.
-// Warning 6660: (32-87): Model checker analysis was not possible because file level functions are not supported.
-// Warning 6660: (32-87): Model checker analysis was not possible because file level functions are not supported.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/smtCheckerTests/operators/fixed_point_add.sol
+++ b/test/libsolidity/smtCheckerTests/operators/fixed_point_add.sol
@@ -5,4 +5,4 @@ contract test {
 	}
 }
 // ----
-// Warning 2072: (80-88): Unused local variable.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/smtCheckerTests/operators/fixed_point_compound_add.sol
+++ b/test/libsolidity/smtCheckerTests/operators/fixed_point_compound_add.sol
@@ -4,3 +4,4 @@ contract C {
   function f() internal { b[0] += 1; }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/array/length/const_cannot_be_fractional.sol
+++ b/test/libsolidity/syntaxTests/array/length/const_cannot_be_fractional.sol
@@ -3,4 +3,4 @@ contract C {
     uint[L] ids;
 }
 // ----
-// TypeError 5462: (51-52): Invalid array length, expected integer literal or constant expression.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/denominations/fixed_point_division.sol
+++ b/test/libsolidity/syntaxTests/denominations/fixed_point_division.sol
@@ -3,4 +3,4 @@ contract C {
 	ufixed constant b = ufixed(4 ether / 3 hours);
 }
 // ----
-// TypeError 2326: (32-49): Type rational_const 10000000000000000 / 27 is not implicitly convertible to expected type uint256. Try converting to type ufixed256x62 or use an explicit conversion.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_fixed_types.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_fixed_types.sol
@@ -5,5 +5,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2072: (50-67): Unused local variable.
-// Warning 2018: (20-119): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_rationals.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_rationals.sol
@@ -5,5 +5,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2072: (50-73): Unused local variable.
-// Warning 2018: (20-118): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/303_fixed_type_int_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/303_fixed_type_int_conversion.sol
@@ -9,4 +9,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2018: (20-147): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/304_fixed_type_rational_int_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/304_fixed_type_rational_int_conversion.sol
@@ -7,4 +7,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2018: (20-104): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/305_fixed_type_rational_fraction_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/305_fixed_type_rational_fraction_conversion.sol
@@ -7,4 +7,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2018: (20-108): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/306_invalid_int_implicit_conversion_from_fixed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/306_invalid_int_implicit_conversion_from_fixed.sol
@@ -6,4 +6,4 @@ contract test {
     }
 }
 // ----
-// TypeError 9574: (73-82): Type fixed128x18 is not implicitly convertible to expected type int256.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/308_rational_unary_plus_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/308_rational_unary_plus_operation.sol
@@ -6,5 +6,5 @@ contract test {
     }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // SyntaxError 9636: (70-75): Use of unary + is disallowed.
-// TypeError 4907: (70-75): Unary operator + cannot be applied to type rational_const 13 / 4

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/313_fixed_type_size_capabilities.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/313_fixed_type_size_capabilities.sol
@@ -10,5 +10,4 @@ contract test {
     }
 }
 // ----
-// TypeError 5107: (153-250): Type rational_const 9208...(70 digits omitted)...7637 / 1000...(71 digits omitted)...0000 is not implicitly convertible to expected type ufixed256x77, but it can be explicitly converted.
-// TypeError 5107: (470-566): Type rational_const -933...(70 digits omitted)...0123 / 1000...(70 digits omitted)...0000 is not implicitly convertible to expected type fixed256x76, but it can be explicitly converted.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/314_fixed_type_zero_handling.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/314_fixed_type_zero_handling.sol
@@ -6,4 +6,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2018: (20-104): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/315_fixed_type_invalid_implicit_conversion_size.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/315_fixed_type_invalid_implicit_conversion_size.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// TypeError 9574: (75-92): Type ufixed128x18 is not implicitly convertible to expected type ufixed248x8. Too many fractional digits.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/316_fixed_type_invalid_implicit_conversion_lost_data.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/316_fixed_type_invalid_implicit_conversion_lost_data.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 4486: (50-69): Type rational_const 1 / 3 is not implicitly convertible to expected type ufixed256x1. Try converting to type ufixed256x77 or use an explicit conversion.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol
@@ -7,4 +7,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2018: (20-182): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/322_fixed_to_bytes_implicit_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/322_fixed_to_bytes_implicit_conversion.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// TypeError 9574: (74-87): Type fixed128x18 is not implicitly convertible to expected type bytes32.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/328_rational_to_fixed_literal_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/328_rational_to_fixed_literal_expression.sol
@@ -13,4 +13,3 @@ contract test {
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // Warning 2519: (238-252): This declaration shadows an existing declaration.
-// Warning 2018: (20-339): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/329_rational_as_exponent_value_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/329_rational_as_exponent_value_signed.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (60-69): Operator ** not compatible with types int_const 2 and rational_const -11 / 5
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/330_rational_as_exponent_value_unsigned.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/330_rational_as_exponent_value_unsigned.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (61-69): Operator ** not compatible with types int_const 3 and rational_const 5 / 2
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/333_fixed_point_casting_exponents_15.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/333_fixed_point_casting_exponents_15.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (61-77): Operator ** not compatible with types int_const 3 and ufixed128x18. Exponent is fractional.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/334_fixed_point_casting_exponents_neg.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/334_fixed_point_casting_exponents_neg.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (61-78): Operator ** not compatible with types int_const 42 and fixed128x18. Exponent is fractional.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/338_rational_bitnot_unary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/338_rational_bitnot_unary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 4907: (50-61): Unary operator ~ cannot be applied to type fixed128x18
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/339_rational_bitor_binary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/339_rational_bitor_binary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-64): Operator | not compatible with types fixed128x18 and int_const 3
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/340_rational_bitxor_binary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/340_rational_bitxor_binary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-65): Operator ^ not compatible with types fixed128x18 and int_const 3
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/341_rational_bitand_binary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/341_rational_bitand_binary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-65): Operator & not compatible with types fixed128x18 and int_const 3
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/343_integer_and_fixed_interaction.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/343_integer_and_fixed_interaction.sol
@@ -5,5 +5,3 @@ contract test {
 }
 // ----
 // UnimplementedFeatureError: Not yet implemented - FixedPointType.
-// Warning 2072: (50-58): Unused local variable.
-// Warning 2018: (20-89): Function state mutability can be restricted to pure

--- a/test/libsolidity/syntaxTests/parsing/declaring_fixed_and_ufixed_variables.sol
+++ b/test/libsolidity/syntaxTests/parsing/declaring_fixed_and_ufixed_variables.sol
@@ -6,9 +6,4 @@ contract A {
     }
 }
 // ----
-// UnimplementedFeatureError: Fixed point types not implemented.
-// Warning 5667: (52-60): Unused function parameter. Remove or comment out the variable name to silence this warning.
-// Warning 5667: (62-74): Unused function parameter. Remove or comment out the variable name to silence this warning.
-// Warning 2072: (93-104): Unused local variable.
-// Warning 2072: (114-121): Unused local variable.
-// Warning 2018: (41-128): Function state mutability can be restricted to pure
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/parsing/declaring_fixed_literal_variables.sol
+++ b/test/libsolidity/syntaxTests/parsing/declaring_fixed_literal_variables.sol
@@ -2,4 +2,4 @@ contract A {
     fixed40x40 pi = 3.14;
 }
 // ----
-// TypeError 2326: (33-37): Type rational_const 157 / 50 is not implicitly convertible to expected type fixed40x40. Try converting to type ufixed16x2 or use an explicit conversion.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed_fail.sol
@@ -9,6 +9,7 @@ contract C {
   }
 }
 // ----
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.
 // SyntaxError 2090: (57-64): Invalid use of underscores in number literal. No trailing underscores allowed.
 // SyntaxError 2990: (81-91): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.
 // SyntaxError 1023: (108-112): Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.

--- a/test/libsolidity/syntaxTests/signed_rational_modulus.sol
+++ b/test/libsolidity/syntaxTests/signed_rational_modulus.sol
@@ -7,4 +7,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (117-123): Operator % not compatible with types rational_const 1 / 2 and fixed128x18. Fractional literals not supported.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/types/address/type_type_to_address.sol
+++ b/test/libsolidity/syntaxTests/types/address/type_type_to_address.sol
@@ -10,7 +10,8 @@ contract C {
         address(bytes16);
         address(bool);
         address(address);
-        address(fixed);
+        // FIXME when fixed point types get implemented
+        // address(fixed);
 
         address(S);
         address(E);
@@ -32,15 +33,14 @@ contract C {
 // TypeError 9640: (119-135): Explicit type conversion not allowed from "type(bytes16)" to "address".
 // TypeError 9640: (145-158): Explicit type conversion not allowed from "type(bool)" to "address".
 // TypeError 9640: (168-184): Explicit type conversion not allowed from "type(address)" to "address".
-// TypeError 9640: (194-208): Explicit type conversion not allowed from "type(fixed128x18)" to "address".
-// TypeError 9640: (219-229): Explicit type conversion not allowed from "type(struct S storage pointer)" to "address".
-// TypeError 9640: (239-249): Explicit type conversion not allowed from "type(enum E)" to "address".
-// TypeError 9640: (260-275): Explicit type conversion not allowed from "type(uint256[] memory)" to "address".
-// TypeError 9640: (285-302): Explicit type conversion not allowed from "type(uint256[] memory[] memory)" to "address".
-// TypeError 9640: (312-328): Explicit type conversion not allowed from "type(uint256[5] memory)" to "address".
-// TypeError 9640: (338-353): Explicit type conversion not allowed from "type(string storage pointer)" to "address".
-// TypeError 9640: (363-377): Explicit type conversion not allowed from "type(bytes storage pointer)" to "address".
-// TypeError 9640: (387-399): Explicit type conversion not allowed from "type(struct S memory[] memory)" to "address".
-// TypeError 9640: (409-421): Explicit type conversion not allowed from "type(enum E[] memory)" to "address".
-// TypeError 9640: (431-452): Explicit type conversion not allowed from "tuple(type(uint256),type(uint256))" to "address".
-// TypeError 9640: (463-482): Explicit type conversion not allowed from "type(uint256)" to "address".
+// TypeError 9640: (278-288): Explicit type conversion not allowed from "type(struct S storage pointer)" to "address".
+// TypeError 9640: (298-308): Explicit type conversion not allowed from "type(enum E)" to "address".
+// TypeError 9640: (319-334): Explicit type conversion not allowed from "type(uint256[] memory)" to "address".
+// TypeError 9640: (344-361): Explicit type conversion not allowed from "type(uint256[] memory[] memory)" to "address".
+// TypeError 9640: (371-387): Explicit type conversion not allowed from "type(uint256[5] memory)" to "address".
+// TypeError 9640: (397-412): Explicit type conversion not allowed from "type(string storage pointer)" to "address".
+// TypeError 9640: (422-436): Explicit type conversion not allowed from "type(bytes storage pointer)" to "address".
+// TypeError 9640: (446-458): Explicit type conversion not allowed from "type(struct S memory[] memory)" to "address".
+// TypeError 9640: (468-480): Explicit type conversion not allowed from "type(enum E[] memory)" to "address".
+// TypeError 9640: (490-511): Explicit type conversion not allowed from "tuple(type(uint256),type(uint256))" to "address".
+// TypeError 9640: (522-541): Explicit type conversion not allowed from "type(uint256)" to "address".

--- a/test/libsolidity/syntaxTests/types/too_small_negative_numbers.sol
+++ b/test/libsolidity/syntaxTests/types/too_small_negative_numbers.sol
@@ -2,4 +2,4 @@ contract C {
   fixed8x80 a = -1e-100;
 }
 // ----
-// TypeError 4426: (29-36): Type rational_const -1 / 1000...(93 digits omitted)...0000 is not implicitly convertible to expected type fixed8x80, but it can be explicitly converted.
+// UnimplementedFeatureError: Not yet implemented - FixedPointType.


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/10941

Hopefully this prevents fuzzer from generating issues related to fixedpoint types.