### PR TITLE
Increase use of C++ constexpr

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -81,7 +81,7 @@ tuple<float, float> myNamespace::meanAndSigma(vector<float> const& _v)
    - Copyright
    - License (e.g. see COPYING)
 2. Never use `#ifdef`/`#define`/`#endif` file guards. Prefer `#pragma` once as first line below file comment.
-3. Prefer static const variable to value macros.
+3. Prefer static constexpr variables to value macros.
 4. Prefer inline constexpr functions to function macros.
 5. Split complex macro on multiple lines with `\`.
 

--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -34,6 +34,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <regex>
+#include <string_view>
 
 using namespace std;
 using namespace solidity;
@@ -233,7 +234,7 @@ void DocStringTagParser::parseDocStrings(
 
 	for (auto const& [tagName, tagValue]: _annotation.docTags)
 	{
-		string static const customPrefix("custom:");
+		string_view static constexpr customPrefix("custom:");
 		if (tagName == "custom" || tagName == "custom:")
 			m_errorReporter.docstringParsingError(
 				6564_error,

--- a/libyul/Utilities.cpp
+++ b/libyul/Utilities.cpp
@@ -42,7 +42,7 @@ string solidity::yul::reindent(string const& _code)
 {
 	int constexpr indentationWidth = 4;
 
-	auto const static countBraces = [](string const& _s) noexcept -> int
+	auto constexpr static countBraces = [](string const& _s) noexcept -> int
 	{
 		auto const i = _s.find("//");
 		auto const e = i == _s.npos ? end(_s) : next(begin(_s), static_cast<ptrdiff_t>(i));

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -856,7 +856,7 @@ void EVMHostPrinter::selfdestructRecords()
 
 void EVMHostPrinter::callRecords()
 {
-	static const auto callKind = [](evmc_call_kind _kind) -> string
+	static auto constexpr callKind = [](evmc_call_kind _kind) -> string
 	{
 		switch (_kind)
 		{

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -49,9 +49,8 @@ namespace solidity::test
 using rational = boost::rational<bigint>;
 
 // The ether and gwei denominations; here for ease of use where needed within code.
-static const u256 gwei = u256(1) << 9;
-static const u256 ether = u256(1) << 18;
-
+static u256 const gwei = u256(1) << 9;
+static u256 const ether = u256(1) << 18;
 class ExecutionFramework
 {
 

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -78,7 +78,7 @@ void FuzzerUtil::testCompilerJsonInterface(string const& _input, bool _optimize,
 void FuzzerUtil::forceSMT(StringMap& _input)
 {
 	// Add SMT checker pragma if not already present in source
-	static const char* smtPragma = "pragma experimental SMTChecker;";
+	static auto constexpr smtPragma = "pragma experimental SMTChecker;";
 	for (auto &sourceUnit: _input)
 		if (sourceUnit.second.find(smtPragma) == string::npos)
 			sourceUnit.second += smtPragma;


### PR DESCRIPTION
As described in issue #7720.
Changed the qualifiers to `static constexpr` instead of `static const` whenever possible. Some types don't have a `constexpr` constructor, e.g. `std::set<T>` or `std::regex`, so I couldn't `constexpr` them without changing the type (e.g. adding a `set` implementation with a `constexpr` constructor, which is an overkill).  `test/tools/ossfuzz/yulOptimizerFuzzDictionary.h` has a `static const std::vector<std::string>` variable defined, which can be made `static constexpr` in C++20.

Note that in `libsolidity/analysis/DocStringTagParser.cpp` I changed the `string static const` to `string_view static constexpr` which has a `constexpr` constructor, but requires C++17.

I refrained from changing `libsolutil/picosha2.h:43` `static const size_t` to `size_t static constexpr` since it's an external dependency, so I believe minimal changes are preferred for easier updates from `picosha`'s repo down the road.

I also changed a coding style guideline accordingly.