### PR TITLE
Updated install_deps.sh to handle Big Sur 11.3 and 11.4

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -93,8 +93,8 @@ case $(uname -s) in
             10.15)
                 echo "Installing solidity dependencies on macOS 10.15 Catalina."
                 ;;
-            11.0 | 11.1 | 11.2)
-                echo "Installing solidity dependencies on macOS 11.0 / 11.1 / 11.2 Big Sur."
+            11.0 | 11.1 | 11.2 | 11.3 | 11.4)
+                echo "Installing solidity dependencies on macOS 11.0 / 11.1 / 11.2 / 11.3 / 11.4 Big Sur."
                 ;;
             *)
                 echo "Unsupported macOS version."


### PR DESCRIPTION
I added Big Sur 11.3 and 11.4 to to the scripts/install_deps.sh file. This should not have impacted any existing functionality; however, I did run the test suite. The only failure was the failure mentioned by @cameel in #11426.