### PR TITLE
More generic source location parsing + more errors

### DIFF
--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -131,7 +131,8 @@ void Parser::fetchSourceLocationFromComment()
 		return;
 
 	static regex const lineRE = std::regex(
-		R"~~~((^|\s*)@src\s+(-1|\d+):(-1|\d+):(-1|\d+)(\s+|$))~~~",
+		R"~~(\s*@src\s+)~~"                           // tag: @src
+		R"~~((-1|\d+):(-1|\d+):(-1|\d+)(?:\s+|$))~~", // index and location, e.g.: 1:234:-1
 		std::regex_constants::ECMAScript | std::regex_constants::optimize
 	);
 
@@ -141,11 +142,11 @@ void Parser::fetchSourceLocationFromComment()
 
 	for (auto const& matchResult: ranges::make_subrange(from, to))
 	{
-		solAssert(matchResult.size() == 6, "");
+		solAssert(matchResult.size() == 4, "");
 
-		auto const sourceIndex = toInt(matchResult[2].str());
-		auto const start = toInt(matchResult[3].str());
-		auto const end = toInt(matchResult[4].str());
+		auto const sourceIndex = toInt(matchResult[1].str());
+		auto const start = toInt(matchResult[2].str());
+		auto const end = toInt(matchResult[3].str());
 
 		auto const commentLocation = m_scanner->currentCommentLocation();
 		m_debugDataOverride = DebugData::create();

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -131,7 +131,7 @@ void Parser::fetchSourceLocationFromComment()
 		return;
 
 	static regex const tagRegex = regex(
-		R"~~(\s*(@[a-zA-Z0-9\-_]+)(?:\s+|$))~~",       // tag, e.g: @src
+		R"~~((?:^|\s+)(@[a-zA-Z0-9\-_]+)(?:\s+|$))~~", // tag, e.g: @src
 		regex_constants::ECMAScript | regex_constants::optimize
 	);
 	static regex const srcTagArgsRegex = regex(

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -194,6 +194,7 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
         "9804", # Tested in test/libyul/ObjectParser.cpp.
         "2674",
         "6367",
+        "8387",
         "3805", # "This is a pre-release compiler version, please do not use it in production."
                 # The warning may or may not exist in a compiler build.
         "4591", # "There are more than 256 warnings. Ignoring the rest."

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -516,7 +516,10 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_suffix)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result && errorList.size() == 0);
+	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(errorList.size() == 1);
+	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
+	BOOST_TEST(errorList[0]->errorId() == 8387_error);
 	CHECK_LOCATION(result->debugData->location, "", -1, -1);
 }
 
@@ -558,7 +561,10 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_non_integer)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result && errorList.size() == 0);
+	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(errorList.size() == 1);
+	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
+	BOOST_TEST(errorList[0]->errorId() == 8387_error);
 	CHECK_LOCATION(result->debugData->location, "", -1, -1);
 }
 
@@ -611,8 +617,11 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_no_whitespace)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source1", 333, 444);
+	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(errorList.size() == 1);
+	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
+	BOOST_TEST(errorList[0]->errorId() == 8387_error);
+	CHECK_LOCATION(result->debugData->location, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_leading_trailing_whitespace)

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -534,7 +534,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_prefix)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 111, 222);
+	CHECK_LOCATION(result->debugData->location, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_unspecified)

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -44,6 +44,9 @@ using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::langutil;
 
+BOOST_TEST_DONT_PRINT_LOG_VALUE(ErrorId)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(Error::Type)
+
 namespace solidity::yul::test
 {
 
@@ -165,7 +168,7 @@ BOOST_AUTO_TEST_CASE(default_types_set)
 		EVMDialectTyped::instance(EVMVersion{}),
 		reporter
 	);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
 	// Use no dialect so that all types are printed.
 	// This tests that the default types are properly assigned.
@@ -210,7 +213,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_empty_block)
 		"{}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
 }
 
@@ -251,7 +254,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_different_sources)
 		"}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
 	BOOST_REQUIRE_EQUAL(3, result->statements.size());
 	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 234, 543);
@@ -273,7 +276,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_nested)
 		"}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
 	CHECK_LOCATION(locationOf(result->statements.at(1)), "source0", 343, 434);
@@ -297,7 +300,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_switch_case)
 		"}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
 
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
@@ -329,7 +332,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_inherit_into_outer_scope)
 		"}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
 	CHECK_LOCATION(result->debugData->location, "source0", 1, 100);
 
@@ -360,7 +363,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_assign_empty)
 		"}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result); // should still parse
+	BOOST_REQUIRE(!!result && errorList.size() == 0); // should still parse
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
 	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 123, 432);
 	CHECK_LOCATION(locationOf(result->statements.at(1)), "source1", 1, 10);
@@ -382,6 +385,9 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_source_index)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result); // should still parse
+	BOOST_REQUIRE(errorList.size() == 1);
+	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
+	BOOST_TEST(errorList[0]->errorId() == 2674_error);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_1)
@@ -398,7 +404,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_1)
 		"}\n";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
 	BOOST_REQUIRE_EQUAL(1, result->statements.size());
 	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 123, 432);
@@ -421,7 +427,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_2)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(1, result->statements.size());
 	CHECK_LOCATION(result->debugData->location, "source0", 0, 5);
 
@@ -455,7 +461,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_3)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
 	CHECK_LOCATION(result->debugData->location, "source1", 23, 45);
 
@@ -491,7 +497,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_comments_after_valid)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(1, result->statements.size());
 	CHECK_LOCATION(result->debugData->location, "source1", 23, 45);
 
@@ -510,7 +516,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_suffix)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->debugData->location, "", -1, -1);
 }
 
@@ -524,7 +530,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_unspecified)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->debugData->location, "", -1, -1);
 }
 
@@ -542,7 +548,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_ensure_last_match)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
 
@@ -563,7 +569,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_reference_original_sloc)
 	)";
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
-	BOOST_REQUIRE(!!result);
+	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
 


### PR DESCRIPTION
~Depends on #11915.~ Merged.

This is the refactor requested in https://github.com/ethereum/solidity/pull/11867#discussion_r701143568 and a bunch of other small tweaks that apply generally to `@src` tags even without code snippets.

- `Parser` tests were not checking for errors reported during parsing.
- A few more tests for corner cases related to whitespace.
- More general parsing. Tags are found first and then for each tag parameters are parsed separately.
    - This allows us to report an error in cases where the invalid tags were just being ignored until now. Note that this part is not strictly a refactor since it changes error behavior.