### PR TITLE
[isoltest] Add support for events using builtins.

### DIFF
--- a/liblangutil/Common.h
+++ b/liblangutil/Common.h
@@ -45,6 +45,11 @@ inline bool isIdentifierPart(char c)
 	return isIdentifierStart(c) || isDecimalDigit(c);
 }
 
+inline bool isIdentifierPartWithDot(char c)
+{
+	return isIdentifierPart(c) || c == '.';
+}
+
 inline int hexValue(char c)
 {
 	if (c >= '0' && c <= '9')

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,8 @@ detect_stray_source_files("${liblangutil_sources}" "liblangutil/")
 set(libsolidity_sources
     libsolidity/TestHook.h
     libsolidity/hooks/SmokeHook.h
+    libsolidity/hooks/LogsHook.h
+    libsolidity/hooks/LogsHook.cpp
     libsolidity/ABIDecoderTests.cpp
     libsolidity/ABIEncoderTests.cpp
     libsolidity/ABIJsonTest.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,8 @@ set(liblangutil_sources
 detect_stray_source_files("${liblangutil_sources}" "liblangutil/")
 
 set(libsolidity_sources
+    libsolidity/TestHook.h
+    libsolidity/hooks/SmokeHook.h
     libsolidity/ABIDecoderTests.cpp
     libsolidity/ABIEncoderTests.cpp
     libsolidity/ABIJsonTest.cpp

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -29,7 +29,7 @@
 
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/FunctionSelector.h>
-
+#include <libsolidity/util/SoltestTypes.h>
 #include <liblangutil/Exceptions.h>
 
 #include <boost/test/framework.hpp>
@@ -264,6 +264,23 @@ bytes ExecutionFramework::logData(size_t _logIdx) const
 	// TODO: Return a copy of log data, because this is expected from REQUIRE_LOG_DATA(),
 	//       but reference type like string_view would be preferable.
 	return {data.begin(), data.end()};
+}
+
+vector<solidity::frontend::test::LogRecord>  ExecutionFramework::recordedLogs() const {
+	vector<solidity::frontend::test::LogRecord> logs{};
+	for (size_t logIdx = 0; logIdx < numLogs(); ++logIdx)
+	{
+		solidity::frontend::test::LogRecord record;
+		const auto& data = m_evmcHost->recorded_logs.at(logIdx).data;
+		record.index = logIdx;
+		record.data = bytes{data.begin(), data.end()};
+		record.creator = EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(logIdx).creator);
+		for (size_t topicIdx = 0; topicIdx < numLogTopics(logIdx); ++topicIdx) {
+			record.topics.emplace_back(EVMHost::convertFromEVMC(m_evmcHost->recorded_logs.at(logIdx).topics.at(topicIdx)));
+		}
+		logs.emplace_back(record);
+	}
+	return logs;
 }
 
 u256 ExecutionFramework::balanceAt(h160 const& _addr)

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -39,6 +39,11 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace solidity::frontend::test
+{
+struct LogRecord;
+} // namespace solidity::frontend::test
+
 namespace solidity::test
 {
 using rational = boost::rational<bigint>;
@@ -240,6 +245,13 @@ public:
 		return result;
 	}
 
+	size_t numLogs() const;
+	size_t numLogTopics(size_t _logIdx) const;
+	util::h256 logTopic(size_t _logIdx, size_t _topicIdx) const;
+	util::h160 logAddress(size_t _logIdx) const;
+	bytes logData(size_t _logIdx) const;
+	std::vector<solidity::frontend::test::LogRecord> recordedLogs() const;
+
 private:
 	template <class CppFunction, class... Args>
 	auto callCppAndEncodeResult(CppFunction const& _cppFunction, Args const&... _arguments)
@@ -270,12 +282,6 @@ protected:
 	u256 balanceAt(util::h160 const& _addr);
 	bool storageEmpty(util::h160 const& _addr);
 	bool addressHasCode(util::h160 const& _addr);
-
-	size_t numLogs() const;
-	size_t numLogTopics(size_t _logIdx) const;
-	util::h256 logTopic(size_t _logIdx, size_t _topicIdx) const;
-	util::h160 logAddress(size_t _logIdx) const;
-	bytes logData(size_t _logIdx) const;
 
 	langutil::EVMVersion m_evmVersion;
 	solidity::frontend::RevertStrings m_revertStrings = solidity::frontend::RevertStrings::Default;

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -13,9 +13,14 @@
 */
 
 #include <test/libsolidity/SemanticTest.h>
+
 #include <libsolutil/Whiskers.h>
 #include <libyul/Exceptions.h>
 #include <test/Common.h>
+#include <test/libsolidity/util/BytesUtils.h>
+#include <test/libsolidity/hooks/SmokeHook.h>
+#include <test/libsolidity/TestHook.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -25,7 +30,9 @@
 #include <cctype>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 using namespace solidity;
@@ -47,6 +54,16 @@ SemanticTest::SemanticTest(string const& _filename, langutil::EVMVersion _evmVer
 	m_lineOffset(m_reader.lineNumber()),
 	m_enforceViaYul(enforceViaYul)
 {
+	using namespace placeholders;
+
+	auto simpleSmokeBuiltin = bind(&SemanticTest::builtinSmokeTest, this, _1);
+	addBuiltin("smoke.test0", simpleSmokeBuiltin);
+	addBuiltin("smoke.test1", simpleSmokeBuiltin);
+	addBuiltin("smoke.test2", simpleSmokeBuiltin);
+	addBuiltin("smoke_test3", simpleSmokeBuiltin);
+
+	addTestHook(make_unique<SmokeHook>());
+
 	string choice = m_reader.stringSetting("compileViaYul", "default");
 	if (choice == "also")
 	{
@@ -119,7 +136,23 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 	return result;
 }
 
-TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _linePrefix, bool _formatted, bool _compileViaYul, bool _compileToEwasm)
+void SemanticTest::addBuiltin(string _name, Builtin _builtin)
+{
+	m_builtins[std::move(_name)] = std::move(_builtin);
+}
+
+void SemanticTest::addTestHook(std::unique_ptr<TestHook> _testHook)
+{
+	m_testHooks.emplace_back(std::move(_testHook));
+}
+
+TestCase::TestResult SemanticTest::runTest(
+	ostream& _stream,
+	string const& _linePrefix,
+	bool _formatted,
+	bool _compileViaYul,
+	bool _compileToEwasm
+)
 {
 	bool success = true;
 
@@ -142,21 +175,31 @@ TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _line
 	if (_compileViaYul)
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Running via Yul:" << endl;
 
-	for (auto& test: m_tests)
+	for (TestFunctionCall& test: m_tests)
 		test.reset();
 
 	map<string, solidity::test::Address> libraries;
 
 	bool constructed = false;
 
-	for (auto& test: m_tests)
+	for (std::unique_ptr<TestHook> const& hook: m_testHooks)
+		hook->beginTestCase();
+
+	for (TestFunctionCall& test: m_tests)
 	{
+		for (std::unique_ptr<TestHook> const& hook: m_testHooks)
+			hook->beforeFunctionCall(test);
+
 		if (constructed)
 		{
-			soltestAssert(test.call().kind != FunctionCall::Kind::Library, "Libraries have to be deployed before any other call.");
+			soltestAssert(
+				test.call().kind != FunctionCall::Kind::Library,
+				"Libraries have to be deployed before any other call."
+			);
 			soltestAssert(
 				test.call().kind != FunctionCall::Kind::Constructor,
-				"Constructor has to be the first function call expect for library deployments.");
+				"Constructor has to be the first function call expect for library deployments."
+			);
 		}
 		else if (test.call().kind == FunctionCall::Kind::Library)
 		{
@@ -197,6 +240,18 @@ TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _line
 			bytes output;
 			if (test.call().kind == FunctionCall::Kind::LowLevel)
 				output = callLowLevel(test.call().arguments.rawBytes(), test.call().value.value);
+			else if (test.call().kind == FunctionCall::Kind::Builtin)
+			{
+				auto builtin = m_builtins[test.call().signature];
+				std::optional<bytes> builtinOutput{builtin(test.call())};
+				if (builtinOutput.has_value())
+				{
+					test.setFailure(false);
+					output = builtinOutput.value();
+				}
+				else
+					test.setFailure(true);
+			}
 			else
 			{
 				soltestAssert(
@@ -212,19 +267,48 @@ TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _line
 				);
 			}
 
-			bool outputMismatch = (output != test.call().expectations.rawBytes());
-			// Pre byzantium, it was not possible to return failure data, so we disregard
-			// output mismatch for those EVM versions.
-			if (test.call().expectations.failure && !m_transactionSuccessful && !m_evmVersion.supportsReturndata())
-				outputMismatch = false;
-			if (m_transactionSuccessful != !test.call().expectations.failure || outputMismatch)
-				success = false;
+			bytes expectationOutput;
+			if (test.call().expectations.builtin)
+			{
+				auto builtin = m_builtins[test.call().expectations.builtin->signature];
+				if (std::optional<bytes> builtinResult = builtin(*test.call().expectations.builtin))
+					expectationOutput = builtinResult.value();
+				else
+					test.setFailure(true);
+			}
+			else
+				expectationOutput = test.call().expectations.rawBytes();
 
-			test.setFailure(!m_transactionSuccessful);
+			bool outputMismatch = (output != expectationOutput);
+			if (test.call().kind == FunctionCall::Kind::Builtin)
+			{
+				if (outputMismatch)
+					success = false;
+			}
+			else
+			{
+				// Pre byzantium, it was not possible to return failure data, so we disregard
+				// output mismatch for those EVM versions.
+				if (test.call().expectations.failure && !m_transactionSuccessful && !m_evmVersion.supportsReturndata())
+					outputMismatch = false;
+				if (m_transactionSuccessful != !test.call().expectations.failure || outputMismatch)
+					success = false;
+				test.setFailure(!m_transactionSuccessful);
+			}
 			test.setRawBytes(std::move(output));
 			test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName()));
 		}
+
+		for (std::unique_ptr<TestHook> const& hook: m_testHooks)
+			hook->afterFunctionCall(test);
 	}
+
+	for (std::unique_ptr<TestHook> const& hook: m_testHooks)
+		hook->endTestCase();
+
+	for (TestFunctionCall& test: m_tests)
+		for (std::unique_ptr<TestHook> const& hook: m_testHooks)
+			success &= hook->verifyFunctionCall(test);
 
 	if (!m_runWithYul && _compileViaYul)
 	{
@@ -241,18 +325,18 @@ TestCase::TestResult SemanticTest::runTest(ostream& _stream, string const& _line
 	if (!success && (m_runWithYul || !_compileViaYul))
 	{
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
-		for (auto const& test: m_tests)
+		for (TestFunctionCall const& test: m_tests)
 		{
 			ErrorReporter errorReporter;
-			_stream << test.format(errorReporter, _linePrefix, false, _formatted) << endl;
+			_stream << test.format(errorReporter, _linePrefix, false, _formatted, &m_testHooks) << endl;
 			_stream << errorReporter.format(_linePrefix, _formatted);
 		}
 		_stream << endl;
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << endl;
-		for (auto const& test: m_tests)
+		for (TestFunctionCall const& test: m_tests)
 		{
 			ErrorReporter errorReporter;
-			_stream << test.format(errorReporter, _linePrefix, true, _formatted) << endl;
+			_stream << test.format(errorReporter, _linePrefix, true, _formatted, &m_testHooks) << endl;
 			_stream << errorReporter.format(_linePrefix, _formatted);
 		}
 		AnsiColorized(_stream, _formatted, {BOLD, RED})
@@ -320,8 +404,8 @@ void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool
 
 void SemanticTest::printUpdatedExpectations(ostream& _stream, string const&) const
 {
-	for (auto const& test: m_tests)
-		_stream << test.format("", true, false) << endl;
+	for (TestFunctionCall const& test: m_tests)
+		_stream << test.format("", true, false, &m_testHooks) << endl;
 }
 
 void SemanticTest::printUpdatedSettings(ostream& _stream, string const& _linePrefix)
@@ -340,13 +424,31 @@ void SemanticTest::printUpdatedSettings(ostream& _stream, string const& _linePre
 
 void SemanticTest::parseExpectations(istream& _stream)
 {
-	TestFileParser parser{_stream};
+	TestFileParser parser{_stream, &this->m_builtins};
 	auto functionCalls = parser.parseFunctionCalls(m_lineOffset);
-	std::move(functionCalls.begin(), functionCalls.end(), back_inserter(m_tests));
+	move(functionCalls.begin(), functionCalls.end(), back_inserter(m_tests));
 }
 
-bool SemanticTest::deploy(string const& _contractName, u256 const& _value, bytes const& _arguments, map<string, solidity::test::Address> const& _libraries)
+bool SemanticTest::deploy(
+	string const& _contractName,
+	u256 const& _value,
+	bytes const& _arguments,
+	map<string, solidity::test::Address> const& _libraries
+)
 {
 	auto output = compileAndRunWithoutCheck(m_sources.sources, _value, _contractName, _arguments, _libraries);
 	return !output.empty() && m_transactionSuccessful;
+}
+
+std::optional<bytes> SemanticTest::builtinSmokeTest(FunctionCall const& call)
+{
+	// This function is only used in test/libsolidity/semanticTests/builtins/smoke.sol.
+	std::optional<bytes> result;
+	if (call.arguments.parameters.size() < 3)
+	{
+		result = bytes();
+		for (const auto& parameter: call.arguments.parameters)
+			result.value() += util::toBigEndian(u256{util::fromHex(parameter.rawString)});
+	}
+	return result;
 }

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -19,6 +19,7 @@
 #include <test/Common.h>
 #include <test/libsolidity/util/BytesUtils.h>
 #include <test/libsolidity/hooks/SmokeHook.h>
+#include <test/libsolidity/hooks/LogsHook.h>
 #include <test/libsolidity/TestHook.h>
 
 #include <boost/algorithm/string.hpp>
@@ -63,6 +64,7 @@ SemanticTest::SemanticTest(string const& _filename, langutil::EVMVersion _evmVer
 	addBuiltin("smoke_test3", simpleSmokeBuiltin);
 
 	addTestHook(make_unique<SmokeHook>());
+	addTestHook(make_unique<LogsHook>(this));
 
 	string choice = m_reader.stringSetting("compileViaYul", "default");
 	if (choice == "also")

--- a/test/libsolidity/SemanticTest.h
+++ b/test/libsolidity/SemanticTest.h
@@ -14,13 +14,14 @@
 
 #pragma once
 
-#include <test/libsolidity/util/TestFileParser.h>
-#include <test/libsolidity/util/TestFunctionCall.h>
-#include <test/libsolidity/SolidityExecutionFramework.h>
-#include <test/libsolidity/AnalysisFramework.h>
-#include <test/TestCase.h>
 #include <liblangutil/Exceptions.h>
 #include <libsolutil/AnsiColorized.h>
+#include <test/TestCase.h>
+#include <test/libsolidity/AnalysisFramework.h>
+#include <test/libsolidity/SolidityExecutionFramework.h>
+#include <test/libsolidity/TestHook.h>
+#include <test/libsolidity/util/TestFileParser.h>
+#include <test/libsolidity/util/TestFunctionCall.h>
 
 #include <iosfwd>
 #include <string>
@@ -58,7 +59,14 @@ public:
 	/// Compiles and deploys currently held source.
 	/// Returns true if deployment was successful, false otherwise.
 	bool deploy(std::string const& _contractName, u256 const& _value, bytes const& _arguments, std::map<std::string, solidity::test::Address> const& _libraries = {});
+
+	void addBuiltin(std::string _name, Builtin _builtin);
+	void addTestHook(std::unique_ptr<TestHook> _testHook);
+
 private:
+	// builtin functions
+	std::optional<bytes> builtinSmokeTest(FunctionCall const& call);
+
 	TestResult runTest(std::ostream& _stream, std::string const& _linePrefix, bool _formatted, bool _compileViaYul, bool _compileToEwasm);
 	SourceMap m_sources;
 	std::size_t m_lineOffset;
@@ -70,6 +78,8 @@ private:
 	bool m_runWithABIEncoderV1Only = false;
 	bool m_allowNonExistingFunctions = false;
 	bool m_compileViaYulCanBeSet = false;
+	Builtins m_builtins{};
+	std::vector<std::unique_ptr<TestHook>> m_testHooks{};
 };
 
 }

--- a/test/libsolidity/TestHook.h
+++ b/test/libsolidity/TestHook.h
@@ -1,0 +1,116 @@
+/*
+	This file is part of solidity.
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <test/libsolidity/util/SoltestErrors.h>
+
+#include <memory>
+#include <vector>
+
+namespace solidity::frontend::test
+{
+
+class TestFunctionCall;
+
+/**
+ * The `TestHook` class can be used to implement checks for semantic tests.
+ *
+ * A `TestHook` normally gets registered in `test/libsolidity/SemanticTest.cpp`.
+ * If instantiated there, they have the same live-time as the SemanticTest instance.
+ *
+ * NOTE: A single `SemanticTest` instance is used per `*.sol` file in the semantic tests.
+ *       A test-case defined by `SemanticTest` may have multiple test-runs, e.g. Yul and/or Ewasm test-runs.
+ *
+ * Pseudo-code how `TestHooks` are used during test-execution
+ * (see test/libsolidity/SemanticTest.cpp, SemanticTest::run & SemanticTest::runTest):
+ *
+ *  // Multiple test-runs are possible.
+ *  // Additional tests_runs are needed for yul and/or ewasm.
+ *  foreach test in test_runs:
+ *      success = true
+ *      foreach hook in test.hooks:
+ *          hook->beginTestCase();
+ *
+ *      foreach call in test.calls:
+ *          foreach hook in test.hooks:
+ *              hook->beforeFunctionCall(call);
+ *          call();
+ *          foreach hook in test.hooks:
+ *              hook->afterFunctionCall(call);
+ *
+ *       foreach hook in test.hooks:
+ *          hook->endTestCase();
+ *
+ *      foreach hook in tests.hook:
+ *          foreach call in test.calls:
+ *              success &= hook->verifyFunctionCall(call);
+ *
+ *      // printing errors/warnings & update expectations
+ *      if !success:
+ *          foreach hook in tests.hooks:
+ *              foreach call in tests.calls:
+ *                  print(hook->formatFunctionCall(call));
+ */
+class TestHook
+{
+public:
+	TestHook() = default;
+	virtual ~TestHook() = default;
+
+	/// If the test-case consists multiple test-runs (e.g. yul and/or ewasm), this function is called per test-run.
+	/// This function is called at the begin of each test-run.
+	virtual void beginTestCase() = 0;
+
+	/// This function gets called, before the actual `TestFunctionCall` got executed.
+	/// @param _call current `TestFunctionCall` defined in the test-case.
+	virtual void beforeFunctionCall(TestFunctionCall const& _call) = 0;
+
+	/// This function gets called, after the actual `TestFunctionCall` got executed.
+	/// @param _call current `TestFunctionCall` defined in the test-case.
+	virtual void afterFunctionCall(TestFunctionCall const& _call) = 0;
+
+	/// If the test-case consists multiple test-runs (e.g. yul and/or ewasm), this function is called per test-run.
+	/// This function is called at the end of each test-run.
+	virtual void endTestCase() = 0;
+
+	/// Normally the methods `beginTestCase`, `beforeFunctionCall`, `afterFunctionCall` and `endTestCase` are used
+	/// to collect information of the test-calls. `verifyFunctionCall` can be used to check whether this information
+	/// is complete and doesn't contain any errors.
+	/// NOTE: if any of the test-call verification fails, the whole test-case fails.
+	/// This function is called on each of the `TestFunctionCall` defined within the test-case.
+	/// @param _call current `TestFunctionCall` defined in the test-case.
+	/// @returns true, if verification of `_call` was successful, false otherwise.
+	virtual bool verifyFunctionCall(TestFunctionCall const& _call) = 0;
+
+	/// This function is used to format a single `TestFunctionCall`.
+	/// It is responsible to generate the textual representation of `_call`
+	/// that will be used to show and/or update expectations.
+	/// @param _call current `TestFunctionCall` defined in the test-case.
+	/// @param _errorReporter ErrorReporter to be used.
+	/// @param _linePrefix contains the indentation prefix of the line.
+	/// @param _renderResult false, the expected result of the call will be returned, otherwise the actual result is
+	/// returned.
+	/// @param _highlight false, if it's formatted without colorized highlighting. If it's true, AnsiColorized used to
+	/// apply a colorized highlighting.
+	/// @returns string that contains the textual representation of `_call`.
+	virtual std::string formatFunctionCall(
+		const TestFunctionCall& _call,
+		ErrorReporter& _errorReporter,
+		std::string const& _linePrefix,
+		bool const _renderResult,
+		bool const _highlight) const = 0;
+};
+
+} // namespace solidity::frontend::test

--- a/test/libsolidity/hooks/LogsHook.cpp
+++ b/test/libsolidity/hooks/LogsHook.cpp
@@ -1,0 +1,217 @@
+#include <test/libsolidity/hooks/LogsHook.h>
+#include <test/libsolidity/SemanticTest.h>
+#include <test/libsolidity/SolidityExecutionFramework.h>
+#include <test/libsolidity/util/SoltestErrors.h>
+#include <libsolutil/AnsiColorized.h>
+#include <libsolutil/CommonData.h>
+#include <libsolutil/FixedHash.h>
+
+using namespace std;
+using namespace solidity::util;
+
+namespace solidity::frontend::test
+{
+
+LogsHook::LogsHook(SemanticTest* _test): m_test(_test) {
+	using namespace std::placeholders;
+
+	m_executionFramework = dynamic_cast<SolidityExecutionFramework*>(m_test);
+	soltestAssert(m_executionFramework != nullptr, "");
+
+	m_test->addBuiltin("logs.numLogs", std::bind(&LogsHook::numLogs, this, _1));
+	m_test->addBuiltin("logs.numLogTopics", std::bind(&LogsHook::numLogTopics, this, _1));
+	m_test->addBuiltin("logs.logTopic", std::bind(&LogsHook::logTopic, this, _1));
+	m_test->addBuiltin("logs.logAddress", std::bind(&LogsHook::logAddress, this, _1));
+	m_test->addBuiltin("logs.logData", std::bind(&LogsHook::logData, this, _1));
+	m_test->addBuiltin("logs.expectEvent", std::bind(&LogsHook::expectEvent, this, _1));
+}
+
+std::optional<bytes> LogsHook::numLogs(FunctionCall const&)
+{
+	size_t result = m_executionFramework->numLogs();
+	bytes r = util::toBigEndian(u256{result});
+	return r;
+}
+
+std::optional<bytes> LogsHook::numLogTopics(FunctionCall const& _call)
+{
+	assert(_call.arguments.parameters.size() == 1);
+	size_t logCount = m_executionFramework->numLogs();
+	// todo: hex strings not supported by lexical_cast<..>(..)
+	auto logIdx = boost::lexical_cast<size_t>(_call.arguments.parameters.front().rawString);
+	if (logCount > 0 && logIdx < logCount)
+	{
+		m_touchedLogs[&_call].insert(logIdx);
+		return util::toBigEndian(u256{m_executionFramework->numLogTopics(logIdx)});
+	}
+	return std::nullopt;
+}
+
+std::optional<bytes> LogsHook::logTopic(FunctionCall const& _call)
+{
+	assert(_call.arguments.parameters.size() == 2);
+	auto logIdx = boost::lexical_cast<size_t>(_call.arguments.parameters.front().rawString);
+	m_touchedLogs[&_call].insert(logIdx);
+	auto topicIdx = boost::lexical_cast<size_t>(_call.arguments.parameters.back().rawString);
+	size_t logCount = m_executionFramework->numLogs();
+	// todo: hex strings not supported by lexical_cast<..>(..)
+	if (logCount > 0 && logIdx < logCount)
+	{
+		size_t topicCount = m_executionFramework->numLogTopics(logIdx);
+		if (topicCount > 0 && topicIdx < topicCount)
+			return util::toBigEndian(u256{m_executionFramework->logTopic(logIdx, topicIdx)});
+	}
+	return std::nullopt;
+}
+
+std::optional<bytes> LogsHook::logAddress(FunctionCall const& _call)
+{
+	// logAddress(uint256)
+	assert(_call.arguments.parameters.size() == 1);
+	size_t logCount = m_executionFramework->numLogs();
+	// todo: hex strings not supported by lexical_cast<..>(..)
+	auto logIdx = boost::lexical_cast<size_t>(_call.arguments.parameters.front().rawString);
+	m_touchedLogs[&_call].insert(logIdx);
+	if (logCount > 0 && logIdx < logCount)
+		return util::toBigEndian(u256{u160{m_executionFramework->logAddress(logIdx)}});
+	return std::nullopt;
+}
+
+std::optional<bytes> LogsHook::logData(FunctionCall const& _call)
+{
+	// logData(uint256)
+	assert(_call.arguments.parameters.size() == 1);
+	size_t logCount = m_executionFramework->numLogs();
+	// todo: hex strings not supported by lexical_cast<..>(..)
+	auto logIdx = boost::lexical_cast<size_t>(_call.arguments.parameters.front().rawString);
+	m_touchedLogs[&_call].insert(logIdx);
+	if (logCount > 0 && logIdx < logCount)
+		return m_executionFramework->logData(logIdx);
+	return std::nullopt;
+}
+
+std::optional<bytes> LogsHook::expectEvent(FunctionCall const& _call)
+{
+	// expectEvent(uint256,string): logIdx, eventSignature
+	assert(_call.arguments.parameters.size() == 2);
+	size_t logCount = m_executionFramework->numLogs();
+	// todo: hex strings not supported by lexical_cast<..>(..)
+	auto logIdx = boost::lexical_cast<size_t>(_call.arguments.parameters.front().rawString);
+	m_touchedLogs[&_call].insert(logIdx);
+	auto logSignature = _call.arguments.parameters.back().rawString;
+	assert(logSignature.length() >= 2);
+	logSignature = logSignature.substr(1, logSignature.length() - 2);
+	h256 logSignatureHash{util::keccak256(logSignature)};
+	if (logCount > 0 && logIdx < logCount)
+	{
+		vector<h256> topics;
+		size_t topicCount = m_executionFramework->numLogTopics(logIdx);
+		for (size_t topicIdx = 0; topicIdx < topicCount; ++topicIdx)
+			topics.push_back(m_executionFramework->logTopic(logIdx, topicIdx));
+		// remove topics[0], if the signature matches.
+		if (!topics.empty() && topics[0] == logSignatureHash)
+			topics.erase(topics.begin());
+		bytes result;
+		for (auto& topic: topics)
+			result += util::toBigEndian(topic);
+		result += m_executionFramework->logData(logIdx);
+		return result;
+	}
+	return std::nullopt;
+}
+
+void LogsHook::beginTestCase()
+{
+	m_producedLogs.clear();
+	m_touchedLogs.clear();
+	m_previousCall = nullptr;
+}
+
+void LogsHook::afterFunctionCall(TestFunctionCall const& _call)
+{
+	m_producedLogs[&_call.call()] = m_executionFramework->recordedLogs();
+	m_previousCalls[&_call] = m_previousCall;
+	m_previousCall = &_call;
+
+	TestFunctionCall const* producer = m_previousCalls[&_call];
+	std::vector<FunctionCall const*> consumers{};
+
+	// Only non-builtins are able to produce logs.
+	// So lets search from the current call up to the first non-builtin.
+	while (producer != nullptr && producer->call().kind == FunctionCall::Kind::Builtin)
+		if (m_previousCalls[producer] == nullptr)
+			break;
+		else
+		{
+			// On the way up to the producer we track all builtins that where on the way.
+			// Only builtins can consume logs, we store them in the consumers vector.
+			consumers.emplace_back(&producer->call());
+			producer = m_previousCalls[producer];
+		}
+
+	// Producer will now point to the call that probably produced a log.
+	if (producer)
+	{
+		consumers.emplace_back(&_call.call());
+		// We iterate through the consumers to find out what logs they have consumed.
+		for (auto& consumer: consumers)
+			for (auto logIdx: m_touchedLogs[consumer])
+				// All logs that where touched by the consumer, will be marked as
+				// touched within the producer.
+				m_touchedLogs[&producer->call()].insert(logIdx);
+	}
+}
+
+bool LogsHook::verifyFunctionCall(const TestFunctionCall& _call)
+{
+	if (_call.call().kind == FunctionCall::Kind::Builtin)
+		// Builtins can not produce events, so everything is ok here.
+		return true;
+	else
+		// If not all produced logs where consumed, indicate an error by returning false.
+		// But it is totally ok if more logs where consumed than produced.
+		return m_touchedLogs[&_call.call()].size() >= m_producedLogs[&_call.call()].size();
+}
+
+string LogsHook::formatFunctionCall(
+	const TestFunctionCall& _call,
+	ErrorReporter& _errorReporter,
+	std::string const& _linePrefix,
+	bool const _renderResult,
+	bool const _highlight) const
+{
+	(void) _errorReporter;
+	(void) _renderResult;
+
+	if (_call.call().kind == FunctionCall::Kind::Builtin)
+		// Builtins can not produce events, so everything is ok here.
+		return "";
+
+	stringstream stream;
+	set<size_t> touchedLogs{m_touchedLogs.at(&_call.call())};
+	vector<LogRecord> producedLogs{m_producedLogs.at(&_call.call())};
+	if (touchedLogs.size() < producedLogs.size())
+	{
+		std::vector<LogRecord> forgottenLogs{};
+		for (auto& log: producedLogs)
+			if (touchedLogs.count(log.index) == 0)
+				forgottenLogs.push_back(log);
+
+		if (!forgottenLogs.empty())
+		{
+			stream << std::endl;
+			for (auto& log: forgottenLogs)
+			{
+				stream << _linePrefix;
+				AnsiColorized(stream, _highlight, {util::formatting::RED_BACKGROUND})
+					<< "// logs.numLogTopics: " << log.index << " -> " << log.topics.size();
+				if (log != (*forgottenLogs.rbegin()))
+					stream << std::endl;
+				AnsiColorized(stream, _highlight, {util::formatting::RESET});
+			}
+		}
+	}
+	return stream.str();
+}
+
+} // namespace solidity::frontend::test

--- a/test/libsolidity/hooks/LogsHook.h
+++ b/test/libsolidity/hooks/LogsHook.h
@@ -1,0 +1,67 @@
+/*
+	This file is part of solidity.
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <test/libsolidity/TestHook.h>
+#include <test/libsolidity/util/SoltestTypes.h>
+
+#include <map>
+#include <set>
+#include <vector>
+
+namespace solidity::frontend::test
+{
+class SemanticTest;
+class SolidityExecutionFramework;
+
+class LogsHook: public TestHook
+{
+public:
+	LogsHook(SemanticTest* _test);
+	~LogsHook() override = default;
+
+	std::optional<bytes> numLogs(FunctionCall const& _call);
+	std::optional<bytes> numLogTopics(FunctionCall const& _call);
+	std::optional<bytes> logTopic(FunctionCall const& _call);
+	std::optional<bytes> logAddress(FunctionCall const& _call);
+	std::optional<bytes> logData(FunctionCall const& _call);
+	std::optional<bytes> expectEvent(FunctionCall const& _call);
+
+	void beginTestCase() override;
+	void afterFunctionCall(TestFunctionCall const&) override;
+
+	void beforeFunctionCall(TestFunctionCall const&) override {}
+	void endTestCase() override {}
+
+	bool verifyFunctionCall(TestFunctionCall const& _call) override;
+
+	std::string formatFunctionCall(
+		const TestFunctionCall& _call,
+		ErrorReporter& _errorReporter,
+		std::string const& _linePrefix,
+		bool const _renderResult,
+		bool const _highlight) const override;
+
+private:
+	SemanticTest* m_test = nullptr;
+	SolidityExecutionFramework* m_executionFramework = nullptr;
+
+	std::map<FunctionCall const*, std::vector<LogRecord>> m_producedLogs{};
+	std::map<FunctionCall const*, std::set<size_t>> m_touchedLogs{};
+	std::map<TestFunctionCall const*, TestFunctionCall const*> m_previousCalls;
+	TestFunctionCall const* m_previousCall;
+};
+
+} // namespace  solidity::frontend::test

--- a/test/libsolidity/hooks/SmokeHook.h
+++ b/test/libsolidity/hooks/SmokeHook.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of solidity.
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <iostream>
+#include <test/libsolidity/TestHook.h>
+
+namespace solidity::frontend::test
+{
+class SmokeHook: public TestHook
+{
+public:
+	SmokeHook() = default;
+	~SmokeHook() override = default;
+
+	void beginTestCase() override {}
+	void beforeFunctionCall(TestFunctionCall const&) override {}
+	void afterFunctionCall(TestFunctionCall const&) override {}
+	void endTestCase() override {}
+
+	bool verifyFunctionCall(TestFunctionCall const&) override { return true; }
+
+	std::string formatFunctionCall(
+		TestFunctionCall const&,
+		ErrorReporter&,
+		std::string const&,
+		const bool,
+		const bool
+	) const override
+	{
+		return "";
+	}
+};
+
+} // namespace  solidity::frontend::test

--- a/test/libsolidity/semanticTests/builtins/logs/logs.sol
+++ b/test/libsolidity/semanticTests/builtins/logs/logs.sol
@@ -1,0 +1,27 @@
+contract ClientReceipt {
+    event A(address _from, bytes32 _id, uint _value);
+    event B(address _from, bytes32 _id, uint indexed _value) anonymous;
+    event C(address _from, bytes32 indexed _id, uint _value);
+    function deposit(bytes32 _id) public payable returns(uint256) {
+        emit A(msg.sender, _id, msg.value);
+        emit B(msg.sender, _id, msg.value);
+        emit C(msg.sender, _id, msg.value);
+        return  msg.value;
+    }
+}
+
+// ====
+// compileViaYul: false
+// ----
+// deposit(bytes32), 28 wei: 0x1234 -> 0x1c
+// logs.numLogTopics: 0 -> 1
+// logs.numLogTopics: 1 -> 1
+// logs.numLogTopics: 2 -> 2
+// deposit(bytes32), 28 wei: 0x1234 -> 0x1c
+// logs.numLogTopics: 0 -> 1
+// logs.numLogTopics: 1 -> 1
+// logs.numLogTopics: 2 -> 2
+// deposit(bytes32), 28 wei: 0x1234 -> 0x1c
+// logs.numLogTopics: 0 -> 1
+// logs.numLogTopics: 1 -> 1
+// logs.numLogTopics: 2 -> 2

--- a/test/libsolidity/semanticTests/builtins/smoke.sol
+++ b/test/libsolidity/semanticTests/builtins/smoke.sol
@@ -1,0 +1,18 @@
+contract ClientReceipt {
+}
+// ====
+// compileViaYul: also
+// ----
+// smoke.test0 ->
+// smoke.test0 -> smoke.test0
+// smoke.test1: 1 -> 1
+// smoke.test1: 1 -> smoke.test1: 1
+// smoke.test2: 2, 3 -> 2, 3
+// smoke.test2: 2, 3 -> smoke.test2: 2, 3
+// smoke.test2: 2, 3, 4 -> FAILURE
+// smoke.test2: 2, 3, 4 -> smoke.test2: 2, 3, 4
+// smoke.test0 ->
+// smoke_test3: 2, 3 -> 2, 3
+// smoke_test3: 2, 3 -> smoke_test3: 2, 3
+// smoke_test3: 2, 3, 4 -> FAILURE
+// smoke_test3: 2, 3, 4 -> smoke_test3: 2, 3, 4

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -17,6 +17,8 @@
 #include <libsolutil/AnsiColorized.h>
 #include <libsolutil/CommonData.h>
 
+#include <test/ExecutionFramework.h>
+
 namespace solidity::frontend::test
 {
 
@@ -174,6 +176,8 @@ struct Parameter
 };
 using ParameterList = std::vector<Parameter>;
 
+struct FunctionCall;
+
 /**
  * Represents the expected result of a function call after it has been executed. This may be a single
  * return value or a comma-separated list of return values. It also contains the detected input
@@ -193,6 +197,9 @@ struct FunctionCallExpectations
 	/// A Comment that can be attached to the expectations,
 	/// that is retained and can be displayed.
 	std::string comment;
+	/// An expectation can also be defined by a builtin function.
+	std::shared_ptr<FunctionCall> builtin;
+
 	/// ABI encoded `bytes` of parsed expected return values. It is checked
 	/// against the actual result of a function call when used in test framework.
 	bytes rawBytes() const
@@ -286,12 +293,17 @@ struct FunctionCall
 		/// Marks a library deployment call.
 		Library,
 		/// Check that the storage of the current contract is empty or non-empty.
-		Storage
+		Storage,
+		/// Call to a builtin.
+		Builtin
 	};
 	Kind kind = Kind::Regular;
 	/// Marks this function call as "short-handed", meaning
 	/// no `->` declared.
 	bool omitsArrow = true;
 };
+
+using Builtin = std::function<std::optional<bytes>(FunctionCall const&)>;
+using Builtins = std::map<std::string, Builtin>;
 
 }

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -306,4 +306,26 @@ struct FunctionCall
 using Builtin = std::function<std::optional<bytes>(FunctionCall const&)>;
 using Builtins = std::map<std::string, Builtin>;
 
+/// LogRecord
+struct LogRecord
+{
+	size_t index;
+	/// The address of the account which created the log.
+	util::h160 creator;
+	/// The data attached to the log.
+	bytes data;
+	/// The log topics.
+	std::vector<util::h256> topics;
+	/// Equal operator.
+	bool operator==(const LogRecord& other) const noexcept
+	{
+		return creator == other.creator && data == other.data && topics == other.topics;
+	}
+
+	bool operator!=(const LogRecord& other) const noexcept
+	{
+		return !operator==(other);
+	}
+};
+
 }

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -55,7 +55,7 @@ vector<solidity::frontend::test::FunctionCall> TestFileParser::parseFunctionCall
 	vector<FunctionCall> calls;
 	if (!accept(Token::EOS))
 	{
-		assert(m_scanner.currentToken() == Token::Unknown);
+		soltestAssert(m_scanner.currentToken() == Token::Unknown, "");
 		m_scanner.scanNextToken();
 
 		while (!accept(Token::EOS))
@@ -106,6 +106,12 @@ vector<solidity::frontend::test::FunctionCall> TestFileParser::parseFunctionCall
 						tie(call.signature, lowLevelCall) = parseFunctionSignature();
 						if (lowLevelCall)
 							call.kind = FunctionCall::Kind::LowLevel;
+
+						if (m_builtins && m_builtins->count(call.signature) > 0)
+						{
+							checkBuiltinFunction(call.signature);
+							call.kind = FunctionCall::Kind::Builtin;
+						}
 
 						if (accept(Token::Comma, true))
 							call.value = parseFunctionCallValue();
@@ -160,6 +166,12 @@ vector<solidity::frontend::test::FunctionCall> TestFileParser::parseFunctionCall
 	return calls;
 }
 
+void TestFileParser::checkBuiltinFunction(std::string const& signature)
+{
+	if (m_builtins->count(signature) == 0)
+		BOOST_THROW_EXCEPTION(TestParserError("Builtin function '" + signature + "' not found."));
+}
+
 bool TestFileParser::accept(Token _token, bool const _expect)
 {
 	if (m_scanner.currentToken() != _token)
@@ -194,6 +206,9 @@ pair<string, bool> TestFileParser::parseFunctionSignature()
 		signature = m_scanner.currentLiteral();
 		expect(Token::Identifier);
 	}
+
+	if (m_builtins && m_builtins->count(signature) > 0)
+		return {signature, false};
 
 	signature += formatToken(Token::LParen);
 	expect(Token::LParen);
@@ -260,21 +275,43 @@ FunctionCallExpectations TestFileParser::parseFunctionCallExpectations()
 {
 	FunctionCallExpectations expectations;
 
-	auto param = parseParameter();
-	if (param.abiType.type == ABIType::None)
+	if (accept(Token::Identifier, false))
 	{
-		expectations.failure = false;
-		return expectations;
+		string signature;
+		FunctionCallArgs arguments;
+
+		signature = parseFunctionSignature().first;
+		if (m_builtins->count(signature) == 0)
+			BOOST_THROW_EXCEPTION(TestParserError("Only builtins can be called as an expectation."));
+
+		checkBuiltinFunction(signature);
+
+		if (accept(Token::Colon, true))
+			arguments = parseFunctionCallArguments();
+
+		expectations.builtin = std::make_unique<FunctionCall>();
+		expectations.builtin->arguments = arguments;
+		expectations.builtin->signature = signature;
+		expectations.builtin->kind = FunctionCall::Kind::Builtin;
 	}
-	expectations.result.emplace_back(param);
+	else
+	{
+		auto param = parseParameter();
+		if (param.abiType.type == ABIType::None)
+		{
+			expectations.failure = false;
+			return expectations;
+		}
+		expectations.result.emplace_back(param);
 
-	while (accept(Token::Comma, true))
-		expectations.result.emplace_back(parseParameter());
+		while (accept(Token::Comma, true))
+			expectations.result.emplace_back(parseParameter());
 
-	/// We have always one virtual parameter in the parameter list.
-	/// If its type is FAILURE, the expected result is also a REVERT etc.
-	if (expectations.result.at(0).abiType.type != ABIType::Failure)
-		expectations.failure = false;
+		/// We have always one virtual parameter in the parameter list.
+		/// If its type is FAILURE, the expected result is also a REVERT etc.
+		if (expectations.result.at(0).abiType.type != ABIType::Failure)
+			expectations.failure = false;
+	}
 	return expectations;
 }
 
@@ -488,7 +525,7 @@ void TestFileParser::Scanner::readStream(istream& _stream)
 void TestFileParser::Scanner::scanNextToken()
 {
 	// Make code coverage happy.
-	assert(formatToken(Token::NUM_TOKENS) == "");
+	soltestAssert(formatToken(Token::NUM_TOKENS) == "", "");
 
 	auto detectKeyword = [](std::string const& _literal = "") -> std::pair<Token, std::string> {
 		if (_literal == "true") return {Token::Boolean, "true"};
@@ -605,7 +642,7 @@ string TestFileParser::Scanner::scanIdentifierOrKeyword()
 {
 	string identifier;
 	identifier += current();
-	while (langutil::isIdentifierPart(peek()))
+	while (langutil::isIdentifierPartWithDot(peek()))
 	{
 		advance();
 		identifier += current();

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <libsolutil/CommonData.h>
 #include <liblangutil/Exceptions.h>
+#include <libsolutil/CommonData.h>
 #include <test/libsolidity/util/SoltestTypes.h>
 
 #include <iosfwd>
@@ -52,7 +52,7 @@ class TestFileParser
 public:
 	/// Constructor that takes an input stream \param _stream to operate on
 	/// and creates the internal scanner.
-	TestFileParser(std::istream& _stream): m_scanner(_stream) {}
+	explicit TestFileParser(std::istream& _stream, Builtins* _builtins = nullptr): m_scanner(_stream), m_builtins(_builtins) {}
 
 	/// Parses function calls blockwise and returns a list of function calls found.
 	/// Throws an exception if a function call cannot be parsed because of its
@@ -177,12 +177,18 @@ private:
 	/// Parses the current string literal.
 	std::string parseString();
 
+	/// Checks whether a builtin function with the given signature exist.
+	/// This function will throw an TestParserError exception, if not.
+	void checkBuiltinFunction(std::string const& signature);
+
 	/// A scanner instance
 	Scanner m_scanner;
 
 	/// The current line number. Incremented when Token::Newline (//) is found and
 	/// used to enhance parser error messages.
 	size_t m_lineNumber = 0;
+
+	Builtins* m_builtins{nullptr};
 };
 
 }

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -36,8 +36,8 @@ string TestFunctionCall::format(
 	ErrorReporter& _errorReporter,
 	string const& _linePrefix,
 	bool const _renderResult,
-	bool const _highlight
-) const
+	bool const _highlight,
+	std::vector<std::unique_ptr<TestHook>> const* _hooks) const
 {
 	stringstream stream;
 
@@ -124,19 +124,36 @@ string TestFunctionCall::format(
 
 		/// Format either the expected output or the actual result output
 		string result;
+		auto& builtin = m_call.expectations.builtin;
 		if (!_renderResult)
 		{
-			bool const isFailure = m_call.expectations.failure;
-			result = isFailure ?
-				formatFailure(_errorReporter, m_call, m_rawBytes, _renderResult, highlight) :
-				formatRawParameters(m_call.expectations.result);
+			if (builtin)
+			{
+				result = builtin->signature;
+				if (!builtin->arguments.parameters.empty())
+					result += ": ";
+				result += formatRawParameters(builtin->arguments.parameters);
+			}
+			else
+			{
+				bool const isFailure = m_call.expectations.failure;
+				result = isFailure ?
+						 formatFailure(_errorReporter, m_call, m_rawBytes, _renderResult, highlight) :
+						 formatRawParameters(m_call.expectations.result);
+			}
 			if (!result.empty())
-				AnsiColorized(stream, highlight, {util::formatting::RED_BACKGROUND}) << ws << result;
+			{
+				AnsiColorized(stream, false, {util::formatting::RESET}) << ws;
+				AnsiColorized(stream, highlight, {util::formatting::RED_BACKGROUND}) << result;
+			}
 		}
 		else
 		{
 			if (m_calledNonExistingFunction)
 				_errorReporter.warning("The function \"" + m_call.signature + "\" is not known to the compiler.");
+
+			if (builtin)
+				_errorReporter.warning("The expectation \"" + builtin->signature + ": " + formatRawParameters(builtin->arguments.parameters) + "\" will be replaced with the actual value returned by the test.");
 
 			bytes output = m_rawBytes;
 			bool const isFailure = m_failure;
@@ -204,6 +221,10 @@ string TestFunctionCall::format(
 				stream << comment << m_call.expectations.comment << comment;
 			}
 		}
+
+		if (_hooks != nullptr)
+			for (auto& hook: *_hooks)
+				stream << hook->formatFunctionCall(*this, _errorReporter, _linePrefix, _renderResult, _highlight);
 	};
 
 	formatOutput(m_call.displayMode == FunctionCall::DisplayMode::SingleLine);

--- a/test/libsolidity/util/TestFunctionCall.h
+++ b/test/libsolidity/util/TestFunctionCall.h
@@ -14,8 +14,9 @@
 
 #pragma once
 
-#include <test/libsolidity/util/TestFileParser.h>
+#include <test/libsolidity/TestHook.h>
 #include <test/libsolidity/util/SoltestErrors.h>
+#include <test/libsolidity/util/TestFileParser.h>
 
 #include <liblangutil/Exceptions.h>
 #include <libsolutil/AnsiColorized.h>
@@ -56,7 +57,8 @@ public:
 		ErrorReporter& _errorReporter,
 		std::string const& _linePrefix = "",
 		bool const _renderResult = false,
-		bool const _highlight = false
+		bool const _highlight = false,
+		std::vector<std::unique_ptr<TestHook>> const* _hooks = nullptr
 	) const;
 
 	/// Overloaded version that passes an error reporter which is never used outside
@@ -64,11 +66,12 @@ public:
 	std::string format(
 		std::string const& _linePrefix = "",
 		bool const _renderResult = false,
-		bool const _highlight = false
+		bool const _highlight = false,
+		std::vector<std::unique_ptr<TestHook>> const* _hooks = nullptr
 	) const
 	{
 		ErrorReporter reporter;
-		return format(reporter, _linePrefix, _renderResult, _highlight);
+		return format(reporter, _linePrefix, _renderResult, _highlight, _hooks);
 	}
 
 	/// Resets current results in case the function was called and the result

--- a/test/libsolidity/util/TestFunctionCallTests.cpp
+++ b/test/libsolidity/util/TestFunctionCallTests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_singleline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_singleline_signed_encoding)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(format_unsigned_multiline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter result{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{result}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{result}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(format_multiple_unsigned_singleline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param, param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param, param}, string{}};
 	FunctionCall call{"f(uint8, uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(format_signed_singleline)
 	bytes expectedBytes = toBigEndian(u256{-1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "-1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(int8)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(format_hex_singleline)
 	bytes expectedBytes = result + bytes(32 - result.size(), 0);
 	ABIType abiType{ABIType::Hex, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "0x31", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bytes32)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(format_hex_string_singleline)
 	bytes expectedBytes = fromHex("4200ef");
 	ABIType abiType{ABIType::HexString, ABIType::AlignLeft, 3};
 	Parameter param{expectedBytes, "hex\"4200ef\"", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(string)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(format_bool_true_singleline)
 	bytes expectedBytes = toBigEndian(u256{true});
 	ABIType abiType{ABIType::Boolean, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "true", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(format_bool_false_singleline)
 	bytes expectedBytes = toBigEndian(u256{false});
 	ABIType abiType{ABIType::Boolean, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "false", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(format_bool_left_singleline)
 	bytes expectedBytes = toBigEndian(u256{false});
 	ABIType abiType{ABIType::Boolean, ABIType::AlignLeft, 32};
 	Parameter param{expectedBytes, "left(false)", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(format_hex_number_right_singleline)
 	bytes expectedBytes = result + bytes(32 - result.size(), 0);
 	ABIType abiType{ABIType::Hex, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "right(0x42)", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(bool)", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(format_empty_byte_range)
 	bytes expectedBytes;
 	ABIType abiType{ABIType::None, ABIType::AlignNone, 0};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{param}, false, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{}, string{}};
 	FunctionCall call{"f()", {0}, arguments, expectations};
 	call.omitsArrow = false;
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(format_failure_singleline)
 	bytes expectedBytes = toBigEndian(u256{1});
 	ABIType abiType{ABIType::UnsignedDec, ABIType::AlignRight, 32};
 	Parameter param{expectedBytes, "1", abiType, FormatInfo{}};
-	FunctionCallExpectations expectations{vector<Parameter>{}, true, string{}};
+	FunctionCallExpectations expectations{vector<Parameter>{}, true, string{}, {}};
 	FunctionCallArgs arguments{vector<Parameter>{param}, string{}};
 	FunctionCall call{"f(uint8)", {0}, arguments, expectations};
 	call.omitsArrow = false;

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -39,5 +39,7 @@ add_executable(isoltest
 	../libyul/YulOptimizerTest.cpp
 	../libyul/YulOptimizerTestCommon.cpp
 	../libyul/YulInterpreterTest.cpp
+	../libsolidity/TestHook.h
+	../libsolidity/hooks/SmokeHook.h
 )
 target_link_libraries(isoltest PRIVATE evmc libsolc solidity yulInterpreter evmasm Boost::boost Boost::program_options Boost::unit_test_framework)

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -41,5 +41,7 @@ add_executable(isoltest
 	../libyul/YulInterpreterTest.cpp
 	../libsolidity/TestHook.h
 	../libsolidity/hooks/SmokeHook.h
+	../libsolidity/hooks/LogsHook.h
+	../libsolidity/hooks/LogsHook.cpp
 )
 target_link_libraries(isoltest PRIVATE evmc libsolc solidity yulInterpreter evmasm Boost::boost Boost::program_options Boost::unit_test_framework)


### PR DESCRIPTION
This is a rewrite of #10728 using builtins as defined in #10867. 

After we have implemented the features already present in #10728, we could close #10728.