### PR TITLE
Document pre-0.5.0 bytesX/uintY conversions

### DIFF
--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -127,7 +127,10 @@ For most of the topics the compiler will provide suggestions.
   adjusted within the type before the conversion.  For example, you can convert
   a ``bytes4`` (4 bytes) to a ``uint64`` (8 bytes) by first converting the
   ``bytes4`` variable to ``bytes8`` and then to ``uint64``. You get the
-  opposite padding when converting through ``uint32``.
+  opposite padding when converting through ``uint32``. Before v0.5.0 any
+  conversion between ``bytesX`` and ``uintY`` would go through ``uint8X``. For
+  example ``uint8(bytes3(0x291807))`` would be converted to ``uint8(uint24(bytes3(0x291807)))``
+  (the result is ``0x07``).
 
 * Using ``msg.value`` in non-payable functions (or introducing it via a
   modifier) is disallowed as a security feature. Turn the function into


### PR DESCRIPTION
Breaking changes sections from 0.6.0, 0.7.0 and 0.8.0 have a subsection titled "How to update your code". Breaking changes from 0.5.0 doesn't have that section. Instead it has an old contract adapted to the new version with some comments. So there are some missing bits.

Since 0.5.0 conversions between ``bytesX`` and ``uintY`` of different size are disallowed for reasons explained in the documentation. But the behavior of pre-0.5.0 is not currently documented, which may be needed to adapt a pre-0.5.0 contract to newer versions when keeping exactly the same contract behavior is a requirement.

This PR documents this pre-0.5.0 behavior. A simple contract can be used to verify the proposed changes.

Calling ```verify()``` will not revert.

```solidity
pragma solidity ^0.4.26;

contract Test {
    constructor() public{      
    }

    function verify() public pure {
        require(uint8(bytes3(0x291807)) == uint8(uint24(bytes3(0x291807))));
        require(uint16(bytes3(0x291807)) == uint16(uint24(bytes3(0x291807))));
        require(uint32(bytes3(0x291807)) == uint32(uint24(bytes3(0x291807))));
        require(uint32(bytes2(0x1234)) == uint32(uint16(bytes2(0x1234))));
        require(bytes1(uint24(0x291807)) == bytes1(uint8(uint24(0x291807))));
        require(bytes2(uint24(0x291807)) == bytes2(uint16(uint24(0x291807))));
        require(bytes4(uint24(0x291807)) == bytes4(uint32(uint24(0x291807))));
    }
}
```