### PR TITLE
Remove scanner from compiler stack

### DIFF
--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <liblangutil/Token.h>
-#include <liblangutil/Scanner.h>
 #include <memory>
 #include <string>
 
@@ -49,8 +48,6 @@ public:
 	}
 
 	virtual ~ParserBase() = default;
-
-	std::shared_ptr<CharStream> source() const { return m_scanner->charStream(); }
 
 protected:
 	/// Utility class that creates an error and throws an exception if the

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -135,26 +135,11 @@ private:
 	bool m_complete;
 };
 
-void Scanner::reset(CharStream _source)
-{
-	m_source = make_shared<CharStream>(std::move(_source));
-	m_sourceName = make_shared<string>(m_source->name());
-	reset();
-}
-
-void Scanner::reset(shared_ptr<CharStream> _source)
-{
-	solAssert(_source.get() != nullptr, "You MUST provide a CharStream when resetting.");
-	m_source = std::move(_source);
-	m_sourceName = make_shared<string>(m_source->name());
-	reset();
-}
-
 void Scanner::reset()
 {
-	m_source->reset();
+	m_source.reset();
 	m_kind = ScannerKind::Solidity;
-	m_char = m_source->get();
+	m_char = m_source.get();
 	skipWhitespace();
 	next();
 	next();
@@ -163,7 +148,7 @@ void Scanner::reset()
 
 void Scanner::setPosition(size_t _offset)
 {
-	m_char = m_source->setPosition(_offset);
+	m_char = m_source.setPosition(_offset);
 	scanToken();
 	next();
 	next();
@@ -229,7 +214,7 @@ void Scanner::rescan()
 		rollbackTo = static_cast<size_t>(m_tokens[Current].location.start);
 	else
 		rollbackTo = static_cast<size_t>(m_skippedComments[Current].location.start);
-	m_char = m_source->rollback(m_source->position() - rollbackTo);
+	m_char = m_source.rollback(m_source.position() - rollbackTo);
 	next();
 	next();
 	next();
@@ -324,12 +309,12 @@ Token Scanner::skipSingleLineComment()
 {
 	// Line terminator is not part of the comment. If it is a
 	// non-ascii line terminator, it will result in a parser error.
-	size_t startPosition = m_source->position();
+	size_t startPosition = m_source.position();
 	while (!isUnicodeLinebreak())
 		if (!advance())
 			break;
 
-	ScannerError unicodeDirectionError = validateBiDiMarkup(*m_source, startPosition);
+	ScannerError unicodeDirectionError = validateBiDiMarkup(m_source, startPosition);
 	if (unicodeDirectionError != ScannerError::NoError)
 		return setError(unicodeDirectionError);
 
@@ -362,28 +347,28 @@ bool Scanner::tryScanEndOfLine()
 size_t Scanner::scanSingleLineDocComment()
 {
 	LiteralScope literal(this, LITERAL_TYPE_COMMENT);
-	size_t endPosition = m_source->position();
+	size_t endPosition = m_source.position();
 
 	skipWhitespaceExceptUnicodeLinebreak();
 
 	while (!isSourcePastEndOfInput())
 	{
-		endPosition = m_source->position();
+		endPosition = m_source.position();
 		if (tryScanEndOfLine())
 		{
 			// Check if next line is also a single-line comment.
 			// If any whitespaces were skipped, use source position before.
 			if (!skipWhitespaceExceptUnicodeLinebreak())
-				endPosition = m_source->position();
+				endPosition = m_source.position();
 
-			if (!m_source->isPastEndOfInput(3) &&
-				m_source->get(0) == '/' &&
-				m_source->get(1) == '/' &&
-				m_source->get(2) == '/')
+			if (!m_source.isPastEndOfInput(3) &&
+				m_source.get(0) == '/' &&
+				m_source.get(1) == '/' &&
+				m_source.get(2) == '/')
 			{
-				if (!m_source->isPastEndOfInput(4) && m_source->get(3) == '/')
+				if (!m_source.isPastEndOfInput(4) && m_source.get(3) == '/')
 					break; // "////" is not a documentation comment
-				m_char = m_source->advanceAndGet(3);
+				m_char = m_source.advanceAndGet(3);
 				if (atEndOfLine())
 					continue;
 				addCommentLiteralChar('\n');
@@ -404,7 +389,7 @@ size_t Scanner::scanSingleLineDocComment()
 
 Token Scanner::skipMultiLineComment()
 {
-	size_t startPosition = m_source->position();
+	size_t startPosition = m_source.position();
 	while (!isSourcePastEndOfInput())
 	{
 		char prevChar = m_char;
@@ -415,7 +400,7 @@ Token Scanner::skipMultiLineComment()
 		// multi-line comments are treated as whitespace.
 		if (prevChar == '*' && m_char == '/')
 		{
-			ScannerError unicodeDirectionError = validateBiDiMarkup(*m_source, startPosition);
+			ScannerError unicodeDirectionError = validateBiDiMarkup(m_source, startPosition);
 			if (unicodeDirectionError != ScannerError::NoError)
 				return setError(unicodeDirectionError);
 
@@ -442,22 +427,22 @@ Token Scanner::scanMultiLineDocComment()
 		if (atEndOfLine())
 		{
 			skipWhitespace();
-			if (!m_source->isPastEndOfInput(1) && m_source->get(0) == '*' && m_source->get(1) == '*')
+			if (!m_source.isPastEndOfInput(1) && m_source.get(0) == '*' && m_source.get(1) == '*')
 			{ // it is unknown if this leads to the end of the comment
 				addCommentLiteralChar('*');
 				advance();
 			}
-			else if (!m_source->isPastEndOfInput(1) && m_source->get(0) == '*' && m_source->get(1) != '/')
+			else if (!m_source.isPastEndOfInput(1) && m_source.get(0) == '*' && m_source.get(1) != '/')
 			{ // skip first '*' in subsequent lines
-				m_char = m_source->advanceAndGet(1);
+				m_char = m_source.advanceAndGet(1);
 				if (atEndOfLine()) // ignores empty lines
 					continue;
 				if (charsAdded)
 					addCommentLiteralChar('\n'); // corresponds to the end of previous line
 			}
-			else if (!m_source->isPastEndOfInput(1) && m_source->get(0) == '*' && m_source->get(1) == '/')
+			else if (!m_source.isPastEndOfInput(1) && m_source.get(0) == '*' && m_source.get(1) == '/')
 			{ // if after newline the comment ends, don't insert the newline
-				m_char = m_source->advanceAndGet(2);
+				m_char = m_source.advanceAndGet(2);
 				endFound = true;
 				break;
 			}
@@ -465,9 +450,9 @@ Token Scanner::scanMultiLineDocComment()
 				addCommentLiteralChar('\n');
 		}
 
-		if (!m_source->isPastEndOfInput(1) && m_source->get(0) == '*' && m_source->get(1) == '/')
+		if (!m_source.isPastEndOfInput(1) && m_source.get(0) == '*' && m_source.get(1) == '/')
 		{
-			m_char = m_source->advanceAndGet(2);
+			m_char = m_source.advanceAndGet(2);
 			endFound = true;
 			break;
 		}
@@ -822,11 +807,11 @@ bool Scanner::isUnicodeLinebreak()
 	if (0x0a <= m_char && m_char <= 0x0d)
 		// line feed, vertical tab, form feed, carriage return
 		return true;
-	if (!m_source->isPastEndOfInput(1) && uint8_t(m_source->get(0)) == 0xc2 && uint8_t(m_source->get(1)) == 0x85)
+	if (!m_source.isPastEndOfInput(1) && uint8_t(m_source.get(0)) == 0xc2 && uint8_t(m_source.get(1)) == 0x85)
 		// NEL - U+0085, C2 85 in utf8
 		return true;
-	if (!m_source->isPastEndOfInput(2) && uint8_t(m_source->get(0)) == 0xe2 && uint8_t(m_source->get(1)) == 0x80 && (
-		uint8_t(m_source->get(2)) == 0xa8 || uint8_t(m_source->get(2)) == 0xa9
+	if (!m_source.isPastEndOfInput(2) && uint8_t(m_source.get(0)) == 0xe2 && uint8_t(m_source.get(1)) == 0x80 && (
+		uint8_t(m_source.get(2)) == 0xa8 || uint8_t(m_source.get(2)) == 0xa9
 	))
 		// LS - U+2028, E2 80 A8  in utf8
 		// PS - U+2029, E2 80 A9  in utf8
@@ -836,7 +821,7 @@ bool Scanner::isUnicodeLinebreak()
 
 Token Scanner::scanString(bool const _isUnicode)
 {
-	size_t startPosition = m_source->position();
+	size_t startPosition = m_source.position();
 	char const quote = m_char;
 	advance();  // consume quote
 	LiteralScope literal(this, LITERAL_TYPE_STRING);
@@ -867,7 +852,7 @@ Token Scanner::scanString(bool const _isUnicode)
 
 	if (_isUnicode)
 	{
-		ScannerError unicodeDirectionError = validateBiDiMarkup(*m_source, startPosition);
+		ScannerError unicodeDirectionError = validateBiDiMarkup(m_source, startPosition);
 		if (unicodeDirectionError != ScannerError::NoError)
 			return setError(unicodeDirectionError);
 	}
@@ -921,7 +906,7 @@ void Scanner::scanDecimalDigits()
 	// May continue with decimal digit or underscore for grouping.
 	do
 		addLiteralCharAndAdvance();
-	while (!m_source->isPastEndOfInput() && (isDecimalDigit(m_char) || m_char == '_'));
+	while (!m_source.isPastEndOfInput() && (isDecimalDigit(m_char) || m_char == '_'));
 
 	// Defer further validation of underscore to SyntaxChecker.
 }
@@ -967,7 +952,7 @@ Token Scanner::scanNumber(char _charSeen)
 			scanDecimalDigits();  // optional
 			if (m_char == '.')
 			{
-				if (!m_source->isPastEndOfInput(1) && m_source->get(1) == '_')
+				if (!m_source.isPastEndOfInput(1) && m_source.get(1) == '_')
 				{
 					// Assume the input may be a floating point number with leading '_' in fraction part.
 					// Recover by consuming it all but returning `Illegal` right away.
@@ -975,7 +960,7 @@ Token Scanner::scanNumber(char _charSeen)
 					addLiteralCharAndAdvance(); // '_'
 					scanDecimalDigits();
 				}
-				if (m_source->isPastEndOfInput() || !isDecimalDigit(m_source->get(1)))
+				if (m_source.isPastEndOfInput() || !isDecimalDigit(m_source.get(1)))
 				{
 					// A '.' has to be followed by a number.
 					literal.complete();
@@ -992,7 +977,7 @@ Token Scanner::scanNumber(char _charSeen)
 		solAssert(kind != HEX, "'e'/'E' must be scanned as part of the hex number");
 		if (kind != DECIMAL)
 			return setError(ScannerError::IllegalExponent);
-		else if (!m_source->isPastEndOfInput(1) && m_source->get(1) == '_')
+		else if (!m_source.isPastEndOfInput(1) && m_source.get(1) == '_')
 		{
 			// Recover from wrongly placed underscore as delimiter in literal with scientific
 			// notation by consuming until the end.

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -119,6 +119,8 @@ public:
 		rescan();
 	}
 
+	CharStream const& charStream() const noexcept { return m_source; }
+
 	/// @returns the next token and advances input
 	Token next();
 

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -100,17 +100,13 @@ class Scanner
 {
 	friend class LiteralScope;
 public:
-	explicit Scanner(std::shared_ptr<CharStream> _source) { reset(std::move(_source)); }
-	explicit Scanner(CharStream _source = CharStream()) { reset(std::move(_source)); }
+	explicit Scanner(CharStream& _source):
+		m_source(_source),
+		m_sourceName{std::make_shared<std::string>(_source.name())}
+	{
+		reset();
+	}
 
-	std::string const& source() const noexcept { return m_source->source(); }
-
-	std::shared_ptr<CharStream> charStream() noexcept { return m_source; }
-	std::shared_ptr<CharStream const> charStream() const noexcept { return m_source; }
-
-	/// Resets the scanner as if newly constructed with _source as input.
-	void reset(CharStream _source);
-	void reset(std::shared_ptr<CharStream> _source);
 	/// Resets scanner to the start of input.
 	void reset();
 
@@ -201,8 +197,8 @@ private:
 	void addUnicodeAsUTF8(unsigned codepoint);
 	///@}
 
-	bool advance() { m_char = m_source->advanceAndGet(); return !m_source->isPastEndOfInput(); }
-	void rollback(size_t _amount) { m_char = m_source->rollback(_amount); }
+	bool advance() { m_char = m_source.advanceAndGet(); return !m_source.isPastEndOfInput(); }
+	void rollback(size_t _amount) { m_char = m_source.rollback(_amount); }
 	/// Rolls back to the start of the current token and re-runs the scanner.
 	void rescan();
 
@@ -251,15 +247,15 @@ private:
 	bool isUnicodeLinebreak();
 
 	/// Return the current source position.
-	size_t sourcePos() const { return m_source->position(); }
-	bool isSourcePastEndOfInput() const { return m_source->isPastEndOfInput(); }
+	size_t sourcePos() const { return m_source.position(); }
+	bool isSourcePastEndOfInput() const { return m_source.isPastEndOfInput(); }
 
 	enum TokenIndex { Current, Next, NextNext };
 
 	TokenDesc m_skippedComments[3] = {}; // desc for the current, next and nextnext skipped comment
 	TokenDesc m_tokens[3] = {}; // desc for the current, next and nextnext token
 
-	std::shared_ptr<CharStream> m_source;
+	CharStream& m_source;
 	std::shared_ptr<std::string const> m_sourceName;
 
 	ScannerKind m_kind = ScannerKind::Solidity;

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -958,7 +958,8 @@ Json::Value ASTJsonImporter::member(Json::Value const& _node, string const& _nam
 
 Token ASTJsonImporter::scanSingleToken(Json::Value const& _node)
 {
-	langutil::Scanner scanner{langutil::CharStream(_node.asString(), "")};
+	langutil::CharStream charStream(_node.asString(), "");
+	langutil::Scanner scanner{charStream};
 	astAssert(scanner.peekNextToken() == Token::EOS, "Token string is too long.");
 	return scanner.currentToken();
 }

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -441,7 +441,7 @@ void CompilerContext::appendInlineAssembly(
 		locationOverride = m_asm->currentSourceLocation();
 	shared_ptr<yul::Block> parserResult =
 		yul::Parser(errorReporter, dialect, std::move(locationOverride))
-		.parse(make_shared<langutil::Scanner>(charStream), false);
+		.parse(charStream);
 #ifdef SOL_OUTPUT_ASM
 	cout << yul::AsmPrinter(&dialect)(*parserResult) << endl;
 #endif
@@ -492,7 +492,7 @@ void CompilerContext::appendInlineAssembly(
 			m_generatedYulUtilityCode = yul::AsmPrinter(dialect)(*obj.code);
 			string code = yul::AsmPrinter{dialect}(*obj.code);
 			langutil::CharStream charStream(m_generatedYulUtilityCode, _sourceName);
-			obj.code = yul::Parser(errorReporter, dialect).parse(make_shared<Scanner>(charStream), false);
+			obj.code = yul::Parser(errorReporter, dialect).parse(charStream);
 			*obj.analysisInfo = yul::AsmAnalyzer::analyzeStrictAssertCorrect(dialect, obj);
 		}
 

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -755,9 +755,8 @@ Json::Value CompilerStack::generatedSources(string const& _contractName, bool _r
 				ErrorList errors;
 				ErrorReporter errorReporter(errors);
 				CharStream charStream(source, sourceName);
-				shared_ptr<Scanner> scanner = make_shared<Scanner>(charStream);
 				yul::EVMDialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(m_evmVersion);
-				shared_ptr<yul::Block> parserResult = yul::Parser{errorReporter, dialect}.parse(scanner, false);
+				shared_ptr<yul::Block> parserResult = yul::Parser{errorReporter, dialect}.parse(charStream);
 				solAssert(parserResult, "");
 				sources[0]["ast"] = yul::AsmJsonConverter{sourceIndex}(*parserResult);
 				sources[0]["name"] = sourceName;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -57,7 +57,6 @@
 
 namespace solidity::langutil
 {
-class Scanner;
 class CharStream;
 }
 
@@ -344,7 +343,7 @@ private:
 	/// The state per source unit. Filled gradually during parsing.
 	struct Source
 	{
-		std::shared_ptr<langutil::Scanner> scanner;
+		std::shared_ptr<langutil::CharStream> charStream;
 		std::shared_ptr<SourceUnit> ast;
 		util::h256 mutable keccak256HashCached;
 		util::h256 mutable swarmHashCached;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -87,7 +87,6 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 	try
 	{
 		m_recursionDepth = 0;
-		m_source = &_charStream;
 		m_scanner = make_shared<Scanner>(_charStream);
 		ASTNodeFactory nodeFactory(*this);
 
@@ -2057,8 +2056,6 @@ bool Parser::variableDeclarationStart()
 
 optional<string> Parser::findLicenseString(std::vector<ASTPointer<ASTNode>> const& _nodes)
 {
-	solAssert(!!m_source, "");
-
 	// We circumvent the scanner here, because it skips non-docstring comments.
 	static regex const licenseRegex("SPDX-License-Identifier:\\s*([a-zA-Z0-9 ()+.-]+)");
 
@@ -2066,7 +2063,7 @@ optional<string> Parser::findLicenseString(std::vector<ASTPointer<ASTNode>> cons
 	// This will leave e.g. "global comments".
 	using iter = std::string::const_iterator;
 	vector<pair<iter, iter>> sequencesToSearch;
-	string const& source = m_source->source();
+	string const& source = m_scanner->charStream().source();
 	sequencesToSearch.emplace_back(source.begin(), source.end());
 	for (ASTPointer<ASTNode> const& node: _nodes)
 		if (node->location().hasText())

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1301,7 +1301,7 @@ ASTPointer<InlineAssembly> Parser::parseInlineAssembly(ASTPointer<ASTString> con
 	}
 
 	yul::Parser asmParser(m_errorReporter, dialect);
-	shared_ptr<yul::Block> block = asmParser.parse(m_scanner, true);
+	shared_ptr<yul::Block> block = asmParser.parseInline(m_scanner);
 	if (block == nullptr)
 		BOOST_THROW_EXCEPTION(FatalError());
 

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -29,7 +29,7 @@
 
 namespace solidity::langutil
 {
-class Scanner;
+class CharStream;
 }
 
 namespace solidity::frontend
@@ -47,7 +47,7 @@ public:
 		m_evmVersion(_evmVersion)
 	{}
 
-	ASTPointer<SourceUnit> parse(std::shared_ptr<langutil::Scanner> const& _scanner);
+	ASTPointer<SourceUnit> parse(langutil::CharStream& _charStream);
 
 private:
 	class ASTNodeFactory;
@@ -211,6 +211,7 @@ private:
 	/// Creates an empty ParameterList at the current location (used if parameters can be omitted).
 	ASTPointer<ParameterList> createEmptyParameterList();
 
+	langutil::CharStream* m_source = nullptr;
 	/// Flag that signifies whether '_' is parsed as a PlaceholderStatement or a regular identifier.
 	bool m_insideModifier = false;
 	langutil::EVMVersion m_evmVersion;

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -211,7 +211,6 @@ private:
 	/// Creates an empty ParameterList at the current location (used if parameters can be omitted).
 	ASTPointer<ParameterList> createEmptyParameterList();
 
-	langutil::CharStream* m_source = nullptr;
 	/// Flag that signifies whether '_' is parsed as a PlaceholderStatement or a regular identifier.
 	bool m_insideModifier = false;
 	langutil::EVMVersion m_evmVersion;

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -166,7 +166,8 @@ Literal AsmJsonImporter::createLiteral(Json::Value const& _node)
 
 	if (kind == "number")
 	{
-		langutil::Scanner scanner{langutil::CharStream(lit.value.str(), "")};
+		langutil::CharStream charStream(lit.value.str(), "");
+		langutil::Scanner scanner{charStream};
 		lit.kind = LiteralKind::Number;
 		yulAssert(
 			scanner.currentToken() == Token::Number,
@@ -175,7 +176,8 @@ Literal AsmJsonImporter::createLiteral(Json::Value const& _node)
 	}
 	else if (kind == "bool")
 	{
-		langutil::Scanner scanner{langutil::CharStream(lit.value.str(), "")};
+		langutil::CharStream charStream(lit.value.str(), "");
+		langutil::Scanner scanner{charStream};
 		lit.kind = LiteralKind::Boolean;
 		yulAssert(
 			scanner.currentToken() == Token::TrueLiteral ||

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -85,7 +85,15 @@ std::shared_ptr<DebugData const> Parser::createDebugData() const
 	solAssert(false, "");
 }
 
-unique_ptr<Block> Parser::parse(std::shared_ptr<Scanner> const& _scanner, bool _reuseScanner)
+unique_ptr<Block> Parser::parse(CharStream& _charStream)
+{
+	m_scanner = make_shared<Scanner>(_charStream);
+	unique_ptr<Block> block = parseInline(m_scanner);
+	expectToken(Token::EOS);
+	return block;
+}
+
+unique_ptr<Block> Parser::parseInline(std::shared_ptr<Scanner> const& _scanner)
 {
 	m_recursionDepth = 0;
 
@@ -97,10 +105,7 @@ unique_ptr<Block> Parser::parse(std::shared_ptr<Scanner> const& _scanner, bool _
 		m_scanner = _scanner;
 		if (m_sourceNames)
 			fetchSourceLocationFromComment();
-		auto block = make_unique<Block>(parseBlock());
-		if (!_reuseScanner)
-			expectToken(Token::EOS);
-		return block;
+		return make_unique<Block>(parseBlock());
 	}
 	catch (FatalError const&)
 	{

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -87,10 +87,13 @@ public:
 	{}
 
 	/// Parses an inline assembly block starting with `{` and ending with `}`.
-	/// @param _reuseScanner if true, do check for end of input after the `}`.
 	/// @returns an empty shared pointer on error.
-	std::unique_ptr<Block> parse(std::shared_ptr<langutil::Scanner> const& _scanner, bool _reuseScanner);
-	// TODO: pass CharStream here instead ^^^^^^
+	std::unique_ptr<Block> parseInline(std::shared_ptr<langutil::Scanner> const& _scanner);
+
+	/// Parses an assembly block starting with `{` and ending with `}`
+	/// and expects end of input after the '}'.
+	/// @returns an empty shared pointer on error.
+	std::unique_ptr<Block> parse(langutil::CharStream& _charStream);
 
 protected:
 	langutil::SourceLocation currentLocation() const override

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -90,6 +90,7 @@ public:
 	/// @param _reuseScanner if true, do check for end of input after the `}`.
 	/// @returns an empty shared pointer on error.
 	std::unique_ptr<Block> parse(std::shared_ptr<langutil::Scanner> const& _scanner, bool _reuseScanner);
+	// TODO: pass CharStream here instead ^^^^^^
 
 protected:
 	langutil::SourceLocation currentLocation() const override

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -130,7 +130,8 @@ optional<ObjectParser::SourceNameMap> ObjectParser::tryParseSourceNameMapping() 
 
 	solAssert(sm.size() == 2, "");
 	auto text = m_scanner->currentCommentLiteral().substr(static_cast<size_t>(sm.position() + sm.length()));
-	Scanner scanner(make_shared<CharStream>(text, ""));
+	CharStream charStream(text, "");
+	Scanner scanner(charStream);
 	if (scanner.currentToken() == Token::EOS)
 		return SourceNameMap{};
 	SourceNameMap sourceNames;

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -168,7 +168,7 @@ optional<ObjectParser::SourceNameMap> ObjectParser::tryParseSourceNameMapping() 
 shared_ptr<Block> ObjectParser::parseBlock()
 {
 	Parser parser(m_errorReporter, m_dialect, m_sourceNameMapping);
-	shared_ptr<Block> block = parser.parse(m_scanner, true);
+	shared_ptr<Block> block = parser.parseInline(m_scanner);
 	yulAssert(block || m_errorReporter.hasErrors(), "Invalid block but no error!");
 	return block;
 }

--- a/libyul/backends/wasm/EVMToEwasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEwasmTranslator.cpp
@@ -125,7 +125,7 @@ void EVMToEwasmTranslator::parsePolyfill()
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	shared_ptr<Scanner> scanner{make_shared<Scanner>(CharStream(
+	CharStream charStream(
 		"{" +
 			string(solidity::yul::wasm::polyfill::Arithmetic) +
 			string(solidity::yul::wasm::polyfill::Bitwise) +
@@ -135,15 +135,18 @@ void EVMToEwasmTranslator::parsePolyfill()
 			string(solidity::yul::wasm::polyfill::Keccak) +
 			string(solidity::yul::wasm::polyfill::Logical) +
 			string(solidity::yul::wasm::polyfill::Memory) +
-		"}", ""))};
-	m_polyfill = Parser(errorReporter, WasmDialect::instance()).parse(scanner, false);
+		"}", "");
+	m_polyfill = Parser(errorReporter, WasmDialect::instance()).parse(
+		make_shared<Scanner>(charStream),
+		false
+	);
 	if (!errors.empty())
 	{
 		string message;
 		for (auto const& err: errors)
 			message += langutil::SourceReferenceFormatter::formatErrorInformation(
 				*err,
-				SingletonCharStreamProvider(*scanner->charStream())
+				SingletonCharStreamProvider(charStream)
 			);
 		yulAssert(false, message);
 	}

--- a/libyul/backends/wasm/EVMToEwasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEwasmTranslator.cpp
@@ -136,10 +136,7 @@ void EVMToEwasmTranslator::parsePolyfill()
 			string(solidity::yul::wasm::polyfill::Logical) +
 			string(solidity::yul::wasm::polyfill::Memory) +
 		"}", "");
-	m_polyfill = Parser(errorReporter, WasmDialect::instance()).parse(
-		make_shared<Scanner>(charStream),
-		false
-	);
+	m_polyfill = Parser(errorReporter, WasmDialect::instance()).parse(charStream);
 	if (!errors.empty())
 	{
 		string message;

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -26,7 +26,8 @@
 #include <liblangutil/SourceLocation.h>
 #include <libevmasm/Assembly.h>
 
-#include <liblangutil/Scanner.h>
+#include <liblangutil/CharStream.h>
+
 #include <libsolidity/parsing/Parser.h>
 #include <libsolidity/analysis/DeclarationTypeChecker.h>
 #include <libsolidity/analysis/NameAndTypeResolver.h>
@@ -58,7 +59,7 @@ evmasm::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 	ErrorReporter errorReporter(errors);
 	Parser parser(errorReporter, solidity::test::CommonOptions::get().evmVersion());
 	ASTPointer<SourceUnit> sourceUnit;
-	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(make_shared<Scanner>(_sourceCode)));
+	BOOST_REQUIRE_NO_THROW(sourceUnit = parser.parse(*_sourceCode));
 	BOOST_CHECK(!!sourceUnit);
 
 	Scoper::assignScopes(*sourceUnit);

--- a/test/libsolidity/SemVerMatcher.cpp
+++ b/test/libsolidity/SemVerMatcher.cpp
@@ -43,7 +43,8 @@ namespace
 
 SemVerMatchExpression parseExpression(string const& _input)
 {
-	Scanner scanner{CharStream(_input, "")};
+	CharStream stream(_input, "");
+	Scanner scanner{stream};
 	vector<string> literals;
 	vector<Token> tokens;
 	while (scanner.currentToken() != Token::EOS)

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -101,15 +101,14 @@ bytes compileFirstExpression(
 )
 {
 	string sourceCode = "pragma solidity >=0.0; // SPDX-License-Identifier: GPL-3\n" + _sourceCode;
+	CharStream stream(sourceCode, "");
 
 	ASTPointer<SourceUnit> sourceUnit;
 	try
 	{
 		ErrorList errors;
 		ErrorReporter errorReporter(errors);
-		sourceUnit = Parser(errorReporter, solidity::test::CommonOptions::get().evmVersion()).parse(
-			make_shared<Scanner>(CharStream(sourceCode, ""))
-		);
+		sourceUnit = Parser(errorReporter, solidity::test::CommonOptions::get().evmVersion()).parse(stream);
 		if (!sourceUnit)
 			return bytes();
 	}

--- a/test/libsolidity/SolidityParser.cpp
+++ b/test/libsolidity/SolidityParser.cpp
@@ -42,11 +42,12 @@ namespace
 ASTPointer<ContractDefinition> parseText(std::string const& _source, ErrorList& _errors, bool errorRecovery = false)
 {
 	ErrorReporter errorReporter(_errors);
+	auto charStream = CharStream(_source, "");
 	ASTPointer<SourceUnit> sourceUnit = Parser(
 		errorReporter,
 		solidity::test::CommonOptions::get().evmVersion(),
 		errorRecovery
-	).parse(std::make_shared<Scanner>(CharStream(_source, "")));
+	).parse(charStream);
 	if (!sourceUnit)
 		return ASTPointer<ContractDefinition>();
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -74,7 +74,8 @@ pair<shared_ptr<Object>, shared_ptr<yul::AsmAnalysisInfo>> yul::test::parse(
 )
 {
 	ErrorReporter errorReporter(_errors);
-	shared_ptr<Scanner> scanner = make_shared<Scanner>(CharStream(_source, ""));
+	CharStream stream(_source, "");
+	shared_ptr<Scanner> scanner = make_shared<Scanner>(stream);
 	shared_ptr<Object> parserResult = yul::ObjectParser(errorReporter, _dialect).parse(scanner, false);
 	if (!parserResult)
 		return {};

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -23,6 +23,8 @@
 
 #include <test/libsolidity/ErrorCheck.h>
 
+#include <liblangutil/Scanner.h>
+
 #include <libyul/AssemblyStack.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
@@ -118,7 +120,8 @@ tuple<optional<ObjectParser::SourceNameMap>, ErrorList> tryGetSourceLocationMapp
 	ErrorReporter reporter(errors);
 	Dialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(EVMVersion::berlin());
 	ObjectParser objectParser{reporter, dialect};
-	objectParser.parse(make_shared<Scanner>(CharStream(move(source), "")), false);
+	CharStream stream(move(source), "");
+	objectParser.parse(make_shared<Scanner>(stream), false);
 	return {objectParser.sourceNameMapping(), std::move(errors)};
 }
 

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -55,7 +55,8 @@ shared_ptr<Block> parse(string const& _source, Dialect const& _dialect, ErrorRep
 {
 	try
 	{
-		auto scanner = make_shared<Scanner>(CharStream(_source, ""));
+		auto stream = CharStream(_source, "");
+		auto scanner = make_shared<Scanner>(stream);
 		map<unsigned, shared_ptr<string const>> indicesToSourceNames;
 		indicesToSourceNames[0] = make_shared<string const>("source0");
 		indicesToSourceNames[1] = make_shared<string const>("source1");

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -30,7 +30,6 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/Dialect.h>
-#include <liblangutil/Scanner.h>
 #include <liblangutil/ErrorReporter.h>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -56,7 +55,6 @@ shared_ptr<Block> parse(string const& _source, Dialect const& _dialect, ErrorRep
 	try
 	{
 		auto stream = CharStream(_source, "");
-		auto scanner = make_shared<Scanner>(stream);
 		map<unsigned, shared_ptr<string const>> indicesToSourceNames;
 		indicesToSourceNames[0] = make_shared<string const>("source0");
 		indicesToSourceNames[1] = make_shared<string const>("source1");
@@ -65,7 +63,7 @@ shared_ptr<Block> parse(string const& _source, Dialect const& _dialect, ErrorRep
 			errorReporter,
 			_dialect,
 			move(indicesToSourceNames)
-		).parse(scanner, false);
+		).parse(stream);
 		if (parserResult)
 		{
 			yul::AsmAnalysisInfo analysisInfo;

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -82,7 +82,7 @@ public:
 	{
 		SourceReferenceFormatter{
 			cerr,
-			SingletonCharStreamProvider(*m_scanner->charStream()),
+			SingletonCharStreamProvider(*m_charStream),
 			true,
 			false
 		}.printErrorInformation(m_errors);
@@ -91,7 +91,8 @@ public:
 	bool parse(string const& _input)
 	{
 		ErrorReporter errorReporter(m_errors);
-		m_scanner = make_shared<Scanner>(CharStream(_input, ""));
+		m_charStream = make_shared<CharStream>(_input, "");
+		m_scanner = make_shared<Scanner>(*m_charStream);
 		m_ast = yul::Parser(errorReporter, m_dialect).parse(m_scanner, false);
 		if (!m_ast || !errorReporter.errors().empty())
 		{
@@ -234,6 +235,7 @@ public:
 
 private:
 	ErrorList m_errors;
+	shared_ptr<CharStream> m_charStream;
 	shared_ptr<Scanner> m_scanner;
 	shared_ptr<yul::Block> m_ast;
 	Dialect const& m_dialect{EVMDialect::strictAssemblyForEVMObjects(EVMVersion{})};

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -22,7 +22,6 @@
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/Exceptions.h>
 #include <liblangutil/ErrorReporter.h>
-#include <liblangutil/Scanner.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libsolidity/parsing/Parser.h>
@@ -45,7 +44,6 @@
 
 #include <libsolidity/interface/OptimiserSettings.h>
 #include <liblangutil/CharStreamProvider.h>
-#include <liblangutil/Scanner.h>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -92,8 +90,7 @@ public:
 	{
 		ErrorReporter errorReporter(m_errors);
 		m_charStream = make_shared<CharStream>(_input, "");
-		m_scanner = make_shared<Scanner>(*m_charStream);
-		m_ast = yul::Parser(errorReporter, m_dialect).parse(m_scanner, false);
+		m_ast = yul::Parser(errorReporter, m_dialect).parse(*m_charStream);
 		if (!m_ast || !errorReporter.errors().empty())
 		{
 			cerr << "Error parsing source." << endl;
@@ -236,7 +233,6 @@ public:
 private:
 	ErrorList m_errors;
 	shared_ptr<CharStream> m_charStream;
-	shared_ptr<Scanner> m_scanner;
 	shared_ptr<yul::Block> m_ast;
 	Dialect const& m_dialect{EVMDialect::strictAssemblyForEVMObjects(EVMVersion{})};
 	shared_ptr<AsmAnalysisInfo> m_analysisInfo;

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -120,7 +120,7 @@ variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _diale
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<Scanner>(move(_source));
+	auto scanner = make_shared<Scanner>(_source);
 
 	ObjectParser parser(errorReporter, _dialect);
 	shared_ptr<Object> object = parser.parse(scanner, false);


### PR DESCRIPTION
It seems that this can even be further simplified so that the parser constructs the scanner itself.