### PR TITLE
Clears EIP-2929 account and storage access indicator on new blocks.

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -168,6 +168,16 @@ void EVMHost::reset()
 	}
 }
 
+void EVMHost::resetWarmAccess()
+{
+	// Clear EIP-2929 account access indicator
+	recorded_account_accesses.clear();
+	// Clear EIP-2929 storage access indicator
+	for (auto& [address, account]: accounts)
+		for (auto& [slot, value]: account.storage)
+			value.access_status = EVMC_ACCESS_COLD;
+}
+
 void EVMHost::transfer(evmc::MockedAccount& _sender, evmc::MockedAccount& _recipient, u256 const& _value) noexcept
 {
 	assertThrow(u256(convertFromEVMC(_sender.balance)) >= _value, Exception, "Insufficient balance for transfer");

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -56,11 +56,14 @@ public:
 	explicit EVMHost(langutil::EVMVersion _evmVersion, evmc::VM& _vm);
 
 	void reset();
+	/// Clears EIP-2929 account and storage access indicator
+	void resetWarmAccess();
 	void newBlock()
 	{
 		tx_context.block_number++;
 		tx_context.block_timestamp += 15;
 		recorded_logs.clear();
+		resetWarmAccess();
 	}
 
 	/// @returns contents of storage at @param _addr.


### PR DESCRIPTION
For semantic tests, each test (in the same test file) happens on a new block, however the storage and
account access indicators were not reset.