### PR TITLE
Mark recursive calls in yul control flow graph.

### DIFF
--- a/libyul/backends/evm/ControlFlowGraph.h
+++ b/libyul/backends/evm/ControlFlowGraph.h
@@ -131,6 +131,9 @@ struct CFG
 		std::shared_ptr<DebugData const> debugData;
 		std::reference_wrapper<Scope::Function const> function;
 		std::reference_wrapper<yul::FunctionCall const> functionCall;
+		/// True, if the call is recursive, i.e. entering the function involves a control flow path (potentially involving
+		/// more intermediate function calls) that leads back to this very call.
+		bool recursive = false;
 	};
 	struct Assignment
 	{


### PR DESCRIPTION
Adds an additional annotation to function call operations in the yul control flow graph: ``recursive``, which is true, iff the call is recursive.

Background: this information will be useful for opting for more aggressive stack compression before any recursive calls, s.t. we are less likely to hit the global 1024 stack slot limit of the EVM during deep recursions.

Related: https://github.com/ethereum/solidity/issues/11715
With this change and opting for aggressive stack compression for recursive calls, the maximal amount of recursions can be reached for the function in the issue.
