### PR TITLE
Don't discard non-fatal errors in Yul mode in Standard JSON when followed by a fatal error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@ Bugfixes:
  * SMTChecker: Fix false positive in external calls from constructors.
  * SMTChecker: Fix internal error on some multi-source uses of ``abi.*``, cryptographic functions and constants.
  * SMTChecker: Fix BMC's constraints regarding internal functions.
+ * Standard JSON: Fix non-fatal errors in Yul mode being discarded if followed by a fatal error.
  * Type Checker: Disallow modifier declarations and definitions in interfaces.
  * Yul Optimizer: Fix a crash in LoadResolver, when ``keccak256`` has particular non-identifier arguments.
 

--- a/test/cmdlineTests/standard_yul_single_file_via_urls/args
+++ b/test/cmdlineTests/standard_yul_single_file_via_urls/args
@@ -1,0 +1,1 @@
+--pretty-json --json-indent 4 --allow-paths .

--- a/test/cmdlineTests/standard_yul_single_file_via_urls/input.json
+++ b/test/cmdlineTests/standard_yul_single_file_via_urls/input.json
@@ -1,0 +1,6 @@
+{
+	"language": "Yul",
+	"sources": {
+		"C": {"urls": ["in.yul"]}
+	}
+}

--- a/test/cmdlineTests/standard_yul_single_file_via_urls/output.json
+++ b/test/cmdlineTests/standard_yul_single_file_via_urls/output.json
@@ -1,0 +1,12 @@
+{
+    "errors":
+    [
+        {
+            "component": "general",
+            "formattedMessage": "Yul mode only supports exactly one input file.",
+            "message": "Yul mode only supports exactly one input file.",
+            "severity": "error",
+            "type": "JSONError"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_yul_single_file_via_urls/output.json
+++ b/test/cmdlineTests/standard_yul_single_file_via_urls/output.json
@@ -3,6 +3,13 @@
     [
         {
             "component": "general",
+            "formattedMessage": "Cannot import url (\"in.yul\"): File not found.",
+            "message": "Cannot import url (\"in.yul\"): File not found.",
+            "severity": "error",
+            "type": "IOError"
+        },
+        {
+            "component": "general",
             "formattedMessage": "Yul mode only supports exactly one input file.",
             "message": "Yul mode only supports exactly one input file.",
             "severity": "error",


### PR DESCRIPTION
In Yul mode `StandardCompiler` ignores any non-fatal errors collected so far when it encounters a fatal error. This results in a nonsensical message in some cases - for example when a path passed to `sources.urls` cannot be resolved by the import callback (a non-fatal error), it only prints a message saying that there were no input files (see the first commit).