### PR TITLE
Upgrade to jsoncpp 1.9.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 
 
 Compiler Features:
+ * Build System: Update internal dependency of jsoncpp to 1.9.4.
  * SMTChecker: Function definitions can be annotated with the custom Natspec tag ``custom:smtchecker abstract-function-nondet`` to be abstracted by a nondeterministic value when called.
  * Standard JSON / combined JSON: New artifact "functionDebugData" that contains bytecode offsets of entry points of functions and potentially more information in the future.
  * Yul Optimizer: Evaluate ``keccak256(a, c)``, when the value at memory location ``a`` is known at compile time and ``c`` is a constant ``<= 32``.

--- a/cmake/jsoncpp.cmake
+++ b/cmake/jsoncpp.cmake
@@ -7,7 +7,7 @@ else()
 endif()
 
 set(prefix "${CMAKE_BINARY_DIR}/deps")
-set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(JSONCPP_LIBRARY "${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp_static${CMAKE_STATIC_LIBRARY_SUFFIX}")
 set(JSONCPP_INCLUDE_DIR "${prefix}/include")
 
 # TODO: Investigate why this breaks some emscripten builds and
@@ -43,9 +43,9 @@ endif()
 ExternalProject_Add(jsoncpp-project
     PREFIX "${prefix}"
     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
-    DOWNLOAD_NAME jsoncpp-1.9.3.tar.gz
-    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
-    URL_HASH SHA256=8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d
+    DOWNLOAD_NAME jsoncpp-1.9.4.tar.gz
+    URL https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.tar.gz
+    URL_HASH SHA256=e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999
     CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/libsolutil/JSON.cpp
+++ b/libsolutil/JSON.cpp
@@ -32,9 +32,12 @@
 
 using namespace std;
 
+// This check is not very useful now, since 1.9.4 had a bug where the STRING was updated, but not the PATCH.
+// The release version: https://github.com/open-source-parsers/jsoncpp/blob/1.9.4/include/json/version.h
+// The fix post-release: https://github.com/open-source-parsers/jsoncpp/issues/1224
 static_assert(
 	(JSONCPP_VERSION_MAJOR == 1) && (JSONCPP_VERSION_MINOR == 9) && (JSONCPP_VERSION_PATCH == 3),
-	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.3."
+	"Unexpected jsoncpp version: " JSONCPP_VERSION_STRING ". Expecting 1.9.4."
 );
 
 namespace solidity::util

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -31,7 +31,7 @@ REPO_ROOT="$(dirname "$0")"/..
     fi
     # Add dependencies
     mkdir -p "$SOLDIR/deps/downloads/" 2>/dev/null || true
-    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.9.3.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
+    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.9.4.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.tar.gz
     mkdir -p "$REPO_ROOT/upload"
     tar --owner 0 --group 0 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
     rm -r "$TEMPDIR"

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -107,7 +107,7 @@ mv solidity solc
 
 # Fetch jsoncpp dependency
 mkdir -p ./solc/deps/downloads/ 2>/dev/null || true
-wget -O ./solc/deps/downloads/jsoncpp-1.9.3.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
+wget -O ./solc/deps/downloads/jsoncpp-1.9.4.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.tar.gz
 wget -O ./solc/deps/downloads/range-v3-0.11.0.tar.gz https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
 
 # Determine version


### PR DESCRIPTION
According to https://github.com/open-source-parsers/jsoncpp/releases/tag/1.9.4:
> This patch contains several fixes found through the OSS-Fuzz project fuzzing, increasing the security of the library, as well as some fixes for different build systems.

It fixes some cases of ownership (and move semantics) issues.