### PR TITLE
[SolYul] Remove (hopefully) unnecessary checks.

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -893,17 +893,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		return;
 	}
 
-	auto memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression());
-	if (memberAccess)
-	{
-		if (auto expressionType = dynamic_cast<TypeType const*>(memberAccess->expression().annotation().type))
-		{
-			solAssert(!functionType->bound(), "");
-			if (auto contractType = dynamic_cast<ContractType const*>(expressionType->actualType()))
-				if (contractType->contractDefinition().isLibrary())
-					solAssert(functionType->kind() == FunctionType::Kind::Internal || functionType->kind() == FunctionType::Kind::DelegateCall, "");
-		}
-	}
+	auto const* memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression());
 
 	switch (functionType->kind())
 	{

--- a/test/libsolidity/semanticTests/structs/event.sol
+++ b/test/libsolidity/semanticTests/structs/event.sol
@@ -1,0 +1,17 @@
+pragma abicoder v2;
+
+struct Item {uint x;}
+library L {
+    event Ev(Item);
+    function o() public { emit L.Ev(Item(1)); }
+}
+contract C {
+    function f() public {
+        L.o();
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// library: L
+// f() ->


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10892

These checks were from the early days when we did not yet have a full implementation of all function kinds. They can be prevented easily by adding parentheses anyway.