### PR TITLE
Only set "runs" if used.

### DIFF
--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -967,7 +967,8 @@ General Information)").c_str(),
 		m_options.optimizer.enabled = (m_args.count(g_strOptimize) > 0);
 		m_options.optimizer.noOptimizeYul = (m_args.count(g_strNoOptimizeYul) > 0);
 
-		m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<unsigned>();
+		if (!m_args[g_strOptimizeRuns].defaulted())
+			m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<unsigned>();
 
 		if (m_args.count(g_strYulOptimizations))
 		{
@@ -1132,7 +1133,8 @@ General Information)").c_str(),
 		m_args.count(g_strModelCheckerTargets) ||
 		m_args.count(g_strModelCheckerTimeout);
 	m_options.output.experimentalViaIR = (m_args.count(g_strExperimentalViaIR) > 0);
-	m_options.optimizer.expectedExecutionsPerDeployment = m_args[g_strOptimizeRuns].as<unsigned>();
+	if (!m_args[g_strOptimizeRuns].defaulted())
+		m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<unsigned>();
 
 	m_options.optimizer.enabled = (m_args.count(g_strOptimize) > 0);
 	m_options.optimizer.noOptimizeYul = (m_args.count(g_strNoOptimizeYul) > 0);

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -78,7 +78,6 @@ BOOST_AUTO_TEST_CASE(no_options)
 
 	CommandLineOptions expectedOptions;
 	expectedOptions.input.paths = {"contract.sol"};
-	expectedOptions.optimizer.expectedExecutionsPerDeployment = 200;
 	expectedOptions.modelChecker.initialize = true;
 	expectedOptions.modelChecker.settings = {
 		ModelCheckerContracts::Default(),
@@ -334,8 +333,6 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 			expectedOptions.optimizer.yulSteps = "agf";
 			expectedOptions.optimizer.expectedExecutionsPerDeployment = 1000;
 		}
-		else
-			expectedOptions.optimizer.expectedExecutionsPerDeployment = OptimiserSettings{}.expectedExecutionsPerDeployment;
 
 		stringstream sout, serr;
 		optional<CommandLineOptions> parsedOptions = parseCommandLine(commandLine, sout, serr);


### PR DESCRIPTION
Was this missed in https://github.com/ethereum/solidity/pull/11717 ?