### PR TITLE
Don't include whitespace after `@src` tag if there's no snippet

### DIFF
--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -293,7 +293,7 @@ string AsmPrinter::formatSourceLocation(
 		":" +
 		to_string(_location.end);
 
-	return joinHumanReadable(vector<string>{sourceLocation, solidityCodeSnippet}, "  ");
+	return sourceLocation + (solidityCodeSnippet.empty() ? "" : "  ") + solidityCodeSnippet;
 }
 
 string AsmPrinter::formatDebugData(shared_ptr<DebugData const> const& _debugData, bool _statement)

--- a/test/cmdlineTests/standard_yul_source_locations/output.json
+++ b/test/cmdlineTests/standard_yul_source_locations/output.json
@@ -599,15 +599,15 @@ object \"C_54\" {
             let newFreePtr := add(160, and(add(argSize, 31), not(31)))
             if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, 160))
             {
-                mstore(/** @src -1:-1:-1   */ 0, /** @src 0:79:435  \"contract C...\" */ shl(224, 0x4e487b71))
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 0:79:435  \"contract C...\" */ shl(224, 0x4e487b71))
                 mstore(4, 0x41)
-                revert(/** @src -1:-1:-1   */ 0, /** @src 0:79:435  \"contract C...\" */ 0x24)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 0:79:435  \"contract C...\" */ 0x24)
             }
             mstore(64, newFreePtr)
             codecopy(160, programSize, argSize)
             if slt(argSize, 32)
             {
-                revert(/** @src -1:-1:-1   */ 0, 0)
+                revert(/** @src -1:-1:-1 */ 0, 0)
             }
             /// @src 0:79:435  \"contract C...\"
             constructor_C(mload(160))
@@ -1431,15 +1431,15 @@ object \"D_72\" {
             let newFreePtr := add(160, and(add(argSize, 31), not(31)))
             if or(gt(newFreePtr, sub(shl(64, 1), 1)), lt(newFreePtr, 160))
             {
-                mstore(/** @src -1:-1:-1   */ 0, /** @src 1:91:166  \"contract D is C(3)...\" */ shl(224, 0x4e487b71))
+                mstore(/** @src -1:-1:-1 */ 0, /** @src 1:91:166  \"contract D is C(3)...\" */ shl(224, 0x4e487b71))
                 mstore(4, 0x41)
-                revert(/** @src -1:-1:-1   */ 0, /** @src 1:91:166  \"contract D is C(3)...\" */ 0x24)
+                revert(/** @src -1:-1:-1 */ 0, /** @src 1:91:166  \"contract D is C(3)...\" */ 0x24)
             }
             mstore(64, newFreePtr)
             codecopy(160, programSize, argSize)
             if slt(argSize, 32)
             {
-                revert(/** @src -1:-1:-1   */ 0, 0)
+                revert(/** @src -1:-1:-1 */ 0, 0)
             }
             /// @src 1:91:166  \"contract D is C(3)...\"
             constructor_D(mload(160))


### PR DESCRIPTION
This fixes a tiny bug in #11867. The was supposed to be no extra whitespace when the `@src` comment contains only location and no code snippet.

It's not that bad now because we do not have this in `///` comments yet. In #11944 this is actually making the code fail `chk_codingstyle` check due to trailing whitespace.