### PR TITLE
Show proper error for misusing the custom natspec tag

### DIFF
--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -163,7 +163,13 @@ void DocStringTagParser::parseDocStrings(
 	for (auto const& [tagName, tagValue]: _annotation.docTags)
 	{
 		string static const customPrefix("custom:");
-		if (boost::starts_with(tagName, customPrefix) && tagName.size() > customPrefix.size())
+		if (tagName == "custom" || tagName == "custom:")
+			m_errorReporter.docstringParsingError(
+				6564_error,
+				_node.documentation()->location(),
+				"Custom documentation tag must contain a chosen name, i.e. @custom:mytag."
+			);
+		else if (boost::starts_with(tagName, customPrefix) && tagName.size() > customPrefix.size())
 		{
 			regex static const customRegex("^custom:[a-z][a-z-]*$");
 			if (!regex_match(tagName, customRegex))

--- a/test/libsolidity/syntaxTests/natspec/invalid/invalid_tag.sol
+++ b/test/libsolidity/syntaxTests/natspec/invalid/invalid_tag.sol
@@ -8,9 +8,12 @@ contract C {
 	function h() public pure {}
 	/// @custom:abc-def
 	function i() public pure {}
+	/// @custom
+	function j() public pure {}
 }
 // ----
 // DocstringParsingError 6546: (0-14): Documentation tag @a&b not valid for contracts.
 // DocstringParsingError 2968: (28-49): Invalid character in custom tag @custom:x^y. Only lowercase letters and "-" are permitted.
 // DocstringParsingError 6546: (80-92): Documentation tag @custom: not valid for functions.
 // DocstringParsingError 2968: (123-141): Invalid character in custom tag @custom:abcDEF. Only lowercase letters and "-" are permitted.
+// DocstringParsingError 6546: (222-233): Documentation tag @custom not valid for functions.

--- a/test/libsolidity/syntaxTests/natspec/invalid/invalid_tag.sol
+++ b/test/libsolidity/syntaxTests/natspec/invalid/invalid_tag.sol
@@ -14,6 +14,6 @@ contract C {
 // ----
 // DocstringParsingError 6546: (0-14): Documentation tag @a&b not valid for contracts.
 // DocstringParsingError 2968: (28-49): Invalid character in custom tag @custom:x^y. Only lowercase letters and "-" are permitted.
-// DocstringParsingError 6546: (80-92): Documentation tag @custom: not valid for functions.
+// DocstringParsingError 6564: (80-92): Custom documentation tag must contain a chosen name, i.e. @custom:mytag.
 // DocstringParsingError 2968: (123-141): Invalid character in custom tag @custom:abcDEF. Only lowercase letters and "-" are permitted.
-// DocstringParsingError 6546: (222-233): Documentation tag @custom not valid for functions.
+// DocstringParsingError 6564: (222-233): Custom documentation tag must contain a chosen name, i.e. @custom:mytag.


### PR DESCRIPTION
I think this is the real solution to #11152.

Made it two commits so the original error is easy to see, but it can be squashed prior to merge.