### PR TITLE
Fix compilation error with GCC 8.

### DIFF
--- a/test/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/test/libsolidity/analysis/FunctionCallGraph.cpp
@@ -39,7 +39,6 @@
 #include <range/v3/view/set_algorithm.hpp>
 #include <range/v3/view/transform.hpp>
 
-#include <functional>
 #include <memory>
 #include <ostream>
 #include <set>
@@ -173,8 +172,8 @@ void checkCallGraphExpectations(
 
 ostream& operator<<(ostream& _out, EdgeNames const& _edgeNames)
 {
-	for (auto const& edge: _edgeNames | to<vector>() | actions::sort(std::less()))
-		_out << "    " << get<0>(edge) << " -> " << get<1>(edge) << endl;
+	for (auto const& [from, to]: _edgeNames)
+		_out << "    " << from << " -> " << to << endl;
 	return _out;
 }
 


### PR DESCRIPTION
Thanks to @jiangshangqifeng for reporting on gitter.

This resulted in
```
solidity/test/libsolidity/analysis/FunctionCallGraph.cpp: In function ‘std::ostream& {anonymous}::operator<<(std::ostream&, const EdgeNames&)’:
/solidity/test/libsolidity/analysis/FunctionCallGraph.cpp:176:77: error: cannot deduce template arguments for ‘less’ from ()
  for (auto const& edge: _edgeNames | to<vector>() | actions::sort(std::less()))
                                                                             ^
test/CMakeFiles/soltest.dir/build.make:1011: recipe for target 'test/CMakeFiles/soltest.dir/libsolidity/analysis/FunctionCallGraph.cpp.o' failed
make[2]: *** [test/CMakeFiles/soltest.dir/libsolidity/analysis/FunctionCallGraph.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:703: recipe for target 'test/CMakeFiles/soltest.dir/all' failed
make[1]: *** [test/CMakeFiles/soltest.dir/all] Error 2
```

But since ``_edgeNames`` is a ``std::set`` anyways, there's no need to convert it to a vector or explicitly sort it again, so we can simplify this and fix that compilation error at the same time.

We should, however, add a CI run for debian buster to prevent us falling out of sync with gcc 8, since ubuntu focal already ships gcc 9. And supporting debian stable seems like quite a reasonable compatibility requirement for us to keep.