### PR TITLE
Turn toCompactHexWithPrefix into a template and support unsigned types

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -340,7 +340,7 @@ CompilerContext& CompilerContext::appendPanic(util::PanicCode _code)
 		revert(0, 0x24)
 	})");
 	templ("selector", util::selectorFromSignature("Panic(uint256)").str());
-	templ("code", u256(_code).str());
+	templ("code", toCompactHexWithPrefix(static_cast<unsigned>(_code)));
 	appendInlineAssembly(templ.render());
 	return *this;
 }

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -4377,7 +4377,7 @@ string YulUtilFunctions::panicFunction(util::PanicCode _code)
 		)")
 		("functionName", functionName)
 		("selector", util::selectorFromSignature("Panic(uint256)").str())
-		("code", toCompactHexWithPrefix(_code))
+		("code", toCompactHexWithPrefix(static_cast<unsigned>(_code)))
 		.render();
 	});
 }

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -404,7 +404,8 @@ inline std::string toHex(u256 val, HexPrefix prefix = HexPrefix::DontAdd)
 	return (prefix == HexPrefix::Add) ? "0x" + str : str;
 }
 
-inline std::string toCompactHexWithPrefix(u256 const& _value)
+template <class T>
+inline std::string toCompactHexWithPrefix(T _value)
 {
 	return toHex(toCompactBigEndian(_value, 1), HexPrefix::Add);
 }


### PR DESCRIPTION
This should help with boost::multiprecision versions where explicit unsigned/enum conversion to bigint do not exists (such as boost 1.76)

Closes #11398