### PR TITLE
Fix pylint warnings about the usage of f-strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1007,7 +1007,7 @@ jobs:
 
   b_bytecode_ems:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:16
     environment:
       SOLC_EMSCRIPTEN: "On"
     steps:

--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -101,12 +101,13 @@ class Statistics:
         self.missing_metadata_count += sum(1 for c in contract_reports if c.metadata is None)
 
     def __str__(self) -> str:
-        return "test cases: {}, contracts: {}, errors: {}, missing bytecode: {}, missing metadata: {}".format(
-            self.file_count,
-            str(self.contract_count) + ('+' if self.error_count > 0 else ''),
-            self.error_count,
-            self.missing_bytecode_count,
-            self.missing_metadata_count,
+        contract_count = str(self.contract_count) + ('+' if self.error_count > 0 else '')
+        return (
+            f"test cases: {self.file_count}, "
+            f"contracts: {contract_count}, "
+            f"errors: {self.error_count}, "
+            f"missing bytecode: {self.missing_bytecode_count}, "
+            f"missing metadata: {self.missing_metadata_count}"
         )
 
 

--- a/scripts/extract_test_cases.py
+++ b/scripts/extract_test_cases.py
@@ -23,7 +23,7 @@ def extract_test_cases(_path):
     for l in lines:
         if inside:
             if l.strip().endswith(')' + delimiter + '";'):
-                with open('%03d_%s.sol' % (ctr, test_name), mode='wb', encoding='utf8') as f:
+                with open(f'{ctr:03d}_{test_name}.sol', mode='wb', encoding='utf8') as f:
                     f.write(test)
                 ctr += 1
                 inside = False

--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -58,7 +58,7 @@ def extract_yul_docs_cases(path):
             if line.startswith("//"):
                 continue
             if not line.startswith("object") and not line.startswith("{"):
-                return indent("{{\n{}\n}}\n\n".format(code.rstrip()), "    ")
+                return indent(f"{{\n{code.rstrip()}\n}}\n\n", "    ")
             break
 
         return code
@@ -107,7 +107,8 @@ def write_cases(f, solidityTests, yulTests):
         # When code examples are extracted they are indented by 8 spaces, which violates the style guide,
         # so before checking remove 4 spaces from each line.
         remainder = dedent(test)
-        sol_filename = 'test_%s_%s.%s' % (hashlib.sha256(test.encode("utf-8")).hexdigest(), cleaned_filename, language)
+        hash = hashlib.sha256(test.encode("utf-8")).hexdigest()
+        sol_filename = f'test_{hash}_{cleaned_filename}.{language}'
         with open(sol_filename, mode='w', encoding='utf8', newline='') as fi:
             fi.write(remainder)
 

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -101,22 +101,20 @@ class regressor():
         """
 
         testStatus = []
-        for fuzzer in glob.iglob("{}/*_ossfuzz".format(self._fuzzer_path)):
+        for fuzzer in glob.iglob(f"{self._fuzzer_path}/*_ossfuzz"):
             basename = os.path.basename(fuzzer)
-            logfile = os.path.join(self._logpath, "{}.log".format(basename))
-            corpus_dir = "/tmp/solidity-fuzzing-corpus/{0}_seed_corpus" \
-                .format(basename)
-            cmd = "find {0} -type f | xargs -n1 sh -c '{1} $0 || exit 255'".format(corpus_dir, fuzzer)
+            logfile = os.path.join(self._logpath, f"{basename}.log")
+            corpus_dir = f"/tmp/solidity-fuzzing-corpus/{basename}_seed_corpus"
+            cmd = f"find {corpus_dir} -type f | xargs -n1 sh -c '{fuzzer} $0 || exit 255'"
             self.run_cmd(cmd, logfile=logfile)
             ret = self.process_log(logfile)
             if not ret:
                 print(
-                    "\t[-] libFuzzer reported failure for {0}. "
-                    "Failure logged to test_results".format(
-                        basename))
+                    f"\t[-] libFuzzer reported failure for {basename}. "
+                    "Failure logged to test_results")
                 testStatus.append(False)
             else:
-                print("\t[+] {0} passed regression tests.".format(basename))
+                print(f"\t[+] {basename} passed regression tests.")
                 testStatus.append(True)
         return all(testStatus)
 

--- a/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
+++ b/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
@@ -46,7 +46,8 @@ def write_cases(f, tests):
     cleaned_filename = f.replace(".","_").replace("-","_").replace(" ","_").lower()
     for test in tests:
         remainder = re.sub(r'^ {4}', '', test, 0, re.MULTILINE)
-        with open('test_%s_%s.sol' % (hashlib.sha256(test).hexdigest(), cleaned_filename), 'w', encoding='utf8') as _f:
+        hash = hashlib.sha256(test).hexdigest()
+        with open(f'test_{hash}_{cleaned_filename}.sol', 'w', encoding='utf8') as _f:
             _f.write(remainder)
 
 


### PR DESCRIPTION
Looks like we're now getting failures in [`chk_pylint`](https://app.circleci.com/pipelines/github/ethereum/solidity/19029/workflows/485209bf-fdcb-4e0d-bfe5-8679390a556f/jobs/845184) because pylint started complaining about `.format()` and `%` used for string formatting.

This PR fixes that by switching to f-string syntax.