### PR TITLE
Don't try to remove `soljson.js` after running `npm install` in cloned `solc-js` repo

### DIFF
--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -109,7 +109,6 @@ cd "$tmp_dir"
 git clone https://github.com/ethereum/solc-js.git "$solcjs_dir"
 cd "$solcjs_dir"
 npm install
-rm soljson.js
 
 cd "${solc_bin_dir}/${platform}/"
 echo "Commit range: ${base_ref}..${top_ref}"


### PR DESCRIPTION
After https://github.com/ethereum/solc-js/pull/542 `npm install` in solc-js no longer automatically downloads the compiler binary. This is good but the PR check from solc-bin needs to be updated not to try to remove it.

This is the cause of CI failures in https://github.com/ethereum/solc-bin/pull/97.