### PR TITLE
Clearer error message for `std::exception` in soltest

### DIFF
--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -83,6 +83,10 @@ void runTestCase(TestCase::Config const& _config, TestCase::TestCaseCreator cons
 	{
 		BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
 	}
+	catch (std::exception const& _e)
+	{
+		BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
+	}
 }
 
 int registerTests(

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -60,6 +60,31 @@ void removeTestSuite(std::string const& _name)
 	master.remove(id);
 }
 
+void runTestCase(TestCase::Config const& _config, TestCase::TestCaseCreator const& _testCaseCreator)
+{
+	try
+	{
+		stringstream errorStream;
+		auto testCase = _testCaseCreator(_config);
+		if (testCase->shouldRun())
+			switch (testCase->run(errorStream))
+			{
+				case TestCase::TestResult::Success:
+					break;
+				case TestCase::TestResult::Failure:
+					BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
+					break;
+				case TestCase::TestResult::FatalError:
+					BOOST_ERROR("Fatal error during test.\n" + errorStream.str());
+					break;
+			}
+	}
+	catch (boost::exception const& _e)
+	{
+		BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
+	}
+}
+
 int registerTests(
 	boost::unit_test::test_suite& _suite,
 	boost::filesystem::path const& _basepath,
@@ -114,28 +139,8 @@ int registerTests(
 			[config, _testCaseCreator]
 			{
 				BOOST_REQUIRE_NO_THROW({
-					try
-					{
-						stringstream errorStream;
-						auto testCase = _testCaseCreator(config);
-						if (testCase->shouldRun())
-							switch (testCase->run(errorStream))
-							{
-								case TestCase::TestResult::Success:
-									break;
-								case TestCase::TestResult::Failure:
-									BOOST_ERROR("Test expectation mismatch.\n" + errorStream.str());
-									break;
-								case TestCase::TestResult::FatalError:
-									BOOST_ERROR("Fatal error during test.\n" + errorStream.str());
-									break;
-							}
-					}
-					catch (boost::exception const& _e)
-					{
-						BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
-					}
-			   });
+					runTestCase(config, _testCaseCreator);
+				});
 			},
 			_path.stem().string(),
 			*filenames.back(),


### PR DESCRIPTION
Currently when a test raises an exception that does not derive from `boost::exception` (like for example the `std::length_error` in #11528) the error message is very hard to understand because it contains a long piece of serialized code with all newlines removed. This PR puts that code in a function to make it shorter in cases where it does get printed and also adds a handler for `std::exception` to print diagnostic info, which should cover most of the exception types we are likely to encounter.

### Output before this PR
```
Running 1 test case...
/solidity/test/boostTest.cpp(116): fatal error: in "semanticTests/externalContracts/tmp": unexpected exception thrown by { try { stringstream errorStream; auto testCase = _testCaseCreator(config); if (testCase->shouldRun()) switch (testCase->run(errorStream)) { case TestCase::TestResult::Success: break; case TestCase::TestResult::Failure: do { ::boost::unit_test::unit_test_log.set_checkpoint( ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(127) ); ::boost::test_tools::tt_detail:: report_assertion ( (false), (::boost::unit_test::lazy_ostream::instance() << "Test expectation mismatch.\n" + errorStream.str()), ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(127), ::boost::test_tools::tt_detail::CHECK, ::boost::test_tools::tt_detail::CHECK_MSG , 0 ); } while( ::boost::test_tools::tt_detail::dummy_cond() ); break; case TestCase::TestResult::FatalError: do { ::boost::unit_test::unit_test_log.set_checkpoint( ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(130) ); ::boost::test_tools::tt_detail:: report_assertion ( (false), (::boost::unit_test::lazy_ostream::instance() << "Fatal error during test.\n" + errorStream.str()), ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(130), ::boost::test_tools::tt_detail::CHECK, ::boost::test_tools::tt_detail::CHECK_MSG , 0 ); } while( ::boost::test_tools::tt_detail::dummy_cond() ); break; } } catch (boost::exception const& _e) { do { ::boost::unit_test::unit_test_log.set_checkpoint( ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(136) ); ::boost::test_tools::tt_detail:: report_assertion ( (false), (::boost::unit_test::lazy_ostream::instance() << "Exception during extracted test: " << boost::diagnostic_information(_e)), ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(136), ::boost::test_tools::tt_detail::CHECK, ::boost::test_tools::tt_detail::CHECK_MSG , 0 ); } while( ::boost::test_tools::tt_detail::dummy_cond() ); } }

*** 1 failure is detected in the test module "SolidityTests"
```

Note that the line is very long. In the console, with wrapping, it looks more like this:
`/solidity/test/boostTest.cpp(116): fatal error: in "semanticTests/externalContracts/tmp": unexpected exception thrown by { try { stringstream errorStream; auto testCase = _testCaseCreator(config); if (testCase->shouldRun()) switch (testCase->run(errorStream)) { case TestCase::TestResult::Success: break; case TestCase::TestResult::Failure: do { ::boost::unit_test::unit_test_log.set_checkpoint( ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(127) ); ::boost::test_tools::tt_detail:: report_assertion ( (false), (::boost::unit_test::lazy_ostream::instance() << "Test expectation mismatch.\n" + errorStream.str()), ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(127), ::boost::test_tools::tt_detail::CHECK, ::boost::test_tools::tt_detail::CHECK_MSG , 0 ); } while( ::boost::test_tools::tt_detail::dummy_cond() ); break; case TestCase::TestResult::FatalError: do { ::boost::unit_test::unit_test_log.set_checkpoint( ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(130) ); ::boost::test_tools::tt_detail:: report_assertion ( (false), (::boost::unit_test::lazy_ostream::instance() << "Fatal error during test.\n" + errorStream.str()), ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(130), ::boost::test_tools::tt_detail::CHECK, ::boost::test_tools::tt_detail::CHECK_MSG , 0 ); } while( ::boost::test_tools::tt_detail::dummy_cond() ); break; } } catch (boost::exception const& _e) { do { ::boost::unit_test::unit_test_log.set_checkpoint( ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(136) ); ::boost::test_tools::tt_detail:: report_assertion ( (false), (::boost::unit_test::lazy_ostream::instance() << "Exception during extracted test: " << boost::diagnostic_information(_e)), ::boost::unit_test::const_string( "/solidity/test/boostTest.cpp", sizeof( "/solidity/test/boostTest.cpp" ) - 1 ), static_cast<std::size_t>(136), ::boost::test_tools::tt_detail::CHECK, ::boost::test_tools::tt_detail::CHECK_MSG , 0 ); } while( ::boost::test_tools::tt_detail::dummy_cond() ); } }`

### Output with the code moved to a function
i.e. with only the first commit from this PR.
```
Running 1 test case...
/solidity/test/boostTest.cpp(141): fatal error: in "semanticTests/externalContracts/tmp": unexpected exception thrown by { runTestCase(config, _testCaseCreator); }

*** 1 failure is detected in the test module "SolidityTests"
```

### Output with special handling for `std::exception`
```
Running 1 test case...
/solidity/test/boostTest.cpp(88): error: in "semanticTests/externalContracts/tmp": Exception during extracted test: Dynamic exception type: std::length_error
std::exception::what: basic_string::_M_replace_aux


*** 1 failure is detected in the test module "SolidityTests"
```