### PR TITLE
Converted hash collision error into a fatal type error.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * SMTChecker: Fix missing type constraints on block and transaction variables in the deployment phase.
  * AST: Added ``referencedDeclaration`` for enum members.
  * Code Generator: Fix internal error when functions are passed as parameters of other callables, when the function types can be implicitly converted, but not identical.
+ * Type Checker: Make function-hash collision errors into fatal type errors.
 
 
 AST Changes:

--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -426,7 +426,7 @@ void ContractLevelChecker::checkHashCollisions(ContractDefinition const& _contra
 	{
 		util::FixedHash<4> const& hash = it.first;
 		if (hashes.count(hash))
-			m_errorReporter.typeError(
+			m_errorReporter.fatalTypeError(
 				1860_error,
 				_contract.location(),
 				string("Function signature hash collision for ") + it.second->externalSignature()

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/hash_collision_in_abstract_contract.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/hash_collision_in_abstract_contract.sol
@@ -1,0 +1,13 @@
+// This contract used to throw
+abstract contract D {
+    function gsf() public {}
+    function tgeo() public {}
+}
+contract C {
+    D d;
+    function g() public returns (uint) {
+        d.d;
+    }
+}
+// ----
+// TypeError 1860: (31-113): Function signature hash collision for tgeo()


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/10988

The check is performed during ContractLevelChecker. However, the TypeChecker throws in certain cases
when it encounters functions, whose hashes collide.

Here is a stack trace

```
#0  0x00007ffff6993492 in __cxxabiv1::__cxa_throw (obj=0x131e620, 
    tinfo=0xdb0200 <typeinfo for boost::wrapexcept<solidity::langutil::InternalCompilerError>>, 
    dest=0x438a58 <boost::wrapexcept<solidity::langutil::InternalCompilerError>::~wrapexcept()>) at ../../../../libstdc++-v3/libsupc++/eh_throw.cc:78
#1  0x0000000000438bb9 in boost::throw_exception<solidity::langutil::InternalCompilerError> (e=...) at /usr/include/boost/throw_exception.hpp:165
#2  0x0000000000715867 in solidity::frontend::ContractDefinition::interfaceFunctions (
    this=0x13120f0, _includeInheritedFunctions=true)
    at /home/hari/s/r2/libsolidity/ast/AST.cpp:100
#3  0x00000000004aa082 in solidity::frontend::ContractType::nativeMembers (
    this=0x131cc00) at /home/hari/s/r2/libsolidity/ast/Types.cpp:1993
#4  0x00000000004991d6 in solidity::frontend::Type::members (this=0x131cc00, 
    _currentScope=0x1312830) at /home/hari/s/r2/libsolidity/ast/Types.cpp:292
#5  0x00000000006f1a76 in solidity::frontend::TypeChecker::visit (
    this=0x7fffffffcd70, _memberAccess=...)
    at /home/hari/s/r2/libsolidity/analysis/TypeChecker.cpp:2683
#6  0x0000000000714a66 in solidity::frontend::MemberAccess::accept (this=0x130e6e0, 
    _visitor=...) at /home/hari/s/r2/libsolidity/ast/AST_accept.h:898
#7  0x0000000000713c6c in solidity::frontend::ExpressionStatement::accept (
    this=0x130dee0, _visitor=...) at /home/hari/s/r2/libsolidity/ast/AST_accept.h:711
#8  0x000000000071e031 in solidity::frontend::ASTNode::listAccept<std::shared_ptr<solidity::frontend::Statement> > (_list=std::vector of length 1, capacity 1 = {...}, 
    _visitor=...) at /home/hari/s/r2/libsolidity/ast/AST.h:108
#9  0x0000000000712e81 in solidity::frontend::Block::accept (this=0x13107a0, 
    _visitor=...) at /home/hari/s/r2/libsolidity/ast/AST_accept.h:501
#10 0x00000000006d893b in solidity::frontend::TypeChecker::visit (
    this=0x7fffffffcd70, _function=...)
    at /home/hari/s/r2/libsolidity/analysis/TypeChecker.cpp:476
#11 0x0000000000711d26 in solidity::frontend::FunctionDefinition::accept (
    this=0x13126f0, _visitor=...) at /home/hari/s/r2/libsolidity/ast/AST_accept.h:251
#12 0x00000000006d4718 in solidity::frontend::TypeChecker::visit (
    this=0x7fffffffcd70, _contract=...)
    at /home/hari/s/r2/libsolidity/analysis/TypeChecker.cpp:99
#13 0x0000000000711356 in solidity::frontend::ContractDefinition::accept (
```