### PR TITLE
[SMTChecker] Small refactoring of defining SMT expressions for structs/tuples

### DIFF
--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -311,6 +311,8 @@ protected:
 	void createExpr(Expression const& _e);
 	/// Creates the expression and sets its value.
 	void defineExpr(Expression const& _e, smtutil::Expression _value);
+	/// Creates the tuple expression and sets its value.
+	void defineExpr(Expression const& _e, std::vector<std::optional<smtutil::Expression>> const& _values);
 	/// Overwrites the current path condition
 	void setPathCondition(smtutil::Expression const& _e);
 	/// Adds a new path condition

--- a/test/libsolidity/smtCheckerTests/crypto/crypto_functions_not_same.sol
+++ b/test/libsolidity/smtCheckerTests/crypto/crypto_functions_not_same.sol
@@ -10,5 +10,7 @@ contract C {
 		assert(h == k);
 	}
 }
+// ====
+// SMTIgnoreCex: yes
 // ----
-// Warning 6328: (229-243): CHC: Assertion violation happens here.\nCounterexample:\n\n\nTransaction trace:\nC.constructor()\nC.f(data)\n    C.fi(data, 39) -- internal call
+// Warning 6328: (229-243): CHC: Assertion violation happens here.


### PR DESCRIPTION
This PR contains small refactoring with the goal to reduce code duplication and reduce the number of places in `SMTEncoder` where `m_context.addAssertion` is called directly.