### PR TITLE
Make command line tests to be able to run on unreleased version

### DIFF
--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -174,7 +174,7 @@ If you want to use string parameters or other types, you need to convert them to
 ::
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >0.8.3;
+    pragma solidity ^0.8.4;
 
     contract C {
         bytes s = "Storage";

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -352,6 +352,7 @@ SOLTMPDIR=$(mktemp -d)
     set -e
     cd "$SOLTMPDIR"
     "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/ docs
+    developmentVersion=$("$REPO_ROOT/scripts/get_version.sh")
 
     for f in *.sol
     do
@@ -378,6 +379,10 @@ SOLTMPDIR=$(mktemp -d)
         then
             opts+=(-o)
         fi
+
+        # Disable the version pragma in code snippets that only work with the current development version.
+        # It's necessary because x.y.z won't match `^x.y.z` or `>=x.y.z` pragmas until it's officially released.
+        sed -i.bak -E -e 's/pragma[[:space:]]+solidity[[:space:]]*(\^|>=)[[:space:]]*'"$developmentVersion"'/pragma solidity >0.0.1/' "$f"
         compileFull "${opts[@]}" "$SOLTMPDIR/$f"
     done
 )


### PR DESCRIPTION
Examples from documentation are run on current build, and unreleased version is strictly less than currentVersion.
This searches for `pragma solidity ^$developmentVersion` or `pragma solidity >=$developmentVersion` and replaces it with `pragma solidity >0.0.1`

Depends on #11162 to be merged because OSX_cli will fail without it. Locally I worked with updates from that PR