### PR TITLE
Improve `pylint_all.sh`

### DIFF
--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -1,14 +1,13 @@
 #! /usr/bin/env python3
 
 """
-Performs pylint on all python files in the project repo's {test,script,docs} directory recursively.
-
-This script is meant to be run from the CI but can also be easily in local dev environment,
-where you can optionally pass `-d` as command line argument to let this script abort on first error.
+Runs pylint on all Python files in project directories known to contain Python scripts.
 """
 
+from argparse import ArgumentParser
 from os import path, walk, system
-from sys import argv, exit as exitwith
+from sys import exit as exitwith
+from textwrap import dedent
 
 PROJECT_ROOT = path.dirname(path.realpath(__file__))
 PYLINT_RCFILE = "{}/pylintrc".format(PROJECT_ROOT)
@@ -40,11 +39,29 @@ def pylint_all_filenames(dev_mode, rootdirs):
 
     return len(failed), len(filenames)
 
+
+def parse_command_line():
+    script_description = dedent("""
+        Runs pylint on all Python files in project directories known to contain Python scripts.
+
+        This script is meant to be run from the CI but can also be easily used in the local dev
+        environment.
+    """)
+
+    parser = ArgumentParser(description=script_description)
+    parser.add_argument(
+        '-d', '--dev-mode',
+        dest='dev_mode',
+        default=False,
+        action='store_true',
+        help="Abort on first error."
+    )
+    return parser.parse_args()
+
+
 def main():
-    """ Collects all python script root dirs and runs pylint on them. You can optionally
-        pass `-d` as command line argument to let this script abort on first error. """
-    dev_mode = len(argv) == 2 and argv[1] == "-d"
-    failed_count, total_count = pylint_all_filenames(dev_mode, [
+    options = parse_command_line()
+    failed_count, total_count = pylint_all_filenames(options.dev_mode, [
         path.abspath(path.dirname(__file__) + "/../docs"),
         path.abspath(path.dirname(__file__) + "/../scripts"),
         path.abspath(path.dirname(__file__) + "/../test")])
@@ -52,6 +69,7 @@ def main():
         exitwith("pylint failed on {}/{} files.".format(failed_count, total_count))
     else:
         print("Successfully tested {} files.".format(total_count))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -9,8 +9,8 @@ from os import path, walk, system
 from sys import exit as exitwith
 from textwrap import dedent
 
-PROJECT_ROOT = path.dirname(path.realpath(__file__))
-PYLINT_RCFILE = "{}/pylintrc".format(PROJECT_ROOT)
+PROJECT_ROOT = path.dirname(path.dirname(path.realpath(__file__)))
+PYLINT_RCFILE = f"{PROJECT_ROOT}/scripts/pylintrc"
 
 SGR_INFO = "\033[1;32m"
 SGR_CLEAR = "\033[0m"
@@ -61,10 +61,14 @@ def parse_command_line():
 
 def main():
     options = parse_command_line()
-    failed_count, total_count = pylint_all_filenames(options.dev_mode, [
-        path.abspath(path.dirname(__file__) + "/../docs"),
-        path.abspath(path.dirname(__file__) + "/../scripts"),
-        path.abspath(path.dirname(__file__) + "/../test")])
+
+    rootdirs = [
+        f"{PROJECT_ROOT}/docs",
+        f"{PROJECT_ROOT}/scripts",
+        f"{PROJECT_ROOT}/test",
+    ]
+    (failed_count, total_count) = pylint_all_filenames(options.dev_mode, rootdirs)
+
     if failed_count != 0:
         exitwith("pylint failed on {}/{} files.".format(failed_count, total_count))
     else:

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -86,4 +86,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        exit("Interrupted by user. Exiting.")

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -23,6 +23,8 @@ def pylint_all_filenames(dev_mode, rootdirs):
     BARE_COMMAND = [
         "pylint",
         f"--rcfile={PYLINT_RCFILE}",
+        "--output-format=colorized",
+        "--score=n"
     ]
 
     filenames = []

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -6,7 +6,7 @@ Runs pylint on all Python files in project directories known to contain Python s
 
 from argparse import ArgumentParser
 from os import path, walk
-from sys import exit as exitwith
+from sys import exit
 from textwrap import dedent
 import subprocess
 
@@ -80,9 +80,9 @@ def main():
     (failed_count, total_count) = pylint_all_filenames(options.dev_mode, rootdirs)
 
     if failed_count != 0:
-        exitwith("pylint failed on {}/{} files.".format(failed_count, total_count))
+        exit(f"pylint failed on {failed_count}/{total_count} files.")
     else:
-        print("Successfully tested {} files.".format(total_count))
+        print(f"Successfully tested {total_count} files.")
 
 
 if __name__ == "__main__":

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -5,9 +5,10 @@ Runs pylint on all Python files in project directories known to contain Python s
 """
 
 from argparse import ArgumentParser
-from os import path, walk, system
+from os import path, walk
 from sys import exit as exitwith
 from textwrap import dedent
+import subprocess
 
 PROJECT_ROOT = path.dirname(path.dirname(path.realpath(__file__)))
 PYLINT_RCFILE = f"{PROJECT_ROOT}/scripts/pylintrc"
@@ -28,11 +29,20 @@ def pylint_all_filenames(dev_mode, rootdirs):
     failed = []
     for filename in filenames:
         checked_count += 1
-        cmdline = "pylint --rcfile=\"{}\" \"{}\"".format(PYLINT_RCFILE, filename)
-        print("{}[{}/{}] Running pylint on file: {}{}".format(SGR_INFO, checked_count, len(filenames),
-                                                              filename, SGR_CLEAR))
-        exit_code = system(cmdline)
-        if exit_code != 0:
+        command_line = [
+            "pylint",
+            f"--rcfile={PYLINT_RCFILE}",
+            f"{filename}",
+        ]
+        print(
+            f"{SGR_INFO}"
+            f"[{checked_count}/{len(filenames)}] "
+            f"Running pylint on file: {filename}{SGR_CLEAR}"
+        )
+
+        process = subprocess.run(command_line)
+
+        if process.returncode != 0:
             if dev_mode:
                 return 1, checked_count
             failed.append(filename)

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -21,6 +21,7 @@ disable=
     bad-indentation,
     bad-whitespace,
     consider-using-sys-exit,
+    duplicate-code,
     invalid-name,
     missing-docstring,
     mixed-indentation,


### PR DESCRIPTION
This PR refactors the `pylint_all.sh` script and fixes a few annoying things about it:
- The script used to run pylint separately on each file, which is **slow**. Now it passes them all in one go.
    - It reverts to the old behavior if you want it to stop on first error (because pylint does not have an option for that).
    - Now pylint can detect `duplicate-code`. Unfortunately we have a lot of duplicated code in `test/formal/`, which is why I had to disable it.
- I enabled pylint's colored output and disabled the score summary. Especially when running on files individually, the summary makes the output hard to read.
- It now uses `subprocess` instead `os.system()`, which means that it actually stops on Ctrl+C. It also no longer prints the huge stack trace if you kill it that way (well, mostly - if you do it at the wrong time, it still prints it but even then it's shorter :)).
- It now uses `argparse` for sane command-line processing.