### PR TITLE
Fix exit code update in cmdlineTests

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -190,7 +190,7 @@ function test_solc_behaviour()
     then
         printError "Incorrect exit code. Expected $exit_code_expected but got $exitCode."
 
-        [[ $exit_code_expectation_file != "" ]] && ask_expectation_update "$exit_code_expected" "$exit_code_expectation_file"
+        [[ $exit_code_expectation_file != "" ]] && ask_expectation_update "$exitCode" "$exit_code_expectation_file"
         [[ $exit_code_expectation_file == "" ]] && exit 1
     fi
 


### PR DESCRIPTION
Looks like I used the wrong value in #10832. The expectation should be updated to match the actual result, not just be overwritten with itself.