### PR TITLE
[isoltest] Leading zero for fixed point types.

### DIFF
--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -232,8 +232,8 @@ std::string BytesUtils::formatFixedPoint(bytes const& _bytes, bool _signed, size
 	if (_fractionalDigits > 0)
 	{
 		size_t numDigits = decimal.length() - (negative ? 1 : 0);
-		if (_fractionalDigits > numDigits)
-			decimal.insert(negative ? 1 : 0, string(_fractionalDigits - numDigits, '0'));
+		if (_fractionalDigits >= numDigits)
+			decimal.insert(negative ? 1 : 0, string(_fractionalDigits + 1 - numDigits, '0'));
 		decimal.insert(decimal.length() - _fractionalDigits, ".");
 	}
 	return decimal;

--- a/test/libsolidity/util/BytesUtilsTests.cpp
+++ b/test/libsolidity/util/BytesUtilsTests.cpp
@@ -35,11 +35,11 @@ BOOST_AUTO_TEST_CASE(format_fixed)
 {
 	BOOST_CHECK_EQUAL(
 		BytesUtils::formatFixedPoint(toBigEndian(u256{0}), true, 2),
-		".00"
+		"0.00"
 	);
 	BOOST_CHECK_EQUAL(
 		BytesUtils::formatFixedPoint(toBigEndian(u256{1}), true, 2),
-		".01"
+		"0.01"
 	);
 	BOOST_CHECK_EQUAL(
 		BytesUtils::formatFixedPoint(toBigEndian(u256{123}), true, 2),
@@ -47,11 +47,11 @@ BOOST_AUTO_TEST_CASE(format_fixed)
 	);
 	BOOST_CHECK_EQUAL(
 		BytesUtils::formatFixedPoint(toBigEndian(u256{-1}), true, 2),
-		"-.01"
+		"-0.01"
 	);
 	BOOST_CHECK_EQUAL(
 		BytesUtils::formatFixedPoint(toBigEndian(u256{-12}), true, 2),
-		"-.12"
+		"-0.12"
 	);
 	BOOST_CHECK_EQUAL(
 		BytesUtils::formatFixedPoint(toBigEndian(u256{-123}), true, 2),


### PR DESCRIPTION
It seems the isoltest parser (or scanner) cannot handle fractional numbers without a leading zero.