### PR TITLE
ControlFlowAnalyzer: Use temporary reference for more readable code

### DIFF
--- a/libsolidity/analysis/ControlFlowAnalyzer.cpp
+++ b/libsolidity/analysis/ControlFlowAnalyzer.cpp
@@ -134,18 +134,20 @@ void ControlFlowAnalyzer::checkUninitializedAccess(CFGNode const* _entry, CFGNod
 
 		for (auto const* variableOccurrence: uninitializedAccessesOrdered)
 		{
+			VariableDeclaration const& varDecl = variableOccurrence->declaration();
+
 			SecondarySourceLocation ssl;
 			if (variableOccurrence->occurrence())
-				ssl.append("The variable was declared here.", variableOccurrence->declaration().location());
+				ssl.append("The variable was declared here.", varDecl.location());
 
-			bool isStorage = variableOccurrence->declaration().type()->dataStoredIn(DataLocation::Storage);
-			bool isCalldata = variableOccurrence->declaration().type()->dataStoredIn(DataLocation::CallData);
+			bool isStorage = varDecl.type()->dataStoredIn(DataLocation::Storage);
+			bool isCalldata = varDecl.type()->dataStoredIn(DataLocation::CallData);
 			if (isStorage || isCalldata)
 				m_errorReporter.typeError(
 					3464_error,
 					variableOccurrence->occurrence() ?
 						*variableOccurrence->occurrence() :
-						variableOccurrence->declaration().location(),
+						varDecl.location(),
 					ssl,
 					"This variable is of " +
 					string(isStorage ? "storage" : "calldata") +
@@ -153,10 +155,10 @@ void ControlFlowAnalyzer::checkUninitializedAccess(CFGNode const* _entry, CFGNod
 					(variableOccurrence->kind() == VariableOccurrence::Kind::Return ? "returned" : "accessed") +
 					" without prior assignment, which would lead to undefined behaviour."
 				);
-			else if (!_emptyBody && variableOccurrence->declaration().name().empty())
+			else if (!_emptyBody && varDecl.name().empty())
 				m_errorReporter.warning(
 					6321_error,
-					variableOccurrence->declaration().location(),
+					varDecl.location(),
 					"Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable."
 				);
 		}


### PR DESCRIPTION
This was extracted from the large controlflow PR.