### PR TITLE
Remove deprecated escapes from docs + rename `escapeAndQuoteYulString()`

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -514,16 +514,20 @@ Additionally, string literals also support the following escape characters:
  - ``\\`` (backslash)
  - ``\'`` (single quote)
  - ``\"`` (double quote)
- - ``\b`` (backspace)
- - ``\f`` (form feed)
  - ``\n`` (newline)
  - ``\r`` (carriage return)
  - ``\t`` (tab)
- - ``\v`` (vertical tab)
  - ``\xNN`` (hex escape, see below)
  - ``\uNNNN`` (unicode escape, see below)
 
 ``\xNN`` takes a hex value and inserts the appropriate byte, while ``\uNNNN`` takes a Unicode codepoint and inserts an UTF-8 sequence.
+
+.. note::
+
+    Until version 0.8.0 there were three additional escape sequences: ``\b``, ``\f`` and ``\v``.
+    They are commonly available in other languages but rarely needed in practice.
+    If you do need them, they can still be inserted via hexadecimal escapes, i.e. ``\x08``, ``\x0c``
+    and ``\x0b``, respectively, just as any other ASCII character.
 
 The string in the following example has a length of ten bytes.
 It starts with a newline byte, followed by a double quote, a single

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -153,7 +153,7 @@ public:
 			return;
 		m_out << m_prefix << "    /*";
 		if (m_location.sourceName)
-			m_out << " " + escapeAndQuoteYulString(*m_location.sourceName);
+			m_out << " " + escapeAndQuoteString(*m_location.sourceName);
 		if (m_location.hasText())
 			m_out << ":" << to_string(m_location.start) + ":" + to_string(m_location.end);
 		m_out << "  " << locationFromSources(m_sourceCodes, m_location);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -3166,5 +3166,5 @@ bool IRGeneratorForStatements::visit(TryCatchClause const& _clause)
 string IRGeneratorForStatements::linkerSymbol(ContractDefinition const& _library) const
 {
 	solAssert(_library.isLibrary(), "");
-	return "linkersymbol(" + util::escapeAndQuoteYulString(_library.fullyQualifiedName()) + ")";
+	return "linkersymbol(" + util::escapeAndQuoteString(_library.fullyQualifiedName()) + ")";
 }

--- a/libsolutil/CommonData.cpp
+++ b/libsolutil/CommonData.cpp
@@ -192,13 +192,11 @@ string solidity::util::formatAsStringOrNumber(string const& _value)
 		if (c <= 0x1f || c >= 0x7f || c == '"')
 			return "0x" + h256(_value, h256::AlignLeft).hex();
 
-	// The difference in escaping is only in characters below 0x1f and the string does not have them
-	// so this will work for Solidity strings too.
-	return escapeAndQuoteYulString(_value);
+	return escapeAndQuoteString(_value);
 }
 
 
-string solidity::util::escapeAndQuoteYulString(string const& _input)
+string solidity::util::escapeAndQuoteString(string const& _input)
 {
 	string out;
 

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -552,9 +552,9 @@ bool isValidDecimal(std::string const& _string);
 /// _value cannot be longer than 32 bytes.
 std::string formatAsStringOrNumber(std::string const& _value);
 
-/// @returns a string with the usual backslash-escapes for non-ASCII
+/// @returns a string with the usual backslash-escapes for non-printable and non-ASCII
 /// characters and surrounded by '"'-characters.
-std::string escapeAndQuoteYulString(std::string const& _input);
+std::string escapeAndQuoteString(std::string const& _input);
 
 template<typename Container, typename Compare>
 bool containerEqual(Container const& _lhs, Container const& _rhs, Compare&& _compare)

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -57,7 +57,7 @@ string AsmPrinter::operator()(Literal const& _literal) const
 		break;
 	}
 
-	return escapeAndQuoteYulString(_literal.value.str()) + appendTypeName(_literal.type);
+	return escapeAndQuoteString(_literal.value.str()) + appendTypeName(_literal.type);
 }
 
 string AsmPrinter::operator()(Identifier const& _identifier) const


### PR DESCRIPTION
In #11575 I mistakenly renamed `escapeAndQuoteString()` to `escapeAndQuoteYulString()` (I was convinced that the escapes were only removed from Yul, not Solidity). This PR fixes that and also updates some comments.

While at it I also noticed we still list these escapes in the docs as usable in strings so the PR also removes them.