### PR TITLE
EVMHost: Use std::map for storage so that slots are stored in some order

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -37,7 +37,7 @@ using namespace solidity::util;
 using namespace solidity::test;
 using namespace evmc::literals;
 
-using StorageMap = std::unordered_map<evmc::bytes32, evmc::storage_value>;
+using StorageMap = std::map<evmc::bytes32, evmc::storage_value>;
 
 evmc::VM& EVMHost::getVM(string const& _path)
 {

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -63,7 +63,7 @@ public:
 	}
 
 	/// @returns contents of storage at @param _addr.
-	std::unordered_map<evmc::bytes32, evmc::storage_value> const& get_address_storage(evmc::address const& _addr);
+	std::map<evmc::bytes32, evmc::storage_value> const& get_address_storage(evmc::address const& _addr);
 
 	bool account_exists(evmc::address const& _addr) const noexcept final
 	{

--- a/test/evmc/mocked_host.hpp
+++ b/test/evmc/mocked_host.hpp
@@ -6,6 +6,7 @@
 #include <evmc/evmc.hpp>
 #include <algorithm>
 #include <string>
+#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -48,7 +49,7 @@ struct MockedAccount
     uint256be balance;
 
     /// The account storage map.
-    std::unordered_map<bytes32, storage_value> storage;
+    std::map<bytes32, storage_value> storage;
 
     /// Helper method for setting balance by numeric type.
     void set_balance(uint64_t x) noexcept


### PR DESCRIPTION
Motivation is the following:

- When testing old code gen vs new code gen, assertion was placed on storage of both code versions being equal
- Since EVMHost used unordered_map, although storage *contents* were equal, their order was not
- This led to false positives

This PR fixes that issue by simply using a map. I don't think a custom comparator is required but if reviewers think otherwise, it may be easily implemented.