### PR TITLE
Fix UBSan CI

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -200,6 +200,10 @@ if (SANITIZE)
 	elseif (sanitizer STREQUAL "undefined")
 		# The following flags not used by fuzzer but used by us may create problems, so consider
 		# disabling them: alignment, pointer-overflow.
+		# The following flag is not used by us to reduce terminal noise
+		# i.e., warnings printed on stderr: unsigned-integer-overflow
+		# Note: The C++ standard does not officially consider unsigned integer overflows
+		# to be undefined behavior since they are implementation independent.
 		# Flags are alphabetically sorted and are for clang v10.0
 		list(APPEND undefinedSanitizerChecks
 			alignment
@@ -217,18 +221,12 @@ if (SANITIZE)
 			returns-nonnull-attribute
 			shift
 			signed-integer-overflow
-			unsigned-integer-overflow
 			unreachable
 			vla-bound
 			vptr
 		)
 		list(JOIN undefinedSanitizerChecks "," sanitizerChecks)
-		list(REMOVE_ITEM undefinedSanitizerChecks unsigned-integer-overflow)
-		# The fuzzer excludes reports of unsigned-integer-overflow. Hence, we remove it
-		# from the -fno-sanitize-recover checks. Consider reducing this list if we do not
-		# want to be notified about other failed checks.
-		list(JOIN undefinedSanitizerChecks "," dontRecoverFromChecks)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${sanitizerChecks} -fno-sanitize-recover=${dontRecoverFromChecks}")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=${sanitizerChecks} -fno-sanitize-recover=${sanitizerChecks}")
 	endif()
 endif()
 


### PR DESCRIPTION
CMake: Remove unsigned-integer-overflow check from UBSan compiler flags because it is too noisy.

This should fix the UBSan CLI failing run that is currently (incorrectly) failing due to noisy prints originating from the check disabled by this PR.

The C++ standard does not officially consider unsigned integer overflows to be undefined behavior since it is implementation independent.