### PR TITLE
Split Common.h into Numeric.h.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -36,9 +36,11 @@
 
 #include <json/json.h>
 
-#include <fstream>
 #include <range/v3/algorithm/any_of.hpp>
 #include <range/v3/view/enumerate.hpp>
+
+#include <fstream>
+#include <limits>
 
 using namespace std;
 using namespace solidity;
@@ -67,7 +69,7 @@ unsigned Assembly::codeSize(unsigned subTagSize) const
 
 		for (AssemblyItem const& i: m_items)
 			ret += i.bytesRequired(tagSize);
-		if (util::numberEncodingSize(ret) <= tagSize)
+		if (numberEncodingSize(ret) <= tagSize)
 			return static_cast<unsigned>(ret);
 	}
 }
@@ -178,7 +180,7 @@ void Assembly::assemblyStream(ostream& _out, string const& _prefix, StringMap co
 		_out << _prefix << "stop" << endl;
 		for (auto const& i: m_data)
 			if (u256(i.first) >= m_subs.size())
-				_out << _prefix << "data_" << toHex(u256(i.first)) << " " << toHex(i.second) << endl;
+				_out << _prefix << "data_" << toHex(u256(i.first)) << " " << util::toHex(i.second) << endl;
 
 		for (size_t i = 0; i < m_subs.size(); ++i)
 		{
@@ -189,7 +191,7 @@ void Assembly::assemblyStream(ostream& _out, string const& _prefix, StringMap co
 	}
 
 	if (m_auxiliaryData.size() > 0)
-		_out << endl << _prefix << "auxdata: 0x" << toHex(m_auxiliaryData) << endl;
+		_out << endl << _prefix << "auxdata: 0x" << util::toHex(m_auxiliaryData) << endl;
 }
 
 string Assembly::assemblyString(StringMap const& _sourceCodes) const
@@ -309,7 +311,7 @@ Json::Value Assembly::assemblyJSON(map<string, unsigned> const& _sourceIndices) 
 			collection.append(createJsonValue("PUSH data", sourceIndex, i.location().start, i.location().end, toStringInHex(i.data())));
 			break;
 		case VerbatimBytecode:
-			collection.append(createJsonValue("VERBATIM", sourceIndex, i.location().start, i.location().end, toHex(i.verbatimData())));
+			collection.append(createJsonValue("VERBATIM", sourceIndex, i.location().start, i.location().end, util::toHex(i.verbatimData())));
 			break;
 		default:
 			assertThrow(false, InvalidOpcode, "");
@@ -321,7 +323,7 @@ Json::Value Assembly::assemblyJSON(map<string, unsigned> const& _sourceIndices) 
 		Json::Value& data = root[".data"] = Json::objectValue;
 		for (auto const& i: m_data)
 			if (u256(i.first) >= m_subs.size())
-				data[toStringInHex((u256)i.first)] = toHex(i.second);
+				data[toStringInHex((u256)i.first)] = util::toHex(i.second);
 
 		for (size_t i = 0; i < m_subs.size(); ++i)
 		{
@@ -332,7 +334,7 @@ Json::Value Assembly::assemblyJSON(map<string, unsigned> const& _sourceIndices) 
 	}
 
 	if (m_auxiliaryData.size() > 0)
-		root[".auxdata"] = toHex(m_auxiliaryData);
+		root[".auxdata"] = util::toHex(m_auxiliaryData);
 
 	return root;
 }
@@ -596,14 +598,14 @@ LinkerObject const& Assembly::assemble() const
 	multimap<h256, unsigned> dataRef;
 	multimap<size_t, size_t> subRef;
 	vector<unsigned> sizeRef; ///< Pointers to code locations where the size of the program is inserted
-	unsigned bytesPerTag = util::numberEncodingSize(bytesRequiredForCode);
+	unsigned bytesPerTag = numberEncodingSize(bytesRequiredForCode);
 	uint8_t tagPush = static_cast<uint8_t>(pushInstruction(bytesPerTag));
 
 	unsigned bytesRequiredIncludingData = bytesRequiredForCode + 1 + static_cast<unsigned>(m_auxiliaryData.size());
 	for (auto const& sub: m_subs)
 		bytesRequiredIncludingData += static_cast<unsigned>(sub->assemble().bytecode.size());
 
-	unsigned bytesPerDataRef = util::numberEncodingSize(bytesRequiredIncludingData);
+	unsigned bytesPerDataRef = numberEncodingSize(bytesRequiredIncludingData);
 	uint8_t dataRefPush = static_cast<uint8_t>(pushInstruction(bytesPerDataRef));
 	ret.bytecode.reserve(bytesRequiredIncludingData);
 
@@ -620,7 +622,7 @@ LinkerObject const& Assembly::assemble() const
 			break;
 		case Push:
 		{
-			unsigned b = max<unsigned>(1, util::numberEncodingSize(i.data()));
+			unsigned b = max<unsigned>(1, numberEncodingSize(i.data()));
 			ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(b)));
 			ret.bytecode.resize(ret.bytecode.size() + b);
 			bytesRef byr(&ret.bytecode.back() + 1 - b, b);
@@ -650,7 +652,7 @@ LinkerObject const& Assembly::assemble() const
 			assertThrow(i.data() <= numeric_limits<size_t>::max(), AssemblyException, "");
 			auto s = subAssemblyById(static_cast<size_t>(i.data()))->assemble().bytecode.size();
 			i.setPushedValue(u256(s));
-			unsigned b = max<unsigned>(1, util::numberEncodingSize(s));
+			unsigned b = max<unsigned>(1, numberEncodingSize(s));
 			ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(b)));
 			ret.bytecode.resize(ret.bytecode.size() + b);
 			bytesRef byr(&ret.bytecode.back() + 1 - b, b);
@@ -755,7 +757,7 @@ LinkerObject const& Assembly::assemble() const
 		assertThrow(tagId < tagPositions.size(), AssemblyException, "Reference to non-existing tag.");
 		size_t pos = tagPositions[tagId];
 		assertThrow(pos != numeric_limits<size_t>::max(), AssemblyException, "Reference to tag without position.");
-		assertThrow(util::numberEncodingSize(pos) <= bytesPerTag, AssemblyException, "Tag too large for reserved space.");
+		assertThrow(numberEncodingSize(pos) <= bytesPerTag, AssemblyException, "Tag too large for reserved space.");
 		bytesRef r(ret.bytecode.data() + i.first, bytesPerTag);
 		toBigEndian(pos, r);
 	}

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -21,11 +21,13 @@
 #include <libevmasm/Assembly.h>
 
 #include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/FixedHash.h>
 #include <liblangutil/SourceLocation.h>
 
 #include <fstream>
+#include <limits>
 
 using namespace std;
 using namespace solidity;
@@ -71,7 +73,7 @@ size_t AssemblyItem::bytesRequired(size_t _addressLength) const
 	case Tag: // 1 byte for the JUMPDEST
 		return 1;
 	case Push:
-		return 1 + max<size_t>(1, util::numberEncodingSize(data()));
+		return 1 + max<size_t>(1, numberEncodingSize(data()));
 	case PushSubSize:
 	case PushProgramSize:
 		return 1 + 4;		// worst case: a 16MB program
@@ -189,7 +191,7 @@ string AssemblyItem::toAssemblyText(Assembly const& _assembly) const
 		break;
 	}
 	case Push:
-		text = toHex(util::toCompactBigEndian(data(), 1), util::HexPrefix::Add);
+		text = toHex(toCompactBigEndian(data(), 1), util::HexPrefix::Add);
 		break;
 	case PushTag:
 	{
@@ -207,7 +209,7 @@ string AssemblyItem::toAssemblyText(Assembly const& _assembly) const
 		text = string("tag_") + to_string(static_cast<size_t>(data())) + ":";
 		break;
 	case PushData:
-		text = string("data_") + util::toHex(data());
+		text = string("data_") + toHex(data());
 		break;
 	case PushSub:
 	case PushSubSize:
@@ -226,16 +228,16 @@ string AssemblyItem::toAssemblyText(Assembly const& _assembly) const
 		text = string("bytecodeSize");
 		break;
 	case PushLibraryAddress:
-		text = string("linkerSymbol(\"") + util::toHex(data()) + string("\")");
+		text = string("linkerSymbol(\"") + toHex(data()) + string("\")");
 		break;
 	case PushDeployTimeAddress:
 		text = string("deployTimeAddress()");
 		break;
 	case PushImmutable:
-		text = string("immutable(\"") + toHex(util::toCompactBigEndian(data(), 1), util::HexPrefix::Add) + "\")";
+		text = string("immutable(\"") + "0x" + util::toHex(toCompactBigEndian(data(), 1)) + "\")";
 		break;
 	case AssignImmutable:
-		text = string("assignImmutable(\"") + toHex(util::toCompactBigEndian(data(), 1), util::HexPrefix::Add) + "\")";
+		text = string("assignImmutable(\"") + "0x" + util::toHex(toCompactBigEndian(data(), 1)) + "\")";
 		break;
 	case UndefinedItem:
 		assertThrow(false, AssemblyException, "Invalid assembly item.");

--- a/libevmasm/BlockDeduplicator.h
+++ b/libevmasm/BlockDeduplicator.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
+
 
 #include <cstddef>
 #include <vector>

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -133,7 +133,7 @@ bigint LiteralMethod::gasNeeded() const
 	return combineGas(
 		simpleRunGas({Instruction::PUSH1}),
 		// PUSHX plus data
-		(m_params.isCreation ? GasCosts::txDataNonZeroGas(m_params.evmVersion) : GasCosts::createDataGas) + dataGas(util::toCompactBigEndian(m_value, 1)),
+		(m_params.isCreation ? GasCosts::txDataNonZeroGas(m_params.evmVersion) : GasCosts::createDataGas) + dataGas(toCompactBigEndian(m_value, 1)),
 		0
 	);
 }
@@ -146,13 +146,13 @@ bigint CodeCopyMethod::gasNeeded() const
 		// Data gas for copy routines: Some bytes are zero, but we ignore them.
 		bytesRequired(copyRoutine()) * (m_params.isCreation ? GasCosts::txDataNonZeroGas(m_params.evmVersion) : GasCosts::createDataGas),
 		// Data gas for data itself
-		dataGas(util::toBigEndian(m_value))
+		dataGas(toBigEndian(m_value))
 	);
 }
 
 AssemblyItems CodeCopyMethod::execute(Assembly& _assembly) const
 {
-	bytes data = util::toBigEndian(m_value);
+	bytes data = toBigEndian(m_value);
 	assertThrow(data.size() == 32, OptimizerException, "Invalid number encoding.");
 	AssemblyItems actualCopyRoutine = copyRoutine();
 	actualCopyRoutine[4] = _assembly.newData(data);
@@ -192,7 +192,7 @@ AssemblyItems ComputeMethod::findRepresentation(u256 const& _value)
 	if (_value < 0x10000)
 		// Very small value, not worth computing
 		return AssemblyItems{_value};
-	else if (util::numberEncodingSize(~_value) < util::numberEncodingSize(_value))
+	else if (numberEncodingSize(~_value) < numberEncodingSize(_value))
 		// Negated is shorter to represent
 		return findRepresentation(~_value) + AssemblyItems{Instruction::NOT};
 	else

--- a/libevmasm/ControlFlowGraph.h
+++ b/libevmasm/ControlFlowGraph.h
@@ -24,11 +24,13 @@
 
 #pragma once
 
-#include <vector>
-#include <memory>
 #include <libsolutil/Common.h>
 #include <libsolutil/Assertions.h>
 #include <libevmasm/ExpressionClasses.h>
+
+#include <vector>
+#include <memory>
+#include <limits>
 
 namespace solidity::evmasm
 {

--- a/libevmasm/ExpressionClasses.cpp
+++ b/libevmasm/ExpressionClasses.cpp
@@ -29,6 +29,7 @@
 
 #include <functional>
 #include <tuple>
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libevmasm/Inliner.cpp
+++ b/libevmasm/Inliner.cpp
@@ -36,7 +36,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <optional>
-
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -25,6 +25,7 @@
 #include <libevmasm/Exceptions.h>
 #include <libsolutil/Common.h>
 #include <libsolutil/Assertions.h>
+#include <libsolutil/Numeric.h>
 #include <functional>
 
 namespace solidity::evmasm
@@ -301,7 +302,7 @@ bool isValidInstruction(Instruction _inst);
 extern const std::map<std::string, Instruction> c_instructions;
 
 /// Iterate through EVM code and call a function on each instruction.
-void eachInstruction(bytes const& _mem, std::function<void(Instruction,u256 const&)> const& _onInstruction);
+void eachInstruction(bytes const& _mem, std::function<void(Instruction, u256 const&)> const& _onInstruction);
 
 /// Convert from EVM code to simple EVM assembly language.
 std::string disassemble(bytes const& _mem, std::string const& _delimiter = " ");

--- a/libevmasm/JumpdestRemover.cpp
+++ b/libevmasm/JumpdestRemover.cpp
@@ -24,6 +24,8 @@
 
 #include <libevmasm/AssemblyItem.h>
 
+#include <limits>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::util;

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -415,7 +415,7 @@ KnownState::Id KnownState::applyKeccak256(
 	{
 		bytes data;
 		for (Id a: arguments)
-			data += util::toBigEndian(*m_expressionClasses->knownConstant(a));
+			data += toBigEndian(*m_expressionClasses->knownConstant(a));
 		data.resize(length);
 		v = m_expressionClasses->find(AssemblyItem(u256(util::keccak256(data)), _location));
 	}

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -24,14 +24,6 @@
 
 #pragma once
 
-#include <utility>
-#include <vector>
-#include <map>
-#include <set>
-#include <tuple>
-#include <memory>
-#include <ostream>
-
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wredeclared-class-member"
@@ -57,6 +49,15 @@
 #include <libsolutil/Exceptions.h>
 #include <libevmasm/ExpressionClasses.h>
 #include <libevmasm/SemanticInformation.h>
+
+#include <limits>
+#include <utility>
+#include <vector>
+#include <map>
+#include <set>
+#include <tuple>
+#include <memory>
+#include <ostream>
 
 namespace solidity::langutil
 {

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -59,6 +59,7 @@
 #include <optional>
 #include <string_view>
 #include <tuple>
+#include <array>
 
 using namespace std;
 

--- a/liblangutil/SemVerHandler.cpp
+++ b/liblangutil/SemVerHandler.cpp
@@ -26,6 +26,7 @@
 #include <liblangutil/Exceptions.h>
 
 #include <functional>
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -22,6 +22,7 @@
 #include <libsmtutil/Sorts.h>
 
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 
 #include <range/v3/view.hpp>
 

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -27,6 +27,8 @@
 #include <libsolidity/ast/TypeProvider.h>
 #include <liblangutil/ErrorReporter.h>
 
+#include <limits>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::frontend;

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -274,7 +274,7 @@ uint32_t ContractDefinition::interfaceId() const
 {
 	uint32_t result{0};
 	for (auto const& function: interfaceFunctionList(false))
-		result ^= util::fromBigEndian<uint32_t>(function.first.ref());
+		result ^= fromBigEndian<uint32_t>(function.first.ref());
 	return result;
 }
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1135,7 +1135,7 @@ IntegerType const* RationalNumberType::integerType() const
 		return nullptr;
 	else
 		return TypeProvider::integer(
-			max(util::numberEncodingSize(value), 1u) * 8,
+			max(numberEncodingSize(value), 1u) * 8,
 			negative ? IntegerType::Modifier::Signed : IntegerType::Modifier::Unsigned
 		);
 }
@@ -1169,7 +1169,7 @@ FixedPointType const* RationalNumberType::fixedPointType() const
 	if (v > u256(-1))
 		return nullptr;
 
-	unsigned totalBits = max(util::numberEncodingSize(v), 1u) * 8;
+	unsigned totalBits = max(numberEncodingSize(v), 1u) * 8;
 	solAssert(totalBits <= 256, "");
 
 	return TypeProvider::fixedPoint(

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -29,6 +29,7 @@
 #include <liblangutil/Exceptions.h>
 
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/LazyInit.h>
 #include <libsolutil/Result.h>

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -46,6 +46,7 @@
 #include <stack>
 #include <queue>
 #include <utility>
+#include <limits>
 
 namespace solidity::frontend
 {

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -40,7 +40,7 @@ using namespace solidity::langutil;
 
 using solidity::util::Whiskers;
 using solidity::util::h256;
-using solidity::util::toCompactHexWithPrefix;
+using solidity::toCompactHexWithPrefix;
 
 unsigned const CompilerUtils::dataStartOffset = 4;
 size_t const CompilerUtils::freeMemoryPointer = 64;

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -52,6 +52,7 @@
 #include <range/v3/view/reverse.hpp>
 
 #include <algorithm>
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -266,7 +266,7 @@ void IRGeneratorForStatements::initializeStateVar(VariableDeclaration const& _va
 			_varDecl.immutable() ?
 			IRLValue{*_varDecl.annotation().type, IRLValue::Immutable{&_varDecl}} :
 			IRLValue{*_varDecl.annotation().type, IRLValue::Storage{
-				util::toCompactHexWithPrefix(m_context.storageLocationOfStateVariable(_varDecl).first),
+				toCompactHexWithPrefix(m_context.storageLocationOfStateVariable(_varDecl).first),
 				m_context.storageLocationOfStateVariable(_varDecl).second
 			}},
 			*_varDecl.value()

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -34,7 +34,7 @@
 
 #include <range/v3/view.hpp>
 
-
+#include <limits>
 #include <deque>
 
 using namespace std;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -78,10 +78,11 @@
 
 #include <json/json.h>
 
+#include <boost/algorithm/string/replace.hpp>
+
 #include <utility>
 #include <map>
-
-#include <boost/algorithm/string/replace.hpp>
+#include <limits>
 
 using namespace std;
 using namespace solidity;
@@ -1558,7 +1559,7 @@ public:
 		// The already encoded key-value pairs
 		ret += m_data;
 		// 16-bit big endian length
-		ret += util::toCompactBigEndian(size, 2);
+		ret += toCompactBigEndian(size, 2);
 		return ret;
 	}
 

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -2,7 +2,6 @@ set(sources
 	Algorithms.h
 	AnsiColorized.h
 	Assertions.h
-	Common.cpp
 	Common.h
 	CommonData.cpp
 	CommonData.h
@@ -24,6 +23,8 @@ set(sources
 	Keccak256.h
 	LazyInit.h
 	LEB128.h
+	Numeric.cpp
+	Numeric.h
 	picosha2.h
 	Result.h
 	SetOnce.h

--- a/libsolutil/Common.h
+++ b/libsolutil/Common.h
@@ -45,8 +45,6 @@
 #error "Unsupported Boost version. At least 1.65 required."
 #endif
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <map>
 #include <utility>
 #include <vector>
@@ -61,65 +59,11 @@ using bytes = std::vector<uint8_t>;
 using bytesRef = util::vector_ref<uint8_t>;
 using bytesConstRef = util::vector_ref<uint8_t const>;
 
-// Numeric types.
-using bigint = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>>;
-using u256 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
-using s256 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void>>;
-
 // Map types.
 using StringMap = std::map<std::string, std::string>;
 
 // String types.
 using strings = std::vector<std::string>;
-
-/// Interprets @a _u as a two's complement signed number and returns the resulting s256.
-inline s256 u2s(u256 _u)
-{
-	static bigint const c_end = bigint(1) << 256;
-	if (boost::multiprecision::bit_test(_u, 255))
-		return s256(-(c_end - _u));
-	else
-		return s256(_u);
-}
-
-/// @returns the two's complement signed representation of the signed number _u.
-inline u256 s2u(s256 _u)
-{
-	static bigint const c_end = bigint(1) << 256;
-	if (_u >= 0)
-		return u256(_u);
-	else
-		return u256(c_end + _u);
-}
-
-inline u256 exp256(u256 _base, u256 _exponent)
-{
-	using boost::multiprecision::limb_type;
-	u256 result = 1;
-	while (_exponent)
-	{
-		if (boost::multiprecision::bit_test(_exponent, 0))
-			result *= _base;
-		_base *= _base;
-		_exponent >>= 1;
-	}
-	return result;
-}
-
-/// Checks whether _mantissa * (X ** _exp) fits into 4096 bits,
-/// where X is given indirectly via _log2OfBase = log2(X).
-bool fitsPrecisionBaseX(bigint const& _mantissa, double _log2OfBase, uint32_t _exp);
-
-inline std::ostream& operator<<(std::ostream& os, bytes const& _bytes)
-{
-	std::ostringstream ss;
-	ss << std::hex;
-	std::copy(_bytes.begin(), _bytes.end(), std::ostream_iterator<int>(ss, ","));
-	std::string result = ss.str();
-	result.pop_back();
-	os << "[" + result + "]";
-	return os;
-}
 
 /// RAII utility class whose destructor calls a given function.
 class ScopeGuard

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -36,6 +36,8 @@
 #include <functional>
 #include <utility>
 #include <type_traits>
+#include <list>
+#include <algorithm>
 
 /// Operators need to stay in the global namespace.
 
@@ -431,94 +433,6 @@ inline bytes asBytes(std::string const& _b)
 	return bytes((uint8_t const*)_b.data(), (uint8_t const*)(_b.data() + _b.size()));
 }
 
-// Big-endian to/from host endian conversion functions.
-
-/// Converts a templated integer value to the big-endian byte-stream represented on a templated collection.
-/// The size of the collection object will be unchanged. If it is too small, it will not represent the
-/// value properly, if too big then the additional elements will be zeroed out.
-/// @a Out will typically be either std::string or bytes.
-/// @a T will typically by unsigned, u160, u256 or bigint.
-template <class T, class Out>
-inline void toBigEndian(T _val, Out& o_out)
-{
-	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
-	for (auto i = o_out.size(); i != 0; _val >>= 8, i--)
-	{
-		T v = _val & (T)0xff;
-		o_out[i - 1] = (typename Out::value_type)(uint8_t)v;
-	}
-}
-
-/// Converts a big-endian byte-stream represented on a templated collection to a templated integer value.
-/// @a In will typically be either std::string or bytes.
-/// @a T will typically by unsigned, u256 or bigint.
-template <class T, class In>
-inline T fromBigEndian(In const& _bytes)
-{
-	T ret = (T)0;
-	for (auto i: _bytes)
-		ret = (T)((ret << 8) | (uint8_t)(typename std::make_unsigned<typename In::value_type>::type)i);
-	return ret;
-}
-inline bytes toBigEndian(u256 _val) { bytes ret(32); toBigEndian(_val, ret); return ret; }
-
-/// Convenience function for toBigEndian.
-/// @returns a byte array just big enough to represent @a _val.
-template <class T>
-inline bytes toCompactBigEndian(T _val, unsigned _min = 0)
-{
-	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
-	unsigned i = 0;
-	for (T v = _val; v; ++i, v >>= 8) {}
-	bytes ret(std::max<unsigned>(_min, i), 0);
-	toBigEndian(_val, ret);
-	return ret;
-}
-
-/// Convenience function for conversion of a u256 to hex
-inline std::string toHex(u256 val, HexPrefix prefix = HexPrefix::DontAdd)
-{
-	std::string str = toHex(toBigEndian(val));
-	return (prefix == HexPrefix::Add) ? "0x" + str : str;
-}
-
-template <class T>
-inline std::string toCompactHexWithPrefix(T _value)
-{
-	return toHex(toCompactBigEndian(_value, 1), HexPrefix::Add);
-}
-
-/// Returns decimal representation for small numbers and hex for large numbers.
-inline std::string formatNumber(bigint const& _value)
-{
-	if (_value < 0)
-		return "-" + formatNumber(-_value);
-	if (_value > 0x1000000)
-		return toHex(toCompactBigEndian(_value, 1), HexPrefix::Add);
-	else
-		return _value.str();
-}
-
-inline std::string formatNumber(u256 const& _value)
-{
-	if (_value > 0x1000000)
-		return toCompactHexWithPrefix(_value);
-	else
-		return _value.str();
-}
-
-
-// Algorithms for string and string-like collections.
-
-/// Determine bytes required to encode the given integer value. @returns 0 if @a _i is zero.
-template <class T>
-inline unsigned numberEncodingSize(T _i)
-{
-	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
-	unsigned i = 0;
-	for (; _i != 0; ++i, _i >>= 8) {}
-	return i;
-}
 template <class T, class V>
 bool contains(T const& _t, V const& _v)
 {

--- a/libsolutil/CommonIO.h
+++ b/libsolutil/CommonIO.h
@@ -31,7 +31,21 @@
 #include <sstream>
 #include <string>
 
-namespace solidity::util
+namespace solidity
+{
+
+inline std::ostream& operator<<(std::ostream& os, bytes const& _bytes)
+{
+	std::ostringstream ss;
+	ss << std::hex;
+	std::copy(_bytes.begin(), _bytes.end(), std::ostream_iterator<int>(ss, ","));
+	std::string result = ss.str();
+	result.pop_back();
+	os << "[" + result + "]";
+	return os;
+}
+
+namespace util
 {
 
 /// Retrieves and returns the contents of the given file as a std::string.
@@ -61,4 +75,5 @@ std::string absolutePath(std::string const& _path, std::string const& _reference
 /// Helper function to return path converted strings.
 std::string sanitizePath(std::string const& _path);
 
+}
 }

--- a/libsolutil/FixedHash.h
+++ b/libsolutil/FixedHash.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
 
 #include <boost/functional/hash.hpp>
 #include <boost/io/ios_state.hpp>

--- a/libsolutil/IpfsHash.cpp
+++ b/libsolutil/IpfsHash.cpp
@@ -21,6 +21,7 @@
 #include <libsolutil/Exceptions.h>
 #include <libsolutil/picosha2.h>
 #include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
 
 using namespace std;
 using namespace solidity;

--- a/libsolutil/Numeric.cpp
+++ b/libsolutil/Numeric.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 
 #include <liblangutil/Exceptions.h>
 

--- a/libsolutil/Numeric.h
+++ b/libsolutil/Numeric.h
@@ -1,0 +1,171 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Definition of u256 and similar types and helper functions.
+ */
+
+#pragma once
+
+#include <libsolutil/Common.h>
+#include <libsolutil/CommonData.h>
+
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 106500)
+#error "Unsupported Boost version. At least 1.65 required."
+#endif
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <limits>
+
+namespace solidity
+{
+
+// Numeric types.
+using bigint = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>>;
+using u256 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
+using s256 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void>>;
+
+/// Interprets @a _u as a two's complement signed number and returns the resulting s256.
+inline s256 u2s(u256 _u)
+{
+	static bigint const c_end = bigint(1) << 256;
+	if (boost::multiprecision::bit_test(_u, 255))
+		return s256(-(c_end - _u));
+	else
+		return s256(_u);
+}
+
+/// @returns the two's complement signed representation of the signed number _u.
+inline u256 s2u(s256 _u)
+{
+	static bigint const c_end = bigint(1) << 256;
+	if (_u >= 0)
+		return u256(_u);
+	else
+		return u256(c_end + _u);
+}
+
+inline u256 exp256(u256 _base, u256 _exponent)
+{
+	using boost::multiprecision::limb_type;
+	u256 result = 1;
+	while (_exponent)
+	{
+		if (boost::multiprecision::bit_test(_exponent, 0))
+			result *= _base;
+		_base *= _base;
+		_exponent >>= 1;
+	}
+	return result;
+}
+
+/// Checks whether _mantissa * (X ** _exp) fits into 4096 bits,
+/// where X is given indirectly via _log2OfBase = log2(X).
+bool fitsPrecisionBaseX(bigint const& _mantissa, double _log2OfBase, uint32_t _exp);
+
+
+// Big-endian to/from host endian conversion functions.
+
+/// Converts a templated integer value to the big-endian byte-stream represented on a templated collection.
+/// The size of the collection object will be unchanged. If it is too small, it will not represent the
+/// value properly, if too big then the additional elements will be zeroed out.
+/// @a Out will typically be either std::string or bytes.
+/// @a T will typically by unsigned, u160, u256 or bigint.
+template <class T, class Out>
+inline void toBigEndian(T _val, Out& o_out)
+{
+	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
+	for (auto i = o_out.size(); i != 0; _val >>= 8, i--)
+	{
+		T v = _val & (T)0xff;
+		o_out[i - 1] = (typename Out::value_type)(uint8_t)v;
+	}
+}
+
+/// Converts a big-endian byte-stream represented on a templated collection to a templated integer value.
+/// @a In will typically be either std::string or bytes.
+/// @a T will typically by unsigned, u256 or bigint.
+template <class T, class In>
+inline T fromBigEndian(In const& _bytes)
+{
+	T ret = (T)0;
+	for (auto i: _bytes)
+		ret = (T)((ret << 8) | (uint8_t)(typename std::make_unsigned<typename In::value_type>::type)i);
+	return ret;
+}
+inline bytes toBigEndian(u256 _val) { bytes ret(32); toBigEndian(_val, ret); return ret; }
+
+/// Convenience function for toBigEndian.
+/// @returns a byte array just big enough to represent @a _val.
+template <class T>
+inline bytes toCompactBigEndian(T _val, unsigned _min = 0)
+{
+	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
+	unsigned i = 0;
+	for (T v = _val; v; ++i, v >>= 8) {}
+	bytes ret(std::max<unsigned>(_min, i), 0);
+	toBigEndian(_val, ret);
+	return ret;
+}
+
+/// Convenience function for conversion of a u256 to hex
+inline std::string toHex(u256 val)
+{
+	return util::toHex(toBigEndian(val));
+}
+
+template <class T>
+inline std::string toCompactHexWithPrefix(T _value)
+{
+	return "0x" + util::toHex(toCompactBigEndian(_value, 1));
+}
+
+/// Returns decimal representation for small numbers and hex for large numbers.
+inline std::string formatNumber(bigint const& _value)
+{
+	if (_value < 0)
+		return "-" + formatNumber(-_value);
+	if (_value > 0x1000000)
+		return "0x" + util::toHex(toCompactBigEndian(_value, 1));
+	else
+		return _value.str();
+}
+
+inline std::string formatNumber(u256 const& _value)
+{
+	if (_value > 0x1000000)
+		return toCompactHexWithPrefix(_value);
+	else
+		return _value.str();
+}
+
+
+// Algorithms for string and string-like collections.
+
+/// Determine bytes required to encode the given integer value. @returns 0 if @a _i is zero.
+template <class T>
+inline unsigned numberEncodingSize(T _i)
+{
+	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
+	unsigned i = 0;
+	for (; _i != 0; ++i, _i >>= 8) {}
+	return i;
+}
+
+}

--- a/libsolutil/StringUtils.h
+++ b/libsolutil/StringUtils.h
@@ -24,10 +24,12 @@
 
 #pragma once
 
+#include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
+
+#include <limits>
 #include <string>
 #include <vector>
-
-#include <libsolutil/CommonData.h>
 
 namespace solidity::util
 {

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <set>
+#include <limits>
 
 namespace solidity::yul
 {

--- a/libyul/Utilities.h
+++ b/libyul/Utilities.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 #include <libyul/ASTForward.h>
 
 namespace solidity::yul

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -27,6 +27,7 @@
 
 #include <libsolutil/Common.h>
 #include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
 
 #include <functional>
 #include <memory>

--- a/libyul/backends/evm/ControlFlowGraph.h
+++ b/libyul/backends/evm/ControlFlowGraph.h
@@ -27,6 +27,8 @@
 #include <libyul/Exceptions.h>
 #include <libyul/Scope.h>
 
+#include <libsolutil/Numeric.h>
+
 #include <functional>
 #include <list>
 #include <vector>

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -24,7 +24,9 @@
 #include <libyul/backends/evm/AbstractAssembly.h>
 #include <libyul/AsmAnalysis.h>
 #include <liblangutil/SourceLocation.h>
+
 #include <functional>
+#include <limits>
 
 namespace solidity::evmasm
 {

--- a/libyul/backends/evm/StackHelpers.h
+++ b/libyul/backends/evm/StackHelpers.h
@@ -39,7 +39,7 @@ inline std::string stackSlotToString(StackSlot const& _slot)
 		[](FunctionCallReturnLabelSlot const& _ret) -> std::string { return "RET[" + _ret.call.get().functionName.name.str() + "]"; },
 		[](FunctionReturnLabelSlot const&) -> std::string { return "RET"; },
 		[](VariableSlot const& _var) { return _var.variable.get().name.str(); },
-		[](LiteralSlot const& _lit) { return util::toCompactHexWithPrefix(_lit.value); },
+		[](LiteralSlot const& _lit) { return toCompactHexWithPrefix(_lit.value); },
 		[](TemporarySlot const& _tmp) -> std::string { return "TMP[" + _tmp.call.get().functionName.name.str() + ", " + std::to_string(_tmp.index) + "]"; },
 		[](JunkSlot const&) -> std::string { return "JUNK"; }
 	}, _slot);

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -25,6 +25,7 @@
 #include <libyul/Exceptions.h>
 
 #include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
 #include <libsolutil/Keccak256.h>
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
@@ -54,7 +55,7 @@ string TextTransform::run(wasm::Module const& _module)
 			"    ;; (@custom \"" +
 			name +
 			"\" \"" +
-			toHex(BinaryTransform::run(module)) +
+			util::toHex(BinaryTransform::run(module)) +
 			"\")\n";
 	for (auto const& [name, data]: _module.customSections)
 		ret +=
@@ -62,7 +63,7 @@ string TextTransform::run(wasm::Module const& _module)
 			"    ;; (@custom \"" +
 			name +
 			"\" \"" +
-			toHex(data) +
+			util::toHex(data) +
 			"\")\n";
 	for (wasm::FunctionImport const& imp: _module.imports)
 	{

--- a/libyul/backends/wasm/WasmCodeTransform.cpp
+++ b/libyul/backends/wasm/WasmCodeTransform.cpp
@@ -31,6 +31,7 @@
 #include <liblangutil/Exceptions.h>
 
 #include <optional>
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/backends/wasm/WasmCodeTransform.h
+++ b/libyul/backends/wasm/WasmCodeTransform.h
@@ -28,6 +28,7 @@
 #include <libyul/optimiser/TypeInfo.h>
 
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 
 #include <stack>
 #include <map>

--- a/libyul/backends/wasm/WordSizeTransform.cpp
+++ b/libyul/backends/wasm/WordSizeTransform.cpp
@@ -27,6 +27,7 @@
 #include <array>
 #include <map>
 #include <variant>
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/DeadCodeEliminator.cpp
+++ b/libyul/optimiser/DeadCodeEliminator.cpp
@@ -27,6 +27,7 @@
 #include <libevmasm/SemanticInformation.h>
 
 #include <algorithm>
+#include <limits>
 
 using namespace std;
 using namespace solidity;

--- a/libyul/optimiser/ExpressionJoiner.cpp
+++ b/libyul/optimiser/ExpressionJoiner.cpp
@@ -31,6 +31,8 @@
 
 #include <range/v3/view/reverse.hpp>
 
+#include <limits>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -25,6 +25,7 @@
 #include <libyul/YulString.h>
 
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 
 #include <map>
 

--- a/libyul/optimiser/Semantics.cpp
+++ b/libyul/optimiser/Semantics.cpp
@@ -31,6 +31,8 @@
 #include <libsolutil/CommonData.h>
 #include <libsolutil/Algorithms.h>
 
+#include <limits>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::yul;

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -241,7 +241,7 @@ Expression Pattern::toExpression(shared_ptr<DebugData const> const& _debugData) 
 	if (m_kind == PatternKind::Constant)
 	{
 		assertThrow(m_data, OptimizerException, "No match group and no constant value given.");
-		return Literal{_debugData, LiteralKind::Number, YulString{util::formatNumber(*m_data)}, {}};
+		return Literal{_debugData, LiteralKind::Number, YulString{formatNumber(*m_data)}, {}};
 	}
 	else if (m_kind == PatternKind::Operation)
 	{

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -163,6 +163,6 @@ void StackLimitEvader::run(
 	{
 		Literal* literal = std::get_if<Literal>(&memoryGuardCall->arguments.front());
 		yulAssert(literal && literal->kind == LiteralKind::Number, "");
-		literal->value = YulString{util::toCompactHexWithPrefix(reservedMemory)};
+		literal->value = YulString{toCompactHexWithPrefix(reservedMemory)};
 	}
 }

--- a/libyul/optimiser/StackToMemoryMover.cpp
+++ b/libyul/optimiser/StackToMemoryMover.cpp
@@ -315,7 +315,7 @@ optional<YulString> StackToMemoryMover::VariableMemoryOffsetTracker::operator()(
 	{
 		uint64_t slot = m_memorySlots.at(_variable);
 		yulAssert(slot < m_numRequiredSlots, "");
-		return YulString{util::toCompactHexWithPrefix(m_reservedMemory + 32 * (m_numRequiredSlots - slot - 1))};
+		return YulString{toCompactHexWithPrefix(m_reservedMemory + 32 * (m_numRequiredSlots - slot - 1))};
 	}
 	else
 		return nullopt;

--- a/libyul/optimiser/StackToMemoryMover.h
+++ b/libyul/optimiser/StackToMemoryMover.h
@@ -26,6 +26,7 @@
 
 #include <liblangutil/SourceLocation.h>
 #include <libsolutil/Common.h>
+#include <libsolutil/Numeric.h>
 
 #include <list>
 

--- a/libyul/optimiser/VarNameCleaner.cpp
+++ b/libyul/optimiser/VarNameCleaner.cpp
@@ -27,6 +27,7 @@
 #include <iterator>
 #include <string>
 #include <regex>
+#include <limits>
 
 using namespace std;
 using namespace solidity::yul;

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -40,6 +40,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <cstdlib>
+#include <limits>
 
 using namespace std;
 using namespace solidity;
@@ -102,8 +103,8 @@ std::pair<bool, string> ExecutionFramework::compareAndCreateMessage(
 	std::string message =
 			"Invalid encoded data\n"
 			"   Result                                                           Expectation\n";
-	auto resultHex = boost::replace_all_copy(toHex(_result), "0", ".");
-	auto expectedHex = boost::replace_all_copy(toHex(_expectation), "0", ".");
+	auto resultHex = boost::replace_all_copy(util::toHex(_result), "0", ".");
+	auto expectedHex = boost::replace_all_copy(util::toHex(_expectation), "0", ".");
 	for (size_t i = 0; i < std::max(resultHex.size(), expectedHex.size()); i += 0x40)
 	{
 		std::string result{i >= resultHex.size() ? string{} : resultHex.substr(i, 0x40)};
@@ -163,7 +164,7 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 			cout << "CALL   " << m_sender.hex() << " -> " << m_contractAddress.hex() << ":" << endl;
 		if (_value > 0)
 			cout << " value: " << _value << endl;
-		cout << " in:      " << toHex(_data) << endl;
+		cout << " in:      " << util::toHex(_data) << endl;
 	}
 	evmc_message message = {};
 	message.input_data = _data.data();
@@ -194,7 +195,7 @@ void ExecutionFramework::sendMessage(bytes const& _data, bool _isCreation, u256 
 
 	if (m_showMessages)
 	{
-		cout << " out:     " << toHex(m_output) << endl;
+		cout << " out:     " << util::toHex(m_output) << endl;
 		cout << " result: " << static_cast<size_t>(result.status_code) << endl;
 		cout << " gas used: " << m_gasUsed.str() << endl;
 	}

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -169,7 +169,7 @@ public:
 	static bytes encode(size_t _value) { return encode(u256(_value)); }
 	static bytes encode(char const* _value) { return encode(std::string(_value)); }
 	static bytes encode(uint8_t _value) { return bytes(31, 0) + bytes{_value}; }
-	static bytes encode(u256 const& _value) { return util::toBigEndian(_value); }
+	static bytes encode(u256 const& _value) { return toBigEndian(_value); }
 	/// @returns the fixed-point encoding of a rational number with a given
 	/// number of fractional bits.
 	static bytes encode(std::pair<rational, int> const& _valueAndPrecision)

--- a/test/libsolidity/ErrorCheck.cpp
+++ b/test/libsolidity/ErrorCheck.cpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <set>
+#include <iostream>
 
 using namespace std;
 using namespace solidity;

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -131,7 +131,7 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 			"isoltest_builtin_test",
 			[](FunctionCall const&) -> optional<bytes>
 			{
-				return util::toBigEndian(u256(0x1234));
+				return toBigEndian(u256(0x1234));
 			}
 		},
 		{
@@ -139,7 +139,7 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 			[](FunctionCall const& _call) -> optional<bytes>
 			{
 				if (_call.arguments.parameters.empty())
-					return util::toBigEndian(0);
+					return toBigEndian(0);
 				else
 					return _call.arguments.rawBytes();
 			}
@@ -154,7 +154,7 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 					address = h160(_call.arguments.parameters.at(0).rawString);
 				else
 					address = m_contractAddress;
-				return util::toBigEndian(balanceAt(address));
+				return toBigEndian(balanceAt(address));
 			}
 		},
 		{

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <tuple>
 #include <memory>
+#include <limits>
 
 using namespace std;
 using namespace solidity::util;

--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -21,6 +21,7 @@
 #include <test/libsolidity/util/SoltestErrors.h>
 
 #include <libsolutil/CommonData.h>
+#include <libsolutil/CommonIO.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -108,7 +109,7 @@ bytes BytesUtils::convertFixedPoint(string const& _literal, size_t& o_fractional
 		u256 value(valueInteger);
 		if (negative)
 			value = s2u(-u2s(value));
-		return util::toBigEndian(value);
+		return toBigEndian(value);
 	}
 	catch (std::exception const&)
 	{
@@ -193,7 +194,7 @@ string BytesUtils::formatHexString(bytes const& _bytes)
 {
 	stringstream os;
 
-	os << "hex\"" << toHex(_bytes) << "\"";
+	os << "hex\"" << util::toHex(_bytes) << "\"";
 
 	return os.str();
 }

--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -963,7 +963,7 @@ BOOST_AUTO_TEST_CASE(call_effects)
 	std::map<std::string, Builtin> builtins;
 	builtins["builtin_returning_call_effect"] = [](FunctionCall const&) -> std::optional<bytes>
 	{
-		return util::toBigEndian(u256(0x1234));
+		return toBigEndian(u256(0x1234));
 	};
 	builtins["builtin_returning_call_effect_no_ret"] = [](FunctionCall const&) -> std::optional<bytes>
 	{

--- a/test/libyul/ObjectCompilerTest.cpp
+++ b/test/libyul/ObjectCompilerTest.cpp
@@ -81,7 +81,7 @@ TestCase::TestResult ObjectCompilerTest::run(ostream& _stream, string const& _li
 		solAssert(obj.bytecode, "");
 
 		m_obtainedResult = "Text:\n" + obj.assembly + "\n";
-		m_obtainedResult += "Binary:\n" + toHex(obj.bytecode->bytecode) + "\n";
+		m_obtainedResult += "Binary:\n" + util::toHex(obj.bytecode->bytecode) + "\n";
 	}
 	else
 	{
@@ -95,7 +95,7 @@ TestCase::TestResult ObjectCompilerTest::run(ostream& _stream, string const& _li
 		else
 			m_obtainedResult +=
 				"Bytecode: " +
-				toHex(obj.bytecode->bytecode) +
+				util::toHex(obj.bytecode->bytecode) +
 				"\nOpcodes: " +
 				boost::trim_copy(evmasm::disassemble(obj.bytecode->bytecode)) +
 				"\nSourceMappings:" +

--- a/test/tools/ossfuzz/protoToAbiV2.h
+++ b/test/tools/ossfuzz/protoToAbiV2.h
@@ -6,6 +6,7 @@
 #include <libsolutil/Keccak256.h>
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Whiskers.h>
+#include <libsolutil/Numeric.h>
 
 #include <liblangutil/Exceptions.h>
 
@@ -505,7 +506,7 @@ public:
 	// Note: Don't change HexPrefix::Add. See comment in fixedByteValueAsString().
 	static std::string maskUnsignedIntToHex(unsigned _counter, unsigned _numMaskNibbles)
 	{
-		return toHex(maskUnsignedInt(_counter, _numMaskNibbles), util::HexPrefix::Add);
+		return "0x" + toHex(maskUnsignedInt(_counter, _numMaskNibbles));
 	}
 
 	/// Dynamically sized arrays can have a length of at least zero

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -29,6 +29,9 @@
 #include <libevmasm/Instruction.h>
 
 #include <libsolutil/Keccak256.h>
+#include <libsolutil/Numeric.h>
+
+#include <limits>
 
 using namespace std;
 using namespace solidity;
@@ -511,7 +514,7 @@ void EVMInstructionInterpreter::logTrace(std::string const& _pseudoInstruction, 
 {
 	string message = _pseudoInstruction + "(";
 	for (size_t i = 0; i < _arguments.size(); ++i)
-		message += (i > 0 ? ", " : "") + util::formatNumber(_arguments[i]);
+		message += (i > 0 ? ", " : "") + formatNumber(_arguments[i]);
 	message += ")";
 	if (!_data.empty())
 		message += " [" + util::toHex(_data) + "]";

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.h
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.h
@@ -24,6 +24,7 @@
 #include <libyul/ASTForward.h>
 
 #include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
 
 #include <vector>
 

--- a/test/tools/yulInterpreter/EwasmBuiltinInterpreter.cpp
+++ b/test/tools/yulInterpreter/EwasmBuiltinInterpreter.cpp
@@ -29,6 +29,9 @@
 #include <libevmasm/Instruction.h>
 
 #include <libsolutil/Keccak256.h>
+#include <libsolutil/Numeric.h>
+
+#include <limits>
 
 using namespace std;
 using namespace solidity;
@@ -601,7 +604,7 @@ void EwasmBuiltinInterpreter::logTrace(std::string const& _pseudoInstruction, st
 {
 	string message = _pseudoInstruction + "(";
 	for (size_t i = 0; i < _arguments.size(); ++i)
-		message += (i > 0 ? ", " : "") + util::formatNumber(_arguments[i]);
+		message += (i > 0 ? ", " : "") + formatNumber(_arguments[i]);
 	message += ")";
 	if (!_data.empty())
 		message += " [" + util::toHex(_data) + "]";

--- a/tools/solidityUpgrade/UpgradeChange.cpp
+++ b/tools/solidityUpgrade/UpgradeChange.cpp
@@ -19,6 +19,7 @@
 
 #include <liblangutil/SourceReferenceExtractor.h>
 #include <liblangutil/SourceReferenceFormatter.h>
+#include <libsolutil/Numeric.h>
 
 using namespace std;
 using namespace solidity;


### PR DESCRIPTION
`Common.h` is essentially included by everything and the hope of this split is that we at least don't need boost multiprecision everywhere.

Depends on https://github.com/ethereum/solidity/pull/12004