### PR TITLE
isoltest: add --accept-updates option

### DIFF
--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -63,6 +63,7 @@ IsolTestOptions::IsolTestOptions(std::string* _editor):
 		("editor", po::value<std::string>(_editor)->default_value(editorPath()), "Path to editor for opening test files.")
 		("help", po::bool_switch(&showHelp), "Show this help screen.")
 		("no-color", po::bool_switch(&noColor), "Don't use colors.")
+		("accept-updates", po::bool_switch(&acceptUpdates), "Automatically accept expectation updates.")
 		("test,t", po::value<std::string>(&testFilter)->default_value("*/*"), "Filters which test units to include.");
 }
 

--- a/test/tools/IsolTestOptions.h
+++ b/test/tools/IsolTestOptions.h
@@ -31,6 +31,7 @@ struct IsolTestOptions: CommonOptions
 {
 	bool showHelp = false;
 	bool noColor = false;
+	bool acceptUpdates = false;
 	std::string testFilter = std::string{};
 
 	IsolTestOptions(std::string* _editor);

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -131,6 +131,7 @@ private:
 		Quit
 	};
 
+	void updateTestCase();
 	Request handleResponse(bool _exception);
 
 	TestCreator m_testCaseCreator;
@@ -213,8 +214,23 @@ TestTool::Result TestTool::process()
 	}
 }
 
+void TestTool::updateTestCase()
+{
+	ofstream file(m_path.string(), ios::trunc);
+	m_test->printSource(file);
+	m_test->printUpdatedSettings(file);
+	file << "// ----" << endl;
+	m_test->printUpdatedExpectations(file, "// ");
+}
+
 TestTool::Request TestTool::handleResponse(bool _exception)
 {
+	if (!_exception && m_options.acceptUpdates)
+	{
+		updateTestCase();
+		return Request::Rerun;
+	}
+
 	if (_exception)
 		cout << "(e)dit/(s)kip/(q)uit? ";
 	else
@@ -234,11 +250,7 @@ TestTool::Request TestTool::handleResponse(bool _exception)
 			else
 			{
 				cout << endl;
-				ofstream file(m_path.string(), ios::trunc);
-				m_test->printSource(file);
-				m_test->printUpdatedSettings(file);
-				file << "// ----" << endl;
-				m_test->printUpdatedExpectations(file, "// ");
+				updateTestCase();
 				return Request::Rerun;
 			}
 		case 'e':


### PR DESCRIPTION
I was fed up with the lack of this, but noticed @chriseth's trick after doing this: https://github.com/ethereum/solidity/pull/10612#issuecomment-745372153.