### PR TITLE
[DOCS] Removed an overflow check and rely on checked arithmetic

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -105,7 +105,6 @@ registering with a username and password, all you need is an Ethereum keypair.
         // Can only be called by the contract creator
         function mint(address receiver, uint amount) public {
             require(msg.sender == minter);
-            require(amount < 1e60);
             balances[receiver] += amount;
         }
 
@@ -205,10 +204,15 @@ always the address where the current (external) function call came from.
 
 The functions that make up the contract, and that users and contracts can call are ``mint`` and ``send``.
 
-The ``mint`` function sends an amount of newly created coins to another address.
-The :ref:`require <assert-and-require>` function call defines conditions that reverts all changes if not met.
-In this example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call ``mint``,
-and ``require(amount < 1e60);`` ensures a maximum amount of tokens. This ensures that there are no overflow errors in the future.
+The ``mint`` function sends an amount of newly created coins to another address. The :ref:`require
+<assert-and-require>` function call defines conditions that reverts all changes if not met. In this
+example, ``require(msg.sender == minter);`` ensures that only the creator of the contract can call
+``mint``. In general, the creator can mint as many tokens as they like, but at some point, this will
+lead to a phenomenon called "overflow". Note that because of the default :ref:`Checked arithmetic
+<unchecked>`, the transaction would revert if the expression ``balances[receiver] += amount;``
+overflows, i.e., when ``balances[receiver] + amount`` in arbitrary precision arithmetic is larger
+than the maximum value of ``uint`` (``2**256 - 1``). This is also true for the statement
+``balances[receiver] += amount;`` in the function ``send``.
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the


### PR DESCRIPTION
The check `require(amount < 1e60);` was removed because it's rather confusing to reason why it
prevents overflow.

Co-authored-by: Wade Dorrell <wade@dorrells.org>

Replaces https://github.com/ethereum/solidity/pull/11207. Fixed the PR comment: https://github.com/ethereum/solidity/pull/11207#discussion_r615677996