### PR TITLE
can not prefix with ``this.``

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -51,8 +51,9 @@ code that manages the database. In this example, the contract defines the
 functions ``set`` and ``get`` that can be used to modify
 or retrieve the value of the variable.
 
-To access a state variable, you can not prefix with ``this.`` as is common in
-other languages.
+To access a state variable, you do not typically add the ``this.`` prefix.
+Unlike in some other languages, omitting it is not just a matter of style,
+it results in a completely different operation.
 
 This contract does not do much yet apart from (due to the infrastructure
 built by Ethereum) allowing anyone to store a single number that is accessible by

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -51,9 +51,10 @@ code that manages the database. In this example, the contract defines the
 functions ``set`` and ``get`` that can be used to modify
 or retrieve the value of the variable.
 
-To access a state variable, you do not typically add the ``this.`` prefix.
+To access a member (like a state variable) of the current contract, you do not typically add the ``this.`` prefix,
+you just access it directly via its name.
 Unlike in some other languages, omitting it is not just a matter of style,
-it results in a completely different operation.
+it results in a completely different way to access the member, but more on this later.
 
 This contract does not do much yet apart from (due to the infrastructure
 built by Ethereum) allowing anyone to store a single number that is accessible by

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -51,7 +51,7 @@ code that manages the database. In this example, the contract defines the
 functions ``set`` and ``get`` that can be used to modify
 or retrieve the value of the variable.
 
-To access a state variable, you do not need the prefix ``this.`` as is common in
+To access a state variable, you can not prefix with ``this.`` as is common in
 other languages.
 
 This contract does not do much yet apart from (due to the infrastructure


### PR DESCRIPTION
I'm a newbie, but I tried the following code

```
pragma solidity 0.8.4;

contract Add {

    uint x;

    constructor(uint a) public {
        this.x = a;
    }

}
```

Compiler gives error:

```
CompileError: TypeError: Member "x" not found or not visible after argument-dependent lookup in contract Add.
  --> /B/add/contracts/add.sol:14:9:
   |
14 |         this.x = a;
   |         ^^^^^^
```

If I remove `this.`, the code compiles successfully.

I checked the documentation on https://docs.soliditylang.org/en/develop/introduction-to-smart-contracts.html, which says "do not need the prefix this". This statement is confusing because it implies people are still able to prefix while the reality is prefixing fails the compiler.

As a result, I made the PR to make the statement clearer.
