### PR TITLE
Allow basefee as Yul identifier for EVMVersion < london

### DIFF
--- a/liblangutil/EVMVersion.cpp
+++ b/liblangutil/EVMVersion.cpp
@@ -46,8 +46,9 @@ bool EVMVersion::hasOpcode(Instruction _opcode) const
 		return hasChainID();
 	case Instruction::SELFBALANCE:
 		return hasSelfBalance();
+	case Instruction::BASEFEE:
+		return hasBaseFee();
 	default:
 		return true;
 	}
 }
-

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -198,7 +198,8 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
                 # The warning may or may not exist in a compiler build.
         "4591", # "There are more than 256 warnings. Ignoring the rest."
                 # Due to 3805, the warning lists look different for different compiler builds.
-        "1834"  # Unimplemented feature error, as we do not test it anymore via cmdLineTests
+        "1834", # Unimplemented feature error, as we do not test it anymore via cmdLineTests
+        "5430"  # basefee being used in inline assembly for EVMVersion < london
     }
     assert len(test_ids & white_ids) == 0, "The sets are not supposed to intersect"
     test_ids |= white_ids

--- a/scripts/test_antlr_grammar.sh
+++ b/scripts/test_antlr_grammar.sh
@@ -118,7 +118,9 @@ done < <(
       grep -v -E 'literals/.*_direction_override.*.sol' |
       # Skipping a test with "revert E;" because ANTLR cannot distinguish it from
       # a variable declaration.
-      grep -v -E 'revertStatement/non_called.sol'
+      grep -v -E 'revertStatement/non_called.sol' |
+      # Skipping a test with "let basefee := ..."
+      grep -v -E 'inlineAssembly/basefee_berlin_function.sol'
 )
 
 YUL_FILES=()

--- a/test/libsolidity/semanticTests/inlineAssembly/basefee_berlin_function.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/basefee_berlin_function.sol
@@ -1,0 +1,22 @@
+contract C {
+    function f() public view returns (uint ret) {
+        assembly {
+            let basefee := sload(0)
+            ret := basefee
+        }
+    }
+    function g() public pure returns (uint ret) {
+        assembly {
+            function basefee() -> r {
+                r := 1000
+            }
+            ret := basefee()
+        }
+    }
+}
+// ====
+// compileViaYul: also
+// EVMVersion: <=berlin
+// ----
+// f() -> 0
+// g() -> 1000

--- a/test/libsolidity/syntaxTests/inlineAssembly/basefee_reserved_london.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/basefee_reserved_london.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f() public view returns (uint ret) {
+        assembly {
+            let basefee := sload(0)
+            ret := basefee
+        }
+    }
+}
+// ====
+// EVMVersion: =london
+// ----
+// ParserError 5568: (98-105): Cannot use builtin function name "basefee" as identifier name.

--- a/test/libsolidity/syntaxTests/types/magic_block_basefee_error.sol
+++ b/test/libsolidity/syntaxTests/types/magic_block_basefee_error.sol
@@ -2,14 +2,8 @@ contract C {
     function f() public view returns (uint) {
         return block.basefee;
     }
-    function g() public view returns (uint ret) {
-        assembly {
-            ret := basefee()
-        }
-    }
 }
 // ====
-// EVMVersion: =berlin
+// EVMVersion: <=berlin
 // ----
 // TypeError 5921: (74-87): "basefee" is not supported by the VM version.
-// TypeError 5430: (183-190): The "basefee" instruction is only available for London-compatible VMs (you are currently compiling for "berlin").


### PR DESCRIPTION
This was done to prevent basefee from being a breaking change. This change will be removed in 0.9.0.

TODO revert this commit in breaking.

- The first commit needs to be reverted in breaking.