### PR TITLE
[Docs] Clarify the statement that docker volumes are not required with `--standard-json`

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -86,7 +86,9 @@ local folder for input and output, and specify the contract to compile. For exam
     docker run -v /local/path:/sources ethereum/solc:stable -o /sources/output --abi --bin /sources/Contract.sol
 
 You can also use the standard JSON interface (which is recommended when using the compiler with tooling).
-When using this interface it is not necessary to mount any directories.
+When using this interface it is not necessary to mount any directories as long as the JSON input is
+self-contained (i.e. it does not refer to any external files that would have to be
+:ref:`loaded by the import callback <initial-vfs-content-standard-json-with-import-callback>`).
 
 .. code-block:: bash
 

--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -104,6 +104,8 @@ The initial content of the VFS depends on how you invoke the compiler:
    The ``sources`` dictionary becomes the initial content of the virtual filesystem and its keys
    are used as source unit names.
 
+   .. _initial-vfs-content-standard-json-with-import-callback:
+
 #. **Standard JSON (via import callback)**
 
    With Standard JSON it is also possible to tell the compiler to use the import callback to obtain


### PR DESCRIPTION
Reported in https://github.com/ethereum/solidity/issues/11543#issuecomment-862554471:

> Ooooook, i'll try it, it's because in the documentation there is a mention that standard-json does not need to mount volumes.
> Maybe should change it no ? cause it's way easier with mounted volume, at least we are quiet tranquil for the remaining problem.