### PR TITLE
[DOCS] Improving the naming consistency in Solidity by Example documentation

### DIFF
--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -346,11 +346,11 @@ The full contract
         address payable public recipient;   // The account receiving the payments.
         uint256 public expiration;  // Timeout in case the recipient never closes.
 
-        constructor (address payable _recipient, uint256 duration)
+        constructor (address payable recipientAddress, uint256 duration)
             payable
         {
             sender = payable(msg.sender);
-            recipient = _recipient;
+            recipient = recipientAddress;
             expiration = block.timestamp + duration;
         }
 

--- a/docs/examples/safe-remote.rst
+++ b/docs/examples/safe-remote.rst
@@ -36,8 +36,8 @@ you can use state machine-like constructs inside a contract.
         // The state variable has a default value of the first member, `State.created`
         State public state;
 
-        modifier condition(bool _condition) {
-            require(_condition);
+        modifier condition(bool condition_) {
+            require(condition_);
             _;
         }
 
@@ -62,8 +62,8 @@ you can use state machine-like constructs inside a contract.
             _;
         }
 
-        modifier inState(State _state) {
-            if (state != _state)
+        modifier inState(State state_) {
+            if (state != state_)
                 revert InvalidState();
             _;
         }


### PR DESCRIPTION
According to Solidity naming convention: https://docs.soliditylang.org/en/latest/style-guide.html#naming-conventions

There is no need to use underscore except when there is a naming collision. In which case, a trailing underscore is used to avoid the collision.
So in this change, I am removing all underscores, except for the ones that could shadow other symbols in their context (none of the changed names is a reserved keyword: https://docs.soliditylang.org/en/latest/cheatsheet.html?highlight=reserved#reserved-keywords )

For ref, this is a follow up PR with reference to issue: #11764