### PR TITLE
Stripping base path from CLI paths (without CLI refactor)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 Compiler Features:
  * AssemblyStack: Also run opcode-based optimizer when compiling Yul code.
+ * Commandline Interface: Normalize paths specified on the command line and make them relative whenever files are located inside base path.
  * Yul EVM Code Transform: Do not reuse stack slots that immediately become unreachable.
  * Yul EVM Code Transform: Also pop unused argument slots for functions without return variables (under the same restrictions as for functions with return variables).
  * Yul Optimizer: Move function arguments and return variables to memory with the experimental Stack Limit Evader (which is not enabled by default).

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -22,6 +22,8 @@
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/Exceptions.h>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 using solidity::frontend::ReadCallback;
 using solidity::langutil::InternalCompilerError;
 using solidity::util::errinfo_comment;
@@ -31,9 +33,17 @@ using std::string;
 namespace solidity::frontend
 {
 
+void FileReader::setBasePath(boost::filesystem::path const& _path)
+{
+	m_basePath = (_path.empty() ? "" : normalizeCLIPathForVFS(_path));
+}
+
 void FileReader::setSource(boost::filesystem::path const& _path, SourceCode _source)
 {
-	m_sourceCodes[_path.generic_string()] = std::move(_source);
+	boost::filesystem::path normalizedPath = normalizeCLIPathForVFS(_path);
+	boost::filesystem::path prefix = (m_basePath.empty() ? normalizeCLIPathForVFS(".") : m_basePath);
+
+	m_sourceCodes[stripPrefixIfPresent(prefix, normalizedPath).generic_string()] = std::move(_source);
 }
 
 void FileReader::setSources(StringMap _sources)
@@ -92,5 +102,138 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 	}
 }
 
+boost::filesystem::path FileReader::normalizeCLIPathForVFS(boost::filesystem::path const& _path)
+{
+	// Detailed normalization rules:
+	// - Makes the path either be absolute or have slash as root (note that on Windows paths with
+	//   slash as root are not considered absolute by Boost). If it is empty, it becomes
+	//   the current working directory.
+	// - Collapses redundant . and .. segments.
+	// - Removes leading .. segments from an absolute path (i.e. /../../ becomes just /).
+	// - Squashes sequences of multiple path separators into one.
+	// - Ensures that forward slashes are used as path separators on all platforms.
+	// - Removes the root name (e.g. drive letter on Windows) when it matches the root name in the
+	//   path to the current working directory.
+	//
+	// Also note that this function:
+	// - Does NOT resolve symlinks (except for symlinks in the path to the current working directory).
+	// - Does NOT check if the path refers to a file or a directory. If the path ends with a slash,
+	//   the slash is preserved even if it's a file.
+	// - Preserves case. Even if the filesystem is case-insensitive but case-preserving and the
+	//   case differs, the actual case from disk is NOT detected.
+
+	boost::filesystem::path canonicalWorkDir = boost::filesystem::weakly_canonical(boost::filesystem::current_path());
+
+	// NOTE: On UNIX systems the path returned from current_path() has symlinks resolved while on
+	// Windows it does not. To get consistent results we resolve them on all platforms.
+	boost::filesystem::path absolutePath = boost::filesystem::absolute(_path, canonicalWorkDir);
+
+	// NOTE: boost path preserves certain differences that are ignored by its operator ==.
+	// E.g. "a//b" vs "a/b" or "a/b/" vs "a/b/.". lexically_normal() does remove these differences.
+	boost::filesystem::path normalizedPath =  absolutePath.lexically_normal();
+	solAssert(normalizedPath.is_absolute() || normalizedPath.root_path() == "/", "");
+
+	// lexically_normal() will not squash paths like "/../../" into "/". We have to do it manually.
+	boost::filesystem::path dotDotPrefix = absoluteDotDotPrefix(normalizedPath);
+
+	// If the path is on the same drive as the working dir, for portability we prefer not to
+	// include the root name. Do this only for non-UNC paths - my experiments show that on Windows
+	// when the working dir is an UNC path, / does not not actually refer to the root of the UNC path.
+	boost::filesystem::path normalizedRootPath = normalizedPath.root_path();
+	if (!isUNCPath(normalizedPath))
+	{
+		boost::filesystem::path workingDirRootPath = canonicalWorkDir.root_path();
+		if (normalizedRootPath == workingDirRootPath)
+			normalizedRootPath = "/";
+	}
+
+	boost::filesystem::path normalizedPathNoDotDot = normalizedPath;
+	if (dotDotPrefix.empty())
+		normalizedPathNoDotDot = normalizedRootPath / normalizedPath.relative_path();
+	else
+		normalizedPathNoDotDot = normalizedRootPath / normalizedPath.lexically_relative(normalizedPath.root_path() / dotDotPrefix);
+	solAssert(!hasDotDotSegments(normalizedPathNoDotDot), "");
+
+	// NOTE: On Windows lexically_normal() converts all separators to forward slashes. Convert them back.
+	// Separators do not affect path comparison but remain in internal representation returned by native().
+	// This will also normalize the root name to start with // in UNC paths.
+	normalizedPathNoDotDot = normalizedPathNoDotDot.generic_string();
+
+	// For some reason boost considers "/." different than "/" even though for other directories
+	// the trailing dot is ignored.
+	if (normalizedPathNoDotDot == "/.")
+		return "/";
+
+	return normalizedPathNoDotDot;
 }
 
+bool FileReader::isPathPrefix(boost::filesystem::path _prefix, boost::filesystem::path const& _path)
+{
+	solAssert(!_prefix.empty() && !_path.empty(), "");
+	// NOTE: On Windows paths starting with a slash (rather than a drive letter) are considered relative by boost.
+	solAssert(_prefix.is_absolute() || isUNCPath(_prefix) || _prefix.root_path() == "/", "");
+	solAssert(_path.is_absolute() || isUNCPath(_path) || _path.root_path() == "/", "");
+	solAssert(_prefix == _prefix.lexically_normal() && _path == _path.lexically_normal(), "");
+	solAssert(!hasDotDotSegments(_prefix) && !hasDotDotSegments(_path), "");
+
+	// Before 1.72.0 lexically_relative() was not handling paths with empty, dot and dot dot segments
+	// correctly (see https://github.com/boostorg/filesystem/issues/76). The only case where this
+	// is possible after our normalization is a directory name ending in a slash (filename is a dot).
+	if (_prefix.filename_is_dot())
+		_prefix.remove_filename();
+
+	boost::filesystem::path strippedPath = _path.lexically_relative(_prefix);
+	return !strippedPath.empty() && *strippedPath.begin() != "..";
+}
+
+boost::filesystem::path FileReader::stripPrefixIfPresent(boost::filesystem::path _prefix, boost::filesystem::path const& _path)
+{
+	if (!isPathPrefix(_prefix, _path))
+		return _path;
+
+	if (_prefix.filename_is_dot())
+		_prefix.remove_filename();
+
+	boost::filesystem::path strippedPath = _path.lexically_relative(_prefix);
+	solAssert(strippedPath.empty() || *strippedPath.begin() != "..", "");
+	return strippedPath;
+}
+
+boost::filesystem::path FileReader::absoluteDotDotPrefix(boost::filesystem::path const& _path)
+{
+	solAssert(_path.is_absolute() || _path.root_path() == "/", "");
+
+	boost::filesystem::path _pathWithoutRoot = _path.relative_path();
+	boost::filesystem::path prefix;
+	for (boost::filesystem::path const& segment: _pathWithoutRoot)
+		if (segment.filename_is_dot_dot())
+			prefix /= segment;
+
+	return prefix;
+}
+
+bool FileReader::hasDotDotSegments(boost::filesystem::path const& _path)
+{
+	for (boost::filesystem::path const& segment: _path)
+		if (segment.filename_is_dot_dot())
+			return true;
+
+	return false;
+}
+
+bool FileReader::isUNCPath(boost::filesystem::path const& _path)
+{
+	string rootName = _path.root_name().string();
+
+	return (
+		rootName.size() == 2 ||
+		(rootName.size() > 2 && rootName[2] != rootName[1])
+	) && (
+		(rootName[0] == '/' && rootName[1] == '/')
+#if defined(_WIN32)
+		|| (rootName[0] == '\\' && rootName[1] == '\\')
+#endif
+	);
+}
+
+}

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -119,6 +119,8 @@ boost::filesystem::path FileReader::normalizeCLIPathForVFS(boost::filesystem::pa
 	// - Does NOT resolve symlinks (except for symlinks in the path to the current working directory).
 	// - Does NOT check if the path refers to a file or a directory. If the path ends with a slash,
 	//   the slash is preserved even if it's a file.
+	//   - The only exception are paths where the file name is a dot (e.g. '.' or 'a/b/.'). These
+	//     always have a trailing slash after normalization.
 	// - Preserves case. Even if the filesystem is case-insensitive but case-preserving and the
 	//   case differs, the actual case from disk is NOT detected.
 

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -133,9 +133,6 @@ boost::filesystem::path FileReader::normalizeCLIPathForVFS(boost::filesystem::pa
 	boost::filesystem::path normalizedPath =  absolutePath.lexically_normal();
 	solAssert(normalizedPath.is_absolute() || normalizedPath.root_path() == "/", "");
 
-	// lexically_normal() will not squash paths like "/../../" into "/". We have to do it manually.
-	boost::filesystem::path dotDotPrefix = absoluteDotDotPrefix(normalizedPath);
-
 	// If the path is on the same drive as the working dir, for portability we prefer not to
 	// include the root name. Do this only for non-UNC paths - my experiments show that on Windows
 	// when the working dir is an UNC path, / does not not actually refer to the root of the UNC path.
@@ -146,6 +143,9 @@ boost::filesystem::path FileReader::normalizeCLIPathForVFS(boost::filesystem::pa
 		if (normalizedRootPath == workingDirRootPath)
 			normalizedRootPath = "/";
 	}
+
+	// lexically_normal() will not squash paths like "/../../" into "/". We have to do it manually.
+	boost::filesystem::path dotDotPrefix = absoluteDotDotPrefix(normalizedPath);
 
 	boost::filesystem::path normalizedPathNoDotDot = normalizedPath;
 	if (dotDotPrefix.empty())

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -45,12 +45,13 @@ public:
 		boost::filesystem::path _basePath = {},
 		FileSystemPathSet _allowedDirectories = {}
 	):
-		m_basePath(std::move(_basePath)),
 		m_allowedDirectories(std::move(_allowedDirectories)),
 		m_sourceCodes()
-	{}
+	{
+		setBasePath(_basePath);
+	}
 
-	void setBasePath(boost::filesystem::path _path) { m_basePath = std::move(_path); }
+	void setBasePath(boost::filesystem::path const& _path);
 	boost::filesystem::path const& basePath() const noexcept { return m_basePath; }
 
 	void allowDirectory(boost::filesystem::path _path) { m_allowedDirectories.insert(std::move(_path)); }
@@ -58,14 +59,14 @@ public:
 
 	StringMap const& sourceCodes() const noexcept { return m_sourceCodes; }
 
-	/// Retrieves the source code for a given source unit ID.
+	/// Retrieves the source code for a given source unit name.
 	SourceCode const& sourceCode(SourceUnitName const& _sourceUnitName) const { return m_sourceCodes.at(_sourceUnitName); }
 
-	/// Resets all sources to the given map of source unit ID to source codes.
+	/// Resets all sources to the given map of source unit name to source codes.
 	/// Does not enforce @a allowedDirectories().
 	void setSources(StringMap _sources);
 
-	/// Adds the source code for a given source unit ID.
+	/// Adds the source code under a source unit name created by normalizing the file path.
 	/// Does not enforce @a allowedDirectories().
 	void setSource(boost::filesystem::path const& _path, SourceCode _source);
 
@@ -83,7 +84,42 @@ public:
 		return [this](std::string const& _kind, std::string const& _path) { return readFile(_kind, _path); };
 	}
 
+	/// Normalizes a filesystem path to make it include all components up to the filesystem root,
+	/// remove small, inconsequential differences that do not affect the meaning and make it look
+	/// the same on all platforms (if possible). Symlinks in the path are not resolved.
+	/// The resulting path uses forward slashes as path separators, has no redundant separators,
+	/// has no redundant . or .. segments and has no root name if removing it does not change the meaning.
+	/// The path does not have to actually exist.
+	static boost::filesystem::path normalizeCLIPathForVFS(boost::filesystem::path const& _path);
+
+	/// @returns true if all the path components of @a _prefix are present at the beginning of @a _path.
+	/// Both paths must be absolute (or have slash as root) and normalized (no . or .. segments, no
+	/// multiple consecutive slashes).
+	/// Paths are treated as case-sensitive. Does not require the path to actually exist in the
+	/// filesystem and does not follow symlinks. Only considers whole segments, e.g. /abc/d is not
+	/// considered a prefix of /abc/def. Both paths must be non-empty.
+	static bool isPathPrefix(boost::filesystem::path _prefix, boost::filesystem::path const& _path);
+
+	/// If @a _prefix is actually a prefix of @p _path, removes it from @a _path to make it relative.
+	/// @returns The path without the prefix or unchanged path if there is not prefix.
+	/// If @a _path and @_prefix are identical, the result is '.'.
+	static boost::filesystem::path stripPrefixIfPresent(boost::filesystem::path _prefix, boost::filesystem::path const& _path);
+
+	// @returns true if the specified path is an UNC path.
+	// UNC paths start with // followed by a name (on Windows they can also start with \\).
+	// They are used for network shares on Windows. On UNIX systems they do not have the same
+	// functionality but usually they are still recognized and treated in a special way.
+	static bool isUNCPath(boost::filesystem::path const& _path);
+
 private:
+	/// If @a _path starts with a number of .. segments, returns a path consisting only of those
+	/// segments (root name is not included). Otherwise returns an empty path. @a _path must be
+	/// absolute (or have slash as root).
+	static boost::filesystem::path absoluteDotDotPrefix(boost::filesystem::path const& _path);
+
+	/// @returns true if the path contains any .. segments.
+	static bool hasDotDotSegments(boost::filesystem::path const& _path);
+
 	/// Base path, used for resolving relative paths in imports.
 	boost::filesystem::path m_basePath;
 

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -98,6 +98,7 @@ public:
 	/// Paths are treated as case-sensitive. Does not require the path to actually exist in the
 	/// filesystem and does not follow symlinks. Only considers whole segments, e.g. /abc/d is not
 	/// considered a prefix of /abc/def. Both paths must be non-empty.
+	/// Ignores the trailing slash, i.e. /a/b/c.sol/ is treated as a valid prefix of /a/b/c.sol.
 	static bool isPathPrefix(boost::filesystem::path _prefix, boost::filesystem::path const& _path);
 
 	/// If @a _prefix is actually a prefix of @p _path, removes it from @a _path to make it relative.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,7 @@ set(libsolidity_sources
     libsolidity/SyntaxTest.h
     libsolidity/ViewPureChecker.cpp
     libsolidity/analysis/FunctionCallGraph.cpp
+    libsolidity/interface/FileReader.cpp
 )
 detect_stray_source_files("${libsolidity_sources}" "libsolidity/")
 

--- a/test/FilesystemUtils.cpp
+++ b/test/FilesystemUtils.cpp
@@ -39,11 +39,16 @@ void solidity::test::createFileWithContent(boost::filesystem::path const& _path,
 
 bool solidity::test::createSymlinkIfSupportedByFilesystem(
 	boost::filesystem::path const& _targetPath,
-	boost::filesystem::path const& _linkName
+	boost::filesystem::path const& _linkName,
+	bool directorySymlink
 )
 {
 	boost::system::error_code symlinkCreationError;
-	boost::filesystem::create_symlink(_targetPath, _linkName, symlinkCreationError);
+
+	if (directorySymlink)
+		boost::filesystem::create_directory_symlink(_targetPath, _linkName, symlinkCreationError);
+	else
+		boost::filesystem::create_symlink(_targetPath, _linkName, symlinkCreationError);
 
 	if (!symlinkCreationError)
 		return true;

--- a/test/FilesystemUtils.h
+++ b/test/FilesystemUtils.h
@@ -34,12 +34,16 @@ void createFileWithContent(boost::filesystem::path const& _path, std::string con
 
 /// Creates a symlink between two paths.
 /// The target does not have to exist.
+/// If @p directorySymlink is true, indicate to the operating system that this is a directory
+/// symlink. On some systems (e.g. Windows) it's possible to create a non-directory symlink pointing
+/// at a directory, which makes such a symlinks unusable.
 /// @returns true if the symlink has been successfully created, false if the filesystem does not
 /// support symlinks.
 /// Throws an exception of the operation fails for a different reason.
 bool createSymlinkIfSupportedByFilesystem(
 	boost::filesystem::path const& _targetPath,
-	boost::filesystem::path const& _linkName
+	boost::filesystem::path const& _linkName,
+	bool directorySymlink
 );
 
 }

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -40,27 +40,27 @@ BOOST_AUTO_TEST_SUITE(FileReaderTest)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_absolute_path)
 {
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/.") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./.") == "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/"), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/./"), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/./."), "/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a") == "/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/") == "/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/.") == "/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./a") == "/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./a/") == "/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./a/.") == "/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b") == "/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/") == "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a"), "/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/"), "/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/."), "/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/./a"), "/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/./a/"), "/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/./a/."), "/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b"), "/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b/"), "/a/b/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/./b/") == "/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/../a/b/") == "/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/..") == "/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/../") == "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/./b/"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/../a/b/"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b/c/.."), "/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b/c/../"), "/a/b/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/../../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/../../../") == "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b/c/../../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b/c/../../../"), "/");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
@@ -76,43 +76,42 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
 	expectedPrefix = "/" / expectedPrefix.relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS(".") == expectedPrefix / "x/y/z/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./") == expectedPrefix / "x/y/z/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../") == expectedPrefix / "x/y/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("."), expectedPrefix / "x/y/z/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./"), expectedPrefix / "x/y/z/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../"), expectedPrefix / "x/y/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a") == expectedPrefix / "x/y/z/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/") == expectedPrefix / "x/y/z/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/.") == expectedPrefix / "x/y/z/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a") == expectedPrefix / "x/y/z/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a/") == expectedPrefix / "x/y/z/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a/.") == expectedPrefix / "x/y/z/a/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b") == expectedPrefix / "x/y/z/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b/") == expectedPrefix / "x/y/z/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a"), expectedPrefix / "x/y/z/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/"), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/."), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a"), expectedPrefix / "x/y/z/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/"), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/."), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b"), expectedPrefix / "x/y/z/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/"), expectedPrefix / "x/y/z/a/b/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a/b") == expectedPrefix / "x/y/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/b") == expectedPrefix / "x/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a/b") == expectedPrefix / "x/y/z/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("././a/b") == expectedPrefix / "x/y/z/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../a/b"), expectedPrefix / "x/y/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../../a/b"), expectedPrefix / "x/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/b"), expectedPrefix / "x/y/z/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("././a/b"), expectedPrefix / "x/y/z/a/b");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/./b/") == expectedPrefix / "x/y/z/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/../a/b/") == expectedPrefix / "x/y/z/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b/c/..") == expectedPrefix / "x/y/z/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b/c/../") == expectedPrefix / "x/y/z/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/./b/"), expectedPrefix / "x/y/z/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/../a/b/"), expectedPrefix / "x/y/z/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/.."), expectedPrefix / "x/y/z/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/../"), expectedPrefix / "x/y/z/a/b/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/.././../p/../q/../a/b") == expectedPrefix / "a/b");
-
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../../a/.././../p/../q/../a/b"), expectedPrefix / "a/b");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_redundant_slashes)
 {
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("///") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("////") == "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("///"), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("////"), "/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("////a/b/") == "/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a//b/") == "/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a////b/") == "/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b//") == "/a/b/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b////") == "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("////a/b/"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a//b/"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a////b/"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b//"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/b////"), "/a/b/");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
@@ -126,20 +125,20 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
 
 	// UNC paths start with // or \\ followed by a name. They are used for network shares on Windows.
 	// On UNIX systems they are not supported but still treated in a special way.
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host/") == "//host/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host/a/b") == "//host/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host/a/b/") == "//host/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("//host/"), "//host/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("//host/a/b"), "//host/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("//host/a/b/"), "//host/a/b/");
 
 #if defined(_WIN32)
 	// On Windows an UNC path can also start with \\ instead of //
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/") == "//host/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b") == "//host/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b/") == "//host/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("\\\\host/"), "//host/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("\\\\host/a/b"), "//host/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("\\\\host/a/b/"), "//host/a/b/");
 #else
 	// On UNIX systems it's just a fancy relative path instead
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/") == expectedWorkDir / "\\\\host/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b") == expectedWorkDir / "\\\\host/a/b");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b/") == expectedWorkDir / "\\\\host/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("\\\\host/"), expectedWorkDir / "\\\\host/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("\\\\host/a/b"), expectedWorkDir / "\\\\host/a/b");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("\\\\host/a/b/"), expectedWorkDir / "\\\\host/a/b/");
 #endif
 }
 
@@ -158,18 +157,18 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
 	// directory.
 
 	// UNC paths
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//") == "//" / expectedWorkDir);
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host") == "//host" / expectedWorkDir);
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("//"), "//" / expectedWorkDir);
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("//host"), "//host" / expectedWorkDir);
 
 	// On UNIX systems root name is empty.
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("") == expectedWorkDir);
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(""), expectedWorkDir);
 
 #if defined(_WIN32)
 	boost::filesystem::path driveLetter = boost::filesystem::current_path().root_name();
 	solAssert(!driveLetter.empty(), "");
 	solAssert(driveLetter.is_relative(), "");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS(driveLetter) == expectedWorkDir);
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(driveLetter), expectedWorkDir);
 #endif
 }
 
@@ -183,9 +182,9 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_stripping_root_name)
 	soltestAssert(!boost::filesystem::current_path().root_name().empty(), "");
 
 	boost::filesystem::path normalizedPath = FileReader::normalizeCLIPathForVFS(boost::filesystem::current_path());
-	BOOST_TEST(normalizedPath == "/" / boost::filesystem::current_path().relative_path());
+	BOOST_CHECK_EQUAL(normalizedPath, "/" / boost::filesystem::current_path().relative_path());
 	BOOST_TEST(normalizedPath.root_name().empty());
-	BOOST_TEST(normalizedPath.root_directory() == "/");
+	BOOST_CHECK_EQUAL(normalizedPath.root_directory(), "/");
 }
 #endif
 
@@ -193,31 +192,31 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_beyond_root)
 {
 	TemporaryWorkingDirectory tempWorkDir("/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../.") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../a") == "/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../a/..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../a/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../../a") == "/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../../a/..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../../a/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/../../b/../..") == "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../"), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../a"), "/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../a/.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../a/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../../a"), "/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../../a/.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/../../a/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("/a/../../b/../.."), "/");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../.") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a") == "/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a/..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a") == "/a");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/../..") == "/");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/../../b/../..") == "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(".."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../"), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../a"), "/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../a/.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../a/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../../a"), "/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../../a/.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../../a/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/../.."), "/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/../../b/../.."), "/");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_case_sensitivity)
@@ -252,8 +251,8 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol"), expectedPrefix / "sym/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol"), expectedPrefix / "abc/contract.sol");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_when_path_is_relative)
@@ -272,9 +271,9 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_w
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
 
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS("contract.sol") == expectedWorkDir / "contract.sol");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol");
-	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("contract.sol"), expectedWorkDir / "contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol"), expectedPrefix / "sym/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol"), expectedPrefix / "abc/contract.sol");
 }
 
 BOOST_AUTO_TEST_CASE(isPathPrefix_file_prefix)
@@ -357,42 +356,41 @@ BOOST_AUTO_TEST_CASE(isPathPrefix_case_sensitivity)
 
 BOOST_AUTO_TEST_CASE(stripPrefixIfPresent_file_prefix)
 {
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/contract.sol") == "contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol", "/contract.sol") == ".");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol/", "/contract.sol") == ".");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol/.", "/contract.sol") == ".");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/", "/contract.sol"), "contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/contract.sol", "/contract.sol"), ".");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/contract.sol/", "/contract.sol"), ".");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/contract.sol/.", "/contract.sol"), ".");
 
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/a/bc/def/contract.sol") == "a/bc/def/contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a", "/a/bc/def/contract.sol") == "bc/def/contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/", "/a/bc/def/contract.sol") == "bc/def/contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc", "/a/bc/def/contract.sol") == "def/contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc/def/", "/a/bc/def/contract.sol") == "contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc/def/contract.sol", "/a/bc/def/contract.sol") == ".");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/", "/a/bc/def/contract.sol"), "a/bc/def/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a", "/a/bc/def/contract.sol"), "bc/def/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/", "/a/bc/def/contract.sol"), "bc/def/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/bc", "/a/bc/def/contract.sol"), "def/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/bc/def/", "/a/bc/def/contract.sol"), "contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/bc/def/contract.sol", "/a/bc/def/contract.sol"), ".");
 
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/contract.sol", "/token.sol"), "/token.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/contract", "/contract.sol"), "/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/contract.sol", "/contract"), "/contract");
 
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol", "/token.sol") == "/token.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract", "/contract.sol") == "/contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol", "/contract") == "/contract");
-
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/c/contract.sol", "/a/b/contract.sol") == "/a/b/contract.sol");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/contract.sol", "/a/b/c/contract.sol") == "/a/b/c/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/b/c/contract.sol", "/a/b/contract.sol"), "/a/b/contract.sol");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/b/contract.sol", "/a/b/c/contract.sol"), "/a/b/c/contract.sol");
 }
 
 BOOST_AUTO_TEST_CASE(stripPrefixIfPresent_directory_prefix)
 {
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/") == ".");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/", "/"), ".");
 
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/a/bc/def/") == "a/bc/def/");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a", "/a/bc/def/") == "bc/def/");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/", "/a/bc/def/") == "bc/def/");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc", "/a/bc/def/") == "def/");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc/def/", "/a/bc/def/") == ".");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/", "/a/bc/def/"), "a/bc/def/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a", "/a/bc/def/"), "bc/def/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/", "/a/bc/def/"), "bc/def/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/bc", "/a/bc/def/"), "def/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/bc/def/", "/a/bc/def/"), ".");
 
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a", "/b/") == "/b/");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/", "/b/") == "/b/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a", "/b/"), "/b/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/", "/b/"), "/b/");
 
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/c/", "/a/b/") == "/a/b/");
-	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/c", "/a/b/") == "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/b/c/", "/a/b/"), "/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::stripPrefixIfPresent("/a/b/c", "/a/b/"), "/a/b/");
 }
 
 BOOST_AUTO_TEST_CASE(isUNCPath)

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -184,21 +184,21 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
 #endif
 }
 
-#if defined(_WIN32)
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_stripping_root_name)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
 
 	soltestAssert(boost::filesystem::current_path().is_absolute(), "");
+#if defined(_WIN32)
 	soltestAssert(!boost::filesystem::current_path().root_name().empty(), "");
+#endif
 
 	boost::filesystem::path normalizedPath = FileReader::normalizeCLIPathForVFS(boost::filesystem::current_path());
 	BOOST_CHECK_EQUAL(normalizedPath, "/" / boost::filesystem::current_path().relative_path());
 	BOOST_TEST(normalizedPath.root_name().empty());
 	BOOST_CHECK_EQUAL(normalizedPath.root_directory(), "/");
 }
-#endif
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_beyond_root)
 {

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -1,0 +1,443 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/// Unit tests for libsolidity/interface/FileReader.h
+
+#include <libsolidity/interface/FileReader.h>
+
+#include <test/Common.h>
+#include <test/FilesystemUtils.h>
+#include <test/TemporaryDirectory.h>
+#include <test/libsolidity/util/SoltestErrors.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace solidity::test;
+
+
+namespace solidity::frontend::test
+{
+
+BOOST_AUTO_TEST_SUITE(FileReaderTest)
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_absolute_path)
+{
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/.") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./.") == "/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a") == "/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/") == "/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/.") == "/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./a") == "/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./a/") == "/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/./a/.") == "/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b") == "/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/") == "/a/b/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/./b/") == "/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/../a/b/") == "/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/..") == "/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/../") == "/a/b/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/../../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b/c/../../../") == "/");
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	boost::filesystem::create_directories(tempDir.path() / "x/y/z");
+	TemporaryWorkingDirectory tempWorkDir(tempDir.path() / "x/y/z");
+
+	// NOTE: If path to work dir contains symlinks (often the case on macOS), boost might resolve
+	// them, making the path different from tempDirPath.
+	boost::filesystem::path expectedPrefix = boost::filesystem::current_path().parent_path().parent_path().parent_path();
+	// On Windows tempDir.path() normally contains the drive letter while the normalized path should not.
+	expectedPrefix = "/" / expectedPrefix.relative_path();
+	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(".") == expectedPrefix / "x/y/z/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./") == expectedPrefix / "x/y/z/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../") == expectedPrefix / "x/y/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a") == expectedPrefix / "x/y/z/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/") == expectedPrefix / "x/y/z/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/.") == expectedPrefix / "x/y/z/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a") == expectedPrefix / "x/y/z/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a/") == expectedPrefix / "x/y/z/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a/.") == expectedPrefix / "x/y/z/a/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b") == expectedPrefix / "x/y/z/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b/") == expectedPrefix / "x/y/z/a/b/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a/b") == expectedPrefix / "x/y/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/b") == expectedPrefix / "x/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("./a/b") == expectedPrefix / "x/y/z/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("././a/b") == expectedPrefix / "x/y/z/a/b");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/./b/") == expectedPrefix / "x/y/z/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/../a/b/") == expectedPrefix / "x/y/z/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b/c/..") == expectedPrefix / "x/y/z/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/b/c/../") == expectedPrefix / "x/y/z/a/b/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/.././../p/../q/../a/b") == expectedPrefix / "a/b");
+
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_redundant_slashes)
+{
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("///") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("////") == "/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("////a/b/") == "/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a//b/") == "/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a////b/") == "/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b//") == "/a/b/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/b////") == "/a/b/");
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+
+	// On Windows tempDir.path() normally contains the drive letter while the normalized path should not.
+	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
+	soltestAssert(expectedWorkDir.is_absolute() || expectedWorkDir.root_path() == "/", "");
+
+	// UNC paths start with // or \\ followed by a name. They are used for network shares on Windows.
+	// On UNIX systems they are not supported but still treated in a special way.
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host/") == "//host/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host/a/b") == "//host/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host/a/b/") == "//host/a/b/");
+
+#if defined(_WIN32)
+	// On Windows an UNC path can also start with \\ instead of //
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/") == "//host/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b") == "//host/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b/") == "//host/a/b/");
+#else
+	// On UNIX systems it's just a fancy relative path instead
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/") == expectedWorkDir / "\\\\host/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b") == expectedWorkDir / "\\\\host/a/b");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("\\\\host/a/b/") == expectedWorkDir / "\\\\host/a/b/");
+#endif
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+
+	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
+	soltestAssert(expectedWorkDir.is_absolute() || expectedWorkDir.root_path() == "/", "");
+
+	// A root **path** consists of a directory name (typically / or \) and the root name (drive
+	// letter (C:), UNC host name (//host), etc.). Either can be empty. Root path as a whole may be
+	// an absolute path but root name on its own is considered relative. For example on Windows
+	// C:\ represents the root directory of drive C: but C: on its own refers to the current working
+	// directory.
+
+	// UNC paths
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//") == "//" / expectedWorkDir);
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("//host") == "//host" / expectedWorkDir);
+
+	// On UNIX systems root name is empty.
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("") == expectedWorkDir);
+
+#if defined(_WIN32)
+	boost::filesystem::path driveLetter = boost::filesystem::current_path().root_name();
+	solAssert(!driveLetter.empty(), "");
+	solAssert(driveLetter.is_relative(), "");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(driveLetter) == expectedWorkDir);
+#endif
+}
+
+#if defined(_WIN32)
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_stripping_root_name)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+
+	soltestAssert(boost::filesystem::current_path().is_absolute(), "");
+	soltestAssert(!boost::filesystem::current_path().root_name().empty(), "");
+
+	boost::filesystem::path normalizedPath = FileReader::normalizeCLIPathForVFS(boost::filesystem::current_path());
+	BOOST_TEST(normalizedPath == "/" / boost::filesystem::current_path().relative_path());
+	BOOST_TEST(normalizedPath.root_name().empty());
+	BOOST_TEST(normalizedPath.root_directory() == "/");
+}
+#endif
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_beyond_root)
+{
+	TemporaryWorkingDirectory tempWorkDir("/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../.") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../a") == "/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../a/..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../a/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../../a") == "/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../../a/..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/../../a/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("/a/../../b/../..") == "/");
+
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../.") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a") == "/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a/..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../a/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a") == "/a");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("../../a/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/../..") == "/");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("a/../../b/../..") == "/");
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_case_sensitivity)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+	boost::filesystem::create_directories(tempDir.path() / "abc");
+
+	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
+	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
+
+	bool caseSensitiveFilesystem = boost::filesystem::create_directories(tempDir.path() / "ABC");
+	soltestAssert(boost::filesystem::equivalent(tempDir.path() / "abc", tempDir.path() / "ABC") != caseSensitiveFilesystem, "");
+
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "abc")) == (expectedPrefix / "abc")));
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "abc")) != (expectedPrefix / "ABC")));
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "ABC")) != (expectedPrefix / "abc")));
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "ABC")) == (expectedPrefix / "ABC")));
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_separators)
+{
+	// Even on Windows we want / as a separator.
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS("/a/b/c").native() == boost::filesystem::path("/a/b/c").native()));
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	soltestAssert(tempDir.path().is_absolute(), "");
+	boost::filesystem::create_directories(tempDir.path() / "abc");
+
+	if (!createSymlinkIfSupportedByFilesystem(tempDir.path() / "abc", tempDir.path() / "sym", true))
+		return;
+
+	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
+	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
+
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol"));
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol"));
+}
+
+BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_when_path_is_relative)
+{
+	TemporaryDirectory tempDir("file-reader-test-");
+	soltestAssert(tempDir.path().is_absolute(), "");
+	boost::filesystem::create_directories(tempDir.path() / "abc");
+
+	if (!createSymlinkIfSupportedByFilesystem(tempDir.path() / "abc", tempDir.path() / "sym", true))
+		return;
+
+	TemporaryWorkingDirectory tempWorkDir(tempDir.path() / "sym");
+	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::weakly_canonical(boost::filesystem::current_path()).relative_path();
+	soltestAssert(expectedWorkDir.is_absolute() || expectedWorkDir.root_path() == "/", "");
+
+	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
+	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
+
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS("contract.sol") == expectedWorkDir / "contract.sol"));
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol"));
+	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol"));
+}
+
+BOOST_AUTO_TEST_CASE(isPathPrefix_file_prefix)
+{
+	BOOST_TEST(FileReader::isPathPrefix("/", "/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/contract.sol", "/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/contract.sol/", "/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/contract.sol/.", "/contract.sol"));
+
+	BOOST_TEST(FileReader::isPathPrefix("/", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/bc", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/bc/def/contract.sol", "/a/bc/def/contract.sol"));
+
+	BOOST_TEST(FileReader::isPathPrefix("/", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/bc", "/a/bc/def/contract.sol"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/bc/def/contract.sol", "/a/bc/def/contract.sol"));
+
+	BOOST_TEST(!FileReader::isPathPrefix("/contract.sol", "/token.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/contract", "/contract.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/contract.sol", "/contract"));
+	BOOST_TEST(!FileReader::isPathPrefix("/contract.so", "/contract.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/contract.sol", "/contract.so"));
+
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/contract.sol", "/a/b/contract.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/contract.sol", "/a/b/c/contract.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/contract.sol", "/a/b/c/d/contract.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/d/contract.sol", "/a/b/c/contract.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/contract.sol", "/contract.sol"));
+}
+
+BOOST_AUTO_TEST_CASE(isPathPrefix_directory_prefix)
+{
+	BOOST_TEST(FileReader::isPathPrefix("/", "/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/", "/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c", "/"));
+
+	BOOST_TEST(FileReader::isPathPrefix("/", "/a/bc/"));
+	BOOST_TEST(FileReader::isPathPrefix("/a", "/a/bc/"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/", "/a/bc/"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/bc", "/a/bc/"));
+	BOOST_TEST(FileReader::isPathPrefix("/a/bc/", "/a/bc/"));
+
+	BOOST_TEST(!FileReader::isPathPrefix("/a", "/b/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/", "/b/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/contract.sol", "/a/b/"));
+
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/", "/a/b/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c", "/a/b/"));
+}
+
+BOOST_AUTO_TEST_CASE(isPathPrefix_unc_path)
+{
+	BOOST_TEST(FileReader::isPathPrefix("//host/a/b/", "//host/a/b/"));
+	BOOST_TEST(FileReader::isPathPrefix("//host/a/b", "//host/a/b/"));
+	BOOST_TEST(FileReader::isPathPrefix("//host/a/", "//host/a/b/"));
+	BOOST_TEST(FileReader::isPathPrefix("//host/a", "//host/a/b/"));
+	BOOST_TEST(FileReader::isPathPrefix("//host/", "//host/a/b/"));
+
+	// NOTE: //host and // cannot be passed to isPathPrefix() because they are considered relative.
+
+	BOOST_TEST(!FileReader::isPathPrefix("//host1/", "//host2/"));
+	BOOST_TEST(!FileReader::isPathPrefix("//host1/a/b/", "//host2/a/b/"));
+
+	BOOST_TEST(!FileReader::isPathPrefix("/a/b/c/", "//a/b/c/"));
+	BOOST_TEST(!FileReader::isPathPrefix("//a/b/c/", "/a/b/c/"));
+}
+
+BOOST_AUTO_TEST_CASE(isPathPrefix_case_sensitivity)
+{
+	BOOST_TEST(!FileReader::isPathPrefix("/a.sol", "/A.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/A.sol", "/a.sol"));
+	BOOST_TEST(!FileReader::isPathPrefix("/A/", "/a/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/", "/A/"));
+	BOOST_TEST(!FileReader::isPathPrefix("/a/BC/def/", "/a/bc/def/contract.sol"));
+}
+
+BOOST_AUTO_TEST_CASE(stripPrefixIfPresent_file_prefix)
+{
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/contract.sol") == "contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol", "/contract.sol") == ".");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol/", "/contract.sol") == ".");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol/.", "/contract.sol") == ".");
+
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/a/bc/def/contract.sol") == "a/bc/def/contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a", "/a/bc/def/contract.sol") == "bc/def/contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/", "/a/bc/def/contract.sol") == "bc/def/contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc", "/a/bc/def/contract.sol") == "def/contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc/def/", "/a/bc/def/contract.sol") == "contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc/def/contract.sol", "/a/bc/def/contract.sol") == ".");
+
+
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol", "/token.sol") == "/token.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract", "/contract.sol") == "/contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/contract.sol", "/contract") == "/contract");
+
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/c/contract.sol", "/a/b/contract.sol") == "/a/b/contract.sol");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/contract.sol", "/a/b/c/contract.sol") == "/a/b/c/contract.sol");
+}
+
+BOOST_AUTO_TEST_CASE(stripPrefixIfPresent_directory_prefix)
+{
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/") == ".");
+
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/", "/a/bc/def/") == "a/bc/def/");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a", "/a/bc/def/") == "bc/def/");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/", "/a/bc/def/") == "bc/def/");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc", "/a/bc/def/") == "def/");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/bc/def/", "/a/bc/def/") == ".");
+
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a", "/b/") == "/b/");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/", "/b/") == "/b/");
+
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/c/", "/a/b/") == "/a/b/");
+	BOOST_TEST(FileReader::stripPrefixIfPresent("/a/b/c", "/a/b/") == "/a/b/");
+}
+
+BOOST_AUTO_TEST_CASE(isUNCPath)
+{
+	BOOST_TEST(FileReader::isUNCPath("//"));
+	BOOST_TEST(FileReader::isUNCPath("//root"));
+	BOOST_TEST(FileReader::isUNCPath("//root/"));
+
+#if defined(_WIN32)
+	// On Windows boost sees these as ///, which is equivalent to /
+	BOOST_TEST(!FileReader::isUNCPath("//\\"));
+	BOOST_TEST(!FileReader::isUNCPath("\\\\/"));
+	BOOST_TEST(!FileReader::isUNCPath("\\/\\"));
+
+	BOOST_TEST(FileReader::isUNCPath("\\\\"));
+	BOOST_TEST(FileReader::isUNCPath("\\\\root"));
+	BOOST_TEST(FileReader::isUNCPath("\\\\root/"));
+#else
+	// On UNIX it's actually an UNC path
+	BOOST_TEST(FileReader::isUNCPath("//\\"));
+
+	// On UNIX these are just weird relative directory names consisting only of backslashes.
+	BOOST_TEST(!FileReader::isUNCPath("\\\\/"));
+	BOOST_TEST(!FileReader::isUNCPath("\\/\\"));
+
+	BOOST_TEST(!FileReader::isUNCPath("\\\\"));
+	BOOST_TEST(!FileReader::isUNCPath("\\\\root"));
+	BOOST_TEST(!FileReader::isUNCPath("\\\\root/"));
+#endif
+
+	BOOST_TEST(!FileReader::isUNCPath("\\/"));
+	BOOST_TEST(!FileReader::isUNCPath("/\\"));
+
+	BOOST_TEST(!FileReader::isUNCPath(""));
+	BOOST_TEST(!FileReader::isUNCPath("."));
+	BOOST_TEST(!FileReader::isUNCPath(".."));
+	BOOST_TEST(!FileReader::isUNCPath("/"));
+	BOOST_TEST(!FileReader::isUNCPath("a"));
+	BOOST_TEST(!FileReader::isUNCPath("a/b/c"));
+	BOOST_TEST(!FileReader::isUNCPath("contract.sol"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace solidity::frontend::test

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -31,6 +31,7 @@
 using namespace std;
 using namespace solidity::test;
 
+#define TEST_CASE_NAME (boost::unit_test::framework::current_test_case().p_name)
 
 namespace solidity::frontend::test
 {
@@ -64,7 +65,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_absolute_path)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	boost::filesystem::create_directories(tempDir.path() / "x/y/z");
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path() / "x/y/z");
 
@@ -116,7 +117,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_redundant_slashes)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
 
 	// On Windows tempDir.path() normally contains the drive letter while the normalized path should not.
@@ -144,7 +145,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
@@ -175,7 +176,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
 #if defined(_WIN32)
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_stripping_root_name)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
 
 	soltestAssert(boost::filesystem::current_path().is_absolute(), "");
@@ -221,7 +222,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_beyond_root)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_case_sensitivity)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
 
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
@@ -241,7 +242,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_separators)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	soltestAssert(tempDir.path().is_absolute(), "");
 	boost::filesystem::create_directories(tempDir.path() / "abc");
 
@@ -257,7 +258,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_when_path_is_relative)
 {
-	TemporaryDirectory tempDir("file-reader-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	soltestAssert(tempDir.path().is_absolute(), "");
 	boost::filesystem::create_directories(tempDir.path() / "abc");
 

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -223,13 +223,9 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_case_sensitivity)
 {
 	TemporaryDirectory tempDir("file-reader-test-");
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
-	boost::filesystem::create_directories(tempDir.path() / "abc");
 
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
-
-	bool caseSensitiveFilesystem = boost::filesystem::create_directories(tempDir.path() / "ABC");
-	soltestAssert(boost::filesystem::equivalent(tempDir.path() / "abc", tempDir.path() / "ABC") != caseSensitiveFilesystem, "");
 
 	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "abc")) == (expectedPrefix / "abc")));
 	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "abc")) != (expectedPrefix / "ABC")));

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -78,7 +78,10 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
 
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("."), expectedPrefix / "x/y/z/");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./"), expectedPrefix / "x/y/z/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(".//"), expectedPrefix / "x/y/z/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS(".."), expectedPrefix / "x/y");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../"), expectedPrefix / "x/y/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("..//"), expectedPrefix / "x/y/");
 
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a"), expectedPrefix / "x/y/z/a");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/"), expectedPrefix / "x/y/z/a/");
@@ -86,6 +89,11 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a"), expectedPrefix / "x/y/z/a");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/"), expectedPrefix / "x/y/z/a/");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/."), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/./"), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/.//"), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/./."), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/././"), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("./a/././/"), expectedPrefix / "x/y/z/a/");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b"), expectedPrefix / "x/y/z/a/b");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/"), expectedPrefix / "x/y/z/a/b/");
 
@@ -98,6 +106,10 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/../a/b/"), expectedPrefix / "x/y/z/a/b/");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/.."), expectedPrefix / "x/y/z/a/b");
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/../"), expectedPrefix / "x/y/z/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/..//"), expectedPrefix / "x/y/z/a/b/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/../.."), expectedPrefix / "x/y/z/a");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/../../"), expectedPrefix / "x/y/z/a/");
+	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("a/b/c/../..//"), expectedPrefix / "x/y/z/a/");
 
 	BOOST_CHECK_EQUAL(FileReader::normalizeCLIPathForVFS("../../a/.././../p/../q/../a/b"), expectedPrefix / "a/b");
 }

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -228,10 +228,10 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_case_sensitivity)
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
 
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "abc")) == (expectedPrefix / "abc")));
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "abc")) != (expectedPrefix / "ABC")));
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "ABC")) != (expectedPrefix / "abc")));
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS((tempDir.path() / "ABC")) == (expectedPrefix / "ABC")));
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc") == expectedPrefix / "abc");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc") != expectedPrefix / "ABC");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "ABC") != expectedPrefix / "abc");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "ABC") == expectedPrefix / "ABC");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_separators)
@@ -252,8 +252,8 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
 
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol"));
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol"));
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol");
 }
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_when_path_is_relative)
@@ -272,9 +272,9 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_w
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");
 
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS("contract.sol") == expectedWorkDir / "contract.sol"));
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol"));
-	BOOST_TEST((FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol"));
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS("contract.sol") == expectedWorkDir / "contract.sol");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol") == expectedPrefix / "sym/contract.sol");
+	BOOST_TEST(FileReader::normalizeCLIPathForVFS(tempDir.path() / "abc/contract.sol") == expectedPrefix / "abc/contract.sol");
 }
 
 BOOST_AUTO_TEST_CASE(isPathPrefix_file_prefix)

--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(readFileAsString_symlink)
 	TemporaryDirectory tempDir("common-io-test-");
 	createFileWithContent(tempDir.path() / "test.txt", "ABC\ndef\n");
 
-	if (!createSymlinkIfSupportedByFilesystem("test.txt", tempDir.path() / "symlink.txt"))
+	if (!createSymlinkIfSupportedByFilesystem("test.txt", tempDir.path() / "symlink.txt", false))
 		return;
 
 	BOOST_TEST(readFileAsString((tempDir.path() / "symlink.txt").string()) == "ABC\ndef\n");


### PR DESCRIPTION
Fixes #4702.
Implements the `solc` part of #11408. `solc-js` changes will be submitted in that repo.

This is a version of #11545 that does not depend on the CLI refactor PRs (#11518, #11520, #11544) and does not include test cases for the CLI.

Things that were not implemented or were implemented differently than specified in the issue:
- Extra normalization: on Windows drive letter is removed from the path if possible.
- On case-sensitive case-preserving filesystems does **not** use the case from disk.
    - I couldn't find any portable way to get the original case. I know how to detect that it differs using Boost though so I am going to propose issuing a warning for this instead (#11412).
