### PR TITLE
Move AND with constant inside OR.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * Optimizer: Try to move ``and`` with constant inside ``or`` to improve storage writes of small types.
 
 
 Bugfixes:

--- a/test/cmdlineTests/optimize_full_storage_write/args
+++ b/test/cmdlineTests/optimize_full_storage_write/args
@@ -1,0 +1,1 @@
+--optimize --asm --metadata-hash none

--- a/test/cmdlineTests/optimize_full_storage_write/input.sol
+++ b/test/cmdlineTests/optimize_full_storage_write/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+contract OptimizeFullSlotWrite {
+	uint64[4] nums;
+	function f() public {
+		nums[0] = 11111;
+		nums[1] = 22222;
+		nums[2] = 33333;
+		nums[3] = 44444;
+	}
+}

--- a/test/cmdlineTests/optimize_full_storage_write/output
+++ b/test/cmdlineTests/optimize_full_storage_write/output
@@ -1,0 +1,64 @@
+
+======= optimize_full_storage_write/input.sol:OptimizeFullSlotWrite =======
+EVM assembly:
+    /* "optimize_full_storage_write/input.sol":60:213  contract OptimizeFullSlotWrite {... */
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  0x00
+  dup1
+  revert
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+        /* "optimize_full_storage_write/input.sol":60:213  contract OptimizeFullSlotWrite {... */
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      0x00
+      dup1
+      revert
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x26121ff0
+      eq
+      tag_3
+      jumpi
+    tag_2:
+      0x00
+      dup1
+      revert
+        /* "optimize_full_storage_write/input.sol":111:211  function f() public {... */
+    tag_3:
+      tag_4
+        /* "optimize_full_storage_write/input.sol":192:207  nums[3] = 44444 */
+      0xad9c000000000000823500000000000056ce0000000000002b67
+        /* "optimize_full_storage_write/input.sol":135:139  nums */
+      0x00
+        /* "optimize_full_storage_write/input.sol":192:207  nums[3] = 44444 */
+      sstore
+        /* "optimize_full_storage_write/input.sol":111:211  function f() public {... */
+      jump
+    tag_4:
+      stop
+
+    auxdata: <AUXDATA REMOVED>
+}

--- a/test/formal/move_and_inside_or.py
+++ b/test/formal/move_and_inside_or.py
@@ -1,0 +1,32 @@
+from rule import Rule
+from opcodes import *
+
+"""
+Rule:
+AND(OR(AND(X, A), Y), B) -> OR(AND(X, A & B), AND(Y, B))
+"""
+
+rule = Rule()
+
+# bit width is irrelevant
+n_bits = 128
+
+# Input vars
+X = BitVec('X', n_bits)
+Y = BitVec('Y', n_bits)
+A = BitVec('A', n_bits)
+B = BitVec('B', n_bits)
+
+# Non optimized result, explicit form
+nonopt = AND(OR(AND(X, A), Y), B)
+
+# Optimized result
+opt = OR(AND(X, A & B), AND(Y, B))
+
+rule.check(nonopt, opt)
+
+# Now the forms as they are constructod in the code.
+for inner in [AND(X, A), AND(A, X)]:
+    for second in [OR(inner, Y), OR(Y, inner)]:
+        rule.check(AND(second, B), opt)
+        rule.check(AND(B, second), opt)

--- a/test/libyul/yulOptimizerTests/fullSuite/and_or_combination.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/and_or_combination.yul
@@ -1,0 +1,25 @@
+{
+    // Tests that masks that "add" up to
+    // the full bit width are removed.
+    let a := sload(0)
+    let x := sload(a)
+    let mask := 0xffffffffffffffff
+    x := or(and(x, not(mask)), 0x2b67)
+    mask := shl(64, mask)
+    x := or(and(x, not(mask)), 0x56ce0000000000000000)
+    mask := shl(64, mask)
+    x := or(and(x, not(mask)), shl(0x80, 0x8235))
+    mask := shl(64, mask)
+    x := or(and(x, not(mask)), shl(0xc2, 0x2b67))
+    sstore(a, x)
+}
+// ====
+// EVMVersion: >byzantium
+// ----
+// step: fullSuite
+//
+// {
+//     {
+//         sstore(sload(0), 0xad9c000000000000823500000000000056ce0000000000002b67)
+//     }
+// }


### PR DESCRIPTION
Inspired by
```
contract C {
   uint64[4] nums;
   function f() public { 
     nums[0] = 11111;
     nums[1] = 22222;
     nums[2] = 33333;
     nums[3] = 44444;
   }
}
```
Optimized assembly before this change:

```
      0x00
      dup1
      sload
      not(0xffffffffffffffff)
      and
      0x2b67
      or
      not(0xffffffffffffffff0000000000000000)
      and
      0x56ce0000000000000000
      or
      not(shl(0x80, 0xffffffffffffffff))
      and
      shl(0x80, 0x8235)
      or
      sub(shl(0xc0, 0x01), 0x01)
      and
      shl(0xc2, 0x2b67)
      or
      swap1
      sstore
```

Optimized assembly after this change:
```
      0xad9c000000000000823500000000000056ce0000000000002b67
      0x00
      sstore
```
(note that it eliminates not only tremendous amounts of code but also the `sload`)

Downside of this change: The rule itself increases code size.