### PR TITLE
[Docs] Add `unchecked` to fix reverting `BigInt` example in `libraries.rst`

### DIFF
--- a/docs/contracts/libraries.rst
+++ b/docs/contracts/libraries.rst
@@ -132,7 +132,7 @@ custom types without the overhead of external function calls:
 .. code-block:: solidity
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >=0.6.8 <0.9.0;
+    pragma solidity >=0.8.0 <0.9.0;
 
     struct bigint {
         uint[] limbs;
@@ -150,11 +150,14 @@ custom types without the overhead of external function calls:
             for (uint i = 0; i < r.limbs.length; ++i) {
                 uint a = limb(_a, i);
                 uint b = limb(_b, i);
-                r.limbs[i] = a + b + carry;
-                if (a + b < a || (a + b == type(uint).max && carry > 0))
-                    carry = 1;
-                else
-                    carry = 0;
+                unchecked {
+                    r.limbs[i] = a + b + carry;
+
+                    if (a + b < a || (a + b == type(uint).max && carry > 0))
+                        carry = 1;
+                    else
+                        carry = 0;
+                }
             }
             if (carry > 0) {
                 // too bad, we have to add a limb


### PR DESCRIPTION
add unchecked