### PR TITLE
cmake: Remove stdlib compile option for Solidity build.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -102,14 +102,6 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 
 		# Some Linux-specific Clang settings.  We don't want these for OS X.
 		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-
-			# TODO - Is this even necessary?  Why?
-			# See http://stackoverflow.com/questions/19774778/when-is-it-necessary-to-use-use-the-flag-stdlib-libstdc.
-			add_compile_options(-stdlib=libstdc++)
-
-			# Tell Boost that we're using Clang's libc++.   Not sure exactly why we need to do.
-			add_definitions(-DBOOST_ASIO_HAS_CLANG_LIBCXX)
-
 			# Use fancy colors in the compiler diagnostics
 			add_compile_options(-fcolor-diagnostics)
 


### PR DESCRIPTION
I'm not sure why we were force setting `-stdlib`. This creates a problem for the fuzzer build that actually uses `libc++`. I'm not sure why the setting being present wasn't a problem for the fuzzer previously. It may have something to do with how clang-14 processes command line options.

Anyway, I don't think removing the said flag is otherwise harmful.