### PR TITLE
Use locationOf helper instead of accessing debugData directly.

### DIFF
--- a/libyul/AST.h
+++ b/libyul/AST.h
@@ -83,32 +83,28 @@ struct Continue { std::shared_ptr<DebugData const> debugData; };
 /// Leave statement (valid within function)
 struct Leave { std::shared_ptr<DebugData const> debugData; };
 
-struct LocationExtractor
-{
-	template <class T> langutil::SourceLocation operator()(T const& _node) const
-	{
-		return _node.debugData ? _node.debugData->location : langutil::SourceLocation{};
-	}
-};
-
 /// Extracts the source location from a Yul node.
 template <class T> inline langutil::SourceLocation locationOf(T const& _node)
 {
-	return std::visit(LocationExtractor(), _node);
+	return _node.debugData ? _node.debugData->location : langutil::SourceLocation{};
 }
 
-struct DebugDataExtractor
+/// Extracts the source location from a Yul node.
+template <class... Args> inline langutil::SourceLocation locationOf(std::variant<Args...> const& _node)
 {
-	template <class T> std::shared_ptr<DebugData const> const& operator()(T const& _node) const
-	{
-		return _node.debugData;
-	}
-};
+	return std::visit([](auto const& _arg) { return locationOf(_arg); }, _node);
+}
 
 /// Extracts the debug data from a Yul node.
-template <class T> inline std::shared_ptr<DebugData const> const& debugDataOf(T const& _node)
+template <class T> inline std::shared_ptr<DebugData const> debugDataOf(T const& _node)
 {
-	return std::visit(DebugDataExtractor(), _node);
+	return _node.debugData;
+}
+
+/// Extracts the debug data from a Yul node.
+template <class... Args> inline std::shared_ptr<DebugData const> debugDataOf(std::variant<Args...> const& _node)
+{
+	return std::visit([](auto const& _arg) { return debugDataOf(_arg); }, _node);
 }
 
 }

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -33,7 +33,7 @@ namespace solidity::yul
 
 Json::Value AsmJsonConverter::operator()(Block const& _node) const
 {
-	Json::Value ret = createAstNode(_node.debugData->location, "YulBlock");
+	Json::Value ret = createAstNode(locationOf(_node), "YulBlock");
 	ret["statements"] = vectorOfVariantsToJson(_node.statements);
 	return ret;
 }
@@ -41,7 +41,7 @@ Json::Value AsmJsonConverter::operator()(Block const& _node) const
 Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid variable name.");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulTypedName");
+	Json::Value ret = createAstNode(locationOf(_node), "YulTypedName");
 	ret["name"] = _node.name.str();
 	ret["type"] = _node.type.str();
 	return ret;
@@ -49,7 +49,7 @@ Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Literal const& _node) const
 {
-	Json::Value ret = createAstNode(_node.debugData->location, "YulLiteral");
+	Json::Value ret = createAstNode(locationOf(_node), "YulLiteral");
 	switch (_node.kind)
 	{
 	case LiteralKind::Number:
@@ -76,7 +76,7 @@ Json::Value AsmJsonConverter::operator()(Literal const& _node) const
 Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid identifier");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulIdentifier");
+	Json::Value ret = createAstNode(locationOf(_node), "YulIdentifier");
 	ret["name"] = _node.name.str();
 	return ret;
 }
@@ -84,7 +84,7 @@ Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
 Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
 {
 	yulAssert(_node.variableNames.size() >= 1, "Invalid assignment syntax");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulAssignment");
+	Json::Value ret = createAstNode(locationOf(_node), "YulAssignment");
 	for (auto const& var: _node.variableNames)
 		ret["variableNames"].append((*this)(var));
 	ret["value"] = _node.value ? std::visit(*this, *_node.value) : Json::nullValue;
@@ -93,7 +93,7 @@ Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
 
 Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
 {
-	Json::Value ret = createAstNode(_node.debugData->location, "YulFunctionCall");
+	Json::Value ret = createAstNode(locationOf(_node), "YulFunctionCall");
 	ret["functionName"] = (*this)(_node.functionName);
 	ret["arguments"] = vectorOfVariantsToJson(_node.arguments);
 	return ret;
@@ -101,14 +101,14 @@ Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
 
 Json::Value AsmJsonConverter::operator()(ExpressionStatement const& _node) const
 {
-	Json::Value ret = createAstNode(_node.debugData->location, "YulExpressionStatement");
+	Json::Value ret = createAstNode(locationOf(_node), "YulExpressionStatement");
 	ret["expression"] = std::visit(*this, _node.expression);
 	return ret;
 }
 
 Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
 {
-	Json::Value ret = createAstNode(_node.debugData->location, "YulVariableDeclaration");
+	Json::Value ret = createAstNode(locationOf(_node), "YulVariableDeclaration");
 	for (auto const& var: _node.variables)
 		ret["variables"].append((*this)(var));
 
@@ -120,7 +120,7 @@ Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
 Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid function name.");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulFunctionDefinition");
+	Json::Value ret = createAstNode(locationOf(_node), "YulFunctionDefinition");
 	ret["name"] = _node.name.str();
 	for (auto const& var: _node.parameters)
 		ret["parameters"].append((*this)(var));
@@ -133,7 +133,7 @@ Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
 Json::Value AsmJsonConverter::operator()(If const& _node) const
 {
 	yulAssert(_node.condition, "Invalid if condition.");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulIf");
+	Json::Value ret = createAstNode(locationOf(_node), "YulIf");
 	ret["condition"] = std::visit(*this, *_node.condition);
 	ret["body"] = (*this)(_node.body);
 	return ret;
@@ -142,7 +142,7 @@ Json::Value AsmJsonConverter::operator()(If const& _node) const
 Json::Value AsmJsonConverter::operator()(Switch const& _node) const
 {
 	yulAssert(_node.expression, "Invalid expression pointer.");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulSwitch");
+	Json::Value ret = createAstNode(locationOf(_node), "YulSwitch");
 	ret["expression"] = std::visit(*this, *_node.expression);
 	for (auto const& var: _node.cases)
 		ret["cases"].append((*this)(var));
@@ -151,7 +151,7 @@ Json::Value AsmJsonConverter::operator()(Switch const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Case const& _node) const
 {
-	Json::Value ret = createAstNode(_node.debugData->location, "YulCase");
+	Json::Value ret = createAstNode(locationOf(_node), "YulCase");
 	ret["value"] = _node.value ? (*this)(*_node.value) : "default";
 	ret["body"] = (*this)(_node.body);
 	return ret;
@@ -160,7 +160,7 @@ Json::Value AsmJsonConverter::operator()(Case const& _node) const
 Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
 {
 	yulAssert(_node.condition, "Invalid for loop condition.");
-	Json::Value ret = createAstNode(_node.debugData->location, "YulForLoop");
+	Json::Value ret = createAstNode(locationOf(_node), "YulForLoop");
 	ret["pre"] = (*this)(_node.pre);
 	ret["condition"] = std::visit(*this, *_node.condition);
 	ret["post"] = (*this)(_node.post);
@@ -170,17 +170,17 @@ Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Break const& _node) const
 {
-	return createAstNode(_node.debugData->location, "YulBreak");
+	return createAstNode(locationOf(_node), "YulBreak");
 }
 
 Json::Value AsmJsonConverter::operator()(Continue const& _node) const
 {
-	return createAstNode(_node.debugData->location, "YulContinue");
+	return createAstNode(locationOf(_node), "YulContinue");
 }
 
 Json::Value AsmJsonConverter::operator()(Leave const& _node) const
 {
-	return createAstNode(_node.debugData->location, "YulLeave");
+	return createAstNode(locationOf(_node), "YulLeave");
 }
 
 Json::Value AsmJsonConverter::createAstNode(langutil::SourceLocation const& _location, string _nodeType) const

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -52,7 +52,7 @@ shared_ptr<DebugData const> updateLocationEndFrom(
 	langutil::SourceLocation const& _location
 )
 {
-	SourceLocation updatedLocation = _debugData->location;
+	SourceLocation updatedLocation = _debugData ? _debugData->location : langutil::SourceLocation{};
 	updatedLocation.end = _location.end;
 	return make_shared<DebugData const>(updatedLocation);
 }
@@ -195,7 +195,7 @@ Statement Parser::parseStatement()
 		_if.condition = make_unique<Expression>(parseExpression());
 		_if.body = parseBlock();
 		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			_if.debugData = updateLocationEndFrom(_if.debugData, _if.body.debugData->location);
+			_if.debugData = updateLocationEndFrom(_if.debugData, locationOf(_if.body));
 		return Statement{move(_if)};
 	}
 	case Token::Switch:
@@ -214,7 +214,7 @@ Statement Parser::parseStatement()
 		if (_switch.cases.empty())
 			fatalParserError(2418_error, "Switch statement without any cases.");
 		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			_switch.debugData = updateLocationEndFrom(_switch.debugData, _switch.cases.back().body.debugData->location);
+			_switch.debugData = updateLocationEndFrom(_switch.debugData, locationOf(_switch.cases.back().body));
 		return Statement{move(_switch)};
 	}
 	case Token::For:
@@ -328,7 +328,7 @@ Case Parser::parseCase()
 		yulAssert(false, "Case or default case expected.");
 	_case.body = parseBlock();
 	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		_case.debugData = updateLocationEndFrom(_case.debugData, _case.body.debugData->location);
+		_case.debugData = updateLocationEndFrom(_case.debugData, locationOf(_case.body));
 	return _case;
 }
 
@@ -349,7 +349,7 @@ ForLoop Parser::parseForLoop()
 	m_currentForLoopComponent = ForLoopComponent::ForLoopBody;
 	forLoop.body = parseBlock();
 	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		forLoop.debugData = updateLocationEndFrom(forLoop.debugData, forLoop.body.debugData->location);
+		forLoop.debugData = updateLocationEndFrom(forLoop.debugData, locationOf(forLoop.body));
 
 	m_currentForLoopComponent = outerForLoopComponent;
 
@@ -369,7 +369,7 @@ Expression Parser::parseExpression()
 			if (m_dialect.builtin(_identifier.name))
 				fatalParserError(
 					7104_error,
-					_identifier.debugData->location,
+					locationOf(_identifier),
 					"Builtin function \"" + _identifier.name.str() + "\" must be called."
 				);
 			return move(_identifier);
@@ -465,7 +465,7 @@ VariableDeclaration Parser::parseVariableDeclaration()
 			varDecl.debugData = updateLocationEndFrom(varDecl.debugData, locationOf(*varDecl.value));
 	}
 	else if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		varDecl.debugData = updateLocationEndFrom(varDecl.debugData, varDecl.variables.back().debugData->location);
+		varDecl.debugData = updateLocationEndFrom(varDecl.debugData, locationOf(varDecl.variables.back()));
 
 	return varDecl;
 }
@@ -512,7 +512,7 @@ FunctionDefinition Parser::parseFunctionDefinition()
 	funDef.body = parseBlock();
 	m_insideFunction = preInsideFunction;
 	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		funDef.debugData = updateLocationEndFrom(funDef.debugData, funDef.body.debugData->location);
+		funDef.debugData = updateLocationEndFrom(funDef.debugData, locationOf(funDef.body));
 
 	m_currentForLoopComponent = outerForLoopComponent;
 	return funDef;

--- a/libyul/ScopeFiller.cpp
+++ b/libyul/ScopeFiller.cpp
@@ -53,7 +53,7 @@ bool ScopeFiller::operator()(ExpressionStatement const& _expr)
 bool ScopeFiller::operator()(VariableDeclaration const& _varDecl)
 {
 	for (auto const& variable: _varDecl.variables)
-		if (!registerVariable(variable, _varDecl.debugData->location, *m_currentScope))
+		if (!registerVariable(variable, locationOf(_varDecl), *m_currentScope))
 			return false;
 	return true;
 }
@@ -68,7 +68,7 @@ bool ScopeFiller::operator()(FunctionDefinition const& _funDef)
 
 	bool success = true;
 	for (auto const& var: _funDef.parameters + _funDef.returnVariables)
-		if (!registerVariable(var, _funDef.debugData->location, varScope))
+		if (!registerVariable(var, locationOf(_funDef), varScope))
 			success = false;
 
 	if (!(*this)(_funDef.body))
@@ -162,7 +162,7 @@ bool ScopeFiller::registerFunction(FunctionDefinition const& _funDef)
 		//@TODO secondary location
 		m_errorReporter.declarationError(
 			6052_error,
-			_funDef.debugData->location,
+			locationOf(_funDef),
 			"Function name " + _funDef.name.str() + " already taken in this scope."
 		);
 		return false;


### PR DESCRIPTION
We had at least one null pointer dereference detected by nightly CI: https://app.circleci.com/pipelines/github/ethereum/solidity/18848/workflows/75f0fbf6-47ba-4cc1-8ab7-ee0883570fcb/jobs/838283.

This way, even if the idea is that eventually every node always has valid ``debugData`` (which is not the case currently), we can just change the helper to assert that instead of using an empty location as default.

I think this PR covers all occurrences of ``debugData->location`` in ``libyul`` that aren't already specifically guarded.