### PR TITLE
Simplifying CircleCi Config: Job aliases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,6 +604,15 @@ defaults:
       nodejs_version: '14'
       resource_class: medium
 
+  - job_b_ubu_asan_clang: &job_b_ubu_asan_clang
+      <<: *workflow_trigger_on_tags
+      name: b_ubu_asan_clang
+      cmake_options: -DSANITIZE=address
+  - job_b_ubu_ubsan_clang: &job_b_ubu_ubsan_clang
+      <<: *workflow_trigger_on_tags
+      name: b_ubu_ubsan_clang
+      cmake_options: -DSANITIZE=address
+
 # -----------------------------------------------------------------------------------------------
 jobs:
 
@@ -770,24 +779,18 @@ jobs:
       MAKEFLAGS: -j 10
     <<: *steps_build
 
-  b_ubu_asan_clang: &b_ubu_asan_clang
+  b_ubu_san_clang:
     # This runs a bit faster on large and xlarge but on nightly efficiency matters more.
+    parameters:
+      cmake_options:
+        type: string
     <<: *base_ubuntu2004_clang
     environment:
+      TERM: xterm
       CC: clang
       CXX: clang++
-      CMAKE_OPTIONS: -DSANITIZE=address
       MAKEFLAGS: -j 3
-    <<: *steps_build
-
-  b_ubu_ubsan_clang: &b_ubu_ubsan_clang
-    # This runs a bit faster on large and xlarge but on nightly efficiency matters more.
-    <<: *base_ubuntu2004_clang
-    environment:
-      CC: clang
-      CXX: clang++
-      CMAKE_OPTIONS: -DSANITIZE=undefined
-      MAKEFLAGS: -j 3
+      CMAKE_OPTIONS: << parameters.cmake_options >>
     <<: *steps_build
 
   b_ubu_release: &b_ubu_release
@@ -1506,13 +1509,13 @@ workflows:
 
       # ASan build and tests
       - b_ubu_asan: *workflow_trigger_on_tags
-      - b_ubu_asan_clang: *workflow_trigger_on_tags
+      - b_ubu_san_clang: *job_b_ubu_asan_clang
       - t_ubu_asan_soltest: *workflow_ubuntu2004_asan
       - t_ubu_asan_clang_soltest: *workflow_ubuntu2004_asan_clang
       - t_ubu_asan_cli: *workflow_ubuntu2004_asan
 
       # UBSan build and tests
-      - b_ubu_ubsan_clang: *workflow_trigger_on_tags
+      - b_ubu_san_clang: *job_b_ubu_ubsan_clang
       - t_ubu_ubsan_clang_soltest: *workflow_ubuntu2004_ubsan_clang
       - t_ubu_ubsan_clang_cli: *workflow_ubuntu2004_ubsan_clang
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,14 @@ defaults:
             command: ./test/lsp.py ./build/solc/solc
         - gitter_notify_failure_unless_pr
 
+  - steps_build: &steps_build
+      steps:
+        - checkout
+        - run: *run_build
+        - store_artifacts: *artifacts_solc
+        - persist_to_workspace: *artifacts_executables
+        - gitter_notify_failure_unless_pr
+
   - steps_soltest_all: &steps_soltest_all
       steps:
         - checkout
@@ -233,6 +241,14 @@ defaults:
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
         - gitter_notify_failure_unless_pr
+
+  - steps_install_dependencies_osx: &steps_install_dependencies_osx
+      steps:
+        - restore_cache:
+            keys:
+              - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+        - attach_workspace:
+            at: .
 
   # --------------------------------------------------------------------------
   # Base Image Templates
@@ -748,12 +764,7 @@ jobs:
       CMAKE_OPTIONS: -DSANITIZE=address
       MAKEFLAGS: -j 3
       CMAKE_BUILD_TYPE: Release
-    steps:
-      - checkout
-      - run: *run_build
-      - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
-      - gitter_notify_failure_unless_pr
+    <<: *steps_build
 
   b_ubu_clang: &b_ubu_clang
     <<: *base_ubuntu2004_clang_large
@@ -762,12 +773,7 @@ jobs:
       CC: clang
       CXX: clang++
       MAKEFLAGS: -j 10
-    steps:
-      - checkout
-      - run: *run_build
-      - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
-      - gitter_notify_failure_unless_pr
+    <<: *steps_build
 
   b_ubu_asan_clang: &b_ubu_asan_clang
     # This runs a bit faster on large and xlarge but on nightly efficiency matters more.
@@ -777,12 +783,7 @@ jobs:
       CXX: clang++
       CMAKE_OPTIONS: -DSANITIZE=address
       MAKEFLAGS: -j 3
-    steps:
-      - checkout
-      - run: *run_build
-      - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
-      - gitter_notify_failure_unless_pr
+    <<: *steps_build
 
   b_ubu_ubsan_clang: &b_ubu_ubsan_clang
     # This runs a bit faster on large and xlarge but on nightly efficiency matters more.
@@ -792,12 +793,7 @@ jobs:
       CXX: clang++
       CMAKE_OPTIONS: -DSANITIZE=undefined
       MAKEFLAGS: -j 3
-    steps:
-      - checkout
-      - run: *run_build
-      - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
-      - gitter_notify_failure_unless_pr
+    <<: *steps_build
 
   b_ubu_release: &b_ubu_release
     <<: *b_ubu
@@ -949,7 +945,7 @@ jobs:
             - build/test/tools/solfuzzer
       - gitter_notify_failure_unless_pr
 
-  t_osx_soltest:
+  t_osx_soltest: &t_osx_soltest
     <<: *base_osx
     environment:
       EVM: << pipeline.parameters.evm-version >>
@@ -957,11 +953,9 @@ jobs:
       TERM: xterm
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-      - attach_workspace:
-          at: .
+      - when:
+          condition: true
+          <<: *steps_install_dependencies_osx
       - run: *run_soltest
       - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
@@ -971,11 +965,9 @@ jobs:
     <<: *base_osx
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-      - attach_workspace:
-          at: .
+      - when:
+          condition: true
+          <<: *steps_install_dependencies_osx
       - run: *run_cmdline_tests
       - store_artifacts: *artifacts_test_results
       - gitter_notify_failure_unless_pr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,8 @@ defaults:
         - checkout
         - run: *run_build
         - store_artifacts: *artifacts_solc
+        - store_artifacts: *artifact_solidity_upgrade
+        - store_artifacts: *artifact_yul_phaser
         - persist_to_workspace: *artifacts_executables
         - gitter_notify_failure_unless_pr
 
@@ -747,14 +749,7 @@ jobs:
     # this runs 2x faster on xlarge but takes 4x more resources (compared to medium).
     # Enough other jobs depend on it that it's worth it though.
     <<: *base_ubuntu2004_xlarge
-    steps:
-      - checkout
-      - run: *run_build
-      - store_artifacts: *artifacts_solc
-      - store_artifacts: *artifact_solidity_upgrade
-      - store_artifacts: *artifact_yul_phaser
-      - persist_to_workspace: *artifacts_executables
-      - gitter_notify_failure_unless_pr
+    <<: *steps_build
 
   # x64 ASAN build, for testing for memory related bugs
   b_ubu_asan: &b_ubu_asan


### PR DESCRIPTION
Implements part of #11846.

> This PR is in continuation to #11868 (i.e. contains changes made in the mentioned PR)

Deduplication
- `steps_b_ubu` template has been created amongst Test Templates (Line 163), to store the steps duplicated in `b_ubu_asan`, `b_ubu_clang`, `b_ubu_asan_clang` and `b_ubu_ubsan_clang`.
- `b_ubu_clang` has been used as the alias in `b_ubu_asan_clang` and `b_ubu_ubsan_clang`, in order to deduplicate the steps, while overriding and merging necessary discrepancies.
- `test_osx` template has been created amongst Test Templates (Line 195), to store the commands duplicated in `t_osx_soltest` and `t_osx_cli`.