### PR TITLE
Allow and require use-src to be repeated for each object.

### DIFF
--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -133,7 +133,7 @@ string IRGenerator::generate(
 	};
 
 	Whiskers t(R"(
-		/// @use-src <useSrcMap>
+		/// @use-src <useSrcMapCreation>
 		object "<CreationObject>" {
 			code {
 				<sourceLocationComment>
@@ -147,6 +147,7 @@ string IRGenerator::generate(
 				<deploy>
 				<functions>
 			}
+			/// @use-src <useSrcMapDeployed>
 			object "<DeployedObject>" {
 				code {
 					<sourceLocationComment>
@@ -177,7 +178,7 @@ string IRGenerator::generate(
 		", "
 	);
 
-	t("useSrcMap", useSrcMap);
+	t("useSrcMapCreation", useSrcMap);
 	t("sourceLocationComment", sourceLocationComment(_contract, m_context));
 
 	t("CreationObject", IRNames::creationObject(_contract));
@@ -219,6 +220,7 @@ string IRGenerator::generate(
 	m_context.initializeInternalDispatch(move(internalDispatchMap));
 
 	// Do not register immutables to avoid assignment.
+	t("useSrcMapDeployed", useSrcMap);
 	t("DeployedObject", IRNames::deployedObject(_contract));
 	t("library_address", IRNames::libraryAddressImmutable());
 	t("dispatch", dispatchRoutine(_contract));

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -49,11 +49,8 @@ struct ObjectNode
 	/// Name of the object.
 	/// Can be empty since .yul files can also just contain code, without explicitly placing it in an object.
 	YulString name;
-protected:
-	virtual std::string toString(Dialect const* _dialect, std::optional<SourceNameMap> _sourceNames) const = 0;
 
-	/// Object should have access to toString
-	friend struct Object;
+	virtual std::string toString(Dialect const* _dialect) const = 0;
 };
 
 /**
@@ -65,8 +62,7 @@ struct Data: public ObjectNode
 
 	bytes data;
 
-protected:
-	std::string toString(Dialect const* _dialect, std::optional<SourceNameMap> _sourceNames) const override;
+	std::string toString(Dialect const* _dialect) const override;
 };
 
 
@@ -114,8 +110,6 @@ public:
 
 	/// @returns the name of the special metadata data object.
 	static std::string metadataName() { return ".metadata"; }
-protected:
-	std::string toString(Dialect const* _dialect, std::optional<SourceNameMap> _sourceNames) const override;
 };
 
 }

--- a/libyul/ObjectParser.h
+++ b/libyul/ObjectParser.h
@@ -55,13 +55,11 @@ public:
 	/// @returns an empty shared pointer on error.
 	std::shared_ptr<Object> parse(std::shared_ptr<langutil::Scanner> const& _scanner, bool _reuseScanner);
 
-	std::optional<SourceNameMap> const& sourceNameMapping() const noexcept { return m_sourceNameMapping; }
-
 private:
 	std::optional<SourceNameMap> tryParseSourceNameMapping() const;
 	std::shared_ptr<Object> parseObject(Object* _containingObject = nullptr);
-	std::shared_ptr<Block> parseCode();
-	std::shared_ptr<Block> parseBlock();
+	std::shared_ptr<Block> parseCode(std::optional<SourceNameMap> _sourceNames);
+	std::shared_ptr<Block> parseBlock(std::optional<SourceNameMap> _sourceNames);
 	void parseData(Object& _containingObject);
 
 	/// Tries to parse a name that is non-empty and unique inside the containing object.
@@ -69,8 +67,6 @@ private:
 	void addNamedSubObject(Object& _container, YulString _name, std::shared_ptr<ObjectNode> _subObject);
 
 	Dialect const& m_dialect;
-
-	std::optional<SourceNameMap> m_sourceNameMapping;
 };
 
 }

--- a/libyul/backends/wasm/EVMToEwasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEwasmTranslator.cpp
@@ -93,6 +93,7 @@ Object EVMToEwasmTranslator::run(Object const& _object)
 	Object ret;
 	ret.name = _object.name;
 	ret.code = make_shared<Block>(move(ast));
+	ret.debugData = _object.debugData;
 	ret.analysisInfo = make_shared<AsmAnalysisInfo>();
 
 	ErrorList errors;

--- a/test/cmdlineTests/constant_optimizer_yul/output
+++ b/test/cmdlineTests/constant_optimizer_yul/output
@@ -21,6 +21,7 @@ object "C_12" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"constant_optimizer_yul/input.sol", 1:"#utility.yul"
     object "C_12_deployed" {
         code {
             {

--- a/test/cmdlineTests/exp_base_literal/output
+++ b/test/cmdlineTests/exp_base_literal/output
@@ -38,6 +38,7 @@ object "C_81" {
         }
 
     }
+    /// @use-src 0:"exp_base_literal/input.sol", 1:"#utility.yul"
     object "C_81_deployed" {
         code {
             /// @src 0:82:370

--- a/test/cmdlineTests/ir_compiler_inheritance_nosubobjects/output
+++ b/test/cmdlineTests/ir_compiler_inheritance_nosubobjects/output
@@ -18,6 +18,7 @@ object "C_7" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"ir_compiler_inheritance_nosubobjects/input.sol", 1:"#utility.yul"
     object "C_7_deployed" {
         code {
             {
@@ -50,6 +51,7 @@ object "D_10" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"ir_compiler_inheritance_nosubobjects/input.sol", 1:"#utility.yul"
     object "D_10_deployed" {
         code {
             {

--- a/test/cmdlineTests/ir_compiler_subobjects/output
+++ b/test/cmdlineTests/ir_compiler_subobjects/output
@@ -18,6 +18,7 @@ object "C_3" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"ir_compiler_subobjects/input.sol", 1:"#utility.yul"
     object "C_3_deployed" {
         code {
             {
@@ -50,6 +51,7 @@ object "D_16" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"ir_compiler_subobjects/input.sol", 1:"#utility.yul"
     object "D_16_deployed" {
         code {
             {
@@ -88,6 +90,7 @@ object "D_16" {
                 revert(0, 0)
             }
         }
+        /// @use-src 0:"ir_compiler_subobjects/input.sol", 1:"#utility.yul"
         object "C_3" {
             code {
                 {
@@ -99,6 +102,7 @@ object "D_16" {
                     return(128, _1)
                 }
             }
+            /// @use-src 0:"ir_compiler_subobjects/input.sol", 1:"#utility.yul"
             object "C_3_deployed" {
                 code {
                     {

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_creation/output
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_creation/output
@@ -18,6 +18,7 @@ object "D_12" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"ir_with_assembly_no_memoryguard_creation/input.sol", 1:"#utility.yul"
     object "D_12_deployed" {
         code {
             {

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/output
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/output
@@ -18,6 +18,7 @@ object "D_8" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"ir_with_assembly_no_memoryguard_runtime/input.sol", 1:"#utility.yul"
     object "D_8_deployed" {
         code {
             {

--- a/test/cmdlineTests/keccak_optimization_deploy_code/output
+++ b/test/cmdlineTests/keccak_optimization_deploy_code/output
@@ -22,6 +22,7 @@ object "C_12" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"keccak_optimization_deploy_code/input.sol", 1:"#utility.yul"
     object "C_12_deployed" {
         code {
             {

--- a/test/cmdlineTests/keccak_optimization_low_runs/output
+++ b/test/cmdlineTests/keccak_optimization_low_runs/output
@@ -18,6 +18,7 @@ object "C_7" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"keccak_optimization_low_runs/input.sol", 1:"#utility.yul"
     object "C_7_deployed" {
         code {
             {

--- a/test/cmdlineTests/name_simplifier/output
+++ b/test/cmdlineTests/name_simplifier/output
@@ -18,6 +18,7 @@ object "C_59" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"name_simplifier/input.sol", 1:"#utility.yul"
     object "C_59_deployed" {
         code {
             {

--- a/test/cmdlineTests/optimizer_array_sload/output
+++ b/test/cmdlineTests/optimizer_array_sload/output
@@ -18,6 +18,7 @@ object "Arraysum_34" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"optimizer_array_sload/input.sol", 1:"#utility.yul"
     object "Arraysum_34_deployed" {
         code {
             {

--- a/test/cmdlineTests/revert_strings/output
+++ b/test/cmdlineTests/revert_strings/output
@@ -53,6 +53,7 @@ object "C_15" {
         }
 
     }
+    /// @use-src 0:"revert_strings/input.sol", 1:"#utility.yul"
     object "C_15_deployed" {
         code {
             /// @src 0:59:147

--- a/test/cmdlineTests/standard_irOptimized_requested/output.json
+++ b/test/cmdlineTests/standard_irOptimized_requested/output.json
@@ -25,6 +25,7 @@ object \"C_7\" {
         function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
         { revert(0, 0) }
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_7_deployed\" {
         code {
             /// @src 0:79:121

--- a/test/cmdlineTests/standard_ir_requested/output.json
+++ b/test/cmdlineTests/standard_ir_requested/output.json
@@ -37,6 +37,7 @@ object \"C_7\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_7_deployed\" {
         code {
             /// @src 0:79:121

--- a/test/cmdlineTests/standard_viair_requested/output.json
+++ b/test/cmdlineTests/standard_viair_requested/output.json
@@ -37,6 +37,7 @@ object \"C_3\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_3_deployed\" {
         code {
             /// @src 0:79:92
@@ -113,6 +114,7 @@ object \"D_16\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"D_16_deployed\" {
         code {
             /// @src 0:93:146
@@ -244,6 +246,7 @@ object \"D_16\" {
                 }
 
             }
+            /// @use-src 0:\"A\", 1:\"#utility.yul\"
             object \"C_3_deployed\" {
                 code {
                     /// @src 0:79:92

--- a/test/cmdlineTests/viair_abicoder_v1/output
+++ b/test/cmdlineTests/viair_abicoder_v1/output
@@ -38,6 +38,7 @@ object "test_11" {
         }
 
     }
+    /// @use-src 0:"viair_abicoder_v1/input.sol", 1:"#utility.yul"
     object "test_11_deployed" {
         code {
             /// @src 0:79:169

--- a/test/cmdlineTests/viair_subobjects/output
+++ b/test/cmdlineTests/viair_subobjects/output
@@ -24,6 +24,7 @@ object "C_3" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"viair_subobjects/input.sol", 1:"#utility.yul"
     object "C_3_deployed" {
         code {
             {
@@ -62,6 +63,7 @@ object "D_16" {
             return(128, _1)
         }
     }
+    /// @use-src 0:"viair_subobjects/input.sol", 1:"#utility.yul"
     object "D_16_deployed" {
         code {
             {
@@ -100,6 +102,7 @@ object "D_16" {
                 revert(0, 0)
             }
         }
+        /// @use-src 0:"viair_subobjects/input.sol", 1:"#utility.yul"
         object "C_3" {
             code {
                 {
@@ -111,6 +114,7 @@ object "D_16" {
                     return(128, _1)
                 }
             }
+            /// @use-src 0:"viair_subobjects/input.sol", 1:"#utility.yul"
             object "C_3_deployed" {
                 code {
                     {

--- a/test/cmdlineTests/yul_optimizer_steps/output
+++ b/test/cmdlineTests/yul_optimizer_steps/output
@@ -25,6 +25,7 @@ object "C_7" {
         function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb()
         { revert(0, 0) }
     }
+    /// @use-src 0:"yul_optimizer_steps/input.sol", 1:"#utility.yul"
     object "C_7_deployed" {
         code {
             {

--- a/test/cmdlineTests/yul_source_locations/output.json
+++ b/test/cmdlineTests/yul_source_locations/output.json
@@ -156,6 +156,7 @@ object \"C_54\" {
         }
 
     }
+    /// @use-src 0:\"C\", 1:\"D\", 2:\"#utility.yul\"
     object \"C_54_deployed\" {
         code {
             /// @src 0:79:428
@@ -780,6 +781,7 @@ object \"D_72\" {
         }
 
     }
+    /// @use-src 0:\"C\", 1:\"D\", 2:\"#utility.yul\"
     object \"D_72_deployed\" {
         code {
             /// @src 1:91:166

--- a/test/cmdlineTests/yul_string_format_ascii/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii/output.json
@@ -37,6 +37,7 @@ object \"C_11\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_11_deployed\" {
         code {
             /// @src 0:78:164

--- a/test/cmdlineTests/yul_string_format_ascii_bytes32/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_bytes32/output.json
@@ -37,6 +37,7 @@ object \"C_11\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_11_deployed\" {
         code {
             /// @src 0:78:158

--- a/test/cmdlineTests/yul_string_format_ascii_bytes32_from_number/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_bytes32_from_number/output.json
@@ -37,6 +37,7 @@ object \"C_11\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_11_deployed\" {
         code {
             /// @src 0:78:159

--- a/test/cmdlineTests/yul_string_format_ascii_long/output.json
+++ b/test/cmdlineTests/yul_string_format_ascii_long/output.json
@@ -37,6 +37,7 @@ object \"C_11\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_11_deployed\" {
         code {
             /// @src 0:78:243

--- a/test/cmdlineTests/yul_string_format_hex/output.json
+++ b/test/cmdlineTests/yul_string_format_hex/output.json
@@ -37,6 +37,7 @@ object \"C_11\" {
         }
 
     }
+    /// @use-src 0:\"A\", 1:\"#utility.yul\"
     object \"C_11_deployed\" {
         code {
             /// @src 0:78:159

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -121,8 +121,9 @@ tuple<optional<SourceNameMap>, ErrorList> tryGetSourceLocationMapping(string _so
 	Dialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(EVMVersion::berlin());
 	ObjectParser objectParser{reporter, dialect};
 	CharStream stream(move(source), "");
-	objectParser.parse(make_shared<Scanner>(stream), false);
-	return {objectParser.sourceNameMapping(), std::move(errors)};
+	auto object = objectParser.parse(make_shared<Scanner>(stream), false);
+	BOOST_REQUIRE(object && object->debugData);
+	return {object->debugData->sourceNames, std::move(errors)};
 }
 
 }

--- a/test/libyul/objectCompiler/sourceLocations.yul
+++ b/test/libyul/objectCompiler/sourceLocations.yul
@@ -10,6 +10,7 @@ object "a" {
       datasize("sub")
     )
   }
+  /// @use-src 3: "abc.sol" , 2: "def.sol"
   object "sub" {
     code {
       /// @src 2:70:72


### PR DESCRIPTION
This is needed for `new` to work properly without having to re-parse the IR code of the created object.

Will combine this with https://github.com/ethereum/solidity/pull/11865