### PR TITLE
Fix control-flow handling of modifiers without body.

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -308,7 +308,7 @@ bool ControlFlowBuilder::visit(ModifierInvocation const& _modifierInvocation)
 		_modifierInvocation.name().annotation().referencedDeclaration
 	);
 	if (!modifierDefinition) return false;
-	solAssert(!!modifierDefinition, "");
+	if (!modifierDefinition->isImplemented()) return false;
 	solAssert(!!m_returnNode, "");
 
 	m_placeholderEntry = newLabel();

--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -29,9 +29,8 @@
 namespace solidity::frontend
 {
 
-/** Helper class that builds the control flow of a function or modifier.
- * Modifiers are not yet applied to the functions. This is done in a second
- * step in the CFG class.
+/**
+ * Helper class that builds the control flow of a function or modifier.
  */
 class ControlFlowBuilder: private ASTConstVisitor, private yul::ASTWalker
 {

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
@@ -23,5 +23,4 @@ contract C is B {
 // ====
 // SMTEngine: all
 // ----
-// Warning 5740: (62-111): Unreachable code.
 // Warning 6328: (66-75): CHC: Assertion violation happens here.\nCounterexample:\ns = false\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
@@ -18,5 +18,4 @@ contract B is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 5740: (62-123): Unreachable code.
 // Warning 6328: (94-104): CHC: Assertion violation happens here.\nCounterexample:\ns = true\nx = true\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/implemented_without_placeholder.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/implemented_without_placeholder.sol
@@ -1,0 +1,8 @@
+abstract contract A {
+    function f() public view mod {
+        require(block.timestamp > 10);
+    }
+    modifier mod() virtual { }
+}
+// ----
+// SyntaxError 2883: (129-132): Modifier body does not contain '_'.

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/non_implemented_modifer.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/non_implemented_modifer.sol
@@ -1,0 +1,6 @@
+abstract contract A {
+    function f() public view mod {
+        require(block.timestamp > 10);
+    }
+    modifier mod() virtual;
+}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10620

I'm still a bit puzzled why the bug does not manifest in
```solidity
abstract contract A {
    function f() public view mod {
        //uint x = 2;
        require(block.timestamp > 10);
    }
    modifier mod() virtual;
}
```
(the require statement is essential for the bug to trigger)

So maybe this is not the right fix.