### PR TITLE
Call graph as contract annotation

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -56,6 +56,8 @@ set(sources
 	ast/ASTJsonImporter.cpp
 	ast/ASTJsonImporter.h
 	ast/ASTVisitor.h
+	ast/CallGraph.cpp
+	ast/CallGraph.h
 	ast/ExperimentalFeatures.h
 	ast/Types.cpp
 	ast/Types.h

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -49,6 +49,8 @@ class Type;
 using TypePointer = Type const*;
 using namespace util;
 
+struct CallGraph;
+
 struct ASTAnnotation
 {
 	ASTAnnotation() = default;
@@ -162,6 +164,10 @@ struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, StructurallyDocu
 	/// Mapping containing the nodes that define the arguments for base constructors.
 	/// These can either be inheritance specifiers or modifier invocations.
 	std::map<FunctionDefinition const*, ASTNode const*> baseConstructorArguments;
+	/// A graph with edges representing calls between functions that may happen during contract construction.
+	SetOnce<std::shared_ptr<CallGraph const>> creationCallGraph;
+	/// A graph with edges representing calls between functions that may happen in a deployed contract.
+	SetOnce<std::shared_ptr<CallGraph const>> deployedCallGraph;
 };
 
 struct CallableDeclarationAnnotation: DeclarationAnnotation

--- a/libsolidity/ast/CallGraph.cpp
+++ b/libsolidity/ast/CallGraph.cpp
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/ast/CallGraph.h>
+
+using namespace std;
+using namespace solidity::frontend;
+
+bool CallGraph::CompareByID::operator()(Node const& _lhs, Node const& _rhs) const
+{
+	if (_lhs.index() != _rhs.index())
+		return _lhs.index() < _rhs.index();
+
+	if (holds_alternative<SpecialNode>(_lhs))
+		return get<SpecialNode>(_lhs) < get<SpecialNode>(_rhs);
+	return get<CallableDeclaration const*>(_lhs)->id() < get<CallableDeclaration const*>(_rhs)->id();
+}
+
+bool CallGraph::CompareByID::operator()(Node const& _lhs, int64_t _rhs) const
+{
+	solAssert(!holds_alternative<SpecialNode>(_lhs), "");
+
+	return get<CallableDeclaration const*>(_lhs)->id() < _rhs;
+}
+
+bool CallGraph::CompareByID::operator()(int64_t _lhs, Node const& _rhs) const
+{
+	solAssert(!holds_alternative<SpecialNode>(_rhs), "");
+
+	return _lhs < get<CallableDeclaration const*>(_rhs)->id();
+}

--- a/libsolidity/ast/CallGraph.h
+++ b/libsolidity/ast/CallGraph.h
@@ -1,0 +1,74 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/// Data structure representing a function call graph.
+
+#pragma once
+
+#include <libsolidity/ast/AST.h>
+
+#include <map>
+#include <set>
+#include <variant>
+
+namespace solidity::frontend
+{
+
+/**
+ * Function call graph for a contract at the granularity of Solidity functions and modifiers.
+ * The graph can represent the situation either at contract creation or after deployment.
+ * The graph does not preserve temporal relations between calls - edges coming out of the same node
+ * show which calls were performed but not in what order.
+ *
+ * Stores also extra information about contracts that can be created and events that can be emitted
+ * from any of the functions in it.
+ */
+struct CallGraph
+{
+	enum class SpecialNode
+	{
+		InternalDispatch,
+		Entry,
+	};
+
+	using Node = std::variant<CallableDeclaration const*, SpecialNode>;
+
+	struct CompareByID
+	{
+		using is_transparent = void;
+		bool operator()(Node const& _lhs, Node const& _rhs) const;
+		bool operator()(Node const& _lhs, int64_t _rhs) const;
+		bool operator()(int64_t _lhs, Node const& _rhs) const;
+	};
+
+	/// Contract for which this is the graph
+	ContractDefinition const& contract;
+
+	/// Graph edges. Edges are directed and lead from the caller to the callee.
+	/// The map contains a key for every possible caller, even if does not actually perform
+	/// any calls.
+	std::map<Node, std::set<Node, CompareByID>, CompareByID> edges;
+
+	/// Contracts that may get created with `new` by functions present in the graph.
+	std::set<ContractDefinition const*, ASTNode::CompareByID> createdContracts;
+
+	/// Events that may get emitted by functions present in the graph.
+	std::set<EventDefinition const*, ASTNode::CompareByID> emittedEvents;
+};
+
+}

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -78,11 +78,11 @@ void verifyCallGraph(
 }
 
 set<CallableDeclaration const*, ASTNode::CompareByID> collectReachableCallables(
-	FunctionCallGraphBuilder::ContractCallGraph const& _graph
+	CallGraph const& _graph
 )
 {
 	set<CallableDeclaration const*, ASTNode::CompareByID> reachableCallables;
-	for (FunctionCallGraphBuilder::Node const& reachableNode: _graph.edges | views::keys)
+	for (CallGraph::Node const& reachableNode: _graph.edges | views::keys)
 		if (holds_alternative<CallableDeclaration const*>(reachableNode))
 			reachableCallables.emplace(get<CallableDeclaration const*>(reachableNode));
 
@@ -119,10 +119,7 @@ pair<string, string> IRGenerator::run(
 	return {warning + ir, warning + asmStack.print()};
 }
 
-void IRGenerator::verifyCallGraphs(
-	FunctionCallGraphBuilder::ContractCallGraph const& _creationGraph,
-	FunctionCallGraphBuilder::ContractCallGraph const& _deployedGraph
-)
+void IRGenerator::verifyCallGraphs(CallGraph const& _creationGraph, CallGraph const& _deployedGraph)
 {
 	// m_creationFunctionList and m_deployedFunctionList are not used for any other purpose so
 	// we can just destroy them without bothering to make a copy.

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -57,8 +57,6 @@ public:
 		std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
 	);
 
-	void verifyCallGraphs(CallGraph const& _creationGraph, CallGraph const& _deployedGraph);
-
 private:
 	std::string generate(
 		ContractDefinition const& _contract,
@@ -118,9 +116,6 @@ private:
 
 	langutil::EVMVersion const m_evmVersion;
 	OptimiserSettings const m_optimiserSettings;
-
-	std::set<FunctionDefinition const*> m_creationFunctionList;
-	std::set<FunctionDefinition const*> m_deployedFunctionList;
 
 	IRGenerationContext m_context;
 	YulUtilFunctions m_utils;

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -25,7 +25,7 @@
 
 #include <libsolidity/interface/OptimiserSettings.h>
 #include <libsolidity/ast/ASTForward.h>
-#include <libsolidity/analysis/FunctionCallGraph.h>
+#include <libsolidity/ast/CallGraph.h>
 #include <libsolidity/codegen/ir/IRGenerationContext.h>
 #include <libsolidity/codegen/YulUtilFunctions.h>
 #include <liblangutil/EVMVersion.h>
@@ -57,10 +57,7 @@ public:
 		std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
 	);
 
-	void verifyCallGraphs(
-		FunctionCallGraphBuilder::ContractCallGraph const& _creationGraph,
-		FunctionCallGraphBuilder::ContractCallGraph const& _deployedGraph
-	);
+	void verifyCallGraphs(CallGraph const& _creationGraph, CallGraph const& _deployedGraph);
 
 private:
 	std::string generate(

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1298,11 +1298,6 @@ void CompilerStack::generateIR(ContractDefinition const& _contract)
 
 	IRGenerator generator(m_evmVersion, m_revertStrings, m_optimiserSettings);
 	tie(compiledContract.yulIR, compiledContract.yulIROptimized) = generator.run(_contract, otherYulSources);
-
-	generator.verifyCallGraphs(
-		**compiledContract.contract->annotation().creationCallGraph,
-		**compiledContract.contract->annotation().deployedCallGraph
-	);
 }
 
 void CompilerStack::generateEVMFromIR(ContractDefinition const& _contract)

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -407,8 +407,18 @@ bool CompilerStack::analyze()
 						if (auto const* contractDefinition = dynamic_cast<ContractDefinition*>(node.get()))
 						{
 							Contract& contractState = m_contracts.at(contractDefinition->fullyQualifiedName());
-							contractState.creationCallGraph.emplace(FunctionCallGraphBuilder::buildCreationGraph(*contractDefinition));
-							contractState.deployedCallGraph.emplace(FunctionCallGraphBuilder::buildDeployedGraph(*contractDefinition, *contractState.creationCallGraph));
+
+							contractState.contract->annotation().creationCallGraph = make_unique<CallGraph>(
+								FunctionCallGraphBuilder::buildCreationGraph(
+									*contractDefinition
+								)
+							);
+							contractState.contract->annotation().deployedCallGraph = make_unique<CallGraph>(
+								FunctionCallGraphBuilder::buildDeployedGraph(
+									*contractDefinition,
+									**contractState.contract->annotation().creationCallGraph
+								)
+							);
 						}
 		}
 
@@ -950,24 +960,6 @@ string const& CompilerStack::metadata(Contract const& _contract) const
 	return _contract.metadata.init([&]{ return createMetadata(_contract); });
 }
 
-CallGraph const& CompilerStack::creationCallGraph(string const& _contractName) const
-{
-	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
-
-	solAssert(contract(_contractName).creationCallGraph.has_value(), "");
-	return contract(_contractName).creationCallGraph.value();
-}
-
-CallGraph const& CompilerStack::deployedCallGraph(string const& _contractName) const
-{
-	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
-
-	solAssert(contract(_contractName).deployedCallGraph.has_value(), "");
-	return contract(_contractName).deployedCallGraph.value();
-}
-
 Scanner const& CompilerStack::scanner(string const& _sourceName) const
 {
 	if (m_stackState < SourcesSet)
@@ -1307,7 +1299,10 @@ void CompilerStack::generateIR(ContractDefinition const& _contract)
 	IRGenerator generator(m_evmVersion, m_revertStrings, m_optimiserSettings);
 	tie(compiledContract.yulIR, compiledContract.yulIROptimized) = generator.run(_contract, otherYulSources);
 
-	generator.verifyCallGraphs(compiledContract.creationCallGraph.value(), compiledContract.deployedCallGraph.value());
+	generator.verifyCallGraphs(
+		**compiledContract.contract->annotation().creationCallGraph,
+		**compiledContract.contract->annotation().deployedCallGraph
+	);
 }
 
 void CompilerStack::generateEVMFromIR(ContractDefinition const& _contract)

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -950,7 +950,7 @@ string const& CompilerStack::metadata(Contract const& _contract) const
 	return _contract.metadata.init([&]{ return createMetadata(_contract); });
 }
 
-FunctionCallGraphBuilder::ContractCallGraph const& CompilerStack::creationCallGraph(string const& _contractName) const
+CallGraph const& CompilerStack::creationCallGraph(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
@@ -959,7 +959,7 @@ FunctionCallGraphBuilder::ContractCallGraph const& CompilerStack::creationCallGr
 	return contract(_contractName).creationCallGraph.value();
 }
 
-FunctionCallGraphBuilder::ContractCallGraph const& CompilerStack::deployedCallGraph(string const& _contractName) const
+CallGraph const& CompilerStack::deployedCallGraph(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -348,10 +348,10 @@ public:
 	Json::Value gasEstimates(std::string const& _contractName) const;
 
 	/// @returns a graph with edges representing calls between functions that may happen during contract construction.
-	FunctionCallGraphBuilder::ContractCallGraph const& creationCallGraph(std::string const& _contractName) const;
+	CallGraph const& creationCallGraph(std::string const& _contractName) const;
 
 	/// @returns a graph with edges representing calls between functions that may happen in a deployed contract.
-	FunctionCallGraphBuilder::ContractCallGraph const& deployedCallGraph(std::string const& _contractName) const;
+	CallGraph const& deployedCallGraph(std::string const& _contractName) const;
 
 	/// Changes the format of the metadata appended at the end of the bytecode.
 	/// This is mostly a workaround to avoid bytecode and gas differences between compiler builds
@@ -394,8 +394,8 @@ private:
 		util::LazyInit<Json::Value const> runtimeGeneratedSources;
 		mutable std::optional<std::string const> sourceMapping;
 		mutable std::optional<std::string const> runtimeSourceMapping;
-		std::optional<FunctionCallGraphBuilder::ContractCallGraph const> creationCallGraph;
-		std::optional<FunctionCallGraphBuilder::ContractCallGraph const> deployedCallGraph;
+		std::optional<CallGraph const> creationCallGraph;
+		std::optional<CallGraph const> deployedCallGraph;
 	};
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -347,12 +347,6 @@ public:
 	/// @returns a JSON representing the estimated gas usage for contract creation, internal and external functions
 	Json::Value gasEstimates(std::string const& _contractName) const;
 
-	/// @returns a graph with edges representing calls between functions that may happen during contract construction.
-	CallGraph const& creationCallGraph(std::string const& _contractName) const;
-
-	/// @returns a graph with edges representing calls between functions that may happen in a deployed contract.
-	CallGraph const& deployedCallGraph(std::string const& _contractName) const;
-
 	/// Changes the format of the metadata appended at the end of the bytecode.
 	/// This is mostly a workaround to avoid bytecode and gas differences between compiler builds
 	/// caused by differences in metadata. Should only be used for testing.
@@ -394,8 +388,6 @@ private:
 		util::LazyInit<Json::Value const> runtimeGeneratedSources;
 		mutable std::optional<std::string const> sourceMapping;
 		mutable std::optional<std::string const> runtimeSourceMapping;
-		std::optional<CallGraph const> creationCallGraph;
-		std::optional<CallGraph const> deployedCallGraph;
 	};
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -251,6 +251,10 @@ public:
 	/// @returns the parsed source unit with the supplied name.
 	SourceUnit const& ast(std::string const& _sourceName) const;
 
+	/// @returns the parsed contract with the supplied name. Throws an exception if the contract
+	/// does not exist.
+	ContractDefinition const& contractDefinition(std::string const& _contractName) const;
+
 	/// Helper function for logs printing. Do only use in error cases, it's quite expensive.
 	/// line and columns are numbered starting from 1 with following order:
 	/// start line, start column, end line, end column
@@ -441,10 +445,6 @@ private:
 	/// @returns the source object for the given @a _sourceName.
 	/// Can only be called after state is SourcesSet.
 	Source const& source(std::string const& _sourceName) const;
-
-	/// @returns the parsed contract with the supplied name. Throws an exception if the contract
-	/// does not exist.
-	ContractDefinition const& contractDefinition(std::string const& _contractName) const;
 
 	/// @returns the metadata JSON as a compact string for the given contract.
 	std::string createMetadata(Contract const& _contract) const;

--- a/test/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/test/libsolidity/analysis/FunctionCallGraph.cpp
@@ -116,8 +116,8 @@ tuple<CallGraphMap, CallGraphMap> collectGraphs(CompilerStack const& _compilerSt
 		soltestAssert(fullyQualifiedContractName.size() > 0 && fullyQualifiedContractName[0] == ':', "");
 		string contractName = fullyQualifiedContractName.substr(1);
 
-		get<0>(graphs).emplace(contractName, &_compilerStack.creationCallGraph(fullyQualifiedContractName));
-		get<1>(graphs).emplace(contractName, &_compilerStack.deployedCallGraph(fullyQualifiedContractName));
+		get<0>(graphs).emplace(contractName, _compilerStack.contractDefinition(fullyQualifiedContractName).annotation().creationCallGraph->get());
+		get<1>(graphs).emplace(contractName, _compilerStack.contractDefinition(fullyQualifiedContractName).annotation().deployedCallGraph->get());
 	}
 
 	return graphs;

--- a/test/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/test/libsolidity/analysis/FunctionCallGraph.cpp
@@ -53,12 +53,12 @@ using namespace solidity::langutil;
 using namespace solidity::frontend;
 
 using EdgeMap = map<
-	FunctionCallGraphBuilder::Node,
-	set<FunctionCallGraphBuilder::Node, FunctionCallGraphBuilder::CompareByID>,
-	FunctionCallGraphBuilder::CompareByID
+	CallGraph::Node,
+	set<CallGraph::Node, CallGraph::CompareByID>,
+	CallGraph::CompareByID
 >;
 using EdgeNames = set<tuple<string, string>>;
-using CallGraphMap = map<string, FunctionCallGraphBuilder::ContractCallGraph const*>;
+using CallGraphMap = map<string, CallGraph const*>;
 
 namespace
 {
@@ -131,7 +131,7 @@ void checkCallGraphExpectations(
 )
 {
 	auto getContractName = [](ContractDefinition const* _contract){ return _contract->name(); };
-	auto eventToString = [](EventDefinition const* _event){ return toString(FunctionCallGraphBuilder::Node(_event)); };
+	auto eventToString = [](EventDefinition const* _event){ return toString(CallGraph::Node(_event)); };
 	auto notEmpty = [](set<string> const& _set){ return !_set.empty(); };
 
 	soltestAssert(
@@ -157,7 +157,7 @@ void checkCallGraphExpectations(
 	for (string const& contractName: _expectedEdges | views::keys)
 	{
 		soltestAssert(_callGraphs.at(contractName) != nullptr, "");
-		FunctionCallGraphBuilder::ContractCallGraph const& callGraph = *_callGraphs.at(contractName);
+		CallGraph const& callGraph = *_callGraphs.at(contractName);
 
 		edges[contractName] = edgeNames(callGraph.edges);
 		if (!callGraph.createdContracts.empty())


### PR DESCRIPTION
Depends on #10973.

This is a refactor on top of #10973 that moves the call graph from `CompilerStack` to an annotation on contract definition. This makes it more convenient to access it.

The PR is already complete and ready for review but waiting for #10973 to get merged.