### PR TITLE
Revert making `error` a keyword

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,6 @@
 ### 0.9.0 (unreleased)
 
 Breaking changes:
- * `error` is now a keyword that can only be used for defining errors.
  * Inline Assembly: Consider functions, function parameters and return variables for shadowing checks.
 
 

--- a/docs/090-breaking-changes.rst
+++ b/docs/090-breaking-changes.rst
@@ -15,7 +15,7 @@ Silent Changes of the Semantics
 New Restrictions
 ================
 
-- `error` is now a keyword and cannot be used as identifier anymore.
+...
 
 Interface Changes
 =================

--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -29,7 +29,7 @@ Do: 'do';
 Else: 'else';
 Emit: 'emit';
 Enum: 'enum';
-Error: 'error';
+Error: 'error'; // not a real keyword
 Revert: 'revert'; // not a real keyword
 Event: 'event';
 External: 'external';

--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -13,7 +13,6 @@ sourceUnit: (
 	pragmaDirective
 	| importDirective
 	| contractDefinition
-	| errorDefinition
 	| interfaceDefinition
 	| libraryDefinition
 	| functionDefinition
@@ -380,9 +379,9 @@ tupleExpression: LParen (expression? ( Comma expression?)* ) RParen;
 inlineArrayExpression: LBrack (expression ( Comma expression)* ) RBrack;
 
 /**
- * Besides regular non-keyword Identifiers, some keywords like 'from' can also be used as identifiers.
+ * Besides regular non-keyword Identifiers, some keywords like 'from' and 'error' can also be used as identifiers.
  */
-identifier: Identifier | From | Revert;
+identifier: Identifier | From | Error | Revert;
 
 literal: stringLiteral | numberLiteral | booleanLiteral | hexStringLiteral | unicodeStringLiteral;
 booleanLiteral: True | False;

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -156,7 +156,6 @@ namespace solidity::langutil
 	K(Else, "else", 0)                                                 \
 	K(Enum, "enum", 0)                                                 \
 	K(Emit, "emit", 0)                                                 \
-	K(Error, "error", 0)                                               \
 	K(Event, "event", 0)                                               \
 	K(External, "external", 0)                                         \
 	K(Fallback, "fallback", 0)                                         \

--- a/test/libsolidity/semanticTests/errors/weird_name.sol
+++ b/test/libsolidity/semanticTests/errors/weird_name.sol
@@ -1,0 +1,11 @@
+error error(uint a);
+contract C {
+    function f() public pure {
+        revert error(2);
+    }
+}
+// ====
+// compileViaYul: also
+// compileToEwasm: also
+// ----
+// f() -> FAILURE, hex"b48fb6cf", hex"0000000000000000000000000000000000000000000000000000000000000002"

--- a/test/libsolidity/semanticTests/reverts/error_struct.sol
+++ b/test/libsolidity/semanticTests/reverts/error_struct.sol
@@ -1,0 +1,18 @@
+struct error { uint error; }
+contract C {
+	error test();
+	error _struct;
+	function f() public {
+		revert test();
+	}
+	function g(uint x) public returns (uint) {
+		_struct.error = x;
+		return _struct.error;
+	}
+}
+// ====
+// compileViaYul: also
+// compileToEwasm: also
+// ----
+// f() -> FAILURE, hex"f8a8fd6d"
+// g(uint256): 7 -> 7

--- a/test/libsolidity/syntaxTests/errors/struct_named_error.sol
+++ b/test/libsolidity/syntaxTests/errors/struct_named_error.sol
@@ -1,6 +1,6 @@
+// Test that the parser workaround is not breaking.
 struct error {uint a;}
 contract C {
     error x;
 }
 // ----
-// ParserError 2314: (7-12): Expected identifier but got 'error'

--- a/test/libsolidity/syntaxTests/errors/weird_name.sol
+++ b/test/libsolidity/syntaxTests/errors/weird_name.sol
@@ -1,8 +1,0 @@
-error error(uint a);
-contract C {
-    function f() public pure {
-        revert error(2);
-    }
-}
-// ----
-// ParserError 2314: (6-11): Expected identifier but got 'error'


### PR DESCRIPTION
Fixes #11743.

Just a direct revert of the original commit in #11218. I kept some minor changes like adding the doc page about breaking changes or changing a `catch` variable name from `error` to `_error` in a test unrelated to errors.