### PR TITLE
Fix: Allow multiple @return tags on public state variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Bugfixes:
  * Code Generator: Fix internal error when super would have to skip an unimplemented function in the virtual resolution order.
  * Control Flow Graph: Take internal calls to functions that always revert into account for reporting unused or unassigned variables.
  * Control Flow Graph: Assume unimplemented modifiers use a placeholder.
+ * Natspec: Allow multiple ``@return`` tags on public state variable documentation.
  * SMTChecker: Fix internal error on struct constructor with fixed bytes member initialized with string literal.
  * SMTChecker: Fix internal error on external calls from the constructor.
  * SMTChecker: Fix internal error on conversion from ``bytes`` to ``fixed bytes``.

--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -47,6 +47,66 @@ bool DocStringTagParser::parseDocStrings(SourceUnit const& _sourceUnit)
 	return errorWatcher.ok();
 }
 
+bool DocStringTagParser::validateDocStringsUsingTypes(SourceUnit const& _sourceUnit)
+{
+	auto errorWatcher = m_errorReporter.errorWatcher();
+
+	SimpleASTVisitor visitReturns(
+		[](ASTNode const&) { return true; },
+		[&](ASTNode const& _node)
+		{
+			if (auto const* annotation = dynamic_cast<StructurallyDocumentedAnnotation const*>(&_node.annotation()))
+			{
+				auto const& documentationNode = dynamic_cast<StructurallyDocumented const&>(_node);
+
+				size_t returnTagsVisited = 0;
+
+				for (auto const& [tagName, tagValue]: annotation->docTags)
+					if (tagName == "return")
+					{
+						returnTagsVisited++;
+						if (auto const* varDecl = dynamic_cast<VariableDeclaration const*>(&_node))
+						{
+							solAssert(varDecl->isPublic(), "@return is only allowed on public state-variables.");
+							if (returnTagsVisited > 1)
+								m_errorReporter.docstringParsingError(
+									5256_error,
+									documentationNode.documentation()->location(),
+									"Documentation tag \"@" + tagName + "\" is only allowed once on state-variables."
+								);
+						}
+						else if (auto const* function = dynamic_cast<FunctionDefinition const*>(&_node))
+						{
+							string content = tagValue.content;
+							string firstWord = content.substr(0, content.find_first_of(" \t"));
+
+							if (returnTagsVisited > function->returnParameters().size())
+								m_errorReporter.docstringParsingError(
+									2604_error,
+									documentationNode.documentation()->location(),
+									"Documentation tag \"@" + tagName + " " + tagValue.content + "\"" +
+									" exceeds the number of return parameters."
+								);
+							else
+							{
+								auto parameter = function->returnParameters().at(returnTagsVisited - 1);
+								if (!parameter->name().empty() && parameter->name() != firstWord)
+									m_errorReporter.docstringParsingError(
+										5856_error,
+										documentationNode.documentation()->location(),
+										"Documentation tag \"@" + tagName + " " + tagValue.content + "\"" +
+										" does not contain the name of its return parameter."
+									);
+							}
+						}
+					}
+			}
+	});
+
+	_sourceUnit.accept(visitReturns);
+	return errorWatcher.ok();
+}
+
 bool DocStringTagParser::visit(ContractDefinition const& _contract)
 {
 	static set<string> const validTags = set<string>{"author", "title", "dev", "notice"};
@@ -169,7 +229,6 @@ void DocStringTagParser::parseDocStrings(
 
 	_annotation.docTags = DocStringParser{*_node.documentation(), m_errorReporter}.parse();
 
-	size_t returnTagsVisited = 0;
 	for (auto const& [tagName, tagValue]: _annotation.docTags)
 	{
 		string static const customPrefix("custom:");
@@ -196,43 +255,6 @@ void DocStringTagParser::parseDocStrings(
 				_node.documentation()->location(),
 				"Documentation tag @" + tagName + " not valid for " + _nodeName + "."
 			);
-		else if (tagName == "return")
-		{
-			returnTagsVisited++;
-			if (auto const* varDecl = dynamic_cast<VariableDeclaration const*>(&_node))
-			{
-				solAssert(varDecl->isPublic(), "@return is only allowed on public state-variables.");
-				if (returnTagsVisited > 1)
-					m_errorReporter.docstringParsingError(
-						5256_error,
-						_node.documentation()->location(),
-						"Documentation tag \"@" + tagName + "\" is only allowed once on state-variables."
-					);
-			}
-			else if (auto const* function = dynamic_cast<FunctionDefinition const*>(&_node))
-			{
-				string content = tagValue.content;
-				string firstWord = content.substr(0, content.find_first_of(" \t"));
-
-				if (returnTagsVisited > function->returnParameters().size())
-					m_errorReporter.docstringParsingError(
-						2604_error,
-						_node.documentation()->location(),
-						"Documentation tag \"@" + tagName + " " + tagValue.content + "\"" +
-						" exceeds the number of return parameters."
-					);
-				else
-				{
-					auto parameter = function->returnParameters().at(returnTagsVisited - 1);
-					if (!parameter->name().empty() && parameter->name() != firstWord)
-						m_errorReporter.docstringParsingError(
-							5856_error,
-							_node.documentation()->location(),
-							"Documentation tag \"@" + tagName + " " + tagValue.content + "\"" +
-							" does not contain the name of its return parameter."
-						);
-				}
-			}
-		}
 	}
 }
+

--- a/libsolidity/analysis/DocStringTagParser.h
+++ b/libsolidity/analysis/DocStringTagParser.h
@@ -37,6 +37,9 @@ class DocStringTagParser: private ASTConstVisitor
 public:
 	explicit DocStringTagParser(langutil::ErrorReporter& _errorReporter): m_errorReporter(_errorReporter) {}
 	bool parseDocStrings(SourceUnit const& _sourceUnit);
+	/// Validate the parsed doc strings, requires parseDocStrings() and the
+	/// DeclarationTypeChecker to have run.
+	bool validateDocStringsUsingTypes(SourceUnit const& _sourceUnit);
 
 private:
 	bool visit(ContractDefinition const& _contract) override;

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -1274,7 +1274,7 @@ BOOST_AUTO_TEST_CASE(dev_default_inherit_variable)
 
 	char const *natspec1 = R"ABCDEF({
 		"methods" : {},
-			"stateVariables" :
+		"stateVariables" :
 		{
 			"x" :
 			{
@@ -1340,7 +1340,7 @@ BOOST_AUTO_TEST_CASE(dev_explicit_inherit_variable)
 
 	char const *natspec1 = R"ABCDEF({
 		"methods" : {},
-			"stateVariables" :
+		"stateVariables" :
 		{
 			"x" :
 			{

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -328,6 +328,73 @@ BOOST_AUTO_TEST_CASE(public_state_variable)
 	checkNatspec(sourceCode, "test", userDoc, true);
 }
 
+BOOST_AUTO_TEST_CASE(public_state_variable_struct)
+{
+	char const* sourceCode = R"(
+		contract Bank {
+			struct Coin {
+				string observeGraphicURL;
+				string reverseGraphicURL;
+			}
+
+			/// @notice Get the n-th coin I own
+			/// @return observeGraphicURL Front pic
+			/// @return reverseGraphicURL Back pic
+			Coin[] public coinStack;
+		}
+	)";
+
+	char const* devDoc = R"R(
+	{
+		"methods" : {},
+		"stateVariables" :
+		{
+			"coinStack" :
+			{
+				"returns" :
+				{
+					"observeGraphicURL" : "Front pic",
+					"reverseGraphicURL" : "Back pic"
+				}
+			}
+		}
+	}
+	)R";
+	checkNatspec(sourceCode, "Bank", devDoc, false);
+
+	char const* userDoc = R"R(
+	{
+		"methods" :
+		{
+			"coinStack(uint256)" :
+			{
+				"notice": "Get the n-th coin I own"
+			}
+		}
+	}
+	)R";
+	checkNatspec(sourceCode, "Bank", userDoc, true);
+}
+
+BOOST_AUTO_TEST_CASE(public_state_variable_struct_repeated)
+{
+	char const* sourceCode = R"(
+		contract Bank {
+			struct Coin {
+				string obverseGraphicURL;
+				string reverseGraphicURL;
+			}
+
+			/// @notice Get the n-th coin I own
+			/// @return obverseGraphicURL Front pic
+			/// @return obverseGraphicURL Front pic
+			Coin[] public coinStack;
+		}
+	)";
+
+	expectNatspecError(sourceCode);
+}
+
 BOOST_AUTO_TEST_CASE(private_state_variable)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/syntaxTests/natspec/docstring_state_variable_too_many_return_tags.sol
+++ b/test/libsolidity/syntaxTests/natspec/docstring_state_variable_too_many_return_tags.sol
@@ -6,4 +6,4 @@ contract test {
   uint public state;
 }
 // ----
-// DocstringParsingError 5256: (18-137): Documentation tag "@return" is only allowed once on state-variables.
+// DocstringParsingError 2604: (18-137): Documentation tag "@return returns something" exceeds the number of return parameters.


### PR DESCRIPTION
fixes #11381

I am not completely happy with how I solved the dependency problem in CompilerStack. If you see a nicer way, please comment.