### PR TITLE
Remove contract reference from function call graph 

### DIFF
--- a/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/libsolidity/analysis/FunctionCallGraph.cpp
@@ -262,13 +262,14 @@ ostream& solidity::frontend::operator<<(ostream& _out, CallGraph::Node const& _n
 	if (holds_alternative<CallGraph::SpecialNode>(_node))
 		switch (get<CallGraph::SpecialNode>(_node))
 		{
-			case CallGraph::SpecialNode::InternalDispatch:
-				_out << "InternalDispatch";
-				break;
-			case CallGraph::SpecialNode::Entry:
-				_out << "Entry";
-				break;
-			default: solAssert(false, "Invalid SpecialNode type");
+		case CallGraph::SpecialNode::InternalDispatch:
+			_out << "InternalDispatch";
+			break;
+		case CallGraph::SpecialNode::Entry:
+			_out << "Entry";
+			break;
+		default:
+			solAssert(false, "Invalid SpecialNode type");
 		}
 	else
 	{

--- a/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/libsolidity/analysis/FunctionCallGraph.cpp
@@ -69,8 +69,6 @@ CallGraph FunctionCallGraphBuilder::buildDeployedGraph(
 	CallGraph const& _creationGraph
 )
 {
-	solAssert(&_creationGraph.contract == &_contract, "");
-
 	FunctionCallGraphBuilder builder(_contract);
 	solAssert(builder.m_currentNode == CallGraph::Node(CallGraph::SpecialNode::Entry), "");
 
@@ -150,7 +148,7 @@ bool FunctionCallGraphBuilder::visit(Identifier const& _identifier)
 
 		// For events kind() == Event, so we have an extra check here
 		if (funType && funType->kind() == FunctionType::Kind::Internal)
-			functionReferenced(callable->resolveVirtual(m_graph.contract), _identifier.annotation().calledDirectly);
+			functionReferenced(callable->resolveVirtual(m_contract), _identifier.annotation().calledDirectly);
 	}
 
 	return true;
@@ -171,8 +169,8 @@ bool FunctionCallGraphBuilder::visit(MemberAccess const& _memberAccess)
 			{
 				solAssert(contractType->isSuper(), "");
 				functionDef = &functionDef->resolveVirtual(
-					m_graph.contract,
-					contractType->contractDefinition().superContract(m_graph.contract)
+					m_contract,
+					contractType->contractDefinition().superContract(m_contract)
 				);
 			}
 	}
@@ -191,7 +189,7 @@ bool FunctionCallGraphBuilder::visit(ModifierInvocation const& _modifierInvocati
 		VirtualLookup const& requiredLookup = *_modifierInvocation.name().annotation().requiredLookup;
 
 		if (requiredLookup == VirtualLookup::Virtual)
-			functionReferenced(modifier->resolveVirtual(m_graph.contract));
+			functionReferenced(modifier->resolveVirtual(m_contract));
 		else
 		{
 			solAssert(requiredLookup == VirtualLookup::Static, "");

--- a/libsolidity/analysis/FunctionCallGraph.h
+++ b/libsolidity/analysis/FunctionCallGraph.h
@@ -65,7 +65,8 @@ public:
 
 private:
 	FunctionCallGraphBuilder(ContractDefinition const& _contract):
-		m_graph{_contract, {}, {}, {}} {}
+		m_contract(_contract),
+		m_graph{{}, {}, {}} {}
 
 	bool visit(FunctionCall const& _functionCall) override;
 	bool visit(EmitStatement const& _emitStatement) override;
@@ -81,6 +82,7 @@ private:
 	void functionReferenced(CallableDeclaration const& _callable, bool _calledDirectly = true);
 
 	CallGraph::Node m_currentNode = CallGraph::SpecialNode::Entry;
+	ContractDefinition const& m_contract;
 	CallGraph m_graph;
 	std::deque<CallableDeclaration const*> m_visitQueue;
 };

--- a/libsolidity/ast/CallGraph.h
+++ b/libsolidity/ast/CallGraph.h
@@ -56,9 +56,6 @@ struct CallGraph
 		bool operator()(int64_t _lhs, Node const& _rhs) const;
 	};
 
-	/// Contract for which this is the graph
-	ContractDefinition const& contract;
-
 	/// Graph edges. Edges are directed and lead from the caller to the callee.
 	/// The map contains a key for every possible caller, even if does not actually perform
 	/// any calls.


### PR DESCRIPTION
Small tweaks for #10973 + #10990.

- We don't really need a reference to the contract inside the graph.
- Review fixes for @bshastry's comments: https://github.com/ethereum/solidity/pull/10973#discussion_r580890204 + https://github.com/ethereum/solidity/pull/10973#discussion_r581008866