### PR TITLE
Path resolution docs + proposed changes (path spec v1)

### DIFF
--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -163,7 +163,7 @@ The component does not yet support all features of the Solidity language and
 likely outputs many warnings. In case it reports unsupported features, the
 analysis may not be fully sound.
 
-.. index:: source file, ! import, module
+.. index:: source file, ! import, module, source unit
 
 .. _import:
 
@@ -216,101 +216,590 @@ the code below creates new global symbols ``alias`` and ``symbol2`` which refere
 
   import {symbol1 as alias, symbol2} from "filename";
 
-Paths
------
+.. _path-resolution:
 
-In the above, ``filename`` is always treated as a path with ``/`` as directory separator,
-and ``.`` as the current and ``..`` as the parent directory.  When ``.`` or ``..`` is followed by a character except ``/``,
-it is not considered as the current or the parent directory.
-All path names are treated as absolute paths unless they start with the current ``.`` or the parent directory ``..``.
+Path Resolution
+---------------
 
-To import a file ``filename`` from the same directory as the current file, use ``import "./filename" as symbolName;``.
-If you use ``import "filename" as symbolName;`` instead, a different file could be referenced
-(in a global "include directory").
+The paths used in imports in a general case do not have to be filesystem paths.
+In the simplest cases they may end up being used directly to load files from disk but in general
+the final path can be substantially different due to abstractions necessary to ensure reproducible
+builds on different platforms.
 
-It depends on the compiler (see :ref:`import-compiler`) how to actually resolve the paths.
-In general, the directory hierarchy does not need to strictly map onto your local
-filesystem, and the path can also map to resources such as ipfs, http or git.
+.. index:: ! virtual filesystem, ! source unit ID, ! import; path, filesystem path
+.. _virtual-filesystem:
 
-.. note::
-    Always use relative imports like ``import "./filename.sol";`` and avoid
-    using ``..`` in path specifiers. In the latter case, it is probably better to use
-    global paths and set up remappings as explained below.
+Virtual Filesystem
+~~~~~~~~~~~~~~~~~~
 
-.. _import-compiler:
+The compiler maintains an internal database (virtual filesystem) where each compiled source unit is
+assigned a unique *source unit ID* which is an opaque and unstructured identifier.
 
-Use in Actual Compilers
------------------------
+While a source unit ID in the virtual filesystem can be anything, it should be a valid path if the
+source is meant to be loaded from the underlying filesystem.
+When the requested ID is not present in the virtual filesystem, it is passed to the file loader.
+In case of the command-line compiler the file loader simply uses it as a path.
+The `JavaScript interface <https://github.com/ethereum/solc-js>`_ is a bit more flexible in that
+regard and allows the user to provide a callback to perform this operation - in this case the
+IDs can be arbitrary.
+For example they could be URLs as long as the custom loader can handle them.
 
-When invoking the compiler, you can specify how to discover the first element
-of a path, and also path prefix remappings. For
-example you can setup a remapping so that everything imported from the virtual
-directory ``github.com/ethereum/dapp-bin/library`` would actually be read from
-your local directory ``/usr/local/dapp-bin/library``.
-If multiple remappings apply, the one with the longest key is tried first.
-An empty prefix is not allowed. The remappings can depend on a context,
-which allows you to configure packages to import e.g., different versions of a
-library of the same name.
+There are several ways to load source units into the virtual filesystem:
 
-**solc**:
+#. **import statement**
 
-For solc (the commandline compiler), you provide these path remappings as
-``context:prefix=target`` arguments, where both the ``context:`` and the
-``=target`` parts are optional (``target`` defaults to ``prefix`` in this
-case). All remapping values that are regular files are compiled (including
-their dependencies).
+   The ``import`` statement requests a module from the compiler and allows to access certain symbols
+   from that module.
 
-This mechanism is backwards-compatible (as long
-as no filename contains ``=`` or ``:``) and thus not a breaking change. All
-files in or below the ``context`` directory that import a file that starts with
-``prefix`` are redirected by replacing ``prefix`` by ``target``.
+   We will refer to the path used in the statement as *import path*.
+   The import path is translated into a source unit ID first and then the compiler uses the ID to
+   look up the file in its virtual filesystem.
 
-For example, if you clone ``github.com/ethereum/dapp-bin/`` locally to
-``/usr/local/dapp-bin``, you can use the following in your source file:
+   Imports can be broadly classified into three categories based on how the path is specified:
+
+   .. code-block:: solidity
+
+       import "/contracts/lib/token.sol";   // Absolute
+       import "contracts/lib/token.sol";    // Relative to base
+       import "./contracts/lib/token.sol";  // Relative to source
+       import "../contracts/lib/token.sol"; // Relative to source
+
+   There is actually no distinction between :ref:`absolute imports <absolute-imports>` and
+   :ref:`imports relative to base <imports-relative-to-base>` at the virtual filesystem level.
+   In both cases the import path is translated into a source unit ID using the same rules and they
+   are only handled differently by the default file loader.
+
+   :ref:`Imports relative to source <imports-relative-to-source>`, on the other hand, need to be
+   interpreted as paths and normalized to be properly resolved into source unit IDs.
+   The path in this case must conform to UNIX path conventions regardless of the underlying platform.
+
+   .. _virtual-filesystem-loading-files-cli:
+
+#. **CLI**
+
+   To compile a file using the command-line interface of the compiler you specify one or more paths:
+
+   .. code-block:: bash
+
+       solc contract.sol /usr/local/dapp-bin/token.sol
+
+   These are interpreted as *filesystem paths* and the rules for translating them into source unit IDs
+   are different than for import paths.
+   Most importantly, filesystem paths are platform-specific while import paths are not.
+   For example a path like ``C:\project\contract.sol`` will be interpreted differently on Windows
+   and on systems that follow the UNIX path conventions.
+
+   It does not matter if the path you specify is relative or absolute.
+   If the path is relative, it is converted into an absolute one by prepending the current working
+   directory.
+   Then the path is normalized, which involves first a conversion from the platform-specific format
+   the internal UNIX-like format, collapsing all the relative ``./`` and ``../`` segments and
+   removing redundant slashes.
+   Finally, :ref:`the base path <imports-relative-to-base>` is stripped from the source unit ID.
+   This way the resulting ID is a path relative to base if and only if the file is located inside
+   the base directory.
+
+#. **Standard JSON (as content)**
+
+   An alternative way to compile your project is to use the ``--standard-json`` option and provide
+   a JSON file containing all of your source code:
+
+   .. code-block:: json
+
+       {
+           "language": "Solidity",
+           "sources": {
+               "contract.sol": {
+                   "content": "import \"./util.sol\";\ncontract C {}"
+               },
+               "util.sol": {
+                   "content": "library Util {}"
+               },
+               "/usr/local/dapp-bin/token.sol": {
+                   "content": "contract Token {}"
+               }
+           },
+           "settings": {"outputSelection": {"*": { "*": ["metadata", "evm.bytecode"]}}}
+       }
+
+   The ``sources`` dictionary specifies the initial content of the virtual filesystem and you
+   can use source unit IDs directly there.
+   They do not undergo any extra translation or normalization.
+
+   The path to the JSON file does not affect the path resolution in any way.
+   In fact, it is common to supply it on the standard input in which case it does not have a path at all.
+
+   .. note::
+
+       When using ``--standard-json`` you cannot provide additional source files as command-line
+       arguments but it does not mean that the compiler will not load any extra files from disk.
+       If a contract imports a file that is not present in ``sources``, the compiler will use the
+       file loader as in any other situation, which may result in the source being read from disk
+       (or provided by the callback when using the JavaScript interface).
+
+#. **Standard JSON (as URL)**
+
+   When using Standard JSON it is possible to tell the compiler to load the files from disk directly:
+
+   .. code-block:: json
+
+       {
+           "language": "Solidity",
+           "sources": {
+               "/usr/local/dapp-bin/token.sol": {
+                   "urls": ["/projects/mytoken.sol"]
+               }
+           },
+           "settings": {"outputSelection": {"*": { "*": ["metadata", "evm.bytecode"]}}}
+       }
+
+   The path specified in ``urls`` is only passed to the file loader and used to locate the file.
+   It does not affect the source unit ID and is not included in contract metadata.
+
+   Paths in ``urls`` are affected by base path and any other transformations performed by the file loader.
+
+#. **Standard input**
+
+   The last way to provide the source is by sending it to compiler's standard input:
+
+   .. code-block:: bash
+
+       echo 'import "./util.sol"; contract C {}' | solc -
+
+   The content of the standard input is identified in the virtual filesystem by a special source unit ID:
+   ``<stdin>``.
+
+.. warning::
+
+    The compiler uses source unit IDs to determine whether imports refer to the same source unit or not.
+    If you refer to a file in multiple ways that translate to different IDs, it will be compiled
+    multiple times.
+
+    For example:
+
+    .. code-block:: solidity
+        :caption: /code/contract.sol
+
+        import "tokens/token.sol" as token1;   // source unit ID: tokens/token.sol
+        import "tokens///token.sol" as token2; // source unit ID: tokens///token.sol
+
+    .. code-block:: bash
+
+        cd /code
+        solc contract.sol /code/tokens/token.sol # source unit ID: /code/tokens/token.sol
+
+    In the above ``token.sol`` will end up in the virtual filesystem under three different
+    source unit IDs even though all the paths refer to the same file in the underlying filesystem.
+
+    To avoid this situation it is recommended to always use the canonical form of paths in your
+    imports and to only list the top-level files that are not imported by other files when
+    invoking the CLI compiler.
+
+Now that we know how the virtual filesystem works, let us go through the rules used to translate
+import paths into source unit IDs in more detail.
+
+.. index:: absolute import
+.. _absolute-imports:
+
+Absolute Imports
+~~~~~~~~~~~~~~~~
+
+An *absolute import* always starts with a forward slash (``/``).
+The import path translates directly to a source unit ID without normalization of any kind:
 
 ::
 
-  import "github.com/ethereum/dapp-bin/library/iterable_mapping.sol" as it_mapping;
+    import "/project/lib/util.sol" as util;          // source unit ID: /project/lib/util.sol
+    import "/project/lib/../lib///math.sol" as math; // source unit ID: /project/lib/../lib///math.sol
+
+In the above you might expect the source unit ID be reduced to ``/project/lib/math.sol`` but it is
+in fact ``/project/lib/../lib///math.sol``, exactly as stated in the file.
+
+If no file is present under that ID in the virtual filesystem, the file loader will also use it as
+is for filesystem lookup.
+The resulting filesystem path is not affected by the value of base path.
+
+.. index:: import relative to base, relative import
+.. _imports-relative-to-base:
+
+Imports Relative to Base
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any import that does not start with ``/``, ``./`` or ``../`` is an *import relative to base*.
+
+::
+
+    import "lib/util.sol" as util;                   // source unit ID: lib/util.sol
+    import "@openzeppelin/address.sol" as address;   // source unit ID: @openzeppelin/address.sol
+    import "https://example.com/token.sol" as token; // source unit ID: https://example.com/token.sol
+
+There is no difference between such imports and absolute ones at the virtual filesystem level.
+The compiler sees both as opaque identifiers and there is no normalization involved:
+
+::
+
+    import "lib/../lib///math.sol" as math; // source unit ID: lib/../lib///math.sol
+
+Only when the ID is passed to the file loader and needs to be converted into an actual filesystem
+path different rules kick in.
+To convert the path into an absolute one, the loader combines it with the path specified using the
+``--base-path`` option.
+If the base path itself is relative, it is interpreted as relative to the current working directory
+just like any other path given on the command line.
+
+Base path also affects :ref:`the way paths specified on the command line are converted into source
+IDs <virtual-filesystem-loading-files-cli>`.
+The source unit ID normally is the absolute, normalized path to the file in the UNIX format but if
+the file happens to be inside the directory designated as the base path or one of its subdirectories
+the prefix is stripped from its source unit ID and it becomes relative to base.
+
+.. code-block:: bash
+
+    cd /home/user
+    solc /project/contract.sol                      # source unit ID: /project/contract.sol
+    solc /project/contract.sol --base-path /project # source unit ID: contract.sol
+
+Note that if you do not specify base path, it is by default equal to the current working directory:
+
+.. code-block:: bash
+
+    cd /project
+    solc /home/user/contract.sol                      # source unit ID: contract.sol
+    solc /home/user/contract.sol --base-path /project # source unit ID: contract.sol
+
+.. index:: import relative to source, relative import
+.. _imports-relative-to-source:
+
+Imports Relative to Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An import starting with ``./`` or ``../`` is *relative to source*.
+It differs from imports relative to base in that the compiler does interpret it as a path and
+combines it with the path of the importing source unit to get the source unit ID.
+
+.. code-block:: solidity
+    :caption: /project/lib/math.sol
+
+    import "./util.sol" as util;    // source unit ID: /project/lib/util.sol
+    import "../token.sol" as token; // source unit ID: /lib/token.sol
+
+If the parent source unit ID is relative to base, the resulting source unit ID is relative to
+base as well:
+
+.. code-block:: solidity
+    :caption: lib/math.sol
+
+    import "./util.sol" as util;    // source unit ID: lib/util.sol
+    import "../token.sol" as token; // source unit ID: token.sol
+
+To evaluate the prefix, the compiler starts with the source unit ID of the importing source unit and
+first strips the file name.
+Then, for every ``../`` segment in the import path it strips one segment from the ID.
+
+.. code-block:: solidity
+    :caption: /a/b/c/contract.sol
+
+    import "../util.sol";          // source unit ID: /a/b/util.sol
+    import "../../util.sol";       // source unit ID: /a/util.sol
+    import "../../../util.sol";    // source unit ID: /util.sol
+
+    import "../././.././util.sol"; // source unit ID: /a/util.sol
+
+If there are more ``../`` segments than directory segments in the parent source unit ID, the
+evaluation stops at the root:
+
+.. code-block:: solidity
+    :caption: /a/b/c/contract.sol
+
+    import "../../../../util.sol";       // source unit ID: /util.sol
+    import "../../../../../util.sol";    // source unit ID: /util.sol
+    import "../../../../../../util.sol"; // source unit ID: /util.sol
+
+.. code-block:: solidity
+    :caption: a/b/c/contract.sol
+
+    import "../../../../util.sol";       // source unit ID: util.sol
+    import "../../../../../util.sol";    // source unit ID: util.sol
+    import "../../../../../../util.sol"; // source unit ID: util.sol
+
+After stripping the leading relative segments, the import path is normalized so that the
+resulting source unit ID does not contain any ``./`` or ``../``:
+
+.. code-block:: solidity
+    :caption: /a/b/c/contract.sol
+
+    import "../../d/e///.././util.sol"; // source unit ID: /a/e/util.sol
+
+This is quite different from imports relative to base where the ``///.././`` part would remain
+in the source unit ID.
+
+Note that the parent source unit ID is **not** normalized, and the ``./`` and ``../`` segments in it
+have no special meaning:
+
+.. code-block:: solidity
+    :caption: ../lib/math.sol
+
+    import "./util.sol" as util;    // source unit ID: ../lib/util.sol
+    import "../token.sol" as token; // source unit ID: ../../token.sol
+
+This may lead to surprising results in corner cases:
+
+.. code-block:: solidity
+    :caption: /a/./b/contract.sol
+
+    import "../c/util.sol";       // source unit ID: /a/./c/util.sol
+    import "../../c/util.sol";    // source unit ID: /a/c/util.sol
+    import "../../../c/util.sol"; // source unit ID: /c/util.sol
+
+.. note::
+
+    The use of relative imports containing leading ``../`` segments is not recommended.
+    The same effect can be achieved in a more reliable way by using either absolute imports with
+    import remapping or imports relative to base.
+
+.. index:: remapping, import remapping
+.. _import-remapping:
+
+Import Remapping
+~~~~~~~~~~~~~~~~
+
+Base path and relative imports on their own allow you to freely move your project around the
+filesystem but force you to keep all files within a single directory and its subdirectories.
+When using external libraries it is often desirable to keep their files in a separate location.
+To help with that, the compiler provides another mechanism: import remapping.
+
+Remapping allows you to use placeholders for source unit ID prefixes and then have the compiler
+replace them with actual paths.
+For example you can set up a remapping so that everything imported from the virtual directory
+``github.com/ethereum/dapp-bin/library`` would actually receive source unit IDs starting with
+``dapp-bin/library``.
+By setting base path to ``/project`` you could then have the compiler find them in
+``/project/dapp-bin/library``
+
+The remappings can depend on a context, which allows you to configure packages to import,
+e.g. different versions of a library of the same name.
+
+.. warning::
+
+    Information about used remappings is stored in contract metadata so, while they let you avoid
+    changing the source, they cannot be used to achieve reproducible builds.
+    The metadata hash embedded in the bytecode will not be the same if you perform import remapping.
+
+Path remappings have the form of ``context:prefix=target``.
+All files in or below the ``context`` directory that import a file that starts with ``prefix`` are
+redirected by replacing ``prefix`` with ``target``.
+For example, if you clone ``github.com/ethereum/dapp-bin/`` locally to ``/project/dapp-bin``,
+you can use the following in your source file:
+
+::
+
+    import "github.com/ethereum/dapp-bin/library/iterable_mapping.sol" as it_mapping;
 
 Then run the compiler:
 
 .. code-block:: bash
 
-  solc github.com/ethereum/dapp-bin/=/usr/local/dapp-bin/ source.sol
+    solc github.com/ethereum/dapp-bin/=dapp-bin/ --base-path /project source.sol
 
-As a more complex example, suppose you rely on a module that uses an old
-version of dapp-bin that you checked out to ``/usr/local/dapp-bin_old``, then you can run:
+As a more complex example, suppose you rely on a module that uses an old version of dapp-bin that
+you checked out to ``/project/dapp-bin_old``, then you can run:
 
 .. code-block:: bash
 
-  solc module1:github.com/ethereum/dapp-bin/=/usr/local/dapp-bin/ \
-       module2:github.com/ethereum/dapp-bin/=/usr/local/dapp-bin_old/ \
-       source.sol
+    solc module1:github.com/ethereum/dapp-bin/=dapp-bin/ \
+         module2:github.com/ethereum/dapp-bin/=dapp-bin_old/ \
+         --base-path /project \
+         source.sol
 
-This means that all imports in ``module2`` point to the old version but imports
-in ``module1`` point to the new version.
+This means that all imports in ``module2`` point to the old version but imports in ``module1``
+point to the new version.
+
+Here are the detailed rules governing the behaviour of remappings:
+
+#. **Remappings only affect the translation between import paths and source unit IDs.**
+
+   Source unit IDs added via other means cannot be remapped.
+   For example the paths you specify on the command-line and the ones in ``sources.urls`` in
+   Standard JSON are not affected.
+
+    .. code-block:: bash
+
+        solc /project=/contracts /project/contract.sol # source unit ID: /project/contract.sol
+
+#. **Context and prefix must match source unit IDs, not import paths.**
+
+   - This means that you cannot remap ``./`` or ``../`` directly since they are replaced during
+     translation to source unit IDs but you can remap the source locations they resolve into:
+
+     .. code-block:: bash
+
+         solc ./=a /project=b /project/contract.sol
+
+     .. code-block:: solidity
+         :caption: /project/contract.sol
+
+         import "./util.sol" as util; // source unit ID: b/util.sol
+
+   - You cannot remap base path or any other part of the path that is only added when the file is
+     looked up in the underlying filesystem by the file loader:
+
+     .. code-block:: bash
+
+         solc /project=/contracts /project/contract.sol --base-path /project
+
+     .. code-block:: solidity
+         :caption: /project/contract.sol
+
+         import "util.sol" as util; // source unit ID: util.sol
+
+#. **Target is inserted directly into the source unit ID and does not necessarily have to be a valid path.**
+
+   - It can be anything as long as the file loader can handle it.
+     In case of the command-line interface this includes also relative paths.
+     When using the JavaScript interface you can just as well use URLs and abstract identifiers if
+     your callback can handle them.
+
+   - Remapping happens after paths relative to the source directory have already been resolved.
+     This means that targets starting with ``./`` and ``../`` have no special meaning and are
+     relative to the base directory rather than to the source location.
+
+   - Remapping targets are not normalized so ``@root=./a/b//`` will remap ``@root/contract.sol``
+     to ``./a/b//contract.sol`` and not ``a/b/contract.sol``.
+
+   - If the target does not end with a slash, the compiler will not add one automatically:
+
+     .. code-block:: bash
+
+         solc /project/=/contracts /project/contract.sol
+
+     .. code-block:: solidity
+         :caption: /project/contract.sol
+
+         import "/project/util.sol" as util; // source unit ID: /contractsutil.sol
+
+#. **Context and prefix are patterns and matches must be exact.**
+
+   - ``a//b=c`` will not match ``a/b``.
+
+   - Source unit IDs are not normalized so ``a/b=c`` will not match ``a//b`` either.
+
+   - Parts of file and directory names can match as well.
+     ``/newProject/con:/new=old`` will match ``/newProject/contract.sol`` and remap it to
+     ``oldProject/contract.sol``.
+
+#. **At most one remapping can be applied to a single import.**
+
+   - If multiple remappings match the same source unit ID, the one with the longest matching
+     prefix is chosen.
+   - If prefixes are identical, the one specified last wins.
+   - Remappings do not work on other remappings. For example ``a=b b=c c=d`` will not result in ``a``
+     being remapped to ``d``.
+
+#. **Prefix cannot be empty but context and target are optional.**
+
+   If ``target`` is omitted, it defaults to the value of the ``prefix``.
 
 .. note::
 
-  ``solc`` only allows you to include files from certain directories. They have
-  to be in the directory (or subdirectory) of one of the explicitly specified
-  source files or in the directory (or subdirectory) of a remapping target. If
-  you want to allow direct absolute includes, add the remapping ``/=/``.
+    ``solc`` only allows you to include files from certain directories.
+    They have to be in the directory (or subdirectory) of one of the explicitly specified source
+    files or in the directory (or subdirectory) of a remapping target.
+    If you want to allow direct absolute includes, add the remapping ``/=/``.
 
-If there are multiple remappings that lead to a valid file, the remapping
-with the longest common prefix is chosen.
+.. index:: Remix IDE, file://
 
-**Remix**:
+Using URLs in imports
+~~~~~~~~~~~~~~~~~~~~~
 
-`Remix <https://remix.ethereum.org/>`_ provides an automatic remapping for
-GitHub and automatically retrieves the file over the network. You can import
-the iterable mapping as above,  e.g.
+Most URL prefixes such as ``https://`` or ``data://`` have no special meaning in import paths.
+The only exception is ``file://`` which is stripped from source unit names by the default file
+loader.
 
-::
+This does not mean you cannot use URLs as import paths at all.
+While the command-line compiler will interpret an URL as a relative path (which will most likely fail),
+the `JavaScript interface <https://github.com/ethereum/solc-js>`_ allows you to provide a callback
+and implement your own, custom lookup rules, which may include supporting arbitrary URLs.
+`The Remix IDE <https://remix.ethereum.org/>`_ uses this mechanism to allow files to be imported
+directly from github:
 
-  import "github.com/ethereum/dapp-bin/library/iterable_mapping.sol" as it_mapping;
+.. code-block:: solidity
+    :caption: contract.sol
 
-Remix may add other source code providers in the future.
+    import "https://github.com/ethereum/dapp-bin/library/iterable_mapping.sol" as it_mapping;
+
+When compiling locally you can use import remapping to replace the protocol and domain part with a
+local path:
+
+.. code-block:: bash
+
+    solc :https://github.com/ethereum/dapp-bin=/usr/local/dapp-bin contract.sol
+
+Note the leading ``:``.
+It is necessary when the remapping context is empty.
+Otherwise the ``https:`` part would be interpreted by the compiler as the context.
+
+.. note::
+
+    When remapping, keep in mind that the prefix must match exactly.
+    ``https://example.com/project=/project`` will match  ``https://example.com/project/contract.sol``
+    but not ``example.com/project/contract.sol``, ``https://example.com/project///contract.sol`` or
+    ``https://EXAMPLE.COM/project/contract.sol``.
+
+    Also, since URLs look to the compiler just like imports relative to base there is no
+    normalization involved.
+    The source unit ID for ``EXAMPLE.COM/project///contract.sol`` is exactly
+    ``EXAMPLE.COM/project///contract.sol`` and not ``https://example.com/project/contract.sol``.
+    It will only get normalized if the compiler passes the ID to the file loader but then the
+    normalization rules for paths, not URLs will be applied.
+
+.. note::
+
+    ``file://`` prefix is stripped from import paths and from filesystem paths specified in
+    ``sources.urls`` in Standard JSON. It is **not** stripped from filesystem paths provided on
+    the command line.
+    For example the following will not result in ``contract.sol`` being loaded:
+
+    .. code-block:: bash
+
+        solc file://contract.sol
+
+    The compiler will instead try to find it in a directory called ``file:`` and fail if such a
+    directory does not exist or does not contain ``contract.sol``.
+
+.. index:: standard input, stdin, <stdin>
+
+Standard Input
+~~~~~~~~~~~~~~
+
+The content of the standard input stream of the command-line compiler for all intents and purposes
+behaves like a source file with an source unit ID of ``<stdin>`` placed directly in compiler's
+virtual filesystem.
+This means that:
+
+- It can be imported like any other file from the virtual filesystem:
+
+  .. code-block:: solidity
+
+      import "<stdin>";
+
+  .. note::
+
+      If the compiler is not instructed to read content from its standard input by specyfing ``-``
+      as one of the arguments, it will actually try to find a file called ``<stdin>`` in the
+      filesystem when it encounters such an import.
+
+- Paths in imports relative to source resolve into source unit IDs relative to base because
+  ``<stdin>`` is not an absolute path.
+
+  .. code-block:: solidity
+      :caption: <stdin>
+
+      import "./contract.sol"; // source unit ID: contract.sol
+      import "../token.sol";   // source unit ID: token.sol
+
+- It can be freely used in remappings. For example ``/project/contract.sol=<stdin>`` and
+  ``<stdin>=contract.sol`` are both valid.
+
 
 .. index:: ! comment, natspec
 

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -33,11 +33,13 @@ This parameter has effects on the following (this might change in the future):
  - the size of the binary search in the function dispatch routine
  - the way constants like large numbers or strings are stored
 
-Path Remapping
---------------
+.. index:: allowed paths, --allow-paths, base path, --base-path
+
+Base Path and Import Remapping
+------------------------------
 
 The commandline compiler will automatically read imported files from the filesystem, but
-it is also possible to provide path redirects using ``prefix=path`` in the following way:
+it is also possible to provide :ref:`path redirects <import-remapping>` using ``prefix=path`` in the following way:
 
 ::
 
@@ -49,18 +51,21 @@ This essentially instructs the compiler to search for anything starting with
 the remapping targets and outside of the directories where explicitly specified source
 files reside, so things like ``import "/etc/passwd";`` only work if you add ``/=/`` as a remapping.
 
-An empty remapping prefix is not allowed.
+When accessing the filesystem to search for imports, :ref:`relative paths that do not start with ./
+or ../ <imports-relative-to-base>` are treated as relative to the directory specified using
+``--base-path`` option (current working directory by default).
+Furthermore, the part added via ``--base-path`` will not appear in the contract metadata.
 
-If there are multiple matches due to remappings, the one with the longest common prefix is selected.
-
-When accessing the filesystem to search for imports, all paths are treated as if they were fully qualified paths.
-This behaviour can be customized by adding the command line option ``--base-path`` with a path to be prepended
-before each filesystem access for imports is performed. Furthermore, the part added via ``--base-path``
-will not appear in the contract metadata.
-
-For security reasons the compiler has restrictions what directories it can access. Paths (and their subdirectories) of source files specified on the commandline and paths defined by remappings are allowed for import statements, but everything else is rejected. Additional paths (and their subdirectories) can be allowed via the ``--allow-paths /sample/path,/another/sample/path`` switch.
-
+For security reasons the compiler has restrictions on what directories it can access.
+Paths of source files (and their subdirectories) specified on the command line and paths defined by
+remappings are automatically allowed in import statements, but everything else is rejected by default.
+Additional paths (and their subdirectories) can be allowed via the
+``--allow-paths /sample/path,/another/sample/path`` switch.
 Everything inside the path specified via ``--base-path`` is always allowed.
+
+The above is only a simplification of how the compiler handles import paths.
+For a detailed explanation with examples and discussion of corner cases please refer to the section on
+:ref:`path resolution <path-resolution>`.
 
 .. _library-linking:
 


### PR DESCRIPTION
Related to #11036 and PR #9353.
Also related to a bunch of smaller bug reports/feature requests related to paths: #9346, #2738, #4702, #5146, #11042, #11039, #11038, #10980, #4623, #5281.

This PR is an attempt to explain how I think the compiler is currently **supposed to** handle paths used in imports, on the command line, in Standard JSON, on the standard input, etc. This means that it does not really reflect how it all works now. I ignored known bugs and introduced some changes to make it match my expectations better and I'm going point out the differences in review comments. This is meant as a starting point for discussion and I think it should be merged into the docs once we agree whether the changes I'm proposing make sense and we implement them.

The docs ended up being pretty long. All the available features and abstractions make this surprisingly complex and produce many weird corner cases, though after working through it systematically many things I considered bugs while reporting #11036 suddenly appear to make sense. They definitely do not seem as such when you first encounter them so unfortunately I think that a long explanation is necessary if we expect users to understand how it all works.

I introduced some new terminology in the PR (import keys, import paths, virtual filesystem, imports relative to base/source) which might be a bit controversial (I'm open to renaming them) but expanding the vocabulary is badly needed here to be able to refer to things without being ambiguous or having to clarify terms with a full sentence every time they appear.