### PR TITLE
Fix yul codegen bug when using binary negation.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * Code Generator: Fix internal compiler error when calling functions bound to calldata structs and arrays.
  * Code Generator: Fix internal compiler error when passing zero to ``bytes.concat()``.
  * Type Checker: Fix internal error and prevent static calls to unimplemented modifiers.
+ * Yul Code Generator: Fix internal compiler error when using a long literal with bitwise negation.
 
 
 ### 0.8.6 (2021-06-22)

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.h
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.h
@@ -105,7 +105,7 @@ public:
 	bool visit(Continue const& _continueStatement) override;
 	bool visit(Break const& _breakStatement) override;
 	void endVisit(Return const& _return) override;
-	void endVisit(UnaryOperation const& _unaryOperation) override;
+	bool visit(UnaryOperation const& _unaryOperation) override;
 	bool visit(BinaryOperation const& _binOp) override;
 	void endVisit(FunctionCall const& _funCall) override;
 	void endVisit(FunctionCallOptions const& _funCallOptions) override;

--- a/test/cmdlineTests/exp_base_literal/output
+++ b/test/cmdlineTests/exp_base_literal/output
@@ -236,8 +236,6 @@ object "C_81" {
                 let expr_25 := checked_exp_t_rational_2_by_1_t_uint256(expr_24)
                 /// @src 0:187,200
                 let var_w_22 := expr_25
-                /// @src 0:214,215
-                let expr_29 := 0x02
                 /// @src 0:213,215
                 let expr_30 := 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
                 /// @src 0:212,216
@@ -285,8 +283,6 @@ object "C_81" {
                 /// @src 0:303,313
                 var_w_22 := expr_56
                 let expr_57 := expr_56
-                /// @src 0:323,324
-                let expr_60 := 0x01
                 /// @src 0:322,324
                 let expr_61 := 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
                 /// @src 0:321,325

--- a/test/libsolidity/semanticTests/expressions/unary_too_long_literal.sol
+++ b/test/libsolidity/semanticTests/expressions/unary_too_long_literal.sol
@@ -1,0 +1,11 @@
+contract C {
+	function f() public returns (bool) {
+		return
+			0 <
+			~~84926290883049832306107864558384249403874903260938453235235091622489261765859;
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> true


### PR DESCRIPTION
I am not sure if this is the way we should fix this, but it is at least
the same way we use in the old codegen...

fixes #11526