### PR TITLE
Fix module member names for importing with renaming.

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -112,7 +112,11 @@ util::Result<TypePointers> transformParametersToExternal(TypePointers const& _pa
 }
 
 MemberList::Member::Member(Declaration const* _declaration, Type const* _type):
-	name(_declaration->name()),
+	Member(_declaration, _type, _declaration->name())
+{}
+
+MemberList::Member::Member(Declaration const* _declaration, Type const* _type, string _name):
+	name(move(_name)),
 	type(_type),
 	declaration(_declaration)
 {
@@ -3808,10 +3812,7 @@ MemberList::MemberMap ModuleType::nativeMembers(ASTNode const*) const
 	MemberList::MemberMap symbols;
 	for (auto const& [name, declarations]: *m_sourceUnit.annotation().exportedSymbols)
 		for (Declaration const* symbol: declarations)
-		{
-			solAssert(name == symbol->name(), "");
-			symbols.emplace_back(symbol, symbol->type());
-		}
+			symbols.emplace_back(symbol, symbol->type(), name);
 	return symbols;
 }
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -110,6 +110,7 @@ public:
 
 		/// Constructs a Member with the name extracted from @p _declaration's name.
 		Member(Declaration const* _declaration, Type const* _type);
+		Member(Declaration const* _declaration, Type const* _type, std::string _name);
 
 		std::string name;
 		Type const* type = nullptr;

--- a/test/libsolidity/syntaxTests/multiSource/import_alias.sol
+++ b/test/libsolidity/syntaxTests/multiSource/import_alias.sol
@@ -1,0 +1,8 @@
+==== Source: s1.sol ====
+int constant a = 2;
+==== Source: s2.sol ====
+import {a as e} from "s1.sol";
+import "s2.sol" as M;
+contract C {
+  function f() public pure returns (int) { return M.e; }
+}

--- a/test/libsolidity/syntaxTests/multiSource/import_alias_mismatch.sol
+++ b/test/libsolidity/syntaxTests/multiSource/import_alias_mismatch.sol
@@ -1,0 +1,10 @@
+==== Source: s1.sol ====
+int constant a = 2;
+==== Source: s2.sol ====
+import {a as e} from "s1.sol";
+import "s2.sol" as M;
+contract C {
+  function f() public pure returns (int) { return M.a; }
+}
+// ----
+// TypeError 9582: (s2.sol:116-119): Member "a" not found or not visible after argument-dependent lookup in module "s2.sol".


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10956