### PR TITLE
Fix remappings with empty targets

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Bugfixes:
  * Code Generator: Fix crash when passing an empty string literal to ``bytes.concat()``.
  * Code Generator: Fix internal compiler error when calling functions bound to calldata structs and arrays.
  * Code Generator: Fix internal compiler error when passing a 32-byte hex literal or a zero literal to ``bytes.concat()`` by disallowing such literals.
+ * Commandline Interface: Using an an empty value for import remapping target was not equivalent to using prefix as the target.
  * Standard JSON: Include source location for errors in files with empty name.
  * Type Checker: Fix internal error and prevent static calls to unimplemented modifiers.
  * Yul Code Generator: Fix internal compiler error when using a long literal with bitwise negation.

--- a/libsolidity/interface/ImportRemapper.cpp
+++ b/libsolidity/interface/ImportRemapper.cpp
@@ -91,6 +91,9 @@ optional<ImportRemapper::Remapping> ImportRemapper::parseRemapping(string const&
 	r.prefix = colon == eq ? string(_remapping.begin(), eq) : string(colon + 1, eq);
 	r.target = string(eq + 1, _remapping.end());
 
+	if (r.target.empty())
+		r.target = r.prefix;
+
 	if (r.prefix.empty())
 		return {};
 

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 		expectedOptions.input.remappings = {
 			{"", "/tmp", "/usr/lib/"},
 			{"a", "b", "c/d"},
-			{"", "contract.sol", ""},
+			{"", "contract.sol", "contract.sol"},
 		};
 		expectedOptions.input.addStdin = true;
 		expectedOptions.input.basePath = "/home/user/";
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 		expectedOptions.input.remappings = {
 			{"", "/tmp", "/usr/lib/"},
 			{"a", "b", "c/d"},
-			{"", "contract.yul", ""},
+			{"", "contract.yul", "contract.yul"},
 		};
 		expectedOptions.input.addStdin = true;
 		expectedOptions.input.basePath = "/home/user/";


### PR DESCRIPTION
[Remapping docs in 0.8.4](https://docs.soliditylang.org/en/v0.8.4/layout-of-source-files.html#use-in-actual-compilers) (i.e. even before my rewrite) state:

> For solc (the commandline compiler), you provide these path remappings as `context:prefix=target` arguments, where both the `context:` and the `=target` parts are optional (`target` defaults to `prefix` in this case).

This is not true. Something like `/a/b/c/=` on the command line currently results in `/a/b/c/contract.sol` being replaced with `contract.sol`. This PR fixes that.

Alternatively we could also just change the docs - removing a prefix might actually be more useful than a no-op. In either case it's an obscure corner case so we could also just disallow it and always require an explicit target.

The docs used to contain also this which is false as well:

> All remapping values that are regular files are compiled (including their dependencies).

Running `solc contractA.sol=contractB.sol` results in `No input files given.`. Neither `contractA.sol` nor `contractB.sol` gets compiled. It's the same as far back as 0.5.0 and before then I think remappings must have not been supported because I get no output and a non-zero exit code (even if a file called `contractA.sol=contractB.sol` exists).

Since this part is no longer in the docs, I did not add this behavior.