### PR TITLE
Errors about nested mapping in event parameter are fatal.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@ Bugfixes:
  * Standard JSON: Properly allow the ``inliner`` setting under ``settings.optimizer.details``.
  * Type Checker: Fix internal compiler error related to having mapping types in constructor parameter for abstract contracts.
  * Type Checker: Fix internal compiler error when attempting to use an invalid external function type on pre-byzantium EVMs.
+ * Type Checker: Make errors about (nested) mapping type in event or error parameter into fatal type errors.
 
 
 AST Changes:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3411,7 +3411,7 @@ void TypeChecker::checkErrorAndEventParameters(CallableDeclaration const& _calla
 	for (ASTPointer<VariableDeclaration> const& var: _callable.parameters())
 	{
 		if (type(*var)->containsNestedMapping())
-			m_errorReporter.typeError(
+			m_errorReporter.fatalTypeError(
 				3448_error,
 				var->location(),
 				"Type containing a (nested) mapping is not allowed as " + kind + " parameter type."

--- a/test/libsolidity/syntaxTests/errors/internal_type.sol
+++ b/test/libsolidity/syntaxTests/errors/internal_type.sol
@@ -1,0 +1,9 @@
+error E1(function() internal);
+error E2(S);
+
+struct S {
+    S[] ss;
+}
+// ----
+// TypeError 3417: (9-29): Internal or recursive type is not allowed as error parameter type.
+// TypeError 3417: (40-41): Internal or recursive type is not allowed as error parameter type.

--- a/test/libsolidity/syntaxTests/errors/no_mappings.sol
+++ b/test/libsolidity/syntaxTests/errors/no_mappings.sol
@@ -4,6 +4,3 @@ contract C {
 }
 // ----
 // TypeError 3448: (14-35): Type containing a (nested) mapping is not allowed as error parameter type.
-// TypeError 3417: (14-35): Internal or recursive type is not allowed as error parameter type.
-// TypeError 3448: (70-91): Type containing a (nested) mapping is not allowed as error parameter type.
-// TypeError 3417: (70-91): Internal or recursive type is not allowed as error parameter type.

--- a/test/libsolidity/syntaxTests/events/event_param_type_outside_storage.sol
+++ b/test/libsolidity/syntaxTests/events/event_param_type_outside_storage.sol
@@ -3,5 +3,3 @@ contract c {
 }
 // ----
 // TypeError 3448: (41-72): Type containing a (nested) mapping is not allowed as event parameter type.
-// TypeError 3417: (41-72): Internal or recursive type is not allowed as event parameter type.
-// TypeError 8598: (17-132): More than 4 indexed arguments for anonymous event.

--- a/test/libsolidity/syntaxTests/events/internal_type.sol
+++ b/test/libsolidity/syntaxTests/events/internal_type.sol
@@ -1,0 +1,11 @@
+struct S {
+    S[] ss;
+}
+
+contract C {
+    event E1(function() internal);
+    event E2(S);
+}
+// ----
+// TypeError 3417: (52-72): Internal or recursive type is not allowed as event parameter type.
+// TypeError 3417: (87-88): Internal or recursive type is not allowed as event parameter type.

--- a/test/libsolidity/syntaxTests/types/mapping/error_parameter.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/error_parameter.sol
@@ -1,0 +1,3 @@
+error E (mapping (uint => uint));
+// ----
+// TypeError 3448: (9-31): Type containing a (nested) mapping is not allowed as error parameter type.

--- a/test/libsolidity/syntaxTests/types/mapping/event_parameter.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/event_parameter.sol
@@ -1,0 +1,5 @@
+contract C {
+    event E (mapping (uint => uint) [2]);
+}
+// ----
+// TypeError 3448: (26-52): Type containing a (nested) mapping is not allowed as event parameter type.


### PR DESCRIPTION
(Also applies for error parameters.)

Closes https://github.com/ethereum/solidity/issues/11353