### PR TITLE
Enable more pylint checks

### DIFF
--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -413,7 +413,7 @@ def commandline_parser() -> ArgumentParser:
         action='store_true',
         help="Immediately exit and print compiler output if the compiler exits with an error.",
     )
-    return parser;
+    return parser
 
 
 if __name__ == "__main__":

--- a/scripts/endToEndExtraction/remove-testcases.py
+++ b/scripts/endToEndExtraction/remove-testcases.py
@@ -39,7 +39,7 @@ def colorize(left, right, id):
     reset = "\x1b[0m"
     colors = [red, yellow]
     color = colors[id % len(colors)]
-    function, arguments, results = parse_call(right)
+    function, _arguments, _results = parse_call(right)
     left = left.replace("compileAndRun", color + "compileAndRun" + reset)
     right = right.replace("constructor", color + "constructor" + reset)
     if function:
@@ -158,7 +158,7 @@ def main(argv):
     interactive = False
     input_file = None
     try:
-        opts, args = getopt.getopt(argv, "if:")
+        opts, _args = getopt.getopt(argv, "if:")
     except getopt.GetoptError:
         print("./remove-testcases.py [-i] [-f <full path to SolidityEndToEndTest.cpp>]")
         sys.exit(1)

--- a/scripts/endToEndExtraction/verify-testcases.py
+++ b/scripts/endToEndExtraction/verify-testcases.py
@@ -158,7 +158,7 @@ class TraceAnalyser:
         for trace_id, trace in enumerate(left.traces):
             left_trace = trace
             right_trace = right.traces[trace_id]
-            assert (left_trace.kind == right_trace.kind)
+            assert left_trace.kind == right_trace.kind
             if str(left_trace) != str(right_trace):
                 mismatch_info = "    " + str(left_trace) + "\n"
                 mismatch_info += "    " + str(right_trace) + "\n"
@@ -179,7 +179,7 @@ def main(argv):
     extracted_tests_trace_file = None
     end_to_end_trace_file = None
     try:
-        opts, args = getopt.getopt(argv, "s:e:")
+        opts, _args = getopt.getopt(argv, "s:e:")
     except getopt.GetoptError:
         print("verify-testcases.py [-s <path to semantic-trace>] [-e <path to endToEndExtraction-trace>]")
         sys.exit(2)

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -261,9 +261,9 @@ def main(argv):
     no_confirm = False
     examine_coverage = False
     next_id = False
-    opts, args = getopt.getopt(argv, "", ["check", "fix", "no-confirm", "examine-coverage", "next"])
+    opts, _args = getopt.getopt(argv, "", ["check", "fix", "no-confirm", "examine-coverage", "next"])
 
-    for opt, arg in opts:
+    for opt, _arg in opts:
         if opt == "--check":
             check = True
         elif opt == "--fix":

--- a/scripts/fix_homebrew_paths_in_standalone_zip.py
+++ b/scripts/fix_homebrew_paths_in_standalone_zip.py
@@ -49,9 +49,10 @@ def readDependencies(fname):
             if line[0] == '\t':
                 library = line.split(' ', 1)[0][1:]
                 if (library.startswith("/usr/local/lib") or
-                        library.startswith("/usr/local/opt") or
-                        library.startswith("/Users/")):
-                    if (os.path.basename(library) != os.path.basename(fname)):
+                    library.startswith("/usr/local/opt") or
+                    library.startswith("/Users/")
+                ):
+                    if os.path.basename(library) != os.path.basename(fname):
                         command = "install_name_tool -change " + \
                             library + " @executable_path/./" + \
                             os.path.basename(library) + " " + fname

--- a/scripts/gas_diff_stats.py
+++ b/scripts/gas_diff_stats.py
@@ -20,7 +20,7 @@ repository. The changes are compared against ``origin/develop``.
 import subprocess
 from pathlib import Path
 from enum import Enum
-from parsec import *
+from parsec import generate, ParseError, regex, string
 from tabulate import tabulate
 
 class Kind(Enum):
@@ -56,10 +56,10 @@ def diff_string() -> (Kind, Diff, int):
     -// gas irOptimized: 138070
 
     """
-    diff_kind = yield (minus | plus)
+    diff_kind = yield minus | plus
     yield comment
     yield space
-    codegen_kind = yield (gas_ir_optimized ^ gas_legacy_optimized ^ gas_legacy)
+    codegen_kind = yield gas_ir_optimized ^ gas_legacy_optimized ^ gas_legacy
     yield colon
     yield space
     val = yield number()

--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -6,7 +6,6 @@
 # into files for e.g. fuzz testing as
 # scripts/isolate_tests.py test/libsolidity/*
 
-import sys
 import re
 import os
 import hashlib

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -9,7 +9,6 @@ from os import path, walk
 from sys import exit
 from textwrap import dedent
 import subprocess
-import sys
 
 PROJECT_ROOT = path.dirname(path.dirname(path.realpath(__file__)))
 PYLINT_RCFILE = f"{PROJECT_ROOT}/scripts/pylintrc"

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -24,24 +24,15 @@ disable=
     duplicate-code,
     invalid-name,
     missing-docstring,
-    mixed-indentation,
     no-else-return,
     no-self-use,
     pointless-string-statement,
     redefined-builtin,
     redefined-outer-name,
     singleton-comparison,
-    superfluous-parens,
     too-few-public-methods,
-    trailing-newlines,
-    undefined-variable,
-    ungrouped-imports,
-    unnecessary-semicolon,
-    unused-import,
-    unused-variable,
-    unused-wildcard-import,
-    useless-object-inheritance,
-    wildcard-import
+    too-many-public-methods,
+    ungrouped-imports
 
 [BASIC]
 

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -11,7 +11,7 @@ import time
 
 DESCRIPTION = """Regressor is a tool to run regression tests in a CI env."""
 
-class PrintDotsThread(object):
+class PrintDotsThread:
     """Prints a dot every "interval" (default is 300) seconds"""
 
     def __init__(self, interval=300):
@@ -30,7 +30,7 @@ class PrintDotsThread(object):
             print(".")
             time.sleep(self.interval)
 
-class regressor():
+class regressor:
     _re_sanitizer_log = re.compile(r"""ERROR: (libFuzzer|UndefinedBehaviorSanitizer)""")
 
     def __init__(self, description, args):

--- a/scripts/splitSources.py
+++ b/scripts/splitSources.py
@@ -44,9 +44,7 @@ def writeSourceToFile(lines):
         os.system("mkdir -p " + filePath)
     with open(srcName, mode='a+', encoding='utf8', newline='') as f:
         createdSources.append(srcName)
-        i = 0
         for idx, line in enumerate(lines[1:]):
-
             # write to file
             if line[:12] != "==== Source:":
                 f.write(line)

--- a/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
+++ b/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
@@ -7,7 +7,8 @@ import sys
 import re
 import os
 import hashlib
-from os.path import join, isfile
+# Pylint for some reason insists that isfile() is unused
+from os.path import join, isfile  # pylint: disable=unused-import
 
 
 def extract_test_cases(path):

--- a/test/formal/byte_big.py
+++ b/test/formal/byte_big.py
@@ -1,5 +1,6 @@
+from opcodes import BYTE
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
 
 """
 byte(A, X) -> 0

--- a/test/formal/byte_equivalence.py
+++ b/test/formal/byte_equivalence.py
@@ -1,5 +1,6 @@
+from opcodes import BYTE
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, Concat, Extract
 
 """
 Checks that the byte opcode (implemented using shift) is equivalent to a

--- a/test/formal/checked_int_add.py
+++ b/test/formal/checked_int_add.py
@@ -1,6 +1,7 @@
+from opcodes import AND, ISZERO, SGT, SLT, SUB
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVSignedMax, BVSignedMin, BVSignedUpCast
+from z3 import BitVec, BVAddNoOverflow, BVAddNoUnderflow, Not
 
 """
 Overflow checked signed integer addition.

--- a/test/formal/checked_int_div.py
+++ b/test/formal/checked_int_div.py
@@ -1,6 +1,7 @@
+from opcodes import AND, EQ, SUB
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVSignedMin, BVSignedUpCast
+from z3 import BitVec, BVSDivNoOverflow, Not
 
 """
 Overflow checked signed integer division.

--- a/test/formal/checked_int_mul_16.py
+++ b/test/formal/checked_int_mul_16.py
@@ -1,6 +1,7 @@
+from opcodes import AND, DIV, GT, SDIV, SGT, SLT
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVSignedMax, BVSignedMin, BVSignedUpCast
+from z3 import BVMulNoOverflow, BVMulNoUnderflow, BitVec, Not, Or
 
 """
 Overflow checked signed integer multiplication.

--- a/test/formal/checked_int_sub.py
+++ b/test/formal/checked_int_sub.py
@@ -1,6 +1,7 @@
+from opcodes import AND, ADD, ISZERO, SLT, SGT
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVSignedMax, BVSignedMin, BVSignedUpCast
+from z3 import BitVec, BVSubNoOverflow, BVSubNoUnderflow, Not
 
 """
 Overflow checked signed integer subtraction.

--- a/test/formal/checked_uint_add.py
+++ b/test/formal/checked_uint_add.py
@@ -1,6 +1,7 @@
+from opcodes import GT, SUB
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVUnsignedMax, BVUnsignedUpCast
+from z3 import BitVec, BVAddNoOverflow, Not
 
 """
 Overflow checked unsigned integer addition.

--- a/test/formal/checked_uint_mul_16.py
+++ b/test/formal/checked_uint_mul_16.py
@@ -1,6 +1,7 @@
+from opcodes import AND, ISZERO, GT, DIV
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVUnsignedUpCast, BVUnsignedMax
+from z3 import BitVec, Not, BVMulNoOverflow
 
 """
 Overflow checked unsigned integer multiplication.

--- a/test/formal/checked_uint_sub.py
+++ b/test/formal/checked_uint_sub.py
@@ -1,6 +1,7 @@
+from opcodes import LT
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVUnsignedMax, BVUnsignedUpCast
+from z3 import BVSubNoUnderflow, BitVec, Not
 
 """
 Overflow checked unsigned integer subtraction.

--- a/test/formal/combine_byte_shl.py
+++ b/test/formal/combine_byte_shl.py
@@ -1,5 +1,6 @@
+from opcodes import BYTE, SHL
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, ULE
 
 """
 byte(A, shl(B, X))

--- a/test/formal/combine_byte_shr_1.py
+++ b/test/formal/combine_byte_shr_1.py
@@ -1,5 +1,6 @@
+from opcodes import BYTE, DIV, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, UGE, ULE, ULT
 
 """
 byte(A, shr(B, X))

--- a/test/formal/combine_byte_shr_2.py
+++ b/test/formal/combine_byte_shr_2.py
@@ -1,5 +1,6 @@
+from opcodes import BYTE, SHR, DIV
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, ULT
 
 """
 byte(A, shr(B, X))

--- a/test/formal/combine_div_shl_one_32.py
+++ b/test/formal/combine_div_shl_one_32.py
@@ -1,5 +1,6 @@
+from opcodes import DIV, SHL, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
 
 """
 Rule:

--- a/test/formal/combine_mul_shl_one_64.py
+++ b/test/formal/combine_mul_shl_one_64.py
@@ -1,5 +1,6 @@
+from opcodes import SHL, MUL
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
 
 """
 Rule:

--- a/test/formal/combine_shl_shr_by_constant_64.py
+++ b/test/formal/combine_shl_shr_by_constant_64.py
@@ -1,5 +1,6 @@
+from opcodes import AND, SHL, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, If, Int2BV, IntVal, UGT, ULT
 
 """
 Rule:

--- a/test/formal/combine_shr_shl_by_constant_64.py
+++ b/test/formal/combine_shr_shl_by_constant_64.py
@@ -1,5 +1,6 @@
+from opcodes import AND, SHL, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, If, Int2BV, IntVal, UGT, ULT
 
 """
 Rule:

--- a/test/formal/eq_sub.py
+++ b/test/formal/eq_sub.py
@@ -1,5 +1,6 @@
+from opcodes import EQ, ISZERO, SUB
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
 
 """
 Rule:

--- a/test/formal/exp_neg_one.py
+++ b/test/formal/exp_neg_one.py
@@ -1,6 +1,7 @@
+from opcodes import AND, ISZERO, MOD, SUB
 from rule import Rule
-from opcodes import *
-from util import *
+from util import BVUnsignedMax
+from z3 import BitVec, BitVecVal, If
 
 """
 Checking conversion of exp(-1, X) to sub(isZero(and(X, 1)), and(X, 1))

--- a/test/formal/exp_to_shl.py
+++ b/test/formal/exp_to_shl.py
@@ -1,6 +1,6 @@
+from opcodes import SHL
 from rule import Rule
-from opcodes import *
-from util import *
+from z3 import BitVec, If
 
 """
 Checking conversion of exp(2, X) to shl(X, 1)

--- a/test/formal/move_and_across_shl_128.py
+++ b/test/formal/move_and_across_shl_128.py
@@ -1,5 +1,6 @@
+from opcodes import AND, SHL
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, ULT
 
 """
 Rule:

--- a/test/formal/move_and_across_shr_128.py
+++ b/test/formal/move_and_across_shr_128.py
@@ -25,12 +25,12 @@ BitWidth = BitVecVal(n_bits, n_bits)
 rule.require(ULT(B, BitWidth))
 
 # Non optimized result
-nonopt_1 = SHR(B, AND(X, A));
-nonopt_2 = SHR(B, AND(A, X));
+nonopt_1 = SHR(B, AND(X, A))
+nonopt_2 = SHR(B, AND(A, X))
 
 # Optimized result
-Mask = SHR(B, A);
-opt = AND(SHR(B, X), Mask);
+Mask = SHR(B, A)
+opt = AND(SHR(B, X), Mask)
 
 rule.check(nonopt_1, opt)
 rule.check(nonopt_2, opt)

--- a/test/formal/move_and_across_shr_128.py
+++ b/test/formal/move_and_across_shr_128.py
@@ -1,5 +1,6 @@
+from opcodes import AND, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, ULT
 
 """
 Rule:

--- a/test/formal/move_and_inside_or.py
+++ b/test/formal/move_and_inside_or.py
@@ -1,5 +1,7 @@
+from opcodes import AND, OR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
+
 
 """
 Rule:

--- a/test/formal/opcodes.py
+++ b/test/formal/opcodes.py
@@ -1,4 +1,4 @@
-from z3 import *
+from z3 import BitVecVal, BV2Int, If, LShR, UDiv, ULT, UGT, URem
 
 def ADD(x, y):
 	return x + y

--- a/test/formal/repeated_and.py
+++ b/test/formal/repeated_and.py
@@ -1,5 +1,6 @@
+from opcodes import AND
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal
 
 """
 Rule:

--- a/test/formal/repeated_or.py
+++ b/test/formal/repeated_or.py
@@ -1,5 +1,6 @@
+from opcodes import OR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal
 
 """
 Rule:

--- a/test/formal/replace_mul_by_shift.py
+++ b/test/formal/replace_mul_by_shift.py
@@ -1,5 +1,6 @@
+from opcodes import DIV, MUL, SHL, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
 
 """
 Rule:

--- a/test/formal/rule.py
+++ b/test/formal/rule.py
@@ -1,6 +1,6 @@
 import sys
 
-from z3 import *
+from z3 import sat, Solver, unknown, unsat
 
 class Rule:
 	def __init__(self):

--- a/test/formal/shl_workaround_8.py
+++ b/test/formal/shl_workaround_8.py
@@ -1,5 +1,6 @@
+from opcodes import SHL
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BV2Int, Int2BV, IntVal
 
 """
 Shift left workaround that Solidity implements

--- a/test/formal/signextend.py
+++ b/test/formal/signextend.py
@@ -34,4 +34,3 @@ rule3.check(
     SIGNEXTEND(A, SIGNEXTEND(B, X)),
     SIGNEXTEND(If(ULT(A, B), A, B), X)
 )
-

--- a/test/formal/signextend.py
+++ b/test/formal/signextend.py
@@ -1,5 +1,6 @@
+from opcodes import SIGNEXTEND
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, If, UGE, ULT
 
 """
 Rule:

--- a/test/formal/signextend_and.py
+++ b/test/formal/signextend_and.py
@@ -1,5 +1,6 @@
+from opcodes import SIGNEXTEND, AND
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, ULT
 
 """
 Rule:

--- a/test/formal/signextend_equivalence.py
+++ b/test/formal/signextend_equivalence.py
@@ -1,5 +1,6 @@
+from opcodes import SIGNEXTEND
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal, Extract, SignExt, UGT
 
 """
 Checking the implementation of SIGNEXTEND using Z3's native SignExt and Extract

--- a/test/formal/signextend_shl.py
+++ b/test/formal/signextend_shl.py
@@ -1,5 +1,6 @@
+from opcodes import SHL, SIGNEXTEND
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, LShR, ULE
 
 """
 Rule:

--- a/test/formal/signextend_shr.py
+++ b/test/formal/signextend_shr.py
@@ -1,5 +1,6 @@
+from opcodes import SIGNEXTEND, SAR, SHR
 from rule import Rule
-from opcodes import *
+from z3 import BitVec,  BitVecVal, ULE
 
 """
 Rule:

--- a/test/formal/signextend_shr.py
+++ b/test/formal/signextend_shr.py
@@ -28,4 +28,3 @@ rule.check(
     SIGNEXTEND(A, SHR(B, X)),
     SAR(B, X)
 )
-

--- a/test/formal/sub_not_zero_x_to_not_x_256.py
+++ b/test/formal/sub_not_zero_x_to_not_x_256.py
@@ -1,5 +1,6 @@
+from opcodes import NOT, SUB
 from rule import Rule
-from opcodes import *
+from z3 import BitVec, BitVecVal
 
 """
 Rule:

--- a/test/formal/sub_sub.py
+++ b/test/formal/sub_sub.py
@@ -1,5 +1,6 @@
+from opcodes import ADD, SUB
 from rule import Rule
-from opcodes import *
+from z3 import BitVec
 
 """
 Rules:

--- a/test/formal/util.py
+++ b/test/formal/util.py
@@ -1,4 +1,4 @@
-from z3 import *
+from z3 import BitVecVal, Concat, If
 
 def BVUnsignedUpCast(x, n_bits):
 	assert x.size() <= n_bits

--- a/test/formal/util.py
+++ b/test/formal/util.py
@@ -1,27 +1,27 @@
 from z3 import *
 
 def BVUnsignedUpCast(x, n_bits):
-	assert(x.size() <= n_bits)
+	assert x.size() <= n_bits
 	if x.size() < n_bits:
 		return Concat(BitVecVal(0, n_bits - x.size()), x)
 	else:
 		return x
 
 def BVUnsignedMax(type_bits, n_bits):
-	assert(type_bits <= n_bits)
+	assert type_bits <= n_bits
 	return BitVecVal((1 << type_bits) - 1, n_bits)
 
 def BVSignedUpCast(x, n_bits):
-	assert(x.size() <= n_bits)
+	assert x.size() <= n_bits
 	if x.size() < n_bits:
 		return Concat(If(x < 0, BitVecVal(-1, n_bits - x.size()), BitVecVal(0, n_bits - x.size())), x)
 	else:
 		return x
 
 def BVSignedMax(type_bits, n_bits):
-	assert(type_bits <= n_bits)
+	assert type_bits <= n_bits
 	return BitVecVal((1 << (type_bits - 1)) - 1, n_bits)
 
 def BVSignedMin(type_bits, n_bits):
-	assert(type_bits <= n_bits)
+	assert type_bits <= n_bits
 	return BitVecVal(-(1 << (type_bits - 1)), n_bits)


### PR DESCRIPTION
~Depends on #11832.~ Merged.

This is an old branch I prepared while working on the bytecode compare script when I discovered that some simple mistakes like unused imports or variables go unnoticed by pylint. I never submitted though because we had a big PR backlog.

Well, we still have a backlog, but having to fix #11832 seems like a good occasion to finally push it through :)