### PR TITLE
Fix ICE in IR when a library is bound to a literal

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1576,19 +1576,6 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 
 	if (memberFunctionType && memberFunctionType->bound())
 	{
-		solAssert((set<Type::Category>{
-			Type::Category::Contract,
-			Type::Category::Bool,
-			Type::Category::Integer,
-			Type::Category::Address,
-			Type::Category::Function,
-			Type::Category::Struct,
-			Type::Category::Enum,
-			Type::Category::Mapping,
-			Type::Category::Array,
-			Type::Category::FixedBytes,
-		}).count(objectCategory) > 0, "");
-
 		define(IRVariable(_memberAccess).part("self"), _memberAccess.expression());
 		solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
 		if (memberFunctionType->kind() == FunctionType::Kind::Internal)

--- a/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_literal.sol
+++ b/test/libsolidity/semanticTests/libraries/internal_library_function_bound_to_literal.sol
@@ -1,0 +1,26 @@
+library L {
+    function double(uint a) internal pure returns (uint) {
+        return a * 2;
+    }
+
+    function double(bytes memory a) internal pure returns (bytes memory) {
+        return bytes.concat(a, a);
+    }
+}
+
+contract C {
+    using L for *;
+
+    function double42() public returns (uint) {
+        return 42.double();
+    }
+
+    function doubleABC() public returns (bytes memory) {
+        return "abc".double();
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// double42() -> 84
+// doubleABC() -> 0x20, 6, "abcabc"


### PR DESCRIPTION
Fixes #11325.

Removing the assertion checking supported types was enough to fix it.
- The list of types was incomplete - there is a way to bind a function to a literal.
- The assertion was meant to guard against silently skipping over types for which there is no handling implemented yet. The current code handles everything in a generic way though and likely will not have to be adjusted for newly added types so the risk of that happening is low.