### PR TITLE
Remove CI workarounds for archlinux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,9 +589,7 @@ jobs:
 
   b_archlinux:
     docker:
-      # FIXME: Newer releases won't work until CircleCI updates its host machines.
-      # See https://github.com/ethereum/solidity/pull/11332
-      - image: archlinux:base-20210131.0.14634
+      - image: archlinux:base
     environment:
       TERM: xterm
       MAKEFLAGS: -j 3
@@ -730,9 +728,7 @@ jobs:
 
   t_archlinux_soltest: &t_archlinux_soltest
       docker:
-        # FIXME: Newer releases won't work until CircleCI updates its host machines.
-        # See https://github.com/ethereum/solidity/pull/11332
-        - image: archlinux:base-20210131.0.14634
+        - image: archlinux:base
       environment:
         EVM: << pipeline.parameters.evm-version >>
         OPTIMIZE: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,10 +739,7 @@ jobs:
         TERM: xterm
         # For Archlinux we do not have prebuilt docker images and we would need to build evmone from source,
         # thus we forgo semantics tests to speed things up.
-        # FIXME: Z3 4.8.11 prerelease is now in main Arch Linux repos but it makes some of our SMT
-        # tests hang. Disabling SMT tests until we get a proper release.
-        # See https://github.com/Z3Prover/z3/issues/5330 for more details.
-        SOLTEST_FLAGS: --no-semantic-tests --no-smt
+        SOLTEST_FLAGS: --no-semantic-tests
       steps:
         - run:
             name: Install runtime dependencies


### PR DESCRIPTION
Another attempt at removing the workaround from #11332.

Also reverts #11532 since we're already on Z3 4.8.12.