### PR TITLE
Add test with event where indexed parameters are not the first.

### DIFF
--- a/test/libsolidity/semanticTests/events/event_indexed_mixed.sol
+++ b/test/libsolidity/semanticTests/events/event_indexed_mixed.sol
@@ -1,0 +1,18 @@
+contract C {
+    // Indexed parameters are always listed first in the output.
+    // The data is the ABI encoding of just the non-indexed parameters,
+    // so putting the indexed parameters "in between" would mess
+    // up the offsets for the reader.
+    event E(uint a, uint indexed r, uint b, bytes c);
+    function deposit() public {
+        emit E(1, 2, 3, "def");
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// deposit() ->
+// ~ emit E(uint256,uint256,uint256,bytes): #0x02, 0x01, 0x03, 0x60, 0x03, "def"
+// gas irOptimized: 23685
+// gas legacy: 24170
+// gas legacyOptimized: 23753


### PR DESCRIPTION
I noticed that we do not have a test where the indexed parameters for an event are not the first parameters.

I think the current behaviour is OK, just wanted to have this documented.

Given this, we could also use a separator between indexed parameters and non-indexed instead of prefixing all indexed arguments.