### PR TITLE
Added a multisource test for UserDefinedValueTypes and imports

### DIFF
--- a/test/libsolidity/semanticTests/userDefinedValueType/multisource.sol
+++ b/test/libsolidity/semanticTests/userDefinedValueType/multisource.sol
@@ -1,0 +1,14 @@
+==== Source: A ====
+type MyInt is int;
+type MyAddress is address;
+==== Source: B ====
+import {MyInt, MyAddress as OurAddress} from "A";
+contract A {
+    function f(int x) external view returns(MyInt) { return MyInt.wrap(x); }
+    function f(address x) external view returns(OurAddress) { return OurAddress.wrap(x); }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(int256): 5 -> 5
+// f(address): 1 -> 1

--- a/test/libsolidity/semanticTests/userDefinedValueType/multisource_module.sol
+++ b/test/libsolidity/semanticTests/userDefinedValueType/multisource_module.sol
@@ -1,0 +1,13 @@
+==== Source: s1.sol ====
+type MyInt is int;
+==== Source: s2.sol ====
+import "s1.sol" as M;
+contract C {
+  function f(int x) public pure returns (M.MyInt) { return M.MyInt.wrap(x); }
+  function g(M.MyInt x) public pure returns (int) { return M.MyInt.unwrap(x); }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(int256): 5 -> 5
+// g(int256): 1 -> 1

--- a/test/libsolidity/syntaxTests/userDefinedValueType/multisource1.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/multisource1.sol
@@ -1,0 +1,10 @@
+==== Source: A ====
+type MyInt is int;
+type MyAddress is address;
+==== Source: B ====
+import {MyAddress as OurAddress} from "A";
+contract A {
+    function f(int x) external view returns(MyInt) { return MyInt.wrap(x); }
+}
+// ----
+// DeclarationError 7920: (B:100-105): Identifier not found or not unique.

--- a/test/libsolidity/syntaxTests/userDefinedValueType/multisource2.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/multisource2.sol
@@ -1,0 +1,10 @@
+==== Source: A ====
+type MyInt is int;
+type MyAddress is address;
+==== Source: B ====
+import {MyAddress as OurAddress} from "A";
+contract A {
+    function f(address x) external view returns(MyAddress) { return MyAddress.wrap(x); }
+}
+// ----
+// DeclarationError 7920: (B:104-113): Identifier not found or not unique.

--- a/test/libsolidity/syntaxTests/userDefinedValueType/multisource3.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/multisource3.sol
@@ -1,0 +1,9 @@
+==== Source: s1.sol ====
+type MyInt is int;
+==== Source: s2.sol ====
+import "s1.sol" as M;
+contract C {
+  function f(int x) public pure returns (M.MyInt) { return M.MyInt.wrap(x); }
+  function g(M.MyInt x) public pure returns (int) { return M.MyInt.unwrap(x); }
+}
+// ----

--- a/test/libsolidity/syntaxTests/userDefinedValueType/multisource4.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/multisource4.sol
@@ -1,0 +1,9 @@
+==== Source: s1.sol ====
+type MyInt is int;
+==== Source: s2.sol ====
+import "s1.sol" as M;
+contract C {
+  function f(int x) public pure returns (MyInt) { return MyInt.wrap(x); }
+}
+// ----
+// DeclarationError 7920: (s2.sol:76-81): Identifier not found or not unique.


### PR DESCRIPTION
Testing if `import {MyType} from "source";` works 

Depends on https://github.com/ethereum/solidity/pull/11965