### PR TITLE
[solc-bin] Fix commit range used by bytecode PR check

### DIFF
--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -74,7 +74,7 @@ cd "${solc_bin_dir}/${platform}/"
 echo "Commit range: ${base_ref}..${top_ref}"
 
 modified_release_versions=$(
-    git diff --name-only "${base_ref}" |
+    git diff --name-only "${base_ref}" "${top_ref}" |
     sed -n -E 's/^[^\/]+\/(solc|soljson)-[0-9a-zA-Z-]+-v([0-9.]+)\+commit\.[0-9a-f]+(.[^.]+)?$/\2/p' |
     sort -V |
     uniq


### PR DESCRIPTION
The check used currently checked out commit as the end of the range instead of the one specified in `top_ref` parameter.

Fortunately this bug did not have any consequences in solc-bin because there we pass the checked out commit in this parameter anyway.