### PR TITLE
Fix Sphinx block parameter parsing in `isolate_tests.py`

### DIFF
--- a/test/scripts/fixtures/code_block.rst
+++ b/test/scripts/fixtures/code_block.rst
@@ -1,0 +1,22 @@
+Some text
+
+
+.. code-block:: solidity
+
+    // SPDX-License-Identifier: GPL-3.0
+    pragma solidity >=0.7.0 <0.9.0;
+
+    contract C {
+        function foo() public view {}
+    }
+
+
+.. warning::
+
+    A Warning.
+
+::
+
+    contract C {}
+
+More text.

--- a/test/scripts/fixtures/code_block_with_directives.rst
+++ b/test/scripts/fixtures/code_block_with_directives.rst
@@ -1,0 +1,48 @@
+A normal block with parameters.
+
+.. code-block:: solidity
+    :force:
+    :language: Solidity
+
+    // SPDX-License-Identifier: GPL-3.0
+    pragma solidity >=0.7.0 <0.9.0;
+
+    contract C {
+        function foo() public view {}
+    }
+
+
+.. warning::
+    A Warning.
+
+.. code-block:: solidity
+
+    uint constant x = 42;
+
+Text.
+
+::
+
+    contract C {}
+
+A block with blank lines between block parameters.
+Sphinx will treat the second one as a part of the code.
+
+.. code-block:: solidity
+    :force:
+
+    :language: Solidity
+
+    contract D {}
+    :linenos:
+
+Block with parameters indented less than code.
+Sphinx does not complain about these.
+
+.. code-block:: solidity
+  :force:
+  :linenos:
+
+    contract E {}
+
+More text.

--- a/test/scripts/test_isolate_tests.py
+++ b/test/scripts/test_isolate_tests.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import unittest
+
+from unittest_helpers import FIXTURE_DIR, load_fixture
+
+# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# pragma pylint: disable=import-error
+from isolate_tests import extract_docs_cases
+# pragma pylint: enable=import-error
+
+
+CODE_BLOCK_RST_PATH = FIXTURE_DIR / 'code_block.rst'
+CODE_BLOCK_RST_CONTENT = load_fixture(CODE_BLOCK_RST_PATH)
+CODE_BLOCK_WITH_DIRECTIVES_RST_PATH = FIXTURE_DIR / 'code_block_with_directives.rst'
+CODE_BLOCK_WITH_DIRECTIVES_RST_CONTENT = load_fixture(CODE_BLOCK_WITH_DIRECTIVES_RST_PATH)
+
+
+class TestExtractDocsCases(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = 10000
+
+    def test_solidity_block(self):
+        expected_cases = [
+            "    // SPDX-License-Identifier: GPL-3.0\n"
+            "    pragma solidity >=0.7.0 <0.9.0;\n"
+            "\n"
+            "    contract C {\n"
+            "        function foo() public view {}\n"
+            "    }\n"
+            "\n"
+            "\n",
+
+            "    contract C {}\n"
+            "\n",
+        ]
+
+        self.assertEqual(extract_docs_cases(CODE_BLOCK_RST_PATH), expected_cases)
+
+    def test_solidity_block_with_directives(self):
+        expected_cases = [
+            "    // SPDX-License-Identifier: GPL-3.0\n"
+            "    pragma solidity >=0.7.0 <0.9.0;\n"
+            "\n"
+            "    contract C {\n"
+            "        function foo() public view {}\n"
+            "    }\n"
+            "\n"
+            "\n",
+
+            "    contract C {}\n"
+            "\n",
+
+            "    contract D {}\n"
+            "    :linenos:\n"
+            "\n",
+
+            "    contract E {}\n"
+            "\n",
+        ]
+
+        self.assertEqual(extract_docs_cases(CODE_BLOCK_WITH_DIRECTIVES_RST_PATH), expected_cases)


### PR DESCRIPTION
I need to add `:force:` parameter to some code snippets in docs (see #11420) but `isolate_tests.py` grabs that as a part of the code and the compilation fails. This PR fixes it so that it only grabs the actual content of the block.