### PR TITLE
[Docs] Clarify optional parts in remappings

### DIFF
--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -464,7 +464,8 @@ Here are the detailed rules governing the behaviour of remappings:
 
 #. **Prefix cannot be empty but context and target are optional.**
 
-   If ``target`` is omitted, it defaults to the value of the ``prefix``.
+   - If ``target`` is the empty string, ``prefix`` is simply removed from import paths.
+   - Empty ``context`` means that the remapping applies to all imports in all source units.
 
 .. index:: Remix IDE, file://
 


### PR DESCRIPTION
Replaces #11685.

Turns out the implementation is fine but the docs are wrong after my recent rewrite. This PR clarifies what exactly is optional.

I only mention `target` and not `=target`. A remapping without the latter can still be seen as a remapping but I think it's clearer to have the user think about it only as an input file. They're not even equivalent in all cases. For example `solc c.sol a/=/a` does not work the same way as `solc c.sol a/` - the latter will produce an error.