### PR TITLE
Drop experimental support for eip-615 and evm15.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * Command Line Interface: Drop experimental support for ``--machine evm15``.
  * Optimizer: Try to move ``and`` with constant inside ``or`` to improve storage writes of small types.
 
 

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -175,17 +175,6 @@ enum class Instruction: uint8_t
 	LOG3,				///< Makes a log entry; 3 topics.
 	LOG4,				///< Makes a log entry; 4 topics.
 
-	EIP615_JUMPTO = 0xb0,      ///< alter the program counter to a jumpdest -- not part of Instructions.cpp
-	EIP615_JUMPIF,             ///< conditionally alter the program counter -- not part of Instructions.cpp
-	EIP615_JUMPV,              ///< alter the program counter to a jumpdest -- not part of Instructions.cpp
-	EIP615_JUMPSUB,            ///< alter the program counter to a beginsub -- not part of Instructions.cpp
-	EIP615_JUMPSUBV,           ///< alter the program counter to a beginsub -- not part of Instructions.cpp
-	EIP615_BEGINSUB,           ///< set a potential jumpsub destination -- not part of Instructions.cpp
-	EIP615_BEGINDATA,          ///< begin the data section -- not part of Instructions.cpp
-	EIP615_RETURNSUB,          ///< return to subroutine jumped from -- not part of Instructions.cpp
-	EIP615_PUTLOCAL,           ///< pop top of stack to local variable -- not part of Instructions.cpp
-	EIP615_GETLOCAL,           ///< push local variable to top of stack -- not part of Instructions.cpp
-
 	CREATE = 0xf0,		///< create a new account with associated code
 	CALL,				///< message-call into an account
 	CALLCODE,			///< message-call with another account's code only

--- a/libyul/AssemblyStack.cpp
+++ b/libyul/AssemblyStack.cpp
@@ -148,7 +148,7 @@ bool AssemblyStack::analyzeParsed(Object& _object)
 	return success;
 }
 
-void AssemblyStack::compileEVM(AbstractAssembly& _assembly, bool _evm15, bool _optimize) const
+void AssemblyStack::compileEVM(AbstractAssembly& _assembly, bool _optimize) const
 {
 	EVMDialect const* dialect = nullptr;
 	switch (m_language)
@@ -165,7 +165,7 @@ void AssemblyStack::compileEVM(AbstractAssembly& _assembly, bool _evm15, bool _o
 			break;
 	}
 
-	EVMObjectCompiler::compile(*m_parserResult, _assembly, *dialect, _evm15, _optimize);
+	EVMObjectCompiler::compile(*m_parserResult, _assembly, *dialect, _optimize);
 }
 
 void AssemblyStack::optimize(Object& _object, bool _isCreation)
@@ -200,15 +200,6 @@ MachineAssemblyObject AssemblyStack::assemble(Machine _machine) const
 	{
 	case Machine::EVM:
 		return assembleWithDeployed().first;
-	case Machine::EVM15:
-	{
-		MachineAssemblyObject object;
-		EVMAssembly assembly(true);
-		compileEVM(assembly, true, m_optimiserSettings.optimizeStackAllocation);
-		object.bytecode = make_shared<evmasm::LinkerObject>(assembly.finalize());
-		/// TODO: fill out text representation
-		return object;
-	}
 	case Machine::Ewasm:
 	{
 		yulAssert(m_language == Language::Ewasm, "");
@@ -235,7 +226,7 @@ std::pair<MachineAssemblyObject, MachineAssemblyObject> AssemblyStack::assembleW
 
 	evmasm::Assembly assembly;
 	EthAssemblyAdapter adapter(assembly);
-	compileEVM(adapter, false, m_optimiserSettings.optimizeStackAllocation);
+	compileEVM(adapter, m_optimiserSettings.optimizeStackAllocation);
 
 	MachineAssemblyObject creationObject;
 	creationObject.bytecode = make_shared<evmasm::LinkerObject>(assembly.assemble());

--- a/libyul/AssemblyStack.h
+++ b/libyul/AssemblyStack.h
@@ -60,7 +60,7 @@ class AssemblyStack
 {
 public:
 	enum class Language { Yul, Assembly, StrictAssembly, Ewasm };
-	enum class Machine { EVM, EVM15, Ewasm };
+	enum class Machine { EVM, Ewasm };
 
 	AssemblyStack():
 		AssemblyStack(langutil::EVMVersion{}, Language::Assembly, solidity::frontend::OptimiserSettings::none())
@@ -114,7 +114,7 @@ private:
 	bool analyzeParsed();
 	bool analyzeParsed(yul::Object& _object);
 
-	void compileEVM(yul::AbstractAssembly& _assembly, bool _evm15, bool _optimize) const;
+	void compileEVM(yul::AbstractAssembly& _assembly, bool _optimize) const;
 
 	void optimize(yul::Object& _object, bool _isCreation);
 

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -87,15 +87,6 @@ public:
 	virtual void appendJumpTo(LabelID _labelId, int _stackDiffAfter = 0, JumpType _jumpType = JumpType::Ordinary) = 0;
 	/// Append a jump-to-if-immediate operation.
 	virtual void appendJumpToIf(LabelID _labelId, JumpType _jumpType = JumpType::Ordinary) = 0;
-	/// Start a subroutine identified by @a _labelId that takes @a _arguments
-	/// stack slots as arguments.
-	virtual void appendBeginsub(LabelID _labelId, int _arguments) = 0;
-	/// Call a subroutine identified by @a _labelId, taking @a _arguments from the
-	/// stack upon call and putting @a _returns arguments onto the stack upon return.
-	virtual void appendJumpsub(LabelID _labelId, int _arguments, int _returns) = 0;
-	/// Return from a subroutine.
-	/// @param _stackDiffAfter the stack adjustment after this instruction.
-	virtual void appendReturnsub(int _returns, int _stackDiffAfter = 0) = 0;
 
 	/// Append the assembled size as a constant.
 	virtual void appendAssemblySize() = 0;

--- a/libyul/backends/evm/AsmCodeGen.cpp
+++ b/libyul/backends/evm/AsmCodeGen.cpp
@@ -117,24 +117,6 @@ void EthAssemblyAdapter::appendJumpToIf(LabelID _labelId, JumpType _jumpType)
 	appendJumpInstruction(evmasm::Instruction::JUMPI, _jumpType);
 }
 
-void EthAssemblyAdapter::appendBeginsub(LabelID, int)
-{
-	// TODO we could emulate that, though
-	yulAssert(false, "BEGINSUB not implemented for EVM 1.0");
-}
-
-void EthAssemblyAdapter::appendJumpsub(LabelID, int, int)
-{
-	// TODO we could emulate that, though
-	yulAssert(false, "JUMPSUB not implemented for EVM 1.0");
-}
-
-void EthAssemblyAdapter::appendReturnsub(int, int)
-{
-	// TODO we could emulate that, though
-	yulAssert(false, "RETURNSUB not implemented for EVM 1.0");
-}
-
 void EthAssemblyAdapter::appendAssemblySize()
 {
 	m_assembly.appendProgramSize();
@@ -239,7 +221,6 @@ void CodeGenerator::assemble(
 		EVMDialect::strictAssemblyForEVM(_evmVersion),
 		builtinContext,
 		_optimizeStackAllocation,
-		false,
 		_identifierAccess,
 		_useNamedLabelsForFunctions
 	);

--- a/libyul/backends/evm/AsmCodeGen.h
+++ b/libyul/backends/evm/AsmCodeGen.h
@@ -53,9 +53,6 @@ public:
 	void appendJump(int _stackDiffAfter, JumpType _jumpType) override;
 	void appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType) override;
 	void appendJumpToIf(LabelID _labelId, JumpType _jumpType) override;
-	void appendBeginsub(LabelID, int) override;
-	void appendJumpsub(LabelID, int, int) override;
-	void appendReturnsub(int, int) override;
 	void appendAssemblySize() override;
 	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name = {}) override;
 	void appendDataOffset(std::vector<SubID> const& _subPath) override;

--- a/libyul/backends/evm/EVMAssembly.cpp
+++ b/libyul/backends/evm/EVMAssembly.cpp
@@ -65,7 +65,6 @@ void EVMAssembly::appendLabel(LabelID _labelId)
 
 void EVMAssembly::appendLabelReference(LabelID _labelId)
 {
-	yulAssert(!m_evm15, "Cannot use plain label references in EMV1.5 mode.");
 	// @TODO we now always use labelReferenceSize for all labels, it could be shortened
 	// for some of them.
 	appendInstruction(evmasm::pushInstruction(labelReferenceSize));
@@ -94,65 +93,20 @@ void EVMAssembly::appendLinkerSymbol(string const&)
 
 void EVMAssembly::appendJump(int _stackDiffAfter, JumpType)
 {
-	yulAssert(!m_evm15, "Plain JUMP used for EVM 1.5");
 	appendInstruction(evmasm::Instruction::JUMP);
 	m_stackHeight += _stackDiffAfter;
 }
 
 void EVMAssembly::appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType)
 {
-	if (m_evm15)
-	{
-		m_bytecode.push_back(uint8_t(evmasm::Instruction::EIP615_JUMPTO));
-		appendLabelReferenceInternal(_labelId);
-		m_stackHeight += _stackDiffAfter;
-	}
-	else
-	{
-		appendLabelReference(_labelId);
-		appendJump(_stackDiffAfter, _jumpType);
-	}
+	appendLabelReference(_labelId);
+	appendJump(_stackDiffAfter, _jumpType);
 }
 
 void EVMAssembly::appendJumpToIf(LabelID _labelId, JumpType)
 {
-	if (m_evm15)
-	{
-		m_bytecode.push_back(uint8_t(evmasm::Instruction::EIP615_JUMPIF));
-		appendLabelReferenceInternal(_labelId);
-		m_stackHeight--;
-	}
-	else
-	{
-		appendLabelReference(_labelId);
-		appendInstruction(evmasm::Instruction::JUMPI);
-	}
-}
-
-void EVMAssembly::appendBeginsub(LabelID _labelId, int _arguments)
-{
-	yulAssert(m_evm15, "BEGINSUB used for EVM 1.0");
-	yulAssert(_arguments >= 0, "");
-	setLabelToCurrentPosition(_labelId);
-	m_bytecode.push_back(uint8_t(evmasm::Instruction::EIP615_BEGINSUB));
-	m_stackHeight += _arguments;
-}
-
-void EVMAssembly::appendJumpsub(LabelID _labelId, int _arguments, int _returns)
-{
-	yulAssert(m_evm15, "JUMPSUB used for EVM 1.0");
-	yulAssert(_arguments >= 0 && _returns >= 0, "");
-	m_bytecode.push_back(uint8_t(evmasm::Instruction::EIP615_JUMPSUB));
-	appendLabelReferenceInternal(_labelId);
-	m_stackHeight += _returns - _arguments;
-}
-
-void EVMAssembly::appendReturnsub(int _returns, int _stackDiffAfter)
-{
-	yulAssert(m_evm15, "RETURNSUB used for EVM 1.0");
-	yulAssert(_returns >= 0, "");
-	m_bytecode.push_back(uint8_t(evmasm::Instruction::EIP615_RETURNSUB));
-	m_stackHeight += _stackDiffAfter - _returns;
+	appendLabelReference(_labelId);
+	appendInstruction(evmasm::Instruction::JUMPI);
 }
 
 evmasm::LinkerObject EVMAssembly::finalize()

--- a/libyul/backends/evm/EVMAssembly.h
+++ b/libyul/backends/evm/EVMAssembly.h
@@ -38,7 +38,7 @@ namespace solidity::yul
 class EVMAssembly: public AbstractAssembly
 {
 public:
-	explicit EVMAssembly(bool _evm15 = false): m_evm15(_evm15) { }
+	explicit EVMAssembly() { }
 	~EVMAssembly() override = default;
 
 	/// Set a new source location valid starting from the next instruction.
@@ -70,12 +70,6 @@ public:
 	void appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType) override;
 	/// Append a jump-to-if-immediate operation.
 	void appendJumpToIf(LabelID _labelId, JumpType _jumpType) override;
-	/// Start a subroutine.
-	void appendBeginsub(LabelID _labelId, int _arguments) override;
-	/// Call a subroutine.
-	void appendJumpsub(LabelID _labelId, int _arguments, int _returns) override;
-	/// Return from a subroutine.
-	void appendReturnsub(int _returns, int _stackDiffAfter) override;
 
 	/// Append the assembled size as a constant.
 	void appendAssemblySize() override;
@@ -97,7 +91,6 @@ private:
 	void appendLabelReferenceInternal(AbstractAssembly::LabelID _labelId);
 	void updateReference(size_t pos, size_t size, u256 value);
 
-	bool m_evm15 = false; ///< if true, switch to evm1.5 mode
 	LabelID m_nextLabelId = 0;
 	int m_stackHeight = 0;
 	bytes m_bytecode;

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -128,7 +128,6 @@ public:
 		EVMDialect const& _dialect,
 		BuiltinContext& _builtinContext,
 		bool _allowStackOpt = false,
-		bool _evm15 = false,
 		ExternalIdentifierAccess const& _identifierAccess = ExternalIdentifierAccess(),
 		bool _useNamedLabelsForFunctions = false
 	): CodeTransform(
@@ -138,7 +137,6 @@ public:
 		_allowStackOpt,
 		_dialect,
 		_builtinContext,
-		_evm15,
 		_identifierAccess,
 		_useNamedLabelsForFunctions,
 		nullptr
@@ -158,7 +156,6 @@ protected:
 		bool _allowStackOpt,
 		EVMDialect const& _dialect,
 		BuiltinContext& _builtinContext,
-		bool _evm15,
 		ExternalIdentifierAccess _identifierAccess,
 		bool _useNamedLabelsForFunctions,
 		std::shared_ptr<Context> _context
@@ -228,7 +225,6 @@ private:
 	EVMDialect const& m_dialect;
 	BuiltinContext& m_builtinContext;
 	bool const m_allowStackOpt = true;
-	bool const m_evm15 = false;
 	bool const m_useNamedLabelsForFunctions = false;
 	ExternalIdentifierAccess m_identifierAccess;
 	std::shared_ptr<Context> m_context;

--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -31,9 +31,9 @@
 using namespace solidity::yul;
 using namespace std;
 
-void EVMObjectCompiler::compile(Object& _object, AbstractAssembly& _assembly, EVMDialect const& _dialect, bool _evm15, bool _optimize)
+void EVMObjectCompiler::compile(Object& _object, AbstractAssembly& _assembly, EVMDialect const& _dialect, bool _optimize)
 {
-	EVMObjectCompiler compiler(_assembly, _dialect, _evm15);
+	EVMObjectCompiler compiler(_assembly, _dialect);
 	compiler.run(_object, _optimize);
 }
 
@@ -49,7 +49,7 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 			auto subAssemblyAndID = m_assembly.createSubAssembly(subObject->name.str());
 			context.subIDs[subObject->name] = subAssemblyAndID.second;
 			subObject->subId = subAssemblyAndID.second;
-			compile(*subObject, *subAssemblyAndID.first, m_dialect, m_evm15, _optimize);
+			compile(*subObject, *subAssemblyAndID.first, m_dialect, _optimize);
 		}
 		else
 		{
@@ -61,7 +61,7 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 	yulAssert(_object.code, "No code.");
 	// We do not catch and re-throw the stack too deep exception here because it is a YulException,
 	// which should be native to this part of the code.
-	CodeTransform transform{m_assembly, *_object.analysisInfo, *_object.code, m_dialect, context, _optimize, m_evm15};
+	CodeTransform transform{m_assembly, *_object.analysisInfo, *_object.code, m_dialect, context, _optimize};
 	transform(*_object.code);
 	if (!transform.stackErrors().empty())
 		BOOST_THROW_EXCEPTION(transform.stackErrors().front());

--- a/libyul/backends/evm/EVMObjectCompiler.h
+++ b/libyul/backends/evm/EVMObjectCompiler.h
@@ -30,17 +30,16 @@ struct EVMDialect;
 class EVMObjectCompiler
 {
 public:
-	static void compile(Object& _object, AbstractAssembly& _assembly, EVMDialect const& _dialect, bool _evm15, bool _optimize);
+	static void compile(Object& _object, AbstractAssembly& _assembly, EVMDialect const& _dialect, bool _optimize);
 private:
-	EVMObjectCompiler(AbstractAssembly& _assembly, EVMDialect const& _dialect, bool _evm15):
-		m_assembly(_assembly), m_dialect(_dialect), m_evm15(_evm15)
+	EVMObjectCompiler(AbstractAssembly& _assembly, EVMDialect const& _dialect):
+		m_assembly(_assembly), m_dialect(_dialect)
 	{}
 
 	void run(Object& _object, bool _optimize);
 
 	AbstractAssembly& m_assembly;
 	EVMDialect const& m_dialect;
-	bool m_evm15 = false;
 };
 
 }

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -26,8 +26,6 @@
 
 #include <libevmasm/Instruction.h>
 
-#include <boost/range/adaptor/reversed.hpp>
-
 
 using namespace std;
 using namespace solidity;
@@ -53,7 +51,6 @@ void NoOutputAssembly::appendLabel(LabelID)
 
 void NoOutputAssembly::appendLabelReference(LabelID)
 {
-	yulAssert(!m_evm15, "Cannot use plain label references in EMV1.5 mode.");
 	appendInstruction(evmasm::pushInstruction(1));
 }
 
@@ -74,52 +71,20 @@ void NoOutputAssembly::appendLinkerSymbol(string const&)
 
 void NoOutputAssembly::appendJump(int _stackDiffAfter, JumpType)
 {
-	yulAssert(!m_evm15, "Plain JUMP used for EVM 1.5");
 	appendInstruction(evmasm::Instruction::JUMP);
 	m_stackHeight += _stackDiffAfter;
 }
 
 void NoOutputAssembly::appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType)
 {
-	if (m_evm15)
-		m_stackHeight += _stackDiffAfter;
-	else
-	{
-		appendLabelReference(_labelId);
-		appendJump(_stackDiffAfter, _jumpType);
-	}
+	appendLabelReference(_labelId);
+	appendJump(_stackDiffAfter, _jumpType);
 }
 
 void NoOutputAssembly::appendJumpToIf(LabelID _labelId, JumpType)
 {
-	if (m_evm15)
-		m_stackHeight--;
-	else
-	{
-		appendLabelReference(_labelId);
-		appendInstruction(evmasm::Instruction::JUMPI);
-	}
-}
-
-void NoOutputAssembly::appendBeginsub(LabelID, int _arguments)
-{
-	yulAssert(m_evm15, "BEGINSUB used for EVM 1.0");
-	yulAssert(_arguments >= 0, "");
-	m_stackHeight += _arguments;
-}
-
-void NoOutputAssembly::appendJumpsub(LabelID, int _arguments, int _returns)
-{
-	yulAssert(m_evm15, "JUMPSUB used for EVM 1.0");
-	yulAssert(_arguments >= 0 && _returns >= 0, "");
-	m_stackHeight += _returns - _arguments;
-}
-
-void NoOutputAssembly::appendReturnsub(int _returns, int _stackDiffAfter)
-{
-	yulAssert(m_evm15, "RETURNSUB used for EVM 1.0");
-	yulAssert(_returns >= 0, "");
-	m_stackHeight += _stackDiffAfter - _returns;
+	appendLabelReference(_labelId);
+	appendInstruction(evmasm::Instruction::JUMPI);
 }
 
 void NoOutputAssembly::appendAssemblySize()

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -45,7 +45,7 @@ namespace solidity::yul
 class NoOutputAssembly: public AbstractAssembly
 {
 public:
-	explicit NoOutputAssembly(bool _evm15 = false): m_evm15(_evm15) { }
+	explicit NoOutputAssembly() { }
 	~NoOutputAssembly() override = default;
 
 	void setSourceLocation(langutil::SourceLocation const&) override {}
@@ -62,9 +62,6 @@ public:
 	void appendJump(int _stackDiffAfter, JumpType _jumpType) override;
 	void appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType) override;
 	void appendJumpToIf(LabelID _labelId, JumpType _jumpType) override;
-	void appendBeginsub(LabelID _labelId, int _arguments) override;
-	void appendJumpsub(LabelID _labelId, int _arguments, int _returns) override;
-	void appendReturnsub(int _returns, int _stackDiffAfter) override;
 
 	void appendAssemblySize() override;
 	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name = "") override;
@@ -78,7 +75,6 @@ public:
 	void markAsInvalid() override {}
 
 private:
-	bool m_evm15 = false; ///< if true, switch to evm1.5 mode
 	int m_stackHeight = 0;
 };
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -128,7 +128,6 @@ static string const g_strCompactJSON = "compact-format";
 static string const g_strContracts = "contracts";
 static string const g_strErrorRecovery = "error-recovery";
 static string const g_strEVM = "evm";
-static string const g_strEVM15 = "evm15";
 static string const g_strEVMVersion = "evm-version";
 static string const g_strEwasm = "ewasm";
 static string const g_strExperimentalViaIR = "experimental-via-ir";
@@ -268,7 +267,6 @@ static set<string> const g_combinedJsonArgs
 static set<string> const g_machineArgs
 {
 	g_strEVM,
-	g_strEVM15,
 	g_strEwasm
 };
 
@@ -1382,8 +1380,6 @@ bool CommandLineInterface::processInput()
 			string machine = m_args[g_argMachine].as<string>();
 			if (machine == g_strEVM)
 				targetMachine = Machine::EVM;
-			else if (machine == g_strEVM15)
-				targetMachine = Machine::EVM15;
 			else if (machine == g_strEwasm)
 				targetMachine = Machine::Ewasm;
 			else
@@ -1938,7 +1934,6 @@ bool CommandLineInterface::assemble(
 	{
 		string machine =
 			_targetMachine == yul::AssemblyStack::Machine::EVM ? "EVM" :
-			_targetMachine == yul::AssemblyStack::Machine::EVM15 ? "EVM 1.5" :
 			"Ewasm";
 		sout() << endl << "======= " << src.first << " (" << machine << ") =======" << endl;
 

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -107,8 +107,7 @@ bool successParse(
 bool successAssemble(string const& _source, bool _allowWarnings = true, AssemblyStack::Language _language = AssemblyStack::Language::Assembly)
 {
 	return
-		successParse(_source, true, _allowWarnings, _language, AssemblyStack::Machine::EVM) &&
-		successParse(_source, true, _allowWarnings, _language, AssemblyStack::Machine::EVM15);
+		successParse(_source, true, _allowWarnings, _language, AssemblyStack::Machine::EVM);
 }
 
 Error expectError(

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -410,17 +410,6 @@ u256 EVMInstructionInterpreter::eval(
 	case Instruction::SWAP14:
 	case Instruction::SWAP15:
 	case Instruction::SWAP16:
-	// --------------- EIP-615 ---------------
-	case Instruction::EIP615_JUMPTO:
-	case Instruction::EIP615_JUMPIF:
-	case Instruction::EIP615_JUMPV:
-	case Instruction::EIP615_JUMPSUB:
-	case Instruction::EIP615_JUMPSUBV:
-	case Instruction::EIP615_BEGINSUB:
-	case Instruction::EIP615_BEGINDATA:
-	case Instruction::EIP615_RETURNSUB:
-	case Instruction::EIP615_PUTLOCAL:
-	case Instruction::EIP615_GETLOCAL:
 	{
 		yulAssert(false, "");
 		return 0;


### PR DESCRIPTION
This, intentionally, doesn't try anything clever, but just drops it. In case things can be simplified on top of this, I'd suggest to do that separately.