### PR TITLE
Add "Big Sur" to codespell whitelist

### DIFF
--- a/scripts/codespell_whitelist.txt
+++ b/scripts/codespell_whitelist.txt
@@ -13,3 +13,4 @@ hist
 otion
 keypair
 ether
+sur


### PR DESCRIPTION
Looks like codespell just does not like capitalized words in the whitelist. Lowercase version works for me.