### PR TITLE
Separate control flow from error reporting in command line parser

### DIFF
--- a/libsolutil/Exceptions.h
+++ b/libsolutil/Exceptions.h
@@ -56,6 +56,10 @@ private:
 		::boost::throw_line(__LINE__) \
 	)
 
+/// Defines an exception type that's meant to signal a specific condition and be caught rather than
+/// unwind the stack all the way to the top-level exception handler and interrupt the program.
+/// As such it does not carry a message - the code catching it is expected to handle it without
+/// letting it escape.
 #define DEV_SIMPLE_EXCEPTION(X) struct X: virtual ::solidity::util::Exception { const char* what() const noexcept override { return #X; } }
 
 DEV_SIMPLE_EXCEPTION(InvalidAddress);

--- a/solc/CMakeLists.txt
+++ b/solc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(libsolcli_sources
 	CommandLineInterface.cpp CommandLineInterface.h
 	CommandLineParser.cpp CommandLineParser.h
+	Exceptions.h
 )
 
 add_library(solcli ${libsolcli_sources})

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -23,6 +23,8 @@
  */
 #include <solc/CommandLineInterface.h>
 
+#include <solc/Exceptions.h>
+
 #include "license.h"
 #include "solidity/BuildInfo.h"
 
@@ -592,9 +594,16 @@ bool CommandLineInterface::parseArguments(int _argc, char const* const* _argv)
 		return false;
 	}
 
-	bool success = parser.parse(_argc, _argv);
-	if (!success)
+	try
+	{
+		parser.parse(_argc, _argv);
+	}
+	catch (CommandLineValidationError const& _exception)
+	{
+		serr() << _exception.what() << endl;
 		return false;
+	}
+
 	m_hasOutput = m_hasOutput || parser.hasOutput();
 	m_options = parser.options();
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -546,19 +546,12 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 
 	string pathName = (m_options.output.dir / _fileName).string();
 	if (fs::exists(pathName) && !m_options.output.overwriteFiles)
-	{
-		serr() << "Refusing to overwrite existing file \"" << pathName << "\" (use --overwrite to force)." << endl;
-		m_outputFailed = true;
-		return;
-	}
+		solThrow(CommandLineOutputError, "Refusing to overwrite existing file \"" + pathName + "\" (use --overwrite to force).");
+
 	ofstream outFile(pathName);
 	outFile << _data;
 	if (!outFile)
-	{
-		serr() << "Could not write to file \"" << pathName << "\"." << endl;
-		m_outputFailed = true;
-		return;
-	}
+		solThrow(CommandLineOutputError, "Could not write to file \"" + pathName + "\".");
 }
 
 void CommandLineInterface::createJson(string const& _fileName, string const& _json)
@@ -643,9 +636,6 @@ void CommandLineInterface::processInput()
 		compile();
 		outputCompilationResults();
 	}
-
-	if (m_outputFailed)
-		solThrow(CommandLineOutputError, "Failed to write all output files to disk.");
 }
 
 void CommandLineInterface::printVersion()
@@ -969,10 +959,7 @@ void CommandLineInterface::writeLinkedFiles()
 			ofstream outFile(src.first);
 			outFile << src.second;
 			if (!outFile)
-			{
-				m_outputFailed = true;
 				solThrow(CommandLineOutputError, "Could not write to file " + src.first + ". Aborting.");
-			}
 		}
 	sout() << "Linking completed." << endl;
 }

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -583,7 +583,7 @@ void CommandLineInterface::createJson(string const& _fileName, string const& _js
 
 bool CommandLineInterface::parseArguments(int _argc, char const* const* _argv)
 {
-	CommandLineParser parser(serr(/* _markAsUsed */ false));
+	CommandLineParser parser;
 
 	if (isatty(fileno(stdin)) && _argc == 1)
 	{
@@ -604,7 +604,6 @@ bool CommandLineInterface::parseArguments(int _argc, char const* const* _argv)
 		return false;
 	}
 
-	m_hasOutput = m_hasOutput || parser.hasOutput();
 	m_options = parser.options();
 
 	return true;
@@ -1002,6 +1001,8 @@ string CommandLineInterface::objectWithLinkRefsHex(evmasm::LinkerObject const& _
 bool CommandLineInterface::assemble(yul::AssemblyStack::Language _language, yul::AssemblyStack::Machine _targetMachine)
 {
 	solAssert(m_options.input.mode == InputMode::Assembler, "");
+
+	serr() << "Warning: Yul is still experimental. Please use the output with care." << endl;
 
 	bool successful = true;
 	map<string, yul::AssemblyStack> assemblyStacks;

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -51,12 +51,28 @@ public:
 		m_options(_options)
 	{}
 
-	/// Parse command line arguments and return false if we should not continue
+	/// Parses command-line arguments, executes the requested operation and handles validation and
+	/// execution errors.
+	/// @returns false if it catches a @p CommandLineValidationError or if the application is
+	/// expected to exit with a non-zero exit code despite there being no error.
+	bool run(int _argc, char const* const* _argv);
+
+	/// Parses command line arguments and stores the result in @p m_options.
+	/// @throws CommandLineValidationError if command-line arguments are invalid.
+	/// @returns false if the application is expected to exit with a non-zero exit code despite
+	/// there being no error.
 	bool parseArguments(int _argc, char const* const* _argv);
-	/// Read the content of all input files and initialize the file reader.
-	bool readInputFiles();
-	/// Parse the files, create source code objects, print the output.
-	bool processInput();
+
+	/// Reads the content of all input files and initializes the file reader.
+	/// @throws CommandLineValidationError if it fails to read the input files (invalid paths,
+	/// non-existent files, not enough or too many input files, etc.).
+	void readInputFiles();
+
+	/// Executes the requested operation (compilation, assembling, standard JSON, etc.) and prints
+	/// results to the terminal.
+	/// @throws CommandLineExecutionError if execution fails due to errors in the input files.
+	/// @throws CommandLineOutputError if creating output files or writing to them fails.
+	void processInput();
 
 	CommandLineOptions const& options() const { return m_options; }
 	FileReader const& fileReader() const { return m_fileReader; }
@@ -65,15 +81,15 @@ public:
 private:
 	void printVersion();
 	void printLicense();
-	bool compile();
-	bool link();
+	void compile();
+	void link();
 	void writeLinkedFiles();
 	/// @returns the ``// <identifier> -> name`` hint for library placeholders.
 	static std::string libraryPlaceholderHint(std::string const& _libraryName);
 	/// @returns the full object with library placeholder hints in hex.
 	static std::string objectWithLinkRefsHex(evmasm::LinkerObject const& _obj);
 
-	bool assemble(yul::AssemblyStack::Language _language, yul::AssemblyStack::Machine _targetMachine);
+	void assemble(yul::AssemblyStack::Language _language, yul::AssemblyStack::Machine _targetMachine);
 
 	void outputCompilationResults();
 

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -136,7 +136,6 @@ private:
 	std::ostream& m_sout;
 	std::ostream& m_serr;
 	bool m_hasOutput = false;
-	bool m_outputFailed = false; ///< If true, creation or write to some of the output files failed.
 	FileReader m_fileReader;
 	std::optional<std::string> m_standardJsonInput;
 	std::unique_ptr<frontend::CompilerStack> m_compiler;

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -38,14 +38,6 @@ namespace po = boost::program_options;
 namespace solidity::frontend
 {
 
-ostream& CommandLineParser::serr()
-{
-	m_hasOutput = true;
-	return m_serr;
-}
-
-#define cerr
-
 static string const g_strAllowPaths = "allow-paths";
 static string const g_strBasePath = "base-path";
 static string const g_strIncludePath = "include-path";
@@ -278,8 +270,6 @@ OptimiserSettings CommandLineOptions::optimiserSettings() const
 
 void CommandLineParser::parse(int _argc, char const* const* _argv)
 {
-	m_hasOutput = false;
-
 	parseArgs(_argc, _argv);
 	processArgs();
 }
@@ -1167,8 +1157,6 @@ void CommandLineParser::processArgs()
 				"The selected input language is not directly supported when targeting the Ewasm machine "
 				"and automatic translation is not available."
 			);
-
-		serr() << "Warning: Yul is still experimental. Please use the output with care." << endl;
 		return;
 	}
 	else if (countEnabledOptions({g_strYulDialect, g_strMachine}) >= 1)

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -238,19 +238,12 @@ struct CommandLineOptions
 class CommandLineParser
 {
 public:
-	explicit CommandLineParser(std::ostream& _serr):
-		m_serr(_serr)
-	{}
-
 	/// Parses the command-line arguments and fills out the internal CommandLineOptions structure.
 	/// @throws CommandLineValidationError if the arguments cannot be properly parsed or are invalid.
 	/// When an exception is thrown, the @p CommandLineOptions may be only partially filled out.
 	void parse(int _argc, char const* const* _argv);
 
 	CommandLineOptions const& options() const { return m_options; }
-
-	/// Returns true if the parser has written anything to any of its output streams.
-	bool hasOutput() const { return m_hasOutput; }
 
 	static void printHelp(std::ostream& _out) { _out << optionsDescription(); }
 
@@ -291,13 +284,6 @@ private:
 	void checkMutuallyExclusive(std::vector<std::string> const& _optionNames);
 	size_t countEnabledOptions(std::vector<std::string> const& _optionNames) const;
 	static std::string joinOptionNames(std::vector<std::string> const& _optionNames, std::string _separator = ", ");
-
-	/// Returns the stream that should receive error output. Sets m_hasOutput to true if the
-	/// stream has ever been used.
-	std::ostream& serr();
-
-	std::ostream& m_serr;
-	bool m_hasOutput = false;
 
 	CommandLineOptions m_options;
 

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -234,7 +234,7 @@ struct CommandLineOptions
 };
 
 /// Parses the command-line arguments and produces a filled-out CommandLineOptions structure.
-/// Validates provided values and prints error messages in case of errors.
+/// Validates provided values and reports errors by throwing @p CommandLineValidationErrors.
 class CommandLineParser
 {
 public:
@@ -243,12 +243,9 @@ public:
 	{}
 
 	/// Parses the command-line arguments and fills out the internal CommandLineOptions structure.
-	/// Performs validation and prints error messages.
-	/// @return true if there were no validation errors when parsing options and the
-	/// CommandLineOptions structure has been fully initialized. false if there were errors - in
-	/// this case CommandLineOptions may be only partially filled out. May also return false if
-	/// there is not further processing necessary and the program should just exit.
-	bool parse(int _argc, char const* const* _argv);
+	/// @throws CommandLineValidationError if the arguments cannot be properly parsed or are invalid.
+	/// When an exception is thrown, the @p CommandLineOptions may be only partially filled out.
+	void parse(int _argc, char const* const* _argv);
 
 	CommandLineOptions const& options() const { return m_options; }
 
@@ -269,30 +266,29 @@ private:
 	/// Uses boost::program_options to parse the command-line arguments and leaves the result in @a m_args.
 	/// Also handles the arguments that result in information being printed followed by immediate exit.
 	/// @returns false if parsing fails due to syntactical errors or the arguments not matching the description.
-	bool parseArgs(int _argc, char const* const* _argv);
+	void parseArgs(int _argc, char const* const* _argv);
 
 	/// Validates parsed arguments stored in @a m_args and fills out the internal CommandLineOptions
 	/// structure.
-	/// @return false if there are any validation errors, true otherwise.
-	bool processArgs();
+	/// @throws CommandLineValidationError in case of validation errors.
+	void processArgs();
 
 	/// Parses the value supplied to --combined-json.
-	/// @return false if there are any validation errors, true otherwise.
-	bool parseCombinedJsonOption();
+	/// @throws CommandLineValidationError in case of validation errors.
+	void parseCombinedJsonOption();
 
-	/// Parses the names of the input files, remappings for all modes except for Standard JSON.
-	/// Does not check if files actually exist.
-	/// @return false if there are any validation errors, true otherwise.
-	bool parseInputPathsAndRemappings();
+	/// Parses the names of the input files, remappings. Does not check if the files actually exist.
+	/// @throws CommandLineValidationError in case of validation errors.
+	void parseInputPathsAndRemappings();
 
 	/// Tries to read from the file @a _input or interprets @a _input literally if that fails.
-	/// It then tries to parse the contents and appends to m_options.libraries.
-	/// @return false if there are any validation errors, true otherwise.
-	bool parseLibraryOption(std::string const& _input);
+	/// It then tries to parse the contents and appends to @a m_options.libraries.
+	/// @throws CommandLineValidationError in case of validation errors.
+	void parseLibraryOption(std::string const& _input);
 
-	bool parseOutputSelection();
+	void parseOutputSelection();
 
-	bool checkMutuallyExclusive(std::vector<std::string> const& _optionNames);
+	void checkMutuallyExclusive(std::vector<std::string> const& _optionNames);
 	size_t countEnabledOptions(std::vector<std::string> const& _optionNames) const;
 	static std::string joinOptionNames(std::vector<std::string> const& _optionNames, std::string _separator = ", ");
 

--- a/solc/Exceptions.h
+++ b/solc/Exceptions.h
@@ -1,0 +1,34 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Exceptions used by the command-line interface.
+ */
+
+#pragma once
+
+#include <liblangutil/Exceptions.h>
+
+namespace solidity::frontend
+{
+
+struct CommandLineError: virtual util::Exception {};
+struct CommandLineExecutionError: virtual CommandLineError {};
+struct CommandLineValidationError: virtual CommandLineError {};
+struct CommandLineOutputError: virtual CommandLineError {};
+
+}

--- a/solc/main.cpp
+++ b/solc/main.cpp
@@ -62,12 +62,7 @@ int main(int argc, char** argv)
 	{
 		setDefaultOrCLocale();
 		solidity::frontend::CommandLineInterface cli(cin, cout, cerr);
-		bool success =
-			cli.parseArguments(argc, argv) &&
-			cli.readInputFiles() &&
-			cli.processInput();
-
-		return success ? 0 : 1;
+		return cli.run(argc, argv) ? 0 : 1;
 	}
 	catch (smtutil::SMTLogicError const& _exception)
 	{

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -19,6 +19,7 @@
 /// Unit tests for solc/CommandLineInterface.h
 
 #include <solc/CommandLineInterface.h>
+#include <solc/Exceptions.h>
 
 #include <test/solc/Common.h>
 
@@ -114,7 +115,7 @@ BOOST_AUTO_TEST_SUITE(CommandLineInterfaceTest)
 
 BOOST_AUTO_TEST_CASE(help)
 {
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({"solc", "--help"}, "", /* _processInput */ true);
+	OptionsReaderAndMessages result = runCLI({"solc", "--help"}, "");
 
 	BOOST_TEST(result.success);
 	BOOST_TEST(boost::starts_with(result.stdoutContent, "solc, the Solidity commandline compiler."));
@@ -124,7 +125,7 @@ BOOST_AUTO_TEST_CASE(help)
 
 BOOST_AUTO_TEST_CASE(license)
 {
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({"solc", "--license"}, "", /* _processInput */ true);
+	OptionsReaderAndMessages result = runCLI({"solc", "--license"}, "");
 
 	BOOST_TEST(result.success);
 	BOOST_TEST(boost::starts_with(result.stdoutContent, "Most of the code is licensed under GPLv3"));
@@ -134,7 +135,7 @@ BOOST_AUTO_TEST_CASE(license)
 
 BOOST_AUTO_TEST_CASE(version)
 {
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({"solc", "--version"}, "", /* _processInput */ true);
+	OptionsReaderAndMessages result = runCLI({"solc", "--version"}, "");
 
 	BOOST_TEST(result.success);
 	BOOST_TEST(boost::ends_with(result.stdoutContent, "Version: " + solidity::frontend::VersionString + "\n"));
@@ -158,17 +159,16 @@ BOOST_AUTO_TEST_CASE(multiple_input_modes)
 	string expectedMessage =
 		"The following options are mutually exclusive: "
 		"--help, --license, --version, --standard-json, --link, --assemble, --strict-assembly, --yul, --import-ast. "
-		"Select at most one.\n";
+		"Select at most one.";
 
 	for (string const& mode1: inputModeOptions)
 		for (string const& mode2: inputModeOptions)
 			if (mode1 != mode2)
-			{
-				vector<string> commandLine = {"solc", mode1, mode2};
-				OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-				BOOST_TEST(!result.success);
-				BOOST_TEST(result.stderrContent == expectedMessage);
-			}
+				BOOST_CHECK_EXCEPTION(
+					parseCommandLineAndReadInputFiles({"solc", mode1, mode2}),
+					CommandLineValidationError,
+					[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+				);
 }
 
 BOOST_AUTO_TEST_CASE(cli_input)
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(cli_ignore_missing_no_files_exist)
 		"\"" + (tempDir.path() / "input2.sol").string() + "\" is not found. Skipping.\n"
 		"All specified input files either do not exist or are not regular files.\n";
 
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({
+	OptionsReaderAndMessages result = runCLI({
 		"solc",
 		(tempDir.path() / "input1.sol").string(),
 		(tempDir.path() / "input2.sol").string(),
@@ -267,11 +267,13 @@ BOOST_AUTO_TEST_CASE(cli_not_a_file)
 {
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
 
-	string expectedMessage = "\"" + tempDir.path().string() + "\" is not a valid file.\n";
+	string expectedMessage = "\"" + tempDir.path().string() + "\" is not a valid file.";
 
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({"solc", tempDir.path().string()});
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({"solc", tempDir.path().string()}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(standard_json_base_path)
@@ -336,24 +338,26 @@ BOOST_AUTO_TEST_CASE(standard_json_two_input_files)
 {
 	string expectedMessage =
 		"Too many input files for --standard-json.\n"
-		"Please either specify a single file name or provide its content on standard input.\n";
+		"Please either specify a single file name or provide its content on standard input.";
 
-	vector<string> commandLine = {"solc", "--standard-json", "input1.json", "input2.json"};
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({"solc", "--standard-json", "input1.json", "input2.json"}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(standard_json_one_input_file_and_stdin)
 {
 	string expectedMessage =
 		"Too many input files for --standard-json.\n"
-		"Please either specify a single file name or provide its content on standard input.\n";
+		"Please either specify a single file name or provide its content on standard input.";
 
-	vector<string> commandLine = {"solc", "--standard-json", "input1.json", "-"};
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({"solc", "--standard-json", "input1.json", "-"}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(standard_json_ignore_missing)
@@ -362,29 +366,31 @@ BOOST_AUTO_TEST_CASE(standard_json_ignore_missing)
 
 	// This option is pretty much useless Standard JSON mode.
 	string expectedMessage =
-		"\"" + (tempDir.path() / "input.json").string() + "\" is not found. Skipping.\n"
-		"All specified input files either do not exist or are not regular files.\n";
+		"All specified input files either do not exist or are not regular files.";
 
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles({
-		"solc",
-		"--standard-json",
-		(tempDir.path() / "input.json").string(),
-		"--ignore-missing",
-	});
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({
+			"solc",
+			"--standard-json",
+			(tempDir.path() / "input.json").string(),
+			"--ignore-missing",
+		}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(standard_json_remapping)
 {
 	string expectedMessage =
 		"Import remappings are not accepted on the command line in Standard JSON mode.\n"
-		"Please put them under 'settings.remappings' in the JSON input.\n";
+		"Please put them under 'settings.remappings' in the JSON input.";
 
-	vector<string> commandLine = {"solc", "--standard-json", "a=b"};
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({"solc", "--standard-json", "a=b"}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(cli_paths_to_source_unit_names_no_base_path)
@@ -997,11 +1003,7 @@ BOOST_AUTO_TEST_CASE(cli_include_paths)
 		canonicalWorkDir / "lib",
 	};
 
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(
-		commandLine,
-		"",
-		true /* _processInput */
-	);
+	OptionsReaderAndMessages result = runCLI(commandLine, "");
 
 	BOOST_TEST(result.stderrContent == "");
 	BOOST_TEST(result.stdoutContent == "");
@@ -1087,11 +1089,7 @@ BOOST_AUTO_TEST_CASE(standard_json_include_paths)
 
 	FileReader::FileSystemPathSet expectedAllowedDirectories = {};
 
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(
-		commandLine,
-		standardJsonInput,
-		true /* _processInput */
-	);
+	OptionsReaderAndMessages result = runCLI(commandLine, standardJsonInput);
 
 	Json::Value parsedStdout;
 	string jsonParsingErrors;
@@ -1119,18 +1117,19 @@ BOOST_AUTO_TEST_CASE(cli_include_paths_empty_path)
 	TemporaryWorkingDirectory tempWorkDir(tempDir);
 	createFilesWithParentDirs({tempDir.path() / "base/main.sol"});
 
-	string expectedMessage = "Empty values are not allowed in --include-path.\n";
+	string expectedMessage = "Empty values are not allowed in --include-path.";
 
-	vector<string> commandLine = {
-		"solc",
-		"--base-path=base/",
-		"--include-path", "include/",
-		"--include-path", "",
-		"base/main.sol",
-	};
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({
+			"solc",
+			"--base-path=base/",
+			"--include-path", "include/",
+			"--include-path", "",
+			"base/main.sol",
+		}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(cli_include_paths_without_base_path)
@@ -1139,12 +1138,13 @@ BOOST_AUTO_TEST_CASE(cli_include_paths_without_base_path)
 	TemporaryWorkingDirectory tempWorkDir(tempDir);
 	createFilesWithParentDirs({tempDir.path() / "contract.sol"});
 
-	string expectedMessage = "--include-path option requires a non-empty base path.\n";
+	string expectedMessage = "--include-path option requires a non-empty base path.";
 
-	vector<string> commandLine = {"solc", "--include-path", "include/", "contract.sol"};
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-	BOOST_TEST(!result.success);
-	BOOST_TEST(result.stderrContent == expectedMessage);
+	BOOST_CHECK_EXCEPTION(
+		parseCommandLineAndReadInputFiles({"solc", "--include-path", "include/", "contract.sol"}),
+		CommandLineValidationError,
+		[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+	);
 }
 
 BOOST_AUTO_TEST_CASE(cli_include_paths_should_detect_source_unit_name_collisions)
@@ -1173,35 +1173,37 @@ BOOST_AUTO_TEST_CASE(cli_include_paths_should_detect_source_unit_name_collisions
 
 	{
 		// import "contract1.sol" and import "contract2.sol" would be ambiguous:
-		vector<string> commandLine = {
-			"solc",
-			"--base-path=dir1/",
-			"--include-path=dir2/",
-			"dir1/contract1.sol",
-			"dir2/contract1.sol",
-			"dir1/contract2.sol",
-			"dir2/contract2.sol",
-		};
-		OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-		BOOST_TEST(result.stderrContent == expectedMessage);
-		BOOST_REQUIRE(!result.success);
+		BOOST_CHECK_EXCEPTION(
+			parseCommandLineAndReadInputFiles({
+				"solc",
+				"--base-path=dir1/",
+				"--include-path=dir2/",
+				"dir1/contract1.sol",
+				"dir2/contract1.sol",
+				"dir1/contract2.sol",
+				"dir2/contract2.sol",
+			}),
+			CommandLineValidationError,
+			[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+		);
 	}
 
 	{
 		// import "contract1.sol" and import "contract2.sol" would be ambiguous:
-		vector<string> commandLine = {
-			"solc",
-			"--base-path=dir3/",
-			"--include-path=dir1/",
-			"--include-path=dir2/",
-			"dir1/contract1.sol",
-			"dir2/contract1.sol",
-			"dir1/contract2.sol",
-			"dir2/contract2.sol",
-		};
-		OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(commandLine);
-		BOOST_TEST(result.stderrContent == expectedMessage);
-		BOOST_REQUIRE(!result.success);
+		BOOST_CHECK_EXCEPTION(
+			parseCommandLineAndReadInputFiles({
+				"solc",
+				"--base-path=dir3/",
+				"--include-path=dir1/",
+				"--include-path=dir2/",
+				"dir1/contract1.sol",
+				"dir2/contract1.sol",
+				"dir1/contract2.sol",
+				"dir2/contract2.sol",
+			}),
+			CommandLineValidationError,
+			[&](auto const& _exception) { BOOST_TEST(_exception.what() == expectedMessage); return true; }
+		);
 	}
 
 	{
@@ -1316,12 +1318,7 @@ BOOST_AUTO_TEST_CASE(cli_include_paths_ambiguous_import)
 		"3 | import \"contract.sol\";\n"
 		"  | ^^^^^^^^^^^^^^^^^^^^^^\n\n";
 
-	OptionsReaderAndMessages result = parseCommandLineAndReadInputFiles(
-		commandLine,
-		mainContractSource,
-		true /* _processInput */
-	);
-
+	OptionsReaderAndMessages result = runCLI(commandLine, mainContractSource);
 	BOOST_TEST(result.stderrContent == expectedMessage);
 	BOOST_REQUIRE(!result.success);
 }

--- a/test/solc/CommandLineInterfaceAllowPaths.cpp
+++ b/test/solc/CommandLineInterfaceAllowPaths.cpp
@@ -95,11 +95,7 @@ ImportCheck checkImport(
 		"pragma solidity >=0.0;\n" +
 		_import + ";";
 
-	test::OptionsReaderAndMessages cliResult = test::parseCommandLineAndReadInputFiles(
-		commandLine,
-		standardInputContent,
-		true /* processInput */
-	);
+	test::OptionsReaderAndMessages cliResult = test::runCLI(commandLine, standardInputContent);
 	if (cliResult.success)
 		return ImportCheck::OK();
 

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -51,8 +51,7 @@ CommandLineOptions parseCommandLine(vector<string> const& _commandLine)
 {
 	vector<char const*> argv = test::makeArgv(_commandLine);
 
-	stringstream serr;
-	CommandLineParser cliParser(serr);
+	CommandLineParser cliParser;
 	cliParser.parse(static_cast<int>(_commandLine.size()), argv.data());
 	return cliParser.options();
 }

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -19,6 +19,7 @@
 /// Unit tests for solc/CommandLineParser.h
 
 #include <solc/CommandLineParser.h>
+#include <solc/Exceptions.h>
 
 #include <test/solc/Common.h>
 
@@ -46,17 +47,14 @@ using namespace solidity::yul;
 namespace
 {
 
-optional<CommandLineOptions> parseCommandLine(vector<string> const& _commandLine, ostream& _stderr)
+CommandLineOptions parseCommandLine(vector<string> const& _commandLine)
 {
 	vector<char const*> argv = test::makeArgv(_commandLine);
 
-	CommandLineParser cliParser(_stderr);
-	bool success = cliParser.parse(static_cast<int>(_commandLine.size()), argv.data());
-
-	if (!success)
-		return nullopt;
-	else
-		return cliParser.options();
+	stringstream serr;
+	CommandLineParser cliParser(serr);
+	cliParser.parse(static_cast<int>(_commandLine.size()), argv.data());
+	return cliParser.options();
 }
 
 } // namespace
@@ -75,12 +73,9 @@ BOOST_AUTO_TEST_CASE(no_options)
 	expectedOptions.modelChecker.initialize = true;
 	expectedOptions.modelChecker.settings = {};
 
-	stringstream serr;
-	optional<CommandLineOptions> parsedOptions = parseCommandLine(commandLine, serr);
+	CommandLineOptions parsedOptions = parseCommandLine(commandLine);
 
-	BOOST_TEST(serr.str() == "");
-	BOOST_REQUIRE(parsedOptions.has_value());
-	BOOST_TEST(parsedOptions.value() == expectedOptions);
+	BOOST_TEST(parsedOptions == expectedOptions);
 }
 
 BOOST_AUTO_TEST_CASE(help_license_version)
@@ -93,15 +88,12 @@ BOOST_AUTO_TEST_CASE(help_license_version)
 
 	for (auto const& [option, expectedMode]: expectedModePerOption)
 	{
-		stringstream serr;
-		optional<CommandLineOptions> parsedOptions = parseCommandLine({"solc", option}, serr);
+		CommandLineOptions parsedOptions = parseCommandLine({"solc", option});
 
 		CommandLineOptions expectedOptions;
 		expectedOptions.input.mode = expectedMode;
 
-		BOOST_TEST(serr.str() == "");
-		BOOST_REQUIRE(parsedOptions.has_value());
-		BOOST_TEST(parsedOptions.value() == expectedOptions);
+		BOOST_TEST(parsedOptions == expectedOptions);
 	}
 }
 
@@ -226,12 +218,9 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 			5,
 		};
 
-		stringstream serr;
-		optional<CommandLineOptions> parsedOptions = parseCommandLine(commandLine, serr);
+		CommandLineOptions parsedOptions = parseCommandLine(commandLine);
 
-		BOOST_TEST(serr.str() == "");
-		BOOST_REQUIRE(parsedOptions.has_value());
-		BOOST_TEST(parsedOptions.value() == expectedOptions);
+		BOOST_TEST(parsedOptions == expectedOptions);
 	}
 }
 
@@ -352,12 +341,9 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 			expectedOptions.optimizer.expectedExecutionsPerDeployment = 1000;
 		}
 
-		stringstream serr;
-		optional<CommandLineOptions> parsedOptions = parseCommandLine(commandLine, serr);
+		CommandLineOptions parsedOptions = parseCommandLine(commandLine);
 
-		BOOST_TEST(serr.str() == "Warning: Yul is still experimental. Please use the output with care.\n");
-		BOOST_REQUIRE(parsedOptions.has_value());
-		BOOST_TEST(parsedOptions.value() == expectedOptions);
+		BOOST_TEST(parsedOptions == expectedOptions);
 	}
 }
 
@@ -420,12 +406,9 @@ BOOST_AUTO_TEST_CASE(standard_json_mode_options)
 	expectedOptions.compiler.combinedJsonRequests->abi = true;
 	expectedOptions.compiler.combinedJsonRequests->binary = true;
 
-	stringstream serr;
-	optional<CommandLineOptions> parsedOptions = parseCommandLine(commandLine, serr);
+	CommandLineOptions parsedOptions = parseCommandLine(commandLine);
 
-	BOOST_TEST(serr.str() == "");
-	BOOST_REQUIRE(parsedOptions.has_value());
-	BOOST_TEST(parsedOptions.value() == expectedOptions);
+	BOOST_TEST(parsedOptions == expectedOptions);
 }
 
 BOOST_AUTO_TEST_CASE(invalid_options_input_modes_combinations)
@@ -441,10 +424,11 @@ BOOST_AUTO_TEST_CASE(invalid_options_input_modes_combinations)
 		{
 			stringstream serr;
 			vector<string> commandLine = {"solc", optionName, "file", inputMode};
-			optional<CommandLineOptions> parsedOptions = parseCommandLine(commandLine, serr);
 
-			BOOST_TEST(serr.str() == "The following options are not supported in the current input mode: " + optionName + "\n");
-			BOOST_REQUIRE(!parsedOptions.has_value());
+			string expectedMessage = "The following options are not supported in the current input mode: " + optionName;
+			auto hasCorrectMessage = [&](CommandLineValidationError const& _exception) { return _exception.what() == expectedMessage; };
+
+			BOOST_CHECK_EXCEPTION(parseCommandLine(commandLine), CommandLineValidationError, hasCorrectMessage);
 		}
 }
 

--- a/test/solc/Common.cpp
+++ b/test/solc/Common.cpp
@@ -41,18 +41,34 @@ vector<char const*> test::makeArgv(vector<string> const& _commandLine)
 
 test::OptionsReaderAndMessages test::parseCommandLineAndReadInputFiles(
 	vector<string> const& _commandLine,
-	string const& _standardInputContent,
-	bool _processInput
+	string const& _standardInputContent
 )
 {
 	vector<char const*> argv = makeArgv(_commandLine);
 	stringstream sin(_standardInputContent), sout, serr;
 	CommandLineInterface cli(sin, sout, serr);
 	bool success = cli.parseArguments(static_cast<int>(_commandLine.size()), argv.data());
-	if (success)
-		success = cli.readInputFiles();
-	if (success && _processInput)
-		success = cli.processInput();
+	cli.readInputFiles();
+
+	return {
+		success,
+		cli.options(),
+		cli.fileReader(),
+		cli.standardJsonInput(),
+		sout.str(),
+		stripPreReleaseWarning(serr.str()),
+	};
+}
+
+test::OptionsReaderAndMessages test::runCLI(
+	vector<string> const& _commandLine,
+	string const& _standardInputContent
+)
+{
+	vector<char const*> argv = makeArgv(_commandLine);
+	stringstream sin(_standardInputContent), sout, serr;
+	CommandLineInterface cli(sin, sout, serr);
+	bool success = cli.run(static_cast<int>(_commandLine.size()), argv.data());
 
 	return {
 		success,

--- a/test/solc/Common.h
+++ b/test/solc/Common.h
@@ -44,10 +44,26 @@ struct OptionsReaderAndMessages
 
 std::vector<char const*> makeArgv(std::vector<std::string> const& _commandLine);
 
+/// Runs only command-line parsing, without compilation, assembling or any other input processing.
+/// Lets through any @a CommandLineErrors throw by the CLI.
+/// Note: This uses the @a CommandLineInterface class and does not actually spawn a new process.
+/// @param _commandLine Arguments in the form of strings that would be specified on the command-line.
+///                     You must specify the program name as the first item.
+/// @param _standardInputContent Content that the CLI will be able to read from its standard input.
 OptionsReaderAndMessages parseCommandLineAndReadInputFiles(
 	std::vector<std::string> const& _commandLine,
-	std::string const& _standardInputContent = "",
-	bool _processInput = false
+	std::string const& _standardInputContent = ""
+);
+
+/// Runs all stages of command-line interface processing, including error handling.
+/// Never throws @a CommandLineError - validation errors are included in the returned stderr content.
+/// Note: This uses the @a CommandLineInterface class and does not actually spawn a new process.
+/// @param _commandLine Arguments in the form of strings that would be specified on the command-line.
+///                     You must specify the program name as the first item.
+/// @param _standardInputContent Content that the CLI will be able to read from its standard input.
+OptionsReaderAndMessages runCLI(
+	std::vector<std::string> const& _commandLine,
+	std::string const& _standardInputContent = ""
 );
 
 std::string stripPreReleaseWarning(std::string const& _stderrContent);


### PR DESCRIPTION
Partially Resolves #11731

I did the following:
- Modified the functions that print version and license info in `CommandLineParser` to make them not use `exit()`.
- Replaced all the code that prints to `serr()` and returns `false` with an exception (uses the `BOOST_THROW_EXCEPTION` macro)

Doesn't change too much. This is my first commit to this repository. Let me know what you think.

EDIT by cameel:
- ~Depends on #12125.~ Merged.
- ~Depends on #12118.~ Merged.

It's not based on these two PRs to avoid github closing it when they're merged. Instead it contains commits from these PRs. I'll rebase it to remove them when those PRs are merged.