### PR TITLE
fix bug of the method bid of SimpleAuction

### DIFF
--- a/docs/examples/blind-auction.rst
+++ b/docs/examples/blind-auction.rst
@@ -98,6 +98,8 @@ to receive their money - contracts cannot activate themselves.
             // it having received the money).
             if (msg.value <= highestBid)
                 revert BidNotHighEnough(highestBid);
+            highestBidder = msg.sender;
+            highestBid = msg.value;
 
             if (highestBid != 0) {
                 // Sending back the money by simply using
@@ -107,8 +109,6 @@ to receive their money - contracts cannot activate themselves.
                 // withdraw their money themselves.
                 pendingReturns[highestBidder] += highestBid;
             }
-            highestBidder = msg.sender;
-            highestBid = msg.value;
             emit HighestBidIncreased(msg.sender, msg.value);
         }
 


### PR DESCRIPTION
test code:
```js
let auction = await SimpleAuction.deployed()

auction.bid({from: accounts[1], value: web3.utils.toWei('1', 'ether')})
auction.bid({from: accounts[2], value: web3.utils.toWei('2', 'ether')})
auction.bid({from: accounts[3], value: web3.utils.toWei('3', 'ether')})// The data of accounts[3] will not pushed into the Array pendingReturns

auction.withdraw({from: accounts[1]})
auction.withdraw({from: accounts[2]})
auction.withdraw({from: accounts[3]}) // This will not work, because the Array pendingReturns dose not include the data of accounts[3]

```

The correct code is as follows:

```solidity
highestBidder = msg.sender;
highestBid = msg.value;
if (highestBid != 0) {
  pendingReturns[highestBidder] += highestBid;
}
```