### PR TITLE
Fix newline error in solidity::util::readUntilEnd

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Commandline Interface: Fix extra newline character being appended to sources passed through standard input, affecting their hashes.
  * SMTChecker: Fix internal error in magic type access (``block``, ``msg``, ``tx``).
 
 

--- a/libsolutil/CommonIO.cpp
+++ b/libsolutil/CommonIO.cpp
@@ -74,16 +74,9 @@ string solidity::util::readFileAsString(boost::filesystem::path const& _file)
 
 string solidity::util::readUntilEnd(istream& _stdin)
 {
-	string ret;
-	while (!_stdin.eof())
-	{
-		string tmp;
-		// NOTE: this will read until EOF or NL
-		getline(_stdin, tmp);
-		ret.append(tmp);
-		ret.append("\n");
-	}
-	return ret;
+	ostringstream ss;
+	ss << _stdin.rdbuf();
+	return ss.str();
 }
 
 #if defined(_WIN32)

--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -66,6 +66,30 @@ BOOST_AUTO_TEST_CASE(readFileAsString_symlink)
 	BOOST_TEST(readFileAsString(tempDir.path() / "symlink.txt") == "ABC\ndef\n");
 }
 
+BOOST_AUTO_TEST_CASE(readUntilEnd_no_ending_newline)
+{
+	istringstream inputStream("ABC\ndef");
+	BOOST_TEST(readUntilEnd(inputStream) == "ABC\ndef");
+}
+
+BOOST_AUTO_TEST_CASE(readUntilEnd_with_ending_newline)
+{
+	istringstream inputStream("ABC\ndef\n");
+	BOOST_TEST(readUntilEnd(inputStream) == "ABC\ndef\n");
+}
+
+BOOST_AUTO_TEST_CASE(readUntilEnd_cr_lf_newline)
+{
+	istringstream inputStream("ABC\r\ndef");
+	BOOST_TEST(readUntilEnd(inputStream) == "ABC\r\ndef");
+}
+
+BOOST_AUTO_TEST_CASE(readUntilEnd_empty)
+{
+	istringstream inputStream("");
+	BOOST_TEST(readUntilEnd(inputStream) == "");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace solidity::util::test

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(cli_input)
 		{"a", "b", "c/d/e/"},
 	};
 	map<string, string> expectedSources = {
-		{"<stdin>", "\n"},
+		{"<stdin>", ""},
 		{(expectedDir1 / "input1.sol").generic_string(), ""},
 		{(expectedDir2 / "input2.sol").generic_string(), ""},
 	};
@@ -854,7 +854,7 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_base_path_and_stdin)
 	expectedOptions.modelChecker.initialize = true;
 
 	map<string, string> expectedSources = {
-		{"<stdin>", "\n"},
+		{"<stdin>", ""},
 	};
 	FileReader::FileSystemPathSet expectedAllowedDirectories = {};
 


### PR DESCRIPTION
Fixes #11553