### PR TITLE
Allow implicitly convertible functions as overrides

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -734,13 +734,19 @@ do not have a default.
 Conversions:
 
 A function type ``A`` is implicitly convertible to a function type ``B`` if and only if
-their parameter types are identical, their return types are identical,
+their parameter types are identical, their return types are identical or return types of
+``A`` can be safely converted to return types of ``B``,
 their internal/external property is identical and the state mutability of ``A``
 is more restrictive than the state mutability of ``B``. In particular:
 
 - ``pure`` functions can be converted to ``view`` and ``non-payable`` functions
 - ``view`` functions can be converted to ``non-payable`` functions
 - ``payable`` functions can be converted to ``non-payable`` functions
+
+Current available safe conversions are:
+
+- Contract types are safely convertible to contracts they inherit from
+- ``address payable`` is safely convertible to ``address``
 
 No other conversions between function types are possible.
 

--- a/libsolidity/analysis/OverrideChecker.cpp
+++ b/libsolidity/analysis/OverrideChecker.cpp
@@ -596,7 +596,7 @@ void OverrideChecker::checkOverride(OverrideProxy const& _overriding, OverridePr
 		{
 			solAssert(functionType->hasEqualParameterTypes(*superType), "Override doesn't have equal parameters!");
 
-			if (!functionType->hasEqualReturnTypes(*superType))
+			if (!functionType->hasSafelyImplicitlyConvertibleReturnTypes(*superType))
 				overrideError(
 					_overriding,
 					_super,

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -406,9 +406,9 @@ BoolResult AddressType::isImplicitlyConvertibleTo(Type const& _other) const
 	return other.m_stateMutability <= m_stateMutability;
 }
 
-BoolResult AddressType::isSafelyImplicitlyConvertibleTo(Type const& _other) const
+BoolResult AddressType::isSafelyImplicitlyConvertibleTo(Type const& _convertTo) const
 {
-    return isImplicitlyConvertibleTo(_other);
+	return isImplicitlyConvertibleTo(_convertTo);
 }
 
 BoolResult AddressType::isExplicitlyConvertibleTo(Type const& _convertTo) const
@@ -1404,7 +1404,7 @@ BoolResult ContractType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 
 BoolResult ContractType::isSafelyImplicitlyConvertibleTo(Type const& _convertTo) const
 {
-    return isImplicitlyConvertibleTo(_convertTo);
+	return isImplicitlyConvertibleTo(_convertTo);
 }
 
 
@@ -3410,16 +3410,16 @@ bool FunctionType::hasEqualReturnTypes(FunctionType const& _other) const
 
 bool FunctionType::hasSafelyImplicitlyConvertibleReturnTypes(FunctionType const& _other) const
 {
-    if (m_returnParameterTypes.size() != _other.m_returnParameterTypes.size())
-        return false;
-    return equal(
-            m_returnParameterTypes.cbegin(),
-            m_returnParameterTypes.cend(),
-            _other.m_returnParameterTypes.cbegin(),
-            [](Type const* _a, Type const* _b) -> bool {
-                return _a->isSafelyImplicitlyConvertibleTo(*_b);
-            }
-    );
+	if (m_returnParameterTypes.size() != _other.m_returnParameterTypes.size())
+		return false;
+	return equal(
+		m_returnParameterTypes.cbegin(),
+		m_returnParameterTypes.cend(),
+		_other.m_returnParameterTypes.cbegin(),
+		[](Type const* _a, Type const* _b) -> bool {
+			return _a->isSafelyImplicitlyConvertibleTo(*_b);
+		}
+	);
 }
 
 bool FunctionType::equalExcludingStateMutability(FunctionType const& _other) const
@@ -3444,22 +3444,22 @@ bool FunctionType::equalExcludingStateMutability(FunctionType const& _other) con
 
 bool FunctionType::compatibleExcludingStateMutability(FunctionType const& _other) const
 {
-    if (m_kind != _other.m_kind)
-        return false;
+	if (m_kind != _other.m_kind)
+		return false;
 
-    if (!hasEqualParameterTypes(_other) || !hasSafelyImplicitlyConvertibleReturnTypes(_other))
-        return false;
+	if (!hasEqualParameterTypes(_other) || !hasSafelyImplicitlyConvertibleReturnTypes(_other))
+		return false;
 
     //@todo this is ugly, but cannot be prevented right now
-    if (m_gasSet != _other.m_gasSet || m_valueSet != _other.m_valueSet || m_saltSet != _other.m_saltSet)
-        return false;
+	if (m_gasSet != _other.m_gasSet || m_valueSet != _other.m_valueSet || m_saltSet != _other.m_saltSet)
+		return false;
 
-    if (bound() != _other.bound())
-        return false;
+	if (bound() != _other.bound())
+		return false;
 
-    solAssert(!bound() || *selfType() == *_other.selfType(), "");
+	solAssert(!bound() || *selfType() == *_other.selfType(), "");
 
-    return true;
+	return true;
 }
 
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -406,6 +406,11 @@ BoolResult AddressType::isImplicitlyConvertibleTo(Type const& _other) const
 	return other.m_stateMutability <= m_stateMutability;
 }
 
+BoolResult AddressType::isSafelyImplicitlyConvertibleTo(Type const& _other) const
+{
+    return isImplicitlyConvertibleTo(_other);
+}
+
 BoolResult AddressType::isExplicitlyConvertibleTo(Type const& _convertTo) const
 {
 	if ((_convertTo.category() == category()) || isImplicitlyConvertibleTo(_convertTo))
@@ -1396,6 +1401,12 @@ BoolResult ContractType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	}
 	return false;
 }
+
+BoolResult ContractType::isSafelyImplicitlyConvertibleTo(Type const& _convertTo) const
+{
+    return isImplicitlyConvertibleTo(_convertTo);
+}
+
 
 BoolResult ContractType::isExplicitlyConvertibleTo(Type const& _convertTo) const
 {
@@ -3395,6 +3406,20 @@ bool FunctionType::hasEqualReturnTypes(FunctionType const& _other) const
 		_other.m_returnParameterTypes.cbegin(),
 		[](Type const* _a, Type const* _b) -> bool { return *_a == *_b; }
 	);
+}
+
+bool FunctionType::hasSafelyImplicitlyConvertibleReturnTypes(FunctionType const& _other) const
+{
+    if (m_returnParameterTypes.size() != _other.m_returnParameterTypes.size())
+        return false;
+    return equal(
+            m_returnParameterTypes.cbegin(),
+            m_returnParameterTypes.cend(),
+            _other.m_returnParameterTypes.cbegin(),
+            [](Type const* _a, Type const* _b) -> bool {
+                return _a->isSafelyImplicitlyConvertibleTo(*_b);
+            }
+    );
 }
 
 bool FunctionType::equalExcludingStateMutability(FunctionType const& _other) const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2994,7 +2994,7 @@ BoolResult FunctionType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	if (convertTo.kind() != kind())
 		return BoolResult::err("Special functions can not be converted to function types.");
 
-	if (!equalExcludingStateMutability(convertTo))
+	if (!compatibleExcludingStateMutability(convertTo))
 		return false;
 
 	// non-payable should not be convertible to payable
@@ -3441,6 +3441,27 @@ bool FunctionType::equalExcludingStateMutability(FunctionType const& _other) con
 
 	return true;
 }
+
+bool FunctionType::compatibleExcludingStateMutability(FunctionType const& _other) const
+{
+    if (m_kind != _other.m_kind)
+        return false;
+
+    if (!hasEqualParameterTypes(_other) || !hasSafelyImplicitlyConvertibleReturnTypes(_other))
+        return false;
+
+    //@todo this is ugly, but cannot be prevented right now
+    if (m_gasSet != _other.m_gasSet || m_valueSet != _other.m_valueSet || m_saltSet != _other.m_saltSet)
+        return false;
+
+    if (bound() != _other.bound())
+        return false;
+
+    solAssert(!bound() || *selfType() == *_other.selfType(), "");
+
+    return true;
+}
+
 
 bool FunctionType::isBareCall() const
 {

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -201,6 +201,12 @@ public:
 	static std::string escapeIdentifier(std::string const& _identifier);
 
 	virtual BoolResult isImplicitlyConvertibleTo(Type const& _other) const { return *this == _other; }
+
+    /// @returns true iff this type can be safely (memory representation are unaffected
+    /// by conversion) implicitly convertible. This is currently only true for contracts
+    /// and conversions from address payable to address.
+    virtual BoolResult isSafelyImplicitlyConvertibleTo(Type const& _other) const { return *this == _other; }
+
 	virtual BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const
 	{
 		return isImplicitlyConvertibleTo(_convertTo);
@@ -408,6 +414,7 @@ public:
 
 	std::string richIdentifier() const override;
 	BoolResult isImplicitlyConvertibleTo(Type const& _other) const override;
+	BoolResult isSafelyImplicitlyConvertibleTo(Type const& _other) const override;
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	TypeResult unaryOperatorResult(Token _operator) const override;
 	TypeResult binaryOperatorResult(Token _operator, Type const* _other) const override;
@@ -919,6 +926,7 @@ public:
 	Category category() const override { return Category::Contract; }
 	/// Contracts can be implicitly converted only to base contracts.
 	BoolResult isImplicitlyConvertibleTo(Type const& _convertTo) const override;
+    BoolResult isSafelyImplicitlyConvertibleTo(Type const& _other) const override;
 	/// Contracts can only be explicitly converted to address types and base contracts.
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	TypeResult unaryOperatorResult(Token _operator) const override;
@@ -1351,6 +1359,8 @@ public:
 	bool hasEqualParameterTypes(FunctionType const& _other) const;
 	/// @returns true iff the return types are equal (does not check parameter types)
 	bool hasEqualReturnTypes(FunctionType const& _other) const;
+    /// @returns true iff the return types are equal or the return types are contracts and can be implicitly converted
+    bool hasSafelyImplicitlyConvertibleReturnTypes(FunctionType const& _other) const;
 	/// @returns true iff the function type is equal to the given type, ignoring state mutability differences.
 	bool equalExcludingStateMutability(FunctionType const& _other) const;
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -205,7 +205,7 @@ public:
     /// @returns true iff this type can be safely (memory representation are unaffected
     /// by conversion) implicitly convertible. This is currently only true for contracts
     /// and conversions from address payable to address.
-    virtual BoolResult isSafelyImplicitlyConvertibleTo(Type const& _other) const { return *this == _other; }
+	virtual BoolResult isSafelyImplicitlyConvertibleTo(Type const& _other) const { return *this == _other; }
 
 	virtual BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const
 	{
@@ -926,7 +926,7 @@ public:
 	Category category() const override { return Category::Contract; }
 	/// Contracts can be implicitly converted only to base contracts.
 	BoolResult isImplicitlyConvertibleTo(Type const& _convertTo) const override;
-    BoolResult isSafelyImplicitlyConvertibleTo(Type const& _other) const override;
+	BoolResult isSafelyImplicitlyConvertibleTo(Type const& _convertTo) const override;
 	/// Contracts can only be explicitly converted to address types and base contracts.
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 	TypeResult unaryOperatorResult(Token _operator) const override;
@@ -1360,12 +1360,12 @@ public:
 	/// @returns true iff the return types are equal (does not check parameter types)
 	bool hasEqualReturnTypes(FunctionType const& _other) const;
     /// @returns true iff the return types are equal or the return types are contracts and can be implicitly converted
-    bool hasSafelyImplicitlyConvertibleReturnTypes(FunctionType const& _other) const;
+	bool hasSafelyImplicitlyConvertibleReturnTypes(FunctionType const& _other) const;
 	/// @returns true iff the function type is equal to the given type, ignoring state mutability differences.
 	bool equalExcludingStateMutability(FunctionType const& _other) const;
     /// @returns true iff the function type is equal to the given type or equal and return types can be safely
     /// implicitly convertible, ignoring state mutability differences.
-    bool compatibleExcludingStateMutability(FunctionType const& _other) const;
+	bool compatibleExcludingStateMutability(FunctionType const& _other) const;
 
 	/// @returns true if the ABI is NOT used for this call (only meaningful for external calls)
 	bool isBareCall() const;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1363,6 +1363,9 @@ public:
     bool hasSafelyImplicitlyConvertibleReturnTypes(FunctionType const& _other) const;
 	/// @returns true iff the function type is equal to the given type, ignoring state mutability differences.
 	bool equalExcludingStateMutability(FunctionType const& _other) const;
+    /// @returns true iff the function type is equal to the given type or equal and return types can be safely
+    /// implicitly convertible, ignoring state mutability differences.
+    bool compatibleExcludingStateMutability(FunctionType const& _other) const;
 
 	/// @returns true if the ABI is NOT used for this call (only meaningful for external calls)
 	bool isBareCall() const;

--- a/test/libsolidity/syntaxTests/inheritance/interface/implementation/more_specific_safe_cast.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/implementation/more_specific_safe_cast.sol
@@ -1,0 +1,26 @@
+interface A {}
+
+interface B is A {}
+
+interface X {
+
+    function a() external view returns(A);
+    function func() external pure returns (A, A);
+    function func2() external pure returns (address);
+}
+
+contract Y is X {
+
+    B public a;
+
+    function func() pure external override returns(B, A){
+        return (B(address(0)), B(address(0)));
+    }
+
+    function func2() pure external override returns(address payable){
+        return payable(address(0));
+    }
+
+}
+
+// ----

--- a/test/libsolidity/syntaxTests/types/function_types/function_parameter_return_types_safely_convertible_success.sol
+++ b/test/libsolidity/syntaxTests/types/function_types/function_parameter_return_types_safely_convertible_success.sol
@@ -1,0 +1,36 @@
+contract A {
+
+}
+
+contract B is A {
+
+}
+
+contract Test
+{
+  function a() internal returns(A) { return new A(); }
+  function b() internal returns(B) { return new B(); }
+
+  function address_() internal pure returns (address) { return address(0); }
+  function address_payable() internal pure returns (address payable) { return payable(0); }
+
+  function tests() internal
+  {
+    function () internal returns (A) var_to_A = a;
+    function () internal returns (A) var_to_A2 = b;
+    function () internal returns (B) var_to_B = b;
+
+    function () internal pure returns (address) var_address = address_;
+    function () internal pure returns (address) var_address2 = address_payable;
+    function () internal pure returns (address payable) var_address_payable = address_payable;
+
+    var_to_A();
+    var_to_A2();
+    var_to_B();
+
+    var_address();
+    var_address2();
+    var_address_payable();
+  }
+}
+// ----


### PR DESCRIPTION
Implements lesser restrictions for functions to be explicitly convertible. Adds (so far only for return values) support to allow implicitly convertible functions in overrides. Fixes #11624.

Until now, `f : A_1 -> B_1` was implicitly convertible to `g : A_2 -> B_2` if and only if: `A_1 == B_1` and `A_2 == B_2`. 

This lessens the restriction to: `A_2` is implicitly convertible to `A_1` (contravariant in arguments) and `B_1` is implicitly convertible to `B_2`. 

I changed the error message from `types differ` to `types are not compatible` to better reflect the semantics of the new checking.