### PR TITLE
Document the panic function of library deployment

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -598,6 +598,7 @@ function calls which will cause a Panic.
 A Panic exception is generated in the following situations.
 The error code supplied with the error data indicates the kind of panic.
 
+#. 0x00: Used for generic compiler inserted panics.
 #. 0x01: If you call ``assert`` with an argument that evaluates to false.
 #. 0x11: If an arithmetic operation results in underflow or overflow outside of an ``unchecked { ... }`` block.
 #. 0x12; If you divide or modulo by zero (e.g. ``5 / 0`` or ``23 % 0``).

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -237,15 +237,18 @@ size_t ContractCompiler::deployLibrary(ContractDefinition const& _contract)
 			codecopy(codepos, subOffset, subSize)
 			// Check that the first opcode is a PUSH20
 			if iszero(eq(0x73, byte(0, mload(codepos)))) {
-				mstore(0, <panicSig>)
-				mstore(4, 0)
+				mstore(0, <panicSelector>)
+				mstore(4, <panicCode>)
 				revert(0, 0x24)
 			}
 			mstore(0, address())
 			mstore8(codepos, 0x73)
 			return(codepos, subSize)
 		}
-		)")("panicSig", util::selectorFromSignature("Panic(uint256)").str()).render(),
+		)")
+		("panicSelector", util::selectorFromSignature("Panic(uint256)").str())
+		("panicCode", "0")
+		.render(),
 		{"subSize", "subOffset"}
 	);
 

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -656,7 +656,6 @@ pair<string, map<ContractDefinition const*, vector<string>>> IRGenerator::evalua
 
 	map<ContractDefinition const*, std::vector<ASTPointer<Expression>>const *, InheritanceOrder>
 		baseConstructorArguments(inheritanceOrder);
-																											;
 
 	for (ASTPointer<InheritanceSpecifier> const& base: _contract.baseContracts())
 		if (FunctionDefinition const* baseConstructor = dynamic_cast<ContractDefinition const*>(

--- a/libsolutil/ErrorCodes.h
+++ b/libsolutil/ErrorCodes.h
@@ -24,8 +24,8 @@ namespace solidity::util
 
 enum class PanicCode
 {
-	Generic = 0x00, // generic / unspecified error.
-	Assert = 0x01, // generic / unspecified error. Used by assert().
+	Generic = 0x00, // generic / unspecified error
+	Assert = 0x01, // used by the assert() builtin
 	UnderOverflow = 0x11, // arithmetic underflow or overflow
 	DivisionByZero = 0x12, // division or modulo by zero
 	EnumConversionError = 0x21, // enum conversion error


### PR DESCRIPTION
This is mostly a documentation piece, but also noticed we ~~do not have the same code for the IR~~ just use immutables for the IR, which eliminates the need for this check.