### PR TITLE
[SMTChecker] Use same sort name for array slice as for the underlying array

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,8 +8,10 @@ Compiler Features:
 
 Bugfixes:
  * SMTChecker: Fix internal error on ``FixedBytes`` constant initialized with string literal.
+ * SMTChecker: Fix internal error on array slices.
  * SMTChecker: Fix internal error on calling public getter on a state variable of type array (possibly nested) of structs.
  * SMTChecker: Fix internal error on pushing to ``string`` casted to ``bytes``.
+
 AST Changes:
 
 ### 0.8.2 (2021-03-02)

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -93,14 +93,14 @@ SortPointer smtSort(frontend::Type const& _type)
 		}
 
 		string tupleName;
+		auto sliceArrayType = dynamic_cast<ArraySliceType const*>(&_type);
+		ArrayType const* arrayType = sliceArrayType ? &sliceArrayType->arrayType() : dynamic_cast<ArrayType const*>(&_type);
 		if (
-			auto arrayType = dynamic_cast<ArrayType const*>(&_type);
 			(arrayType && (arrayType->isString() || arrayType->isByteArray())) ||
-			_type.category() == frontend::Type::Category::ArraySlice ||
 			_type.category() == frontend::Type::Category::StringLiteral
 		)
 			tupleName = "bytes";
-		else if (auto arrayType = dynamic_cast<ArrayType const*>(&_type))
+		else if (arrayType)
 		{
 			auto baseType = arrayType->baseType();
 			// Solidity allows implicit conversion also when assigning arrays.

--- a/test/libsolidity/smtCheckerTests/abi/abi_encode_array_slice_2.sol
+++ b/test/libsolidity/smtCheckerTests/abi/abi_encode_array_slice_2.sol
@@ -22,10 +22,12 @@ contract C {
 }
 // ----
 // Warning 6328: (312-342): CHC: Assertion violation happens here.
-// Warning 6328: (548-578): CHC: Assertion violation happens here.
+// Warning 1218: (548-578): CHC: Error trying to invoke SMT solver.
+// Warning 6328: (548-578): CHC: Assertion violation might happen here.
 // Warning 1218: (644-674): CHC: Error trying to invoke SMT solver.
 // Warning 6328: (644-674): CHC: Assertion violation might happen here.
 // Warning 1218: (895-925): CHC: Error trying to invoke SMT solver.
 // Warning 6328: (895-925): CHC: Assertion violation might happen here.
+// Warning 4661: (548-578): BMC: Assertion violation happens here.
 // Warning 4661: (644-674): BMC: Assertion violation happens here.
 // Warning 4661: (895-925): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/operators/slices_2.sol
+++ b/test/libsolidity/smtCheckerTests/operators/slices_2.sol
@@ -1,0 +1,5 @@
+pragma experimental SMTChecker;
+contract e {
+	function f(uint[] calldata) internal {}
+	function h(uint[] calldata c) external { f(c[:]); }
+}

--- a/test/libsolidity/smtCheckerTests/operators/slices_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/slices_3.sol
@@ -1,0 +1,17 @@
+pragma experimental SMTChecker;
+
+contract C {
+int[] s;
+function f(int[] calldata b, uint256 start, uint256 end) public returns (int) {
+    s = b[start:end];
+    uint len = end - start;
+    assert(len == s.length);
+    for (uint i = 0; i < len; i++) {
+        assert(b[start:end][i] == s[i]);
+    }
+    return s[0];
+}
+}
+// ----
+// Warning 6328: (259-290): CHC: Assertion violation might happen here.
+// Warning 4661: (259-290): BMC: Assertion violation happens here.


### PR DESCRIPTION
This PR fixes the creation of SMT sort for expressions of type `ArraySlice`. Previously, the name of this sort was always `bytes_tuple` regardless of the type of the underlying array.
Now the name of the sort is the same as for an expression of type corresponding to the underlying array.

Fixes #11063.
Fixes #11064.
