### PR TITLE
Fixed the grammer of a sentence in the docs

### DIFF
--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -49,7 +49,7 @@ Pragmas
 
 The ``pragma`` keyword is used to enable certain compiler features
 or checks. A pragma directive is always local to a source file, so
-you have to add the pragma to all your files if you want enable it
+you have to add the pragma to all your files if you want to enable it
 in your whole project. If you :ref:`import<import>` another file, the pragma
 from that file does *not* automatically apply to the importing file.
 


### PR DESCRIPTION
Fixed a small grammer error in the docs

![image](https://user-images.githubusercontent.com/61436699/108046697-d6dba680-703c-11eb-8d4e-a84bb501ecf0.png)
