### PR TITLE
FileReader unit tests and refactor

### DIFF
--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -90,7 +90,7 @@ bool FileReader::inAllowedDirectory(boost::filesystem::path const& _canonicalPat
 
 void FileReader::setSource(boost::filesystem::path const& _path, string _source)
 {
-	m_sourceCodes[_path.generic_string()] = move(_source);
+	m_sourceCodes[toSourceUnitName(_path)] = move(_source);
 }
 
 void FileReader::setSources(StringMap _sources)
@@ -107,11 +107,8 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 				"ReadFile callback used as callback kind " +
 				_kind
 			));
-		string strippedSourceUnitName = _sourceUnitName;
-		if (strippedSourceUnitName.find("file://") == 0)
-			strippedSourceUnitName.erase(0, 7);
 
-		boost::filesystem::path canonicalPath = boost::filesystem::weakly_canonical(m_basePath / strippedSourceUnitName);
+		boost::filesystem::path canonicalPath = fromSourceUnitName(_sourceUnitName);
 
 		if (!inAllowedDirectory(canonicalPath))
 			return ReadCallback::Result{false, "File outside of allowed directories."};
@@ -137,5 +134,17 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 	}
 }
 
+string FileReader::toSourceUnitName(boost::filesystem::path const& _fsPath) const
+{
+	return _fsPath.generic_string();
 }
 
+boost::filesystem::path FileReader::fromSourceUnitName(string _sourceUnitName) const
+{
+	if (_sourceUnitName.find("file://") == 0)
+		_sourceUnitName.erase(0, 7);
+
+	return boost::filesystem::weakly_canonical(m_basePath / _sourceUnitName);
+}
+
+}

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -32,7 +32,7 @@ using std::string;
 namespace solidity::frontend
 {
 
-void FileReader::setSource(boost::filesystem::path const& _path, SourceCode _source)
+void FileReader::setSource(boost::filesystem::path const& _path, std::string _source)
 {
 	m_sourceCodes[_path.generic_string()] = std::move(_source);
 }

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -35,8 +35,8 @@ namespace solidity::frontend
 class FileReader
 {
 public:
-	using StringMap = std::map<SourceUnitName, SourceCode>;
-	using PathMap = std::map<SourceUnitName, boost::filesystem::path>;
+	using StringMap = std::map<std::string, std::string>;
+	using PathMap = std::map<std::string, boost::filesystem::path>;
 	using FileSystemPathSet = std::set<boost::filesystem::path>;
 
 	/// Constructs a FileReader with a base path and a set of allowed directories that
@@ -59,7 +59,7 @@ public:
 	StringMap const& sourceCodes() const noexcept { return m_sourceCodes; }
 
 	/// Retrieves the source code for a given source unit ID.
-	SourceCode const& sourceCode(SourceUnitName const& _sourceUnitName) const { return m_sourceCodes.at(_sourceUnitName); }
+	std::string const& sourceCode(std::string const& _sourceUnitName) const { return m_sourceCodes.at(_sourceUnitName); }
 
 	/// Resets all sources to the given map of source unit ID to source codes.
 	/// Does not enforce @a allowedDirectories().
@@ -67,7 +67,7 @@ public:
 
 	/// Adds the source code for a given source unit ID.
 	/// Does not enforce @a allowedDirectories().
-	void setSource(boost::filesystem::path const& _path, SourceCode _source);
+	void setSource(boost::filesystem::path const& _path, std::string _source);
 
 	/// Receives a @p _sourceUnitName that refers to a source unit in compiler's virtual filesystem
 	/// and attempts to interpret it as a path and read the corresponding file from disk.

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -81,6 +81,9 @@ public:
 		return [this](std::string const& _kind, std::string const& _path) { return readFile(_kind, _path); };
 	}
 
+	std::string toSourceUnitName(boost::filesystem::path const& _cliPath) const;
+	boost::filesystem::path fromSourceUnitName(std::string _sourceUnitName) const;
+
 private:
 	/// Base path, used for resolving relative paths in imports.
 	boost::filesystem::path m_basePath;

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -46,7 +46,6 @@ public:
 		FileSystemPathSet _allowedDirectories = {}
 	);
 
-	void setBasePath(boost::filesystem::path _path) { m_basePath = std::move(_path); }
 	boost::filesystem::path const& basePath() const noexcept { return m_basePath; }
 
 	void allowDirectory(boost::filesystem::path _path);

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -44,16 +44,14 @@ public:
 	explicit FileReader(
 		boost::filesystem::path _basePath = {},
 		FileSystemPathSet _allowedDirectories = {}
-	):
-		m_basePath(std::move(_basePath)),
-		m_allowedDirectories(std::move(_allowedDirectories)),
-		m_sourceCodes()
-	{}
+	);
 
 	void setBasePath(boost::filesystem::path _path) { m_basePath = std::move(_path); }
 	boost::filesystem::path const& basePath() const noexcept { return m_basePath; }
 
-	void allowDirectory(boost::filesystem::path _path) { m_allowedDirectories.insert(std::move(_path)); }
+	void allowDirectory(boost::filesystem::path _path);
+	void allowParentDirectory(boost::filesystem::path _file);
+	bool inAllowedDirectory(boost::filesystem::path const& _canonicalPath) const;
 	FileSystemPathSet const& allowedDirectories() const noexcept { return m_allowedDirectories; }
 
 	StringMap const& sourceCodes() const noexcept { return m_sourceCodes; }

--- a/libsolidity/interface/ImportRemapper.cpp
+++ b/libsolidity/interface/ImportRemapper.cpp
@@ -36,7 +36,7 @@ void ImportRemapper::setRemappings(vector<Remapping> _remappings)
 	m_remappings = move(_remappings);
 }
 
-SourceUnitName ImportRemapper::apply(ImportPath const& _path, string const& _context) const
+std::string ImportRemapper::apply(std::string const& _path, string const& _context) const
 {
 	// Try to find the longest prefix match in all remappings that are active in the current context.
 	auto isPrefixOf = [](string const& _a, string const& _b)

--- a/libsolidity/interface/ImportRemapper.h
+++ b/libsolidity/interface/ImportRemapper.h
@@ -24,11 +24,6 @@
 namespace solidity::frontend
 {
 
-// Some helper typedefs to make reading the signatures more self explaining.
-using SourceUnitName = std::string;
-using SourceCode = std::string;
-using ImportPath = std::string;
-
 /// The ImportRemapper is being used on imported file paths for being remapped to source unit IDs before being loaded.
 class ImportRemapper
 {
@@ -45,7 +40,7 @@ public:
 	void setRemappings(std::vector<Remapping> _remappings);
 	std::vector<Remapping> const& remappings() const noexcept { return m_remappings; }
 
-	SourceUnitName apply(ImportPath const& _path, std::string const& _context) const;
+	std::string apply(std::string const& _path, std::string const& _context) const;
 
 	// Parses a remapping of the format "context:prefix=target".
 	static std::optional<Remapping> parseRemapping(std::string const& _remapping);

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -605,36 +605,36 @@ bool CommandLineInterface::readInputFilesAndConfigureRemappings()
 				addStdin = true;
 			else
 			{
-				auto infile = boost::filesystem::path(path);
-				if (!boost::filesystem::exists(infile))
+				boost::filesystem::path inputFilePath = path;
+				if (!boost::filesystem::exists(inputFilePath))
 				{
 					if (!ignoreMissing)
 					{
-						serr() << infile << " is not found." << endl;
+						serr() << inputFilePath << " is not found." << endl;
 						return false;
 					}
 					else
-						serr() << infile << " is not found. Skipping." << endl;
+						serr() << inputFilePath << " is not found. Skipping." << endl;
 
 					continue;
 				}
 
-				if (!boost::filesystem::is_regular_file(infile))
+				if (!boost::filesystem::is_regular_file(inputFilePath))
 				{
 					if (!ignoreMissing)
 					{
-						serr() << infile << " is not a valid file." << endl;
+						serr() << inputFilePath << " is not a valid file." << endl;
 						return false;
 					}
 					else
-						serr() << infile << " is not a valid file. Skipping." << endl;
+						serr() << inputFilePath << " is not a valid file. Skipping." << endl;
 
 					continue;
 				}
 
 				// NOTE: we ignore the FileNotFound exception as we manually check above
-				m_fileReader.setSource(infile, readFileAsString(infile.string()));
-				m_fileReader.allowDirectory(boost::filesystem::path(boost::filesystem::canonical(infile).string()).remove_filename());
+				m_fileReader.setSource(inputFilePath, readFileAsString(inputFilePath.string()));
+				m_fileReader.allowDirectory(boost::filesystem::path(boost::filesystem::canonical(inputFilePath).string()).remove_filename());
 			}
 		}
 
@@ -1184,13 +1184,13 @@ bool CommandLineInterface::processInput()
 {
 	if (m_args.count(g_argBasePath))
 	{
-		boost::filesystem::path const fspath{m_args[g_argBasePath].as<string>()};
-		if (!boost::filesystem::is_directory(fspath))
+		boost::filesystem::path basePath = m_args[g_argBasePath].as<string>();
+		if (!boost::filesystem::is_directory(basePath))
 		{
-			serr() << "Base path must be a directory: \"" << fspath << "\"\n";
+			serr() << "Base path must be a directory: \"" << basePath << "\"\n";
 			return false;
 		}
-		m_fileReader.setBasePath(fspath);
+		m_fileReader.setBasePath(basePath);
 	}
 
 	if (m_args.count(g_argAllowPaths))

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -750,7 +750,7 @@ map<string, Json::Value> CommandLineInterface::parseAstFromInput()
 	map<string, Json::Value> sourceJsons;
 	map<string, string> tmpSources;
 
-	for (SourceCode const& sourceCode: m_fileReader.sourceCodes() | ranges::views::values)
+	for (string const& sourceCode: m_fileReader.sourceCodes() | ranges::views::values)
 	{
 		Json::Value ast;
 		astAssert(jsonParseStrict(sourceCode, ast), "Input file could not be parsed to JSON");

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -114,7 +114,7 @@ private:
 
 	bool m_onlyLink = false;
 
-	FileReader m_fileReader;
+	std::optional<FileReader> m_fileReader;
 
 	/// Compiler arguments variable map
 	boost::program_options::variables_map m_args;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ set(libsolidity_sources
     libsolidity/SyntaxTest.h
     libsolidity/ViewPureChecker.cpp
     libsolidity/analysis/FunctionCallGraph.cpp
+    libsolidity/interface/FileReader.cpp
 )
 detect_stray_source_files("${libsolidity_sources}" "libsolidity/")
 

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -1,0 +1,506 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/// Unit tests for libsolidity/interface/FileReader.h
+
+#include <libsolidity/interface/FileReader.h>
+
+#include <test/Common.h>
+#include <test/TemporaryDirectory.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+using boost::filesystem::create_directories;
+using boost::filesystem::current_path;
+using solidity::test::TemporaryDirectory;
+using solidity::test::TemporaryWorkingDirectory;
+
+namespace solidity::frontend::test
+{
+
+BOOST_AUTO_TEST_SUITE(FileReaderTest)
+
+BOOST_AUTO_TEST_CASE(default_initialization)
+{
+	FileReader reader;
+
+	BOOST_TEST(reader.basePath() == "");
+	BOOST_TEST(reader.allowedDirectories() == FileReader::FileSystemPathSet{""});
+	BOOST_TEST(reader.sourceCodes() == FileReader::StringMap{});
+}
+
+BOOST_AUTO_TEST_CASE(initialization)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	create_directories(tempDir.path() / "a/b/c");
+
+	FileReader reader(tempDir.path() / "a/b/c", {"/a", "/b", "/c/d/e"});
+
+	BOOST_TEST(reader.basePath() == tempDir.path() / "a/b/c");
+	BOOST_TEST(reader.allowedDirectories() == FileReader::FileSystemPathSet(
+		{tempDir.path() / "a/b/c", "/a", "/b", "/c/d/e"}
+	));
+	BOOST_TEST(reader.sourceCodes() == FileReader::StringMap{});
+}
+
+BOOST_AUTO_TEST_CASE(sources)
+{
+	FileReader::StringMap initialSources = {
+		{"/a/contract.sol", "contract C {}"},
+		{"token.sol", "contract Token {}"},
+		{"<stdin>", "library L {}"},
+		{"..", "// comment"},
+	};
+
+	FileReader reader;
+
+	BOOST_TEST(reader.sourceCodes() == StringMap{});
+
+	reader.setSources(initialSources);
+
+	BOOST_TEST(reader.sourceCodes() == initialSources);
+	BOOST_TEST(reader.sourceCode("/a/contract.sol") == initialSources.at("/a/contract.sol"));
+	BOOST_TEST(reader.sourceCode("token.sol") == initialSources.at("token.sol"));
+	BOOST_TEST(reader.sourceCode("<stdin>") == initialSources.at("<stdin>"));
+	BOOST_TEST(reader.sourceCode("..") == initialSources.at(".."));
+
+	reader.setSource("<stdin>", "x");
+	reader.setSource("y", "y");
+
+	BOOST_TEST(reader.sourceCodes() == (StringMap{
+		{"/a/contract.sol", initialSources.at("/a/contract.sol")},
+		{"token.sol", initialSources.at("token.sol")},
+		{"<stdin>", "x"},
+		{"..", initialSources.at("..")},
+		{"y", "y"},
+	}));
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_relative_paths_as_is)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("contract.sol") == "contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("c/d/contract.sol") == "c/d/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_absolute_paths_as_is_when_base_path_is_empty)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryDirectory tempDirOther("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	solAssert(tempDirCurrent.path().is_absolute(), "");
+	solAssert(tempDirOther.path().is_absolute(), "");
+
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName(tempDirCurrent.path() / "contract.sol") == tempDirCurrent.path().string() + "/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirOther.path() / "contract.sol") == tempDirOther.path().string() + "/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_absolute_paths_as_is_when_base_path_matches_working_directory)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryDirectory tempDirOther("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+
+	FileReader reader(tempDirCurrent.path());
+	BOOST_TEST(reader.toSourceUnitName(tempDirCurrent.path() / "contract.sol") == tempDirCurrent.path().string() + "/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirOther.path() / "contract.sol") == tempDirOther.path().string() + "/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_absolute_paths_as_is_when_base_path_does_not_match_working_directory)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryDirectory tempDirBase("file-reader-test-");
+	TemporaryDirectory tempDirOther("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+
+	FileReader reader(tempDirBase.path());
+	BOOST_TEST(reader.toSourceUnitName(tempDirCurrent.path() / "contract.sol") == tempDirCurrent.path().string() + "/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirBase.path() / "contract.sol") == tempDirBase.path().string() + "/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirOther.path() / "contract.sol") == tempDirOther.path().string() + "/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_absolute_paths_as_is_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryDirectory tempDirOther("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.toSourceUnitName(tempDirCurrent.path() / "contract.sol") == tempDirCurrent.path().string() + "/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirCurrent.path() / "base/contract.sol") == tempDirCurrent.path().string() + "/base/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirOther.path() / "contract.sol") == tempDirOther.path().string() + "/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName(tempDirOther.path() / "base/contract.sol") == tempDirOther.path().string() + "/base/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_relative_paths_inside_base_path_as_is_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.toSourceUnitName("contract.sol") == "contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("base/contract.sol") == "base/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_special_stdin_path_as_is)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("<stdin>") == "<stdin>");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_empty_path_as_is)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("") == "");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_path_with_root_as_is)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("//contract.sol") == "//contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_use_urls_as_is)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("file://c/d/contract.sol") == "file://c/d/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("file:///c/d/contract.sol") == "file:///c/d/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("https://example.com/contract.sol") == "https://example.com/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_not_remove_redundant_slashes)
+{
+	FileReader reader;
+
+	BOOST_TEST(reader.toSourceUnitName("a/b//contract.sol") == "a/b//contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("a/b///contract.sol") == "a/b///contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("a/b////contract.sol") == "a/b////contract.sol");
+
+	BOOST_TEST(reader.toSourceUnitName("a/b/contract/") == "a/b/contract/");
+	BOOST_TEST(reader.toSourceUnitName("a/b/contract//") == "a/b/contract//");
+	BOOST_TEST(reader.toSourceUnitName("a/b/contract////") == "a/b/contract////");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_not_remove_dot_segments)
+{
+	FileReader reader;
+
+	BOOST_TEST(reader.toSourceUnitName("./a/b/contract.sol") == "./a/b/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("././a/b/contract.sol") == "././a/b/contract.sol");
+
+	BOOST_TEST(reader.toSourceUnitName("a/./b/contract.sol") == "a/./b/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("a/././b/contract.sol") == "a/././b/contract.sol");
+
+	BOOST_TEST(reader.toSourceUnitName("a/b/contract/.") == "a/b/contract/.");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_not_remove_dot_dot_segments)
+{
+	FileReader reader;
+
+	BOOST_TEST(reader.toSourceUnitName("../a/b/contract.sol") == "../a/b/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("../../a/b/contract.sol") == "../../a/b/contract.sol");
+
+	BOOST_TEST(reader.toSourceUnitName("a/../b/contract.sol") == "a/../b/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("a/b/../../contract.sol") == "a/b/../../contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("/a/../b/contract.sol") == "/a/../b/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("/a/b/../../contract.sol") == "/a/b/../../contract.sol");
+
+	BOOST_TEST(reader.toSourceUnitName("a/b/contract/..") == "a/b/contract/..");
+	BOOST_TEST(reader.toSourceUnitName("/a/b/contract/..") == "/a/b/contract/..");
+}
+
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_not_remove_dot_dot_segments_going_beyond_root)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("/../contract/") == "/../contract/");
+	BOOST_TEST(reader.toSourceUnitName("/../../contract/") == "/../../contract/");
+}
+
+#if defined(_WIN32)
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_convert_backslashes_on_windows)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("a\\b\\contract.sol") == "a/b/contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("C:\\a\\b\\contract.sol") == "C:/a/b/contract.sol");
+}
+#else
+BOOST_AUTO_TEST_CASE(toSourceUnitName_should_not_convert_backslashes_when_not_on_windows)
+{
+	FileReader reader;
+	BOOST_TEST(reader.toSourceUnitName("a\\b\\contract.sol") == "a\\b\\contract.sol");
+	BOOST_TEST(reader.toSourceUnitName("C:\\a\\b\\contract.sol") == "C:\\a\\b\\contract.sol");
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_not_preprend_current_directory_to_relative_paths_when_base_path_is_empty)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("contract.sol") == "contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("c/d/contract.sol") == "c/d/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_not_preprend_current_directory_to_absolute_paths_when_base_path_is_empty)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName((tempDir.path() / "contract.sol").generic_string()) == tempDir.path() / "/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName((tempDir.path() / "c/d/contract.sol").generic_string()) == tempDir.path() / "/c/d/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_relative_paths_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("contract.sol") == tempDirCurrent.path() / "base/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_relative_paths_when_base_path_is_absolute)
+{
+	TemporaryDirectory tempDirBase("file-reader-test-");
+	solAssert(tempDirBase.path().is_absolute(), "");
+
+	FileReader reader(tempDirBase.path());
+	BOOST_TEST(reader.fromSourceUnitName("contract.sol") == tempDirBase.path() / "contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_absolute_paths_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("/root/contract.sol") == tempDirCurrent.path() / "base/root/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_absolute_paths_when_base_path_is_absolute)
+{
+	TemporaryDirectory tempDirBase("file-reader-test-");
+	solAssert(tempDirBase.path().is_absolute(), "");
+
+	FileReader reader(tempDirBase.path());
+	BOOST_TEST(reader.fromSourceUnitName("/root/contract.sol") == tempDirBase.path() / "root/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_absolute_paths_when_base_path_matches_working_directory)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+
+	FileReader reader(tempDirCurrent.path());
+	BOOST_TEST(
+		reader.fromSourceUnitName((tempDirCurrent.path() / "contract.sol").generic_string()) ==
+		tempDirCurrent.path() / tempDirCurrent.path() / "contract.sol"
+	);
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_return_special_stdin_path_as_is_when_base_path_is_empty)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("<stdin>") == tempDirCurrent.path() / "base/<stdin>");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_relative_paths_within_relative_base_path)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("contract.sol") == tempDirCurrent.path() / "base/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("base/contract.sol") == tempDirCurrent.path() / "base/base/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_return_empty_path_when_path_is_empty_and_base_path_is_empty)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("") == "");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_return_absolute_base_path_when_path_is_empty_but_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("") == tempDirCurrent.path() / "base");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_return_path_with_root_as_is_when_base_path_is_empty)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("//contract.sol") == "//contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_prepend_absolute_base_path_to_path_with_root_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("//contract.sol") == tempDirCurrent.path() / "base//contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_strip_protocol_from_file_urls)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("file://c/d/contract.sol") == "c/d/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("file:///c/d/contract.sol") == "/c/d/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_use_non_file_urls_as_paths)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("https://example.com/contract.sol") == "https:/example.com/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_remove_redundant_slashes)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("a/b//contract.sol") == "a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("a/b///contract.sol") == "a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("a/b////contract.sol") == "a/b/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_replace_trailing_slashes_with_a_dot)
+{
+	// TODO: This behavior is unintuitive. The trailing dot should not be there.
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("a/b/contract/") == "a/b/contract/.");
+	BOOST_TEST(reader.fromSourceUnitName("a/b/contract//") == "a/b/contract/.");
+	BOOST_TEST(reader.fromSourceUnitName("a/b/contract////") == "a/b/contract/.");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_remove_leading_dot_segments_and_prepend_working_directory_when_base_path_is_empty)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+
+	// TODO: Work dir path should not be included. This is inconsistent with how empty base path behaves in other cases.
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("./a/b/contract.sol") == tempDirCurrent.path().string() + "/a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("././a/b/contract.sol") == tempDirCurrent.path().string() + "/a/b/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_remove_leading_dot_segments_and_prepend_absolute_base_directory_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base");
+
+	FileReader reader("base");
+	BOOST_TEST(reader.fromSourceUnitName("./a/b/contract.sol") == tempDirCurrent.path().string() + "/base/a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("././a/b/contract.sol") == tempDirCurrent.path().string() + "/base/a/b/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_remove_internal_dot_segments)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("a/./b/contract.sol") == "a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("a/././b/contract.sol") == "a/b/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_not_remove_trailing_dot_segments)
+{
+	// TODO: This should behave the same way as for internal and leading dot segments.
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("a/b/contract/.") == "a/b/contract/.");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_normalize_leading_dot_dot_segments_and_prepend_working_directory_when_base_path_is_empty)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("x/y/z");
+	current_path(tempDirCurrent.path() / "x/y/z");
+
+	// TODO: Work dir path should not be included. This is inconsistent with how empty base path behaves in other cases.
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("../a/b/contract.sol") == tempDirCurrent.path().string() + "/x/y/a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("../../a/b/contract.sol") == tempDirCurrent.path().string() + "/x/a/b/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_normalize_leading_dot_dot_segments_and_prepend_absolute_base_directory_when_base_path_is_relative)
+{
+	TemporaryDirectory tempDirCurrent("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	create_directories("base/base");
+
+	FileReader reader("base/base");
+	BOOST_TEST(reader.fromSourceUnitName("../a/b/contract.sol") == tempDirCurrent.path().string() + "/base/a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("../../a/b/contract.sol") == tempDirCurrent.path().string() + "/a/b/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_normalize_internal_and_trailing_dot_dot_segments)
+{
+	FileReader reader;
+
+	BOOST_TEST(reader.fromSourceUnitName("a/../b/contract.sol") == "b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("a/b/../../contract.sol") == "contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("/a/../b/contract.sol") == "/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("/a/b/../../contract.sol") == "/contract.sol");
+
+	BOOST_TEST(reader.fromSourceUnitName("a/b/contract/..") == "a/b");
+	BOOST_TEST(reader.fromSourceUnitName("/a/b/contract/..") == "/a/b");
+}
+
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_remove_dot_dot_segments_going_beyond_root)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("/../contract/") == "/contract/");
+	BOOST_TEST(reader.fromSourceUnitName("/../../contract/") == "/contract/");
+}
+
+#if defined(_WIN32)
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_convert_backslashes_on_windows)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("a\\b\\contract.sol") == "a\\b\\contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("a\\b\\contract.sol") == "a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("C:\\a\\b\\contract.sol") == "C:\\a\\b\\contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("C:\\a\\b\\contract.sol") == "C:/a/b/contract.sol");
+}
+#else
+BOOST_AUTO_TEST_CASE(fromSourceUnitName_should_not_convert_backslashes_when_not_on_windows)
+{
+	FileReader reader;
+	BOOST_TEST(reader.fromSourceUnitName("a\\b\\contract.sol") == "a\\b\\contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("a\\b\\contract.sol") != "a/b/contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("C:\\a\\b\\contract.sol") == "C:\\a\\b\\contract.sol");
+	BOOST_TEST(reader.fromSourceUnitName("C:\\a\\b\\contract.sol") != "C:/a/b/contract.sol");
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace solidity::frontend::test


### PR DESCRIPTION
This is a continuation of #11113.
Depends on #11385. Marked as draft until the dependency gets merged.

This PR adds some tweaks that we discussed after #11113 got merged. In particular https://github.com/ethereum/solidity/pull/11113#discussion_r608442183 but also a few other tiny changes.

More importantly, it extracts the path<->source unit name conversions and checks into `toSourceUnitName()`, `fromSourceUnitName()`, `inAllowedDirectory()`, `allowParentDirectory()` methods and covers it with unit tests. That logic is currently pretty trivial but and that's only because we completely rely on how boost does things. There are actually a lot of corner cases and we need those covered because we'll be changing the behavior and it's hard to keep track of what we're actually changing without good test coverage.

This PR only covers `FileReader`. There'll be another one with coverage for `ImportRemapper`.