### PR TITLE
remove ref to Python in language similarities

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Solidity is an object-oriented, high-level language for implementing smart
 contracts. Smart contracts are programs which govern the behaviour of accounts
 within the Ethereum state.
 
-Solidity was influenced by C++, Python and JavaScript and is designed to target
+Solidity was influenced by C++ and JavaScript and is designed to target
 the Ethereum Virtual Machine (EVM).
 
 Solidity is statically typed, supports inheritance, libraries and complex


### PR DESCRIPTION
I was looking at the ethereum.org website, and noticed it said "Solidity is inspired by C++, Python and JavaScript" and I got to thinking to myself "where's the Python influence?"

I think most people agree that Solidity has really heavy influence from Javascript and C++, but I really don't see the Python. It looks like this change was introduced from this commit, which doesn't really explain where it came from either: https://github.com/ethereum/solidity/commit/03b3faa8ef5a4e4342c541102526214519ab9f5a

Feel free to accept or reject, it just causes me a little cognitive dissonance to see it listed as an influence since I definitely don't think of Solidity as having much Python influence.