### PR TITLE
Update pygments-lexer-solidity to 0.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Solidity'
-copyright = '2016-2020, Ethereum'
+copyright = '2016-2021, Ethereum'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx_rtd_theme>=0.3.1
-pygments-lexer-solidity>=0.5.1
+pygments-lexer-solidity>=0.7.0
 sphinx-a4doc>=1.2.1


### PR DESCRIPTION
Closes #11171.

This PR is not strictly required, because circleci just install `pygments-lexer-solidity` globally, without the `requirements.txt`. This means the CI doesn't care what version we require, but at least any update is automatically visible on docs.soliditylang.org.

Anyhow, for clarity it is nice to merge this and we may want to fix CI later.