### PR TITLE
Adds @custom:.... natspec example to the natspec-format documentation.

### DIFF
--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -60,12 +60,13 @@ The following example shows a contract and a function using all available tags.
 .. code:: Solidity
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >=0.6.12 <0.9.0;
+    pragma solidity >=0.8.2 < 0.9.0;
 
     /// @title A simulator for trees
     /// @author Larry A. Gardner
     /// @notice You can use this contract for only the most basic simulation
     /// @dev All function calls are currently implemented without side effects
+    /// @custom:experimental This is an experimental contract.
     contract Tree {
         /// @notice Calculate tree age in years, rounded up, for live trees
         /// @dev The Alexandr N. Tetearing algorithm could increase precision
@@ -236,6 +237,7 @@ file should also be produced and should look like this:
       "kind" : "dev",
       "author" : "Larry A. Gardner",
       "details" : "All function calls are currently implemented without side effects",
+      "custom:experimental": "This is an experimental contract.",
       "methods" :
       {
         "age(uint256)" :


### PR DESCRIPTION
Closes #11152, references #2992.

I think there's not much more needed, is there?