### PR TITLE
Fix command-line test filtering via script arguments

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -37,9 +37,11 @@ source "${REPO_ROOT}/scripts/common.sh"
 # shellcheck source=scripts/common_cmdline.sh
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
 
+pushd "${REPO_ROOT}/test/cmdlineTests" > /dev/null
 autoupdate=false
 no_smt=false
 declare -a selected_tests
+declare -a patterns_with_no_matches
 while [[ $# -gt 0 ]]
 do
     case "$1" in
@@ -52,11 +54,25 @@ do
             shift
             ;;
         *)
-            selected_tests+=("$1")
+            matching_tests=$(find . -mindepth 1 -maxdepth 1 -type d -name "$1" | cut --characters 3- | sort)
+
+            if [[ $matching_tests == "" ]]; then
+                patterns_with_no_matches+=("$1")
+                printWarning "No tests matching pattern '$1' found."
+            else
+                # shellcheck disable=SC2206 # We do not support test names containing spaces.
+                selected_tests+=($matching_tests)
+            fi
+
             shift
             ;;
     esac
 done
+
+if (( ${#selected_tests[@]} == 0 && ${#patterns_with_no_matches[@]} == 0 )); then
+    selected_tests=(*)
+fi
+popd > /dev/null
 
 case "$OSTYPE" in
     msys)
@@ -320,7 +336,6 @@ test_solc_behaviour "${0}" "ctx:=/some/remapping/target" "" "" 1 "" "Invalid rem
 printTask "Running general commandline tests..."
 (
     cd "$REPO_ROOT"/test/cmdlineTests/
-    (( ${#selected_tests[@]} > 0 )) || selected_tests=(*)
     for tdir in "${selected_tests[@]}"
     do
         if ! [[ -d $tdir ]]; then

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -85,7 +85,7 @@ case "$OSTYPE" in
         SOLC="${SOLIDITY_BUILD_DIR}/solc/solc"
         ;;
 esac
-echo "${SOLC}"
+echo "Using solc binary at ${SOLC}"
 
 INTERACTIVE=true
 if ! tty -s || [ "$CI" ]


### PR DESCRIPTION
Apparently #11933 broke support for specifying test name pattern in `cmdlineTests.sh`. This went undetected because we don't really use that feature in CI.

Originally patterns worked because we evaluated the whole argument list as the range of the `for` loop in side test dir. Now that we process arguments one by one, `selected_tests+=("$1")` just treats the pattern as a full test name specified verbatim.

The PR also adds a warning when one or more of the specified patterns match no tests.