### PR TITLE
[SMTChecker] Assign cast from constants directly

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1113,6 +1113,14 @@ void SMTEncoder::visitTypeConversion(FunctionCall const& _funCall)
 	{
 		solAssert(smt::isNumber(*funCallType), "");
 
+		RationalNumberType const* rationalType = isConstant(*argument);
+		if (rationalType)
+		{
+			// The TypeChecker guarantees that a constant fits in the cast size.
+			defineExpr(_funCall, symbArg);
+			return;
+		}
+
 		auto const* fixedCast = dynamic_cast<FixedBytesType const*>(funCallType);
 		auto const* fixedArg = dynamic_cast<FixedBytesType const*>(argType);
 		if (fixedCast && fixedArg)


### PR DESCRIPTION
Currently something like `bytes8(0)` would compute bitvector operations to assign the constant, even though it could be assigned directly. This PR adds code that shortcuts casts from constants, removing the more complicated bv operations. The operation is safe without extra checks since the TypeChecker guarantees that a constant fits the cast size at that point.