### PR TITLE
TemporaryWorkingDirectory helper

### DIFF
--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -43,8 +43,8 @@ TemporaryDirectory::~TemporaryDirectory()
 {
 	// A few paranoid sanity checks just to be extra sure we're not deleting someone's homework.
 	assert(m_path.string().find(fs::temp_directory_path().string()) == 0);
-	assert(m_path != fs::temp_directory_path());
-	assert(m_path != m_path.root_path());
+	assert(!fs::equivalent(m_path, fs::temp_directory_path()));
+	assert(!fs::equivalent(m_path, m_path.root_path()));
 	assert(!m_path.empty());
 
 	boost::system::error_code errorCode;

--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -56,3 +56,14 @@ TemporaryDirectory::~TemporaryDirectory()
 		cerr << "Reason: " << errorCode.message() << endl;
 	}
 }
+
+TemporaryWorkingDirectory::TemporaryWorkingDirectory(fs::path const& _newDirectory):
+	m_originalWorkingDirectory(fs::current_path())
+{
+	fs::current_path(_newDirectory);
+}
+
+TemporaryWorkingDirectory::~TemporaryWorkingDirectory()
+{
+	fs::current_path(m_originalWorkingDirectory);
+}

--- a/test/TemporaryDirectory.h
+++ b/test/TemporaryDirectory.h
@@ -16,7 +16,8 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 /**
- * Utility for creating temporary directories for use in tests.
+ * Utilities for creating temporary directories and temporarily changing the working directory
+ * for use in tests.
  */
 
 #pragma once
@@ -46,6 +47,21 @@ public:
 
 private:
 	boost::filesystem::path m_path;
+};
+
+/**
+ * An object that changes current working directory and restores it upon destruction.
+ */
+class TemporaryWorkingDirectory
+{
+public:
+	TemporaryWorkingDirectory(boost::filesystem::path const& _newDirectory);
+	~TemporaryWorkingDirectory();
+
+	boost::filesystem::path const& originalWorkingDirectory() const { return m_originalWorkingDirectory; }
+
+private:
+	boost::filesystem::path m_originalWorkingDirectory;
 };
 
 }

--- a/test/TemporaryDirectoryTest.cpp
+++ b/test/TemporaryDirectoryTest.cpp
@@ -66,6 +66,31 @@ BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_
 	BOOST_TEST(!fs::exists(dirPath / "test-file.txt"));
 }
 
+BOOST_AUTO_TEST_CASE(TemporaryWorkingDirectory_should_change_and_restore_working_directory)
+{
+	fs::path originalWorkingDirectory = fs::current_path();
+
+	try
+	{
+		{
+			TemporaryDirectory tempDir("temporary-directory-test-");
+			assert(fs::equivalent(fs::current_path(), originalWorkingDirectory));
+			assert(!fs::equivalent(tempDir.path(), originalWorkingDirectory));
+
+			TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+
+			BOOST_TEST(fs::equivalent(fs::current_path(), tempDir.path()));
+		}
+		BOOST_TEST(fs::equivalent(fs::current_path(), originalWorkingDirectory));
+
+		fs::current_path(originalWorkingDirectory);
+	}
+	catch (...)
+	{
+		fs::current_path(originalWorkingDirectory);
+	}
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
Depends on #11384. Marked as draft until the dependency gets merged.

This PR adds a very simple `TemporaryWorkingDirectory` test helper that lets you change working directory in a test without risking the change being permanent and affecting other tests. If your test crashes, the object ensures upon destruction that the directory gets changed back.