### PR TITLE
Tests: Do not remove filename from boost filesystem path for corner cases

### DIFF
--- a/libsolutil/CommonIO.cpp
+++ b/libsolutil/CommonIO.cpp
@@ -137,7 +137,11 @@ string solidity::util::absolutePath(string const& _path, string const& _referenc
 	if (p.begin() == p.end() || (*p.begin() != "." && *p.begin() != ".."))
 		return _path;
 	boost::filesystem::path result(_reference);
-	result.remove_filename();
+
+	// If filename is "/", then remove_filename() throws.
+	// See: https://github.com/boostorg/filesystem/issues/176
+	if (result.filename() != boost::filesystem::path("/"))
+		result.remove_filename();
 	for (boost::filesystem::path::iterator it = p.begin(); it != p.end(); ++it)
 		if (*it == "..")
 			result = result.parent_path();

--- a/scripts/ASTImportTest.sh
+++ b/scripts/ASTImportTest.sh
@@ -84,7 +84,10 @@ echo "Looking at $NSOURCES .sol files..."
 WORKINGDIR=$PWD
 
 # for solfile in $(find $DEV_DIR -name *.sol)
-for solfile in $(find "$SYNTAXTESTS_DIR" "$ASTJSONTESTS_DIR" -name *.sol)
+# boost_filesystem_bug specifically tests a local fix for a boost::filesystem
+# bug. Since the test involves a malformed path, there is no point in running
+# AST tests on it. See https://github.com/boostorg/filesystem/issues/176
+for solfile in $(find "$SYNTAXTESTS_DIR" "$ASTJSONTESTS_DIR" -name *.sol -and -not -name "boost_filesystem_bug.sol")
 do
     echo -n "."
     # create a temporary sub-directory

--- a/test/libsolidity/syntaxTests/imports/boost_filesystem_bug.sol
+++ b/test/libsolidity/syntaxTests/imports/boost_filesystem_bug.sol
@@ -1,0 +1,4 @@
+==== Source://// ====
+// This test used to throw due to a bug in boost::filesystem.
+// See https://github.com/boostorg/filesystem/issues/176
+import ".";

--- a/test/stopAfterParseTests.sh
+++ b/test/stopAfterParseTests.sh
@@ -70,5 +70,5 @@ while read -r file; do
 		echo "$file"
 		exit 1
 	fi
-done < <(find "${REPO_ROOT}/test" -iname "*.sol" -and -not -name "documentation.sol")
+done < <(find "${REPO_ROOT}/test" -iname "*.sol" -and -not -name "documentation.sol" -and -not -name "boost_filesystem_bug.sol")
 echo


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10713

Also see https://github.com/boostorg/filesystem/issues/176 for upstream issue