### PR TITLE
Make CommonIO testable

### DIFF
--- a/libsolutil/CommonIO.cpp
+++ b/libsolutil/CommonIO.cpp
@@ -25,7 +25,6 @@
 
 #include <boost/filesystem.hpp>
 
-#include <iostream>
 #include <fstream>
 #if defined(_WIN32)
 #include <windows.h>
@@ -75,14 +74,14 @@ string solidity::util::readFileAsString(string const& _file)
 	return readFile<string>(_file);
 }
 
-string solidity::util::readStandardInput()
+string solidity::util::readUntilEnd(istream& _stdin)
 {
 	string ret;
-	while (!cin.eof())
+	while (!_stdin.eof())
 	{
 		string tmp;
 		// NOTE: this will read until EOF or NL
-		getline(cin, tmp);
+		getline(_stdin, tmp);
 		ret.append(tmp);
 		ret.append("\n");
 	}

--- a/libsolutil/CommonIO.h
+++ b/libsolutil/CommonIO.h
@@ -25,22 +25,23 @@
 #pragma once
 
 #include <libsolutil/Common.h>
+#include <iostream>
 #include <sstream>
 #include <string>
 
 namespace solidity::util
 {
 
-/// Retrieve and returns the contents of the given file as a std::string.
+/// Retrieves and returns the contents of the given file as a std::string.
 /// If the file doesn't exist, it will throw a FileNotFound exception.
 /// If the file exists but is not a regular file, it will throw NotAFile exception.
 /// If the file is empty, returns an empty string.
 std::string readFileAsString(std::string const& _file);
 
-/// Retrieve and returns the contents of standard input (until EOF).
-std::string readStandardInput();
+/// Retrieves and returns the whole content of the specified input stream (until EOF).
+std::string readUntilEnd(std::istream& _stdin);
 
-/// Retrieve and returns a character from standard input (without waiting for EOL).
+/// Retrieves and returns a character from standard input (without waiting for EOL).
 int readStandardInputChar();
 
 /// Converts arbitrary value to string representation using std::stringstream.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -640,7 +640,7 @@ bool CommandLineInterface::readInputFilesAndConfigureRemappings()
 		}
 
 	if (addStdin)
-		m_fileReader.setSource(g_stdinFileName, readStandardInput());
+		m_fileReader.setSource(g_stdinFileName, readUntilEnd(cin));
 
 	if (m_fileReader.sourceCodes().size() == 0)
 	{
@@ -1255,7 +1255,7 @@ bool CommandLineInterface::processInput()
 		}
 		string input;
 		if (jsonFile.empty())
-			input = readStandardInput();
+			input = readUntilEnd(cin);
 		else
 		{
 			try

--- a/test/tools/afl_fuzzer.cpp
+++ b/test/tools/afl_fuzzer.cpp
@@ -114,7 +114,7 @@ Allowed options)",
 	{
 		string input;
 		if (inputFile.size() == 0)
-			input = readStandardInput();
+			input = readUntilEnd(cin);
 		else
 			input = readFileAsString(inputFile);
 

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -155,7 +155,7 @@ Allowed options)",
 				}
 			}
 		else
-			input = readStandardInput();
+			input = readUntilEnd(cin);
 
 		interpret(input);
 	}


### PR DESCRIPTION
Especially standard input reading so that we can add a test in #11584.

Note: This PR contains bits from #11579 and #11520 to avoid creating more dependencies between PRs. As it is now they can all be reviewed and merged independently and whichever of these PRs goes in first, the duplicated bits will disappear from the others during the rebase.