### PR TITLE
Allow accessing user defined value type members via contract name.

### DIFF
--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -751,6 +751,7 @@ public:
 	Type const* type() const override;
 
 	TypeName const* underlyingType() const { return m_underlyingType.get(); }
+	bool isVisibleViaContractTypeAccess() const override { return true; }
 
 private:
 	/// The name of the underlying type

--- a/test/libsolidity/semanticTests/userDefinedValueType/wrap_unwrap_via_contract_name.sol
+++ b/test/libsolidity/semanticTests/userDefinedValueType/wrap_unwrap_via_contract_name.sol
@@ -1,0 +1,24 @@
+contract C {
+    type T is uint;
+}
+contract D {
+    function f(C.T x) public pure returns(uint) {
+        return C.T.unwrap(x);
+    }
+    function g(uint x) public pure returns(C.T) {
+        return C.T.wrap(x);
+    }
+    function h(uint x) public pure returns(uint) {
+        return f(g(x));
+    }
+    function i(C.T x) public pure returns(C.T) {
+        return g(f(x));
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256): 0x42 -> 0x42
+// g(uint256): 0x42 -> 0x42
+// h(uint256): 0x42 -> 0x42
+// i(uint256): 0x42 -> 0x42

--- a/test/libsolidity/syntaxTests/userDefinedValueType/wrap_unwrap_via_contract_name.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/wrap_unwrap_via_contract_name.sol
@@ -1,0 +1,9 @@
+contract C { type T is uint; }
+library L { type T is uint; }
+interface I { type T is uint; }
+contract D
+{
+    C.T x = C.T.wrap(uint(1));
+    L.T y = L.T.wrap(uint(1));
+    I.T z = I.T.wrap(uint(1));
+}

--- a/test/libsolidity/syntaxTests/userDefinedValueType/wrap_unwrap_via_contract_name_different.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/wrap_unwrap_via_contract_name_different.sol
@@ -1,0 +1,8 @@
+contract C { type T is uint; }
+library L { type T is uint; }
+contract D
+{
+    C.T x = L.T.wrap(uint(1));
+}
+// ----
+// TypeError 7407: (86-103): Type user defined type T is not implicitly convertible to expected type user defined type T.


### PR DESCRIPTION
Seems to be as simple as this, ~~but I'll still add a few semantics tests just to be sure.~~ (added one)
Fixes https://github.com/ethereum/solidity/issues/11955.