### PR TITLE
Convenience features in `TemporaryDirectory`

### DIFF
--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -20,6 +20,7 @@
 
 #include <test/libsolidity/util/SoltestErrors.h>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 
 #include <regex>
@@ -38,6 +39,24 @@ TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
 	soltestAssert(fs::path(_prefix) == fs::path(_prefix).stem(), "");
 
 	fs::create_directory(m_path);
+}
+
+TemporaryDirectory::TemporaryDirectory(
+	vector<boost::filesystem::path> const& _subdirectories,
+	string const& _prefix
+):
+	TemporaryDirectory(_prefix)
+{
+	for (boost::filesystem::path const& subdirectory: _subdirectories)
+	{
+		soltestAssert(!subdirectory.is_absolute() && subdirectory.root_path() != "/", "");
+		soltestAssert(
+			m_path.lexically_relative(subdirectory).empty() ||
+			*m_path.lexically_relative(subdirectory).begin() != "..",
+			""
+		);
+		boost::filesystem::create_directories(m_path / subdirectory);
+	}
 }
 
 TemporaryDirectory::~TemporaryDirectory()

--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -31,7 +31,7 @@ using namespace solidity::test;
 namespace fs = boost::filesystem;
 
 TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
-	m_path(fs::temp_directory_path() / fs::unique_path(_prefix + "%%%%-%%%%-%%%%-%%%%"))
+	m_path(fs::temp_directory_path() / fs::unique_path(_prefix + "-%%%%-%%%%-%%%%-%%%%"))
 {
 	// Prefix should just be a file name and not contain anything that would make us step out of /tmp.
 	assert(fs::path(_prefix) == fs::path(_prefix).stem());

--- a/test/TemporaryDirectory.cpp
+++ b/test/TemporaryDirectory.cpp
@@ -18,9 +18,10 @@
 
 #include <test/TemporaryDirectory.h>
 
+#include <test/libsolidity/util/SoltestErrors.h>
+
 #include <boost/filesystem.hpp>
 
-#include <cassert>
 #include <regex>
 #include <iostream>
 
@@ -34,7 +35,7 @@ TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
 	m_path(fs::temp_directory_path() / fs::unique_path(_prefix + "-%%%%-%%%%-%%%%-%%%%"))
 {
 	// Prefix should just be a file name and not contain anything that would make us step out of /tmp.
-	assert(fs::path(_prefix) == fs::path(_prefix).stem());
+	soltestAssert(fs::path(_prefix) == fs::path(_prefix).stem(), "");
 
 	fs::create_directory(m_path);
 }
@@ -42,10 +43,10 @@ TemporaryDirectory::TemporaryDirectory(std::string const& _prefix):
 TemporaryDirectory::~TemporaryDirectory()
 {
 	// A few paranoid sanity checks just to be extra sure we're not deleting someone's homework.
-	assert(m_path.string().find(fs::temp_directory_path().string()) == 0);
-	assert(!fs::equivalent(m_path, fs::temp_directory_path()));
-	assert(!fs::equivalent(m_path, m_path.root_path()));
-	assert(!m_path.empty());
+	soltestAssert(m_path.string().find(fs::temp_directory_path().string()) == 0, "");
+	soltestAssert(!fs::equivalent(m_path, fs::temp_directory_path()), "");
+	soltestAssert(!fs::equivalent(m_path, m_path.root_path()), "");
+	soltestAssert(!m_path.empty(), "");
 
 	boost::system::error_code errorCode;
 	uintmax_t numRemoved = fs::remove_all(m_path, errorCode);

--- a/test/TemporaryDirectory.h
+++ b/test/TemporaryDirectory.h
@@ -25,6 +25,7 @@
 #include <boost/filesystem.hpp>
 
 #include <string>
+#include <vector>
 
 namespace solidity::test
 {
@@ -41,6 +42,10 @@ class TemporaryDirectory
 {
 public:
 	TemporaryDirectory(std::string const& _prefix = "solidity-test");
+	TemporaryDirectory(
+		std::vector<boost::filesystem::path> const& _subdirectories,
+		std::string const& _prefix = "solidity-test"
+	);
 	~TemporaryDirectory();
 
 	boost::filesystem::path const& path() const { return m_path; }

--- a/test/TemporaryDirectory.h
+++ b/test/TemporaryDirectory.h
@@ -40,7 +40,7 @@ namespace solidity::test
 class TemporaryDirectory
 {
 public:
-	TemporaryDirectory(std::string const& _prefix = "solidity-test-");
+	TemporaryDirectory(std::string const& _prefix = "solidity-test");
 	~TemporaryDirectory();
 
 	boost::filesystem::path const& path() const { return m_path; }

--- a/test/TemporaryDirectory.h
+++ b/test/TemporaryDirectory.h
@@ -44,6 +44,7 @@ public:
 	~TemporaryDirectory();
 
 	boost::filesystem::path const& path() const { return m_path; }
+	operator boost::filesystem::path() const { return m_path; }
 
 private:
 	boost::filesystem::path m_path;
@@ -59,6 +60,7 @@ public:
 	~TemporaryWorkingDirectory();
 
 	boost::filesystem::path const& originalWorkingDirectory() const { return m_originalWorkingDirectory; }
+	operator boost::filesystem::path() const { return boost::filesystem::current_path(); }
 
 private:
 	boost::filesystem::path m_originalWorkingDirectory;

--- a/test/TemporaryDirectoryTest.cpp
+++ b/test/TemporaryDirectoryTest.cpp
@@ -37,10 +37,10 @@ BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_create_and_delete_a_unique_and_em
 {
 	fs::path dirPath;
 	{
-		TemporaryDirectory tempDir("temporary-directory-test-");
+		TemporaryDirectory tempDir("temporary-directory-test");
 		dirPath = tempDir.path();
 
-		BOOST_TEST(dirPath.stem().string().find("temporary-directory-test-") == 0);
+		BOOST_TEST(dirPath.stem().string().find("temporary-directory-test") == 0);
 		BOOST_TEST(fs::equivalent(dirPath.parent_path(), fs::temp_directory_path()));
 		BOOST_TEST(fs::is_directory(dirPath));
 		BOOST_TEST(fs::is_empty(dirPath));
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_
 {
 	fs::path dirPath;
 	{
-		TemporaryDirectory tempDir("temporary-directory-test-");
+		TemporaryDirectory tempDir("temporary-directory-test");
 		dirPath = tempDir.path();
 
 		BOOST_TEST(fs::is_directory(dirPath));
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(TemporaryWorkingDirectory_should_change_and_restore_working
 	try
 	{
 		{
-			TemporaryDirectory tempDir("temporary-directory-test-");
+			TemporaryDirectory tempDir("temporary-directory-test");
 			assert(fs::equivalent(fs::current_path(), originalWorkingDirectory));
 			assert(!fs::equivalent(tempDir.path(), originalWorkingDirectory));
 

--- a/test/TemporaryDirectoryTest.cpp
+++ b/test/TemporaryDirectoryTest.cpp
@@ -66,6 +66,19 @@ BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_
 	BOOST_TEST(!boost::filesystem::exists(dirPath / "test-file.txt"));
 }
 
+BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_create_subdirectories)
+{
+	boost::filesystem::path dirPath;
+	{
+		TemporaryDirectory tempDir({"a", "a/", "a/b/c", "x.y/z"}, "temporary-directory-test");
+		dirPath = tempDir.path();
+
+		BOOST_TEST(boost::filesystem::is_directory(dirPath / "a"));
+		BOOST_TEST(boost::filesystem::is_directory(dirPath / "a/b/c"));
+		BOOST_TEST(boost::filesystem::is_directory(dirPath / "x.y/z"));
+	}
+}
+
 BOOST_AUTO_TEST_CASE(TemporaryWorkingDirectory_should_change_and_restore_working_directory)
 {
 	boost::filesystem::path originalWorkingDirectory = boost::filesystem::current_path();

--- a/test/TemporaryDirectoryTest.cpp
+++ b/test/TemporaryDirectoryTest.cpp
@@ -18,6 +18,8 @@
 
 #include <test/TemporaryDirectory.h>
 
+#include <test/libsolidity/util/SoltestErrors.h>
+
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -26,8 +28,6 @@
 using namespace std;
 using namespace boost::test_tools;
 
-namespace fs = boost::filesystem;
-
 namespace solidity::test
 {
 
@@ -35,59 +35,59 @@ BOOST_AUTO_TEST_SUITE(TemporaryDirectoryTest)
 
 BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_create_and_delete_a_unique_and_empty_directory)
 {
-	fs::path dirPath;
+	boost::filesystem::path dirPath;
 	{
 		TemporaryDirectory tempDir("temporary-directory-test");
 		dirPath = tempDir.path();
 
 		BOOST_TEST(dirPath.stem().string().find("temporary-directory-test") == 0);
-		BOOST_TEST(fs::equivalent(dirPath.parent_path(), fs::temp_directory_path()));
-		BOOST_TEST(fs::is_directory(dirPath));
-		BOOST_TEST(fs::is_empty(dirPath));
+		BOOST_TEST(boost::filesystem::equivalent(dirPath.parent_path(), boost::filesystem::temp_directory_path()));
+		BOOST_TEST(boost::filesystem::is_directory(dirPath));
+		BOOST_TEST(boost::filesystem::is_empty(dirPath));
 	}
-	BOOST_TEST(!fs::exists(dirPath));
+	BOOST_TEST(!boost::filesystem::exists(dirPath));
 }
 
 BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_empty)
 {
-	fs::path dirPath;
+	boost::filesystem::path dirPath;
 	{
 		TemporaryDirectory tempDir("temporary-directory-test");
 		dirPath = tempDir.path();
 
-		BOOST_TEST(fs::is_directory(dirPath));
+		BOOST_TEST(boost::filesystem::is_directory(dirPath));
 
 		{
 			ofstream tmpFile((dirPath / "test-file.txt").string());
 			tmpFile << "Delete me!" << endl;
 		}
-		assert(fs::is_regular_file(dirPath / "test-file.txt"));
+		soltestAssert(boost::filesystem::is_regular_file(dirPath / "test-file.txt"), "");
 	}
-	BOOST_TEST(!fs::exists(dirPath / "test-file.txt"));
+	BOOST_TEST(!boost::filesystem::exists(dirPath / "test-file.txt"));
 }
 
 BOOST_AUTO_TEST_CASE(TemporaryWorkingDirectory_should_change_and_restore_working_directory)
 {
-	fs::path originalWorkingDirectory = fs::current_path();
+	boost::filesystem::path originalWorkingDirectory = boost::filesystem::current_path();
 
 	try
 	{
 		{
 			TemporaryDirectory tempDir("temporary-directory-test");
-			assert(fs::equivalent(fs::current_path(), originalWorkingDirectory));
-			assert(!fs::equivalent(tempDir.path(), originalWorkingDirectory));
+			soltestAssert(boost::filesystem::equivalent(boost::filesystem::current_path(), originalWorkingDirectory), "");
+			soltestAssert(!boost::filesystem::equivalent(tempDir.path(), originalWorkingDirectory), "");
 
 			TemporaryWorkingDirectory tempWorkDir(tempDir.path());
 
-			BOOST_TEST(fs::equivalent(fs::current_path(), tempDir.path()));
+			BOOST_TEST(boost::filesystem::equivalent(boost::filesystem::current_path(), tempDir.path()));
 		}
-		BOOST_TEST(fs::equivalent(fs::current_path(), originalWorkingDirectory));
+		BOOST_TEST(boost::filesystem::equivalent(boost::filesystem::current_path(), originalWorkingDirectory));
 
-		fs::current_path(originalWorkingDirectory);
+		boost::filesystem::current_path(originalWorkingDirectory);
 	}
 	catch (...)
 	{
-		fs::current_path(originalWorkingDirectory);
+		boost::filesystem::current_path(originalWorkingDirectory);
 	}
 }
 

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -65,8 +65,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_absolute_path)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_relative_path)
 {
-	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	boost::filesystem::create_directories(tempDir.path() / "x/y/z");
+	TemporaryDirectory tempDir({"x/y/z"}, TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path() / "x/y/z");
 
 	// NOTE: If path to work dir contains symlinks (often the case on macOS), boost might resolve
@@ -253,9 +252,8 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_separators)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
 {
-	TemporaryDirectory tempDir(TEST_CASE_NAME);
+	TemporaryDirectory tempDir({"abc/"}, TEST_CASE_NAME);
 	soltestAssert(tempDir.path().is_absolute(), "");
-	boost::filesystem::create_directories(tempDir.path() / "abc");
 
 	if (!createSymlinkIfSupportedByFilesystem(tempDir.path() / "abc", tempDir.path() / "sym", true))
 		return;
@@ -269,9 +267,8 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks)
 
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_resolve_symlinks_in_workdir_when_path_is_relative)
 {
-	TemporaryDirectory tempDir(TEST_CASE_NAME);
+	TemporaryDirectory tempDir({"abc/"}, TEST_CASE_NAME);
 	soltestAssert(tempDir.path().is_absolute(), "");
-	boost::filesystem::create_directories(tempDir.path() / "abc");
 
 	if (!createSymlinkIfSupportedByFilesystem(tempDir.path() / "abc", tempDir.path() / "sym", true))
 		return;

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_redundant_slashes)
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDir);
 
 	// On Windows tempDir.path() normally contains the drive letter while the normalized path should not.
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_unc_path)
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDir);
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
 	soltestAssert(expectedWorkDir.is_absolute() || expectedWorkDir.root_path() == "/", "");
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_root_name_only)
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_stripping_root_name)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDir);
 
 	soltestAssert(boost::filesystem::current_path().is_absolute(), "");
 #if defined(_WIN32)
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_path_beyond_root)
 BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_case_sensitivity)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDir);
 
 	boost::filesystem::path expectedPrefix = "/" / tempDir.path().relative_path();
 	soltestAssert(expectedPrefix.is_absolute() || expectedPrefix.root_path() == "/", "");

--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(readFileAsString_regular_file)
 BOOST_AUTO_TEST_CASE(readFileAsString_directory)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	BOOST_CHECK_THROW(readFileAsString(tempDir.path()), NotAFile);
+	BOOST_CHECK_THROW(readFileAsString(tempDir), NotAFile);
 }
 
 BOOST_AUTO_TEST_CASE(readFileAsString_symlink)

--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -34,6 +34,8 @@
 using namespace std;
 using namespace solidity::test;
 
+#define TEST_CASE_NAME (boost::unit_test::framework::current_test_case().p_name)
+
 namespace solidity::util::test
 {
 
@@ -41,7 +43,7 @@ BOOST_AUTO_TEST_SUITE(CommonIOTest)
 
 BOOST_AUTO_TEST_CASE(readFileAsString_regular_file)
 {
-	TemporaryDirectory tempDir("common-io-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	createFileWithContent(tempDir.path() / "test.txt", "ABC\ndef\n");
 
 	BOOST_TEST(readFileAsString(tempDir.path() / "test.txt") == "ABC\ndef\n");
@@ -49,13 +51,13 @@ BOOST_AUTO_TEST_CASE(readFileAsString_regular_file)
 
 BOOST_AUTO_TEST_CASE(readFileAsString_directory)
 {
-	TemporaryDirectory tempDir("common-io-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	BOOST_CHECK_THROW(readFileAsString(tempDir.path()), NotAFile);
 }
 
 BOOST_AUTO_TEST_CASE(readFileAsString_symlink)
 {
-	TemporaryDirectory tempDir("common-io-test-");
+	TemporaryDirectory tempDir(TEST_CASE_NAME);
 	createFileWithContent(tempDir.path() / "test.txt", "ABC\ndef\n");
 
 	if (!createSymlinkIfSupportedByFilesystem("test.txt", tempDir.path() / "symlink.txt", false))

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -614,8 +614,7 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_relative_base_path)
 
 BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_normalization_and_weird_names)
 {
-	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	boost::filesystem::create_directories(tempDir.path() / "x/y/z");
+	TemporaryDirectory tempDir({"x/y/z"}, TEST_CASE_NAME);
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path() / "x/y/z");
 	soltestAssert(tempDir.path().is_absolute(), "");
 
@@ -782,9 +781,8 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_normalization_and_weird_name
 
 BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_symlinks)
 {
-	TemporaryDirectory tempDir(TEST_CASE_NAME);
+	TemporaryDirectory tempDir({"r/"}, TEST_CASE_NAME);
 	createFilesWithParentDirs({tempDir.path() / "x/y/z/contract.sol"});
-	boost::filesystem::create_directories(tempDir.path() / "r");
 	TemporaryWorkingDirectory tempWorkDir(tempDir.path() / "r");
 
 	if (

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -156,8 +156,8 @@ BOOST_AUTO_TEST_CASE(cli_input)
 		{(expectedDir2 / "input2.sol").generic_string(), ""},
 	};
 	PathSet expectedAllowedPaths = {
-		boost::filesystem::canonical(tempDir1.path()),
-		boost::filesystem::canonical(tempDir2.path()),
+		boost::filesystem::canonical(tempDir1),
+		boost::filesystem::canonical(tempDir2),
 		"b/c",
 		"c/d/e",
 	};
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(cli_ignore_missing_some_files_exist)
 
 	// NOTE: Allowed paths should not be added for skipped files.
 	map<string, string> expectedSources = {{(expectedDir1 / "input1.sol").generic_string(), ""}};
-	PathSet expectedAllowedPaths = {boost::filesystem::canonical(tempDir1.path())};
+	PathSet expectedAllowedPaths = {boost::filesystem::canonical(tempDir1)};
 
 	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({
 		"solc",
@@ -354,14 +354,14 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_no_base_path)
 {
 	TemporaryDirectory tempDirCurrent(TEST_CASE_NAME);
 	TemporaryDirectory tempDirOther(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent);
 	soltestAssert(tempDirCurrent.path().is_absolute(), "");
 	soltestAssert(tempDirOther.path().is_absolute(), "");
 
 	// NOTE: On macOS the path usually contains symlinks which prevents base path from being stripped.
 	// Use canonical() to resolve symnlinks and get consistent results on all platforms.
-	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent.path());
-	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther.path());
+	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent);
+	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther);
 
 	boost::filesystem::path expectedOtherDir = "/" / otherDirNoSymlinks.relative_path();
 	soltestAssert(expectedOtherDir.is_absolute() || expectedOtherDir.root_path() == "/", "");
@@ -412,14 +412,14 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_base_path_same_as_work_dir)
 {
 	TemporaryDirectory tempDirCurrent(TEST_CASE_NAME);
 	TemporaryDirectory tempDirOther(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent);
 	soltestAssert(tempDirCurrent.path().is_absolute(), "");
 	soltestAssert(tempDirOther.path().is_absolute(), "");
 
 	// NOTE: On macOS the path usually contains symlinks which prevents base path from being stripped.
 	// Use canonical() to resolve symnlinks and get consistent results on all platforms.
-	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent.path());
-	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther.path());
+	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent);
+	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther);
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
 	boost::filesystem::path expectedOtherDir = "/" / otherDirNoSymlinks.relative_path();
@@ -475,16 +475,16 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_base_path_different_from_wor
 	TemporaryDirectory tempDirCurrent(TEST_CASE_NAME);
 	TemporaryDirectory tempDirOther(TEST_CASE_NAME);
 	TemporaryDirectory tempDirBase(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent);
 	soltestAssert(tempDirCurrent.path().is_absolute(), "");
 	soltestAssert(tempDirOther.path().is_absolute(), "");
 	soltestAssert(tempDirBase.path().is_absolute(), "");
 
 	// NOTE: On macOS the path usually contains symlinks which prevents base path from being stripped.
 	// Use canonical() to resolve symnlinks and get consistent results on all platforms.
-	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent.path());
-	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther.path());
-	boost::filesystem::path baseDirNoSymlinks = boost::filesystem::canonical(tempDirBase.path());
+	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent);
+	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther);
+	boost::filesystem::path baseDirNoSymlinks = boost::filesystem::canonical(tempDirBase);
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
 	boost::filesystem::path expectedCurrentDir = "/" / currentDirNoSymlinks.relative_path();
@@ -547,14 +547,14 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_relative_base_path)
 {
 	TemporaryDirectory tempDirCurrent(TEST_CASE_NAME);
 	TemporaryDirectory tempDirOther(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDirCurrent);
 	soltestAssert(tempDirCurrent.path().is_absolute(), "");
 	soltestAssert(tempDirOther.path().is_absolute(), "");
 
 	// NOTE: On macOS the path usually contains symlinks which prevents base path from being stripped.
 	// Use canonical() to resolve symnlinks and get consistent results on all platforms.
-	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent.path());
-	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther.path());
+	boost::filesystem::path currentDirNoSymlinks = boost::filesystem::canonical(tempDirCurrent);
+	boost::filesystem::path otherDirNoSymlinks = boost::filesystem::canonical(tempDirOther);
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
 	boost::filesystem::path expectedOtherDir = "/" / otherDirNoSymlinks.relative_path();
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_normalization_and_weird_name
 	string uncPath = "//" + tempDir.path().relative_path().generic_string();
 	soltestAssert(FileReader::isUNCPath(uncPath), "");
 
-	boost::filesystem::path tempDirNoSymlinks = boost::filesystem::canonical(tempDir.path());
+	boost::filesystem::path tempDirNoSymlinks = boost::filesystem::canonical(tempDir);
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();
 	soltestAssert(expectedWorkDir.is_absolute() || expectedWorkDir.root_path() == "/", "");
@@ -829,7 +829,7 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_symlinks)
 	};
 
 	FileReader::FileSystemPathSet expectedAllowedDirectories = {
-		boost::filesystem::canonical(tempDir.path()) / "x/y/z",
+		boost::filesystem::canonical(tempDir) / "x/y/z",
 	};
 
 	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_symlinks)
 BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_base_path_and_stdin)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
-	TemporaryWorkingDirectory tempWorkDir(tempDir.path());
+	TemporaryWorkingDirectory tempWorkDir(tempDir);
 	boost::filesystem::create_directories(tempDir.path() / "base");
 
 	boost::filesystem::path expectedWorkDir = "/" / boost::filesystem::current_path().relative_path();


### PR DESCRIPTION
Depends on #11545 (draft until that one's merged).

Just a bunch of minor improvements I found useful while working on the PR for `--allow-paths`:
- `TemporaryDirectory` constructor can now create empty subdirectories inside the temp dir. I really need this to be able to have a `TemporaryWorkingDirectory` instance initialized with a subdirectory as a member variable in a fixture.
- Automatic conversion to `boost::filesystem::path()` so so that the object can be used as a path. Unfortunately this conversion only works in simple cases. You still can't use it with `/` operator or to call `path`'s methods.
- Some cleanup (plain `assert()` and `fs` namespace alias for `boost::filesystem` removed).
- `TEST_CASE_NAME` macros in individual tests to avoid hard-coding test name but still keep it concise.