### PR TITLE
Disable assertion that gives non-deterministic results in slice tests for SMTChecker

### DIFF
--- a/test/libsolidity/smtCheckerTests/operators/slices_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/slices_3.sol
@@ -5,7 +5,8 @@ function f(int[] calldata b, uint256 start, uint256 end) public returns (int) {
     uint len = end - start;
     assert(len == s.length);
     for (uint i = 0; i < len; i++) {
-        assert(b[start:end][i] == s[i]);
+        // Removed because of Spacer nondeterminism.
+        //assert(b[start:end][i] == s[i]);
     }
     return s[0];
 }
@@ -13,5 +14,3 @@ function f(int[] calldata b, uint256 start, uint256 end) public returns (int) {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (226-257): CHC: Assertion violation might happen here.
-// Warning 4661: (226-257): BMC: Assertion violation happens here.


### PR DESCRIPTION
The assertion [makes `t_osx_soltest` fail](https://app.circleci.com/pipelines/github/ethereum/solidity/15022/workflows/18783d20-6c02-4ed5-af01-a37639a0c930/jobs/684667) in #11258.

```
slices_3 - smtCheckerTests.operators

failure

ASSERTION FAILURE:
- file   : boostTest.cpp
- line   : 121
- message: Test expectation mismatch.
Expected result:
  Warning 6328: (226-257): CHC: Assertion violation might happen here.
  Warning 4661: (226-257): BMC: Assertion violation happens here.
Obtained result:
  Warning 1218: (226-257): CHC: Error trying to invoke SMT solver.
  Warning 6328: (226-257): CHC: Assertion violation might happen here.
  Warning 4661: (226-257): BMC: Assertion violation happens here.
```
 