### PR TITLE
[DOCS] Sphinx 4.x.y compatibility fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ prerelease.txt
 /build*
 emscripten_build/
 docs/_build
+docs/_static/robots.txt
 __pycache__
 docs/utils/*.pyc
 /deps/downloads/

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -141,7 +141,8 @@ Both expressions can also be assigned to.
 
 Local Solidity variables are available for assignments, for example:
 
-.. code::
+.. code-block:: solidity
+    :force:
 
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >=0.7.0 <0.9.0;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,10 @@ from pygments_lexer_solidity import SolidityLexer, YulLexer
 def setup(sphinx):
     thisdir = os.path.dirname(os.path.realpath(__file__))
     sys.path.insert(0, thisdir + '/utils')
-    sphinx.add_lexer('Solidity', SolidityLexer())
-    sphinx.add_lexer('Yul', YulLexer())
+    sphinx.add_lexer('Solidity', SolidityLexer)
+    sphinx.add_lexer('Yul', YulLexer)
 
-    sphinx.add_stylesheet('css/custom.css')
+    sphinx.add_css_file('css/custom.css')
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -263,7 +263,7 @@ We mainly use `AFL <https://lcamtuf.coredump.cx/afl/>`_ for fuzzing. You need to
 install the AFL packages from your repositories (afl, afl-clang) or build them manually.
 Next, build Solidity (or just the ``solfuzzer`` binary) with AFL as your compiler:
 
-::
+.. code-block:: shell
 
     cd build
     # if needed
@@ -273,7 +273,7 @@ Next, build Solidity (or just the ``solfuzzer`` binary) with AFL as your compile
 
 At this stage you should be able to see a message similar to the following:
 
-::
+.. code-block:: text
 
     Scanning dependencies of target solfuzzer
     [ 98%] Building CXX object test/tools/CMakeFiles/solfuzzer.dir/fuzzer.cpp.o
@@ -284,7 +284,7 @@ At this stage you should be able to see a message similar to the following:
 
 If the instrumentation messages did not appear, try switching the cmake flags pointing to AFL's clang binaries:
 
-::
+.. code-block:: shell
 
     # if previously failed
     make clean
@@ -293,7 +293,7 @@ If the instrumentation messages did not appear, try switching the cmake flags po
 
 Otherwise, upon execution the fuzzer halts with an error saying binary is not instrumented:
 
-::
+.. code-block:: text
 
     afl-fuzz 2.52b by <lcamtuf@google.com>
     ... (truncated messages)
@@ -317,7 +317,7 @@ Next, you need some example source files. This makes it much easier for the fuzz
 to find errors. You can either copy some files from the syntax tests or extract test files
 from the documentation or the other tests:
 
-::
+.. code-block:: shell
 
     mkdir /tmp/test_cases
     cd /tmp/test_cases
@@ -334,7 +334,7 @@ that result in similar behaviour of the binary.
 
 Now run the fuzzer (the ``-m`` extends the size of memory to 60 MB):
 
-::
+.. code-block:: shell
 
     afl-fuzz -m 60 -i /tmp/test_cases -o /tmp/fuzzer_reports -- /path/to/solfuzzer
 

--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -139,7 +139,8 @@ The functions ``prefixed`` and ``recoverSigner`` do this in the ``claimPayment``
 The full contract
 -----------------
 
-::
+.. code-block:: solidity
+    :force:
 
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >=0.7.0 <0.9.0;
@@ -335,7 +336,8 @@ so it is important that Bob closes the channel before the expiration is reached.
 The full contract
 -----------------
 
-::
+.. code-block:: solidity
+    :force:
 
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >=0.7.0 <0.9.0;

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
 sphinx_rtd_theme>=0.3.1
 pygments-lexer-solidity>=0.7.0
 sphinx-a4doc>=1.2.1
+
+# Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
+sphinx>=2.1.0


### PR DESCRIPTION
Depends on #11565.

Sphinx 4.0.0 has been released recently and deprecated some of the older features. Now `scripts/docs.sh` fails for me locally on that version. This PR adds some minor tweaks to make our docs work with both Sphinx 3 and Sphinx 4:
- `add_stylesheet()` has long been deprecated. `add_css_file()` is the replacement (https://github.com/sphinx-doc/sphinx/issues/7747). This has exposed a bug in our lexer. See details below.
- `add_lexer()` used to accept both a class and an instance. Starting with Sphinx 4 it only accepts a lexer class.
- We did have some non-Solidity snippets using Solidity highlighting that started failing due to the lexer change mentioned above. I changed their highlighting to the correct one.
- I added `robots.txt` to `.gitignore`. This is unrelated to Sphinx update and should have been done in #11317.

### Bug in `pygments-lexer-solidity`
[`add_lexer()` has a weird quirk](https://github.com/sphinx-doc/sphinx/issues/6497#issuecomment-506922270):
- When it gets an instance of the lexer, syntax errors are ignored and snippets with errors still get highlighted (the error just gets a red outline)
- When it gets a class, syntax errors result in a warning on the command-line (`WARNING: Could not lex literal_block as "Solidity". Highlighting skipped.`) and highlighting is completely disabled for the buggy code snippet.

This has exposed a bug in [pygments-lexer-solidity](https://gitlab.com/veox/pygments-lexer-solidity). The lexer apparently has problems handling `assembly` blocks that are followed by other Solidity instructions (but extra instructions before them are fine). Note for example [the red outline in one of the examples in our current docs](https://docs.soliditylang.org/en/v0.8.4/solidity-by-example.html#the-full-contract):

![solidity-by-example-lexer-error-after-assembly-block](https://user-images.githubusercontent.com/137030/119037790-b4965380-b9b2-11eb-8d2d-167f07cb6215.png)

The error goes away only if I remove the `return` statement or the `assembly` block. We have 3 snippets like this. The snippets look fine to me and do compile so it must be a bug in the lexer rather than in the snippet.

~I originally wanted to use the `:force:` option of the [`code-block`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block) directive to suppress these errors until the lexer is fixed. But it turns out that switching from `::` to `code-block` was enough to suppress them.~ **EDIT**: Weird, it only works locally. I did need `:force:` to make it build in CI.