### PR TITLE
Fix pylint warnings about encoding in `open()`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ copyright = '2016-2021, Ethereum'
 # built documents.
 #
 # The short X.Y version.
-with open('../CMakeLists.txt', 'r') as f:
+with open('../CMakeLists.txt', 'r', encoding='utf8') as f:
     version = re.search('PROJECT_VERSION "([^"]+)"', f.read()).group(1)
 # The full version, including alpha/beta/rc tags.
 if os.path.isfile('../prerelease.txt') != True or os.path.getsize('../prerelease.txt') == 0:

--- a/docs/ext/html_extra_template_renderer.py
+++ b/docs/ext/html_extra_template_renderer.py
@@ -14,14 +14,14 @@ def render_html_extra_templates(app):
         if not os.path.isabs(template_config['target']):
             raise RuntimeError(f"Template target path is not absolute: {template_config['target']}")
 
-        with open(input_path, 'r') as input_file:
+        with open(input_path, 'r', encoding='utf8') as input_file:
             # This runs Jinja2, which supports rendering {{ }} tags among other things.
             rendered_template = app.builder.templates.render_string(
                 input_file.read(),
                 template_config['context'],
             )
 
-        with open(template_config['target'], 'w') as target_file:
+        with open(template_config['target'], 'w', encoding='utf8') as target_file:
             target_file.write(rendered_template)
 
         app.config.html_extra_path.append(template_config['target'])

--- a/scripts/endToEndExtraction/remove-testcases.py
+++ b/scripts/endToEndExtraction/remove-testcases.py
@@ -61,7 +61,7 @@ def get_checks(content, sol_file_path):
             constructors.append(line)
         if line.startswith("ABI_CHECK") or line.startswith("BOOST_REQUIRE"):
             checks.append(line)
-    with open(sol_file_path, "r") as sol_file:
+    with open(sol_file_path, "r", encoding='utf8') as sol_file:
         sol_constructors = []
         sol_checks = []
         inside_expectations = False
@@ -118,7 +118,7 @@ def get_tests(e2e_path):
 
 def process_input_file(e2e_path, input_file, interactive):
     tests = get_tests(e2e_path)
-    with open(input_file, "r") as cpp_file:
+    with open(input_file, "r", encoding='utf8') as cpp_file:
         inside_test = False
         test_name = ""
         inside_extracted_test = False

--- a/scripts/endToEndExtraction/verify-testcases.py
+++ b/scripts/endToEndExtraction/verify-testcases.py
@@ -7,7 +7,7 @@
 #     ./soltest --color_output=false --log_level=test_suite -t semanticTests/extracted/ -- --no-smt
 #         --evmonepath /Users/alex/evmone/lib/libevmone.dylib --show-messages > semanticTests.trace
 #
-# verify-testcases.py will compare both traces. If these traces are identical, the extracted tests where
+# verify-testcases.py will compare both traces. If these traces are identical, the extracted tests were
 # identical with the tests specified in SolidityEndToEndTest.cpp.
 #
 # pylint: disable=too-many-instance-attributes
@@ -75,7 +75,7 @@ class TraceAnalyser:
         self.ready = False
 
     def analyse(self):
-        with open(self.file, "r") as trace_file:
+        with open(self.file, "r", encoding='utf8') as trace_file:
             trace = None
             test_case = None
             for line in trace_file.readlines():

--- a/scripts/fix_homebrew_paths_in_standalone_zip.py
+++ b/scripts/fix_homebrew_paths_in_standalone_zip.py
@@ -44,21 +44,20 @@ import subprocess
 import sys
 
 def readDependencies(fname):
-    with open(fname) as f:
-        with subprocess.Popen(['otool', '-L', fname], stdout=subprocess.PIPE) as o:
-            for line in o.stdout:
-                if line[0] == '\t':
-                    library = line.split(' ', 1)[0][1:]
-                    if (library.startswith("/usr/local/lib") or
-                            library.startswith("/usr/local/opt") or
-                            library.startswith("/Users/")):
-                        if (os.path.basename(library) != os.path.basename(fname)):
-                            command = "install_name_tool -change " + \
-                                library + " @executable_path/./" + \
-                                os.path.basename(library) + " " + fname
-                            print(command)
-                            os.system("chmod +w " + fname)
-                            os.system(command)
+    with subprocess.Popen(['otool', '-L', fname], stdout=subprocess.PIPE) as o:
+        for line in o.stdout:
+            if line[0] == '\t':
+                library = line.split(' ', 1)[0][1:]
+                if (library.startswith("/usr/local/lib") or
+                        library.startswith("/usr/local/opt") or
+                        library.startswith("/Users/")):
+                    if (os.path.basename(library) != os.path.basename(fname)):
+                        command = "install_name_tool -change " + \
+                            library + " @executable_path/./" + \
+                            os.path.basename(library) + " " + fname
+                        print(command)
+                        os.system("chmod +w " + fname)
+                        os.system(command)
 
 root = sys.argv[1]
 for (dirpath, dirnames, filenames) in os.walk(root):

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -10,7 +10,9 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
   tar -xf cmake.zip
   mv cmake-3.18.2-win64-x64 "$PSScriptRoot\..\deps\cmake"
 
-  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip
+  # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
+  # and serving it a page that requires JavaScript.
+  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip -UserAgent ""
   tar -xf boost.zip
   cd boost_1_74_0
   .\bootstrap.bat

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -67,7 +67,7 @@ class regressor():
         if not env:
             env = os.environ.copy()
 
-        with open(logfile, 'w') as logfh:
+        with open(logfile, 'w', encoding='utf8') as logfh:
             with subprocess.Popen(command, shell=True, executable='/bin/bash',
                                     env=env, stdout=logfh,
                                     stderr=subprocess.STDOUT) as proc:
@@ -88,7 +88,7 @@ class regressor():
 
         ## Log may contain non ASCII characters, so we simply stringify them
         ## since they don't matter for regular expression matching
-        with open(logfile, 'rb') as f:
+        with open(logfile, 'rb', encoding=None) as f:
             rawtext = str(f.read())
         return not re.search(self._re_sanitizer_log, rawtext)
 

--- a/scripts/update_bugs_by_version.py
+++ b/scripts/update_bugs_by_version.py
@@ -15,11 +15,11 @@ def comp(version_string):
     return [int(c) for c in version_string.split('.')]
 
 path = os.path.dirname(os.path.realpath(__file__))
-with open(path + '/../docs/bugs.json') as bugsFile:
+with open(path + '/../docs/bugs.json', encoding='utf8') as bugsFile:
     bugs = json.load(bugsFile)
 
 versions = {}
-with open(path + '/../Changelog.md') as changelog:
+with open(path + '/../Changelog.md', encoding='utf8') as changelog:
     for line in changelog:
         m = re.search(r'^### (\S+) \((\d+-\d+-\d+)\)$', line)
         if m:
@@ -36,8 +36,8 @@ for key, value in versions.items():
         value['bugs'] += [bug['name']]
 
 new_contents = json.dumps(versions, sort_keys=True, indent=4, separators=(',', ': '))
-with open(path + '/../docs/bugs_by_version.json', 'r') as bugs_by_version:
+with open(path + '/../docs/bugs_by_version.json', 'r', encoding='utf8') as bugs_by_version:
     old_contents = bugs_by_version.read()
-with open(path + '/../docs/bugs_by_version.json', 'w') as bugs_by_version:
+with open(path + '/../docs/bugs_by_version.json', 'w', encoding='utf8') as bugs_by_version:
     bugs_by_version.write(new_contents)
 sys.exit(old_contents != new_contents)

--- a/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
+++ b/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
@@ -36,7 +36,7 @@ def extract_test_cases(path):
 
 def extract_and_write(f, path):
     if f.endswith('.sol'):
-        with open(path, 'r') as _f:
+        with open(path, 'r', encoding='utf8') as _f:
             cases = [_f.read()]
     else:
         cases = extract_test_cases(path)
@@ -46,7 +46,7 @@ def write_cases(f, tests):
     cleaned_filename = f.replace(".","_").replace("-","_").replace(" ","_").lower()
     for test in tests:
         remainder = re.sub(r'^ {4}', '', test, 0, re.MULTILINE)
-        with open('test_%s_%s.sol' % (hashlib.sha256(test).hexdigest(), cleaned_filename), 'w') as _f:
+        with open('test_%s_%s.sol' % (hashlib.sha256(test).hexdigest(), cleaned_filename), 'w', encoding='utf8') as _f:
             _f.write(remainder)
 
 


### PR DESCRIPTION
Fixes the failing [`chk_pylint` job](https://app.circleci.com/pipelines/github/ethereum/solidity/18273/workflows/9a7347b4-cbbd-4b99-a714-f017e128dd19/jobs/814903) in CI. [Pylint 2.10](https://pylint.pycqa.org/en/stable/whatsnew/2.10.html) emitts the `unspecified-encoding` warning if `open()` does not specify encoding and we had quite a few of these.