### PR TITLE
Fix broken bullet points in docs caused by a bug in dependencies of `sphinx-rtd-theme`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,8 @@
-sphinx_rtd_theme>=0.3.1
+# Older versions of sphinx-rtd-theme do not work with never docutils but have a bug in the dependency
+# which could result in it being installed anyway and the style (especially bullet points) being broken.
+# See https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+sphinx_rtd_theme>=0.5.2
+
 pygments-lexer-solidity>=0.7.0
 sphinx-a4doc>=1.2.1
 


### PR DESCRIPTION
Styling in our documentation is slightly broken due to https://github.com/readthedocs/sphinx_rtd_theme/issues/1115. Most noticeably, bullet points are not displayed for unordered lists.

This does not affect docs built using the `scripts/docs.sh` script but the docs at https://docs.soliditylang.org are not built using that.

Here are the commands to reproduce this problem locally (based on [build log #14231164 from readthedocs](https://readthedocs.org/api/v2/build/14231164.txt)):

```
virtualenv venv-solidity-docs/
source venv-solidity-docs/bin/activate
pip install --upgrade --no-cache-dir "mock==1.0.1" "pillow==5.4.1" "alabaster>=0.7,<0.8,!=0.7.5" "commonmark==0.8.1" "recommonmark==0.5.0" "sphinx<2" "sphinx-rtd-theme<0.5" "readthedocs-sphinx-ext<2.2"
pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
cd docs
sphinx-build -n -b html -d _build/doctrees . _build/html
```
The commands should be executed from repo root.