### PR TITLE
docs: mention the v0.8 restrictions on negative unary

### DIFF
--- a/docs/080-breaking-changes.rst
+++ b/docs/080-breaking-changes.rst
@@ -173,4 +173,4 @@ How to update your code
 - Change ``msg.sender.transfer(x)`` to ``payable(msg.sender).transfer(x)`` or use a stored variable of ``address payable`` type.
 - Change ``x**y**z`` to ``(x**y)**z``.
 - Use inline assembly as a replacement for ``log0``, ..., ``log4``.
-- Negate unsigned integers by subtracting them from the max uint and adding 1 (e.g. `type(uint256).max - x + 1`, while ensuring that `x` is not zero)
+- Negate unsigned integers by subtracting them from the maximum value of the type and adding 1 (e.g. ``type(uint256).max - x + 1``, while ensuring that `x` is not zero)

--- a/docs/080-breaking-changes.rst
+++ b/docs/080-breaking-changes.rst
@@ -146,6 +146,8 @@ This section lists changes that might cause existing contracts to not compile an
 
 * The ``chainid`` builtin in inline assembly is now considered ``view`` instead of ``pure``.
 
+* Unary negation cannot be used on unsigned integers anymore, only on signed integers.
+
 Interface Changes
 =================
 
@@ -171,3 +173,4 @@ How to update your code
 - Change ``msg.sender.transfer(x)`` to ``payable(msg.sender).transfer(x)`` or use a stored variable of ``address payable`` type.
 - Change ``x**y**z`` to ``(x**y)**z``.
 - Use inline assembly as a replacement for ``log0``, ..., ``log4``.
+- Negate unsigned integers by subtracting them from the max uint and adding 1 (e.g. `type(uint256).max - x + 1`, while ensuring that `x` is not zero)


### PR DESCRIPTION
I didn't see the new behaviour mentioned in the v0.8 breaking changes list, which led me to post the following question on StackExchange: [Unary operator - cannot be applied to type uint256](https://ethereum.stackexchange.com/questions/96642/unary-operator-cannot-be-applied-to-type-uint256).