### PR TITLE
Replace boost::adaptors with range-v3

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -41,11 +41,11 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/reverse.hpp>
+#include <range/v3/view/tail.hpp>
 #include <range/v3/view/transform.hpp>
 
 #include <limits>
@@ -3694,7 +3694,7 @@ MemberList::MemberMap TypeType::nativeMembers(ASTNode const* _currentScope) cons
 			auto bases = contract.annotation().linearizedBaseContracts;
 			solAssert(bases.size() >= 1, "linearizedBaseContracts should at least contain the most derived contract.");
 			// `sliced(1, ...)` ignores the most derived contract, which should not be searchable from `super`.
-			for (ContractDefinition const* base: bases | boost::adaptors::sliced(1, bases.size()))
+			for (ContractDefinition const* base: bases | ranges::views::tail)
 				for (FunctionDefinition const* function: base->definedFunctions())
 				{
 					if (!function->isVisibleInDerivedContracts() || !function->isImplemented())

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -25,6 +25,8 @@
 #include <boost/algorithm/string.hpp>
 
 #include <range/v3/view/transform.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/range/conversion.hpp>
 
 using namespace std;
 using namespace solidity::langutil;
@@ -961,7 +963,7 @@ General Information)").c_str(),
 		if (countEnabledOptions(nonAssemblyModeOptions) >= 1)
 		{
 			auto optionEnabled = [&](string const& name){ return m_args.count(name) > 0; };
-			auto enabledOptions = boost::copy_range<vector<string>>(nonAssemblyModeOptions | boost::adaptors::filtered(optionEnabled));
+			auto enabledOptions = nonAssemblyModeOptions | ranges::views::filter(optionEnabled) | ranges::to_vector;
 
 			serr() << "The following options are invalid in assembly mode: ";
 			serr() << joinOptionNames(enabledOptions) << ".";


### PR DESCRIPTION
Ref #10738 

According to the above issue, I replaced two usages of boost::adaptors with range-v3 counterpart functions. The only thing that we don't have in cpp20 namespace is ranges::to_vector, but I couldn't resist not to use it.