### PR TITLE
Prevent the optimizer from removing ``memoryguard``.

### DIFF
--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -179,7 +179,17 @@ map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVe
 			"memoryguard",
 			1,
 			1,
-			SideEffects{},
+			// Cannot be removed, but otherwise no side effects.
+			SideEffects{
+				true,
+				true,
+				false,
+				false,
+				true,
+				SideEffects::None,
+				SideEffects::None,
+				SideEffects::None
+			},
 			{LiteralKind::Number},
 			[](
 				FunctionCall const& _call,


### PR DESCRIPTION
Disallows removing the ``memoryguard`` instruction, since that will prevent stack limit evasion.

Thinking about that, I'm wondering if we should also set ``movable`` to ``false``, since allowing to copy ``memoryguard`` without being able to remove it might otherwise result in multiple stray ``pop(memoryguard(...))``s... on the other hand that would also be fine, since the peephole optimizer would ultimately get rid of those later anyways...

The proper side-effect for ``memoryguard`` would be "cannot be removed, if it is the last occurrence", but I'd say it's not worth introducing that specifically as special case... if we end up actually seeing a lot of duplicated ``pop(memoryguard(...))``s, we can still specifically remove all but one of those during the cleanup phase.

This will probably have some effects together with https://github.com/ethereum/solidity/pull/11493, i.e. without this PR, some rare cases might fail, since they can't run the stack limit evader due to a removed memoryguard.