### PR TITLE
[DOCS] Update resources.rst

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,45 +1,49 @@
+#########
 Resources
----------
+#########
 
-General
-~~~~~~~
+General Resources
+=================
 
-* `Ethereum <https://ethereum.org>`_
+* `Ethereum.org Developer Portal <https://ethereum.org/en/developers/>`_
+* `Ethereum StackExchange <https://ethereum.stackexchange.com/>`_
+* `Solidity Portal <https://soliditylang.org/>`_
+* `Solidity Changelog <https://github.com/ethereum/solidity/blob/develop/Changelog.md>`_
+* `Solidity Source Code on GitHub <https://github.com/ethereum/solidity/>`_
+* `Solidity Language Users Chat <https://matrix.to/#/#ethereum_solidity:gitter.im>`_
+* `Solidity Compiler Developers Chat <https://matrix.to/#/#ethereum_solidity-dev:gitter.im>`_
+* `Awesome Solidity <https://github.com/bkrem/awesome-solidity>`_
+* `Solidity by Example <https://solidity-by-example.org/>`_
 
-* `Changelog <https://github.com/ethereum/solidity/blob/develop/Changelog.md>`_
 
-* `Source Code <https://github.com/ethereum/solidity/>`_
+Integrated (Ethereum) Development Environments
+==============================================
 
-* `Ethereum Stackexchange <https://ethereum.stackexchange.com/>`_
+    * `Brownie <https://eth-brownie.readthedocs.io/en/stable/>`_
+        Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
 
-* `Language Users Chat <https://gitter.im/ethereum/solidity/>`_
+    * `Dapp <https://dapp.tools/>`_
+        Tool for building, testing and deploying smart contracts from the command line.
 
-* `Compiler Developers Chat <https://gitter.im/ethereum/solidity-dev/>`_
+    * `Embark <https://framework.embarklabs.io/>`_
+        Developer platform for building and deploying decentralized applications.
 
-Solidity Integrations
-~~~~~~~~~~~~~~~~~~~~~
-
-* Generic:
-
-    * `EthFiddle <https://ethfiddle.com/>`_
-        Solidity IDE in the Browser. Write and share your Solidity code. Uses server-side components.
+    * `Hardhat <https://hardhat.org/>`_
+        Ethereum development environment with local Ethereum network, debugging features and plugin ecosystem.
 
     * `Remix <https://remix.ethereum.org/>`_
         Browser-based IDE with integrated compiler and Solidity runtime environment without server-side components.
 
-    * `Solhint <https://github.com/protofire/solhint>`_
-        Solidity linter that provides security, style guide and best practice rules for smart contract validation.
+    * `Scaffold-ETH <https://github.com/austintgriffith/scaffold-eth>`_
+        Ethereum development stack focused on fast product iterations.
 
-    * `Solidity IDE <https://github.com/System-Glitch/Solidity-IDE>`_
-        Browser-based IDE with integrated compiler, Ganache and local file system support.
+    * `Truffle <https://www.trufflesuite.com/truffle>`_
+        Ethereum development framework.
 
-    * `Ethlint <https://github.com/duaraghav8/Ethlint>`_
-        Linter to identify and fix style and security issues in Solidity.
+Editor Integrations
+===================
 
-    * `Superblocks Lab <https://lab.superblocks.com/>`_
-        Browser-based IDE. Built-in browser-based VM and Metamask integration (one click deployment to Testnet/Mainnet).
-
-* Atom:
+* Atom
 
     * `Etheratom <https://github.com/0mkara/etheratom>`_
         Plugin for the Atom editor that features syntax highlighting, compilation and a runtime environment (Backend node & VM compatible).
@@ -50,27 +54,22 @@ Solidity Integrations
     * `Atom Solium Linter <https://atom.io/packages/linter-solium>`_
         Configurable Solidity linter for Atom using Solium (now Ethlint) as a base.
 
-* Eclipse:
-
-   * `YAKINDU Solidity Tools <https://yakindu.github.io/solidity-ide/>`_
-        Eclipse based IDE. Features context sensitive code completion and help, code navigation, syntax coloring, built in compiler, quick fixes and templates.
-
-* Emacs:
+* Emacs
 
     * `Emacs Solidity <https://github.com/ethereum/emacs-solidity/>`_
         Plugin for the Emacs editor providing syntax highlighting and compilation error reporting.
 
-* IntelliJ:
+* IntelliJ
 
     * `IntelliJ IDEA plugin <https://plugins.jetbrains.com/plugin/9475-intellij-solidity>`_
         Solidity plugin for IntelliJ IDEA (and all other JetBrains IDEs)
 
-* Sublime:
+* Sublime
 
     * `Package for SublimeText - Solidity language syntax <https://packagecontrol.io/packages/Ethereum/>`_
         Solidity syntax highlighting for SublimeText editor.
 
-* Vim:
+* Vim
 
     * `Vim Solidity <https://github.com/tomlion/vim-solidity/>`_
         Plugin for the Vim editor providing syntax highlighting.
@@ -78,22 +77,25 @@ Solidity Integrations
     * `Vim Syntastic <https://github.com/vim-syntastic/syntastic>`_
         Plugin for the Vim editor providing compile checking.
 
-* Visual Studio Code:
+* Visual Studio Code
 
     * `Visual Studio Code extension <https://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
         Solidity plugin for Microsoft Visual Studio Code that includes syntax highlighting and the Solidity compiler.
 
 Solidity Tools
-~~~~~~~~~~~~~~
+==============
 
 * `ABI to Solidity interface converter <https://gist.github.com/chriseth/8f533d133fa0c15b0d6eaf3ec502c82b>`_
     A script for generating contract interfaces from the ABI of a smart contract.
 
-* `Dapp <https://dapp.tools/dapp/>`_
-    Build tool, package manager, and deployment assistant for Solidity.
+* `abi-to-sol <https://github.com/gnidan/abi-to-sol>`_
+    Tool to generate Solidity interface source from a given ABI JSON.
 
 * `Doxity <https://github.com/DigixGlobal/doxity>`_
     Documentation Generator for Solidity.
+
+* `Ethlint <https://github.com/duaraghav8/Ethlint>`_
+    Linter to identify and fix style and security issues in Solidity.
 
 * `evmdis <https://github.com/Arachnid/evmdis>`_
     EVM Disassembler that performs static analysis on the bytecode to provide a higher level of abstraction than raw EVM operations.
@@ -101,11 +103,17 @@ Solidity Tools
 * `EVM Lab <https://github.com/ethereum/evmlab/>`_
     Rich tool package to interact with the EVM. Includes a VM, Etherchain API, and a trace-viewer with gas cost display.
 
+* `hevm <https://github.com/dapphub/dapptools/tree/master/src/hevm#readme>`_
+    EVM debugger and symbolic execution engine.
+
 * `leafleth <https://github.com/clemlak/leafleth>`_
     A documentation generator for Solidity smart-contracts.
 
 * `PIET <https://piet.slock.it/>`_
     A tool to develop, audit and use Solidity smart contracts through a simple graphical interface.
+
+* `sol2uml <https://www.npmjs.com/package/sol2uml>`_
+    Unified Modeling Language (UML) class diagram generator for Solidity contracts.
 
 * `solc-select <https://github.com/crytic/solc-select>`_
     A script to quickly switch between Solidity compiler versions.
@@ -119,8 +127,8 @@ Solidity Tools
 * `solgraph <https://github.com/raineorshine/solgraph>`_
     Visualize Solidity control flow and highlight potential security vulnerabilities.
 
-* `Securify <https://securify.ch/>`_
-    Fully automated online static analyzer for smart contracts, providing a security report based on vulnerability patterns.
+* `Solhint <https://github.com/protofire/solhint>`_
+    Solidity linter that provides security, style guide and best practice rules for smart contract validation.
 
 * `Sūrya <https://github.com/ConsenSys/surya/>`_
     Utility tool for smart contract systems, offering a number of visual outputs and information about the contracts' structure. Also supports querying the function call graph.
@@ -129,7 +137,7 @@ Solidity Tools
     A tool for mutation generation, with configurable rules and support for Solidity and Vyper.
 
 Third-Party Solidity Parsers and Grammars
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=========================================
 
 * `Solidity Parser for JavaScript <https://github.com/solidity-parser/parser>`_
     A Solidity parser for JS built on top of a robust ANTLR4 grammar.


### PR DESCRIPTION
## Changes Done

Updates the resources section of the docs:
- Deletes all outdated tools and 404 links
- Adds missing IDEs and tools
- Adds some new relevant links to the "general" section

## Remaining Issue

For some reason, the formatting looks different now. 

It used to show the IDEs like this:

![image](https://user-images.githubusercontent.com/41991517/128892130-70b49022-58f7-42b5-8d62-4e32ae803a91.png)

while now for me locally it looks like this: 

![image](https://user-images.githubusercontent.com/41991517/128892185-6e9d7a7e-c550-423f-928d-1877dac3137d.png)

I don't know why. Can anybody help me?
