### PR TITLE
Reports an error on unimplemented modifiers in a function definition.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@ Bugfixes:
  * Type Checker: Fix internal compiler error when attempting to use an invalid external function type on pre-byzantium EVMs.
  * Type Checker: Make errors about (nested) mapping type in event or error parameter into fatal type errors.
  * Type Checker: Fix internal compiler error when overriding receive ether function with one having different parameters during inheritance.
+ * Type Checker: Fix internal compiler error when overriding an implemented modifier with an unimplemented one.
 
 
 AST Changes:

--- a/libsolidity/analysis/OverrideChecker.cpp
+++ b/libsolidity/analysis/OverrideChecker.cpp
@@ -573,6 +573,19 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 			);
 	}
 
+	if (_overriding.unimplemented() && !_super.unimplemented())
+	{
+		solAssert(!_overriding.isVariable() || !_overriding.unimplemented(), "");
+		overrideError(
+			_overriding,
+			_super,
+			4593_error,
+			"Overriding an implemented " + _super.astNodeName() +
+			" with an unimplemented " + _overriding.astNodeName() +
+			" is not allowed."
+		);
+	}
+
 	if (_super.isFunction())
 	{
 		FunctionType const* functionType = _overriding.functionType();
@@ -612,14 +625,6 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 				"\" to \"" +
 				stateMutabilityToString(_overriding.stateMutability()) +
 				"\"."
-			);
-
-		if (_overriding.unimplemented() && !_super.unimplemented())
-			overrideError(
-				_overriding,
-				_super,
-				4593_error,
-				"Overriding an implemented function with an unimplemented function is not allowed."
 			);
 	}
 }

--- a/test/libsolidity/syntaxTests/modifiers/modifier_abstract_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/modifier_abstract_override.sol
@@ -1,0 +1,11 @@
+contract A {
+    modifier m() virtual { _; }
+}
+abstract contract B is A {
+    modifier m() virtual override;
+}
+contract C is B {
+    function f() m public {}
+}
+// ----
+// TypeError 4593: (78-108): Overriding an implemented modifier with an unimplemented modifier is not allowed.

--- a/test/libsolidity/syntaxTests/modifiers/multiple_inheritance_unimplemented_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/multiple_inheritance_unimplemented_override.sol
@@ -1,0 +1,11 @@
+contract A {
+    modifier m() virtual { _; }
+}
+abstract contract B {
+    modifier m() virtual;
+}
+contract C is A, B {
+    modifier m() override(A, B) { _; }
+    function f() m public {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/modifiers/unimplemented_override_unimplemented.sol
+++ b/test/libsolidity/syntaxTests/modifiers/unimplemented_override_unimplemented.sol
@@ -1,0 +1,11 @@
+abstract contract A {
+    modifier m() virtual;
+}
+abstract contract B is A {
+    modifier m() virtual override;
+}
+abstract contract C is B {
+    modifier m() virtual override;
+    function f() m public {}
+}
+// ----

--- a/test/libsolidity/syntaxTests/modifiers/use_unimplemented_from_base.sol
+++ b/test/libsolidity/syntaxTests/modifiers/use_unimplemented_from_base.sol
@@ -1,0 +1,8 @@
+abstract contract A {
+    modifier m() virtual;
+    function f() m public {}
+}
+contract B is A {
+    modifier m() virtual override { _; }
+}
+// ----

--- a/test/libsolidity/syntaxTests/modifiers/use_unimplemented_on_overridden_func.sol
+++ b/test/libsolidity/syntaxTests/modifiers/use_unimplemented_on_overridden_func.sol
@@ -1,0 +1,8 @@
+abstract contract A {
+    modifier m() virtual;
+    function f() m public virtual {}
+}
+abstract contract B is A {
+    function f() public override {}
+}
+// ----


### PR DESCRIPTION
Partial fix for #11468

(some tests are still failing though. working on it).

I'll squash commits once :+1:'d