### PR TITLE
Use `boost::filesystem::path` in `readFileAsString()`

### DIFF
--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -78,7 +78,7 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 			return ReadCallback::Result{false, "Not a valid file."};
 
 		// NOTE: we ignore the FileNotFound exception as we manually check above
-		auto contents = readFileAsString(canonicalPath.string());
+		auto contents = readFileAsString(canonicalPath);
 		m_sourceCodes[_sourceUnitName] = contents;
 		return ReadCallback::Result{true, contents};
 	}

--- a/libsolutil/CommonIO.cpp
+++ b/libsolutil/CommonIO.cpp
@@ -23,8 +23,6 @@
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/Assertions.h>
 
-#include <boost/filesystem.hpp>
-
 #include <fstream>
 #if defined(_WIN32)
 #include <windows.h>
@@ -40,20 +38,20 @@ namespace
 {
 
 template <typename T>
-inline T readFile(std::string const& _file)
+inline T readFile(boost::filesystem::path const& _file)
 {
-	assertThrow(boost::filesystem::exists(_file), FileNotFound, _file);
+	assertThrow(boost::filesystem::exists(_file), FileNotFound, _file.string());
 
 	// ifstream does not always fail when the path leads to a directory. Instead it might succeed
 	// with tellg() returning a nonsensical value so that std::length_error gets raised in resize().
-	assertThrow(boost::filesystem::is_regular_file(_file), NotAFile, _file);
+	assertThrow(boost::filesystem::is_regular_file(_file), NotAFile, _file.string());
 
 	T ret;
 	size_t const c_elementSize = sizeof(typename T::value_type);
-	std::ifstream is(_file, std::ifstream::binary);
+	std::ifstream is(_file.string(), std::ifstream::binary);
 
 	// Technically, this can still fail even though we checked above because FS content can change at any time.
-	assertThrow(is, FileNotFound, _file);
+	assertThrow(is, FileNotFound, _file.string());
 
 	// get length of file:
 	is.seekg(0, is.end);
@@ -69,7 +67,7 @@ inline T readFile(std::string const& _file)
 
 }
 
-string solidity::util::readFileAsString(string const& _file)
+string solidity::util::readFileAsString(boost::filesystem::path const& _file)
 {
 	return readFile<string>(_file);
 }

--- a/libsolutil/CommonIO.h
+++ b/libsolutil/CommonIO.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <boost/filesystem.hpp>
+
 #include <libsolutil/Common.h>
 #include <iostream>
 #include <sstream>
@@ -36,7 +38,7 @@ namespace solidity::util
 /// If the file doesn't exist, it will throw a FileNotFound exception.
 /// If the file exists but is not a regular file, it will throw NotAFile exception.
 /// If the file is empty, returns an empty string.
-std::string readFileAsString(std::string const& _file);
+std::string readFileAsString(boost::filesystem::path const& _file);
 
 /// Retrieves and returns the whole content of the specified input stream (until EOF).
 std::string readUntilEnd(std::istream& _stdin);

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -430,7 +430,7 @@ bool CommandLineInterface::readInputFiles()
 		}
 
 		// NOTE: we ignore the FileNotFound exception as we manually check above
-		string fileContent = readFileAsString(infile.string());
+		string fileContent = readFileAsString(infile);
 		if (m_options.input.mode == InputMode::StandardJson)
 		{
 			solAssert(!m_standardJsonInput.has_value(), "");

--- a/test/TestCaseReader.cpp
+++ b/test/TestCaseReader.cpp
@@ -168,7 +168,7 @@ pair<SourceMap, size_t> TestCaseReader::parseSourcesAndSettingsWithLineNumber(is
 				if (!fs::exists(externalSourceFullPath))
 					BOOST_THROW_EXCEPTION(runtime_error("External Source '" + externalSourceTarget.string() + "' not found."));
 				else
-					externalSourceContent = util::readFileAsString(externalSourceFullPath.string());
+					externalSourceContent = util::readFileAsString(externalSourceFullPath);
 
 				if (sources.count(externalSourceName))
 					BOOST_THROW_EXCEPTION(runtime_error("Multiple definitions of test source \"" + externalSourceName + "\"."));

--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -44,13 +44,13 @@ BOOST_AUTO_TEST_CASE(readFileAsString_regular_file)
 	TemporaryDirectory tempDir("common-io-test-");
 	createFileWithContent(tempDir.path() / "test.txt", "ABC\ndef\n");
 
-	BOOST_TEST(readFileAsString((tempDir.path() / "test.txt").string()) == "ABC\ndef\n");
+	BOOST_TEST(readFileAsString(tempDir.path() / "test.txt") == "ABC\ndef\n");
 }
 
 BOOST_AUTO_TEST_CASE(readFileAsString_directory)
 {
 	TemporaryDirectory tempDir("common-io-test-");
-	BOOST_CHECK_THROW(readFileAsString(tempDir.path().string()), NotAFile);
+	BOOST_CHECK_THROW(readFileAsString(tempDir.path()), NotAFile);
 }
 
 BOOST_AUTO_TEST_CASE(readFileAsString_symlink)
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(readFileAsString_symlink)
 	if (!createSymlinkIfSupportedByFilesystem("test.txt", tempDir.path() / "symlink.txt"))
 		return;
 
-	BOOST_TEST(readFileAsString((tempDir.path() / "symlink.txt").string()) == "ABC\ndef\n");
+	BOOST_TEST(readFileAsString(tempDir.path() / "symlink.txt") == "ABC\ndef\n");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -454,7 +454,7 @@ bool SourceUpgrade::readInputFiles()
 
 	if (m_sourceCodes.size() == 0)
 	{
-		warning() << "No input files given. If you wish to use the standard input please specify \"-\" explicitly." << endl;
+		warning() << "No input files given." << endl;
 		return false;
 	}
 

--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -421,7 +421,7 @@ bool SourceUpgrade::readInputFiles()
 	if (m_args.count(g_argInputFile))
 		for (string path: m_args[g_argInputFile].as<vector<string>>())
 		{
-			auto infile = boost::filesystem::path(path);
+			boost::filesystem::path infile = path;
 			if (!boost::filesystem::exists(infile))
 			{
 				if (!ignoreMissing)
@@ -448,8 +448,7 @@ bool SourceUpgrade::readInputFiles()
 				continue;
 			}
 
-			m_sourceCodes[infile.generic_string()] = readFileAsString(infile.string());
-			path = boost::filesystem::canonical(infile).string();
+			m_sourceCodes[infile.generic_string()] = readFileAsString(infile);
 		}
 
 	if (m_sourceCodes.size() == 0)
@@ -484,8 +483,8 @@ ReadCallback::Callback SourceUpgrade::fileReader()
 	{
 		try
 		{
-			auto path = boost::filesystem::path(_path);
-			auto canonicalPath = boost::filesystem::weakly_canonical(path);
+			boost::filesystem::path path = _path;
+			boost::filesystem::path canonicalPath = boost::filesystem::weakly_canonical(path);
 			bool isAllowed = false;
 			for (auto const& allowedDir: m_allowedDirectories)
 			{
@@ -508,7 +507,7 @@ ReadCallback::Callback SourceUpgrade::fileReader()
 			if (!boost::filesystem::is_regular_file(canonicalPath))
 				return ReadCallback::Result{false, "Not a valid file."};
 
-			auto contents = readFileAsString(canonicalPath.string());
+			string contents = readFileAsString(canonicalPath);
 			m_sourceCodes[path.generic_string()] = contents;
 			return ReadCallback::Result{true, contents};
 		}

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -35,8 +35,6 @@
 #include <libsolutil/CommonData.h>
 #include <libsolutil/CommonIO.h>
 
-#include <boost/filesystem.hpp>
-
 #include <iostream>
 
 using namespace std;
@@ -405,12 +403,12 @@ vector<Program> ProgramFactory::build(Options const& _options)
 	return inputPrograms;
 }
 
-CharStream ProgramFactory::loadSource(string const& _sourcePath)
+CharStream ProgramFactory::loadSource(boost::filesystem::path const& _sourcePath)
 {
-	assertThrow(boost::filesystem::exists(_sourcePath), MissingFile, "Source file does not exist: " + _sourcePath);
+	assertThrow(boost::filesystem::exists(_sourcePath), MissingFile, "Source file does not exist: " + _sourcePath.string());
 
 	string sourceCode = readFileAsString(_sourcePath);
-	return CharStream(sourceCode, _sourcePath);
+	return CharStream(sourceCode, _sourcePath.string());
 }
 
 void Phaser::main(int _argc, char** _argv)

--- a/tools/yulPhaser/Phaser.h
+++ b/tools/yulPhaser/Phaser.h
@@ -25,6 +25,7 @@
 #include <tools/yulPhaser/AlgorithmRunner.h>
 #include <tools/yulPhaser/GeneticAlgorithms.h>
 
+#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <cstddef>
@@ -242,7 +243,7 @@ public:
 	static std::vector<Program> build(Options const& _options);
 
 private:
-	static langutil::CharStream loadSource(std::string const& _sourcePath);
+	static langutil::CharStream loadSource(boost::filesystem::path const& _sourcePath);
 };
 
 /**


### PR DESCRIPTION
Small refactor of `readFileAsString()` requested in https://github.com/ethereum/solidity/pull/11544#discussion_r667943576.

Originally the function accepted the path as `std::string`, now it's `boost::filesystem::path`.