### PR TITLE
[isoltest] Remove storage command left overs.

### DIFF
--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -59,7 +59,6 @@ namespace solidity::frontend::test
 	K(Library, "library", 0)           \
 	K(Right, "right", 0)               \
 	K(Failure, "FAILURE", 0)           \
-	K(Storage, "storage", 0)           \
 	K(Gas, "gas", 0)                   \
 
 namespace soltest

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -512,7 +512,6 @@ void TestFileParser::Scanner::scanNextToken()
 		if (_literal == "right") return {Token::Right, ""};
 		if (_literal == "hex") return {Token::Hex, ""};
 		if (_literal == "FAILURE") return {Token::Failure, ""};
-		if (_literal == "storage") return {Token::Storage, ""};
 		if (_literal == "gas") return {Token::Gas, ""};
 		return {Token::Identifier, _literal};
 	};


### PR DESCRIPTION
Related to #10982.

Looks like that we missed some things.