### PR TITLE
Treat invalid external function type as a fatal error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Bugfixes:
  * Source Locations: Properly set source location of scoped blocks.
  * Standard JSON: Properly allow the ``inliner`` setting under ``settings.optimizer.details``.
  * Type Checker: Fix internal compiler error related to having mapping types in constructor parameter for abstract contracts.
+ * Type Checker: Fix internal compiler error when attempting to use an invalid external function type on pre-byzantium EVMs.
 
 
 AST Changes:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -721,7 +721,7 @@ void TypeChecker::endVisit(FunctionTypeName const& _funType)
 		{
 			solAssert(t->annotation().type, "Type not set for parameter.");
 			if (!t->annotation().type->interfaceType(false).get())
-				m_errorReporter.typeError(2582_error, t->location(), "Internal type cannot be used for external function type.");
+				m_errorReporter.fatalTypeError(2582_error, t->location(), "Internal type cannot be used for external function type.");
 		}
 		solAssert(fun.interfaceType(false), "External function type uses internal types.");
 	}

--- a/test/libsolidity/syntaxTests/iceRegressionTests/calling_external_function_via_local_variable_with_invalid_type.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/calling_external_function_via_local_variable_with_invalid_type.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public {
+        function() external returns (function() internal) getCallback;
+        getCallback();
+    }
+}
+// ----
+// TypeError 2582: (76-96): Internal type cannot be used for external function type.

--- a/test/libsolidity/syntaxTests/iceRegressionTests/calling_external_function_via_parameter_with_invalid_type.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/calling_external_function_via_parameter_with_invalid_type.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(
+        function() external returns (function() internal) getCallback
+    ) public {
+        getCallback();
+    }
+}
+// ----
+// TypeError 2582: (66-86): Internal type cannot be used for external function type.


### PR DESCRIPTION
Fixes #10113.

Without this it is possible that we'll proceed to type check function body and encounter a call using such an invalid function type. On pre-Byzantium EVMs this requires inspecting the return types of such a function type for disallowed dynamic types and fails because `returnParameterTypesWithoutDynamicTypes()` assumes that it's dealing with a valid external function type.