### PR TITLE
Remove the last remains of --ast-json option

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -17,7 +17,7 @@ Basic Usage
 
 One of the build targets of the Solidity repository is ``solc``, the solidity commandline compiler.
 Using ``solc --help`` provides you with an explanation of all options. The compiler can produce various outputs, ranging from simple binaries and assembly over an abstract syntax tree (parse tree) to estimations of gas usage.
-If you only want to compile a single file, you run it as ``solc --bin sourceFile.sol`` and it will print the binary. If you want to get some of the more advanced output variants of ``solc``, it is probably better to tell it to output everything to separate files using ``solc -o outputDirectory --bin --ast-json --asm sourceFile.sol``.
+If you only want to compile a single file, you run it as ``solc --bin sourceFile.sol`` and it will print the binary. If you want to get some of the more advanced output variants of ``solc``, it is probably better to tell it to output everything to separate files using ``solc -o outputDirectory --bin --ast-compact-json --asm sourceFile.sol``.
 
 Optimizer Options
 -----------------

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -120,7 +120,6 @@ static string const g_strAsm = "asm";
 static string const g_strAsmJson = "asm-json";
 static string const g_strAssemble = "assemble";
 static string const g_strAst = "ast";
-static string const g_strAstJson = "ast-json";
 static string const g_strAstCompactJson = "ast-compact-json";
 static string const g_strBinary = "bin";
 static string const g_strBinaryRuntime = "bin-runtime";
@@ -203,7 +202,6 @@ static string const g_argAsm = g_strAsm;
 static string const g_argAsmJson = g_strAsmJson;
 static string const g_argAssemble = g_strAssemble;
 static string const g_argAstCompactJson = g_strAstCompactJson;
-static string const g_argAstJson = g_strAstJson;
 static string const g_argBinary = g_strBinary;
 static string const g_argBinaryRuntime = g_strBinaryRuntime;
 static string const g_argCombinedJson = g_strCombinedJson;
@@ -318,7 +316,6 @@ static bool needsHumanTargetedStdout(po::variables_map const& _args)
 		g_argAbi,
 		g_argAsm,
 		g_argAsmJson,
-		g_argAstJson,
 		g_argBinary,
 		g_argBinaryRuntime,
 		g_argMetadata,
@@ -974,7 +971,6 @@ General Information)").c_str(),
 
 	po::options_description outputComponents("Output Components");
 	outputComponents.add_options()
-		(g_argAstJson.c_str(), "AST of all source files in JSON format.")
 		(g_argAstCompactJson.c_str(), "AST of all source files in a compact JSON format.")
 		(g_argAsm.c_str(), "EVM assembly of the contracts.")
 		(g_argAsmJson.c_str(), "EVM assembly of the contracts in JSON format.")

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -465,12 +465,12 @@ SOLTMPDIR=$(mktemp -d)
 
     # This should not fail
     set +e
-    output=$(echo '' | "$SOLC" --ast-json - 2>/dev/null)
+    output=$(echo '' | "$SOLC" --ast-compact-json - 2>/dev/null)
     result=$?
     set -e
     if [[ $result != 0 ]]
     then
-        printError "Incorrect response to --ast-json option with empty stdin"
+        printError "Incorrect response to --ast-compact-json option with empty stdin"
         exit 1
     fi
 )


### PR DESCRIPTION
The legacy AST has already been removed by #10363 and #9512. Why are we we still keeping the `--ast-json` option available in the CLI?

This PR removes the option from the CLI and also removes some stray mentions/uses from docs and scripts.