### PR TITLE
Clarify `block.*` and `tx.*` values in off-chain calls

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -131,6 +131,12 @@ Global Variables
 - ``type(T).max`` (``T``): the maximum value representable by the integer type ``T``, see :ref:`Type Information<meta-type>`.
 
 .. note::
+    When contracts are evaluated off-chain rather than in context of a transaction included in a
+    block, you should not assume that ``block.*`` and ``tx.*`` refer to values from any specific
+    block or transaction. These values are provided by the EVM implementation that executes the
+    contract and can be arbitrary.
+
+.. note::
     Do not rely on ``block.timestamp`` or ``blockhash`` as a source of randomness,
     unless you know what you are doing.
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -93,6 +93,12 @@ Block and Transaction Properties
     This includes calls to library functions.
 
 .. note::
+    When contracts are evaluated off-chain rather than in context of a transaction included in a
+    block, you should not assume that ``block.*`` and ``tx.*`` refer to values from any specific
+    block or transaction. These values are provided by the EVM implementation that executes the
+    contract and can be arbitrary.
+
+.. note::
     Do not rely on ``block.timestamp`` or ``blockhash`` as a source of randomness,
     unless you know what you are doing.
 


### PR DESCRIPTION
Looks like this may vary between different EVM implementations and confuses users.