### PR TITLE
Ensure jsoncpp isn't installed with _static suffix

### DIFF
--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -52,6 +52,8 @@ ExternalProject_Add(jsoncpp-project
                -DCMAKE_INSTALL_LIBDIR=lib
                # Build static lib but suitable to be included in a shared lib.
                -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+               # avoid "_static" being appended. E.g. libjsoncpp_static.a
+               -DSTATIC_SUFFIX=
                -DJSONCPP_WITH_EXAMPLE=OFF
                -DJSONCPP_WITH_TESTS=OFF
                -DJSONCPP_WITH_PKGCONFIG_SUPPORT=OFF


### PR DESCRIPTION
Trying to package this for Nixpkgs, the build kept failing because it assumed that `libjsoncpp.a` would be available, however, `libjsoncpp_static.a` was being created.