### PR TITLE
Fix IR bug on deleting storage variables of function type.

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3888,11 +3888,13 @@ string YulUtilFunctions::storageSetToZeroFunction(Type const& _type)
 		if (_type.isValueType())
 			return Whiskers(R"(
 				function <functionName>(slot, offset) {
-					<store>(slot, offset, <zeroValue>())
+					let <values> := <zeroValue>()
+					<store>(slot, offset, <values>)
 				}
 			)")
 			("functionName", functionName)
 			("store", updateStorageValueFunction(_type, _type))
+			("values", suffixedVariableNameList("zero_", 0, _type.sizeOnStack()))
 			("zeroValue", zeroValueFunction(_type))
 			.render();
 		else if (_type.category() == Type::Category::Array)

--- a/test/libsolidity/semanticTests/functionTypes/function_external_delete_storage.sol
+++ b/test/libsolidity/semanticTests/functionTypes/function_external_delete_storage.sol
@@ -1,0 +1,39 @@
+contract C {
+    function() external public x;
+    uint public y = 0;
+
+    function increment() public {
+        ++y;
+    }
+
+    function set() external {
+        x = this.increment;
+    }
+
+    function incrementIndirectly() public {
+        x();
+    }
+
+    function deleteFunction() public {
+        // used to lead to an ICE during IR
+        delete x;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// x() -> 0
+// y() -> 0
+// increment() ->
+// y() -> 1
+// set() ->
+// x() -> 0xfdd67305928fcac8d213d1e47bfa6165cd0b87bd09de08a0000000000000000
+// increment() ->
+// y() -> 2
+// incrementIndirectly() ->
+// y() -> 3
+// deleteFunction() ->
+// increment() ->
+// y() -> 4
+// incrementIndirectly() -> FAILURE
+// y() -> 4


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/10917

Calling the zeroing function assumed that the stack slots needed for the type was always 1.