### PR TITLE
Correctly determine revert state of functions depending on internal library calls.

### DIFF
--- a/libsolidity/analysis/ControlFlowRevertPruner.cpp
+++ b/libsolidity/analysis/ControlFlowRevertPruner.cpp
@@ -113,6 +113,8 @@ void ControlFlowRevertPruner::findRevertStates()
 				if (
 					item.contract == nullptr ||
 					nextItem.contract == nullptr ||
+					item.contract->isLibrary() ||
+					nextItem.contract->isLibrary() ||
 					nextItem.contract == item.contract
 				)
 					pendingFunctions.insert(nextItem);

--- a/test/libsolidity/syntaxTests/controlFlow/unreachableCode/library_function_import_bug.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/unreachableCode/library_function_import_bug.sol
@@ -1,0 +1,18 @@
+==== Source: a ====
+import "b";
+contract Test is Bar {}
+==== Source: b ====
+library Foo {
+    function nop() internal {}
+}
+
+contract Bar {
+    function example() public returns (uint256) {
+        foo();
+        return 0;
+    }
+
+    function foo() public {
+        Foo.nop();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/11522.

Not too familiar with this code, so maybe @chriseth and @Marenz take a look and maybe @Marenz take over, if this PR is a helpful start or feel free to close otherwise.