### PR TITLE
[Docs] Remove keyword already in use from cheatsheet

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -193,7 +193,7 @@ Reserved Keywords
 These keywords are reserved in Solidity. They might become part of the syntax in the future:
 
 ``after``, ``alias``, ``apply``, ``auto``, ``case``, ``copyof``, ``default``,
-``define``, ``final``, ``immutable``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
+``define``, ``final``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
 ``mutable``, ``null``, ``of``, ``partial``, ``promise``, ``reference``, ``relocatable``,
 ``sealed``, ``sizeof``, ``static``, ``supports``, ``switch``, ``typedef``, ``typeof``,
 ``unchecked``.


### PR DESCRIPTION
* Remove the `immutable` keyword from the list of reserved keywords as it is in use