### PR TITLE
Extracts import file reading & remapping logic out of CommandLineInterface into their own classes.

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -133,6 +133,8 @@ set(sources
 	interface/CompilerStack.cpp
 	interface/CompilerStack.h
 	interface/DebugSettings.h
+	interface/FileReader.cpp
+	interface/FileReader.h
 	interface/ImportRemapper.cpp
 	interface/ImportRemapper.h
 	interface/GasEstimator.cpp

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -133,6 +133,8 @@ set(sources
 	interface/CompilerStack.cpp
 	interface/CompilerStack.h
 	interface/DebugSettings.h
+	interface/ImportRemapper.cpp
+	interface/ImportRemapper.h
 	interface/GasEstimator.cpp
 	interface/GasEstimator.h
 	interface/Natspec.cpp

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -24,6 +24,7 @@
 
 
 #include <libsolidity/interface/CompilerStack.h>
+#include <libsolidity/interface/ImportRemapper.h>
 
 #include <libsolidity/analysis/ControlFlowAnalyzer.h>
 #include <libsolidity/analysis/ControlFlowGraph.h>
@@ -196,33 +197,13 @@ void CompilerStack::findAndReportCyclicContractDependencies()
 	}
 }
 
-std::optional<CompilerStack::Remapping> CompilerStack::parseRemapping(string const& _remapping)
-{
-	auto eq = find(_remapping.begin(), _remapping.end(), '=');
-	if (eq == _remapping.end())
-		return {};
-
-	auto colon = find(_remapping.begin(), eq, ':');
-
-	Remapping r;
-
-	r.context = colon == eq ? string() : string(_remapping.begin(), colon);
-	r.prefix = colon == eq ? string(_remapping.begin(), eq) : string(colon + 1, eq);
-	r.target = string(eq + 1, _remapping.end());
-
-	if (r.prefix.empty())
-		return {};
-
-	return r;
-}
-
-void CompilerStack::setRemappings(vector<Remapping> const& _remappings)
+void CompilerStack::setRemappings(vector<ImportRemapper::Remapping> _remappings)
 {
 	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set remappings before parsing."));
 	for (auto const& remapping: _remappings)
 		solAssert(!remapping.prefix.empty(), "");
-	m_remappings = _remappings;
+	m_importRemapper.setRemappings(move(_remappings));
 }
 
 void CompilerStack::setViaIR(bool _viaIR)
@@ -312,7 +293,7 @@ void CompilerStack::reset(bool _keepSettings)
 	m_unhandledSMTLib2Queries.clear();
 	if (!_keepSettings)
 	{
-		m_remappings.clear();
+		m_importRemapper.clear();
 		m_libraries.clear();
 		m_viaIR = false;
 		m_evmVersion = langutil::EVMVersion();
@@ -1170,43 +1151,7 @@ StringMap CompilerStack::loadMissingSources(SourceUnit const& _ast, std::string 
 string CompilerStack::applyRemapping(string const& _path, string const& _context)
 {
 	solAssert(m_stackState < ParsedAndImported, "");
-	// Try to find the longest prefix match in all remappings that are active in the current context.
-	auto isPrefixOf = [](string const& _a, string const& _b)
-	{
-		if (_a.length() > _b.length())
-			return false;
-		return std::equal(_a.begin(), _a.end(), _b.begin());
-	};
-
-	size_t longestPrefix = 0;
-	size_t longestContext = 0;
-	string bestMatchTarget;
-
-	for (auto const& redir: m_remappings)
-	{
-		string context = util::sanitizePath(redir.context);
-		string prefix = util::sanitizePath(redir.prefix);
-
-		// Skip if current context is closer
-		if (context.length() < longestContext)
-			continue;
-		// Skip if redir.context is not a prefix of _context
-		if (!isPrefixOf(context, _context))
-			continue;
-		// Skip if we already have a closer prefix match.
-		if (prefix.length() < longestPrefix && context.length() == longestContext)
-			continue;
-		// Skip if the prefix does not match.
-		if (!isPrefixOf(prefix, _path))
-			continue;
-
-		longestContext = context.length();
-		longestPrefix = prefix.length();
-		bestMatchTarget = util::sanitizePath(redir.target);
-	}
-	string path = bestMatchTarget;
-	path.append(_path.begin() + static_cast<string::difference_type>(longestPrefix), _path.end());
-	return path;
+	return m_importRemapper.apply(_path, _context);
 }
 
 void CompilerStack::resolveImports()
@@ -1584,7 +1529,7 @@ string CompilerStack::createMetadata(Contract const& _contract) const
 
 	meta["settings"]["remappings"] = Json::arrayValue;
 	set<string> remappings;
-	for (auto const& r: m_remappings)
+	for (auto const& r: m_importRemapper.remappings())
 		remappings.insert(r.context + ":" + r.prefix + "=" + r.target);
 	for (auto const& r: remappings)
 		meta["settings"]["remappings"].append(r);

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -889,7 +889,7 @@ evmasm::LinkerObject const& CompilerStack::runtimeObject(string const& _contract
 }
 
 /// TODO: cache this string
-string CompilerStack::assemblyString(string const& _contractName, StringMap _sourceCodes) const
+string CompilerStack::assemblyString(string const& _contractName, StringMap const& _sourceCodes) const
 {
 	if (m_stackState != CompilationSuccessful)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -26,6 +26,7 @@
 
 #include <libsolidity/analysis/FunctionCallGraph.h>
 #include <libsolidity/interface/ReadFile.h>
+#include <libsolidity/interface/ImportRemapper.h>
 #include <libsolidity/interface/OptimiserSettings.h>
 #include <libsolidity/interface/Version.h>
 #include <libsolidity/interface/DebugSettings.h>
@@ -111,13 +112,6 @@ public:
 		None
 	};
 
-	struct Remapping
-	{
-		std::string context;
-		std::string prefix;
-		std::string target;
-	};
-
 	/// Creates a new compiler stack.
 	/// @param _readFile callback used to read files for import statements. Must return
 	/// and must not emit exceptions.
@@ -139,12 +133,9 @@ public:
 	/// all settings are reset as well.
 	void reset(bool _keepSettings = false);
 
-	// Parses a remapping of the format "context:prefix=target".
-	static std::optional<Remapping> parseRemapping(std::string const& _remapping);
-
 	/// Sets path remappings.
 	/// Must be set before parsing.
-	void setRemappings(std::vector<Remapping> const& _remappings);
+	void setRemappings(std::vector<ImportRemapper::Remapping> _remappings);
 
 	/// Sets library addresses. Addresses are cleared iff @a _libraries is missing.
 	/// Must be set before parsing.
@@ -487,9 +478,7 @@ private:
 	bool m_generateIR = false;
 	bool m_generateEwasm = false;
 	std::map<std::string, util::h160> m_libraries;
-	/// list of path prefix remappings, e.g. mylibrary: github.com/ethereum = /usr/local/ethereum
-	/// "context:prefix=target"
-	std::vector<Remapping> m_remappings;
+	ImportRemapper m_importRemapper;
 	std::map<std::string const, Source> m_sources;
 	// if imported, store AST-JSONS for each filename
 	std::map<std::string, Json::Value> m_sourceJsons;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -312,7 +312,7 @@ public:
 	/// @return a verbose text representation of the assembly.
 	/// @arg _sourceCodes is the map of input files to source code strings
 	/// Prerequisite: Successful compilation.
-	std::string assemblyString(std::string const& _contractName, StringMap _sourceCodes = StringMap()) const;
+	std::string assemblyString(std::string const& _contractName, StringMap const& _sourceCodes = StringMap()) const;
 
 	/// @returns a JSON representation of the assembly.
 	/// @arg _sourceCodes is the map of input files to source code strings

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -1,0 +1,98 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/interface/FileReader.h>
+
+#include <liblangutil/Exceptions.h>
+
+#include <libsolutil/CommonData.h>
+#include <libsolutil/CommonIO.h>
+#include <libsolutil/Exceptions.h>
+
+using solidity::frontend::ReadCallback;
+using solidity::langutil::InternalCompilerError;
+using solidity::util::errinfo_comment;
+using solidity::util::readFileAsString;
+using std::string;
+
+namespace solidity::frontend
+{
+
+void FileReader::setSource(boost::filesystem::path const& _path, SourceCode _source)
+{
+	m_sourceCodes[_path.generic_string()] = std::move(_source);
+}
+
+void FileReader::setSources(StringMap _sources)
+{
+	m_sourceCodes = std::move(_sources);
+}
+
+ReadCallback::Result FileReader::readFile(string const& _kind, string const& _path)
+{
+	try
+	{
+		if (_kind != ReadCallback::kindString(ReadCallback::Kind::ReadFile))
+			BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment(
+				"ReadFile callback used as callback kind " +
+				_kind
+			));
+		string validPath = _path;
+		if (validPath.find("file://") == 0)
+			validPath.erase(0, 7);
+
+		auto const path = m_basePath / validPath;
+		auto canonicalPath = boost::filesystem::weakly_canonical(path);
+		bool isAllowed = false;
+		for (auto const& allowedDir: m_allowedDirectories)
+		{
+			// If dir is a prefix of boostPath, we are fine.
+			if (
+				std::distance(allowedDir.begin(), allowedDir.end()) <= std::distance(canonicalPath.begin(), canonicalPath.end()) &&
+				std::equal(allowedDir.begin(), allowedDir.end(), canonicalPath.begin())
+			)
+			{
+				isAllowed = true;
+				break;
+			}
+		}
+		if (!isAllowed)
+			return ReadCallback::Result{false, "File outside of allowed directories."};
+
+		if (!boost::filesystem::exists(canonicalPath))
+			return ReadCallback::Result{false, "File not found."};
+
+		if (!boost::filesystem::is_regular_file(canonicalPath))
+			return ReadCallback::Result{false, "Not a valid file."};
+
+		// NOTE: we ignore the FileNotFound exception as we manually check above
+		auto contents = readFileAsString(canonicalPath.string());
+		m_sourceCodes[path.generic_string()] = contents;
+		return ReadCallback::Result{true, contents};
+	}
+	catch (util::Exception const& _exception)
+	{
+		return ReadCallback::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
+	}
+	catch (...)
+	{
+		return ReadCallback::Result{false, "Unknown exception in read callback."};
+	}
+}
+
+}
+

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -1,0 +1,90 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <libsolidity/interface/ImportRemapper.h>
+#include <libsolidity/interface/ReadFile.h>
+
+#include <boost/filesystem.hpp>
+
+#include <map>
+#include <set>
+
+namespace solidity::frontend
+{
+
+/// FileReader - used for progressively loading source code.
+///
+/// It is used in solc to load files from CLI parameters, stdin, or from JSON and
+/// also used in the solc language server where solc is a long running process.
+class FileReader
+{
+public:
+	using StringMap = std::map<SourceUnitName, SourceCode>;
+	using PathMap = std::map<SourceUnitName, boost::filesystem::path>;
+	using FileSystemPathSet = std::set<boost::filesystem::path>;
+
+	/// Constructs a FileReader with a base path and a set of allowed directories that
+	/// will be used when requesting files from this file reader instance.
+	explicit FileReader(
+		boost::filesystem::path _basePath = {},
+		FileSystemPathSet _allowedDirectories = {}
+	):
+		m_basePath(std::move(_basePath)),
+		m_allowedDirectories(std::move(_allowedDirectories)),
+		m_sourceCodes()
+	{}
+
+	void setBasePath(boost::filesystem::path _path) { m_basePath = std::move(_path); }
+	boost::filesystem::path const& basePath() const noexcept { return m_basePath; }
+
+	void allowDirectory(boost::filesystem::path _path) { m_allowedDirectories.insert(std::move(_path)); }
+	FileSystemPathSet const& allowedDirectories() const noexcept { return m_allowedDirectories; }
+
+	StringMap const& sourceCodes() const noexcept { return m_sourceCodes; }
+
+	/// Retrieves the source code for a given source unit ID.
+	SourceCode const& sourceCode(SourceUnitName const& _sourceUnitName) const { return m_sourceCodes.at(_sourceUnitName); }
+
+	/// Resets all sources to the given map of source unit ID to source codes.
+	void setSources(StringMap _sources);
+
+	/// Adds the source code for a given source unit ID.
+	void setSource(boost::filesystem::path const& _path, SourceCode _source);
+
+	/// Reads a given file at @p _path of kind @p _kind from the local filesystem and returns the result.
+	/// @p _kind must always be passed as "source".
+	frontend::ReadCallback::Result readFile(std::string const& _kind, std::string const& _path);
+
+	frontend::ReadCallback::Callback reader()
+	{
+		return [this](std::string const& _kind, std::string const& _path) { return readFile(_kind, _path); };
+	}
+
+private:
+	/// Base path, used for resolving relative paths in imports.
+	boost::filesystem::path m_basePath;
+
+	/// list of allowed directories to read files from
+	FileSystemPathSet m_allowedDirectories;
+
+	/// map of input files to source code strings
+	StringMap m_sourceCodes;
+};
+
+}

--- a/libsolidity/interface/ImportRemapper.cpp
+++ b/libsolidity/interface/ImportRemapper.cpp
@@ -1,0 +1,100 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/interface/ImportRemapper.h>
+#include <libsolutil/CommonIO.h>
+#include <liblangutil/Exceptions.h>
+
+using std::equal;
+using std::move;
+using std::optional;
+using std::string;
+using std::string;
+using std::vector;
+
+namespace solidity::frontend
+{
+
+void ImportRemapper::setRemappings(vector<Remapping> _remappings)
+{
+	for (auto const& remapping: _remappings)
+		solAssert(!remapping.prefix.empty(), "");
+	m_remappings = move(_remappings);
+}
+
+SourceUnitName ImportRemapper::apply(ImportPath const& _path, string const& _context) const
+{
+	// Try to find the longest prefix match in all remappings that are active in the current context.
+	auto isPrefixOf = [](string const& _a, string const& _b)
+	{
+		if (_a.length() > _b.length())
+			return false;
+		return equal(_a.begin(), _a.end(), _b.begin());
+	};
+
+	size_t longestPrefix = 0;
+	size_t longestContext = 0;
+	string bestMatchTarget;
+
+	for (auto const& redir: m_remappings)
+	{
+		string context = util::sanitizePath(redir.context);
+		string prefix = util::sanitizePath(redir.prefix);
+
+		// Skip if current context is closer
+		if (context.length() < longestContext)
+			continue;
+		// Skip if redir.context is not a prefix of _context
+		if (!isPrefixOf(context, _context))
+			continue;
+		// Skip if we already have a closer prefix match.
+		if (prefix.length() < longestPrefix && context.length() == longestContext)
+			continue;
+		// Skip if the prefix does not match.
+		if (!isPrefixOf(prefix, _path))
+			continue;
+
+		longestContext = context.length();
+		longestPrefix = prefix.length();
+		bestMatchTarget = util::sanitizePath(redir.target);
+	}
+	string path = bestMatchTarget;
+	path.append(_path.begin() + static_cast<string::difference_type>(longestPrefix), _path.end());
+	return path;
+}
+
+optional<ImportRemapper::Remapping> ImportRemapper::parseRemapping(string const& _remapping)
+{
+	auto eq = find(_remapping.begin(), _remapping.end(), '=');
+	if (eq == _remapping.end())
+		return {};
+
+	auto colon = find(_remapping.begin(), eq, ':');
+
+	Remapping r;
+
+	r.context = colon == eq ? string() : string(_remapping.begin(), colon);
+	r.prefix = colon == eq ? string(_remapping.begin(), eq) : string(colon + 1, eq);
+	r.target = string(eq + 1, _remapping.end());
+
+	if (r.prefix.empty())
+		return {};
+
+	return r;
+}
+
+}

--- a/libsolidity/interface/ImportRemapper.h
+++ b/libsolidity/interface/ImportRemapper.h
@@ -1,0 +1,59 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace solidity::frontend
+{
+
+// Some helper typedefs to make reading the signatures more self explaining.
+using SourceUnitName = std::string;
+using SourceCode = std::string;
+using ImportPath = std::string;
+
+/// The ImportRemapper is being used on imported file paths for being remapped to source unit IDs before being loaded.
+class ImportRemapper
+{
+public:
+	struct Remapping
+	{
+		std::string context;
+		std::string prefix;
+		std::string target;
+	};
+
+	void clear() { m_remappings.clear(); }
+
+	void setRemappings(std::vector<Remapping> _remappings);
+	std::vector<Remapping> const& remappings() const noexcept { return m_remappings; }
+
+	SourceUnitName apply(ImportPath const& _path, std::string const& _context) const;
+
+	// Parses a remapping of the format "context:prefix=target".
+	static std::optional<Remapping> parseRemapping(std::string const& _remapping);
+
+private:
+	/// list of path prefix remappings, e.g. mylibrary: github.com/ethereum = /usr/local/ethereum
+	/// "context:prefix=target"
+	std::vector<Remapping> m_remappings = {};
+};
+
+}

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <libsolidity/interface/StandardCompiler.h>
+#include <libsolidity/interface/ImportRemapper.h>
 
 #include <libsolidity/ast/ASTJsonConverter.h>
 #include <libyul/AssemblyStack.h>
@@ -810,7 +811,7 @@ std::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompiler:
 	{
 		if (!remapping.isString())
 			return formatFatalError("JSONError", "\"settings.remappings\" must be an array of strings");
-		if (auto r = CompilerStack::parseRemapping(remapping.asString()))
+		if (auto r = ImportRemapper::parseRemapping(remapping.asString()))
 			ret.remappings.emplace_back(std::move(*r));
 		else
 			return formatFatalError("JSONError", "Invalid remapping: \"" + remapping.asString() + "\"");
@@ -941,7 +942,7 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 	compilerStack.setViaIR(_inputsAndSettings.viaIR);
 	compilerStack.setEVMVersion(_inputsAndSettings.evmVersion);
 	compilerStack.setParserErrorRecovery(_inputsAndSettings.parserErrorRecovery);
-	compilerStack.setRemappings(_inputsAndSettings.remappings);
+	compilerStack.setRemappings(move(_inputsAndSettings.remappings));
 	compilerStack.setOptimiserSettings(std::move(_inputsAndSettings.optimiserSettings));
 	compilerStack.setRevertStringBehaviour(_inputsAndSettings.revertStrings);
 	compilerStack.setLibraries(_inputsAndSettings.libraries);

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -64,7 +64,7 @@ private:
 		std::map<std::string, std::string> sources;
 		std::map<util::h256, std::string> smtLib2Responses;
 		langutil::EVMVersion evmVersion;
-		std::vector<CompilerStack::Remapping> remappings;
+		std::vector<ImportRemapper::Remapping> remappings;
 		RevertStrings revertStrings = RevertStrings::Default;
 		OptimiserSettings optimiserSettings = OptimiserSettings::minimal();
 		std::map<std::string, util::h160> libraries;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -26,6 +26,7 @@
 #include "solidity/BuildInfo.h"
 #include "license.h"
 
+#include <libsolidity/interface/FileReader.h>
 #include <libsolidity/interface/Version.h>
 #include <libsolidity/parsing/Parser.h>
 #include <libsolidity/ast/ASTJsonConverter.h>
@@ -57,6 +58,8 @@
 
 #include <algorithm>
 #include <memory>
+
+#include <range/v3/view/map.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -623,14 +626,16 @@ bool CommandLineInterface::readInputFilesAndConfigureRemappings()
 				}
 
 				// NOTE: we ignore the FileNotFound exception as we manually check above
-				m_sourceCodes[infile.generic_string()] = readFileAsString(infile.string());
+				m_fileReader.setSource(infile, readFileAsString(infile.string()));
 				path = boost::filesystem::canonical(infile).string();
 			}
-			m_allowedDirectories.push_back(boost::filesystem::path(path).remove_filename());
+			m_fileReader.allowDirectory(boost::filesystem::path(path).remove_filename());
 		}
+
 	if (addStdin)
-		m_sourceCodes[g_stdinFileName] = readStandardInput();
-	if (m_sourceCodes.size() == 0)
+		m_fileReader.setSource(g_stdinFileName, readStandardInput());
+
+	if (m_fileReader.sourceCodes().size() == 0)
 	{
 		serr() << "No input files given. If you wish to use the standard input please specify \"-\" explicitly." << endl;
 		return false;
@@ -739,10 +744,10 @@ map<string, Json::Value> CommandLineInterface::parseAstFromInput()
 	map<string, Json::Value> sourceJsons;
 	map<string, string> tmpSources;
 
-	for (auto const& srcPair: m_sourceCodes)
+	for (SourceCode const& sourceCode: m_fileReader.sourceCodes() | ranges::views::values)
 	{
 		Json::Value ast;
-		astAssert(jsonParseStrict(srcPair.second, ast), "Input file could not be parsed to JSON");
+		astAssert(jsonParseStrict(sourceCode, ast), "Input file could not be parsed to JSON");
 		astAssert(ast.isMember("sources"), "Invalid Format for import-JSON: Must have 'sources'-object");
 
 		for (auto& src: ast["sources"].getMemberNames())
@@ -757,7 +762,8 @@ map<string, Json::Value> CommandLineInterface::parseAstFromInput()
 		}
 	}
 
-	m_sourceCodes = std::move(tmpSources);
+	m_fileReader.setSources(tmpSources);
+
 	return sourceJsons;
 }
 
@@ -1163,58 +1169,6 @@ General Information)").c_str(),
 
 bool CommandLineInterface::processInput()
 {
-	ReadCallback::Callback fileReader = [this](string const& _kind, string const& _path)
-	{
-		try
-		{
-			if (_kind != ReadCallback::kindString(ReadCallback::Kind::ReadFile))
-				BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment(
-					"ReadFile callback used as callback kind " +
-					_kind
-				));
-			string validPath = _path;
-			if (validPath.find("file://") == 0)
-				validPath.erase(0, 7);
-
-			auto const path = m_basePath / validPath;
-			auto canonicalPath = boost::filesystem::weakly_canonical(path);
-			bool isAllowed = false;
-			for (auto const& allowedDir: m_allowedDirectories)
-			{
-				// If dir is a prefix of boostPath, we are fine.
-				if (
-					std::distance(allowedDir.begin(), allowedDir.end()) <= std::distance(canonicalPath.begin(), canonicalPath.end()) &&
-					std::equal(allowedDir.begin(), allowedDir.end(), canonicalPath.begin())
-				)
-				{
-					isAllowed = true;
-					break;
-				}
-			}
-			if (!isAllowed)
-				return ReadCallback::Result{false, "File outside of allowed directories."};
-
-			if (!boost::filesystem::exists(canonicalPath))
-				return ReadCallback::Result{false, "File not found."};
-
-			if (!boost::filesystem::is_regular_file(canonicalPath))
-				return ReadCallback::Result{false, "Not a valid file."};
-
-			// NOTE: we ignore the FileNotFound exception as we manually check above
-			auto contents = readFileAsString(canonicalPath.string());
-			m_sourceCodes[path.generic_string()] = contents;
-			return ReadCallback::Result{true, contents};
-		}
-		catch (Exception const& _exception)
-		{
-			return ReadCallback::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
-		}
-		catch (...)
-		{
-			return ReadCallback::Result{false, "Unknown exception in read callback."};
-		}
-	};
-
 	if (m_args.count(g_argBasePath))
 	{
 		boost::filesystem::path const fspath{m_args[g_argBasePath].as<string>()};
@@ -1223,9 +1177,7 @@ bool CommandLineInterface::processInput()
 			serr() << "Base path must be a directory: \"" << fspath << "\"\n";
 			return false;
 		}
-		m_basePath = fspath;
-		if (!contains(m_allowedDirectories, fspath))
-			m_allowedDirectories.push_back(fspath);
+		m_fileReader.setBasePath(fspath);
 	}
 
 	if (m_args.count(g_argAllowPaths))
@@ -1240,7 +1192,7 @@ bool CommandLineInterface::processInput()
 			// it.
 			if (filesystem_path.filename() == ".")
 				filesystem_path.remove_filename();
-			m_allowedDirectories.push_back(filesystem_path);
+			m_fileReader.allowDirectory(filesystem_path);
 		}
 	}
 
@@ -1298,7 +1250,7 @@ bool CommandLineInterface::processInput()
 				return false;
 			}
 		}
-		StandardCompiler compiler(fileReader);
+		StandardCompiler compiler(m_fileReader.reader());
 		sout() << compiler.compile(std::move(input)) << endl;
 		return true;
 	}
@@ -1490,7 +1442,7 @@ bool CommandLineInterface::processInput()
 	if (m_args.count(g_argModelCheckerTimeout))
 		m_modelCheckerSettings.timeout = m_args[g_argModelCheckerTimeout].as<unsigned>();
 
-	m_compiler = make_unique<CompilerStack>(fileReader);
+	m_compiler = make_unique<CompilerStack>(m_fileReader.reader());
 
 	SourceReferenceFormatter formatter(serr(false), m_coloredOutput, m_withErrorIds);
 
@@ -1564,7 +1516,7 @@ bool CommandLineInterface::processInput()
 		}
 		else
 		{
-			m_compiler->setSources(m_sourceCodes);
+			m_compiler->setSources(m_fileReader.sourceCodes());
 			if (m_args.count(g_argErrorRecovery))
 				m_compiler->setParserErrorRecovery(true);
 		}
@@ -1714,7 +1666,7 @@ void CommandLineInterface::handleCombinedJSON()
 	if (requests.count(g_strAst))
 	{
 		output[g_strSources] = Json::Value(Json::objectValue);
-		for (auto const& sourceCode: m_sourceCodes)
+		for (auto const& sourceCode: m_fileReader.sourceCodes())
 		{
 			ASTJsonConverter converter(m_compiler->state(), m_compiler->sourceIndices());
 			output[g_strSources][sourceCode.first] = Json::Value(Json::objectValue);
@@ -1737,12 +1689,12 @@ void CommandLineInterface::handleAst()
 		return;
 
 	vector<ASTNode const*> asts;
-	for (auto const& sourceCode: m_sourceCodes)
+	for (auto const& sourceCode: m_fileReader.sourceCodes())
 		asts.push_back(&m_compiler->ast(sourceCode.first));
 
 	if (m_args.count(g_argOutputDir))
 	{
-		for (auto const& sourceCode: m_sourceCodes)
+		for (auto const& sourceCode: m_fileReader.sourceCodes())
 		{
 			stringstream data;
 			string postfix = "";
@@ -1755,7 +1707,7 @@ void CommandLineInterface::handleAst()
 	else
 	{
 		sout() << "JSON AST (compact format):" << endl << endl;
-		for (auto const& sourceCode: m_sourceCodes)
+		for (auto const& sourceCode: m_fileReader.sourceCodes())
 		{
 			sout() << endl << "======= " << sourceCode.first << " =======" << endl;
 			ASTJsonConverter(m_compiler->state(), m_compiler->sourceIndices()).print(sout(), m_compiler->ast(sourceCode.first));
@@ -1796,7 +1748,9 @@ bool CommandLineInterface::link()
 		replacement += "__";
 		librariesReplacements[replacement] = library.second;
 	}
-	for (auto& src: m_sourceCodes)
+
+	FileReader::StringMap sourceCodes = m_fileReader.sourceCodes();
+	for (auto& src: sourceCodes)
 	{
 		auto end = src.second.end();
 		for (auto it = src.second.begin(); it != end;)
@@ -1831,12 +1785,14 @@ bool CommandLineInterface::link()
 		while (!src.second.empty() && *prev(src.second.end()) == '\n')
 			src.second.resize(src.second.size() - 1);
 	}
+	m_fileReader.setSources(move(sourceCodes));
+
 	return true;
 }
 
 void CommandLineInterface::writeLinkedFiles()
 {
-	for (auto const& src: m_sourceCodes)
+	for (auto const& src: m_fileReader.sourceCodes())
 		if (src.first == g_stdinFileName)
 			sout() << src.second << endl;
 		else
@@ -1880,7 +1836,7 @@ bool CommandLineInterface::assemble(
 
 	bool successful = true;
 	map<string, yul::AssemblyStack> assemblyStacks;
-	for (auto const& src: m_sourceCodes)
+	for (auto const& src: m_fileReader.sourceCodes())
 	{
 		OptimiserSettings settings = _optimize ? OptimiserSettings::full() : OptimiserSettings::minimal();
 		if (_yulOptimiserSteps.has_value())
@@ -1931,7 +1887,7 @@ bool CommandLineInterface::assemble(
 	if (!successful)
 		return false;
 
-	for (auto const& src: m_sourceCodes)
+	for (auto const& src: m_fileReader.sourceCodes())
 	{
 		string machine =
 			_targetMachine == yul::AssemblyStack::Machine::EVM ? "EVM" :
@@ -2043,7 +1999,7 @@ void CommandLineInterface::outputCompilationResults()
 			if (m_args.count(g_argAsmJson))
 				ret = jsonPrettyPrint(removeNullMembers(m_compiler->assemblyJSON(contract)));
 			else
-				ret = m_compiler->assemblyString(contract, m_sourceCodes);
+				ret = m_compiler->assemblyString(contract, m_fileReader.sourceCodes());
 
 			if (m_args.count(g_argOutputDir))
 			{

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -35,6 +35,7 @@
 #include <libsolidity/interface/StandardCompiler.h>
 #include <libsolidity/interface/GasEstimator.h>
 #include <libsolidity/interface/DebugSettings.h>
+#include <libsolidity/interface/ImportRemapper.h>
 #include <libsolidity/interface/StorageLayout.h>
 
 #include <libyul/AssemblyStack.h>
@@ -579,7 +580,7 @@ bool CommandLineInterface::readInputFilesAndConfigureRemappings()
 			auto eq = find(path.begin(), path.end(), '=');
 			if (eq != path.end())
 			{
-				if (auto r = CompilerStack::parseRemapping(path))
+				if (auto r = ImportRemapper::parseRemapping(path))
 				{
 					m_remappings.emplace_back(std::move(*r));
 					path = string(eq + 1, path.end());

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -24,6 +24,7 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/DebugSettings.h>
+#include <libsolidity/interface/FileReader.h>
 #include <libsolidity/interface/ImportRemapper.h>
 #include <libyul/AssemblyStack.h>
 #include <liblangutil/EVMVersion.h>
@@ -113,16 +114,12 @@ private:
 
 	bool m_onlyLink = false;
 
+	FileReader m_fileReader;
+
 	/// Compiler arguments variable map
 	boost::program_options::variables_map m_args;
-	/// map of input files to source code strings
-	std::map<std::string, std::string> m_sourceCodes;
 	/// list of remappings
 	std::vector<ImportRemapper::Remapping> m_remappings;
-	/// list of allowed directories to read files from
-	std::vector<boost::filesystem::path> m_allowedDirectories;
-	/// Base path, used for resolving relative paths in imports.
-	boost::filesystem::path m_basePath;
 	/// map of library names to addresses
 	std::map<std::string, util::h160> m_libraries;
 	/// Solidity compiler stack

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -24,6 +24,7 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/DebugSettings.h>
+#include <libsolidity/interface/ImportRemapper.h>
 #include <libyul/AssemblyStack.h>
 #include <liblangutil/EVMVersion.h>
 
@@ -117,7 +118,7 @@ private:
 	/// map of input files to source code strings
 	std::map<std::string, std::string> m_sourceCodes;
 	/// list of remappings
-	std::vector<frontend::CompilerStack::Remapping> m_remappings;
+	std::vector<ImportRemapper::Remapping> m_remappings;
 	/// list of allowed directories to read files from
 	std::vector<boost::filesystem::path> m_allowedDirectories;
 	/// Base path, used for resolving relative paths in imports.

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -26,6 +26,7 @@
 
 #include <liblangutil/Exceptions.h>
 #include <libsolidity/interface/CompilerStack.h>
+#include <libsolidity/interface/ImportRemapper.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -41,7 +42,7 @@ BOOST_AUTO_TEST_SUITE(SolidityImports)
 BOOST_AUTO_TEST_CASE(remappings)
 {
 	CompilerStack c;
-	c.setRemappings(vector<CompilerStack::Remapping>{{"", "s", "s_1.4.6"},{"", "t", "Tee"}});
+	c.setRemappings(vector<ImportRemapper::Remapping>{{"", "s", "s_1.4.6"},{"", "t", "Tee"}});
 	c.setSources({
 		{"a", "import \"s/s.sol\"; contract A is S {} pragma solidity >=0.0;"},
 		{"b", "import \"t/tee.sol\"; contract A is Tee {} pragma solidity >=0.0;"},
@@ -55,7 +56,7 @@ BOOST_AUTO_TEST_CASE(remappings)
 BOOST_AUTO_TEST_CASE(context_dependent_remappings)
 {
 	CompilerStack c;
-	c.setRemappings(vector<CompilerStack::Remapping>{{"a", "s", "s_1.4.6"}, {"b", "s", "s_1.4.7"}});
+	c.setRemappings(vector<ImportRemapper::Remapping>{{"a", "s", "s_1.4.6"}, {"b", "s", "s_1.4.7"}});
 	c.setSources({
 		{"a/a.sol", "import \"s/s.sol\"; contract A is SSix {} pragma solidity >=0.0;"},
 		{"b/b.sol", "import \"s/s.sol\"; contract B is SSeven {} pragma solidity >=0.0;"},
@@ -69,7 +70,7 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings)
 BOOST_AUTO_TEST_CASE(context_dependent_remappings_ensure_default_and_module_preserved)
 {
 	CompilerStack c;
-	c.setRemappings(vector<CompilerStack::Remapping>{
+	c.setRemappings(vector<ImportRemapper::Remapping>{
 		{"", "foo", "vendor/foo_2.0.0"},
 		{"vendor/bar", "foo", "vendor/foo_1.0.0"},
 		{"", "bar", "vendor/bar"}
@@ -87,7 +88,7 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings_ensure_default_and_module_pres
 BOOST_AUTO_TEST_CASE(context_dependent_remappings_order_independent_1)
 {
 	CompilerStack c;
-	c.setRemappings(vector<CompilerStack::Remapping>{{"a", "x/y/z", "d"}, {"a/b", "x", "e"}});
+	c.setRemappings(vector<ImportRemapper::Remapping>{{"a", "x/y/z", "d"}, {"a/b", "x", "e"}});
 	c.setSources({
 		{"a/main.sol", "import \"x/y/z/z.sol\"; contract Main is D {} pragma solidity >=0.0;"},
 		{"a/b/main.sol", "import \"x/y/z/z.sol\"; contract Main is E {} pragma solidity >=0.0;"},
@@ -101,7 +102,7 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings_order_independent_1)
 BOOST_AUTO_TEST_CASE(context_dependent_remappings_order_independent_2)
 {
 	CompilerStack c;
-	c.setRemappings(vector<CompilerStack::Remapping>{{"a/b", "x", "e"}, {"a", "x/y/z", "d"}});
+	c.setRemappings(vector<ImportRemapper::Remapping>{{"a/b", "x", "e"}, {"a", "x/y/z", "d"}});
 	c.setSources({
 		{"a/main.sol", "import \"x/y/z/z.sol\"; contract Main is D {} pragma solidity >=0.0;"},
 		{"a/b/main.sol", "import \"x/y/z/z.sol\"; contract Main is E {} pragma solidity >=0.0;"},


### PR DESCRIPTION
this interface is also used in the LSP PR #8125 (splitout, and now more....):

/cc @cameel (what did you want to work on here?)

- Adds FileReader: extracted from CommandLineInterface, to share the logic between CLI and LSP.
- Adds FileRemapper: extracted from CompilerStack