### PR TITLE
Fix asan stack-use-after-scope in TestFileParserTest

### DIFF
--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -726,7 +726,7 @@ char TestFileParser::Scanner::scanHexPart()
 	return static_cast<char>(value);
 }
 
-bool TestFileParser::isBuiltinFunction(std::string const& signature)
+bool TestFileParser::isBuiltinFunction(std::string const& _signature)
 {
-	return m_builtins.count(signature) > 0;
+	return m_builtins.count(_signature) > 0;
 }

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -52,7 +52,10 @@ class TestFileParser
 public:
 	/// Constructor that takes an input stream \param _stream to operate on
 	/// and creates the internal scanner.
-	explicit TestFileParser(std::istream& _stream, std::map<std::string, Builtin> const& _builtins): m_scanner(_stream), m_builtins(_builtins) {}
+	explicit TestFileParser(std::istream& _stream, std::map<std::string, Builtin> const& _builtins):
+		m_scanner(_stream),
+		m_builtins(_builtins)
+	{}
 
 	/// Parses function calls blockwise and returns a list of function calls found.
 	/// Throws an exception if a function call cannot be parsed because of its
@@ -179,7 +182,7 @@ private:
 
 	/// Checks whether a builtin function with the given signature exist.
 	/// @returns true, if builtin found, false otherwise
-	bool isBuiltinFunction(std::string const& signature);
+	bool isBuiltinFunction(std::string const& _signature);
 
 	/// A scanner instance
 	Scanner m_scanner;

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -44,8 +44,10 @@ namespace
 
 vector<FunctionCall> parse(string const& _source)
 {
+	static std::map<std::string, Builtin> const builtins = {};
+
 	istringstream stream{_source, ios_base::out};
-	return TestFileParser{stream, {}}.parseFunctionCalls(0);
+	return TestFileParser{stream, builtins}.parseFunctionCalls(0);
 }
 
 void testFunctionCall(

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -45,8 +45,7 @@ namespace
 vector<FunctionCall> parse(string const& _source)
 {
 	istringstream stream{_source, ios_base::out};
-	TestFileParser parser{stream, {}};
-	return parser.parseFunctionCalls(0);
+	return TestFileParser{stream, {}}.parseFunctionCalls(0);
 }
 
 void testFunctionCall(
@@ -99,7 +98,7 @@ BOOST_AUTO_TEST_CASE(smoke_test)
 	BOOST_REQUIRE_EQUAL(parse(source).size(), 0);
 }
 
-BOOST_AUTO_TEST_CASE(call_succees)
+BOOST_AUTO_TEST_CASE(call_success)
 {
 	char const* source = R"(
 		// success() ->


### PR DESCRIPTION
This fixes the asan failure in our nightly CI run (https://app.circleci.com/pipelines/github/ethereum/solidity/15942/workflows/abd0c9b1-22d9-4190-ac7f-2a396d82cb1e/jobs/721523). Or at least the one I managed to reproduce locally (https://github.com/ethereum/solidity/pull/11406#issuecomment-844397471).

The issue was caused by the fact that `TestFileParser` stores a `const` reference to a `map` of builtins rather than a copy. It was being passed a temporary which resulted in a dangling reference.