### PR TITLE
Resolving Keccak-256: check if arguments are identifiers early.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Compiler Features:
  * SMTChecker: Add constraints to better correlate ``address(this).balance`` and ``msg.value``.
  * SMTChecker: Support the ``value`` option for external function calls.
  * Commandline Interface: Disallowed the ``--experimental-via-ir`` option to be used with Standard Json, Assembler and Linker modes.
+ * Yul Optimizer: Fix a crash in LoadResolver, when ``keccak256`` has particular non-identifier arguments.
 
 
 Bugfixes:

--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -97,6 +97,13 @@ void LoadResolver::tryEvaluateKeccak(
 	std::vector<Expression> const& _arguments
 )
 {
+	yulAssert(_arguments.size() == 2, "");
+	Identifier const* memoryKey = std::get_if<Identifier>(&_arguments.at(0));
+	Identifier const* length = std::get_if<Identifier>(&_arguments.at(1));
+
+	if (!memoryKey || !length)
+		return;
+
 	// The costs are only correct for hashes of 32 bytes or 1 word (when rounded up).
 	GasMeter gasMeter{
 		dynamic_cast<EVMDialect const&>(m_dialect),
@@ -120,13 +127,6 @@ void LoadResolver::tryEvaluateKeccak(
 	// `costOfLiteral = 7200` and `costOfKeccak = 9000` for runtime context.
 	// For creation context: `costOfLiteral = 531` and `costOfKeccak = 90`.
 	if (costOfLiteral > costOfKeccak)
-		return;
-
-	yulAssert(_arguments.size() == 2, "");
-	Identifier const* memoryKey = std::get_if<Identifier>(&_arguments.at(0));
-	Identifier const* length = std::get_if<Identifier>(&_arguments.at(1));
-
-	if (!memoryKey || !length)
 		return;
 
 	auto memoryValue = util::valueOrNullptr(m_memory, memoryKey->name);

--- a/test/libyul/yulOptimizerTests/loadResolver/keccak_crash.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/keccak_crash.yul
@@ -1,0 +1,13 @@
+// This test used to crash: https://github.com/ethereum/solidity/issues/11801
+{
+  for {} addmod(keccak256(0x0,create(0x0, 0x0, 0x0)), 0x0, 0x0) {} {}
+}
+// ----
+// step: loadResolver
+//
+// {
+//     for { }
+//     addmod(keccak256(0x0, create(0x0, 0x0, 0x0)), 0x0, 0x0)
+//     { }
+//     { }
+// }


### PR DESCRIPTION
Previously, the check on whether the optimization was useful gas wise was done before checking if
the keccak256 opcode had identifier as arguments. Since the gas meter crashes when encountering
certain Yul opcodes (create2, dataoffset, etc.), this optimizer step crashed.

Closes https://github.com/ethereum/solidity/issues/11803 and https://github.com/ethereum/solidity/issues/11801