### PR TITLE
[SMTChecker] Reset reference variables on assignment to a variable of reference type

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -2034,7 +2034,11 @@ void SMTEncoder::assignment(
 			m_context.newValue(*varDecl);
 	}
 	else if (auto varDecl = identifierToVariable(*left))
+	{
+		if (varDecl->hasReferenceOrMappingType())
+			resetReferences(*varDecl);
 		assignment(*varDecl, _right);
+	}
 	else if (
 		dynamic_cast<IndexAccess const*>(left) ||
 		dynamic_cast<MemberAccess const*>(left)

--- a/test/libsolidity/smtCheckerTests/operators/assignment_contract_member_variable_array_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/assignment_contract_member_variable_array_3.sol
@@ -1,0 +1,21 @@
+pragma experimental SMTChecker;
+contract A {
+	int[] a;
+	function f() public {
+		require(a.length == 1 && a[0] == 1);
+		int[] storage u = a;
+		assert(u[0] == 1); // should hold
+		int[] memory b = new int[](2);
+		a = b;
+		assert(u[0] == 1); // should fail
+		A.a = b;
+		assert(u[0] == 1); // should fail
+	}
+
+	function push_v(int x) public {
+		a.push(x);
+	}
+}
+// ----
+// Warning 6328: (220-237): CHC: Assertion violation happens here.
+// Warning 6328: (267-284): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/types/bytes_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/bytes_2.sol
@@ -7,3 +7,5 @@ contract C
 		assert(b1[1] == b2[1]);
 	}
 }
+// ----
+// Warning 6328: (119-141): CHC: Assertion violation happens here.\nCounterexample:\n\n\nTransaction trace:\nC.constructor()\nC.f(b1, b2)


### PR DESCRIPTION
Resolves #10847.

This is the second PR regarding handling of assignment in SMTChecker.
Previously, on an assignment to a reference variable, the knowledge about variables potentially aliasing the variable being assigned was not reset. This could lead to false negative as witnessed by #10847.

Unfortunately, this change introduces more false positives, as witneseds by the changed test. However, false positives are more acceptable than false negatives.

I plan to address the introduced false positive with the next PR in the series.