### PR TITLE
`SMTSolverChoice` tweaks: fix `&` modifying the object and add more `const`/`noexcept`

### DIFF
--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -42,11 +42,11 @@ struct SMTSolverChoice
 	bool smtlib2 = false;
 	bool z3 = false;
 
-	static constexpr SMTSolverChoice All() { return {true, true, true}; }
-	static constexpr SMTSolverChoice CVC4() { return {true, false, false}; }
-	static constexpr SMTSolverChoice SMTLIB2() { return {false, true, false}; }
-	static constexpr SMTSolverChoice Z3() { return {false, false, true}; }
-	static constexpr SMTSolverChoice None() { return {false, false, false}; }
+	static constexpr SMTSolverChoice All() noexcept { return {true, true, true}; }
+	static constexpr SMTSolverChoice CVC4() noexcept { return {true, false, false}; }
+	static constexpr SMTSolverChoice SMTLIB2() noexcept { return {false, true, false}; }
+	static constexpr SMTSolverChoice Z3() noexcept { return {false, false, true}; }
+	static constexpr SMTSolverChoice None() noexcept { return {false, false, false}; }
 
 	static std::optional<SMTSolverChoice> fromString(std::string const& _solvers)
 	{
@@ -101,9 +101,9 @@ struct SMTSolverChoice
 		return true;
 	}
 
-	bool none() { return !some(); }
-	bool some() { return cvc4 || smtlib2 || z3; }
-	bool all() { return cvc4 && smtlib2 && z3; }
+	bool none() const noexcept { return !some(); }
+	bool some() const noexcept { return cvc4 || smtlib2 || z3; }
+	bool all() const noexcept { return cvc4 && smtlib2 && z3; }
 };
 
 enum class CheckResult

--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -65,7 +65,7 @@ struct SMTSolverChoice
 		return solvers;
 	}
 
-	SMTSolverChoice& operator&(SMTSolverChoice const& _other)
+	SMTSolverChoice& operator&=(SMTSolverChoice const& _other)
 	{
 		cvc4 &= _other.cvc4;
 		smtlib2 &= _other.smtlib2;
@@ -73,9 +73,10 @@ struct SMTSolverChoice
 		return *this;
 	}
 
-	SMTSolverChoice& operator&=(SMTSolverChoice const& _other)
+	SMTSolverChoice operator&(SMTSolverChoice _other) const noexcept
 	{
-		return *this & _other;
+		_other &= *this;
+		return _other;
 	}
 
 	bool operator!=(SMTSolverChoice const& _other) const noexcept { return !(*this == _other); }


### PR DESCRIPTION
I noticed that the `&` operator in `SMTSolverChoice` modifies its argument in place. This is a weird thing for an operator to do and probably just a bug.

While at it, I added `const` and `noexcept` in a few more places.