### PR TITLE
[CI] Bump OpenJDK version from 14 to 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
       - checkout
       - run:
           name: Install Java
-          command: apt -q update && apt install -y openjdk-14-jdk
+          command: apt -q update && apt install -y openjdk-16-jdk
       - run:
           name: Run tests
           command: ./scripts/test_antlr_grammar.sh


### PR DESCRIPTION
`chk_antlr_grammar` is failing in #11850 because apparently OpenJDK 14 has been removed from Ubuntu Focal repos. Only OpenJDK 8, 13 and 16 are available.

This PR bumps version to 16.
