### PR TITLE
macOS get_version

### DIFF
--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -26,6 +26,11 @@
 # (c) 2017 solidity contributors.
 #------------------------------------------------------------------------------
 
-set -e
+set -eu
 
-grep -oP "PROJECT_VERSION \"?\K[0-9.]+(?=\")?" "$(dirname "$0")/../CMakeLists.txt"
+version=$(sed -n -E -e 's/^\s*set\(PROJECT_VERSION "([0-9.]+)"\)\s*$/\1/p' "$(dirname "$0")/../CMakeLists.txt")
+
+# Sanity check. Sed does not fail if it does not find a match or finds more than one.
+[[ $version =~ ^[0-9.]+$ ]] || { echo "Failed to find version in CMakeLists.txt"; exit 1; }
+
+echo "$version"


### PR DESCRIPTION
grep's `-o` and `-P` are GNU extensions and do not work on macOS.