### PR TITLE
Remove import of ranges namespace.

### DIFF
--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -46,7 +46,6 @@
 #include <variant>
 
 using namespace std;
-using namespace ranges;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::frontend;
@@ -80,7 +79,7 @@ set<CallableDeclaration const*, ASTNode::CompareByID> collectReachableCallables(
 )
 {
 	set<CallableDeclaration const*, ASTNode::CompareByID> reachableCallables;
-	for (CallGraph::Node const& reachableNode: _graph.edges | views::keys)
+	for (CallGraph::Node const& reachableNode: _graph.edges | ranges::views::keys)
 		if (holds_alternative<CallableDeclaration const*>(reachableNode))
 			reachableCallables.emplace(get<CallableDeclaration const*>(reachableNode));
 


### PR DESCRIPTION
``ranges`` generally conflicts with ``std``, so since we import ``std`` we should **never** import ``ranges`` in *any* source file.
Doing so will cause random issues, even if it seems to work at first. Once any unrelated common header, e.g. ``CommonData.h`` or the like, wants to include any `ranges` functionality that has a counterpart in `std` used in that source file, things will break.