### PR TITLE
Remove the usage of boost::noncopyable

### DIFF
--- a/libevmasm/SimplificationRules.h
+++ b/libevmasm/SimplificationRules.h
@@ -29,8 +29,6 @@
 
 #include <libsolutil/CommonData.h>
 
-#include <boost/noncopyable.hpp>
-
 #include <functional>
 #include <vector>
 
@@ -47,9 +45,13 @@ class Pattern;
 /**
  * Container for all simplification rules.
  */
-class Rules: public boost::noncopyable
+class Rules
 {
 public:
+	/// Noncopyable.
+	Rules(Rules const&) = delete;
+	Rules& operator=(Rules const&) = delete;
+
 	using Expression = ExpressionClasses::Expression;
 
 	Rules();

--- a/libsmtutil/CVC4Interface.h
+++ b/libsmtutil/CVC4Interface.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <libsmtutil/SolverInterface.h>
-#include <boost/noncopyable.hpp>
 
 #if defined(__GLIBC__)
 // The CVC4 headers includes the deprecated system headers <ext/hash_map>
@@ -37,9 +36,13 @@
 namespace solidity::smtutil
 {
 
-class CVC4Interface: public SolverInterface, public boost::noncopyable
+class CVC4Interface: public SolverInterface
 {
 public:
+	/// Noncopyable.
+	CVC4Interface(CVC4Interface const&) = delete;
+	CVC4Interface& operator=(CVC4Interface const&) = delete;
+
 	CVC4Interface(std::optional<unsigned> _queryTimeout = {});
 
 	void reset() override;

--- a/libsmtutil/SMTLib2Interface.h
+++ b/libsmtutil/SMTLib2Interface.h
@@ -25,7 +25,6 @@
 #include <libsolutil/Common.h>
 #include <libsolutil/FixedHash.h>
 
-#include <boost/noncopyable.hpp>
 #include <cstdio>
 #include <map>
 #include <set>
@@ -35,9 +34,13 @@
 namespace solidity::smtutil
 {
 
-class SMTLib2Interface: public SolverInterface, public boost::noncopyable
+class SMTLib2Interface: public SolverInterface
 {
 public:
+	/// Noncopyable.
+	SMTLib2Interface(SMTLib2Interface const&) = delete;
+	SMTLib2Interface& operator=(SMTLib2Interface const&) = delete;
+
 	explicit SMTLib2Interface(
 		std::map<util::h256, std::string> _queryResponses = {},
 		frontend::ReadCallback::Callback _smtCallback = {},

--- a/libsmtutil/SMTPortfolio.h
+++ b/libsmtutil/SMTPortfolio.h
@@ -23,7 +23,6 @@
 #include <libsolidity/interface/ReadFile.h>
 #include <libsolutil/FixedHash.h>
 
-#include <boost/noncopyable.hpp>
 #include <map>
 #include <vector>
 
@@ -36,9 +35,13 @@ namespace solidity::smtutil
  * It also checks whether different solvers give conflicting answers
  * to SMT queries.
  */
-class SMTPortfolio: public SolverInterface, public boost::noncopyable
+class SMTPortfolio: public SolverInterface
 {
 public:
+	/// Noncopyable.
+	SMTPortfolio(SMTPortfolio const&) = delete;
+	SMTPortfolio& operator=(SMTPortfolio const&) = delete;
+
 	SMTPortfolio(
 		std::map<util::h256, std::string> _smtlib2Responses = {},
 		frontend::ReadCallback::Callback _smtCallback = {},

--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -23,7 +23,6 @@
 
 #include <libsolutil/Common.h>
 
-#include <boost/noncopyable.hpp>
 #include <cstdio>
 #include <map>
 #include <memory>

--- a/libsmtutil/Z3Interface.h
+++ b/libsmtutil/Z3Interface.h
@@ -19,15 +19,18 @@
 #pragma once
 
 #include <libsmtutil/SolverInterface.h>
-#include <boost/noncopyable.hpp>
 #include <z3++.h>
 
 namespace solidity::smtutil
 {
 
-class Z3Interface: public SolverInterface, public boost::noncopyable
+class Z3Interface: public SolverInterface
 {
 public:
+	/// Noncopyable.
+	Z3Interface(Z3Interface const&) = delete;
+	Z3Interface& operator=(Z3Interface const&) = delete;
+
 	Z3Interface(std::optional<unsigned> _queryTimeout = {});
 
 	static bool available();

--- a/libsolidity/analysis/DeclarationContainer.h
+++ b/libsolidity/analysis/DeclarationContainer.h
@@ -26,7 +26,6 @@
 #include <libsolidity/ast/ASTForward.h>
 #include <liblangutil/Exceptions.h>
 #include <liblangutil/SourceLocation.h>
-#include <boost/noncopyable.hpp>
 
 namespace solidity::frontend
 {

--- a/libsolidity/analysis/DeclarationTypeChecker.h
+++ b/libsolidity/analysis/DeclarationTypeChecker.h
@@ -22,7 +22,6 @@
 #include <libsolidity/ast/ASTAnnotations.h>
 #include <liblangutil/EVMVersion.h>
 
-#include <boost/noncopyable.hpp>
 #include <list>
 #include <map>
 

--- a/libsolidity/analysis/GlobalContext.h
+++ b/libsolidity/analysis/GlobalContext.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <libsolidity/ast/ASTForward.h>
-#include <boost/noncopyable.hpp>
 #include <map>
 #include <memory>
 #include <string>
@@ -41,9 +40,13 @@ class Type; // forward
  * @note must not be destroyed or moved during compilation as its objects can be referenced from
  * other objects.
  */
-class GlobalContext: private boost::noncopyable
+class GlobalContext
 {
 public:
+	/// Noncopyable.
+	GlobalContext(GlobalContext const&) = delete;
+	GlobalContext& operator=(GlobalContext const&) = delete;
+
 	GlobalContext();
 	void setCurrentContract(ContractDefinition const& _contract);
 	void resetCurrentContract() { m_currentContract = nullptr; }

--- a/libsolidity/analysis/NameAndTypeResolver.h
+++ b/libsolidity/analysis/NameAndTypeResolver.h
@@ -31,8 +31,6 @@
 
 #include <liblangutil/EVMVersion.h>
 
-#include <boost/noncopyable.hpp>
-
 #include <list>
 #include <map>
 
@@ -48,9 +46,13 @@ namespace solidity::frontend
  * Resolves name references, typenames and sets the (explicitly given) types for all variable
  * declarations.
  */
-class NameAndTypeResolver: private boost::noncopyable
+class NameAndTypeResolver
 {
 public:
+	/// Noncopyable.
+	NameAndTypeResolver(NameAndTypeResolver const&) = delete;
+	NameAndTypeResolver& operator=(NameAndTypeResolver const&) = delete;
+
 	/// Creates the resolver with the given declarations added to the global scope.
 	/// @param _scopes mapping of scopes to be used (usually default constructed), these
 	/// are filled during the lifetime of this object.

--- a/libsolidity/analysis/ReferencesResolver.h
+++ b/libsolidity/analysis/ReferencesResolver.h
@@ -28,7 +28,6 @@
 #include <liblangutil/EVMVersion.h>
 #include <libyul/optimiser/ASTWalker.h>
 
-#include <boost/noncopyable.hpp>
 #include <list>
 #include <map>
 

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -34,7 +34,6 @@
 #include <libsolutil/FixedHash.h>
 #include <libsolutil/LazyInit.h>
 
-#include <boost/noncopyable.hpp>
 #include <json/json.h>
 
 #include <memory>
@@ -62,9 +61,13 @@ class ASTConstVisitor;
  * It is possible to traverse all direct and indirect children of an AST node by calling
  * accept, providing an ASTVisitor.
  */
-class ASTNode: private boost::noncopyable
+class ASTNode
 {
 public:
+	/// Noncopyable.
+	ASTNode(ASTNode const&) = delete;
+	ASTNode& operator=(ASTNode const&) = delete;
+
 	using CompareByID = frontend::ASTCompareByID<ASTNode>;
 	using SourceLocation = langutil::SourceLocation;
 

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -31,7 +31,6 @@
 #include <liblangutil/SourceLocation.h>
 #include <libsolutil/Common.h>
 
-#include <boost/noncopyable.hpp>
 #include <functional>
 #include <memory>
 

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -45,7 +45,6 @@
 #include <libsolutil/FixedHash.h>
 #include <libsolutil/LazyInit.h>
 
-#include <boost/noncopyable.hpp>
 #include <json/json.h>
 
 #include <functional>
@@ -88,9 +87,13 @@ class DeclarationContainer;
  * If error recovery is active, it is possible to progress through the stages even when
  * there are errors. In any case, producing code is only possible without errors.
  */
-class CompilerStack: boost::noncopyable
+class CompilerStack
 {
 public:
+	/// Noncopyable.
+	CompilerStack(CompilerStack const&) = delete;
+	CompilerStack& operator=(CompilerStack const&) = delete;
+
 	enum State {
 		Empty,
 		SourcesSet,

--- a/libsolidity/interface/ReadFile.h
+++ b/libsolidity/interface/ReadFile.h
@@ -20,16 +20,19 @@
 
 #include <liblangutil/Exceptions.h>
 
-#include <boost/noncopyable.hpp>
 #include <functional>
 #include <string>
 
 namespace solidity::frontend
 {
 
-class ReadCallback: boost::noncopyable
+class ReadCallback
 {
 public:
+	/// Noncopyable.
+	ReadCallback(ReadCallback const&) = delete;
+	ReadCallback& operator=(ReadCallback const&) = delete;
+
 	/// File reading or generic query result.
 	struct Result
 	{

--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -36,9 +36,13 @@ namespace solidity::frontend
  * Standard JSON compiler interface, which expects a JSON input and returns a JSON output.
  * See docs/using-the-compiler#compiler-input-and-output-json-description.
  */
-class StandardCompiler: boost::noncopyable
+class StandardCompiler
 {
 public:
+	/// Noncopyable.
+	StandardCompiler(StandardCompiler const&) = delete;
+	StandardCompiler& operator=(StandardCompiler const&) = delete;
+
 	/// Creates a new StandardCompiler.
 	/// @param _readFile callback used to read files for import statements. Must return
 	/// and must not emit exceptions.

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -25,8 +25,6 @@
 #include <libyul/SideEffects.h>
 #include <libyul/ControlFlowSideEffects.h>
 
-#include <boost/noncopyable.hpp>
-
 #include <vector>
 #include <set>
 #include <optional>
@@ -57,8 +55,12 @@ struct BuiltinFunction
 	}
 };
 
-struct Dialect: boost::noncopyable
+struct Dialect
 {
+	/// Noncopiable.
+	Dialect(Dialect const&) = delete;
+	Dialect& operator=(Dialect const&) = delete;
+
 	/// Default type, can be omitted.
 	YulString defaultType;
 	/// Type used for the literals "true" and "false".

--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -21,8 +21,6 @@
 
 #pragma once
 
-#include <boost/noncopyable.hpp>
-
 #include <unordered_map>
 #include <memory>
 #include <vector>

--- a/libyul/optimiser/SimplificationRules.h
+++ b/libyul/optimiser/SimplificationRules.h
@@ -31,8 +31,6 @@
 #include <liblangutil/EVMVersion.h>
 #include <liblangutil/SourceLocation.h>
 
-#include <boost/noncopyable.hpp>
-
 #include <functional>
 #include <optional>
 #include <vector>
@@ -46,9 +44,13 @@ class Pattern;
 /**
  * Container for all simplification rules.
  */
-class SimplificationRules: public boost::noncopyable
+class SimplificationRules
 {
 public:
+	/// Noncopiable.
+	SimplificationRules(SimplificationRules const&) = delete;
+	SimplificationRules& operator=(SimplificationRules const&) = delete;
+
 	using Rule = evmasm::SimplificationRule<Pattern>;
 
 	explicit SimplificationRules(std::optional<langutil::EVMVersion> _evmVersion = std::nullopt);

--- a/test/Common.h
+++ b/test/Common.h
@@ -24,7 +24,6 @@
 #include <test/evmc/evmc.h>
 
 #include <boost/filesystem/path.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/program_options.hpp>
 
 namespace solidity::test
@@ -49,8 +48,12 @@ static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases
 
 struct ConfigException : public util::Exception {};
 
-struct CommonOptions: boost::noncopyable
+struct CommonOptions
 {
+	/// Noncopyable.
+	CommonOptions(CommonOptions const&) = delete;
+	CommonOptions& operator=(CommonOptions const&) = delete;
+
 	std::vector<boost::filesystem::path> vmPaths;
 	boost::filesystem::path testPath;
 	bool ewasm = false;


### PR DESCRIPTION
Part of #7259.

Prior to this half of the codebase used explicit deleted copy constructors, the others used boost::noncopyable. I do not care which approach we take, but would prefer we follow a single one and not a mix as of today.

Disclaimer: I did this a while back, but felt never is a good time submitting more refactorings 😬 
