### PR TITLE
Docker: Update ossfuzz docker image

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -33,7 +33,7 @@ RUN apt-get update; \
 		ninja-build git wget \
 		libbz2-dev zlib1g-dev git curl uuid-dev \
 		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4; \
-    apt-get install -qy python3-pip sphinx-doc sphinx-common;
+    apt-get install -qy python3-pip;
 
 # Install cmake 3.21.2 (minimum requirement is cmake 3.10)
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.sh; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with solidity.  If not, see <http://www.gnu.org/licenses/>
 #
-# (c) 2016-2019 solidity contributors.
+# (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang as base
 LABEL version="12"

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -33,7 +33,7 @@ RUN apt-get update; \
 		ninja-build git wget \
 		libbz2-dev zlib1g-dev git curl uuid-dev \
 		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4; \
-    apt-get install -qy python-pip python-sphinx;
+    apt-get install -qy python3-pip sphinx-doc sphinx-common;
 
 # Install cmake 3.21.2 (minimum requirement is cmake 3.10)
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.sh; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang as base
-LABEL version="11"
+LABEL version="12"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -35,10 +35,11 @@ RUN apt-get update; \
 		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4; \
     apt-get install -qy python-pip python-sphinx;
 
-# Install cmake 3.14 (minimum requirement is cmake 3.10)
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.sh; \
-    chmod +x cmake-3.14.5-Linux-x86_64.sh; \
-    ./cmake-3.14.5-Linux-x86_64.sh --skip-license --prefix="/usr"
+# Install cmake 3.21.2 (minimum requirement is cmake 3.10)
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.sh; \
+    test "$(sha256sum cmake-3.21.2-Linux-x86_64.sh)" = "3310362c6fe4d4b2dc00823835f3d4a7171bbd73deb7d059738494761f1c908c  cmake-3.21.2-Linux-x86_64.sh"; \
+    chmod +x cmake-3.21.2-Linux-x86_64.sh; \
+    ./cmake-3.21.2-Linux-x86_64.sh --skip-license --prefix="/usr"
 
 FROM base AS libraries
 
@@ -92,7 +93,7 @@ RUN set -ex; \
 # EVMONE
 RUN set -ex; \
 	cd /usr/src; \
-	git clone --branch="v0.8.0" --recurse-submodules https://github.com/ethereum/evmone.git; \
+	git clone --branch="v0.8.2" --recurse-submodules https://github.com/ethereum/evmone.git; \
 	cd evmone; \
 	mkdir build; \
 	cd build; \


### PR DESCRIPTION
The update does the following
  - pulls in clang-14 that is currently used by ossfuzz
  - updates cmake
  - updates evmone (in order to fix https://github.com/ethereum/evmone/issues/373)