### PR TITLE
Use range-v3 loops (reverse, keys, values)

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -23,10 +23,11 @@
  */
 
 #include <functional>
-#include <boost/range/adaptor/reversed.hpp>
 #include <libsolutil/Keccak256.h>
 #include <libevmasm/CommonSubexpressionEliminator.h>
 #include <libevmasm/AssemblyItem.h>
+
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -330,7 +331,7 @@ void CSECodeGenerator::generateClassElement(Id _c, bool _allowSequenced)
 		"Undefined item requested but not available."
 	);
 	vector<Id> const& arguments = expr.arguments;
-	for (Id arg: boost::adaptors::reverse(arguments))
+	for (Id arg: arguments | ranges::views::reverse)
 		generateClassElement(arg);
 
 	SourceLocation const& itemLocation = expr.item->location();

--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -27,7 +27,8 @@
 #include <libsolidity/analysis/TypeChecker.h>
 #include <libsolutil/FunctionSelector.h>
 #include <liblangutil/ErrorReporter.h>
-#include <boost/range/adaptor/reversed.hpp>
+
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -238,7 +239,7 @@ void ContractLevelChecker::checkAbstractDefinitions(ContractDefinition const& _c
 
 	// Search from base to derived, collect all functions and modifiers and
 	// update proxies.
-	for (ContractDefinition const* contract: boost::adaptors::reverse(_contract.annotation().linearizedBaseContracts))
+	for (ContractDefinition const* contract: _contract.annotation().linearizedBaseContracts | ranges::views::reverse)
 	{
 		for (VariableDeclaration const* v: contract->stateVariables())
 			if (v->isPartOfExternalInterface())
@@ -511,7 +512,7 @@ void ContractLevelChecker::checkPayableFallbackWithoutReceive(ContractDefinition
 void ContractLevelChecker::checkStorageSize(ContractDefinition const& _contract)
 {
 	bigint size = 0;
-	for (ContractDefinition const* contract: boost::adaptors::reverse(_contract.annotation().linearizedBaseContracts))
+	for (ContractDefinition const* contract: _contract.annotation().linearizedBaseContracts | ranges::views::reverse)
 		for (VariableDeclaration const* variable: contract->stateVariables())
 			if (!(variable->isConstant() || variable->immutable()))
 			{

--- a/libsolidity/analysis/ImmutableValidator.cpp
+++ b/libsolidity/analysis/ImmutableValidator.cpp
@@ -20,7 +20,7 @@
 
 #include <libsolutil/CommonData.h>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 using namespace solidity::frontend;
 using namespace solidity::langutil;
@@ -29,7 +29,7 @@ void ImmutableValidator::analyze()
 {
 	m_inConstructionContext = true;
 
-	auto linearizedContracts = m_currentContract.annotation().linearizedBaseContracts | boost::adaptors::reversed;
+	auto linearizedContracts = m_currentContract.annotation().linearizedBaseContracts | ranges::views::reverse;
 
 	for (ContractDefinition const* contract: linearizedContracts)
 		for (VariableDeclaration const* stateVar: contract->stateVariables())

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -41,12 +41,12 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
 #include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/reverse.hpp>
 
 #include <limits>
 #include <unordered_set>
@@ -2014,7 +2014,7 @@ FunctionType const* ContractType::newExpressionType() const
 vector<tuple<VariableDeclaration const*, u256, unsigned>> ContractType::stateVariables() const
 {
 	vector<VariableDeclaration const*> variables;
-	for (ContractDefinition const* contract: boost::adaptors::reverse(m_contract.annotation().linearizedBaseContracts))
+	for (ContractDefinition const* contract: m_contract.annotation().linearizedBaseContracts | ranges::views::reverse)
 		for (VariableDeclaration const* variable: contract->stateVariables())
 			if (!(variable->isConstant() || variable->immutable()))
 				variables.push_back(variable);
@@ -2034,7 +2034,7 @@ vector<tuple<VariableDeclaration const*, u256, unsigned>> ContractType::stateVar
 vector<VariableDeclaration const*> ContractType::immutableVariables() const
 {
 	vector<VariableDeclaration const*> variables;
-	for (ContractDefinition const* contract: boost::adaptors::reverse(m_contract.annotation().linearizedBaseContracts))
+	for (ContractDefinition const* contract: m_contract.annotation().linearizedBaseContracts | ranges::views::reverse)
 		for (VariableDeclaration const* variable: contract->stateVariables())
 			if (variable->immutable())
 				variables.push_back(variable);

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -49,7 +49,7 @@
 #include <libsolutil/Whiskers.h>
 #include <libsolutil/FunctionSelector.h>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 #include <algorithm>
 
@@ -152,9 +152,7 @@ void ContractCompiler::appendInitAndConstructorCode(ContractDefinition const& _c
 	m_baseArguments = &_contract.annotation().baseConstructorArguments;
 
 	// Initialization of state variables in base-to-derived order.
-	for (ContractDefinition const* contract: boost::adaptors::reverse(
-		_contract.annotation().linearizedBaseContracts
-	))
+	for (ContractDefinition const* contract: _contract.annotation().linearizedBaseContracts | ranges::views::reverse)
 		initializeStateVariables(*contract);
 
 	if (FunctionDefinition const* constructor = _contract.constructor())
@@ -200,10 +198,10 @@ size_t ContractCompiler::packIntoContractCreator(ContractDefinition const& _cont
 	m_context.pushSubroutineOffset(m_context.runtimeSub());
 	m_context << u256(0) << Instruction::CODECOPY;
 	// Assign immutable values from stack in reversed order.
-	for (auto const& immutable: immutables | boost::adaptors::reversed)
+	for (auto const& immutable: immutables | ranges::views::reverse)
 	{
 		auto slotNames = m_context.immutableVariableSlotNames(*immutable);
-		for (auto&& slotName: slotNames | boost::adaptors::reversed)
+		for (auto&& slotName: slotNames | ranges::views::reverse)
 		{
 			m_context << u256(0);
 			m_context.appendImmutableAssignment(slotName);
@@ -1096,7 +1094,7 @@ bool ContractCompiler::visit(TryCatchClause const& _clause)
 	unsigned varSize = 0;
 
 	if (_clause.parameters())
-		for (ASTPointer<VariableDeclaration> const& varDecl: _clause.parameters()->parameters() | boost::adaptors::reversed)
+		for (ASTPointer<VariableDeclaration> const& varDecl: _clause.parameters()->parameters() | ranges::views::reverse)
 		{
 			solAssert(varDecl, "");
 			varSize += varDecl->annotation().type->sizeOnStack();
@@ -1258,7 +1256,7 @@ bool ContractCompiler::visit(Return const& _return)
 			expectedType = types.front();
 		compileExpression(*expression, expectedType);
 
-		for (auto const& retVariable: boost::adaptors::reverse(returnParameters))
+		for (auto const& retVariable: returnParameters | ranges::views::reverse)
 			CompilerUtils(m_context).moveToStackVariable(*retVariable);
 	}
 

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -30,7 +30,7 @@
 #include <libsolutil/Whiskers.h>
 #include <libsolutil/StringUtils.h>
 
-#include <boost/range/adaptor/map.hpp>
+#include <range/v3/view/map.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -133,7 +133,7 @@ void IRGenerationContext::initializeInternalDispatch(InternalDispatchMap _intern
 {
 	solAssert(internalDispatchClean(), "");
 
-	for (DispatchSet const& functions: _internalDispatch | boost::adaptors::map_values)
+	for (DispatchSet const& functions: _internalDispatch | ranges::views::values)
 		for (auto function: functions)
 			enqueueFunctionForCodeGeneration(*function);
 

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -42,8 +42,6 @@
 
 #include <range/v3/view/map.hpp>
 
-#include <boost/range/adaptor/map.hpp>
-
 #include <sstream>
 #include <variant>
 
@@ -255,7 +253,7 @@ InternalDispatchMap IRGenerator::generateInternalDispatchFunctions()
 	);
 
 	InternalDispatchMap internalDispatchMap = m_context.consumeInternalDispatchMap();
-	for (YulArity const& arity: internalDispatchMap | boost::adaptors::map_keys)
+	for (YulArity const& arity: internalDispatchMap | ranges::views::keys)
 	{
 		string funName = IRNames::internalDispatch(arity);
 		m_context.functionCollector().createFunction(funName, [&]() {

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -34,7 +34,7 @@
 
 #include <range/v3/algorithm/for_each.hpp>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 #ifdef HAVE_Z3_DLOPEN
 #include <z3_version.h>
@@ -190,7 +190,7 @@ void CHC::endVisit(ContractDefinition const& _contract)
 		}
 	m_errorDest = nullptr;
 	// Then call initializer_Base from base -> derived
-	for (auto base: _contract.annotation().linearizedBaseContracts | boost::adaptors::reversed)
+	for (auto base: _contract.annotation().linearizedBaseContracts | ranges::views::reverse)
 	{
 		errorFlag().increaseIndex();
 		m_context.addAssertion(smt::constructorCall(*m_contractInitializers.at(&_contract).at(base), m_context));
@@ -1737,7 +1737,7 @@ optional<string> CHC::generateCounterexample(CHCSolverInterface::CexGraph const&
 		path.emplace_back(boost::algorithm::join(calls, "\n"));
 	}
 
-	return localState + "\nTransaction trace:\n" + boost::algorithm::join(boost::adaptors::reverse(path), "\n");
+	return localState + "\nTransaction trace:\n" + boost::algorithm::join(path | ranges::views::reverse, "\n");
 }
 
 map<unsigned, vector<unsigned>> CHC::summaryCalls(CHCSolverInterface::CexGraph const& _graph, unsigned _root)

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -33,7 +33,7 @@
 #include <range/v3/view.hpp>
 
 #include <boost/range/adaptors.hpp>
-#include <boost/range/adaptor/reversed.hpp>
+
 
 #include <deque>
 
@@ -2499,7 +2499,7 @@ SecondarySourceLocation SMTEncoder::callStackMessage(vector<CallStackEntry> cons
 	SecondarySourceLocation callStackLocation;
 	solAssert(!_callStack.empty(), "");
 	callStackLocation.append("Callstack:", SourceLocation());
-	for (auto const& call: _callStack | boost::adaptors::reversed)
+	for (auto const& call: _callStack | ranges::views::reverse)
 		if (call.second)
 			callStackLocation.append("", call.second->location());
 	return callStackLocation;

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -28,7 +28,7 @@
 
 #include <liblangutil/Exceptions.h>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 #include <utility>
 #include <variant>
@@ -278,7 +278,7 @@ void CodeTransform::operator()(FunctionCall const& _call)
 		}), "Function name not found.");
 		yulAssert(function, "");
 		yulAssert(function->arguments.size() == _call.arguments.size(), "");
-		for (auto const& arg: _call.arguments | boost::adaptors::reversed)
+		for (auto const& arg: _call.arguments | ranges::views::reverse)
 			visitExpression(arg);
 		m_assembly.setSourceLocation(_call.location);
 		m_assembly.appendJumpTo(
@@ -397,7 +397,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 	yulAssert(m_info.scopes.at(&_function.body), "");
 	Scope* varScope = m_info.scopes.at(m_info.virtualBlocks.at(&_function).get()).get();
 	yulAssert(varScope, "");
-	for (auto const& v: _function.parameters | boost::adaptors::reversed)
+	for (auto const& v: _function.parameters | ranges::views::reverse)
 	{
 		auto& var = std::get<Scope::Variable>(varScope->identifiers.at(v.name));
 		m_context->variableStackHeights[&var] = height++;
@@ -664,7 +664,7 @@ void CodeTransform::finalizeBlock(Block const& _block, int blockStartStackHeight
 void CodeTransform::generateMultiAssignment(vector<Identifier> const& _variableNames)
 {
 	yulAssert(m_scope, "");
-	for (auto const& variableName: _variableNames | boost::adaptors::reversed)
+	for (auto const& variableName: _variableNames | ranges::views::reverse)
 		generateAssignment(variableName);
 }
 

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -33,7 +33,7 @@
 
 #include <liblangutil/Exceptions.h>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -49,7 +49,7 @@ void visitArguments(
 	function<void(Expression const&)> _visitExpression
 )
 {
-	for (auto const& arg: _call.arguments | boost::adaptors::reversed)
+	for (auto const& arg: _call.arguments | ranges::views::reverse)
 		_visitExpression(arg);
 
 	_assembly.setSourceLocation(_call.location);

--- a/libyul/backends/wasm/BinaryTransform.cpp
+++ b/libyul/backends/wasm/BinaryTransform.cpp
@@ -26,9 +26,10 @@
 #include <libsolutil/Visitor.h>
 #include <libsolutil/LEB128.h>
 
-#include <boost/range/adaptor/reversed.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -580,7 +581,7 @@ map<string, size_t> BinaryTransform::enumerateFunctionTypes(map<Type, vector<str
 {
 	map<string, size_t> functionTypes;
 	size_t typeID = 0;
-	for (vector<string> const& funNames: _typeToFunctionMap | boost::adaptors::map_values)
+	for (vector<string> const& funNames: _typeToFunctionMap | ranges::views::values)
 	{
 		for (string const& name: funNames)
 			functionTypes[name] = typeID;
@@ -594,7 +595,7 @@ bytes BinaryTransform::typeSection(map<BinaryTransform::Type, vector<string>> co
 {
 	bytes result;
 	size_t index = 0;
-	for (Type const& type: _typeToFunctionMap | boost::adaptors::map_keys)
+	for (Type const& type: _typeToFunctionMap | ranges::views::keys)
 	{
 		result += toBytes(ValueType::Function);
 		result += lebEncode(type.first.size()) + type.first;
@@ -695,7 +696,7 @@ bytes BinaryTransform::visit(vector<Expression> const& _expressions)
 bytes BinaryTransform::visitReversed(vector<Expression> const& _expressions)
 {
 	bytes result;
-	for (auto const& expr: _expressions | boost::adaptors::reversed)
+	for (auto const& expr: _expressions | ranges::views::reverse)
 		result += std::visit(*this, expr);
 	return result;
 }
@@ -704,7 +705,7 @@ bytes BinaryTransform::encodeLabelIdx(string const& _label) const
 {
 	yulAssert(!_label.empty(), "Empty label.");
 	size_t depth = 0;
-	for (string const& label: m_labels | boost::adaptors::reversed)
+	for (string const& label: m_labels | ranges::views::reverse)
 		if (label == _label)
 			return lebEncode(depth);
 		else

--- a/libyul/optimiser/ASTWalker.cpp
+++ b/libyul/optimiser/ASTWalker.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/AST.h>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -33,7 +33,7 @@ using namespace solidity::util;
 void ASTWalker::operator()(FunctionCall const& _funCall)
 {
 	// Does not visit _funCall.functionName on purpose
-	walkVector(_funCall.arguments | boost::adaptors::reversed);
+	walkVector(_funCall.arguments | ranges::views::reverse);
 }
 
 void ASTWalker::operator()(ExpressionStatement const& _statement)
@@ -102,7 +102,7 @@ void ASTWalker::visit(Expression const& _e)
 void ASTModifier::operator()(FunctionCall& _funCall)
 {
 	// Does not visit _funCall.functionName on purpose
-	walkVector(_funCall.arguments | boost::adaptors::reversed);
+	walkVector(_funCall.arguments | ranges::views::reverse);
 }
 
 void ASTModifier::operator()(ExpressionStatement& _statement)

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -31,9 +31,10 @@
 #include <libsolutil/CommonData.h>
 #include <libsolutil/cxx20.h>
 
-#include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
 #include <variant>
+
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -387,7 +388,7 @@ void DataFlowAnalyzer::joinKnowledgeHelper(
 
 bool DataFlowAnalyzer::inScope(YulString _variableName) const
 {
-	for (auto const& scope: m_variableScopes | boost::adaptors::reversed)
+	for (auto const& scope: m_variableScopes | ranges::views::reverse)
 	{
 		if (scope.variables.count(_variableName))
 			return true;

--- a/libyul/optimiser/ExpressionJoiner.cpp
+++ b/libyul/optimiser/ExpressionJoiner.cpp
@@ -29,7 +29,7 @@
 
 #include <libsolutil/CommonData.h>
 
-#include <boost/range/adaptor/reversed.hpp>
+#include <range/v3/view/reverse.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -94,7 +94,7 @@ void ExpressionJoiner::handleArguments(vector<Expression>& _arguments)
 	// on the right is an identifier or literal.
 
 	size_t i = _arguments.size();
-	for (Expression const& arg: _arguments | boost::adaptors::reversed)
+	for (Expression const& arg: _arguments | ranges::views::reverse)
 	{
 		--i;
 		if (!holds_alternative<Identifier>(arg) && !holds_alternative<Literal>(arg))

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -73,9 +73,10 @@
 
 #include <libsolutil/CommonData.h>
 
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
 #include <libyul/CompilabilityChecker.h>
+
+#include <range/v3/view/map.hpp>
 
 using namespace std;
 using namespace solidity;
@@ -250,7 +251,7 @@ map<string, char> const& OptimiserSuite::stepNameToAbbreviationMap()
 	yulAssert(lookupTable.size() == allSteps().size(), "");
 	yulAssert((
 			util::convertContainer<set<char>>(string(NonStepAbbreviations)) -
-			util::convertContainer<set<char>>(lookupTable | boost::adaptors::map_values)
+			util::convertContainer<set<char>>(lookupTable | ranges::views::values)
 		).size() == string(NonStepAbbreviations).size(),
 		"Step abbreviation conflicts with a character reserved for another syntactic element"
 	);

--- a/test/TestCaseReader.cpp
+++ b/test/TestCaseReader.cpp
@@ -21,8 +21,9 @@
 #include <libsolutil/StringUtils.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/throw_exception.hpp>
+
+#include <range/v3/view/map.hpp>
 
 using namespace std;
 using namespace solidity::frontend::test;
@@ -97,7 +98,7 @@ void TestCaseReader::ensureAllSettingsRead() const
 	if (!m_unreadSettings.empty())
 		BOOST_THROW_EXCEPTION(runtime_error(
 			"Unknown setting(s): " +
-			util::joinHumanReadable(m_unreadSettings | boost::adaptors::map_keys)
+			util::joinHumanReadable(m_unreadSettings | ranges::views::keys)
 		));
 }
 

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -34,8 +34,9 @@
 
 #include <libsolutil/FixedHash.h>
 
-#include <boost/range/adaptor/reversed.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
+
+#include <range/v3/view/reverse.hpp>
 
 #include <ostream>
 #include <variant>
@@ -332,7 +333,7 @@ void ExpressionEvaluator::evaluateArgs(
 	vector<u256> values;
 	size_t i = 0;
 	/// Function arguments are evaluated in reverse.
-	for (auto const& expr: _expr | boost::adaptors::reversed)
+	for (auto const& expr: _expr | ranges::views::reverse)
 	{
 		if (!_literalArguments || !_literalArguments->at(_expr.size() - i - 1))
 			visit(expr);


### PR DESCRIPTION
Partial fixes for #10738

Replaced boost::adaptors::map_keys and boost::adaptors::map_values with ranges::views::keys and ranges::views::values
And boost::algorithm::reverse with ranges::views::reverse