### PR TITLE
Add missing header.

### DIFF
--- a/libyul/optimiser/StackToMemoryMover.h
+++ b/libyul/optimiser/StackToMemoryMover.h
@@ -27,6 +27,8 @@
 #include <liblangutil/SourceLocation.h>
 #include <libsolutil/Common.h>
 
+#include <list>
+
 namespace solidity::yul
 {
 


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/11811.

I wonder if our policy should be to directly include all STL headers required by a class, independently of them being included by other headers already. Otherwise, I see little chance of reviewing against these kinds of things and STL implementations will pull in whatever they like, so CI won't avoid this either.