### PR TITLE
Add missing header to Algorithms.h.

### DIFF
--- a/libsolutil/Algorithms.h
+++ b/libsolutil/Algorithms.h
@@ -19,6 +19,7 @@
 
 
 #include <functional>
+#include <list>
 #include <set>
 
 namespace solidity::util


### PR DESCRIPTION
Should fix https://github.com/ethereum/solidity/issues/11103, although I'm not sure why our CI wouldn't catch that... I wonder whether that's a built against the ubuntu bionic STL instead of the gcc-10 one - also not sure where that gcc package in the issue is coming from. Anyways, the header should be there.