### PR TITLE
Expose TemporaryDirectory helper

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,9 @@ set(sources
     InteractiveTests.h
     Metadata.cpp
     Metadata.h
+    TemporaryDirectory.cpp
+    TemporaryDirectory.h
+    TemporaryDirectoryTest.cpp
     TestCase.cpp
     TestCase.h
     TestCaseReader.cpp

--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -31,7 +31,7 @@ using namespace solidity::test;
 namespace fs = boost::filesystem;
 
 TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
-	m_path((fs::temp_directory_path() / fs::unique_path(_prefix + "%%%%-%%%%-%%%%-%%%%")).string())
+	m_path(fs::temp_directory_path() / fs::unique_path(_prefix + "%%%%-%%%%-%%%%-%%%%"))
 {
 	// Prefix should just be a file name and not contain anything that would make us step out of /tmp.
 	assert(fs::path(_prefix) == fs::path(_prefix).stem());
@@ -42,10 +42,10 @@ TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
 TemporaryDirectory::~TemporaryDirectory()
 {
 	// A few paranoid sanity checks just to be extra sure we're not deleting someone's homework.
-	assert(m_path.find(fs::temp_directory_path().string()) == 0);
-	assert(fs::path(m_path) != fs::temp_directory_path());
-	assert(fs::path(m_path) != fs::path(m_path).root_path());
-	assert(!fs::path(m_path).empty());
+	assert(m_path.string().find(fs::temp_directory_path().string()) == 0);
+	assert(m_path != fs::temp_directory_path());
+	assert(m_path != m_path.root_path());
+	assert(!m_path.empty());
 
 	boost::system::error_code errorCode;
 	uintmax_t numRemoved = fs::remove_all(m_path, errorCode);
@@ -55,11 +55,4 @@ TemporaryDirectory::~TemporaryDirectory()
 		cerr << "Only " << numRemoved << " files were actually removed." << endl;
 		cerr << "Reason: " << errorCode.message() << endl;
 	}
-}
-
-string TemporaryDirectory::memberPath(string const& _relativePath) const
-{
-	assert(fs::path(_relativePath).is_relative());
-
-	return (fs::path(m_path) / _relativePath).string();
 }

--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -1,0 +1,65 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/TemporaryDirectory.h>
+
+#include <boost/filesystem.hpp>
+
+#include <cassert>
+#include <regex>
+#include <iostream>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::test;
+
+namespace fs = boost::filesystem;
+
+TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
+	m_path((fs::temp_directory_path() / fs::unique_path(_prefix + "%%%%-%%%%-%%%%-%%%%")).string())
+{
+	// Prefix should just be a file name and not contain anything that would make us step out of /tmp.
+	assert(fs::path(_prefix) == fs::path(_prefix).stem());
+
+	fs::create_directory(m_path);
+}
+
+TemporaryDirectory::~TemporaryDirectory()
+{
+	// A few paranoid sanity checks just to be extra sure we're not deleting someone's homework.
+	assert(m_path.find(fs::temp_directory_path().string()) == 0);
+	assert(fs::path(m_path) != fs::temp_directory_path());
+	assert(fs::path(m_path) != fs::path(m_path).root_path());
+	assert(!fs::path(m_path).empty());
+
+	boost::system::error_code errorCode;
+	uintmax_t numRemoved = fs::remove_all(m_path, errorCode);
+	if (errorCode.value() != boost::system::errc::success)
+	{
+		cerr << "Failed to completely remove temporary directory '" << m_path << "'. ";
+		cerr << "Only " << numRemoved << " files were actually removed." << endl;
+		cerr << "Reason: " << errorCode.message() << endl;
+	}
+}
+
+string TemporaryDirectory::memberPath(string const& _relativePath) const
+{
+	assert(fs::path(_relativePath).is_relative());
+
+	return (fs::path(m_path) / _relativePath).string();
+}

--- a/test/TemporaryDirectory.h
+++ b/test/TemporaryDirectory.h
@@ -1,0 +1,52 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Utility for creating temporary directories for use in tests.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace solidity::test
+{
+
+/**
+ * An object that creates a unique temporary directory and automatically deletes it and its
+ * content upon being destroyed.
+ *
+ * The directory is guaranteed to be newly created and empty. Directory names are generated
+ * randomly. If a directory with the same name already exists (very unlikely but possible) the
+ * object won't reuse it and will fail with an exception instead.
+ */
+class TemporaryDirectory
+{
+public:
+	TemporaryDirectory(std::string const& _prefix = "solidity-test-");
+	~TemporaryDirectory();
+
+	std::string const& path() const { return m_path; }
+
+	/// Converts a path relative to the directory held by the object into an absolute one.
+	std::string memberPath(std::string const& _relativePath) const;
+
+private:
+	std::string m_path;
+};
+
+}

--- a/test/TemporaryDirectory.h
+++ b/test/TemporaryDirectory.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <boost/filesystem.hpp>
+
 #include <string>
 
 namespace solidity::test
@@ -40,13 +42,10 @@ public:
 	TemporaryDirectory(std::string const& _prefix = "solidity-test-");
 	~TemporaryDirectory();
 
-	std::string const& path() const { return m_path; }
-
-	/// Converts a path relative to the directory held by the object into an absolute one.
-	std::string memberPath(std::string const& _relativePath) const;
+	boost::filesystem::path const& path() const { return m_path; }
 
 private:
-	std::string m_path;
+	boost::filesystem::path m_path;
 };
 
 }

--- a/test/TemporaryDirectoryTest.cpp
+++ b/test/TemporaryDirectoryTest.cpp
@@ -66,30 +66,6 @@ BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_
 	BOOST_TEST(!fs::exists(dirPath / "test-file.txt"));
 }
 
-BOOST_AUTO_TEST_CASE(TemporaryDirectory_memberPath_should_construct_paths_relative_to_the_temporary_directory)
-{
-	TemporaryDirectory tempDir("temporary-directory-test-");
-
-	BOOST_TEST(fs::equivalent(tempDir.memberPath(""), tempDir.path()));
-	BOOST_TEST(fs::equivalent(tempDir.memberPath("."), tempDir.path() / fs::path(".")));
-	BOOST_TEST(fs::equivalent(tempDir.memberPath(".."), tempDir.path() / fs::path("..")));
-
-	// NOTE: fs::equivalent() only works with paths that actually exist
-	{
-		ofstream file;
-		file.open(tempDir.memberPath("file.txt"), ios::out);
-	}
-	BOOST_TEST(fs::equivalent(tempDir.memberPath("file.txt"), tempDir.path() / fs::path("file.txt")));
-
-	{
-		fs::create_directories(tempDir.memberPath("a/b/"));
-
-		ofstream file;
-		file.open(tempDir.memberPath("a/b/file.txt"), ios::out);
-	}
-	BOOST_TEST(fs::equivalent(tempDir.memberPath("a/b/file.txt"), tempDir.path() / fs::path("a") / fs::path("b") / fs::path("file.txt")));
-}
-
 BOOST_AUTO_TEST_SUITE_END()
 
 }

--- a/test/TemporaryDirectoryTest.cpp
+++ b/test/TemporaryDirectoryTest.cpp
@@ -1,0 +1,95 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/TemporaryDirectory.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <fstream>
+
+using namespace std;
+using namespace boost::test_tools;
+
+namespace fs = boost::filesystem;
+
+namespace solidity::test
+{
+
+BOOST_AUTO_TEST_SUITE(TemporaryDirectoryTest)
+
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_create_and_delete_a_unique_and_empty_directory)
+{
+	fs::path dirPath;
+	{
+		TemporaryDirectory tempDir("temporary-directory-test-");
+		dirPath = tempDir.path();
+
+		BOOST_TEST(dirPath.stem().string().find("temporary-directory-test-") == 0);
+		BOOST_TEST(fs::equivalent(dirPath.parent_path(), fs::temp_directory_path()));
+		BOOST_TEST(fs::is_directory(dirPath));
+		BOOST_TEST(fs::is_empty(dirPath));
+	}
+	BOOST_TEST(!fs::exists(dirPath));
+}
+
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_empty)
+{
+	fs::path dirPath;
+	{
+		TemporaryDirectory tempDir("temporary-directory-test-");
+		dirPath = tempDir.path();
+
+		BOOST_TEST(fs::is_directory(dirPath));
+
+		{
+			ofstream tmpFile((dirPath / "test-file.txt").string());
+			tmpFile << "Delete me!" << endl;
+		}
+		assert(fs::is_regular_file(dirPath / "test-file.txt"));
+	}
+	BOOST_TEST(!fs::exists(dirPath / "test-file.txt"));
+}
+
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_memberPath_should_construct_paths_relative_to_the_temporary_directory)
+{
+	TemporaryDirectory tempDir("temporary-directory-test-");
+
+	BOOST_TEST(fs::equivalent(tempDir.memberPath(""), tempDir.path()));
+	BOOST_TEST(fs::equivalent(tempDir.memberPath("."), tempDir.path() / fs::path(".")));
+	BOOST_TEST(fs::equivalent(tempDir.memberPath(".."), tempDir.path() / fs::path("..")));
+
+	// NOTE: fs::equivalent() only works with paths that actually exist
+	{
+		ofstream file;
+		file.open(tempDir.memberPath("file.txt"), ios::out);
+	}
+	BOOST_TEST(fs::equivalent(tempDir.memberPath("file.txt"), tempDir.path() / fs::path("file.txt")));
+
+	{
+		fs::create_directories(tempDir.memberPath("a/b/"));
+
+		ofstream file;
+		file.open(tempDir.memberPath("a/b/file.txt"), ios::out);
+	}
+	BOOST_TEST(fs::equivalent(tempDir.memberPath("a/b/file.txt"), tempDir.path() / fs::path("a") / fs::path("b") / fs::path("file.txt")));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -120,7 +120,7 @@ public:
 
 protected:
 	TemporaryDirectory m_tempDir;
-	string const m_autosavePath = m_tempDir.memberPath("population-autosave.txt");
+	string const m_autosavePath = (m_tempDir.path() / "population-autosave.txt").string();
 	RandomisingAlgorithm m_algorithm;
 };
 

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -16,6 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
+#include <test/TemporaryDirectory.h>
 #include <test/yulPhaser/TestHelpers.h>
 
 #include <tools/yulPhaser/AlgorithmRunner.h>
@@ -37,6 +38,7 @@ using namespace std;
 using namespace boost::unit_test::framework;
 using namespace boost::test_tools;
 using namespace solidity::langutil;
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::yul;
 

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -75,11 +75,11 @@ BOOST_AUTO_TEST_SUITE(CommonTest)
 BOOST_FIXTURE_TEST_CASE(readLinesFromFile_should_return_all_lines_from_a_text_file_as_strings_without_newlines, ReadLinesFromFileFixture)
 {
 	{
-		ofstream tmpFile(m_tempDir.memberPath("test-file.txt"));
+		ofstream tmpFile((m_tempDir.path() / "test-file.txt").string());
 		tmpFile << endl << "Line 1" << endl << endl << endl << "Line 2" << endl << "#" << endl << endl;
 	}
 
-	vector<string> lines = readLinesFromFile(m_tempDir.memberPath("test-file.txt"));
+	vector<string> lines = readLinesFromFile((m_tempDir.path() / "test-file.txt").string());
 	BOOST_TEST((lines == vector<string>{"", "Line 1", "", "", "Line 2", "#", ""}));
 }
 

--- a/test/yulPhaser/Common.cpp
+++ b/test/yulPhaser/Common.cpp
@@ -16,6 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
+#include <test/TemporaryDirectory.h>
 #include <test/yulPhaser/TestHelpers.h>
 
 #include <tools/yulPhaser/Common.h>
@@ -31,6 +32,7 @@
 
 using namespace std;
 using namespace boost::test_tools;
+using namespace solidity::test;
 using namespace solidity::util;
 
 namespace solidity::phaser::test

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -16,6 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
+#include <test/TemporaryDirectory.h>
 #include <test/yulPhaser/TestHelpers.h>
 
 #include <tools/yulPhaser/Exceptions.h>
@@ -31,6 +32,7 @@
 #include <algorithm>
 
 using namespace std;
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::yul;

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -328,11 +328,11 @@ BOOST_FIXTURE_TEST_CASE(build_should_respect_population_from_file_option, Poulat
 	TemporaryDirectory tempDir;
 	for (auto const& [fileName, chromosomes]: fileContent)
 	{
-		ofstream tmpFile(tempDir.memberPath(fileName));
+		ofstream tmpFile((tempDir.path() / fileName).string());
 		for (auto const& chromosome: chromosomes)
 			tmpFile << chromosome << endl;
 
-		m_options.populationFromFile.push_back(tempDir.memberPath(fileName));
+		m_options.populationFromFile.push_back((tempDir.path() / fileName).string());
 	}
 
 	BOOST_TEST(
@@ -361,13 +361,13 @@ BOOST_FIXTURE_TEST_CASE(build_should_combine_populations_from_all_sources, Poula
 {
 	TemporaryDirectory tempDir;
 	{
-		ofstream tmpFile(tempDir.memberPath("population.txt"));
+		ofstream tmpFile((tempDir.path() / "population.txt").string());
 		tmpFile << "axc" << endl << "fcL" << endl;
 	}
 
 	m_options.population = {"axc", "fcL"};
 	m_options.randomPopulation = {2};
-	m_options.populationFromFile = {tempDir.memberPath("population.txt")};
+	m_options.populationFromFile = {(tempDir.path() / "population.txt").string()};
 	m_options.minChromosomeLength = 3;
 	m_options.maxChromosomeLength = 3;
 
@@ -419,9 +419,9 @@ BOOST_AUTO_TEST_CASE(build_should_load_programs_from_files)
 	vector<string> sources{"{}", "{{}}", "{{{}}}"};
 	ProgramFactory::Options options{
 		/* inputFiles = */ {
-			tempDir.memberPath("program1.yul"),
-			tempDir.memberPath("program2.yul"),
-			tempDir.memberPath("program3.yul"),
+			(tempDir.path() / "program1.yul").string(),
+			(tempDir.path() / "program2.yul").string(),
+			(tempDir.path() / "program3.yul").string(),
 		},
 		/* prefix = */ "",
 	};
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(build_should_apply_prefix)
 {
 	TemporaryDirectory tempDir;
 	ProgramFactory::Options options{
-		/* inputFiles = */ {tempDir.memberPath("program1.yul")},
+		/* inputFiles = */ {(tempDir.path() / "program1.yul").string()},
 		/* prefix = */ "f",
 	};
 

--- a/test/yulPhaser/TestHelpers.cpp
+++ b/test/yulPhaser/TestHelpers.cpp
@@ -20,18 +20,13 @@
 
 #include <libyul/optimiser/Suite.h>
 
-#include <boost/filesystem.hpp>
-
 #include <regex>
-#include <iostream>
 
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::phaser;
 using namespace solidity::phaser::test;
-
-namespace fs = boost::filesystem;
 
 function<Mutation> phaser::test::wholeChromosomeReplacement(Chromosome _newChromosome)
 {
@@ -80,40 +75,6 @@ size_t phaser::test::countDifferences(Chromosome const& _chromosome1, Chromosome
 		static_cast<long>(_chromosome1.length()) -
 		static_cast<long>(_chromosome2.length())
 	));
-}
-
-TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
-	m_path((fs::temp_directory_path() / fs::unique_path(_prefix + "%%%%-%%%%-%%%%-%%%%")).string())
-{
-	// Prefix should just be a file name and not contain anything that would make us step out of /tmp.
-	assert(fs::path(_prefix) == fs::path(_prefix).stem());
-
-	fs::create_directory(m_path);
-}
-
-TemporaryDirectory::~TemporaryDirectory()
-{
-	// A few paranoid sanity checks just to be extra sure we're not deleting someone's homework.
-	assert(m_path.find(fs::temp_directory_path().string()) == 0);
-	assert(fs::path(m_path) != fs::temp_directory_path());
-	assert(fs::path(m_path) != fs::path(m_path).root_path());
-	assert(!fs::path(m_path).empty());
-
-	boost::system::error_code errorCode;
-	uintmax_t numRemoved = fs::remove_all(m_path, errorCode);
-	if (errorCode.value() != boost::system::errc::success)
-	{
-		cerr << "Failed to completely remove temporary directory '" << m_path << "'. ";
-		cerr << "Only " << numRemoved << " files were actually removed." << endl;
-		cerr << "Reason: " << errorCode.message() << endl;
-	}
-}
-
-string TemporaryDirectory::memberPath(string const& _relativePath) const
-{
-	assert(fs::path(_relativePath).is_relative());
-
-	return (fs::path(m_path) / _relativePath).string();
 }
 
 string phaser::test::stripWhitespace(string const& input)

--- a/test/yulPhaser/TestHelpers.h
+++ b/test/yulPhaser/TestHelpers.h
@@ -107,31 +107,6 @@ size_t countDifferences(Chromosome const& _chromosome1, Chromosome const& _chrom
 /// integers.
 std::map<std::string, size_t> enumerateOptmisationSteps();
 
-// FILESYSTEM UTILITIES
-
-/**
- * An object that creates a unique temporary directory and automatically deletes it and its
- * content upon being destroyed.
- *
- * The directory is guaranteed to be newly created and empty. Directory names are generated
- * randomly. If a directory with the same name already exists (very unlikely but possible) the
- * object won't reuse it and will fail with an exception instead.
- */
-class TemporaryDirectory
-{
-public:
-	TemporaryDirectory(std::string const& _prefix = "yul-phaser-test-");
-	~TemporaryDirectory();
-
-	std::string const& path() const { return m_path; }
-
-	/// Converts a path relative to the directory held by the object into an absolute one.
-	std::string memberPath(std::string const& _relativePath) const;
-
-private:
-	std::string m_path;
-};
-
 // STRING UTILITIES
 
 /// Returns the input string with all the whitespace characters (spaces, line endings, etc.) removed.

--- a/test/yulPhaser/TestHelpersTest.cpp
+++ b/test/yulPhaser/TestHelpersTest.cpp
@@ -20,17 +20,13 @@
 
 #include <libyul/optimiser/Suite.h>
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <fstream>
 #include <set>
 
 using namespace std;
 using namespace solidity::yul;
 using namespace boost::test_tools;
-
-namespace fs = boost::filesystem;
 
 namespace solidity::phaser::test
 {
@@ -117,63 +113,6 @@ BOOST_AUTO_TEST_CASE(enumerateOptimisationSteps_should_assing_indices_to_all_ava
 
 		stepsSoFar.insert(name);
 	}
-}
-
-BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_create_and_delete_a_unique_and_empty_directory)
-{
-	fs::path dirPath;
-	{
-		TemporaryDirectory tempDir("temporary-directory-test-");
-		dirPath = tempDir.path();
-
-		BOOST_TEST(dirPath.stem().string().find("temporary-directory-test-") == 0);
-		BOOST_TEST(fs::equivalent(dirPath.parent_path(), fs::temp_directory_path()));
-		BOOST_TEST(fs::is_directory(dirPath));
-		BOOST_TEST(fs::is_empty(dirPath));
-	}
-	BOOST_TEST(!fs::exists(dirPath));
-}
-
-BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_empty)
-{
-	fs::path dirPath;
-	{
-		TemporaryDirectory tempDir("temporary-directory-test-");
-		dirPath = tempDir.path();
-
-		BOOST_TEST(fs::is_directory(dirPath));
-
-		{
-			ofstream tmpFile((dirPath / "test-file.txt").string());
-			tmpFile << "Delete me!" << endl;
-		}
-		assert(fs::is_regular_file(dirPath / "test-file.txt"));
-	}
-	BOOST_TEST(!fs::exists(dirPath / "test-file.txt"));
-}
-
-BOOST_AUTO_TEST_CASE(TemporaryDirectory_memberPath_should_construct_paths_relative_to_the_temporary_directory)
-{
-	TemporaryDirectory tempDir("temporary-directory-test-");
-
-	BOOST_TEST(fs::equivalent(tempDir.memberPath(""), tempDir.path()));
-	BOOST_TEST(fs::equivalent(tempDir.memberPath("."), tempDir.path() / fs::path(".")));
-	BOOST_TEST(fs::equivalent(tempDir.memberPath(".."), tempDir.path() / fs::path("..")));
-
-	// NOTE: fs::equivalent() only works with paths that actually exist
-	{
-		ofstream file;
-		file.open(tempDir.memberPath("file.txt"), ios::out);
-	}
-	BOOST_TEST(fs::equivalent(tempDir.memberPath("file.txt"), tempDir.path() / fs::path("file.txt")));
-
-	{
-		fs::create_directories(tempDir.memberPath("a/b/"));
-
-		ofstream file;
-		file.open(tempDir.memberPath("a/b/file.txt"), ios::out);
-	}
-	BOOST_TEST(fs::equivalent(tempDir.memberPath("a/b/file.txt"), tempDir.path() / fs::path("a") / fs::path("b") / fs::path("file.txt")));
 }
 
 BOOST_AUTO_TEST_CASE(stripWhitespace_should_remove_all_whitespace_characters_from_a_string)


### PR DESCRIPTION
This is a simple refactor extracted from the upcoming `FileReader` refactor. This PR basically does two things:
- Moves the `TemporaryDirectory` helper I created for `yul-phaser` into a better spot to make it more generally available. I don't see any specific directory for test helpers so I placed it directly in `test/`.
- Refactors `TemporaryDirectory` not to hide the fact that it uses `boost::filesystem`. Originally I considered it an implementation detail but it actually hinders interoperability with the rest of our code.

It's best to review commits separately since the first, bigger one just moves code around and the actual changes to the implementation (second) commit are relatively small.