### PR TITLE
Fix missing error when events are used without an emit statement.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ Bugfixes:
  * SMTChecker: Fix false positive in contracts that cannot be deployed.
  * SMTChecker: Fix internal error on public getter returning dynamic data on older EVM versions where these are not available.
  * SMTChecker: Fix internal error on try-catch with function call in catch block.
+ * Type Checker: Fix missing error when events are used without an emit statement.
 
 
 AST Changes:

--- a/test/libsolidity/syntaxTests/events/multiple_event_without_emit.sol
+++ b/test/libsolidity/syntaxTests/events/multiple_event_without_emit.sol
@@ -1,0 +1,16 @@
+contract test {
+    event SetFirstElem(uint indexed elem);
+    event SetSecondElem(uint indexed elem);
+    function setVal() external  {
+        emit SetFirstElem(0);
+    }
+    function setValX() external  {
+        // There was a missing error for this case.
+        // Whenever there was a proper invocation of events,
+        // the compiler assumed that all the subsequent invocations
+        // were proper.
+        SetFirstElem(1);
+    }
+}
+// ----
+// TypeError 3132: (421-436): Event invocations have to be prefixed by "emit".


### PR DESCRIPTION
Whenever there was a proper invocation of events, the compiler assumed that all the subsequent
invocations were proper.

The fix was part of custom errors.

Fixes https://github.com/ethereum/solidity/issues/11226