### PR TITLE
EVMHost: Fix selfdestruct with non-zero value at beneficiary and value-transfers with insufficient funds

### DIFF
--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -91,6 +91,8 @@ public:
 private:
 	evmc::address m_currentAddress = {};
 
+	void transfer(evmc::MockedAccount& _sender, evmc::MockedAccount& _recipient, u256 const& _value) noexcept;
+
 	/// Records calls made via @param _message.
 	void recordCalls(evmc_message const& _message) noexcept;
 


### PR DESCRIPTION
Create a helper for transfering balance between two accounts. Check sufficient funds are available during a call-with-value.