### PR TITLE
factor out some StandardCompiler' input JSON parsing/configuration…

### DIFF
--- a/libsolidity/interface/StandardCompiler.h
+++ b/libsolidity/interface/StandardCompiler.h
@@ -62,7 +62,6 @@ public:
 		std::map<std::string, evmasm::LinkerObject::FunctionDebugData> const& _debugInfo
 	);
 
-private:
 	struct InputsAndSettings
 	{
 		std::string language;
@@ -83,6 +82,10 @@ private:
 		bool viaIR = false;
 	};
 
+	/// Configures @p _compilerStack according to the input settings in @p _inputsAndSettings.
+	static void configure(InputsAndSettings const& _inputsAndSettings, CompilerStack& _compilerStack);
+
+private:
 	/// Parses the input json (and potentially invokes the read callback) and either returns
 	/// it in condensed form or an error as a json object.
 	std::variant<InputsAndSettings, Json::Value> parseInput(Json::Value const& _input);


### PR DESCRIPTION
factor out some parsing/configuration API to be able to use them at other places too.

This refactoring is needed in order to share some code bits with the LSP PR to avoid code duplication.