### PR TITLE
optimizationPreset setting in object compiler tests + refactor

### DIFF
--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -23,11 +23,21 @@
 
 #pragma once
 
+#include <liblangutil/Exceptions.h>
+
 #include <cstddef>
 #include <string>
 
 namespace solidity::frontend
 {
+
+enum class OptimisationPreset
+{
+	None,
+	Minimal,
+	Standard,
+	Full,
+};
 
 struct OptimiserSettings
 {
@@ -82,6 +92,18 @@ struct OptimiserSettings
 	static OptimiserSettings full()
 	{
 		return standard();
+	}
+
+	static OptimiserSettings preset(OptimisationPreset _preset)
+	{
+		switch (_preset)
+		{
+			case OptimisationPreset::None: return none();
+			case OptimisationPreset::Minimal: return minimal();
+			case OptimisationPreset::Standard: return standard();
+			case OptimisationPreset::Full: return full();
+			default: solAssert(false, "");
+		}
 	}
 
 	bool operator==(OptimiserSettings const& _other) const

--- a/test/TestCaseReader.cpp
+++ b/test/TestCaseReader.cpp
@@ -18,18 +18,12 @@
 
 #include <test/TestCaseReader.h>
 
-#include <libsolidity/parsing/Parser.h>
-#include <libsolutil/StringUtils.h>
 #include <libsolutil/CommonIO.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/throw_exception.hpp>
 #include <boost/filesystem.hpp>
 
-#include <range/v3/view/map.hpp>
-
 using namespace std;
-using namespace solidity::langutil;
 using namespace solidity::frontend::test;
 
 namespace fs = boost::filesystem;
@@ -162,7 +156,7 @@ pair<SourceMap, size_t> TestCaseReader::parseSourcesAndSettingsWithLineNumber(is
 				else
 					externalSourceName = externalSourceString;
 
-				solAssert(!externalSourceName.empty(), "");
+				soltestAssert(!externalSourceName.empty(), "");
 				fs::path externalSourceTarget(externalSourceString);
 				fs::path testCaseParentDir = m_fileName.parent_path();
 				if (!externalSourceTarget.is_relative())

--- a/test/libsolidity/util/SoltestErrors.h
+++ b/test/libsolidity/util/SoltestErrors.h
@@ -25,7 +25,7 @@ namespace solidity::frontend::test
 	do \
 	{ \
 		if (!(CONDITION)) \
-			BOOST_THROW_EXCEPTION(runtime_error(DESCRIPTION)); \
+			BOOST_THROW_EXCEPTION(std::runtime_error(DESCRIPTION)); \
 	} \
 	while (false)
 

--- a/test/libyul/ObjectCompilerTest.cpp
+++ b/test/libyul/ObjectCompilerTest.cpp
@@ -18,6 +18,8 @@
 
 #include <test/libyul/ObjectCompilerTest.h>
 
+#include <test/libsolidity/util/SoltestErrors.h>
+
 #include <libsolutil/AnsiColorized.h>
 
 #include <libyul/AssemblyStack.h>
@@ -43,7 +45,16 @@ ObjectCompilerTest::ObjectCompilerTest(string const& _filename):
 	TestCase(_filename)
 {
 	m_source = m_reader.source();
-	m_optimize = m_reader.boolSetting("optimize", false);
+	m_optimisationPreset = m_reader.enumSetting<OptimisationPreset>(
+		"optimizationPreset",
+		{
+			{"none", OptimisationPreset::None},
+			{"minimal", OptimisationPreset::Minimal},
+			{"standard", OptimisationPreset::Standard},
+			{"full", OptimisationPreset::Full},
+		},
+		"minimal"
+	);
 	m_wasm = m_reader.boolSetting("wasm", false);
 	m_expectation = m_reader.simpleExpectations();
 }
@@ -53,7 +64,7 @@ TestCase::TestResult ObjectCompilerTest::run(ostream& _stream, string const& _li
 	AssemblyStack stack(
 		EVMVersion(),
 		m_wasm ? AssemblyStack::Language::Ewasm : AssemblyStack::Language::StrictAssembly,
-		m_optimize ? OptimiserSettings::full() : OptimiserSettings::minimal()
+		OptimiserSettings::preset(m_optimisationPreset)
 	);
 	if (!stack.parseAndAnalyze("source", m_source))
 	{

--- a/test/libyul/ObjectCompilerTest.h
+++ b/test/libyul/ObjectCompilerTest.h
@@ -20,6 +20,8 @@
 
 #include <test/TestCase.h>
 
+#include <libsolidity/interface/OptimiserSettings.h>
+
 namespace solidity::langutil
 {
 class Scanner;
@@ -54,7 +56,7 @@ private:
 
 	static void printErrors(std::ostream& _stream, langutil::ErrorList const& _errors);
 
-	bool m_optimize = false;
+	frontend::OptimisationPreset m_optimisationPreset;
 	bool m_wasm = false;
 };
 

--- a/test/libyul/objectCompiler/function_series.yul
+++ b/test/libyul/objectCompiler/function_series.yul
@@ -6,6 +6,8 @@ object "Contract" {
   }
 }
 
+// ====
+// optimizationPreset: none
 // ----
 // Assembly:
 //     /* "source":33:48   */

--- a/test/libyul/objectCompiler/jump_tags.yul
+++ b/test/libyul/objectCompiler/jump_tags.yul
@@ -6,6 +6,8 @@ object "Contract" {
   }
 }
 
+// ====
+// optimizationPreset: none
 // ----
 // Assembly:
 //     /* "source":33:54   */

--- a/test/libyul/objectCompiler/long_object_name.yul
+++ b/test/libyul/objectCompiler/long_object_name.yul
@@ -7,7 +7,7 @@ object "t" {
 	}
 }
 // ====
-// optimize: true
+// optimizationPreset: full
 // ----
 // Assembly:
 //     /* "source":23:147   */

--- a/test/libyul/objectCompiler/nested_optimizer.yul
+++ b/test/libyul/objectCompiler/nested_optimizer.yul
@@ -15,7 +15,7 @@ object "a" {
   }
 }
 // ====
-// optimize: true
+// optimizationPreset: full
 // ----
 // Assembly:
 //     /* "source":48:49   */

--- a/test/libyul/objectCompiler/simple_optimizer.yul
+++ b/test/libyul/objectCompiler/simple_optimizer.yul
@@ -5,7 +5,7 @@
   sstore(add(x, 0), z)
 }
 // ====
-// optimize: true
+// optimizationPreset: full
 // ----
 // Assembly:
 //     /* "source":26:27   */


### PR DESCRIPTION
Adds a way to disable the optimizer for https://github.com/ethereum/solidity/pull/10286#discussion_r618645372 + a bunch of refactors to make the implementation neater.

- Adds `OptimisationPreset` enum and `OptimiserSettings preset()` that uses it.
- Adds `TestCaseReader::enumSetting()` as a convenience helper for settings backed by enums rather than strings.
- Replaces the boolean `optimize` setting in `ObjectCompilerTest` with one that allows selecting an optimization preset.
- Switches `optimizationPreset` to `none` in those tests that assume that there is no optimization.