### PR TITLE
Use unknown file for invalid source index.

### DIFF
--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -131,10 +131,8 @@ void Parser::fetchSourceLocationFromComment()
 		m_debugDataOverride = DebugData::create();
 		if (!sourceIndex || !start || !end)
 			m_errorReporter.syntaxError(6367_error, commentLocation, "Invalid value in source location mapping. Could not parse location specification.");
-		else if (!((*start < 0 && *end < 0) || (*start >= 0 && *start <= *end)))
-			m_errorReporter.syntaxError(5798_error, commentLocation, "Invalid value in source location mapping. Start offset larger than end offset.");
-		else if (sourceIndex == -1 && (0 <= *start && *start <= *end)) // Use source index -1 to indicate original source.
-			m_debugDataOverride = DebugData::create(SourceLocation{*start, *end, ParserBase::currentLocation().source});
+		else if (sourceIndex == -1)
+			m_debugDataOverride = DebugData::create(SourceLocation{*start, *end, nullptr});
 		else if (!(sourceIndex >= 0 && m_charStreamMap->count(static_cast<unsigned>(*sourceIndex))))
 			m_errorReporter.syntaxError(2674_error, commentLocation, "Invalid source mapping. Source index not defined via @use-src.");
 		else

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -573,9 +573,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_reference_original_sloc)
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
 
-	// -1 points to original source code, which in this case is `sourceText` (which is also
-	// available via `0`, that's why the first @src is set to `1` instead.)
-	CHECK_LOCATION(varDecl.debugData->location, sourceText, 10, 20);
+	CHECK_LOCATION(varDecl.debugData->location, "", 10, 20);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Maybe we shouldn't be that strict in general?