### PR TITLE
Fixing auto update for macos

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -93,7 +93,7 @@ function ask_expectation_update
 
             while true
             do
-                read -r -N 1 -p "(e)dit/(u)pdate expectations/(s)kip/(q)uit? "
+                read -r -n 1 -p "(e)dit/(u)pdate expectations/(s)kip/(q)uit? "
                 echo
                 case $REPLY in
                     e*) "$editor" "$expectationFile"; break;;


### PR DESCRIPTION
`-N` is not supported on macos, so we need to use `-n` which has slightly different behaviour according to manual:

```
-n nchars return after reading NCHARS characters rather than waiting for a newline, 
but honor a delimiter if fewer than NCHARS characters are read before the delimiter

-N nchars return only after reading exactly NCHARS characters, 
unless EOF is encountered or read times out, ignoring any delimiter
```

If we are fine with that change, I would like to merge, as it will fix auto-update feature for command line tests.