### PR TITLE
Detect assignment to function in inline assembly.

### DIFF
--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -530,11 +530,9 @@ void AsmAnalyzer::checkAssignment(Identifier const& _variable, YulString _valueT
 	bool found = false;
 	if (Scope::Identifier const* var = m_currentScope->lookup(_variable.name))
 	{
-		// Check that it is a variable.
-		// This can also hold a function, but that is caught by error 6041.
-		yulAssert(holds_alternative<Scope::Variable>(*var), "Assignment requires variable.");
-
-		if (!m_activeVariables.count(&std::get<Scope::Variable>(*var)))
+		if (!holds_alternative<Scope::Variable>(*var))
+			m_errorReporter.typeError(2657_error, _variable.location, "Assignment requires variable.");
+		else if (!m_activeVariables.count(&std::get<Scope::Variable>(*var)))
 			m_errorReporter.declarationError(
 				1133_error,
 				_variable.location,

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/assignment_to_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/assignment_to_function.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f() public pure {
+        assembly {
+            function f() {}
+            f := 1
+        }
+    }
+}
+// ----
+// TypeError 2657: (103-104): Assignment requires variable.


### PR DESCRIPTION
Reverts https://github.com/ethereum/solidity/pull/10964 and adds the test case found in https://github.com/ethereum/solidity/issues/10975
Fixes https://github.com/ethereum/solidity/issues/10975