### PR TITLE
Remove incorrect statement that calldata must be used for external functions

### DIFF
--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -29,10 +29,10 @@ annotation, the "data location", about where it is stored. There are three data 
 non-persistent area where function arguments are stored, and behaves mostly like memory.
 
 .. note::
-    If you can, try to use ``calldata`` as data location because it will avoid copies and
+    If you can, try to use ``calldata`` as a data location because it will avoid copies and
     also makes sure that the data cannot be modified. Calldata is typically preferred over 
     memory in  external functions (though not required after version 0.6.9). Arrays and 
-    structs with  ``calldata`` data location can also be returned from functions, but it 
+    structs with ``calldata`` data location can also be returned from functions, but it 
     is not possible to allocate such types.
 
 .. note::

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -28,7 +28,7 @@ annotation, the "data location", about where it is stored. There are three data 
 ``memory``, ``storage`` and ``calldata``. Calldata is a non-modifiable,
 non-persistent area where function arguments are stored, and behaves mostly like memory.
 
-Calldata is usually preferred over memory for external functions but is not required after Solidity `0.6.9`.
+Calldata is usually preferred over memory for external functions but is not required after version 0.6.9.
 
 .. note::
     Prior to version 0.5.0 the data location could be omitted, and would default to different locations

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -28,18 +28,17 @@ annotation, the "data location", about where it is stored. There are three data 
 ``memory``, ``storage`` and ``calldata``. Calldata is a non-modifiable,
 non-persistent area where function arguments are stored, and behaves mostly like memory.
 
-Calldata is usually preferred over memory for external functions but is not required after version 0.6.9.
+.. note::
+    If you can, try to use ``calldata`` as data location because it will avoid copies and
+    also makes sure that the data cannot be modified. Calldata is typically preferred over 
+    memory in  external functions (though not required after version 0.6.9). Arrays and 
+    structs with  ``calldata`` data location can also be returned from functions, but it 
+    is not possible to allocate such types.
 
 .. note::
     Prior to version 0.5.0 the data location could be omitted, and would default to different locations
     depending on the kind of variable, function type, etc., but all complex types must now give an explicit
     data location.
-
-.. note::
-    If you can, try to use ``calldata`` as data location because it will avoid copies and
-    also makes sure that the data cannot be modified. Arrays and structs with ``calldata``
-    data location can also be returned from functions, but it is not possible to
-    allocate such types.
 
 .. _data-location-assignment:
 

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -28,6 +28,7 @@ annotation, the "data location", about where it is stored. There are three data 
 ``memory``, ``storage`` and ``calldata``. Calldata is a non-modifiable,
 non-persistent area where function arguments are stored, and behaves mostly like memory.
 
+Calldata is usually preferred over memory for external functions but is not required after Solidity `0.6.9`.
 
 .. note::
     Prior to version 0.5.0 the data location could be omitted, and would default to different locations

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -30,9 +30,9 @@ non-persistent area where function arguments are stored, and behaves mostly like
 
 .. note::
     If you can, try to use ``calldata`` as a data location because it will avoid copies and
-    also makes sure that the data cannot be modified. Calldata is typically preferred over 
-    memory in  external functions (though not required after version 0.6.9). Arrays and 
-    structs with ``calldata`` data location can also be returned from functions, but it 
+    also makes sure that the data cannot be modified. Calldata is typically preferred over
+    memory in  external functions (though not required after version 0.6.9). Arrays and
+    structs with ``calldata`` data location can also be returned from functions, but it
     is not possible to allocate such types.
 
 .. note::

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -27,7 +27,6 @@ Every reference type has an additional
 annotation, the "data location", about where it is stored. There are three data locations:
 ``memory``, ``storage`` and ``calldata``. Calldata is a non-modifiable,
 non-persistent area where function arguments are stored, and behaves mostly like memory.
-It is required for parameters of external functions but can also be used for other variables.
 
 
 .. note::

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -29,11 +29,16 @@ annotation, the "data location", about where it is stored. There are three data 
 non-persistent area where function arguments are stored, and behaves mostly like memory.
 
 .. note::
-    If you can, try to use ``calldata`` as a data location because it will avoid copies and
-    also makes sure that the data cannot be modified. Calldata is typically preferred over
-    memory in  external functions (though not required after version 0.6.9). Arrays and
-    structs with ``calldata`` data location can also be returned from functions, but it
-    is not possible to allocate such types.
+    If you can, try to use ``calldata`` as data location because it will avoid copies and
+    also makes sure that the data cannot be modified. Arrays and structs with ``calldata``
+    data location can also be returned from functions, but it is not possible to
+    allocate such types.
+
+.. note::
+    Prior to version 0.6.9 data location for reference-type arguments was limited to
+    ``calldata`` in external functions, ``memory`` in public functions and either
+    ``memory`` or ``storage`` in internal and private ones.
+    Now ``memory`` and ``calldata`` are allowed in all functions regardless of their visibility.
 
 .. note::
     Prior to version 0.5.0 the data location could be omitted, and would default to different locations


### PR DESCRIPTION
I have tested this locally and am still able to compile and run unit tests for projects which have external functions that take `bytes memory` instead of `bytes calldata`. I believe this statement is incorrect and should be removed. Happy to take feedback on how we could reword this instead of flat out removing :)