### PR TITLE
Fix ICE when assigning implicitly convertible function array to storage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Compiler Features:
 
 Bugfixes:
  * AST: Do not output value of Yul literal if it is not a valid UTF-8 string.
+ * Code Generator: Fix internal error when function arrays are assigned to storage variables and the function types can be implicitly converted but are not identical.
  * Code Generator: Fix internal error when super would have to skip an unimplemented function in the virtual resolution order.
  * Control Flow Graph: Take internal calls to functions that always revert into account for reporting unused or unassigned variables.
  * SMTChecker: Fix internal error on struct constructor with fixed bytes member initialized with string literal.

--- a/test/libsolidity/semanticTests/conversions/function_type_array_to_storage.sol
+++ b/test/libsolidity/semanticTests/conversions/function_type_array_to_storage.sol
@@ -1,0 +1,44 @@
+contract C {
+    function () external returns(uint)[1] externalDefaultArray;
+    function () external view returns(uint)[1] externalViewArray;
+    function () external pure returns(uint)[1] externalPureArray;
+
+    function () internal returns(uint)[1] internalDefaultArray;
+    function () internal view returns(uint)[1] internalViewArray;
+    function () internal pure returns(uint)[1] internalPureArray;
+
+    function externalDefault() external returns(uint) { return 11; }
+    function externalView() external view returns(uint) { return 12; }
+    function externalPure() external pure returns(uint) { return 13; }
+
+    function internalDefault() internal returns(uint) { return 21; }
+    function internalView() internal view returns(uint) { return 22; }
+    function internalPure() internal pure returns(uint) { return 23; }
+
+    function testViewToDefault() public returns (uint, uint) {
+        externalDefaultArray = [this.externalView];
+        internalDefaultArray = [internalView];
+
+        return (externalDefaultArray[0](), internalDefaultArray[0]());
+    }
+
+    function testPureToDefault() public returns (uint, uint) {
+        externalDefaultArray = [this.externalPure];
+        internalDefaultArray = [internalPure];
+
+        return (externalDefaultArray[0](), internalDefaultArray[0]());
+    }
+
+    function testPureToView() public returns (uint, uint) {
+        externalViewArray = [this.externalPure];
+        internalViewArray = [internalPure];
+
+        return (externalViewArray[0](), internalViewArray[0]());
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// testViewToDefault() -> 12, 22
+// testPureToDefault() -> 13, 23
+// testPureToView() -> 13, 23

--- a/test/libsolidity/syntaxTests/conversion/function_type_array_to_memory.sol
+++ b/test/libsolidity/syntaxTests/conversion/function_type_array_to_memory.sol
@@ -1,0 +1,49 @@
+contract C {
+    function externalDefault() external returns(uint) { return 11; }
+    function externalView() external view returns(uint) { return 12; }
+    function externalPure() external pure returns(uint) { return 13; }
+
+    function internalDefault() internal returns(uint) { return 21; }
+    function internalView() internal view returns(uint) { return 22; }
+    function internalPure() internal pure returns(uint) { return 23; }
+
+    function testViewToDefault() public returns (uint, uint) {
+        function () external returns(uint)[1] memory externalDefaultArray;
+        function () internal returns(uint)[1] memory internalDefaultArray;
+
+        // This would work if we were assigning to storage rather than memory
+        externalDefaultArray = [this.externalView];
+        internalDefaultArray = [internalView];
+
+        return (externalDefaultArray[0](), internalDefaultArray[0]());
+    }
+
+    function testPureToDefault() public returns (uint, uint) {
+        function () external returns(uint)[1] memory externalDefaultArray;
+        function () internal returns(uint)[1] memory internalDefaultArray;
+
+        // This would work if we were assigning to storage rather than memory
+        externalDefaultArray = [this.externalPure];
+        internalDefaultArray = [internalPure];
+
+        return (externalDefaultArray[0](), internalDefaultArray[0]());
+    }
+
+    function testPureToView() public returns (uint, uint) {
+        function () external returns(uint)[1] memory externalViewArray;
+        function () internal returns(uint)[1] memory internalViewArray;
+
+        // This would work if we were assigning to storage rather than memory
+        externalViewArray = [this.externalPure];
+        internalViewArray = [internalPure];
+
+        return (externalViewArray[0](), internalViewArray[0]());
+    }
+}
+// ----
+// TypeError 7407: (760-779): Type function () view external returns (uint256)[1] memory is not implicitly convertible to expected type function () external returns (uint256)[1] memory.
+// TypeError 7407: (812-826): Type function () view returns (uint256)[1] memory is not implicitly convertible to expected type function () returns (uint256)[1] memory.
+// TypeError 7407: (1230-1249): Type function () pure external returns (uint256)[1] memory is not implicitly convertible to expected type function () external returns (uint256)[1] memory.
+// TypeError 7407: (1282-1296): Type function () pure returns (uint256)[1] memory is not implicitly convertible to expected type function () returns (uint256)[1] memory.
+// TypeError 7407: (1688-1707): Type function () pure external returns (uint256)[1] memory is not implicitly convertible to expected type function () external returns (uint256)[1] memory.
+// TypeError 7407: (1737-1751): Type function () pure returns (uint256)[1] memory is not implicitly convertible to expected type function () returns (uint256)[1] memory.


### PR DESCRIPTION
Fixes #10667.