### PR TITLE
Adjust Colors for the Solidity Docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,14 +1,14 @@
 pre {
-  white-space: pre-wrap;       /* css-3 */
-  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-  white-space: -pre-wrap;      /* Opera 4-6 */
-  white-space: -o-pre-wrap;    /* Opera 7 */
-  word-wrap: break-word;
+    white-space: pre-wrap;       /* css-3 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;
 }
 
 .wy-table-responsive table td, .wy-table-responsive table th {
-  white-space: normal;
+    white-space: normal;
 }
 .rst-content table.docutils td {
-  vertical-align: top;
+    vertical-align: top;
 }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -12,3 +12,37 @@ pre {
 .rst-content table.docutils td {
     vertical-align: top;
 }
+
+/* links */
+.rst-content a:not(:visited) {
+    color: #002fa7;
+}
+
+.rst-content .highlighted {
+    background: #eac545;
+}
+
+/* code block highlights */
+.rst-content pre {
+    background: #fafafa;
+}
+
+.wy-side-nav-search img.logo {
+    width: 100px !important;
+    padding: 0;
+}
+
+.wy-side-nav-search > a {
+    padding: 0;
+    margin: 0;
+}
+
+/* project version (displayed under project logo) */
+.wy-side-nav-search .version {
+    color: #272525 !important;
+}
+
+/* menu section headers */
+.wy-menu .caption {
+    color: #65afff !important;
+}

--- a/docs/_static/css/dark.css
+++ b/docs/_static/css/dark.css
@@ -1,10 +1,8 @@
 /* links */
 
-a,
-a:visited {
-    color: #aaddff;
+.rst-content a:not(:visited) {
+    color: #aaddff !important;
 }
-
 
 /* code directives */
 
@@ -46,6 +44,9 @@ em.property {
     background-color: #5a5a5a;
 }
 
+.rst-content pre {
+    background: none;
+}
 
 /* inlined code highlights */
 
@@ -70,6 +71,12 @@ code.docutils.literal.notranslate {
     color: #ddd;
 }
 
+/* highlight color search text */
+
+.rst-content .highlighted {
+    background: #ff5722;
+    box-shadow: 0 0 0 2px #f0978b;
+}
 
 /* notes, warnings, hints */
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,6 +1,6 @@
 {% extends "!layout.html" %}
 
-  {% block menu %}
+{% block menu %}
     {{ super() }}
-	<a href="{{ pathto('genindex') }}">Keyword Index</a>
-  {% endblock %}
+    <a href="{{ pathto('genindex') }}">Keyword Index</a>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -238,7 +238,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-        ('index', 'solidity.tex', 'Solidity Documentation', 'Ethereum', 'manual'),
+    ('index', 'solidity.tex', 'Solidity Documentation', 'Ethereum', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,11 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    'logo_only': True,
+    'style_nav_header_background': '#65afff',
+    'display_version': True,
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -142,7 +146,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+html_logo = "logo.svg"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,6 @@
 Solidity
 ========
 
-.. image:: logo.svg
-    :width: 120px
-    :alt: Solidity logo
-    :align: center
-
 Solidity is an object-oriented, high-level language for implementing smart
 contracts. Smart contracts are programs which govern the behaviour of accounts
 within the Ethereum state.


### PR DESCRIPTION
Made the following changes in this PR  (#11900): 

- [x] Add custom CSS file called "light.css" with the color changes as follows:
- Make code block background Solidity light grey: #E5E5E5
- Make titles / highlights Solidity light blue: #65AFFF
- Make hyperlinks Solidity electric blue: #002fa7
- Make highlights for searched words warmer yellow: #EAC545

- [x] In the dark mode CSS file, adjust the search highlight color to be soft red: #F0978B (yellow is currently not readable)
- [x] [optional] Add Solidity logo in the menu bar and delete logo from the index page
- [ ] [optional] Adjust font to Work Sans to be consistent with the font across blog, portal and docs