### PR TITLE
Detail or remove overflow handling (I needed to know max value of uint to understand commentary.)

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -209,7 +209,7 @@ The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
 and ``require(amount < 1e60);``ensures a maximum amount of tokens: The function can be called very often,
-but due to gas costs, there is still a practical limit (``uint`` maximum value exceeds 1e77.)
+but due to gas costs, there is still a practical limit, and ``uint`` maximum value exceeds 1e77.
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -208,7 +208,7 @@ The functions that make up the contract, and that users and contracts can call a
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60)`` ensures a maximum amount of tokens: The function can be called very often,
+and ``require(amount < 1e60);`` ensures a maximum amount of tokens: The function can be called very often,
 but due to gas costs, there is still a practical limit, and ``uint`` maximum value exceeds 1e77.
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -206,7 +206,7 @@ The functions that make up the contract, and that users and contracts can call a
 
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
-In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``. Note that because of the default :ref:`Checked arithmetic <unchecked>`, the transaction would revert if the expression ``balances[receiver] += amount;`` overflows, i.e., when ``balances[receiver] + amount`` in arbitrary precision arithmetic is larger than the maximum value of ``uint`` (``2**256 - 1``).
+In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``. Note that because of the default :ref:`Checked arithmetic <unchecked>`, the transaction would revert if the expression ``balances[receiver] += amount;`` overflows, i.e., when ``balances[receiver] + amount`` in arbitrary precision arithmetic is larger than the maximum value of ``uint`` (``2**256 - 1``). This is also true for the statement ``balances[receiver] += amount;`` in the function ``send``.
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -209,7 +209,7 @@ The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
 and ``require(amount < 1e60);`` ensures balance isn't overflowed by any feasible number of calls (``uint`` 
-maximum value exceeds 1e71.)
+maximum value exceeds 1e77.)
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -206,7 +206,7 @@ The functions that make up the contract, and that users and contracts can call a
 
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
-In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``. Note that because of the default :ref:`Checked arithmetic <_unchecked>`, the transaction would revert if the expression ``balances[receiver] += amount;`` overflows, i.e., when ``balances[receiver] + amount`` in arbitrary precision arithmetic is larger than the maximum value of ``uint`` (``2**256 - 1``).
+In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``. Note that because of the default :ref:`Checked arithmetic <unchecked>`, the transaction would revert if the expression ``balances[receiver] += amount;`` overflows, i.e., when ``balances[receiver] + amount`` in arbitrary precision arithmetic is larger than the maximum value of ``uint`` (``2**256 - 1``).
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -208,8 +208,8 @@ The functions that make up the contract, and that users and contracts can call a
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60);`` ensures balance isn't overflowed by any feasible number of calls (``uint``
-maximum value exceeds 1e77.)
+and ``require(amount < 1e60);``ensures a maximum amount of tokens: The function can be called very often,
+but due to gas costs, there is still a practical limit (``uint`` maximum value exceeds 1e77.)
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -208,7 +208,8 @@ The functions that make up the contract, and that users and contracts can call a
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60);`` ensures a maximum amount of tokens. This ensures that there are no overflow errors in the future.
+and ``require(amount < 1e60);`` ensures balance isn't overflowed by any feasible number of calls (``uint`` 
+maximum value exceeds 1e71.)
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -208,7 +208,7 @@ The functions that make up the contract, and that users and contracts can call a
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60);``ensures a maximum amount of tokens: The function can be called very often,
+and ``require(amount < 1e60)`` ensures a maximum amount of tokens: The function can be called very often,
 but due to gas costs, there is still a practical limit, and ``uint`` maximum value exceeds 1e77.
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -208,7 +208,7 @@ The functions that make up the contract, and that users and contracts can call a
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
 In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60);`` ensures balance isn't overflowed by any feasible number of calls (``uint`` 
+and ``require(amount < 1e60);`` ensures balance isn't overflowed by any feasible number of calls (``uint``
 maximum value exceeds 1e77.)
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -206,7 +206,7 @@ The functions that make up the contract, and that users and contracts can call a
 
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
-In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``.
+In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``. Note that because of the default :ref:`Checked arithmetic <_unchecked>`, the transaction would revert if the expression ``balances[receiver] += amount;`` overflows, i.e., when ``balances[receiver] + amount`` in arbitrary precision arithmetic is larger than the maximum value of ``uint`` (``2**256 - 1``).
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -105,7 +105,6 @@ registering with a username and password, all you need is an Ethereum keypair.
         // Can only be called by the contract creator
         function mint(address receiver, uint amount) public {
             require(msg.sender == minter);
-            require(amount < 1e60);
             balances[receiver] += amount;
         }
 
@@ -207,9 +206,7 @@ The functions that make up the contract, and that users and contracts can call a
 
 The ``mint`` function sends an amount of newly created coins to another address.
 The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
-In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60);`` ensures a maximum amount of tokens: The function can be called very often,
-but due to gas costs, there is still a practical limit, and ``uint`` maximum value exceeds 1e77.
+In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``.
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the


### PR DESCRIPTION
My first reaction when reading "ensures that there are no overflow errors in the future" was "yeah right", because it only checked input.  What I needed to understand is that the amount being minted is limited to a very small amount relative to the maximum value that can be held by `uint` (I did not know what that was off the top of my head) - no overflow is not entirely prevented, but it will not overflow in the first call to mint(), or any reasonable feasible of calls, and so not easily by calls to send() either where there's no such checks. If that's the intent/design, perhaps being more specific as in this edit will help people like me see that right off.

Update: Second option is to remove the LOC purported to handle overflow, simplifying the sample, removing the bump I hit altogether.