### PR TITLE
Update evmone and boost download links in docker images.

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -29,7 +29,7 @@
 #   make version=2.0.12 build
 #
 FROM emscripten/emsdk:2.0.12 AS base
-LABEL version="4"
+LABEL version="5"
 
 ADD emscripten.jam /usr/src
 RUN set -ex; \
@@ -51,7 +51,8 @@ RUN set -ex; \
 	make ; make install; \
 	rm -r /usr/src/z3; \
 	cd /usr/src; \
-	wget -q 'https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2' -O boost.tar.bz2; \
+
+	wget -q 'https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2' -O boost.tar.bz2; \
 	test "$(sha256sum boost.tar.bz2)" = "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb  boost.tar.bz2"; \
 	tar -xf boost.tar.bz2; \
 	rm boost.tar.bz2; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -104,7 +104,7 @@ RUN set -ex; \
 # HERA
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.3.2" --depth 1 --recurse-submodules https://github.com/ewasm/hera.git; \
+	git clone --branch="v0.3.2-evmc8" --depth 1 --recurse-submodules https://github.com/ewasm/hera.git; \
 	cd hera; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang as base
-LABEL version="8"
+LABEL version="9"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -45,7 +45,7 @@ FROM base AS libraries
 # Boost
 RUN set -ex; \
     cd /usr/src; \
-    wget -q 'https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
+    wget -q 'https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
     test "$(sha256sum boost.tar.bz2)" = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402  boost.tar.bz2"; \
     tar -xf boost.tar.bz2; \
     rm boost.tar.bz2; \
@@ -92,7 +92,7 @@ RUN set -ex; \
 # EVMONE
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.4.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
+	git clone --branch="v0.7.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
 	cd evmone; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -60,7 +60,7 @@ RUN set -ex; \
 # HERA
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.3.2" --depth 1 --recurse-submodules https://github.com/ewasm/hera.git; \
+	git clone --branch="v0.3.2-evmc8" --depth 1 --recurse-submodules https://github.com/ewasm/hera.git; \
 	cd hera; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="5"
+LABEL version="6"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -48,7 +48,7 @@ FROM base AS libraries
 # EVMONE
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.4.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
+	git clone --branch="v0.7.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
 	cd evmone; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -62,7 +62,7 @@ RUN set -ex; \
 # HERA
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.3.2" --depth 1 --recurse-submodules https://github.com/ewasm/hera.git; \
+	git clone --branch="v0.3.2-evmc8" --depth 1 --recurse-submodules https://github.com/ewasm/hera.git; \
 	cd hera; \
 	mkdir build; \
 	cd build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="5"
+LABEL version="6"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -50,7 +50,7 @@ ENV CXX clang++
 # EVMONE
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.4.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
+	git clone --branch="v0.7.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
 	cd evmone; \
 	mkdir build; \
 	cd build; \


### PR DESCRIPTION
Build the required docker images for https://github.com/ethereum/solidity/pull/11286/