### PR TITLE
[SMTChecker] Handle InaccessibleDynamicType

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 Bugfixes:
  * AST Output: Fix ``kind`` field of ``ModifierInvocation`` for base constructor calls.
+ * SMTChecker: Fix internal error on public getter returning dynamic data on older EVM versions where these are not available.
 
 
 AST Changes:

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -386,6 +386,11 @@ bool isNonRecursiveStruct(frontend::Type const& _type)
 	return structType && !structType->recursive();
 }
 
+bool isInaccessibleDynamic(frontend::Type const& _type)
+{
+	return _type.category() == frontend::Type::Category::InaccessibleDynamic;
+}
+
 smtutil::Expression minValue(frontend::IntegerType const& _type)
 {
 	return smtutil::Expression(_type.minValue());

--- a/libsolidity/formal/SymbolicTypes.h
+++ b/libsolidity/formal/SymbolicTypes.h
@@ -59,6 +59,7 @@ bool isArray(frontend::Type const& _type);
 bool isTuple(frontend::Type const& _type);
 bool isStringLiteral(frontend::Type const& _type);
 bool isNonRecursiveStruct(frontend::Type const& _type);
+bool isInaccessibleDynamic(frontend::Type const& _type);
 
 /// Returns a new symbolic variable, according to _type.
 /// Also returns whether the type is abstract or not,

--- a/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_1.sol
@@ -1,0 +1,15 @@
+pragma experimental SMTChecker;
+contract C {
+	struct S {
+		string a;
+		uint256 y;
+	}
+	S public s;
+	function g() public view returns (uint256) {
+		this.s();
+	}
+}
+// ====
+// EVMVersion: <=spuriousDragon
+// ----
+// Warning 6321: (133-140): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.

--- a/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_2.sol
@@ -1,0 +1,10 @@
+pragma experimental SMTChecker;
+contract C {
+	function f() public returns(bool[]memory) {
+		this.f();
+	}
+}
+// ====
+// EVMVersion: <=spuriousDragon
+// ----
+// Warning 6321: (74-86): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.

--- a/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_3.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_3.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+contract C {
+	struct S {
+		string a;
+	}
+	S public s;
+	function g() public view returns (uint256) {
+		this.s();
+	}
+}
+// ====
+// EVMVersion: <=spuriousDragon
+// ----
+// Warning 6321: (120-127): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.

--- a/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_4.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/inaccessible_dynamic_type_4.sol
@@ -1,0 +1,11 @@
+pragma experimental SMTChecker;
+contract C {
+	string public s;
+	function g() public view returns (uint256) {
+		this.s();
+	}
+}
+// ====
+// EVMVersion: <=spuriousDragon
+// ----
+// Warning 6321: (98-105): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.


### PR DESCRIPTION
This PR makes SMTChecker aware of `InaccessibleDynamic` type which was part of the type of a return value from external call on older EVM versions (up to spuriousDragon) if dynamically encoded data were to be returned.

This was causing a sort mismatch when SMTChecker was trying to create an SMT representation of the function call expression.

Fixes #10985.