### PR TITLE
Template code for disallowing options in input modes that do not support them (handles `--error-recovery`)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ Bugfixes:
  * Commandline Interface: Fix extra newline character being appended to sources passed through standard input, affecting their hashes.
  * Commandline Interface: Report output selection options unsupported by the selected input mode instead of ignoring them.
  * Commandline Interface: Don't return zero exit code when writing linked files to disk fails.
+ * Commandline Interface: Disallow ``--error-recovery`` option outside of the compiler mode.
  * SMTChecker: Fix internal error in magic type access (``block``, ``msg``, ``tx``).
  * TypeChecker: Fix internal error when using user defined value types in public library functions.
  * Yul IR Generator: Do not output empty switches/if-bodies for empty contracts.

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -898,13 +898,21 @@ bool CommandLineParser::processArgs()
 	else
 		m_options.input.mode = InputMode::Compiler;
 
-	if (
-		m_args.count(g_strExperimentalViaIR) > 0 &&
-		m_options.input.mode != InputMode::Compiler &&
-		m_options.input.mode != InputMode::CompilerWithASTImport
-	)
+	map<string, set<InputMode>> validOptionInputModeCombinations = {
+		// TODO: This should eventually contain all options.
+		{g_strErrorRecovery, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strExperimentalViaIR, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+	};
+	vector<string> invalidOptionsForCurrentInputMode;
+	for (auto const& [optionName, inputModes]: validOptionInputModeCombinations)
 	{
-		serr() << "The option --" << g_strExperimentalViaIR << " is only supported in the compiler mode." << endl;
+		if (m_args.count(optionName) > 0 && inputModes.count(m_options.input.mode) == 0)
+			invalidOptionsForCurrentInputMode.push_back(optionName);
+	}
+
+	if (!invalidOptionsForCurrentInputMode.empty())
+	{
+		serr() << "The following options are not supported in the current input mode: " << joinOptionNames(invalidOptionsForCurrentInputMode) << endl;
 		return false;
 	}
 


### PR DESCRIPTION
I have disallowed `--error-recovery` option with input modes Standard json, Assembly and Linker modes. Also this is a template for all the other invalid options mentioned in the issue #11629.