### PR TITLE
Do not use the expression callback in memoryguard builtin code generation.

### DIFF
--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -26,8 +26,8 @@
 #include <libyul/Object.h>
 #include <libyul/Exceptions.h>
 #include <libyul/AsmParser.h>
+#include <libyul/Utilities.h>
 #include <libyul/backends/evm/AbstractAssembly.h>
-
 #include <libevmasm/SemanticInformation.h>
 #include <libevmasm/Instruction.h>
 
@@ -185,9 +185,12 @@ map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVe
 				FunctionCall const& _call,
 				AbstractAssembly& _assembly,
 				BuiltinContext&,
-				function<void(Expression const&)> _visitExpression
+				function<void(Expression const&)>
 			) {
-				visitArguments(_assembly, _call, _visitExpression);
+				yulAssert(_call.arguments.size() == 1, "");
+				Literal const* literal = get_if<Literal>(&_call.arguments.front());
+				yulAssert(literal, "");
+				_assembly.appendConstant(valueOfLiteral(*literal));
 			})
 		);
 


### PR DESCRIPTION
The new code transform ignores the expression callback and handles function arguments on its own.

However, contrary to all other builtins with literal arguments, the literal argument of ``memoryguard`` actually still ends up on stack despite being literal. Hence instead of visiting the literal argument, I directly push the constant in the builtin.

An extension of this is https://github.com/ethereum/solidity/pull/11894, which removes the expression visit callback from the builtins entirely - if we agree on that one, we can close this one, but merging one of them will be required for https://github.com/ethereum/solidity/pull/11493