### PR TITLE
Use empty user agent when downloading Boost from jfrog in powershell

### DIFF
--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -10,7 +10,9 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
   tar -xf cmake.zip
   mv cmake-3.18.2-win64-x64 "$PSScriptRoot\..\deps\cmake"
 
-  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip
+  # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
+  # and serving it a page that requires JavaScript.
+  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip -UserAgent ""
   tar -xf boost.zip
   cd boost_1_74_0
   .\bootstrap.bat


### PR DESCRIPTION
This fixes the [`b_win`](https://app.circleci.com/pipelines/github/ethereum/solidity/18272/workflows/f6534c77-5660-4de4-af2a-f2f9abc3db43/jobs/814852) and `b_win_release` jobs in CI. They have been failing intermittently for some time and now they seem to be failing in all PRs.

Looks like it's a server-side problem: [[RTFACT-26216] Native browser redirect prevents windows Power Shell (Invoke-WebRequest command) from downloading a file](https://www.jfrog.com/jira/si/jira.issueviews:issue-html/RTFACT-26216/RTFACT-26216.html). One of the workarounds is to use a different user agent. An empty one does the job.

EDIT: I just realized that this and #11832 can't be merged separately because the failing checks in both of them are marked as `required`. I'm putting this PR on top of #11832 to make it mergable. Please review them both and then merge just this one.