### PR TITLE
[BREAKING] Revert commit and Make basefee a reserved identifier in 0.9.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Breaking changes:
  * Inline Assembly: Consider functions, function parameters and return variables for shadowing checks.
  * Commandline Interface: Remapping targets are not automatically added to allowed paths.
  * Commandline Interface: Assembler mode no longer enables all outputs by default.
+ * General: The identifier ``basefee`` is a reserved identifier in Yul for all EVM versions.
 
 
 ### 0.8.13 (unreleased)

--- a/docs/090-breaking-changes.rst
+++ b/docs/090-breaking-changes.rst
@@ -15,7 +15,7 @@ Silent Changes of the Semantics
 New Restrictions
 ================
 
-...
+- Make ``basefee`` a reserved identifier in assembly.
 
 Interface Changes
 =================

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -109,22 +109,14 @@ pair<YulString, BuiltinFunctionForEVM> createFunction(
 	return {name, f};
 }
 
-set<YulString> createReservedIdentifiers(langutil::EVMVersion _evmVersion)
+set<YulString> createReservedIdentifiers()
 {
-	// TODO remove this in 0.9.0. We allow creating functions or identifiers in Yul with the name
-	// basefee for VMs before london.
-	auto baseFeeException = [&](evmasm::Instruction _instr) -> bool
-	{
-		return _instr == evmasm::Instruction::BASEFEE && _evmVersion < langutil::EVMVersion::london();
-	};
-
 	set<YulString> reserved;
 	for (auto const& instr: evmasm::c_instructions)
 	{
 		string name = instr.first;
 		transform(name.begin(), name.end(), name.begin(), [](unsigned char _c) { return tolower(_c); });
-		if (!baseFeeException(instr.second))
-			reserved.emplace(name);
+		reserved.emplace(name);
 	}
 	reserved += vector<YulString>{
 		"linkersymbol"_yulstring,
@@ -292,7 +284,7 @@ EVMDialect::EVMDialect(langutil::EVMVersion _evmVersion, bool _objectAccess):
 	m_objectAccess(_objectAccess),
 	m_evmVersion(_evmVersion),
 	m_functions(createBuiltins(_evmVersion, _objectAccess)),
-	m_reserved(createReservedIdentifiers(_evmVersion))
+	m_reserved(createReservedIdentifiers())
 {
 }
 

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -201,8 +201,7 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
                 # The warning may or may not exist in a compiler build.
         "4591", # "There are more than 256 warnings. Ignoring the rest."
                 # Due to 3805, the warning lists look different for different compiler builds.
-        "1834", # Unimplemented feature error, as we do not test it anymore via cmdLineTests
-        "5430"  # basefee being used in inline assembly for EVMVersion < london
+        "1834"  # Unimplemented feature error, as we do not test it anymore via cmdLineTests
     }
     assert len(test_ids & white_ids) == 0, "The sets are not supposed to intersect"
     test_ids |= white_ids

--- a/test/libsolidity/syntaxTests/inlineAssembly/basefee_berlin_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/basefee_berlin_function.sol
@@ -15,8 +15,7 @@ contract C {
     }
 }
 // ====
-// compileViaYul: also
-// EVMVersion: <=berlin
+// EVMVersion: =berlin
 // ----
-// f() -> 0
-// g() -> 1000
+// DeclarationError 5017: (98-105): The identifier "basefee" is reserved and can not be used.
+// DeclarationError 5017: (242-307): The identifier "basefee" is reserved and can not be used.

--- a/test/libsolidity/syntaxTests/types/magic_block_basefee_error.sol
+++ b/test/libsolidity/syntaxTests/types/magic_block_basefee_error.sol
@@ -2,8 +2,15 @@ contract C {
     function f() public view returns (uint) {
         return block.basefee;
     }
+    function g() public view returns (uint ret) {
+        assembly {
+            ret := basefee()
+        }
+    }
 }
 // ====
-// EVMVersion: <=berlin
+// EVMVersion: =berlin
 // ----
 // TypeError 5921: (74-87): "basefee" is not supported by the VM version.
+// TypeError 5430: (183-190): The "basefee" instruction is only available for London-compatible VMs (you are currently compiling for "berlin").
+// DeclarationError 8678: (176-192): Variable count for assignment to "ret" does not match number of values (1 vs. 0)


### PR DESCRIPTION
Reverted the commit https://github.com/ethereum/solidity/commit/7f1a2be0fee99531b5e9c0eca7dc1c70b9ffcaa0 and added the changes in changelog and rst files respectively

closes https://github.com/ethereum/solidity/issues/11836