### PR TITLE
Extract VariableReferenceCounter and StackTooDeep error from EVMCodeTransform.

### DIFF
--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -33,6 +33,7 @@
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/StringUtils.h>
+#include <libsolutil/Visitor.h>
 
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/algorithm/string.hpp>

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -65,6 +65,8 @@ add_library(yul
 	backends/evm/EVMMetrics.h
 	backends/evm/NoOutputAssembly.h
 	backends/evm/NoOutputAssembly.cpp
+	backends/evm/VariableReferenceCounter.h
+	backends/evm/VariableReferenceCounter.cpp
 	backends/wasm/EVMToEwasmTranslator.cpp
 	backends/wasm/EVMToEwasmTranslator.h
 	backends/wasm/BinaryTransform.cpp

--- a/libyul/Exceptions.h
+++ b/libyul/Exceptions.h
@@ -24,6 +24,8 @@
 #include <libsolutil/Exceptions.h>
 #include <libsolutil/Assertions.h>
 
+#include <libyul/YulString.h>
+
 namespace solidity::yul
 {
 
@@ -31,6 +33,23 @@ struct YulException: virtual util::Exception {};
 struct OptimizerException: virtual YulException {};
 struct CodegenException: virtual YulException {};
 struct YulAssertion: virtual YulException {};
+
+struct StackTooDeepError: virtual YulException
+{
+	StackTooDeepError(YulString _variable, int _depth, std::string const& _message):
+		variable(_variable), depth(_depth)
+	{
+		*this << util::errinfo_comment(_message);
+	}
+	StackTooDeepError(YulString _functionName, YulString _variable, int _depth, std::string const& _message):
+		functionName(_functionName), variable(_variable), depth(_depth)
+	{
+		*this << util::errinfo_comment(_message);
+	}
+	YulString functionName;
+	YulString variable;
+	int depth;
+};
 
 /// Assertion that throws an YulAssertion containing the given description if it is not met.
 #define yulAssert(CONDITION, DESCRIPTION) \

--- a/libyul/Scope.cpp
+++ b/libyul/Scope.cpp
@@ -21,6 +21,8 @@
 
 #include <libyul/Scope.h>
 
+#include <libsolutil/Visitor.h>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;

--- a/libyul/Scope.h
+++ b/libyul/Scope.h
@@ -25,8 +25,6 @@
 
 #include <libyul/YulString.h>
 
-#include <libsolutil/Visitor.h>
-
 #include <functional>
 #include <memory>
 #include <optional>

--- a/libyul/backends/evm/VariableReferenceCounter.cpp
+++ b/libyul/backends/evm/VariableReferenceCounter.cpp
@@ -1,0 +1,83 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Counts the number of references to a variable.
+ */
+#include <libyul/backends/evm/VariableReferenceCounter.h>
+#include <libyul/AsmAnalysisInfo.h>
+#include <libyul/AST.h>
+
+#include <libsolutil/Visitor.h>
+
+using namespace solidity::yul;
+
+void VariableReferenceCounter::operator()(Identifier const& _identifier)
+{
+	increaseRefIfFound(_identifier.name);
+}
+
+void VariableReferenceCounter::operator()(FunctionDefinition const& _function)
+{
+	Scope* originalScope = m_scope;
+
+	yulAssert(m_info.virtualBlocks.at(&_function), "");
+	m_scope = m_info.scopes.at(m_info.virtualBlocks.at(&_function).get()).get();
+	yulAssert(m_scope, "Variable scope does not exist.");
+
+	for (auto const& v: _function.returnVariables)
+		increaseRefIfFound(v.name);
+
+	(*this)(_function.body);
+
+	m_scope = originalScope;
+}
+
+void VariableReferenceCounter::operator()(ForLoop const& _forLoop)
+{
+	Scope* originalScope = m_scope;
+	// Special scoping rules.
+	m_scope = m_info.scopes.at(&_forLoop.pre).get();
+
+	walkVector(_forLoop.pre.statements);
+	visit(*_forLoop.condition);
+	(*this)(_forLoop.body);
+	(*this)(_forLoop.post);
+
+	m_scope = originalScope;
+}
+
+void VariableReferenceCounter::operator()(Block const& _block)
+{
+	Scope* originalScope = m_scope;
+	m_scope = m_info.scopes.at(&_block).get();
+
+	ASTWalker::operator()(_block);
+
+	m_scope = originalScope;
+}
+
+void VariableReferenceCounter::increaseRefIfFound(YulString _variableName)
+{
+	m_scope->lookup(_variableName, util::GenericVisitor{
+		[&](Scope::Variable const& _var)
+		{
+			++m_variableReferences[&_var];
+		},
+		[](Scope::Function const&) { }
+	});
+}

--- a/libyul/backends/evm/VariableReferenceCounter.h
+++ b/libyul/backends/evm/VariableReferenceCounter.h
@@ -1,0 +1,68 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Counts the number of references to a variable.
+ */
+#pragma once
+
+#include <libyul/optimiser/ASTWalker.h>
+#include <libyul/Scope.h>
+
+namespace solidity::yul
+{
+struct AsmAnalysisInfo;
+
+/**
+ * Counts the number of references to a variable. This includes actual (read) references
+ * but also assignments to the variable. It does not include the declaration itself or
+ * function parameters, but it does include function return parameters.
+ *
+ * This component can handle multiple variables of the same name.
+ *
+ * Can only be applied to strict assembly.
+ */
+struct VariableReferenceCounter: public yul::ASTWalker
+{
+public:
+	static std::map<Scope::Variable const*, unsigned> run(AsmAnalysisInfo const& _assemblyInfo, Block const& _block)
+	{
+		VariableReferenceCounter variableReferenceCounter(_assemblyInfo);
+		variableReferenceCounter(_block);
+		return std::move(variableReferenceCounter.m_variableReferences);
+	}
+
+protected:
+	void operator()(Block const& _block) override;
+	void operator()(Identifier const& _identifier) override;
+	void operator()(FunctionDefinition const&) override;
+	void operator()(ForLoop const&) override;
+
+private:
+	explicit VariableReferenceCounter(
+		AsmAnalysisInfo const& _assemblyInfo
+	): m_info(_assemblyInfo)
+	{}
+
+	void increaseRefIfFound(YulString _variableName);
+
+	AsmAnalysisInfo const& m_info;
+	Scope* m_scope = nullptr;
+	std::map<Scope::Variable const*, unsigned> m_variableReferences;
+};
+
+}


### PR DESCRIPTION
Refactoring in preparation of writing a new optimized code transform.