### PR TITLE
docs: delete stale note about reading code

### DIFF
--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -35,9 +35,9 @@ Example
 -------
 
 The following example provides library code to access the code of another contract and
-load it into a ``bytes`` variable. This is not possible with "plain Solidity" and the
-idea is that reusable assembly libraries can enhance the Solidity language
-without a compiler change.
+load it into a ``bytes`` variable. This is possible with "plain Solidity" too, by using
+``<address>.code``. But the point here is that reusable assembly libraries can enhance the
+Solidity language without a compiler change.
 
 .. code-block:: solidity
 


### PR DESCRIPTION
As per the docs on [Members of Address Types](https://docs.soliditylang.org/en/v0.8.7/units-and-global-variables.html#members-of-address-types), it is now possible to read the code of a contract using high-level Solidity.