### PR TITLE
Allow the Rematerializer to be restricted to an exact set of variables.

### DIFF
--- a/libyul/optimiser/Rematerialiser.cpp
+++ b/libyul/optimiser/Rematerialiser.cpp
@@ -32,39 +32,44 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 
-void Rematerialiser::run(Dialect const& _dialect, Block& _ast, set<YulString> _varsToAlwaysRematerialize)
+void Rematerialiser::run(Dialect const& _dialect, Block& _ast, set<YulString> _varsToAlwaysRematerialize, bool _onlySelectedVariables)
 {
-	Rematerialiser{_dialect, _ast, std::move(_varsToAlwaysRematerialize)}(_ast);
+	Rematerialiser{_dialect, _ast, std::move(_varsToAlwaysRematerialize), _onlySelectedVariables}(_ast);
 }
 
 void Rematerialiser::run(
 	Dialect const& _dialect,
 	FunctionDefinition& _function,
-	set<YulString> _varsToAlwaysRematerialize
+	set<YulString> _varsToAlwaysRematerialize,
+	bool _onlySelectedVariables
 )
 {
-	Rematerialiser{_dialect, _function, std::move(_varsToAlwaysRematerialize)}(_function);
+	Rematerialiser{_dialect, _function, std::move(_varsToAlwaysRematerialize), _onlySelectedVariables}(_function);
 }
 
 Rematerialiser::Rematerialiser(
 	Dialect const& _dialect,
 	Block& _ast,
-	set<YulString> _varsToAlwaysRematerialize
+	set<YulString> _varsToAlwaysRematerialize,
+	bool _onlySelectedVariables
 ):
 	DataFlowAnalyzer(_dialect),
 	m_referenceCounts(ReferencesCounter::countReferences(_ast)),
-	m_varsToAlwaysRematerialize(std::move(_varsToAlwaysRematerialize))
+	m_varsToAlwaysRematerialize(std::move(_varsToAlwaysRematerialize)),
+	m_onlySelectedVariables(_onlySelectedVariables)
 {
 }
 
 Rematerialiser::Rematerialiser(
 	Dialect const& _dialect,
 	FunctionDefinition& _function,
-	set<YulString> _varsToAlwaysRematerialize
+	set<YulString> _varsToAlwaysRematerialize,
+	bool _onlySelectedVariables
 ):
 	DataFlowAnalyzer(_dialect),
 	m_referenceCounts(ReferencesCounter::countReferences(_function)),
-	m_varsToAlwaysRematerialize(std::move(_varsToAlwaysRematerialize))
+	m_varsToAlwaysRematerialize(std::move(_varsToAlwaysRematerialize)),
+	m_onlySelectedVariables(_onlySelectedVariables)
 {
 }
 
@@ -81,10 +86,13 @@ void Rematerialiser::visit(Expression& _e)
 			size_t refs = m_referenceCounts[name];
 			size_t cost = CodeCost::codeCost(m_dialect, *value.value);
 			if (
-				(refs <= 1 && value.loopDepth == m_loopDepth) ||
-				cost == 0 ||
-				(refs <= 5 && cost <= 1 && m_loopDepth == 0) ||
-				m_varsToAlwaysRematerialize.count(name)
+				(
+					!m_onlySelectedVariables && (
+						(refs <= 1 && value.loopDepth == m_loopDepth) ||
+						cost == 0 ||
+						(refs <= 5 && cost <= 1 && m_loopDepth == 0)
+					)
+				) || m_varsToAlwaysRematerialize.count(name)
 			)
 			{
 				assertThrow(m_referenceCounts[name] > 0, OptimizerException, "");

--- a/libyul/optimiser/Rematerialiser.h
+++ b/libyul/optimiser/Rematerialiser.h
@@ -50,24 +50,28 @@ public:
 	static void run(
 		Dialect const& _dialect,
 		Block& _ast,
-		std::set<YulString> _varsToAlwaysRematerialize = {}
+		std::set<YulString> _varsToAlwaysRematerialize = {},
+		bool _onlySelectedVariables = false
 	);
 	static void run(
 		Dialect const& _dialect,
 		FunctionDefinition& _function,
-		std::set<YulString> _varsToAlwaysRematerialize = {}
+		std::set<YulString> _varsToAlwaysRematerialize = {},
+		bool _onlySelectedVariables = false
 	);
 
 protected:
 	Rematerialiser(
 		Dialect const& _dialect,
 		Block& _ast,
-		std::set<YulString> _varsToAlwaysRematerialize = {}
+		std::set<YulString> _varsToAlwaysRematerialize = {},
+		bool _onlySelectedVariables = false
 	);
 	Rematerialiser(
 		Dialect const& _dialect,
 		FunctionDefinition& _function,
-		std::set<YulString> _varsToAlwaysRematerialize = {}
+		std::set<YulString> _varsToAlwaysRematerialize = {},
+		bool _onlySelectedVariables = false
 	);
 
 	using DataFlowAnalyzer::operator();
@@ -77,6 +81,7 @@ protected:
 
 	std::map<YulString, size_t> m_referenceCounts;
 	std::set<YulString> m_varsToAlwaysRematerialize;
+	bool m_onlySelectedVariables = false;
 };
 
 /**


### PR DESCRIPTION
In contrast to the old code transform, https://github.com/ethereum/solidity/pull/11890 will provide a precise set of variables, s.t. rematerializing them will solve stack errors. In https://github.com/ethereum/solidity/pull/11493 this is exploited by having the ``StackCompressor`` run late and have it pass this precise set of variables to the rematerializer.

To that end the rematerializer needs to be restrictable to an exact set of variables (whereas before it was only possible to tell it to *additionally* rematerialize some variables).

This PR adds a simple flag for that, which will remain unused until https://github.com/ethereum/solidity/pull/11493