### PR TITLE
Store both Yul and Solidity locations in debug data

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -409,7 +409,7 @@ bool ControlFlowBuilder::visit(InlineAssembly const& _inlineAssembly)
 void ControlFlowBuilder::visit(yul::Statement const& _statement)
 {
 	solAssert(m_currentNode && m_inlineAssembly, "");
-	m_currentNode->location = langutil::SourceLocation::smallestCovering(m_currentNode->location, locationOf(_statement));
+	m_currentNode->location = langutil::SourceLocation::smallestCovering(m_currentNode->location, nativeLocationOf(_statement));
 	ASTWalker::visit(_statement);
 }
 
@@ -501,7 +501,7 @@ void ControlFlowBuilder::operator()(yul::Identifier const& _identifier)
 			m_currentNode->variableOccurrences.emplace_back(
 				*declaration,
 				VariableOccurrence::Kind::Access,
-				_identifier.debugData->location
+				nativeLocationOf(_identifier)
 			);
 	}
 }
@@ -517,7 +517,7 @@ void ControlFlowBuilder::operator()(yul::Assignment const& _assignment)
 				m_currentNode->variableOccurrences.emplace_back(
 					*declaration,
 					VariableOccurrence::Kind::Assignment,
-					variable.debugData->location
+					nativeLocationOf(variable)
 				);
 }
 

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -201,9 +201,9 @@ bool ReferencesResolver::visit(Return const& _return)
 
 void ReferencesResolver::operator()(yul::FunctionDefinition const& _function)
 {
-	validateYulIdentifierName(_function.name, _function.debugData->location);
+	validateYulIdentifierName(_function.name, nativeLocationOf(_function));
 	for (yul::TypedName const& varName: _function.parameters + _function.returnVariables)
-		validateYulIdentifierName(varName.name, varName.debugData->location);
+		validateYulIdentifierName(varName.name, nativeLocationOf(varName));
 
 	bool wasInsideFunction = m_yulInsideFunction;
 	m_yulInsideFunction = true;
@@ -238,7 +238,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 	{
 		m_errorReporter.declarationError(
 			4718_error,
-			_identifier.debugData->location,
+			nativeLocationOf(_identifier),
 			"Multiple matching identifiers. Resolving overloaded identifiers is not supported."
 		);
 		return;
@@ -251,7 +251,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 		)
 			m_errorReporter.declarationError(
 				9467_error,
-				_identifier.debugData->location,
+				nativeLocationOf(_identifier),
 				"Identifier not found. Use \".slot\" and \".offset\" to access storage variables."
 			);
 		return;
@@ -261,7 +261,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 		{
 			m_errorReporter.declarationError(
 				6578_error,
-				_identifier.debugData->location,
+				nativeLocationOf(_identifier),
 				"Cannot access local Solidity variables from inside an inline assembly function."
 			);
 			return;
@@ -275,7 +275,7 @@ void ReferencesResolver::operator()(yul::VariableDeclaration const& _varDecl)
 {
 	for (auto const& identifier: _varDecl.variables)
 	{
-		validateYulIdentifierName(identifier.name, identifier.debugData->location);
+		validateYulIdentifierName(identifier.name, nativeLocationOf(identifier));
 
 
 		if (
@@ -289,7 +289,7 @@ void ReferencesResolver::operator()(yul::VariableDeclaration const& _varDecl)
 			if (!ssl.infos.empty())
 				m_errorReporter.declarationError(
 					3859_error,
-					identifier.debugData->location,
+					nativeLocationOf(identifier),
 					ssl,
 					"This declaration shadows a declaration outside the inline assembly block."
 				);

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -201,9 +201,13 @@ bool ReferencesResolver::visit(Return const& _return)
 
 void ReferencesResolver::operator()(yul::FunctionDefinition const& _function)
 {
+	solAssert(nativeLocationOf(_function) == originLocationOf(_function), "");
 	validateYulIdentifierName(_function.name, nativeLocationOf(_function));
 	for (yul::TypedName const& varName: _function.parameters + _function.returnVariables)
+	{
+		solAssert(nativeLocationOf(varName) == originLocationOf(varName), "");
 		validateYulIdentifierName(varName.name, nativeLocationOf(varName));
+	}
 
 	bool wasInsideFunction = m_yulInsideFunction;
 	m_yulInsideFunction = true;
@@ -213,6 +217,8 @@ void ReferencesResolver::operator()(yul::FunctionDefinition const& _function)
 
 void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 {
+	solAssert(nativeLocationOf(_identifier) == originLocationOf(_identifier), "");
+
 	static set<string> suffixes{"slot", "offset", "length"};
 	string suffix;
 	for (string const& s: suffixes)
@@ -275,8 +281,8 @@ void ReferencesResolver::operator()(yul::VariableDeclaration const& _varDecl)
 {
 	for (auto const& identifier: _varDecl.variables)
 	{
+		solAssert(nativeLocationOf(identifier) == originLocationOf(identifier), "");
 		validateYulIdentifierName(identifier.name, nativeLocationOf(identifier));
-
 
 		if (
 			auto declarations = m_resolver.nameFromCurrentScope(identifier.name.str());

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -772,7 +772,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			solAssert(var->type(), "Expected variable type!");
 			if (var->immutable())
 			{
-				m_errorReporter.typeError(3773_error, _identifier.debugData->location, "Assembly access to immutable variables is not supported.");
+				m_errorReporter.typeError(3773_error, nativeLocationOf(_identifier), "Assembly access to immutable variables is not supported.");
 				return false;
 			}
 			if (var->isConstant())
@@ -781,7 +781,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 				{
 					m_errorReporter.typeError(
 						3558_error,
-						_identifier.debugData->location,
+						nativeLocationOf(_identifier),
 						"Constant variable is circular."
 					);
 					return false;
@@ -791,24 +791,24 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 
 				if (var && !var->value())
 				{
-					m_errorReporter.typeError(3224_error, _identifier.debugData->location, "Constant has no value.");
+					m_errorReporter.typeError(3224_error, nativeLocationOf(_identifier), "Constant has no value.");
 					return false;
 				}
 				else if (_context == yul::IdentifierContext::LValue)
 				{
-					m_errorReporter.typeError(6252_error, _identifier.debugData->location, "Constant variables cannot be assigned to.");
+					m_errorReporter.typeError(6252_error, nativeLocationOf(_identifier), "Constant variables cannot be assigned to.");
 					return false;
 				}
 				else if (identifierInfo.suffix == "slot" || identifierInfo.suffix == "offset")
 				{
-					m_errorReporter.typeError(6617_error, _identifier.debugData->location, "The suffixes .offset and .slot can only be used on non-constant storage variables.");
+					m_errorReporter.typeError(6617_error, nativeLocationOf(_identifier), "The suffixes .offset and .slot can only be used on non-constant storage variables.");
 					return false;
 				}
 				else if (var && var->value() && !var->value()->annotation().type && !dynamic_cast<Literal const*>(var->value().get()))
 				{
 					m_errorReporter.typeError(
 						2249_error,
-						_identifier.debugData->location,
+						nativeLocationOf(_identifier),
 						"Constant variables with non-literal values cannot be forward referenced from inline assembly."
 					);
 					return false;
@@ -818,7 +818,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 					type(*var->value())->category() != Type::Category::RationalNumber
 				))
 				{
-					m_errorReporter.typeError(7615_error, _identifier.debugData->location, "Only direct number constants and references to such constants are supported by inline assembly.");
+					m_errorReporter.typeError(7615_error, nativeLocationOf(_identifier), "Only direct number constants and references to such constants are supported by inline assembly.");
 					return false;
 				}
 			}
@@ -833,19 +833,19 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 				{
 					if (suffix != "slot" && suffix != "offset")
 					{
-						m_errorReporter.typeError(4656_error, _identifier.debugData->location, "State variables only support \".slot\" and \".offset\".");
+						m_errorReporter.typeError(4656_error, nativeLocationOf(_identifier), "State variables only support \".slot\" and \".offset\".");
 						return false;
 					}
 					else if (_context == yul::IdentifierContext::LValue)
 					{
 						if (var->isStateVariable())
 						{
-							m_errorReporter.typeError(4713_error, _identifier.debugData->location, "State variables cannot be assigned to - you have to use \"sstore()\".");
+							m_errorReporter.typeError(4713_error, nativeLocationOf(_identifier), "State variables cannot be assigned to - you have to use \"sstore()\".");
 							return false;
 						}
 						else if (suffix != "slot")
 						{
-							m_errorReporter.typeError(9739_error, _identifier.debugData->location, "Only .slot can be assigned to.");
+							m_errorReporter.typeError(9739_error, nativeLocationOf(_identifier), "Only .slot can be assigned to.");
 							return false;
 						}
 					}
@@ -857,13 +857,13 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 				{
 					if (suffix != "offset" && suffix != "length")
 					{
-						m_errorReporter.typeError(1536_error, _identifier.debugData->location, "Calldata variables only support \".offset\" and \".length\".");
+						m_errorReporter.typeError(1536_error, nativeLocationOf(_identifier), "Calldata variables only support \".offset\" and \".length\".");
 						return false;
 					}
 				}
 				else
 				{
-					m_errorReporter.typeError(3622_error, _identifier.debugData->location, "The suffix \"." + suffix + "\" is not supported by this variable or type.");
+					m_errorReporter.typeError(3622_error, nativeLocationOf(_identifier), "The suffix \"." + suffix + "\" is not supported by this variable or type.");
 					return false;
 				}
 			}
@@ -871,14 +871,14 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			{
 				m_errorReporter.typeError(
 					1408_error,
-					_identifier.debugData->location,
+					nativeLocationOf(_identifier),
 					"Only local variables are supported. To access storage variables, use the \".slot\" and \".offset\" suffixes."
 				);
 				return false;
 			}
 			else if (var->type()->dataStoredIn(DataLocation::Storage))
 			{
-				m_errorReporter.typeError(9068_error, _identifier.debugData->location, "You have to use the \".slot\" or \".offset\" suffix to access storage reference variables.");
+				m_errorReporter.typeError(9068_error, nativeLocationOf(_identifier), "You have to use the \".slot\" or \".offset\" suffix to access storage reference variables.");
 				return false;
 			}
 			else if (var->type()->sizeOnStack() != 1)
@@ -887,18 +887,18 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 					auto const* arrayType = dynamic_cast<ArrayType const*>(var->type());
 					arrayType && arrayType->isDynamicallySized() && arrayType->dataStoredIn(DataLocation::CallData)
 				)
-					m_errorReporter.typeError(1397_error, _identifier.debugData->location, "Call data elements cannot be accessed directly. Use \".offset\" and \".length\" to access the calldata offset and length of this array and then use \"calldatacopy\".");
+					m_errorReporter.typeError(1397_error, nativeLocationOf(_identifier), "Call data elements cannot be accessed directly. Use \".offset\" and \".length\" to access the calldata offset and length of this array and then use \"calldatacopy\".");
 				else
 				{
 					solAssert(!var->type()->dataStoredIn(DataLocation::CallData), "");
-					m_errorReporter.typeError(9857_error, _identifier.debugData->location, "Only types that use one stack slot are supported.");
+					m_errorReporter.typeError(9857_error, nativeLocationOf(_identifier), "Only types that use one stack slot are supported.");
 				}
 				return false;
 			}
 		}
 		else if (!identifierInfo.suffix.empty())
 		{
-			m_errorReporter.typeError(7944_error, _identifier.debugData->location, "The suffixes \".offset\", \".slot\" and \".length\" can only be used with variables.");
+			m_errorReporter.typeError(7944_error, nativeLocationOf(_identifier), "The suffixes \".offset\", \".slot\" and \".length\" can only be used with variables.");
 			return false;
 		}
 		else if (_context == yul::IdentifierContext::LValue)
@@ -906,7 +906,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			if (dynamic_cast<MagicVariableDeclaration const*>(declaration))
 				return false;
 
-			m_errorReporter.typeError(1990_error, _identifier.debugData->location, "Only local variables can be assigned to in inline assembly.");
+			m_errorReporter.typeError(1990_error, nativeLocationOf(_identifier), "Only local variables can be assigned to in inline assembly.");
 			return false;
 		}
 
@@ -915,7 +915,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			solAssert(!!declaration->type(), "Type of declaration required but not yet determined.");
 			if (dynamic_cast<FunctionDefinition const*>(declaration))
 			{
-				m_errorReporter.declarationError(2025_error, _identifier.debugData->location, "Access to functions is not allowed in inline assembly.");
+				m_errorReporter.declarationError(2025_error, nativeLocationOf(_identifier), "Access to functions is not allowed in inline assembly.");
 				return false;
 			}
 			else if (dynamic_cast<VariableDeclaration const*>(declaration))
@@ -925,7 +925,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			{
 				if (!contract->isLibrary())
 				{
-					m_errorReporter.typeError(4977_error, _identifier.debugData->location, "Expected a library.");
+					m_errorReporter.typeError(4977_error, nativeLocationOf(_identifier), "Expected a library.");
 					return false;
 				}
 			}

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -69,7 +69,7 @@ public:
 		if (yul::EVMDialect const* dialect = dynamic_cast<decltype(dialect)>(&m_dialect))
 			if (yul::BuiltinFunctionForEVM const* fun = dialect->builtin(_funCall.functionName.name))
 				if (fun->instruction)
-					checkInstruction(_funCall.debugData->location, *fun->instruction);
+					checkInstruction(nativeLocationOf(_funCall), *fun->instruction);
 
 		for (auto const& arg: _funCall.arguments)
 			std::visit(*this, arg);

--- a/libsolidity/ast/ASTJsonConverter.cpp
+++ b/libsolidity/ast/ASTJsonConverter.cpp
@@ -171,10 +171,10 @@ void ASTJsonConverter::appendExpressionAttributes(
 	_attributes += exprAttributes;
 }
 
-Json::Value ASTJsonConverter::inlineAssemblyIdentifierToJson(pair<yul::Identifier const* ,InlineAssemblyAnnotation::ExternalIdentifierInfo> _info) const
+Json::Value ASTJsonConverter::inlineAssemblyIdentifierToJson(pair<yul::Identifier const*, InlineAssemblyAnnotation::ExternalIdentifierInfo> _info) const
 {
 	Json::Value tuple(Json::objectValue);
-	tuple["src"] = sourceLocationToString(_info.first->debugData->location);
+	tuple["src"] = sourceLocationToString(nativeLocationOf(*_info.first));
 	tuple["declaration"] = idOrNull(_info.second.declaration);
 	tuple["isSlot"] = Json::Value(_info.second.suffix == "slot");
 	tuple["isOffset"] = Json::Value(_info.second.suffix == "offset");

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -421,7 +421,7 @@ void CompilerContext::appendInlineAssembly(
 		if (stackDiff < 1 || stackDiff > 16)
 			BOOST_THROW_EXCEPTION(
 				StackTooDeepError() <<
-				errinfo_sourceLocation(_identifier.debugData->location) <<
+				errinfo_sourceLocation(nativeLocationOf(_identifier)) <<
 				util::errinfo_comment("Stack too deep (" + to_string(stackDiff) + "), try removing local variables.")
 			);
 		if (_context == yul::IdentifierContext::RValue)

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1326,7 +1326,7 @@ ASTPointer<InlineAssembly> Parser::parseInlineAssembly(ASTPointer<ASTString> con
 	if (block == nullptr)
 		BOOST_THROW_EXCEPTION(FatalError());
 
-	location.end = block->debugData->location.end;
+	location.end = nativeLocationOf(*block).end;
 	return make_shared<InlineAssembly>(nextID(), location, _docString, dialect, block);
 }
 

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -96,22 +96,22 @@ AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Dialect const& _dialect,
 
 vector<YulString> AsmAnalyzer::operator()(Literal const& _literal)
 {
-	expectValidType(_literal.type, locationOf(_literal));
+	expectValidType(_literal.type, nativeLocationOf(_literal));
 	if (_literal.kind == LiteralKind::String && _literal.value.str().size() > 32)
 		m_errorReporter.typeError(
 			3069_error,
-			locationOf(_literal),
+			nativeLocationOf(_literal),
 			"String literal too long (" + to_string(_literal.value.str().size()) + " > 32)"
 		);
 	else if (_literal.kind == LiteralKind::Number && bigint(_literal.value.str()) > u256(-1))
-		m_errorReporter.typeError(6708_error, locationOf(_literal), "Number literal too large (> 256 bits)");
+		m_errorReporter.typeError(6708_error, nativeLocationOf(_literal), "Number literal too large (> 256 bits)");
 	else if (_literal.kind == LiteralKind::Boolean)
 		yulAssert(_literal.value == "true"_yulstring || _literal.value == "false"_yulstring, "");
 
 	if (!m_dialect.validTypeForLiteral(_literal.kind, _literal.value, _literal.type))
 		m_errorReporter.typeError(
 			5170_error,
-			locationOf(_literal),
+			nativeLocationOf(_literal),
 			"Invalid type \"" + _literal.type.str() + "\" for literal \"" + _literal.value.str() + "\"."
 		);
 
@@ -131,7 +131,7 @@ vector<YulString> AsmAnalyzer::operator()(Identifier const& _identifier)
 			if (!m_activeVariables.count(&_var))
 				m_errorReporter.declarationError(
 					4990_error,
-					locationOf(_identifier),
+					nativeLocationOf(_identifier),
 					"Variable " + _identifier.name.str() + " used before it was declared."
 				);
 			type = _var.type;
@@ -140,7 +140,7 @@ vector<YulString> AsmAnalyzer::operator()(Identifier const& _identifier)
 		{
 			m_errorReporter.typeError(
 				6041_error,
-				locationOf(_identifier),
+				nativeLocationOf(_identifier),
 				"Function " + _identifier.name.str() + " used without being called."
 			);
 		}
@@ -165,7 +165,7 @@ vector<YulString> AsmAnalyzer::operator()(Identifier const& _identifier)
 			// Only add an error message if the callback did not do it.
 			m_errorReporter.declarationError(
 				8198_error,
-				locationOf(_identifier),
+				nativeLocationOf(_identifier),
 				"Identifier \"" + _identifier.name.str() + "\" not found."
 			);
 
@@ -181,7 +181,7 @@ void AsmAnalyzer::operator()(ExpressionStatement const& _statement)
 	if (watcher.ok() && !types.empty())
 		m_errorReporter.typeError(
 			3083_error,
-			locationOf(_statement),
+			nativeLocationOf(_statement),
 			"Top-level expressions are not supposed to return values (this expression returns " +
 			to_string(types.size()) +
 			" value" +
@@ -201,7 +201,7 @@ void AsmAnalyzer::operator()(Assignment const& _assignment)
 		if (!variables.insert(_variableName.name).second)
 			m_errorReporter.declarationError(
 				9005_error,
-				locationOf(_assignment),
+				nativeLocationOf(_assignment),
 				"Variable " +
 				_variableName.name.str() +
 				" occurs multiple times on the left-hand side of the assignment."
@@ -212,7 +212,7 @@ void AsmAnalyzer::operator()(Assignment const& _assignment)
 	if (types.size() != numVariables)
 		m_errorReporter.declarationError(
 			8678_error,
-			locationOf(_assignment),
+			nativeLocationOf(_assignment),
 			"Variable count for assignment to \"" +
 			joinHumanReadable(applyMap(_assignment.variableNames, [](auto const& _identifier){ return _identifier.name.str(); })) +
 			"\" does not match number of values (" +
@@ -240,8 +240,8 @@ void AsmAnalyzer::operator()(VariableDeclaration const& _varDecl)
 			);
 	for (auto const& variable: _varDecl.variables)
 	{
-		expectValidIdentifier(variable.name, locationOf(variable));
-		expectValidType(variable.type, locationOf(variable));
+		expectValidIdentifier(variable.name, nativeLocationOf(variable));
+		expectValidType(variable.type, nativeLocationOf(variable));
 	}
 
 	if (_varDecl.value)
@@ -250,7 +250,7 @@ void AsmAnalyzer::operator()(VariableDeclaration const& _varDecl)
 		if (types.size() != numVariables)
 			m_errorReporter.declarationError(
 				3812_error,
-				locationOf(_varDecl),
+				nativeLocationOf(_varDecl),
 				"Variable count mismatch for declaration of \"" +
 				joinHumanReadable(applyMap(_varDecl.variables, [](auto const& _identifier){ return _identifier.name.str(); })) +
 				+ "\": " +
@@ -269,7 +269,7 @@ void AsmAnalyzer::operator()(VariableDeclaration const& _varDecl)
 			if (variable.type != givenType)
 				m_errorReporter.typeError(
 					3947_error,
-					locationOf(variable),
+					nativeLocationOf(variable),
 					"Assigning value of type \"" + givenType.str() + "\" to variable of type \"" + variable.type.str() + "\"."
 				);
 		}
@@ -284,14 +284,14 @@ void AsmAnalyzer::operator()(VariableDeclaration const& _varDecl)
 void AsmAnalyzer::operator()(FunctionDefinition const& _funDef)
 {
 	yulAssert(!_funDef.name.empty(), "");
-	expectValidIdentifier(_funDef.name, locationOf(_funDef));
+	expectValidIdentifier(_funDef.name, nativeLocationOf(_funDef));
 	Block const* virtualBlock = m_info.virtualBlocks.at(&_funDef).get();
 	yulAssert(virtualBlock, "");
 	Scope& varScope = scope(virtualBlock);
 	for (auto const& var: _funDef.parameters + _funDef.returnVariables)
 	{
-		expectValidIdentifier(var.name, locationOf(var));
-		expectValidType(var.type, locationOf(var));
+		expectValidIdentifier(var.name, nativeLocationOf(var));
+		expectValidType(var.type, nativeLocationOf(var));
 		m_activeVariables.insert(&std::get<Scope::Variable>(varScope.identifiers.at(var.name)));
 	}
 
@@ -320,7 +320,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 		{
 			m_errorReporter.typeError(
 				4202_error,
-				locationOf(_funCall.functionName),
+				nativeLocationOf(_funCall.functionName),
 				"Attempt to call variable instead of function."
 			);
 		},
@@ -344,7 +344,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 		if (!validateInstructions(_funCall))
 			m_errorReporter.declarationError(
 				4619_error,
-				locationOf(_funCall.functionName),
+				nativeLocationOf(_funCall.functionName),
 				"Function \"" + _funCall.functionName.name.str() + "\" not found."
 			);
 		yulAssert(!watcher.ok(), "Expected a reported error.");
@@ -353,7 +353,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 	if (parameterTypes && _funCall.arguments.size() != parameterTypes->size())
 		m_errorReporter.typeError(
 			7000_error,
-			locationOf(_funCall.functionName),
+			nativeLocationOf(_funCall.functionName),
 			"Function \"" + _funCall.functionName.name.str() + "\" expects " +
 			to_string(parameterTypes->size()) +
 			" arguments but got " +
@@ -373,13 +373,13 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 			if (!holds_alternative<Literal>(arg))
 				m_errorReporter.typeError(
 					9114_error,
-					locationOf(_funCall.functionName),
+					nativeLocationOf(_funCall.functionName),
 					"Function expects direct literals as arguments."
 				);
 			else if (*literalArgumentKind != get<Literal>(arg).kind)
 				m_errorReporter.typeError(
 					5859_error,
-					locationOf(arg),
+					nativeLocationOf(arg),
 					"Function expects " + to_string(*literalArgumentKind) + " literal."
 				);
 			else if (*literalArgumentKind == LiteralKind::String)
@@ -390,7 +390,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 					if (!m_dataNames.count(get<Literal>(arg).value))
 						m_errorReporter.typeError(
 							3517_error,
-							locationOf(arg),
+							nativeLocationOf(arg),
 							"Unknown data object \"" + std::get<Literal>(arg).value.str() + "\"."
 						);
 				}
@@ -399,7 +399,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 					if (get<Literal>(arg).value.empty())
 						m_errorReporter.typeError(
 							1844_error,
-							locationOf(arg),
+							nativeLocationOf(arg),
 							"The \"verbatim_*\" builtins cannot be used with empty bytecode."
 						);
 				}
@@ -414,7 +414,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 
 	if (parameterTypes && parameterTypes->size() == argTypes.size())
 		for (size_t i = 0; i < parameterTypes->size(); ++i)
-			expectType((*parameterTypes)[i], argTypes[i], locationOf(_funCall.arguments[i]));
+			expectType((*parameterTypes)[i], argTypes[i], nativeLocationOf(_funCall.arguments[i]));
 
 	if (watcher.ok())
 	{
@@ -442,7 +442,7 @@ void AsmAnalyzer::operator()(Switch const& _switch)
 	if (_switch.cases.size() == 1 && !_switch.cases[0].value)
 		m_errorReporter.warning(
 			9592_error,
-			locationOf(_switch),
+			nativeLocationOf(_switch),
 			"\"switch\" statement with only a default case."
 		);
 
@@ -455,7 +455,7 @@ void AsmAnalyzer::operator()(Switch const& _switch)
 		{
 			auto watcher = m_errorReporter.errorWatcher();
 
-			expectType(valueType, _case.value->type, locationOf(*_case.value));
+			expectType(valueType, _case.value->type, nativeLocationOf(*_case.value));
 
 			// We cannot use "expectExpression" here because *_case.value is not an
 			// Expression and would be converted to an Expression otherwise.
@@ -465,7 +465,7 @@ void AsmAnalyzer::operator()(Switch const& _switch)
 			if (watcher.ok() && !cases.insert(valueOfLiteral(*_case.value)).second)
 				m_errorReporter.declarationError(
 					6792_error,
-					locationOf(_case),
+					nativeLocationOf(_case),
 					"Duplicate case \"" +
 					valueOfLiteral(*_case.value).str() +
 					"\" defined."
@@ -517,7 +517,7 @@ YulString AsmAnalyzer::expectExpression(Expression const& _expr)
 	if (types.size() != 1)
 		m_errorReporter.typeError(
 			3950_error,
-			locationOf(_expr),
+			nativeLocationOf(_expr),
 			"Expected expression to evaluate to one value, but got " +
 			to_string(types.size()) +
 			" values instead."
@@ -539,7 +539,7 @@ void AsmAnalyzer::expectBoolExpression(Expression const& _expr)
 	if (type != m_dialect.boolType)
 		m_errorReporter.typeError(
 			1733_error,
-			locationOf(_expr),
+			nativeLocationOf(_expr),
 			"Expected a value of boolean type \"" +
 			m_dialect.boolType.str() +
 			"\" but got \"" +
@@ -565,11 +565,11 @@ void AsmAnalyzer::checkAssignment(Identifier const& _variable, YulString _valueT
 			);
 
 		if (!holds_alternative<Scope::Variable>(*var))
-			m_errorReporter.typeError(2657_error, locationOf(_variable), "Assignment requires variable.");
+			m_errorReporter.typeError(2657_error, nativeLocationOf(_variable), "Assignment requires variable.");
 		else if (!m_activeVariables.count(&std::get<Scope::Variable>(*var)))
 			m_errorReporter.declarationError(
 				1133_error,
-				locationOf(_variable),
+				nativeLocationOf(_variable),
 				"Variable " + _variable.name.str() + " used before it was declared."
 			);
 		else
@@ -588,11 +588,11 @@ void AsmAnalyzer::checkAssignment(Identifier const& _variable, YulString _valueT
 
 	if (!found && watcher.ok())
 		// Only add message if the callback did not.
-		m_errorReporter.declarationError(4634_error, locationOf(_variable), "Variable not found or variable not lvalue.");
+		m_errorReporter.declarationError(4634_error, nativeLocationOf(_variable), "Variable not found or variable not lvalue.");
 	if (variableType && *variableType != _valueType)
 		m_errorReporter.typeError(
 			9547_error,
-			locationOf(_variable),
+			nativeLocationOf(_variable),
 			"Assigning a value of type \"" +
 			_valueType.str() +
 			"\" to a variable of type \"" +
@@ -738,5 +738,5 @@ bool AsmAnalyzer::validateInstructions(evmasm::Instruction _instr, SourceLocatio
 
 bool AsmAnalyzer::validateInstructions(FunctionCall const& _functionCall)
 {
-	return validateInstructions(_functionCall.functionName.name.str(), locationOf(_functionCall.functionName));
+	return validateInstructions(_functionCall.functionName.name.str(), nativeLocationOf(_functionCall.functionName));
 }

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -33,7 +33,7 @@ namespace solidity::yul
 
 Json::Value AsmJsonConverter::operator()(Block const& _node) const
 {
-	Json::Value ret = createAstNode(locationOf(_node), "YulBlock");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulBlock");
 	ret["statements"] = vectorOfVariantsToJson(_node.statements);
 	return ret;
 }
@@ -41,7 +41,7 @@ Json::Value AsmJsonConverter::operator()(Block const& _node) const
 Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid variable name.");
-	Json::Value ret = createAstNode(locationOf(_node), "YulTypedName");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulTypedName");
 	ret["name"] = _node.name.str();
 	ret["type"] = _node.type.str();
 	return ret;
@@ -49,7 +49,7 @@ Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Literal const& _node) const
 {
-	Json::Value ret = createAstNode(locationOf(_node), "YulLiteral");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulLiteral");
 	switch (_node.kind)
 	{
 	case LiteralKind::Number:
@@ -76,7 +76,7 @@ Json::Value AsmJsonConverter::operator()(Literal const& _node) const
 Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid identifier");
-	Json::Value ret = createAstNode(locationOf(_node), "YulIdentifier");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulIdentifier");
 	ret["name"] = _node.name.str();
 	return ret;
 }
@@ -84,7 +84,7 @@ Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
 Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
 {
 	yulAssert(_node.variableNames.size() >= 1, "Invalid assignment syntax");
-	Json::Value ret = createAstNode(locationOf(_node), "YulAssignment");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulAssignment");
 	for (auto const& var: _node.variableNames)
 		ret["variableNames"].append((*this)(var));
 	ret["value"] = _node.value ? std::visit(*this, *_node.value) : Json::nullValue;
@@ -93,7 +93,7 @@ Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
 
 Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
 {
-	Json::Value ret = createAstNode(locationOf(_node), "YulFunctionCall");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulFunctionCall");
 	ret["functionName"] = (*this)(_node.functionName);
 	ret["arguments"] = vectorOfVariantsToJson(_node.arguments);
 	return ret;
@@ -101,14 +101,14 @@ Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
 
 Json::Value AsmJsonConverter::operator()(ExpressionStatement const& _node) const
 {
-	Json::Value ret = createAstNode(locationOf(_node), "YulExpressionStatement");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulExpressionStatement");
 	ret["expression"] = std::visit(*this, _node.expression);
 	return ret;
 }
 
 Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
 {
-	Json::Value ret = createAstNode(locationOf(_node), "YulVariableDeclaration");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulVariableDeclaration");
 	for (auto const& var: _node.variables)
 		ret["variables"].append((*this)(var));
 
@@ -120,7 +120,7 @@ Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
 Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid function name.");
-	Json::Value ret = createAstNode(locationOf(_node), "YulFunctionDefinition");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulFunctionDefinition");
 	ret["name"] = _node.name.str();
 	for (auto const& var: _node.parameters)
 		ret["parameters"].append((*this)(var));
@@ -133,7 +133,7 @@ Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
 Json::Value AsmJsonConverter::operator()(If const& _node) const
 {
 	yulAssert(_node.condition, "Invalid if condition.");
-	Json::Value ret = createAstNode(locationOf(_node), "YulIf");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulIf");
 	ret["condition"] = std::visit(*this, *_node.condition);
 	ret["body"] = (*this)(_node.body);
 	return ret;
@@ -142,7 +142,7 @@ Json::Value AsmJsonConverter::operator()(If const& _node) const
 Json::Value AsmJsonConverter::operator()(Switch const& _node) const
 {
 	yulAssert(_node.expression, "Invalid expression pointer.");
-	Json::Value ret = createAstNode(locationOf(_node), "YulSwitch");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulSwitch");
 	ret["expression"] = std::visit(*this, *_node.expression);
 	for (auto const& var: _node.cases)
 		ret["cases"].append((*this)(var));
@@ -151,7 +151,7 @@ Json::Value AsmJsonConverter::operator()(Switch const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Case const& _node) const
 {
-	Json::Value ret = createAstNode(locationOf(_node), "YulCase");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulCase");
 	ret["value"] = _node.value ? (*this)(*_node.value) : "default";
 	ret["body"] = (*this)(_node.body);
 	return ret;
@@ -160,7 +160,7 @@ Json::Value AsmJsonConverter::operator()(Case const& _node) const
 Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
 {
 	yulAssert(_node.condition, "Invalid for loop condition.");
-	Json::Value ret = createAstNode(locationOf(_node), "YulForLoop");
+	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulForLoop");
 	ret["pre"] = (*this)(_node.pre);
 	ret["condition"] = std::visit(*this, *_node.condition);
 	ret["post"] = (*this)(_node.post);
@@ -170,17 +170,17 @@ Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Break const& _node) const
 {
-	return createAstNode(locationOf(_node), "YulBreak");
+	return createAstNode(nativeLocationOf(_node), "YulBreak");
 }
 
 Json::Value AsmJsonConverter::operator()(Continue const& _node) const
 {
-	return createAstNode(locationOf(_node), "YulContinue");
+	return createAstNode(nativeLocationOf(_node), "YulContinue");
 }
 
 Json::Value AsmJsonConverter::operator()(Leave const& _node) const
 {
-	return createAstNode(locationOf(_node), "YulLeave");
+	return createAstNode(nativeLocationOf(_node), "YulLeave");
 }
 
 Json::Value AsmJsonConverter::createAstNode(langutil::SourceLocation const& _location, string _nodeType) const

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -53,9 +53,9 @@ template <class T>
 T AsmJsonImporter::createAsmNode(Json::Value const& _node)
 {
 	T r;
-	SourceLocation location = createSourceLocation(_node);
-	yulAssert(location.hasText(), "Invalid source location in Asm AST");
-	r.debugData = DebugData::create(location);
+	SourceLocation nativeLocation = createSourceLocation(_node);
+	yulAssert(nativeLocation.hasText(), "Invalid source location in Asm AST");
+	r.debugData = DebugData::create(nativeLocation);
 	return r;
 }
 

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -55,7 +55,10 @@ T AsmJsonImporter::createAsmNode(Json::Value const& _node)
 	T r;
 	SourceLocation nativeLocation = createSourceLocation(_node);
 	yulAssert(nativeLocation.hasText(), "Invalid source location in Asm AST");
-	r.debugData = DebugData::create(nativeLocation);
+	// TODO: We should add originLocation to the AST.
+	// While it's not included, we'll use nativeLocation for it because we only support importing
+	// inline assembly as a part of a Solidity AST and there these locations are always the same.
+	r.debugData = DebugData::create(nativeLocation, nativeLocation);
 	return r;
 }
 

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<DebugData const> Parser::createDebugData() const
 		case UseSourceLocationFrom::LocationOverride:
 			return DebugData::create(m_locationOverride);
 		case UseSourceLocationFrom::Comments:
-			return m_debugDataOverride;
+			return DebugData::create(m_locationFromComment, m_astIDFromComment);
 	}
 	solAssert(false, "");
 }
@@ -135,7 +135,7 @@ void Parser::fetchDebugDataFromComment()
 	string_view commentLiteral = m_scanner->currentCommentLiteral();
 	match_results<string_view::const_iterator> match;
 
-	langutil::SourceLocation sourceLocation = m_debugDataOverride->location;
+	langutil::SourceLocation sourceLocation = m_locationFromComment;
 	// Empty for each new node.
 	optional<int> astID;
 
@@ -163,7 +163,8 @@ void Parser::fetchDebugDataFromComment()
 			continue;
 	}
 
-	m_debugDataOverride = DebugData::create(sourceLocation, astID);
+	m_locationFromComment = sourceLocation;
+	m_astIDFromComment = astID;
 }
 
 optional<pair<string_view, SourceLocation>> Parser::parseSrcComment(

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -46,17 +46,6 @@ using namespace solidity::yul;
 namespace
 {
 
-[[nodiscard]]
-shared_ptr<DebugData const> updateLocationEndFrom(
-	shared_ptr<DebugData const> const& _debugData,
-	langutil::SourceLocation const& _location
-)
-{
-	SourceLocation updatedLocation = _debugData ? _debugData->location : langutil::SourceLocation{};
-	updatedLocation.end = _location.end;
-	return make_shared<DebugData const>(updatedLocation);
-}
-
 optional<int> toInt(string const& _value)
 {
 	try
@@ -76,13 +65,43 @@ std::shared_ptr<DebugData const> Parser::createDebugData() const
 	switch (m_useSourceLocationFrom)
 	{
 		case UseSourceLocationFrom::Scanner:
-			return DebugData::create(ParserBase::currentLocation());
+			return DebugData::create(ParserBase::currentLocation(), ParserBase::currentLocation());
 		case UseSourceLocationFrom::LocationOverride:
-			return DebugData::create(m_locationOverride);
+			return DebugData::create(m_locationOverride, m_locationOverride);
 		case UseSourceLocationFrom::Comments:
-			return DebugData::create(m_locationFromComment, m_astIDFromComment);
+			return DebugData::create(ParserBase::currentLocation(), m_locationFromComment, m_astIDFromComment);
 	}
 	solAssert(false, "");
+}
+
+void Parser::updateLocationEndFrom(
+	shared_ptr<DebugData const>& _debugData,
+	SourceLocation const& _location
+) const
+{
+	solAssert(_debugData, "");
+
+	switch (m_useSourceLocationFrom)
+	{
+		case UseSourceLocationFrom::Scanner:
+		{
+			DebugData updatedDebugData = *_debugData;
+			updatedDebugData.nativeLocation.end = _location.end;
+			updatedDebugData.originLocation.end = _location.end;
+			_debugData = make_shared<DebugData const>(move(updatedDebugData));
+			break;
+		}
+		case UseSourceLocationFrom::LocationOverride:
+			// Ignore the update. The location we're overriding with is not supposed to change
+			break;
+		case UseSourceLocationFrom::Comments:
+		{
+			DebugData updatedDebugData = *_debugData;
+			updatedDebugData.nativeLocation.end = _location.end;
+			_debugData = make_shared<DebugData const>(move(updatedDebugData));
+			break;
+		}
+	}
 }
 
 unique_ptr<Block> Parser::parse(CharStream& _charStream)
@@ -135,7 +154,7 @@ void Parser::fetchDebugDataFromComment()
 	string_view commentLiteral = m_scanner->currentCommentLiteral();
 	match_results<string_view::const_iterator> match;
 
-	langutil::SourceLocation sourceLocation = m_locationFromComment;
+	langutil::SourceLocation originLocation = m_locationFromComment;
 	// Empty for each new node.
 	optional<int> astID;
 
@@ -147,7 +166,7 @@ void Parser::fetchDebugDataFromComment()
 		if (match[1] == "@src")
 		{
 			if (auto parseResult = parseSrcComment(commentLiteral, m_scanner->currentCommentLocation()))
-				tie(commentLiteral, sourceLocation) = *parseResult;
+				tie(commentLiteral, originLocation) = *parseResult;
 			else
 				break;
 		}
@@ -163,7 +182,7 @@ void Parser::fetchDebugDataFromComment()
 			continue;
 	}
 
-	m_locationFromComment = sourceLocation;
+	m_locationFromComment = originLocation;
 	m_astIDFromComment = astID;
 }
 
@@ -271,8 +290,7 @@ Block Parser::parseBlock()
 	expectToken(Token::LBrace);
 	while (currentToken() != Token::RBrace)
 		block.statements.emplace_back(parseStatement());
-	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		block.debugData = updateLocationEndFrom(block.debugData, currentLocation());
+	updateLocationEndFrom(block.debugData, currentLocation());
 	advance();
 	return block;
 }
@@ -294,8 +312,7 @@ Statement Parser::parseStatement()
 		advance();
 		_if.condition = make_unique<Expression>(parseExpression());
 		_if.body = parseBlock();
-		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			_if.debugData = updateLocationEndFrom(_if.debugData, locationOf(_if.body));
+		updateLocationEndFrom(_if.debugData, nativeLocationOf(_if.body));
 		return Statement{move(_if)};
 	}
 	case Token::Switch:
@@ -313,8 +330,7 @@ Statement Parser::parseStatement()
 			fatalParserError(4904_error, "Case not allowed after default case.");
 		if (_switch.cases.empty())
 			fatalParserError(2418_error, "Switch statement without any cases.");
-		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			_switch.debugData = updateLocationEndFrom(_switch.debugData, locationOf(_switch.cases.back().body));
+		updateLocationEndFrom(_switch.debugData, nativeLocationOf(_switch.cases.back().body));
 		return Statement{move(_switch)};
 	}
 	case Token::For:
@@ -396,8 +412,7 @@ Statement Parser::parseStatement()
 		expectToken(Token::AssemblyAssign);
 
 		assignment.value = make_unique<Expression>(parseExpression());
-		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			assignment.debugData = updateLocationEndFrom(assignment.debugData, locationOf(*assignment.value));
+		updateLocationEndFrom(assignment.debugData, nativeLocationOf(*assignment.value));
 
 		return Statement{move(assignment)};
 	}
@@ -427,8 +442,7 @@ Case Parser::parseCase()
 	else
 		yulAssert(false, "Case or default case expected.");
 	_case.body = parseBlock();
-	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		_case.debugData = updateLocationEndFrom(_case.debugData, locationOf(_case.body));
+	updateLocationEndFrom(_case.debugData, nativeLocationOf(_case.body));
 	return _case;
 }
 
@@ -448,8 +462,7 @@ ForLoop Parser::parseForLoop()
 	forLoop.post = parseBlock();
 	m_currentForLoopComponent = ForLoopComponent::ForLoopBody;
 	forLoop.body = parseBlock();
-	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		forLoop.debugData = updateLocationEndFrom(forLoop.debugData, locationOf(forLoop.body));
+	updateLocationEndFrom(forLoop.debugData, nativeLocationOf(forLoop.body));
 
 	m_currentForLoopComponent = outerForLoopComponent;
 
@@ -469,7 +482,7 @@ Expression Parser::parseExpression()
 			if (m_dialect.builtin(_identifier.name))
 				fatalParserError(
 					7104_error,
-					locationOf(_identifier),
+					nativeLocationOf(_identifier),
 					"Builtin function \"" + _identifier.name.str() + "\" must be called."
 				);
 			return move(_identifier);
@@ -528,8 +541,7 @@ variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 		if (currentToken() == Token::Colon)
 		{
 			expectToken(Token::Colon);
-			if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-				literal.debugData = updateLocationEndFrom(literal.debugData, currentLocation());
+			updateLocationEndFrom(literal.debugData, currentLocation());
 			literal.type = expectAsmIdentifier();
 		}
 
@@ -561,11 +573,10 @@ VariableDeclaration Parser::parseVariableDeclaration()
 	{
 		expectToken(Token::AssemblyAssign);
 		varDecl.value = make_unique<Expression>(parseExpression());
-		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			varDecl.debugData = updateLocationEndFrom(varDecl.debugData, locationOf(*varDecl.value));
+		updateLocationEndFrom(varDecl.debugData, nativeLocationOf(*varDecl.value));
 	}
-	else if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		varDecl.debugData = updateLocationEndFrom(varDecl.debugData, locationOf(varDecl.variables.back()));
+	else
+		updateLocationEndFrom(varDecl.debugData, nativeLocationOf(varDecl.variables.back()));
 
 	return varDecl;
 }
@@ -611,8 +622,7 @@ FunctionDefinition Parser::parseFunctionDefinition()
 	m_insideFunction = true;
 	funDef.body = parseBlock();
 	m_insideFunction = preInsideFunction;
-	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		funDef.debugData = updateLocationEndFrom(funDef.debugData, locationOf(funDef.body));
+	updateLocationEndFrom(funDef.debugData, nativeLocationOf(funDef.body));
 
 	m_currentForLoopComponent = outerForLoopComponent;
 	return funDef;
@@ -639,8 +649,7 @@ FunctionCall Parser::parseCall(variant<Literal, Identifier>&& _initialOp)
 			ret.arguments.emplace_back(parseExpression());
 		}
 	}
-	if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-		ret.debugData = updateLocationEndFrom(ret.debugData, currentLocation());
+	updateLocationEndFrom(ret.debugData, currentLocation());
 	expectToken(Token::RParen);
 	return ret;
 }
@@ -653,8 +662,7 @@ TypedName Parser::parseTypedName()
 	if (currentToken() == Token::Colon)
 	{
 		expectToken(Token::Colon);
-		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			typedName.debugData = updateLocationEndFrom(typedName.debugData, currentLocation());
+		updateLocationEndFrom(typedName.debugData, currentLocation());
 		typedName.type = expectAsmIdentifier();
 	}
 	else

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -61,7 +61,6 @@ public:
 		ParserBase(_errorReporter),
 		m_dialect(_dialect),
 		m_locationOverride{_locationOverride ? *_locationOverride : langutil::SourceLocation{}},
-		m_debugDataOverride{},
 		m_useSourceLocationFrom{
 			_locationOverride ?
 			UseSourceLocationFrom::LocationOverride :
@@ -79,7 +78,6 @@ public:
 		ParserBase(_errorReporter),
 		m_dialect(_dialect),
 		m_sourceNames{std::move(_sourceNames)},
-		m_debugDataOverride{DebugData::create()},
 		m_useSourceLocationFrom{
 			m_sourceNames.has_value() ?
 			UseSourceLocationFrom::Comments :
@@ -154,7 +152,8 @@ private:
 
 	std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> m_sourceNames;
 	langutil::SourceLocation m_locationOverride;
-	std::shared_ptr<DebugData const> m_debugDataOverride;
+	langutil::SourceLocation m_locationFromComment;
+	std::optional<int64_t> m_astIDFromComment;
 	UseSourceLocationFrom m_useSourceLocationFrom = UseSourceLocationFrom::Scanner;
 	ForLoopComponent m_currentForLoopComponent = ForLoopComponent::None;
 	bool m_insideFunction = false;

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -97,9 +97,10 @@ public:
 protected:
 	langutil::SourceLocation currentLocation() const override
 	{
-		if (m_useSourceLocationFrom == UseSourceLocationFrom::Scanner)
-			return ParserBase::currentLocation();
-		return m_locationOverride;
+		if (m_useSourceLocationFrom == UseSourceLocationFrom::LocationOverride)
+			return m_locationOverride;
+
+		return ParserBase::currentLocation();
 	}
 
 	langutil::Token advance() override;

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -119,6 +119,11 @@ protected:
 	/// Creates a DebugData object with the correct source location set.
 	std::shared_ptr<DebugData const> createDebugData() const;
 
+	void updateLocationEndFrom(
+		std::shared_ptr<DebugData const>& _debugData,
+		langutil::SourceLocation const& _location
+	) const;
+
 	/// Creates an inline assembly node with the current source location.
 	template <class T> T createWithLocation() const
 	{

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -306,14 +306,14 @@ string AsmPrinter::formatDebugData(shared_ptr<DebugData const> const& _debugData
 		items.emplace_back("@ast-id " + to_string(*id));
 
 	if (
-		m_lastLocation != _debugData->location &&
+		m_lastLocation != _debugData->originLocation &&
 		!m_nameToSourceIndex.empty()
 	)
 	{
-		m_lastLocation = _debugData->location;
+		m_lastLocation = _debugData->originLocation;
 
 		items.emplace_back(formatSourceLocation(
-			_debugData->location,
+			_debugData->originLocation,
 			m_nameToSourceIndex,
 			m_soliditySourceProvider
 		));

--- a/libyul/ScopeFiller.cpp
+++ b/libyul/ScopeFiller.cpp
@@ -53,7 +53,7 @@ bool ScopeFiller::operator()(ExpressionStatement const& _expr)
 bool ScopeFiller::operator()(VariableDeclaration const& _varDecl)
 {
 	for (auto const& variable: _varDecl.variables)
-		if (!registerVariable(variable, locationOf(_varDecl), *m_currentScope))
+		if (!registerVariable(variable, nativeLocationOf(_varDecl), *m_currentScope))
 			return false;
 	return true;
 }
@@ -68,7 +68,7 @@ bool ScopeFiller::operator()(FunctionDefinition const& _funDef)
 
 	bool success = true;
 	for (auto const& var: _funDef.parameters + _funDef.returnVariables)
-		if (!registerVariable(var, locationOf(_funDef), varScope))
+		if (!registerVariable(var, nativeLocationOf(_funDef), varScope))
 			success = false;
 
 	if (!(*this)(_funDef.body))
@@ -162,7 +162,7 @@ bool ScopeFiller::registerFunction(FunctionDefinition const& _funDef)
 		//@TODO secondary location
 		m_errorReporter.declarationError(
 			6052_error,
-			locationOf(_funDef),
+			nativeLocationOf(_funDef),
 			"Function name " + _funDef.name.str() + " already taken in this scope."
 		);
 		return false;

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_empty_block)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 234, 543);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_block_with_children)
@@ -232,12 +232,12 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_with_children)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
-	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 234, 543);
 	BOOST_REQUIRE_EQUAL(3, result->statements.size());
-	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 234, 543);
-	CHECK_LOCATION(locationOf(result->statements.at(1)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(0)), "source0", 234, 543);
+	CHECK_LOCATION(originLocationOf(result->statements.at(1)), "source0", 123, 432);
 	// [2] is inherited source location
-	CHECK_LOCATION(locationOf(result->statements.at(2)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(2)), "source0", 123, 432);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_block_different_sources)
@@ -255,12 +255,12 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_different_sources)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 234, 543);
 	BOOST_REQUIRE_EQUAL(3, result->statements.size());
-	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 234, 543);
-	CHECK_LOCATION(locationOf(result->statements.at(1)), "source1", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(0)), "source0", 234, 543);
+	CHECK_LOCATION(originLocationOf(result->statements.at(1)), "source1", 123, 432);
 	// [2] is inherited source location
-	CHECK_LOCATION(locationOf(result->statements.at(2)), "source1", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(2)), "source1", 123, 432);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_block_nested)
@@ -277,9 +277,9 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_nested)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 234, 543);
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
-	CHECK_LOCATION(locationOf(result->statements.at(1)), "source0", 343, 434);
+	CHECK_LOCATION(originLocationOf(result->statements.at(1)), "source0", 343, 434);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_block_switch_case)
@@ -301,19 +301,19 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_switch_case)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 234, 543);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 234, 543);
 
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
 	BOOST_REQUIRE(holds_alternative<Switch>(result->statements.at(1)));
 	auto const& switchStmt = get<Switch>(result->statements.at(1));
 
-	CHECK_LOCATION(switchStmt.debugData->location, "source0", 343, 434);
+	CHECK_LOCATION(switchStmt.debugData->originLocation, "source0", 343, 434);
 	BOOST_REQUIRE_EQUAL(1, switchStmt.cases.size());
-	CHECK_LOCATION(switchStmt.cases.at(0).debugData->location, "source0", 3141, 59265);
+	CHECK_LOCATION(switchStmt.cases.at(0).debugData->originLocation, "source0", 3141, 59265);
 
 	auto const& caseBody = switchStmt.cases.at(0).body;
 	BOOST_REQUIRE_EQUAL(1, caseBody.statements.size());
-	CHECK_LOCATION(locationOf(caseBody.statements.at(0)), "source0", 271, 828);
+	CHECK_LOCATION(originLocationOf(caseBody.statements.at(0)), "source0", 271, 828);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_inherit_into_outer_scope)
@@ -334,19 +334,19 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_inherit_into_outer_scope)
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
-	CHECK_LOCATION(result->debugData->location, "source0", 1, 100);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 1, 100);
 
 	BOOST_REQUIRE_EQUAL(3, result->statements.size());
-	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 1, 100);
+	CHECK_LOCATION(originLocationOf(result->statements.at(0)), "source0", 1, 100);
 
 	// First child element must be a block itself with one statement.
 	BOOST_REQUIRE(holds_alternative<Block>(result->statements.at(0)));
 	BOOST_REQUIRE_EQUAL(get<Block>(result->statements.at(0)).statements.size(), 1);
-	CHECK_LOCATION(locationOf(get<Block>(result->statements.at(0)).statements.at(0)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(get<Block>(result->statements.at(0)).statements.at(0)), "source0", 123, 432);
 
 	// The next two elements have an inherited source location from the prior inner scope.
-	CHECK_LOCATION(locationOf(result->statements.at(1)), "source0", 123, 432);
-	CHECK_LOCATION(locationOf(result->statements.at(2)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(1)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(2)), "source0", 123, 432);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_assign_empty)
@@ -365,8 +365,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_assign_empty)
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0); // should still parse
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
-	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 123, 432);
-	CHECK_LOCATION(locationOf(result->statements.at(1)), "source1", 1, 10);
+	CHECK_LOCATION(originLocationOf(result->statements.at(0)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(1)), "source1", 1, 10);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_source_index)
@@ -407,10 +407,10 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_1)
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
 	BOOST_REQUIRE_EQUAL(1, result->statements.size());
-	CHECK_LOCATION(locationOf(result->statements.at(0)), "source0", 123, 432);
+	CHECK_LOCATION(originLocationOf(result->statements.at(0)), "source0", 123, 432);
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
-	CHECK_LOCATION(locationOf(*varDecl.value), "source0", 234, 2026);
+	CHECK_LOCATION(originLocationOf(*varDecl.value), "source0", 234, 2026);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_2)
@@ -429,20 +429,20 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_2)
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(1, result->statements.size());
-	CHECK_LOCATION(result->debugData->location, "source0", 0, 5);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 0, 5);
 
 	// `let x := add(1, `
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
-	CHECK_LOCATION(varDecl.debugData->location, "source0", 0, 5);
+	CHECK_LOCATION(varDecl.debugData->originLocation, "source0", 0, 5);
 	BOOST_REQUIRE(!!varDecl.value);
 	BOOST_REQUIRE(holds_alternative<FunctionCall>(*varDecl.value));
 	FunctionCall const& call = get<FunctionCall>(*varDecl.value);
-	CHECK_LOCATION(call.debugData->location, "source1", 2, 3);
+	CHECK_LOCATION(call.debugData->originLocation, "source1", 2, 3);
 
 	// `2`
 	BOOST_REQUIRE_EQUAL(2, call.arguments.size());
-	CHECK_LOCATION(locationOf(call.arguments.at(1)), "source0", 4, 8);
+	CHECK_LOCATION(originLocationOf(call.arguments.at(1)), "source0", 4, 8);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_3)
@@ -463,24 +463,24 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_3)
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(2, result->statements.size());
-	CHECK_LOCATION(result->debugData->location, "source1", 23, 45);
+	CHECK_LOCATION(result->debugData->originLocation, "source1", 23, 45);
 
 	BOOST_REQUIRE(holds_alternative<Block>(result->statements.at(0)));
 	Block const& innerBlock = get<Block>(result->statements.at(0));
-	CHECK_LOCATION(innerBlock.debugData->location, "source1", 23, 45);
+	CHECK_LOCATION(innerBlock.debugData->originLocation, "source1", 23, 45);
 
 	BOOST_REQUIRE_EQUAL(1, innerBlock.statements.size());
 	BOOST_REQUIRE(holds_alternative<ExpressionStatement>(result->statements.at(1)));
 	ExpressionStatement const& sstoreStmt = get<ExpressionStatement>(innerBlock.statements.at(0));
 	BOOST_REQUIRE(holds_alternative<FunctionCall>(sstoreStmt.expression));
 	FunctionCall const& sstoreCall = get<FunctionCall>(sstoreStmt.expression);
-	CHECK_LOCATION(sstoreCall.debugData->location, "source1", 23, 45);
+	CHECK_LOCATION(sstoreCall.debugData->originLocation, "source1", 23, 45);
 
 	BOOST_REQUIRE(holds_alternative<ExpressionStatement>(result->statements.at(1)));
 	ExpressionStatement mstoreStmt = get<ExpressionStatement>(result->statements.at(1));
 	BOOST_REQUIRE(holds_alternative<FunctionCall>(mstoreStmt.expression));
 	FunctionCall const& mstoreCall = get<FunctionCall>(mstoreStmt.expression);
-	CHECK_LOCATION(mstoreCall.debugData->location, "source0", 420, 680);
+	CHECK_LOCATION(mstoreCall.debugData->originLocation, "source0", 420, 680);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_comments_after_valid)
@@ -499,11 +499,11 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_comments_after_valid)
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(1, result->statements.size());
-	CHECK_LOCATION(result->debugData->location, "source1", 23, 45);
+	CHECK_LOCATION(result->debugData->originLocation, "source1", 23, 45);
 
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
-	CHECK_LOCATION(varDecl.debugData->location, "source0", 420, 680);
+	CHECK_LOCATION(varDecl.debugData->originLocation, "source0", 420, 680);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_suffix)
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_suffix)
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 8387_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_prefix)
@@ -534,7 +534,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_prefix)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_unspecified)
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_unspecified)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_non_integer)
@@ -565,7 +565,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_non_integer)
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 8387_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_bad_integer)
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_bad_integer)
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 6367_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_ensure_last_match)
@@ -604,7 +604,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_ensure_last_match)
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
 
 	// Ensure the latest @src per documentation-comment is used (0:30:40).
-	CHECK_LOCATION(varDecl.debugData->location, "source0", 30, 40);
+	CHECK_LOCATION(varDecl.debugData->originLocation, "source0", 30, 40);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_no_whitespace)
@@ -621,7 +621,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_no_whitespace)
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 8387_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_separated_with_single_space)
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_separated_with_single_s
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source1", 333, 444);
+	CHECK_LOCATION(result->debugData->originLocation, "source1", 333, 444);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_leading_trailing_whitespace)
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_leading_trailing_whitespace)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 111, 222);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 111, 222);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_reference_original_sloc)
@@ -667,7 +667,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_reference_original_sloc)
 	VariableDeclaration const& varDecl = get<VariableDeclaration>(result->statements.at(0));
 
 	// -1 points to original source code, which in this case is `"source0"` (which is also
-	CHECK_LOCATION(varDecl.debugData->location, "", 10, 20);
+	CHECK_LOCATION(varDecl.debugData->originLocation, "", 10, 20);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets)
@@ -689,14 +689,14 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets)
 
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varX = get<VariableDeclaration>(result->statements.at(0));
-	CHECK_LOCATION(varX.debugData->location, "source0", 149, 156);
+	CHECK_LOCATION(varX.debugData->originLocation, "source0", 149, 156);
 
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(1)));
 	VariableDeclaration const& varY = get<VariableDeclaration>(result->statements.at(1));
 	BOOST_REQUIRE(!!varY.value);
 	BOOST_REQUIRE(holds_alternative<Literal>(*varY.value));
 	Literal const& literal128 = get<Literal>(*varY.value);
-	CHECK_LOCATION(literal128.debugData->location, "source1", 96, 165);
+	CHECK_LOCATION(literal128.debugData->originLocation, "source1", 96, 165);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_empty_snippet)
@@ -710,7 +710,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_empty_snippet)
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 111, 222);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 111, 222);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_no_whitespace_before_snippet)
@@ -727,7 +727,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_no_whitespace_befo
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 8387_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_no_whitespace_after_snippet)
@@ -741,7 +741,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_no_whitespace_afte
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source0", 111, 222);
+	CHECK_LOCATION(result->debugData->originLocation, "source0", 111, 222);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_with_snippets_no_whitespace)
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_with_snippets_no_whites
 	EVMDialectTyped const& dialect = EVMDialectTyped::instance(EVMVersion{});
 	shared_ptr<Block> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
-	CHECK_LOCATION(result->debugData->location, "source1", 333, 444);
+	CHECK_LOCATION(result->debugData->originLocation, "source1", 333, 444);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_with_snippets_unterminated_quote)
@@ -772,7 +772,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_with_snippets_untermina
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 1544_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_with_nested_locations)
@@ -794,14 +794,14 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_with_nested_locati
 
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varX = get<VariableDeclaration>(result->statements.at(0));
-	CHECK_LOCATION(varX.debugData->location, "source0", 149, 156);
+	CHECK_LOCATION(varX.debugData->originLocation, "source0", 149, 156);
 
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(1)));
 	VariableDeclaration const& varY = get<VariableDeclaration>(result->statements.at(1));
 	BOOST_REQUIRE(!!varY.value);
 	BOOST_REQUIRE(holds_alternative<Literal>(*varY.value));
 	Literal const& literal128 = get<Literal>(*varY.value);
-	CHECK_LOCATION(literal128.debugData->location, "source1", 96, 165);
+	CHECK_LOCATION(literal128.debugData->originLocation, "source1", 96, 165);
 }
 
 BOOST_AUTO_TEST_CASE(astid)
@@ -876,7 +876,7 @@ BOOST_AUTO_TEST_CASE(astid_invalid)
 	BOOST_REQUIRE(errorList.size() == 1);
 	BOOST_TEST(errorList[0]->type() == Error::Type::SyntaxError);
 	BOOST_TEST(errorList[0]->errorId() == 1749_error);
-	CHECK_LOCATION(result->debugData->location, "", -1, -1);
+	CHECK_LOCATION(result->debugData->originLocation, "", -1, -1);
 }
 
 BOOST_AUTO_TEST_CASE(astid_too_large)
@@ -948,7 +948,7 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_multiple_src_tags_on_one_line)
 
 	BOOST_REQUIRE(holds_alternative<VariableDeclaration>(result->statements.at(0)));
 	VariableDeclaration const& varX = get<VariableDeclaration>(result->statements.at(0));
-	CHECK_LOCATION(varX.debugData->location, "source1", 4, 5);
+	CHECK_LOCATION(varX.debugData->originLocation, "source1", 4, 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libyul/yulSyntaxTests/invalid/leave_items_on_stack_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/invalid/leave_items_on_stack_with_debug_info.yul
@@ -6,4 +6,4 @@ object "C" {
     }
 }
 // ----
-// TypeError 3083: (0-0): Top-level expressions are not supposed to return values (this expression returns 1 value). Use ``pop()`` or assign them.
+// TypeError 3083: (82-97): Top-level expressions are not supposed to return values (this expression returns 1 value). Use ``pop()`` or assign them.

--- a/test/libyul/yulSyntaxTests/invalid/leave_items_on_stack_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/invalid/leave_items_on_stack_with_debug_info.yul
@@ -1,0 +1,9 @@
+/// @use-src 0:"input.sol"
+object "C" {
+    code {
+        /// @src 0:0:0
+        calldataload(0)
+    }
+}
+// ----
+// TypeError 3083: (0-0): Top-level expressions are not supposed to return values (this expression returns 1 value). Use ``pop()`` or assign them.

--- a/test/libyul/yulSyntaxTests/invalid/literals_on_stack_disallowed_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/invalid/literals_on_stack_disallowed_with_debug_info.yul
@@ -5,5 +5,5 @@ object "C" {
     }
 }
 // ----
-// ParserError 6913: Call or assignment expected.
+// ParserError 6913: (65-66): Call or assignment expected.
 // ParserError 2314: (67-68): Expected end of source but got '}'

--- a/test/libyul/yulSyntaxTests/invalid/literals_on_stack_disallowed_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/invalid/literals_on_stack_disallowed_with_debug_info.yul
@@ -1,0 +1,9 @@
+/// @use-src 0:"input.sol"
+object "C" {
+    code {
+        1
+    }
+}
+// ----
+// ParserError 6913: Call or assignment expected.
+// ParserError 2314: (67-68): Expected end of source but got '}'

--- a/test/libyul/yulSyntaxTests/invalid_tuple_assignment_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/invalid_tuple_assignment_with_debug_info.yul
@@ -1,0 +1,8 @@
+/// @use-src 0:"input.sol"
+object "C" {
+    code {
+        let x, y := 1
+    }
+}
+// ----
+// DeclarationError 3812: Variable count mismatch for declaration of "x, y": 2 variables and 1 values.

--- a/test/libyul/yulSyntaxTests/invalid_tuple_assignment_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/invalid_tuple_assignment_with_debug_info.yul
@@ -5,4 +5,4 @@ object "C" {
     }
 }
 // ----
-// DeclarationError 3812: Variable count mismatch for declaration of "x, y": 2 variables and 1 values.
+// DeclarationError 3812: (59-72): Variable count mismatch for declaration of "x, y": 2 variables and 1 values.

--- a/test/libyul/yulSyntaxTests/name_clash_sub_scope_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/name_clash_sub_scope_with_debug_info.yul
@@ -8,4 +8,4 @@ object "C" {
     }
 }
 // ----
-// DeclarationError 6052: (0-0): Function name g already taken in this scope.
+// DeclarationError 6052: (109-124): Function name g already taken in this scope.

--- a/test/libyul/yulSyntaxTests/name_clash_sub_scope_with_debug_info.yul
+++ b/test/libyul/yulSyntaxTests/name_clash_sub_scope_with_debug_info.yul
@@ -1,0 +1,11 @@
+/// @use-src 0:"input.sol"
+object "C" {
+    code {
+        /// @src 0:0:0
+        function g() {
+            function g() {}
+        }
+    }
+}
+// ----
+// DeclarationError 6052: (0-0): Function name g already taken in this scope.


### PR DESCRIPTION
Fixes #11932.

- [x] ICE is gone but still not all errors from https://github.com/ethereum/solidity/issues/11932#issuecomment-922848821 have locations. This might still be using the original location in places where IR location should be used.
- [x] Make sure nothing is broken and maybe add some tests if the current ones did not detect all the breakage.
- [x] Some of the updated lines should be using the `locationOf()` helper. I only started adding it halfway through.