### PR TITLE
Switch from archlinux/base to archlinux:base image in CI and add a workaround for runc breakage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,9 @@ jobs:
 
   b_archlinux:
     docker:
-      - image: archlinux:base
+      # FIXME: Newer releases won't work until CircleCI updates its host machines.
+      # See https://github.com/ethereum/solidity/pull/11332
+      - image: archlinux:base-20210131.0.14634
     environment:
       TERM: xterm
       MAKEFLAGS: -j 3
@@ -710,7 +712,9 @@ jobs:
 
   t_archlinux_soltest: &t_archlinux_soltest
       docker:
-        - image: archlinux:base
+        # FIXME: Newer releases won't work until CircleCI updates its host machines.
+        # See https://github.com/ethereum/solidity/pull/11332
+        - image: archlinux:base-20210131.0.14634
       environment:
         EVM: constantinople
         OPTIMIZE: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,7 @@ jobs:
 
   b_archlinux:
     docker:
-      - image: archlinux/base
+      - image: archlinux:base
     environment:
       TERM: xterm
       MAKEFLAGS: -j 3
@@ -710,7 +710,7 @@ jobs:
 
   t_archlinux_soltest: &t_archlinux_soltest
       docker:
-        - image: archlinux/base
+        - image: archlinux:base
       environment:
         EVM: constantinople
         OPTIMIZE: 0


### PR DESCRIPTION
Our `b_archlinux` jobs in all PRs are failing (see for example [this `b_archlinux` run on `develop`](https://app.circleci.com/pipelines/github/ethereum/solidity/15547/workflows/36b3b079-843a-4af6-9c6b-e933520b4a2e/jobs/705625)).

```
  image cache not found on this host, downloading archlinux/base

Error response from daemon: pull access denied for archlinux/base, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

Looks like [`archlinux/base` image we've been using is gone](https://hub.docker.com/r/archlinux/base/).

Found a thread about it on Arch forum: [Confused about two DockerHub "archlinux" images available](https://bbs.archlinux.org/viewtopic.php?id=255272). So it appears that `archlinux/base` and `archlinux:base` were two different images, but both official. There were plans to remove the former and it's probably what happened. There's `archlinux/archlinux:base` available now and I suspect it's the same as `archlinux/base` but `archlinux:base` seems to be better suited to CI (it's smaller) so in this PR I'm trying to switch us to that.