### PR TITLE
Do not run evm codegen if not asked.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 
 
 Compiler Features:
+ * Commandline Interface: Do not implicitly run evm bytecode generation unless needed for the requested output.
  * Commandline Interface: Normalize paths specified on the command line and make them relative for files located inside base path.
  * Immutable variables can be read at construction time once they are initialized.
  * SMTChecker: Support low level ``call`` as external calls to unknown code.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -594,6 +594,26 @@ bool CommandLineInterface::compile()
 
 		m_compiler->enableIRGeneration(m_options.compiler.outputs.ir || m_options.compiler.outputs.irOptimized);
 		m_compiler->enableEwasmGeneration(m_options.compiler.outputs.ewasm);
+		m_compiler->enableEvmBytecodeGeneration(
+			m_options.compiler.estimateGas ||
+			m_options.compiler.outputs.asm_ ||
+			m_options.compiler.outputs.asmJson ||
+			m_options.compiler.outputs.opcodes ||
+			m_options.compiler.outputs.binary ||
+			m_options.compiler.outputs.binaryRuntime ||
+			(m_options.compiler.combinedJsonRequests && (
+				m_options.compiler.combinedJsonRequests->binary ||
+				m_options.compiler.combinedJsonRequests->binaryRuntime ||
+				m_options.compiler.combinedJsonRequests->opcodes ||
+				m_options.compiler.combinedJsonRequests->asm_ ||
+				m_options.compiler.combinedJsonRequests->generatedSources ||
+				m_options.compiler.combinedJsonRequests->generatedSourcesRuntime ||
+				m_options.compiler.combinedJsonRequests->srcMap ||
+				m_options.compiler.combinedJsonRequests->srcMapRuntime ||
+				m_options.compiler.combinedJsonRequests->funDebug ||
+				m_options.compiler.combinedJsonRequests->funDebugRuntime
+			))
+		);
 
 		OptimiserSettings settings = m_options.optimizer.enabled ? OptimiserSettings::standard() : OptimiserSettings::minimal();
 		if (m_options.optimizer.expectedExecutionsPerDeployment.has_value())


### PR DESCRIPTION
It's absolutely driving me nuts that the CLI always runs old codegen evm bytecode generation, even if I just ask for ``--ir``.
I have the CLI locally patched almost permanently because of that... (it's especially infuriating, if there are stack-too-deep errors, but I cannot even query the code that triggered it because of this)

Generally, I'd have said, we should get rid of the current CLI implementation entirely and replace it by a shiny fresh new (decidedly not generally backwards-compatible to crazy behaviour like this here ;-)) StandardCompiler-wrapper... but since for some reason we don't just do that, maybe we can at least patch this part :-).

I haven't checked that this is the exhaustive set of conditions that require evm bytecode generation, so it'd be good if someone double-checked.