### PR TITLE
Properly export symbols from aliased imports.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Name Resolver: Fix that when importing an aliased symbol using ``import {AliasedName} from "a.sol"`` it would use the original name of the symbol and not the aliased one.
  * SMTChecker: Fix false negative caused by ``push`` on storage array references returned by internal functions.
  * SMTChecker: Fix false positive in external calls from constructors.
  * SMTChecker: Fix internal error on some multi-source uses of ``abi.*``, cryptographic functions and constants.

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -102,7 +102,12 @@ bool NameAndTypeResolver::performImports(SourceUnit& _sourceUnit, map<string, So
 					else
 						for (Declaration const* declaration: declarations)
 							if (!DeclarationRegistrationHelper::registerDeclaration(
-								target, *declaration, alias.alias.get(), &alias.location, false, m_errorReporter
+								target,
+								*declaration,
+								alias.alias ? alias.alias.get() : &alias.symbol->name(),
+								&alias.location,
+								false,
+								m_errorReporter
 							))
 								error = true;
 				}

--- a/test/libsolidity/syntaxTests/imports/alias_import_not_forwarded.sol
+++ b/test/libsolidity/syntaxTests/imports/alias_import_not_forwarded.sol
@@ -1,0 +1,8 @@
+==== Source: dummy ====
+contract Dummy { string public constant FOO = "FOO"; }
+==== Source: hasAlias ====
+import {Dummy as AliasedDummy} from "dummy";
+==== Source: Main ====
+import {AliasedDummy} from "hasAlias";
+contract TestAlias is AliasedDummy {}
+// ----


### PR DESCRIPTION
fixes #11855