### PR TITLE
[SMTChecker] Fix handling of assignments of array/mapping state variable accessed using contract name.

### DIFF
--- a/test/libsolidity/smtCheckerTests/operators/assignment_contract_member_variable_array_2.sol
+++ b/test/libsolidity/smtCheckerTests/operators/assignment_contract_member_variable_array_2.sol
@@ -1,0 +1,8 @@
+pragma experimental SMTChecker;
+contract A {
+    int[] a;
+    function f() public {
+        A.a[0] = 2;
+    }
+}
+


### PR DESCRIPTION
Fixes #10831.