### PR TITLE
Run SMTChecker tests for all EVM versions

### DIFF
--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -67,7 +67,7 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"Semantic",            "libsolidity", "semanticTests",       false, true,  &SemanticTest::create},
 	{"JSON AST",            "libsolidity", "ASTJSON",             false, false, &ASTJSONTest::create},
 	{"JSON ABI",            "libsolidity", "ABIJson",             false, false, &ABIJsonTest::create},
-	{"SMT Checker",         "libsolidity", "smtCheckerTests",     true,  false, &SMTCheckerTest::create, {"nooptions"}},
+	{"SMT Checker",         "libsolidity", "smtCheckerTests",     true,  false, &SMTCheckerTest::create},
 	{"Gas Estimates",       "libsolidity", "gasTests",            false, false, &GasTest::create}
 };
 


### PR DESCRIPTION
The aim of this PR is to test if we can run SMTChecker tests for more than one version of EVM; if it will not have negative effect on test time.