### PR TITLE
SMTChecker: Fix struct constructor where fixed-bytes member is initialized with a string literal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 
 Bugfixes:
  * AST: Do not output value of Yul literal if it is not a valid UTF-8 string.
+ * SMTChecker: Fix internal error on struct constructor with fixed bytes member initialized with string literal.
 
 
 AST Changes:

--- a/test/libsolidity/smtCheckerTests/types/struct/struct_constructor_fixed_bytes_from_string_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/struct/struct_constructor_fixed_bytes_from_string_1.sol
@@ -1,0 +1,14 @@
+pragma experimental SMTChecker;
+contract C {
+  struct S {
+    int a;
+    bytes5 b;
+  }
+  function f() public pure {
+    assert(S({a:2, b:""}).b == bytes5(0)); // should hold
+    assert(S({a:2, b:""}).a == 0); // should fail
+  }
+}
+// ----
+// Warning 5523: (0-31): The SMTChecker pragma has been deprecated and will be removed in the future. Please use the "model checker engine" compiler setting to activate the SMTChecker instead. If the pragma is enabled, all engines will be used.
+// Warning 6328: (178-207): CHC: Assertion violation happens here.\nCounterexample:\n\n\nTransaction trace:\nC.constructor()\nC.f()


### PR DESCRIPTION
Fixes #11336.

The crash happened because `SMTEncoder::visitStructConstructorCall` did not take the possible conversion from String literal to fixed-bytes into account.

The added test case simplifies the one from issue a bit (the array is unnecessary, the crash happened also without it) and adds assertions.