### PR TITLE
docs: Fix for broken genindex.html URLs

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -2,5 +2,5 @@
 
   {% block menu %}
     {{ super() }}
-    <a href="genindex.html">Keyword Index</a>
+	<a href="{{ pathto('genindex') }}">Keyword Index</a>
   {% endblock %}


### PR DESCRIPTION
The solution is much simpler than what I all tried (custom layouts / custom designs per sub-dir). After digging a lot through the sphinx docs it turns out that one should use the `genindex(DOCUMENT)` Jinja function in order to generate links to that given `DOCUMENT` with a correctly working URL.

Locally tested.

Fixes #11446 