### PR TITLE
Generalized install_deps.sh for all Big Sur

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -93,8 +93,8 @@ case $(uname -s) in
             10.15)
                 echo "Installing solidity dependencies on macOS 10.15 Catalina."
                 ;;
-            11.0 | 11.1 | 11.2 | 11.3 | 11.4)
-                echo "Installing solidity dependencies on macOS 11.0 / 11.1 / 11.2 / 11.3 / 11.4 Big Sur."
+            11.*)
+                echo "Installing solidity dependencies on macOS Big Sur."
                 ;;
             *)
                 echo "Unsupported macOS version."


### PR DESCRIPTION
I generalized the case statement in install_deps.sh for Big Sur. Any version of the format 11.X will now work.