### PR TITLE
Workaround for archlinux z3 4.8.11 + remove runc workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,7 +721,10 @@ jobs:
         TERM: xterm
         # For Archlinux we do not have prebuilt docker images and we would need to build evmone from source,
         # thus we forgo semantics tests to speed things up.
-        SOLTEST_FLAGS: --no-semantic-tests
+        # FIXME: Z3 4.8.11 prerelease is now in main Arch Linux repos but it makes some of our SMT
+        # tests hang. Disabling SMT tests until we get a proper release.
+        # See https://github.com/Z3Prover/z3/issues/5330 for more details.
+        SOLTEST_FLAGS: --no-semantic-tests --no-smt
       steps:
         - run:
             name: Install runtime dependencies


### PR DESCRIPTION
Z3 4.8.11 has hit main Arch Linux repos. Since it's just a prerelease (see https://github.com/Z3Prover/z3/issues/5330) and it makes one of the SMT tests cases hang and time out in CI (`smtCheckerTests/file_level/recursion.sol`), we're just going to disable SMT tests on Arch for now and wait for a proper release.

~The PR also removes an older Arch Linux workaround: #11332. (Need to see if it actually works now; draft until then)~ Looks like it's still an issue.