### PR TITLE
`"origin"` locations in Yul AST

### DIFF
--- a/liblangutil/SourceLocation.h
+++ b/liblangutil/SourceLocation.h
@@ -79,6 +79,10 @@ struct SourceLocation
 
 	bool hasText() const { return sourceName && 0 <= start && start <= end; }
 
+	/// @returns the length of text covered by the location if both @a start and @a end are defined.
+	/// Otherwise returns -1.
+	int length() const { return (start >= 0 && end >= 0 ? end - start : -1); }
+
 	/// @returns the smallest SourceLocation that contains both @param _a and @param _b.
 	/// Assumes that @param _a and @param _b refer to the same source (exception: if the source of either one
 	/// is unset, the source of the other will be used for the result, even if that is unset as well).

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -27,6 +27,7 @@
 #include <libsolutil/UTF8.h>
 
 using namespace std;
+using namespace solidity::langutil;
 
 namespace solidity::yul
 {
@@ -183,14 +184,23 @@ Json::Value AsmJsonConverter::operator()(Leave const& _node) const
 	return createAstNode(nativeLocationOf(_node), "YulLeave");
 }
 
-Json::Value AsmJsonConverter::createAstNode(langutil::SourceLocation const& _location, string _nodeType) const
+string AsmJsonConverter::formatLocation(SourceLocation const& _location, optional<size_t> const& _sourceIndex)
+{
+	return
+		to_string(_location.start) +
+		":" +
+		to_string(_location.length()) +
+		":" +
+		(_sourceIndex.has_value() ? to_string(_sourceIndex.value()) : "-1");
+}
+
+Json::Value AsmJsonConverter::createAstNode(SourceLocation const& _location, string _nodeType) const
 {
 	Json::Value ret{Json::objectValue};
 	ret["nodeType"] = std::move(_nodeType);
-	int length = -1;
-	if (_location.start >= 0 && _location.end >= 0)
-		length = _location.end - _location.start;
-	ret["src"] = to_string(_location.start) + ":" + to_string(length) + ":" + (m_sourceIndex.has_value() ? to_string(m_sourceIndex.value()) : "-1");
+
+	ret["src"] = formatLocation(_location, m_sourceIndex);
+
 	return ret;
 }
 

--- a/libyul/AsmJsonConverter.h
+++ b/libyul/AsmJsonConverter.h
@@ -62,9 +62,10 @@ public:
 	Json::Value operator()(Label const& _node) const;
 
 private:
-	static std::string formatLocation(langutil::SourceLocation const& _location, std::optional<size_t> const& m_sourceIndex);
+	static std::string formatLocationWithFileName(langutil::SourceLocation const& _location);
+	static std::string formatLocationWithFileIndex(langutil::SourceLocation const& _location, std::optional<size_t> const& m_sourceIndex);
 
-	Json::Value createAstNode(langutil::SourceLocation const& _location, std::string _nodeType) const;
+	Json::Value createAstNode(yul::DebugData const* _debugData, std::string _nodeType) const;
 
 	template <class T>
 	Json::Value vectorOfVariantsToJson(std::vector<T> const& vec) const;

--- a/libyul/AsmJsonConverter.h
+++ b/libyul/AsmJsonConverter.h
@@ -62,7 +62,10 @@ public:
 	Json::Value operator()(Label const& _node) const;
 
 private:
+	static std::string formatLocation(langutil::SourceLocation const& _location, std::optional<size_t> const& m_sourceIndex);
+
 	Json::Value createAstNode(langutil::SourceLocation const& _location, std::string _nodeType) const;
+
 	template <class T>
 	Json::Value vectorOfVariantsToJson(std::vector<T> const& vec) const;
 

--- a/libyul/AsmJsonImporter.h
+++ b/libyul/AsmJsonImporter.h
@@ -44,12 +44,13 @@ public:
 	yul::Block createBlock(Json::Value const& _node);
 
 private:
-	langutil::SourceLocation const createSourceLocation(Json::Value const& _node);
+	std::shared_ptr<yul::DebugData const> createDebugData(Json::Value const& _node) const;
+
 	template <class T>
 	T createAsmNode(Json::Value const& _node);
 	/// helper function to access member functions of the JSON
 	/// and throw an error if it does not exist
-	Json::Value member(Json::Value const& _node, std::string const& _name);
+	Json::Value member(Json::Value const& _node, std::string const& _name) const;
 
 	yul::Statement createStatement(Json::Value const& _node);
 	yul::Expression createExpression(Json::Value const& _node);

--- a/test/cmdlineTests/combined_json_generated_sources/output
+++ b/test/cmdlineTests/combined_json_generated_sources/output
@@ -10,6 +10,7 @@
           "ast":
           {
             "nodeType": "YulBlock",
+            "origin": "0:1856:1",
             "src": "0:1856:1",
             "statements":
             [
@@ -17,11 +18,13 @@
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "47:35:1",
                   "src": "47:35:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulAssignment",
+                      "origin": "57:19:1",
                       "src": "57:19:1",
                       "value":
                       {
@@ -30,6 +33,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "73:2:1",
                             "src": "73:2:1",
                             "type": "",
                             "value": "64"
@@ -39,9 +43,11 @@
                         {
                           "name": "mload",
                           "nodeType": "YulIdentifier",
+                          "origin": "67:5:1",
                           "src": "67:5:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "67:9:1",
                         "src": "67:9:1"
                       },
                       "variableNames":
@@ -49,6 +55,7 @@
                         {
                           "name": "memPtr",
                           "nodeType": "YulIdentifier",
+                          "origin": "57:6:1",
                           "src": "57:6:1"
                         }
                       ]
@@ -57,11 +64,13 @@
                 },
                 "name": "allocate_unbounded",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "7:75:1",
                 "returnVariables":
                 [
                   {
                     "name": "memPtr",
                     "nodeType": "YulTypedName",
+                    "origin": "40:6:1",
                     "src": "40:6:1",
                     "type": ""
                   }
@@ -72,6 +81,7 @@
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "177:28:1",
                   "src": "177:28:1",
                   "statements":
                   [
@@ -83,6 +93,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "194:1:1",
                             "src": "194:1:1",
                             "type": "",
                             "value": "0"
@@ -90,6 +101,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "197:1:1",
                             "src": "197:1:1",
                             "type": "",
                             "value": "0"
@@ -99,24 +111,29 @@
                         {
                           "name": "revert",
                           "nodeType": "YulIdentifier",
+                          "origin": "187:6:1",
                           "src": "187:6:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "187:12:1",
                         "src": "187:12:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "187:12:1",
                       "src": "187:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "88:117:1",
                 "src": "88:117:1"
               },
               {
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "300:28:1",
                   "src": "300:28:1",
                   "statements":
                   [
@@ -128,6 +145,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "317:1:1",
                             "src": "317:1:1",
                             "type": "",
                             "value": "0"
@@ -135,6 +153,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "320:1:1",
                             "src": "320:1:1",
                             "type": "",
                             "value": "0"
@@ -144,24 +163,29 @@
                         {
                           "name": "revert",
                           "nodeType": "YulIdentifier",
+                          "origin": "310:6:1",
                           "src": "310:6:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "310:12:1",
                         "src": "310:12:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "310:12:1",
                       "src": "310:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "211:117:1",
                 "src": "211:117:1"
               },
               {
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "423:28:1",
                   "src": "423:28:1",
                   "statements":
                   [
@@ -173,6 +197,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "440:1:1",
                             "src": "440:1:1",
                             "type": "",
                             "value": "0"
@@ -180,6 +205,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "443:1:1",
                             "src": "443:1:1",
                             "type": "",
                             "value": "0"
@@ -189,24 +215,29 @@
                         {
                           "name": "revert",
                           "nodeType": "YulIdentifier",
+                          "origin": "433:6:1",
                           "src": "433:6:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "433:12:1",
                         "src": "433:12:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "433:12:1",
                       "src": "433:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "334:117:1",
                 "src": "334:117:1"
               },
               {
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "546:28:1",
                   "src": "546:28:1",
                   "statements":
                   [
@@ -218,6 +249,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "563:1:1",
                             "src": "563:1:1",
                             "type": "",
                             "value": "0"
@@ -225,6 +257,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "566:1:1",
                             "src": "566:1:1",
                             "type": "",
                             "value": "0"
@@ -234,24 +267,29 @@
                         {
                           "name": "revert",
                           "nodeType": "YulIdentifier",
+                          "origin": "556:6:1",
                           "src": "556:6:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "556:12:1",
                         "src": "556:12:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "556:12:1",
                       "src": "556:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_15abf5612cd996bc235ba1e55a4a30ac60e6bb601ff7ba4ad3f179b6be8d0490",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "457:117:1",
                 "src": "457:117:1"
               },
               {
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "669:28:1",
                   "src": "669:28:1",
                   "statements":
                   [
@@ -263,6 +301,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "686:1:1",
                             "src": "686:1:1",
                             "type": "",
                             "value": "0"
@@ -270,6 +309,7 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "689:1:1",
                             "src": "689:1:1",
                             "type": "",
                             "value": "0"
@@ -279,24 +319,29 @@
                         {
                           "name": "revert",
                           "nodeType": "YulIdentifier",
+                          "origin": "679:6:1",
                           "src": "679:6:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "679:12:1",
                         "src": "679:12:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "679:12:1",
                       "src": "679:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "580:117:1",
                 "src": "580:117:1"
               },
               {
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "810:478:1",
                   "src": "810:478:1",
                   "statements":
                   [
@@ -304,6 +349,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "859:83:1",
                         "src": "859:83:1",
                         "statements":
                         [
@@ -315,12 +361,15 @@
                               {
                                 "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
                                 "nodeType": "YulIdentifier",
+                                "origin": "861:77:1",
                                 "src": "861:77:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "861:79:1",
                               "src": "861:79:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "861:79:1",
                             "src": "861:79:1"
                           }
                         ]
@@ -338,11 +387,13 @@
                                   {
                                     "name": "offset",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "838:6:1",
                                     "src": "838:6:1"
                                   },
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
+                                    "origin": "846:4:1",
                                     "src": "846:4:1",
                                     "type": "",
                                     "value": "0x1f"
@@ -352,14 +403,17 @@
                                 {
                                   "name": "add",
                                   "nodeType": "YulIdentifier",
+                                  "origin": "834:3:1",
                                   "src": "834:3:1"
                                 },
                                 "nodeType": "YulFunctionCall",
+                                "origin": "834:17:1",
                                 "src": "834:17:1"
                               },
                               {
                                 "name": "end",
                                 "nodeType": "YulIdentifier",
+                                "origin": "853:3:1",
                                 "src": "853:3:1"
                               }
                             ],
@@ -367,9 +421,11 @@
                             {
                               "name": "slt",
                               "nodeType": "YulIdentifier",
+                              "origin": "830:3:1",
                               "src": "830:3:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "830:27:1",
                             "src": "830:27:1"
                           }
                         ],
@@ -377,16 +433,20 @@
                         {
                           "name": "iszero",
                           "nodeType": "YulIdentifier",
+                          "origin": "823:6:1",
                           "src": "823:6:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "823:35:1",
                         "src": "823:35:1"
                       },
                       "nodeType": "YulIf",
+                      "origin": "820:122:1",
                       "src": "820:122:1"
                     },
                     {
                       "nodeType": "YulAssignment",
+                      "origin": "951:30:1",
                       "src": "951:30:1",
                       "value":
                       {
@@ -395,6 +455,7 @@
                           {
                             "name": "offset",
                             "nodeType": "YulIdentifier",
+                            "origin": "974:6:1",
                             "src": "974:6:1"
                           }
                         ],
@@ -402,9 +463,11 @@
                         {
                           "name": "calldataload",
                           "nodeType": "YulIdentifier",
+                          "origin": "961:12:1",
                           "src": "961:12:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "961:20:1",
                         "src": "961:20:1"
                       },
                       "variableNames":
@@ -412,6 +475,7 @@
                         {
                           "name": "length",
                           "nodeType": "YulIdentifier",
+                          "origin": "951:6:1",
                           "src": "951:6:1"
                         }
                       ]
@@ -420,6 +484,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "1024:83:1",
                         "src": "1024:83:1",
                         "statements":
                         [
@@ -431,12 +496,15 @@
                               {
                                 "name": "revert_error_15abf5612cd996bc235ba1e55a4a30ac60e6bb601ff7ba4ad3f179b6be8d0490",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1026:77:1",
                                 "src": "1026:77:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "1026:79:1",
                               "src": "1026:79:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "1026:79:1",
                             "src": "1026:79:1"
                           }
                         ]
@@ -448,11 +516,13 @@
                           {
                             "name": "length",
                             "nodeType": "YulIdentifier",
+                            "origin": "996:6:1",
                             "src": "996:6:1"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "1004:18:1",
                             "src": "1004:18:1",
                             "type": "",
                             "value": "0xffffffffffffffff"
@@ -462,16 +532,20 @@
                         {
                           "name": "gt",
                           "nodeType": "YulIdentifier",
+                          "origin": "993:2:1",
                           "src": "993:2:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "993:30:1",
                         "src": "993:30:1"
                       },
                       "nodeType": "YulIf",
+                      "origin": "990:117:1",
                       "src": "990:117:1"
                     },
                     {
                       "nodeType": "YulAssignment",
+                      "origin": "1116:29:1",
                       "src": "1116:29:1",
                       "value":
                       {
@@ -480,11 +554,13 @@
                           {
                             "name": "offset",
                             "nodeType": "YulIdentifier",
+                            "origin": "1132:6:1",
                             "src": "1132:6:1"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "1140:4:1",
                             "src": "1140:4:1",
                             "type": "",
                             "value": "0x20"
@@ -494,9 +570,11 @@
                         {
                           "name": "add",
                           "nodeType": "YulIdentifier",
+                          "origin": "1128:3:1",
                           "src": "1128:3:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "1128:17:1",
                         "src": "1128:17:1"
                       },
                       "variableNames":
@@ -504,6 +582,7 @@
                         {
                           "name": "arrayPos",
                           "nodeType": "YulIdentifier",
+                          "origin": "1116:8:1",
                           "src": "1116:8:1"
                         }
                       ]
@@ -512,6 +591,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "1199:83:1",
                         "src": "1199:83:1",
                         "statements":
                         [
@@ -523,12 +603,15 @@
                               {
                                 "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1201:77:1",
                                 "src": "1201:77:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "1201:79:1",
                               "src": "1201:79:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "1201:79:1",
                             "src": "1201:79:1"
                           }
                         ]
@@ -543,6 +626,7 @@
                               {
                                 "name": "arrayPos",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1164:8:1",
                                 "src": "1164:8:1"
                               },
                               {
@@ -551,11 +635,13 @@
                                   {
                                     "name": "length",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "1178:6:1",
                                     "src": "1178:6:1"
                                   },
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
+                                    "origin": "1186:4:1",
                                     "src": "1186:4:1",
                                     "type": "",
                                     "value": "0x20"
@@ -565,9 +651,11 @@
                                 {
                                   "name": "mul",
                                   "nodeType": "YulIdentifier",
+                                  "origin": "1174:3:1",
                                   "src": "1174:3:1"
                                 },
                                 "nodeType": "YulFunctionCall",
+                                "origin": "1174:17:1",
                                 "src": "1174:17:1"
                               }
                             ],
@@ -575,14 +663,17 @@
                             {
                               "name": "add",
                               "nodeType": "YulIdentifier",
+                              "origin": "1160:3:1",
                               "src": "1160:3:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "1160:32:1",
                             "src": "1160:32:1"
                           },
                           {
                             "name": "end",
                             "nodeType": "YulIdentifier",
+                            "origin": "1194:3:1",
                             "src": "1194:3:1"
                           }
                         ],
@@ -590,29 +681,35 @@
                         {
                           "name": "gt",
                           "nodeType": "YulIdentifier",
+                          "origin": "1157:2:1",
                           "src": "1157:2:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "1157:41:1",
                         "src": "1157:41:1"
                       },
                       "nodeType": "YulIf",
+                      "origin": "1154:128:1",
                       "src": "1154:128:1"
                     }
                   ]
                 },
                 "name": "abi_decode_t_array$_t_uint256_$dyn_calldata_ptr",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "720:568:1",
                 "parameters":
                 [
                   {
                     "name": "offset",
                     "nodeType": "YulTypedName",
+                    "origin": "777:6:1",
                     "src": "777:6:1",
                     "type": ""
                   },
                   {
                     "name": "end",
                     "nodeType": "YulTypedName",
+                    "origin": "785:3:1",
                     "src": "785:3:1",
                     "type": ""
                   }
@@ -622,12 +719,14 @@
                   {
                     "name": "arrayPos",
                     "nodeType": "YulTypedName",
+                    "origin": "793:8:1",
                     "src": "793:8:1",
                     "type": ""
                   },
                   {
                     "name": "length",
                     "nodeType": "YulTypedName",
+                    "origin": "803:6:1",
                     "src": "803:6:1",
                     "type": ""
                   }
@@ -638,6 +737,7 @@
                 "body":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "1395:458:1",
                   "src": "1395:458:1",
                   "statements":
                   [
@@ -645,6 +745,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "1441:83:1",
                         "src": "1441:83:1",
                         "statements":
                         [
@@ -656,12 +757,15 @@
                               {
                                 "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1443:77:1",
                                 "src": "1443:77:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "1443:79:1",
                               "src": "1443:79:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "1443:79:1",
                             "src": "1443:79:1"
                           }
                         ]
@@ -676,11 +780,13 @@
                               {
                                 "name": "dataEnd",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1416:7:1",
                                 "src": "1416:7:1"
                               },
                               {
                                 "name": "headStart",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1425:9:1",
                                 "src": "1425:9:1"
                               }
                             ],
@@ -688,14 +794,17 @@
                             {
                               "name": "sub",
                               "nodeType": "YulIdentifier",
+                              "origin": "1412:3:1",
                               "src": "1412:3:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "1412:23:1",
                             "src": "1412:23:1"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "1437:2:1",
                             "src": "1437:2:1",
                             "type": "",
                             "value": "32"
@@ -705,21 +814,26 @@
                         {
                           "name": "slt",
                           "nodeType": "YulIdentifier",
+                          "origin": "1408:3:1",
                           "src": "1408:3:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "1408:32:1",
                         "src": "1408:32:1"
                       },
                       "nodeType": "YulIf",
+                      "origin": "1405:119:1",
                       "src": "1405:119:1"
                     },
                     {
                       "nodeType": "YulBlock",
+                      "origin": "1534:312:1",
                       "src": "1534:312:1",
                       "statements":
                       [
                         {
                           "nodeType": "YulVariableDeclaration",
+                          "origin": "1549:45:1",
                           "src": "1549:45:1",
                           "value":
                           {
@@ -731,11 +845,13 @@
                                   {
                                     "name": "headStart",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "1580:9:1",
                                     "src": "1580:9:1"
                                   },
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
+                                    "origin": "1591:1:1",
                                     "src": "1591:1:1",
                                     "type": "",
                                     "value": "0"
@@ -745,9 +861,11 @@
                                 {
                                   "name": "add",
                                   "nodeType": "YulIdentifier",
+                                  "origin": "1576:3:1",
                                   "src": "1576:3:1"
                                 },
                                 "nodeType": "YulFunctionCall",
+                                "origin": "1576:17:1",
                                 "src": "1576:17:1"
                               }
                             ],
@@ -755,9 +873,11 @@
                             {
                               "name": "calldataload",
                               "nodeType": "YulIdentifier",
+                              "origin": "1563:12:1",
                               "src": "1563:12:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "1563:31:1",
                             "src": "1563:31:1"
                           },
                           "variables":
@@ -765,6 +885,7 @@
                             {
                               "name": "offset",
                               "nodeType": "YulTypedName",
+                              "origin": "1553:6:1",
                               "src": "1553:6:1",
                               "type": ""
                             }
@@ -774,6 +895,7 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "1641:83:1",
                             "src": "1641:83:1",
                             "statements":
                             [
@@ -785,12 +907,15 @@
                                   {
                                     "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "1643:77:1",
                                     "src": "1643:77:1"
                                   },
                                   "nodeType": "YulFunctionCall",
+                                  "origin": "1643:79:1",
                                   "src": "1643:79:1"
                                 },
                                 "nodeType": "YulExpressionStatement",
+                                "origin": "1643:79:1",
                                 "src": "1643:79:1"
                               }
                             ]
@@ -802,11 +927,13 @@
                               {
                                 "name": "offset",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1613:6:1",
                                 "src": "1613:6:1"
                               },
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "1621:18:1",
                                 "src": "1621:18:1",
                                 "type": "",
                                 "value": "0xffffffffffffffff"
@@ -816,16 +943,20 @@
                             {
                               "name": "gt",
                               "nodeType": "YulIdentifier",
+                              "origin": "1610:2:1",
                               "src": "1610:2:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "1610:30:1",
                             "src": "1610:30:1"
                           },
                           "nodeType": "YulIf",
+                          "origin": "1607:117:1",
                           "src": "1607:117:1"
                         },
                         {
                           "nodeType": "YulAssignment",
+                          "origin": "1738:98:1",
                           "src": "1738:98:1",
                           "value":
                           {
@@ -837,11 +968,13 @@
                                   {
                                     "name": "headStart",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "1808:9:1",
                                     "src": "1808:9:1"
                                   },
                                   {
                                     "name": "offset",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "1819:6:1",
                                     "src": "1819:6:1"
                                   }
                                 ],
@@ -849,14 +982,17 @@
                                 {
                                   "name": "add",
                                   "nodeType": "YulIdentifier",
+                                  "origin": "1804:3:1",
                                   "src": "1804:3:1"
                                 },
                                 "nodeType": "YulFunctionCall",
+                                "origin": "1804:22:1",
                                 "src": "1804:22:1"
                               },
                               {
                                 "name": "dataEnd",
                                 "nodeType": "YulIdentifier",
+                                "origin": "1828:7:1",
                                 "src": "1828:7:1"
                               }
                             ],
@@ -864,9 +1000,11 @@
                             {
                               "name": "abi_decode_t_array$_t_uint256_$dyn_calldata_ptr",
                               "nodeType": "YulIdentifier",
+                              "origin": "1756:47:1",
                               "src": "1756:47:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "1756:80:1",
                             "src": "1756:80:1"
                           },
                           "variableNames":
@@ -874,11 +1012,13 @@
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
+                              "origin": "1738:6:1",
                               "src": "1738:6:1"
                             },
                             {
                               "name": "value1",
                               "nodeType": "YulIdentifier",
+                              "origin": "1746:6:1",
                               "src": "1746:6:1"
                             }
                           ]
@@ -889,17 +1029,20 @@
                 },
                 "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_calldata_ptr",
                 "nodeType": "YulFunctionDefinition",
+                "origin": "1294:559:1",
                 "parameters":
                 [
                   {
                     "name": "headStart",
                     "nodeType": "YulTypedName",
+                    "origin": "1357:9:1",
                     "src": "1357:9:1",
                     "type": ""
                   },
                   {
                     "name": "dataEnd",
                     "nodeType": "YulTypedName",
+                    "origin": "1368:7:1",
                     "src": "1368:7:1",
                     "type": ""
                   }
@@ -909,12 +1052,14 @@
                   {
                     "name": "value0",
                     "nodeType": "YulTypedName",
+                    "origin": "1380:6:1",
                     "src": "1380:6:1",
                     "type": ""
                   },
                   {
                     "name": "value1",
                     "nodeType": "YulTypedName",
+                    "origin": "1388:6:1",
                     "src": "1388:6:1",
                     "type": ""
                   }

--- a/test/cmdlineTests/standard_ast_with_inline_assembly/args
+++ b/test/cmdlineTests/standard_ast_with_inline_assembly/args
@@ -1,0 +1,1 @@
+--pretty-json --json-indent 4 --allow-paths .

--- a/test/cmdlineTests/standard_ast_with_inline_assembly/in.sol
+++ b/test/cmdlineTests/standard_ast_with_inline_assembly/in.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity >=0.0;
+
+contract C {
+    uint[] x;
+
+    fallback() external {
+        uint y_slot = 2;
+        uint y_offset = 3;
+        uint[] storage y = x;
+
+        assembly {
+            pop(y_slot)
+            pop(y_offset)
+
+            let z1, z2, z3 := f()
+
+            function f() -> a, b, c {
+                a := 1
+                b := 2
+                c := 3
+            }
+        }
+        y[0] = 2;
+    }
+}

--- a/test/cmdlineTests/standard_ast_with_inline_assembly/input.json
+++ b/test/cmdlineTests/standard_ast_with_inline_assembly/input.json
@@ -1,0 +1,11 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"C": {"urls": ["standard_ast_with_inline_assembly/in.sol"]}
+	},
+	"settings": {
+		"outputSelection": {
+			"*": {"": ["ast"]}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_ast_with_inline_assembly/output.json
+++ b/test/cmdlineTests/standard_ast_with_inline_assembly/output.json
@@ -1,0 +1,618 @@
+{
+    "sources":
+    {
+        "C":
+        {
+            "ast":
+            {
+                "absolutePath": "C",
+                "exportedSymbols":
+                {
+                    "C":
+                    [
+                        31
+                    ]
+                },
+                "id": 32,
+                "license": "GPL-2.0",
+                "nodeType": "SourceUnit",
+                "nodes":
+                [
+                    {
+                        "id": 1,
+                        "literals":
+                        [
+                            "solidity",
+                            ">=",
+                            "0.0"
+                        ],
+                        "nodeType": "PragmaDirective",
+                        "src": "36:22:0"
+                    },
+                    {
+                        "abstract": false,
+                        "baseContracts": [],
+                        "contractDependencies": [],
+                        "contractKind": "contract",
+                        "fullyImplemented": true,
+                        "id": 31,
+                        "linearizedBaseContracts":
+                        [
+                            31
+                        ],
+                        "name": "C",
+                        "nameLocation": "69:1:0",
+                        "nodeType": "ContractDefinition",
+                        "nodes":
+                        [
+                            {
+                                "constant": false,
+                                "id": 4,
+                                "mutability": "mutable",
+                                "name": "x",
+                                "nameLocation": "84:1:0",
+                                "nodeType": "VariableDeclaration",
+                                "scope": 31,
+                                "src": "77:8:0",
+                                "stateVariable": true,
+                                "storageLocation": "default",
+                                "typeDescriptions":
+                                {
+                                    "typeIdentifier": "t_array$_t_uint256_$dyn_storage",
+                                    "typeString": "uint256[]"
+                                },
+                                "typeName":
+                                {
+                                    "baseType":
+                                    {
+                                        "id": 2,
+                                        "name": "uint",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "77:4:0",
+                                        "typeDescriptions":
+                                        {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        }
+                                    },
+                                    "id": 3,
+                                    "nodeType": "ArrayTypeName",
+                                    "src": "77:6:0",
+                                    "typeDescriptions":
+                                    {
+                                        "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                                        "typeString": "uint256[]"
+                                    }
+                                },
+                                "visibility": "internal"
+                            },
+                            {
+                                "body":
+                                {
+                                    "id": 29,
+                                    "nodeType": "Block",
+                                    "src": "112:344:0",
+                                    "statements":
+                                    [
+                                        {
+                                            "assignments":
+                                            [
+                                                8
+                                            ],
+                                            "declarations":
+                                            [
+                                                {
+                                                    "constant": false,
+                                                    "id": 8,
+                                                    "mutability": "mutable",
+                                                    "name": "y_slot",
+                                                    "nameLocation": "127:6:0",
+                                                    "nodeType": "VariableDeclaration",
+                                                    "scope": 29,
+                                                    "src": "122:11:0",
+                                                    "stateVariable": false,
+                                                    "storageLocation": "default",
+                                                    "typeDescriptions":
+                                                    {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    },
+                                                    "typeName":
+                                                    {
+                                                        "id": 7,
+                                                        "name": "uint",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "122:4:0",
+                                                        "typeDescriptions":
+                                                        {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    },
+                                                    "visibility": "internal"
+                                                }
+                                            ],
+                                            "id": 10,
+                                            "initialValue":
+                                            {
+                                                "hexValue": "32",
+                                                "id": 9,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "kind": "number",
+                                                "lValueRequested": false,
+                                                "nodeType": "Literal",
+                                                "src": "136:1:0",
+                                                "typeDescriptions":
+                                                {
+                                                    "typeIdentifier": "t_rational_2_by_1",
+                                                    "typeString": "int_const 2"
+                                                },
+                                                "value": "2"
+                                            },
+                                            "nodeType": "VariableDeclarationStatement",
+                                            "src": "122:15:0"
+                                        },
+                                        {
+                                            "assignments":
+                                            [
+                                                12
+                                            ],
+                                            "declarations":
+                                            [
+                                                {
+                                                    "constant": false,
+                                                    "id": 12,
+                                                    "mutability": "mutable",
+                                                    "name": "y_offset",
+                                                    "nameLocation": "152:8:0",
+                                                    "nodeType": "VariableDeclaration",
+                                                    "scope": 29,
+                                                    "src": "147:13:0",
+                                                    "stateVariable": false,
+                                                    "storageLocation": "default",
+                                                    "typeDescriptions":
+                                                    {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    },
+                                                    "typeName":
+                                                    {
+                                                        "id": 11,
+                                                        "name": "uint",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "147:4:0",
+                                                        "typeDescriptions":
+                                                        {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    },
+                                                    "visibility": "internal"
+                                                }
+                                            ],
+                                            "id": 14,
+                                            "initialValue":
+                                            {
+                                                "hexValue": "33",
+                                                "id": 13,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "kind": "number",
+                                                "lValueRequested": false,
+                                                "nodeType": "Literal",
+                                                "src": "163:1:0",
+                                                "typeDescriptions":
+                                                {
+                                                    "typeIdentifier": "t_rational_3_by_1",
+                                                    "typeString": "int_const 3"
+                                                },
+                                                "value": "3"
+                                            },
+                                            "nodeType": "VariableDeclarationStatement",
+                                            "src": "147:17:0"
+                                        },
+                                        {
+                                            "assignments":
+                                            [
+                                                19
+                                            ],
+                                            "declarations":
+                                            [
+                                                {
+                                                    "constant": false,
+                                                    "id": 19,
+                                                    "mutability": "mutable",
+                                                    "name": "y",
+                                                    "nameLocation": "189:1:0",
+                                                    "nodeType": "VariableDeclaration",
+                                                    "scope": 29,
+                                                    "src": "174:16:0",
+                                                    "stateVariable": false,
+                                                    "storageLocation": "storage",
+                                                    "typeDescriptions":
+                                                    {
+                                                        "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                                                        "typeString": "uint256[]"
+                                                    },
+                                                    "typeName":
+                                                    {
+                                                        "baseType":
+                                                        {
+                                                            "id": 17,
+                                                            "name": "uint",
+                                                            "nodeType": "ElementaryTypeName",
+                                                            "src": "174:4:0",
+                                                            "typeDescriptions":
+                                                            {
+                                                                "typeIdentifier": "t_uint256",
+                                                                "typeString": "uint256"
+                                                            }
+                                                        },
+                                                        "id": 18,
+                                                        "nodeType": "ArrayTypeName",
+                                                        "src": "174:6:0",
+                                                        "typeDescriptions":
+                                                        {
+                                                            "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                                                            "typeString": "uint256[]"
+                                                        }
+                                                    },
+                                                    "visibility": "internal"
+                                                }
+                                            ],
+                                            "id": 21,
+                                            "initialValue":
+                                            {
+                                                "id": 20,
+                                                "name": "x",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 4,
+                                                "src": "193:1:0",
+                                                "typeDescriptions":
+                                                {
+                                                    "typeIdentifier": "t_array$_t_uint256_$dyn_storage",
+                                                    "typeString": "uint256[] storage ref"
+                                                }
+                                            },
+                                            "nodeType": "VariableDeclarationStatement",
+                                            "src": "174:20:0"
+                                        },
+                                        {
+                                            "AST":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "214:218:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "y_slot",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "232:6:0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "pop",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "228:3:0"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "228:11:0"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "228:11:0"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "y_offset",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "256:8:0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "pop",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "252:3:0"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "252:13:0"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "252:13:0"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "279:21:0",
+                                                        "value":
+                                                        {
+                                                            "arguments": [],
+                                                            "functionName":
+                                                            {
+                                                                "name": "f",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "297:1:0"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "297:3:0"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "z1",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "283:2:0",
+                                                                "type": ""
+                                                            },
+                                                            {
+                                                                "name": "z2",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "287:2:0",
+                                                                "type": ""
+                                                            },
+                                                            {
+                                                                "name": "z3",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "291:2:0",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "338:84:0",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "356:6:0",
+                                                                    "value":
+                                                                    {
+                                                                        "kind": "number",
+                                                                        "nodeType": "YulLiteral",
+                                                                        "src": "361:1:0",
+                                                                        "type": "",
+                                                                        "value": "1"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "a",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "356:1:0"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "379:6:0",
+                                                                    "value":
+                                                                    {
+                                                                        "kind": "number",
+                                                                        "nodeType": "YulLiteral",
+                                                                        "src": "384:1:0",
+                                                                        "type": "",
+                                                                        "value": "2"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "b",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "379:1:0"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "402:6:0",
+                                                                    "value":
+                                                                    {
+                                                                        "kind": "number",
+                                                                        "nodeType": "YulLiteral",
+                                                                        "src": "407:1:0",
+                                                                        "type": "",
+                                                                        "value": "3"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "c",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "402:1:0"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "name": "f",
+                                                        "nodeType": "YulFunctionDefinition",
+                                                        "returnVariables":
+                                                        [
+                                                            {
+                                                                "name": "a",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "330:1:0",
+                                                                "type": ""
+                                                            },
+                                                            {
+                                                                "name": "b",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "333:1:0",
+                                                                "type": ""
+                                                            },
+                                                            {
+                                                                "name": "c",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "336:1:0",
+                                                                "type": ""
+                                                            }
+                                                        ],
+                                                        "src": "314:108:0"
+                                                    }
+                                                ]
+                                            },
+                                            "evmVersion": "london",
+                                            "externalReferences":
+                                            [
+                                                {
+                                                    "declaration": 12,
+                                                    "isOffset": false,
+                                                    "isSlot": false,
+                                                    "src": "256:8:0",
+                                                    "valueSize": 1
+                                                },
+                                                {
+                                                    "declaration": 8,
+                                                    "isOffset": false,
+                                                    "isSlot": false,
+                                                    "src": "232:6:0",
+                                                    "valueSize": 1
+                                                }
+                                            ],
+                                            "id": 22,
+                                            "nodeType": "InlineAssembly",
+                                            "src": "205:227:0"
+                                        },
+                                        {
+                                            "expression":
+                                            {
+                                                "id": 27,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "lValueRequested": false,
+                                                "leftHandSide":
+                                                {
+                                                    "baseExpression":
+                                                    {
+                                                        "id": 23,
+                                                        "name": "y",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 19,
+                                                        "src": "441:1:0",
+                                                        "typeDescriptions":
+                                                        {
+                                                            "typeIdentifier": "t_array$_t_uint256_$dyn_storage_ptr",
+                                                            "typeString": "uint256[] storage pointer"
+                                                        }
+                                                    },
+                                                    "id": 25,
+                                                    "indexExpression":
+                                                    {
+                                                        "hexValue": "30",
+                                                        "id": 24,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "kind": "number",
+                                                        "lValueRequested": false,
+                                                        "nodeType": "Literal",
+                                                        "src": "443:1:0",
+                                                        "typeDescriptions":
+                                                        {
+                                                            "typeIdentifier": "t_rational_0_by_1",
+                                                            "typeString": "int_const 0"
+                                                        },
+                                                        "value": "0"
+                                                    },
+                                                    "isConstant": false,
+                                                    "isLValue": true,
+                                                    "isPure": false,
+                                                    "lValueRequested": true,
+                                                    "nodeType": "IndexAccess",
+                                                    "src": "441:4:0",
+                                                    "typeDescriptions":
+                                                    {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    }
+                                                },
+                                                "nodeType": "Assignment",
+                                                "operator": "=",
+                                                "rightHandSide":
+                                                {
+                                                    "hexValue": "32",
+                                                    "id": 26,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "kind": "number",
+                                                    "lValueRequested": false,
+                                                    "nodeType": "Literal",
+                                                    "src": "448:1:0",
+                                                    "typeDescriptions":
+                                                    {
+                                                        "typeIdentifier": "t_rational_2_by_1",
+                                                        "typeString": "int_const 2"
+                                                    },
+                                                    "value": "2"
+                                                },
+                                                "src": "441:8:0",
+                                                "typeDescriptions":
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            },
+                                            "id": 28,
+                                            "nodeType": "ExpressionStatement",
+                                            "src": "441:8:0"
+                                        }
+                                    ]
+                                },
+                                "id": 30,
+                                "implemented": true,
+                                "kind": "fallback",
+                                "modifiers": [],
+                                "name": "",
+                                "nameLocation": "-1:-1:-1",
+                                "nodeType": "FunctionDefinition",
+                                "parameters":
+                                {
+                                    "id": 5,
+                                    "nodeType": "ParameterList",
+                                    "parameters": [],
+                                    "src": "100:2:0"
+                                },
+                                "returnParameters":
+                                {
+                                    "id": 6,
+                                    "nodeType": "ParameterList",
+                                    "parameters": [],
+                                    "src": "112:0:0"
+                                },
+                                "scope": 31,
+                                "src": "92:364:0",
+                                "stateMutability": "nonpayable",
+                                "virtual": false,
+                                "visibility": "external"
+                            }
+                        ],
+                        "scope": 32,
+                        "src": "60:398:0",
+                        "usedErrors": []
+                    }
+                ],
+                "src": "36:423:0"
+            },
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_ast_with_inline_assembly/output.json
+++ b/test/cmdlineTests/standard_ast_with_inline_assembly/output.json
@@ -285,6 +285,7 @@
                                             "AST":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "214:218:0",
                                                 "src": "214:218:0",
                                                 "statements":
                                                 [
@@ -296,6 +297,7 @@
                                                                 {
                                                                     "name": "y_slot",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "232:6:0",
                                                                     "src": "232:6:0"
                                                                 }
                                                             ],
@@ -303,12 +305,15 @@
                                                             {
                                                                 "name": "pop",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "228:3:0",
                                                                 "src": "228:3:0"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "228:11:0",
                                                             "src": "228:11:0"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "228:11:0",
                                                         "src": "228:11:0"
                                                     },
                                                     {
@@ -319,6 +324,7 @@
                                                                 {
                                                                     "name": "y_offset",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "256:8:0",
                                                                     "src": "256:8:0"
                                                                 }
                                                             ],
@@ -326,16 +332,20 @@
                                                             {
                                                                 "name": "pop",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "252:3:0",
                                                                 "src": "252:3:0"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "252:13:0",
                                                             "src": "252:13:0"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "252:13:0",
                                                         "src": "252:13:0"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "279:21:0",
                                                         "src": "279:21:0",
                                                         "value":
                                                         {
@@ -344,9 +354,11 @@
                                                             {
                                                                 "name": "f",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "297:1:0",
                                                                 "src": "297:1:0"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "297:3:0",
                                                             "src": "297:3:0"
                                                         },
                                                         "variables":
@@ -354,18 +366,21 @@
                                                             {
                                                                 "name": "z1",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "283:2:0",
                                                                 "src": "283:2:0",
                                                                 "type": ""
                                                             },
                                                             {
                                                                 "name": "z2",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "287:2:0",
                                                                 "src": "287:2:0",
                                                                 "type": ""
                                                             },
                                                             {
                                                                 "name": "z3",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "291:2:0",
                                                                 "src": "291:2:0",
                                                                 "type": ""
                                                             }
@@ -375,16 +390,19 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "338:84:0",
                                                             "src": "338:84:0",
                                                             "statements":
                                                             [
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "356:6:0",
                                                                     "src": "356:6:0",
                                                                     "value":
                                                                     {
                                                                         "kind": "number",
                                                                         "nodeType": "YulLiteral",
+                                                                        "origin": "361:1:0",
                                                                         "src": "361:1:0",
                                                                         "type": "",
                                                                         "value": "1"
@@ -394,17 +412,20 @@
                                                                         {
                                                                             "name": "a",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "356:1:0",
                                                                             "src": "356:1:0"
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "379:6:0",
                                                                     "src": "379:6:0",
                                                                     "value":
                                                                     {
                                                                         "kind": "number",
                                                                         "nodeType": "YulLiteral",
+                                                                        "origin": "384:1:0",
                                                                         "src": "384:1:0",
                                                                         "type": "",
                                                                         "value": "2"
@@ -414,17 +435,20 @@
                                                                         {
                                                                             "name": "b",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "379:1:0",
                                                                             "src": "379:1:0"
                                                                         }
                                                                     ]
                                                                 },
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "402:6:0",
                                                                     "src": "402:6:0",
                                                                     "value":
                                                                     {
                                                                         "kind": "number",
                                                                         "nodeType": "YulLiteral",
+                                                                        "origin": "407:1:0",
                                                                         "src": "407:1:0",
                                                                         "type": "",
                                                                         "value": "3"
@@ -434,6 +458,7 @@
                                                                         {
                                                                             "name": "c",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "402:1:0",
                                                                             "src": "402:1:0"
                                                                         }
                                                                     ]
@@ -442,23 +467,27 @@
                                                         },
                                                         "name": "f",
                                                         "nodeType": "YulFunctionDefinition",
+                                                        "origin": "314:108:0",
                                                         "returnVariables":
                                                         [
                                                             {
                                                                 "name": "a",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "330:1:0",
                                                                 "src": "330:1:0",
                                                                 "type": ""
                                                             },
                                                             {
                                                                 "name": "b",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "333:1:0",
                                                                 "src": "333:1:0",
                                                                 "type": ""
                                                             },
                                                             {
                                                                 "name": "c",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "336:1:0",
                                                                 "src": "336:1:0",
                                                                 "type": ""
                                                             }

--- a/test/cmdlineTests/standard_generatedSources/args
+++ b/test/cmdlineTests/standard_generatedSources/args
@@ -1,0 +1,1 @@
+--pretty-json --json-indent 4 --allow-paths .

--- a/test/cmdlineTests/standard_generatedSources/in.sol
+++ b/test/cmdlineTests/standard_generatedSources/in.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+pragma abicoder v2;
+
+contract A {
+    function f(uint[] memory) public view returns (uint256) {}
+}

--- a/test/cmdlineTests/standard_generatedSources/input.json
+++ b/test/cmdlineTests/standard_generatedSources/input.json
@@ -1,20 +1,18 @@
 {
- "language": "Solidity",
- "sources": {
-  "a.sol": {
-   "content": "// SPDX-License-Identifier: GPL-3.0\npragma abicoder v2; contract A { function f(uint[] memory) public view returns (uint256) { } }"
-  }
- },
- "settings": {
-  "evmVersion": "petersburg",
-  "outputSelection": {
-   "*": {
-    "A": [
-     "evm.bytecode.object",
-     "evm.deployedBytecode.generatedSources",
-     "evm.bytecode.generatedSources"
-    ]
-   }
-  }
- }
+	"language": "Solidity",
+	"sources": {
+		"a.sol": {"urls": ["standard_generatedSources/in.sol"]}
+	},
+	"settings": {
+		"evmVersion": "petersburg",
+		"outputSelection": {
+			"*": {
+				"A": [
+					"evm.bytecode.object",
+					"evm.deployedBytecode.generatedSources",
+					"evm.bytecode.generatedSources"
+				]
+			}
+		}
+	}
 }

--- a/test/cmdlineTests/standard_generatedSources/output.json
+++ b/test/cmdlineTests/standard_generatedSources/output.json
@@ -1,4 +1,2351 @@
-{"contracts":{"a.sol":{"A":{"evm":{"bytecode":{"generatedSources":[],"object":"<BYTECODE REMOVED>"},"deployedBytecode":{"generatedSources":[{"ast":{"nodeType":"YulBlock","src":"0:3989:1","statements":[{"body":{"nodeType":"YulBlock","src":"47:35:1","statements":[{"nodeType":"YulAssignment","src":"57:19:1","value":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"73:2:1","type":"","value":"64"}],"functionName":{"name":"mload","nodeType":"YulIdentifier","src":"67:5:1"},"nodeType":"YulFunctionCall","src":"67:9:1"},"variableNames":[{"name":"memPtr","nodeType":"YulIdentifier","src":"57:6:1"}]}]},"name":"allocate_unbounded","nodeType":"YulFunctionDefinition","returnVariables":[{"name":"memPtr","nodeType":"YulTypedName","src":"40:6:1","type":""}],"src":"7:75:1"},{"body":{"nodeType":"YulBlock","src":"177:28:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"194:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"197:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"187:6:1"},"nodeType":"YulFunctionCall","src":"187:12:1"},"nodeType":"YulExpressionStatement","src":"187:12:1"}]},"name":"revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b","nodeType":"YulFunctionDefinition","src":"88:117:1"},{"body":{"nodeType":"YulBlock","src":"300:28:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"317:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"320:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"310:6:1"},"nodeType":"YulFunctionCall","src":"310:12:1"},"nodeType":"YulExpressionStatement","src":"310:12:1"}]},"name":"revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db","nodeType":"YulFunctionDefinition","src":"211:117:1"},{"body":{"nodeType":"YulBlock","src":"423:28:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"440:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"443:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"433:6:1"},"nodeType":"YulFunctionCall","src":"433:12:1"},"nodeType":"YulExpressionStatement","src":"433:12:1"}]},"name":"revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d","nodeType":"YulFunctionDefinition","src":"334:117:1"},{"body":{"nodeType":"YulBlock","src":"505:54:1","statements":[{"nodeType":"YulAssignment","src":"515:38:1","value":{"arguments":[{"arguments":[{"name":"value","nodeType":"YulIdentifier","src":"533:5:1"},{"kind":"number","nodeType":"YulLiteral","src":"540:2:1","type":"","value":"31"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"529:3:1"},"nodeType":"YulFunctionCall","src":"529:14:1"},{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"549:2:1","type":"","value":"31"}],"functionName":{"name":"not","nodeType":"YulIdentifier","src":"545:3:1"},"nodeType":"YulFunctionCall","src":"545:7:1"}],"functionName":{"name":"and","nodeType":"YulIdentifier","src":"525:3:1"},"nodeType":"YulFunctionCall","src":"525:28:1"},"variableNames":[{"name":"result","nodeType":"YulIdentifier","src":"515:6:1"}]}]},"name":"round_up_to_mul_of_32","nodeType":"YulFunctionDefinition","parameters":[{"name":"value","nodeType":"YulTypedName","src":"488:5:1","type":""}],"returnVariables":[{"name":"result","nodeType":"YulTypedName","src":"498:6:1","type":""}],"src":"457:102:1"},{"body":{"nodeType":"YulBlock","src":"593:152:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"610:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"613:77:1","type":"","value":"35408467139433450592217433187231851964531694900788300625387963629091585785856"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"603:6:1"},"nodeType":"YulFunctionCall","src":"603:88:1"},"nodeType":"YulExpressionStatement","src":"603:88:1"},{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"707:1:1","type":"","value":"4"},{"kind":"number","nodeType":"YulLiteral","src":"710:4:1","type":"","value":"0x41"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"700:6:1"},"nodeType":"YulFunctionCall","src":"700:15:1"},"nodeType":"YulExpressionStatement","src":"700:15:1"},{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"731:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"734:4:1","type":"","value":"0x24"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"724:6:1"},"nodeType":"YulFunctionCall","src":"724:15:1"},"nodeType":"YulExpressionStatement","src":"724:15:1"}]},"name":"panic_error_0x41","nodeType":"YulFunctionDefinition","src":"565:180:1"},{"body":{"nodeType":"YulBlock","src":"794:238:1","statements":[{"nodeType":"YulVariableDeclaration","src":"804:58:1","value":{"arguments":[{"name":"memPtr","nodeType":"YulIdentifier","src":"826:6:1"},{"arguments":[{"name":"size","nodeType":"YulIdentifier","src":"856:4:1"}],"functionName":{"name":"round_up_to_mul_of_32","nodeType":"YulIdentifier","src":"834:21:1"},"nodeType":"YulFunctionCall","src":"834:27:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"822:3:1"},"nodeType":"YulFunctionCall","src":"822:40:1"},"variables":[{"name":"newFreePtr","nodeType":"YulTypedName","src":"808:10:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"973:22:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"panic_error_0x41","nodeType":"YulIdentifier","src":"975:16:1"},"nodeType":"YulFunctionCall","src":"975:18:1"},"nodeType":"YulExpressionStatement","src":"975:18:1"}]},"condition":{"arguments":[{"arguments":[{"name":"newFreePtr","nodeType":"YulIdentifier","src":"916:10:1"},{"kind":"number","nodeType":"YulLiteral","src":"928:18:1","type":"","value":"0xffffffffffffffff"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"913:2:1"},"nodeType":"YulFunctionCall","src":"913:34:1"},{"arguments":[{"name":"newFreePtr","nodeType":"YulIdentifier","src":"952:10:1"},{"name":"memPtr","nodeType":"YulIdentifier","src":"964:6:1"}],"functionName":{"name":"lt","nodeType":"YulIdentifier","src":"949:2:1"},"nodeType":"YulFunctionCall","src":"949:22:1"}],"functionName":{"name":"or","nodeType":"YulIdentifier","src":"910:2:1"},"nodeType":"YulFunctionCall","src":"910:62:1"},"nodeType":"YulIf","src":"907:88:1"},{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"1011:2:1","type":"","value":"64"},{"name":"newFreePtr","nodeType":"YulIdentifier","src":"1015:10:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"1004:6:1"},"nodeType":"YulFunctionCall","src":"1004:22:1"},"nodeType":"YulExpressionStatement","src":"1004:22:1"}]},"name":"finalize_allocation","nodeType":"YulFunctionDefinition","parameters":[{"name":"memPtr","nodeType":"YulTypedName","src":"780:6:1","type":""},{"name":"size","nodeType":"YulTypedName","src":"788:4:1","type":""}],"src":"751:281:1"},{"body":{"nodeType":"YulBlock","src":"1079:88:1","statements":[{"nodeType":"YulAssignment","src":"1089:30:1","value":{"arguments":[],"functionName":{"name":"allocate_unbounded","nodeType":"YulIdentifier","src":"1099:18:1"},"nodeType":"YulFunctionCall","src":"1099:20:1"},"variableNames":[{"name":"memPtr","nodeType":"YulIdentifier","src":"1089:6:1"}]},{"expression":{"arguments":[{"name":"memPtr","nodeType":"YulIdentifier","src":"1148:6:1"},{"name":"size","nodeType":"YulIdentifier","src":"1156:4:1"}],"functionName":{"name":"finalize_allocation","nodeType":"YulIdentifier","src":"1128:19:1"},"nodeType":"YulFunctionCall","src":"1128:33:1"},"nodeType":"YulExpressionStatement","src":"1128:33:1"}]},"name":"allocate_memory","nodeType":"YulFunctionDefinition","parameters":[{"name":"size","nodeType":"YulTypedName","src":"1063:4:1","type":""}],"returnVariables":[{"name":"memPtr","nodeType":"YulTypedName","src":"1072:6:1","type":""}],"src":"1038:129:1"},{"body":{"nodeType":"YulBlock","src":"1255:229:1","statements":[{"body":{"nodeType":"YulBlock","src":"1360:22:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"panic_error_0x41","nodeType":"YulIdentifier","src":"1362:16:1"},"nodeType":"YulFunctionCall","src":"1362:18:1"},"nodeType":"YulExpressionStatement","src":"1362:18:1"}]},"condition":{"arguments":[{"name":"length","nodeType":"YulIdentifier","src":"1332:6:1"},{"kind":"number","nodeType":"YulLiteral","src":"1340:18:1","type":"","value":"0xffffffffffffffff"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"1329:2:1"},"nodeType":"YulFunctionCall","src":"1329:30:1"},"nodeType":"YulIf","src":"1326:56:1"},{"nodeType":"YulAssignment","src":"1392:25:1","value":{"arguments":[{"name":"length","nodeType":"YulIdentifier","src":"1404:6:1"},{"kind":"number","nodeType":"YulLiteral","src":"1412:4:1","type":"","value":"0x20"}],"functionName":{"name":"mul","nodeType":"YulIdentifier","src":"1400:3:1"},"nodeType":"YulFunctionCall","src":"1400:17:1"},"variableNames":[{"name":"size","nodeType":"YulIdentifier","src":"1392:4:1"}]},{"nodeType":"YulAssignment","src":"1454:23:1","value":{"arguments":[{"name":"size","nodeType":"YulIdentifier","src":"1466:4:1"},{"kind":"number","nodeType":"YulLiteral","src":"1472:4:1","type":"","value":"0x20"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"1462:3:1"},"nodeType":"YulFunctionCall","src":"1462:15:1"},"variableNames":[{"name":"size","nodeType":"YulIdentifier","src":"1454:4:1"}]}]},"name":"array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulFunctionDefinition","parameters":[{"name":"length","nodeType":"YulTypedName","src":"1239:6:1","type":""}],"returnVariables":[{"name":"size","nodeType":"YulTypedName","src":"1250:4:1","type":""}],"src":"1173:311:1"},{"body":{"nodeType":"YulBlock","src":"1579:28:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"1596:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"1599:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"1589:6:1"},"nodeType":"YulFunctionCall","src":"1589:12:1"},"nodeType":"YulExpressionStatement","src":"1589:12:1"}]},"name":"revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef","nodeType":"YulFunctionDefinition","src":"1490:117:1"},{"body":{"nodeType":"YulBlock","src":"1658:32:1","statements":[{"nodeType":"YulAssignment","src":"1668:16:1","value":{"name":"value","nodeType":"YulIdentifier","src":"1679:5:1"},"variableNames":[{"name":"cleaned","nodeType":"YulIdentifier","src":"1668:7:1"}]}]},"name":"cleanup_t_uint256","nodeType":"YulFunctionDefinition","parameters":[{"name":"value","nodeType":"YulTypedName","src":"1640:5:1","type":""}],"returnVariables":[{"name":"cleaned","nodeType":"YulTypedName","src":"1650:7:1","type":""}],"src":"1613:77:1"},{"body":{"nodeType":"YulBlock","src":"1739:79:1","statements":[{"body":{"nodeType":"YulBlock","src":"1796:16:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"1805:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"1808:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"1798:6:1"},"nodeType":"YulFunctionCall","src":"1798:12:1"},"nodeType":"YulExpressionStatement","src":"1798:12:1"}]},"condition":{"arguments":[{"arguments":[{"name":"value","nodeType":"YulIdentifier","src":"1762:5:1"},{"arguments":[{"name":"value","nodeType":"YulIdentifier","src":"1787:5:1"}],"functionName":{"name":"cleanup_t_uint256","nodeType":"YulIdentifier","src":"1769:17:1"},"nodeType":"YulFunctionCall","src":"1769:24:1"}],"functionName":{"name":"eq","nodeType":"YulIdentifier","src":"1759:2:1"},"nodeType":"YulFunctionCall","src":"1759:35:1"}],"functionName":{"name":"iszero","nodeType":"YulIdentifier","src":"1752:6:1"},"nodeType":"YulFunctionCall","src":"1752:43:1"},"nodeType":"YulIf","src":"1749:63:1"}]},"name":"validator_revert_t_uint256","nodeType":"YulFunctionDefinition","parameters":[{"name":"value","nodeType":"YulTypedName","src":"1732:5:1","type":""}],"src":"1696:122:1"},{"body":{"nodeType":"YulBlock","src":"1876:87:1","statements":[{"nodeType":"YulAssignment","src":"1886:29:1","value":{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"1908:6:1"}],"functionName":{"name":"calldataload","nodeType":"YulIdentifier","src":"1895:12:1"},"nodeType":"YulFunctionCall","src":"1895:20:1"},"variableNames":[{"name":"value","nodeType":"YulIdentifier","src":"1886:5:1"}]},{"expression":{"arguments":[{"name":"value","nodeType":"YulIdentifier","src":"1951:5:1"}],"functionName":{"name":"validator_revert_t_uint256","nodeType":"YulIdentifier","src":"1924:26:1"},"nodeType":"YulFunctionCall","src":"1924:33:1"},"nodeType":"YulExpressionStatement","src":"1924:33:1"}]},"name":"abi_decode_t_uint256","nodeType":"YulFunctionDefinition","parameters":[{"name":"offset","nodeType":"YulTypedName","src":"1854:6:1","type":""},{"name":"end","nodeType":"YulTypedName","src":"1862:3:1","type":""}],"returnVariables":[{"name":"value","nodeType":"YulTypedName","src":"1870:5:1","type":""}],"src":"1824:139:1"},{"body":{"nodeType":"YulBlock","src":"2088:608:1","statements":[{"nodeType":"YulAssignment","src":"2098:90:1","value":{"arguments":[{"arguments":[{"name":"length","nodeType":"YulIdentifier","src":"2180:6:1"}],"functionName":{"name":"array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulIdentifier","src":"2123:56:1"},"nodeType":"YulFunctionCall","src":"2123:64:1"}],"functionName":{"name":"allocate_memory","nodeType":"YulIdentifier","src":"2107:15:1"},"nodeType":"YulFunctionCall","src":"2107:81:1"},"variableNames":[{"name":"array","nodeType":"YulIdentifier","src":"2098:5:1"}]},{"nodeType":"YulVariableDeclaration","src":"2197:16:1","value":{"name":"array","nodeType":"YulIdentifier","src":"2208:5:1"},"variables":[{"name":"dst","nodeType":"YulTypedName","src":"2201:3:1","type":""}]},{"expression":{"arguments":[{"name":"array","nodeType":"YulIdentifier","src":"2230:5:1"},{"name":"length","nodeType":"YulIdentifier","src":"2237:6:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"2223:6:1"},"nodeType":"YulFunctionCall","src":"2223:21:1"},"nodeType":"YulExpressionStatement","src":"2223:21:1"},{"nodeType":"YulAssignment","src":"2253:23:1","value":{"arguments":[{"name":"array","nodeType":"YulIdentifier","src":"2264:5:1"},{"kind":"number","nodeType":"YulLiteral","src":"2271:4:1","type":"","value":"0x20"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"2260:3:1"},"nodeType":"YulFunctionCall","src":"2260:16:1"},"variableNames":[{"name":"dst","nodeType":"YulIdentifier","src":"2253:3:1"}]},{"nodeType":"YulVariableDeclaration","src":"2286:44:1","value":{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"2304:6:1"},{"arguments":[{"name":"length","nodeType":"YulIdentifier","src":"2316:6:1"},{"kind":"number","nodeType":"YulLiteral","src":"2324:4:1","type":"","value":"0x20"}],"functionName":{"name":"mul","nodeType":"YulIdentifier","src":"2312:3:1"},"nodeType":"YulFunctionCall","src":"2312:17:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"2300:3:1"},"nodeType":"YulFunctionCall","src":"2300:30:1"},"variables":[{"name":"srcEnd","nodeType":"YulTypedName","src":"2290:6:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"2358:103:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef","nodeType":"YulIdentifier","src":"2372:77:1"},"nodeType":"YulFunctionCall","src":"2372:79:1"},"nodeType":"YulExpressionStatement","src":"2372:79:1"}]},"condition":{"arguments":[{"name":"srcEnd","nodeType":"YulIdentifier","src":"2345:6:1"},{"name":"end","nodeType":"YulIdentifier","src":"2353:3:1"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"2342:2:1"},"nodeType":"YulFunctionCall","src":"2342:15:1"},"nodeType":"YulIf","src":"2339:122:1"},{"body":{"nodeType":"YulBlock","src":"2546:144:1","statements":[{"nodeType":"YulVariableDeclaration","src":"2561:21:1","value":{"name":"src","nodeType":"YulIdentifier","src":"2579:3:1"},"variables":[{"name":"elementPos","nodeType":"YulTypedName","src":"2565:10:1","type":""}]},{"expression":{"arguments":[{"name":"dst","nodeType":"YulIdentifier","src":"2603:3:1"},{"arguments":[{"name":"elementPos","nodeType":"YulIdentifier","src":"2629:10:1"},{"name":"end","nodeType":"YulIdentifier","src":"2641:3:1"}],"functionName":{"name":"abi_decode_t_uint256","nodeType":"YulIdentifier","src":"2608:20:1"},"nodeType":"YulFunctionCall","src":"2608:37:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"2596:6:1"},"nodeType":"YulFunctionCall","src":"2596:50:1"},"nodeType":"YulExpressionStatement","src":"2596:50:1"},{"nodeType":"YulAssignment","src":"2659:21:1","value":{"arguments":[{"name":"dst","nodeType":"YulIdentifier","src":"2670:3:1"},{"kind":"number","nodeType":"YulLiteral","src":"2675:4:1","type":"","value":"0x20"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"2666:3:1"},"nodeType":"YulFunctionCall","src":"2666:14:1"},"variableNames":[{"name":"dst","nodeType":"YulIdentifier","src":"2659:3:1"}]}]},"condition":{"arguments":[{"name":"src","nodeType":"YulIdentifier","src":"2499:3:1"},{"name":"srcEnd","nodeType":"YulIdentifier","src":"2504:6:1"}],"functionName":{"name":"lt","nodeType":"YulIdentifier","src":"2496:2:1"},"nodeType":"YulFunctionCall","src":"2496:15:1"},"nodeType":"YulForLoop","post":{"nodeType":"YulBlock","src":"2512:25:1","statements":[{"nodeType":"YulAssignment","src":"2514:21:1","value":{"arguments":[{"name":"src","nodeType":"YulIdentifier","src":"2525:3:1"},{"kind":"number","nodeType":"YulLiteral","src":"2530:4:1","type":"","value":"0x20"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"2521:3:1"},"nodeType":"YulFunctionCall","src":"2521:14:1"},"variableNames":[{"name":"src","nodeType":"YulIdentifier","src":"2514:3:1"}]}]},"pre":{"nodeType":"YulBlock","src":"2474:21:1","statements":[{"nodeType":"YulVariableDeclaration","src":"2476:17:1","value":{"name":"offset","nodeType":"YulIdentifier","src":"2487:6:1"},"variables":[{"name":"src","nodeType":"YulTypedName","src":"2480:3:1","type":""}]}]},"src":"2470:220:1"}]},"name":"abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulFunctionDefinition","parameters":[{"name":"offset","nodeType":"YulTypedName","src":"2058:6:1","type":""},{"name":"length","nodeType":"YulTypedName","src":"2066:6:1","type":""},{"name":"end","nodeType":"YulTypedName","src":"2074:3:1","type":""}],"returnVariables":[{"name":"array","nodeType":"YulTypedName","src":"2082:5:1","type":""}],"src":"1986:710:1"},{"body":{"nodeType":"YulBlock","src":"2796:293:1","statements":[{"body":{"nodeType":"YulBlock","src":"2845:83:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d","nodeType":"YulIdentifier","src":"2847:77:1"},"nodeType":"YulFunctionCall","src":"2847:79:1"},"nodeType":"YulExpressionStatement","src":"2847:79:1"}]},"condition":{"arguments":[{"arguments":[{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"2824:6:1"},{"kind":"number","nodeType":"YulLiteral","src":"2832:4:1","type":"","value":"0x1f"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"2820:3:1"},"nodeType":"YulFunctionCall","src":"2820:17:1"},{"name":"end","nodeType":"YulIdentifier","src":"2839:3:1"}],"functionName":{"name":"slt","nodeType":"YulIdentifier","src":"2816:3:1"},"nodeType":"YulFunctionCall","src":"2816:27:1"}],"functionName":{"name":"iszero","nodeType":"YulIdentifier","src":"2809:6:1"},"nodeType":"YulFunctionCall","src":"2809:35:1"},"nodeType":"YulIf","src":"2806:122:1"},{"nodeType":"YulVariableDeclaration","src":"2937:34:1","value":{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"2964:6:1"}],"functionName":{"name":"calldataload","nodeType":"YulIdentifier","src":"2951:12:1"},"nodeType":"YulFunctionCall","src":"2951:20:1"},"variables":[{"name":"length","nodeType":"YulTypedName","src":"2941:6:1","type":""}]},{"nodeType":"YulAssignment","src":"2980:103:1","value":{"arguments":[{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"3056:6:1"},{"kind":"number","nodeType":"YulLiteral","src":"3064:4:1","type":"","value":"0x20"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"3052:3:1"},"nodeType":"YulFunctionCall","src":"3052:17:1"},{"name":"length","nodeType":"YulIdentifier","src":"3071:6:1"},{"name":"end","nodeType":"YulIdentifier","src":"3079:3:1"}],"functionName":{"name":"abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulIdentifier","src":"2989:62:1"},"nodeType":"YulFunctionCall","src":"2989:94:1"},"variableNames":[{"name":"array","nodeType":"YulIdentifier","src":"2980:5:1"}]}]},"name":"abi_decode_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulFunctionDefinition","parameters":[{"name":"offset","nodeType":"YulTypedName","src":"2774:6:1","type":""},{"name":"end","nodeType":"YulTypedName","src":"2782:3:1","type":""}],"returnVariables":[{"name":"array","nodeType":"YulTypedName","src":"2790:5:1","type":""}],"src":"2719:370:1"},{"body":{"nodeType":"YulBlock","src":"3186:448:1","statements":[{"body":{"nodeType":"YulBlock","src":"3232:83:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b","nodeType":"YulIdentifier","src":"3234:77:1"},"nodeType":"YulFunctionCall","src":"3234:79:1"},"nodeType":"YulExpressionStatement","src":"3234:79:1"}]},"condition":{"arguments":[{"arguments":[{"name":"dataEnd","nodeType":"YulIdentifier","src":"3207:7:1"},{"name":"headStart","nodeType":"YulIdentifier","src":"3216:9:1"}],"functionName":{"name":"sub","nodeType":"YulIdentifier","src":"3203:3:1"},"nodeType":"YulFunctionCall","src":"3203:23:1"},{"kind":"number","nodeType":"YulLiteral","src":"3228:2:1","type":"","value":"32"}],"functionName":{"name":"slt","nodeType":"YulIdentifier","src":"3199:3:1"},"nodeType":"YulFunctionCall","src":"3199:32:1"},"nodeType":"YulIf","src":"3196:119:1"},{"nodeType":"YulBlock","src":"3325:302:1","statements":[{"nodeType":"YulVariableDeclaration","src":"3340:45:1","value":{"arguments":[{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"3371:9:1"},{"kind":"number","nodeType":"YulLiteral","src":"3382:1:1","type":"","value":"0"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"3367:3:1"},"nodeType":"YulFunctionCall","src":"3367:17:1"}],"functionName":{"name":"calldataload","nodeType":"YulIdentifier","src":"3354:12:1"},"nodeType":"YulFunctionCall","src":"3354:31:1"},"variables":[{"name":"offset","nodeType":"YulTypedName","src":"3344:6:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"3432:83:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db","nodeType":"YulIdentifier","src":"3434:77:1"},"nodeType":"YulFunctionCall","src":"3434:79:1"},"nodeType":"YulExpressionStatement","src":"3434:79:1"}]},"condition":{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"3404:6:1"},{"kind":"number","nodeType":"YulLiteral","src":"3412:18:1","type":"","value":"0xffffffffffffffff"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"3401:2:1"},"nodeType":"YulFunctionCall","src":"3401:30:1"},"nodeType":"YulIf","src":"3398:117:1"},{"nodeType":"YulAssignment","src":"3529:88:1","value":{"arguments":[{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"3589:9:1"},{"name":"offset","nodeType":"YulIdentifier","src":"3600:6:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"3585:3:1"},"nodeType":"YulFunctionCall","src":"3585:22:1"},{"name":"dataEnd","nodeType":"YulIdentifier","src":"3609:7:1"}],"functionName":{"name":"abi_decode_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulIdentifier","src":"3539:45:1"},"nodeType":"YulFunctionCall","src":"3539:78:1"},"variableNames":[{"name":"value0","nodeType":"YulIdentifier","src":"3529:6:1"}]}]}]},"name":"abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulFunctionDefinition","parameters":[{"name":"headStart","nodeType":"YulTypedName","src":"3156:9:1","type":""},{"name":"dataEnd","nodeType":"YulTypedName","src":"3167:7:1","type":""}],"returnVariables":[{"name":"value0","nodeType":"YulTypedName","src":"3179:6:1","type":""}],"src":"3095:539:1"},{"body":{"nodeType":"YulBlock","src":"3705:53:1","statements":[{"expression":{"arguments":[{"name":"pos","nodeType":"YulIdentifier","src":"3722:3:1"},{"arguments":[{"name":"value","nodeType":"YulIdentifier","src":"3745:5:1"}],"functionName":{"name":"cleanup_t_uint256","nodeType":"YulIdentifier","src":"3727:17:1"},"nodeType":"YulFunctionCall","src":"3727:24:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"3715:6:1"},"nodeType":"YulFunctionCall","src":"3715:37:1"},"nodeType":"YulExpressionStatement","src":"3715:37:1"}]},"name":"abi_encode_t_uint256_to_t_uint256_fromStack","nodeType":"YulFunctionDefinition","parameters":[{"name":"value","nodeType":"YulTypedName","src":"3693:5:1","type":""},{"name":"pos","nodeType":"YulTypedName","src":"3700:3:1","type":""}],"src":"3640:118:1"},{"body":{"nodeType":"YulBlock","src":"3862:124:1","statements":[{"nodeType":"YulAssignment","src":"3872:26:1","value":{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"3884:9:1"},{"kind":"number","nodeType":"YulLiteral","src":"3895:2:1","type":"","value":"32"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"3880:3:1"},"nodeType":"YulFunctionCall","src":"3880:18:1"},"variableNames":[{"name":"tail","nodeType":"YulIdentifier","src":"3872:4:1"}]},{"expression":{"arguments":[{"name":"value0","nodeType":"YulIdentifier","src":"3952:6:1"},{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"3965:9:1"},{"kind":"number","nodeType":"YulLiteral","src":"3976:1:1","type":"","value":"0"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"3961:3:1"},"nodeType":"YulFunctionCall","src":"3961:17:1"}],"functionName":{"name":"abi_encode_t_uint256_to_t_uint256_fromStack","nodeType":"YulIdentifier","src":"3908:43:1"},"nodeType":"YulFunctionCall","src":"3908:71:1"},"nodeType":"YulExpressionStatement","src":"3908:71:1"}]},"name":"abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed","nodeType":"YulFunctionDefinition","parameters":[{"name":"headStart","nodeType":"YulTypedName","src":"3834:9:1","type":""},{"name":"value0","nodeType":"YulTypedName","src":"3846:6:1","type":""}],"returnVariables":[{"name":"tail","nodeType":"YulTypedName","src":"3857:4:1","type":""}],"src":"3764:222:1"}]},"contents":"{
+{
+    "contracts":
+    {
+        "a.sol":
+        {
+            "A":
+            {
+                "evm":
+                {
+                    "bytecode":
+                    {
+                        "generatedSources": [],
+                        "object": "<BYTECODE REMOVED>"
+                    },
+                    "deployedBytecode":
+                    {
+                        "generatedSources":
+                        [
+                            {
+                                "ast":
+                                {
+                                    "nodeType": "YulBlock",
+                                    "src": "0:3989:1",
+                                    "statements":
+                                    [
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "47:35:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "57:19:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "73:2:1",
+                                                                    "type": "",
+                                                                    "value": "64"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mload",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "67:5:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "67:9:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "memPtr",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "57:6:1"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "allocate_unbounded",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "memPtr",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "40:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "7:75:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "177:28:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "194:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "197:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "187:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "187:12:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "187:12:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "88:117:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "300:28:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "317:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "320:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "310:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "310:12:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "310:12:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "211:117:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "423:28:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "440:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "443:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "433:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "433:12:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "433:12:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "334:117:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "505:54:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "515:38:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "value",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "533:5:1"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "540:2:1",
+                                                                            "type": "",
+                                                                            "value": "31"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "add",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "529:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "529:14:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "549:2:1",
+                                                                            "type": "",
+                                                                            "value": "31"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "not",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "545:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "545:7:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "and",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "525:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "525:28:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "result",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "515:6:1"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "round_up_to_mul_of_32",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "488:5:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "result",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "498:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "457:102:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "593:152:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "610:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "613:77:1",
+                                                                    "type": "",
+                                                                    "value": "35408467139433450592217433187231851964531694900788300625387963629091585785856"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "603:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "603:88:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "603:88:1"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "707:1:1",
+                                                                    "type": "",
+                                                                    "value": "4"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "710:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x41"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "700:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "700:15:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "700:15:1"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "731:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "734:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x24"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "724:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "724:15:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "724:15:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "panic_error_0x41",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "565:180:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "794:238:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "804:58:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "memPtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "826:6:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "size",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "856:4:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "round_up_to_mul_of_32",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "834:21:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "834:27:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "822:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "822:40:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "newFreePtr",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "808:10:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "973:22:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "panic_error_0x41",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "975:16:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "975:18:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "975:18:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "newFreePtr",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "916:10:1"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "928:18:1",
+                                                                            "type": "",
+                                                                            "value": "0xffffffffffffffff"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "gt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "913:2:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "913:34:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "newFreePtr",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "952:10:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "memPtr",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "964:6:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "lt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "949:2:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "949:22:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "or",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "910:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "910:62:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "907:88:1"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1011:2:1",
+                                                                    "type": "",
+                                                                    "value": "64"
+                                                                },
+                                                                {
+                                                                    "name": "newFreePtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1015:10:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1004:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1004:22:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "1004:22:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "finalize_allocation",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "memPtr",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "780:6:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "size",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "788:4:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "751:281:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1079:88:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1089:30:1",
+                                                        "value":
+                                                        {
+                                                            "arguments": [],
+                                                            "functionName":
+                                                            {
+                                                                "name": "allocate_unbounded",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1099:18:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1099:20:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "memPtr",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1089:6:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "memPtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1148:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "size",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1156:4:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "finalize_allocation",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1128:19:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1128:33:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "1128:33:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "allocate_memory",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "size",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1063:4:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "memPtr",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1072:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1038:129:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1255:229:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "1360:22:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "panic_error_0x41",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1362:16:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "1362:18:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "1362:18:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "length",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1332:6:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1340:18:1",
+                                                                    "type": "",
+                                                                    "value": "0xffffffffffffffff"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "gt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1329:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1329:30:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "1326:56:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1392:25:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "length",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1404:6:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1412:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x20"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mul",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1400:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1400:17:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "size",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1392:4:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1454:23:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "size",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1466:4:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1472:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x20"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1462:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1462:15:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "size",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1454:4:1"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "length",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1239:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "size",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1250:4:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1173:311:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1579:28:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1596:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1599:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1589:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1589:12:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "1589:12:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "1490:117:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1658:32:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1668:16:1",
+                                                        "value":
+                                                        {
+                                                            "name": "value",
+                                                            "nodeType": "YulIdentifier",
+                                                            "src": "1679:5:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "cleaned",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1668:7:1"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "cleanup_t_uint256",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1640:5:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "cleaned",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1650:7:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1613:77:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1739:79:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "1796:16:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "1805:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "1808:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1798:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "1798:12:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "1798:12:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "value",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1762:5:1"
+                                                                        },
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "name": "value",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "1787:5:1"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "cleanup_t_uint256",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "1769:17:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "1769:24:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "eq",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "1759:2:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "1759:35:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "iszero",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1752:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1752:43:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "1749:63:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "validator_revert_t_uint256",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1732:5:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1696:122:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1876:87:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1886:29:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "offset",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1908:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "calldataload",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1895:12:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1895:20:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "value",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1886:5:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "value",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1951:5:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "validator_revert_t_uint256",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1924:26:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1924:33:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "1924:33:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_decode_t_uint256",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "offset",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1854:6:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "end",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1862:3:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1870:5:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1824:139:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "2088:608:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "2098:90:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "length",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2180:6:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "2123:56:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "2123:64:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "allocate_memory",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2107:15:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2107:81:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "array",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2098:5:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "2197:16:1",
+                                                        "value":
+                                                        {
+                                                            "name": "array",
+                                                            "nodeType": "YulIdentifier",
+                                                            "src": "2208:5:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "dst",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "2201:3:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "array",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2230:5:1"
+                                                                },
+                                                                {
+                                                                    "name": "length",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2237:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2223:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2223:21:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "2223:21:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "2253:23:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "array",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2264:5:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "2271:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x20"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2260:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2260:16:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "dst",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2253:3:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "2286:44:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "offset",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2304:6:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "length",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2316:6:1"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "2324:4:1",
+                                                                            "type": "",
+                                                                            "value": "0x20"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "mul",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "2312:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "2312:17:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2300:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2300:30:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "srcEnd",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "2290:6:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "2358:103:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2372:77:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "2372:79:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "2372:79:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "srcEnd",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2345:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "end",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2353:3:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "gt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2342:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2342:15:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "2339:122:1"
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "2546:144:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "nodeType": "YulVariableDeclaration",
+                                                                    "src": "2561:21:1",
+                                                                    "value":
+                                                                    {
+                                                                        "name": "src",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "2579:3:1"
+                                                                    },
+                                                                    "variables":
+                                                                    [
+                                                                        {
+                                                                            "name": "elementPos",
+                                                                            "nodeType": "YulTypedName",
+                                                                            "src": "2565:10:1",
+                                                                            "type": ""
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "name": "dst",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "2603:3:1"
+                                                                            },
+                                                                            {
+                                                                                "arguments":
+                                                                                [
+                                                                                    {
+                                                                                        "name": "elementPos",
+                                                                                        "nodeType": "YulIdentifier",
+                                                                                        "src": "2629:10:1"
+                                                                                    },
+                                                                                    {
+                                                                                        "name": "end",
+                                                                                        "nodeType": "YulIdentifier",
+                                                                                        "src": "2641:3:1"
+                                                                                    }
+                                                                                ],
+                                                                                "functionName":
+                                                                                {
+                                                                                    "name": "abi_decode_t_uint256",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "2608:20:1"
+                                                                                },
+                                                                                "nodeType": "YulFunctionCall",
+                                                                                "src": "2608:37:1"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "mstore",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2596:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "2596:50:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "2596:50:1"
+                                                                },
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "2659:21:1",
+                                                                    "value":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "name": "dst",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "2670:3:1"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "2675:4:1",
+                                                                                "type": "",
+                                                                                "value": "0x20"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "add",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2666:3:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "2666:14:1"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "dst",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2659:3:1"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "src",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2499:3:1"
+                                                                },
+                                                                {
+                                                                    "name": "srcEnd",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2504:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "lt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2496:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2496:15:1"
+                                                        },
+                                                        "nodeType": "YulForLoop",
+                                                        "post":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "2512:25:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "2514:21:1",
+                                                                    "value":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "name": "src",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "2525:3:1"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "2530:4:1",
+                                                                                "type": "",
+                                                                                "value": "0x20"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "add",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2521:3:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "2521:14:1"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "src",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2514:3:1"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "pre":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "2474:21:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "nodeType": "YulVariableDeclaration",
+                                                                    "src": "2476:17:1",
+                                                                    "value":
+                                                                    {
+                                                                        "name": "offset",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "2487:6:1"
+                                                                    },
+                                                                    "variables":
+                                                                    [
+                                                                        {
+                                                                            "name": "src",
+                                                                            "nodeType": "YulTypedName",
+                                                                            "src": "2480:3:1",
+                                                                            "type": ""
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "src": "2470:220:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "offset",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2058:6:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "length",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2066:6:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "end",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2074:3:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "array",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2082:5:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1986:710:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "2796:293:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "2845:83:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2847:77:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "2847:79:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "2847:79:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "name": "offset",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "2824:6:1"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "number",
+                                                                                    "nodeType": "YulLiteral",
+                                                                                    "src": "2832:4:1",
+                                                                                    "type": "",
+                                                                                    "value": "0x1f"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "add",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "2820:3:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "2820:17:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "end",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "2839:3:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "slt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "2816:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "2816:27:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "iszero",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2809:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2809:35:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "2806:122:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "2937:34:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "offset",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "2964:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "calldataload",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2951:12:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2951:20:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "length",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "2941:6:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "2980:103:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "offset",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3056:6:1"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "3064:4:1",
+                                                                            "type": "",
+                                                                            "value": "0x20"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "add",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3052:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3052:17:1"
+                                                                },
+                                                                {
+                                                                    "name": "length",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "3071:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "end",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "3079:3:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2989:62:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "2989:94:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "array",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "2980:5:1"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_decode_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "offset",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2774:6:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "end",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2782:3:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "array",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "2790:5:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "2719:370:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "3186:448:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "3232:83:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3234:77:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "3234:79:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "3234:79:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "dataEnd",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3207:7:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "headStart",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3216:9:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "sub",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3203:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3203:23:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "3228:2:1",
+                                                                    "type": "",
+                                                                    "value": "32"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "slt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "3199:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "3199:32:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "3196:119:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulBlock",
+                                                        "src": "3325:302:1",
+                                                        "statements":
+                                                        [
+                                                            {
+                                                                "nodeType": "YulVariableDeclaration",
+                                                                "src": "3340:45:1",
+                                                                "value":
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "name": "headStart",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "3371:9:1"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "number",
+                                                                                    "nodeType": "YulLiteral",
+                                                                                    "src": "3382:1:1",
+                                                                                    "type": "",
+                                                                                    "value": "0"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "add",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "3367:3:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "3367:17:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "calldataload",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3354:12:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3354:31:1"
+                                                                },
+                                                                "variables":
+                                                                [
+                                                                    {
+                                                                        "name": "offset",
+                                                                        "nodeType": "YulTypedName",
+                                                                        "src": "3344:6:1",
+                                                                        "type": ""
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "body":
+                                                                {
+                                                                    "nodeType": "YulBlock",
+                                                                    "src": "3432:83:1",
+                                                                    "statements":
+                                                                    [
+                                                                        {
+                                                                            "expression":
+                                                                            {
+                                                                                "arguments": [],
+                                                                                "functionName":
+                                                                                {
+                                                                                    "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "3434:77:1"
+                                                                                },
+                                                                                "nodeType": "YulFunctionCall",
+                                                                                "src": "3434:79:1"
+                                                                            },
+                                                                            "nodeType": "YulExpressionStatement",
+                                                                            "src": "3434:79:1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "condition":
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "offset",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3404:6:1"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "3412:18:1",
+                                                                            "type": "",
+                                                                            "value": "0xffffffffffffffff"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "gt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3401:2:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3401:30:1"
+                                                                },
+                                                                "nodeType": "YulIf",
+                                                                "src": "3398:117:1"
+                                                            },
+                                                            {
+                                                                "nodeType": "YulAssignment",
+                                                                "src": "3529:88:1",
+                                                                "value":
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "name": "headStart",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "3589:9:1"
+                                                                                },
+                                                                                {
+                                                                                    "name": "offset",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "3600:6:1"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "add",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "3585:3:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "3585:22:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "dataEnd",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3609:7:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "abi_decode_t_array$_t_uint256_$dyn_memory_ptr",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3539:45:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3539:78:1"
+                                                                },
+                                                                "variableNames":
+                                                                [
+                                                                    {
+                                                                        "name": "value0",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3529:6:1"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "headStart",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3156:9:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "dataEnd",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3167:7:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "value0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3179:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "3095:539:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "3705:53:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "pos",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "3722:3:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "value",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3745:5:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "cleanup_t_uint256",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3727:17:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3727:24:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "3715:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "3715:37:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "3715:37:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_encode_t_uint256_to_t_uint256_fromStack",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3693:5:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "pos",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3700:3:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "3640:118:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "3862:124:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "3872:26:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "headStart",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "3884:9:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "3895:2:1",
+                                                                    "type": "",
+                                                                    "value": "32"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "3880:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "3880:18:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "tail",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "3872:4:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "value0",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "3952:6:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "headStart",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "3965:9:1"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "3976:1:1",
+                                                                            "type": "",
+                                                                            "value": "0"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "add",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "3961:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "3961:17:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "abi_encode_t_uint256_to_t_uint256_fromStack",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "3908:43:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "3908:71:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "3908:71:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "headStart",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3834:9:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "value0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3846:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "tail",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "3857:4:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "3764:222:1"
+                                        }
+                                    ]
+                                },
+                                "contents": "{
 
     function allocate_unbounded() -> memPtr {
         memPtr := mload(64)
@@ -120,7 +2467,22 @@
     }
 
 }
-","id":1,"language":"Yul","name":"#utility.yul"}]}}}}},"errors":[{"component":"general","errorCode":"3420","formattedMessage":"Warning: Source file does not specify required compiler version!
---> a.sol
-
-","message":"Source file does not specify required compiler version!","severity":"warning","sourceLocation":{"end":-1,"file":"a.sol","start":-1},"type":"Warning"}],"sources":{"a.sol":{"id":0}}}
+",
+                                "id": 1,
+                                "language": "Yul",
+                                "name": "#utility.yul"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "sources":
+    {
+        "a.sol":
+        {
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_generatedSources/output.json
+++ b/test/cmdlineTests/standard_generatedSources/output.json
@@ -20,6 +20,7 @@
                                 "ast":
                                 {
                                     "nodeType": "YulBlock",
+                                    "origin": "0:3989:1",
                                     "src": "0:3989:1",
                                     "statements":
                                     [
@@ -27,11 +28,13 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "47:35:1",
                                                 "src": "47:35:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "57:19:1",
                                                         "src": "57:19:1",
                                                         "value":
                                                         {
@@ -40,6 +43,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "73:2:1",
                                                                     "src": "73:2:1",
                                                                     "type": "",
                                                                     "value": "64"
@@ -49,9 +53,11 @@
                                                             {
                                                                 "name": "mload",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "67:5:1",
                                                                 "src": "67:5:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "67:9:1",
                                                             "src": "67:9:1"
                                                         },
                                                         "variableNames":
@@ -59,6 +65,7 @@
                                                             {
                                                                 "name": "memPtr",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "57:6:1",
                                                                 "src": "57:6:1"
                                                             }
                                                         ]
@@ -67,11 +74,13 @@
                                             },
                                             "name": "allocate_unbounded",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "7:75:1",
                                             "returnVariables":
                                             [
                                                 {
                                                     "name": "memPtr",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "40:6:1",
                                                     "src": "40:6:1",
                                                     "type": ""
                                                 }
@@ -82,6 +91,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "177:28:1",
                                                 "src": "177:28:1",
                                                 "statements":
                                                 [
@@ -93,6 +103,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "194:1:1",
                                                                     "src": "194:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -100,6 +111,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "197:1:1",
                                                                     "src": "197:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -109,24 +121,29 @@
                                                             {
                                                                 "name": "revert",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "187:6:1",
                                                                 "src": "187:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "187:12:1",
                                                             "src": "187:12:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "187:12:1",
                                                         "src": "187:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "88:117:1",
                                             "src": "88:117:1"
                                         },
                                         {
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "300:28:1",
                                                 "src": "300:28:1",
                                                 "statements":
                                                 [
@@ -138,6 +155,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "317:1:1",
                                                                     "src": "317:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -145,6 +163,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "320:1:1",
                                                                     "src": "320:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -154,24 +173,29 @@
                                                             {
                                                                 "name": "revert",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "310:6:1",
                                                                 "src": "310:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "310:12:1",
                                                             "src": "310:12:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "310:12:1",
                                                         "src": "310:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "211:117:1",
                                             "src": "211:117:1"
                                         },
                                         {
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "423:28:1",
                                                 "src": "423:28:1",
                                                 "statements":
                                                 [
@@ -183,6 +207,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "440:1:1",
                                                                     "src": "440:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -190,6 +215,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "443:1:1",
                                                                     "src": "443:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -199,29 +225,35 @@
                                                             {
                                                                 "name": "revert",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "433:6:1",
                                                                 "src": "433:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "433:12:1",
                                                             "src": "433:12:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "433:12:1",
                                                         "src": "433:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "334:117:1",
                                             "src": "334:117:1"
                                         },
                                         {
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "505:54:1",
                                                 "src": "505:54:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "515:38:1",
                                                         "src": "515:38:1",
                                                         "value":
                                                         {
@@ -233,11 +265,13 @@
                                                                         {
                                                                             "name": "value",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "533:5:1",
                                                                             "src": "533:5:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "540:2:1",
                                                                             "src": "540:2:1",
                                                                             "type": "",
                                                                             "value": "31"
@@ -247,9 +281,11 @@
                                                                     {
                                                                         "name": "add",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "529:3:1",
                                                                         "src": "529:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "529:14:1",
                                                                     "src": "529:14:1"
                                                                 },
                                                                 {
@@ -258,6 +294,7 @@
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "549:2:1",
                                                                             "src": "549:2:1",
                                                                             "type": "",
                                                                             "value": "31"
@@ -267,9 +304,11 @@
                                                                     {
                                                                         "name": "not",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "545:3:1",
                                                                         "src": "545:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "545:7:1",
                                                                     "src": "545:7:1"
                                                                 }
                                                             ],
@@ -277,9 +316,11 @@
                                                             {
                                                                 "name": "and",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "525:3:1",
                                                                 "src": "525:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "525:28:1",
                                                             "src": "525:28:1"
                                                         },
                                                         "variableNames":
@@ -287,6 +328,7 @@
                                                             {
                                                                 "name": "result",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "515:6:1",
                                                                 "src": "515:6:1"
                                                             }
                                                         ]
@@ -295,11 +337,13 @@
                                             },
                                             "name": "round_up_to_mul_of_32",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "457:102:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "488:5:1",
                                                     "src": "488:5:1",
                                                     "type": ""
                                                 }
@@ -309,6 +353,7 @@
                                                 {
                                                     "name": "result",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "498:6:1",
                                                     "src": "498:6:1",
                                                     "type": ""
                                                 }
@@ -319,6 +364,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "593:152:1",
                                                 "src": "593:152:1",
                                                 "statements":
                                                 [
@@ -330,6 +376,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "610:1:1",
                                                                     "src": "610:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -337,6 +384,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "613:77:1",
                                                                     "src": "613:77:1",
                                                                     "type": "",
                                                                     "value": "35408467139433450592217433187231851964531694900788300625387963629091585785856"
@@ -346,12 +394,15 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "603:6:1",
                                                                 "src": "603:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "603:88:1",
                                                             "src": "603:88:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "603:88:1",
                                                         "src": "603:88:1"
                                                     },
                                                     {
@@ -362,6 +413,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "707:1:1",
                                                                     "src": "707:1:1",
                                                                     "type": "",
                                                                     "value": "4"
@@ -369,6 +421,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "710:4:1",
                                                                     "src": "710:4:1",
                                                                     "type": "",
                                                                     "value": "0x41"
@@ -378,12 +431,15 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "700:6:1",
                                                                 "src": "700:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "700:15:1",
                                                             "src": "700:15:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "700:15:1",
                                                         "src": "700:15:1"
                                                     },
                                                     {
@@ -394,6 +450,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "731:1:1",
                                                                     "src": "731:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -401,6 +458,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "734:4:1",
                                                                     "src": "734:4:1",
                                                                     "type": "",
                                                                     "value": "0x24"
@@ -410,29 +468,35 @@
                                                             {
                                                                 "name": "revert",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "724:6:1",
                                                                 "src": "724:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "724:15:1",
                                                             "src": "724:15:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "724:15:1",
                                                         "src": "724:15:1"
                                                     }
                                                 ]
                                             },
                                             "name": "panic_error_0x41",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "565:180:1",
                                             "src": "565:180:1"
                                         },
                                         {
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "794:238:1",
                                                 "src": "794:238:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "804:58:1",
                                                         "src": "804:58:1",
                                                         "value":
                                                         {
@@ -441,6 +505,7 @@
                                                                 {
                                                                     "name": "memPtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "826:6:1",
                                                                     "src": "826:6:1"
                                                                 },
                                                                 {
@@ -449,6 +514,7 @@
                                                                         {
                                                                             "name": "size",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "856:4:1",
                                                                             "src": "856:4:1"
                                                                         }
                                                                     ],
@@ -456,9 +522,11 @@
                                                                     {
                                                                         "name": "round_up_to_mul_of_32",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "834:21:1",
                                                                         "src": "834:21:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "834:27:1",
                                                                     "src": "834:27:1"
                                                                 }
                                                             ],
@@ -466,9 +534,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "822:3:1",
                                                                 "src": "822:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "822:40:1",
                                                             "src": "822:40:1"
                                                         },
                                                         "variables":
@@ -476,6 +546,7 @@
                                                             {
                                                                 "name": "newFreePtr",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "808:10:1",
                                                                 "src": "808:10:1",
                                                                 "type": ""
                                                             }
@@ -485,6 +556,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "973:22:1",
                                                             "src": "973:22:1",
                                                             "statements":
                                                             [
@@ -496,12 +568,15 @@
                                                                         {
                                                                             "name": "panic_error_0x41",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "975:16:1",
                                                                             "src": "975:16:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "975:18:1",
                                                                         "src": "975:18:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "975:18:1",
                                                                     "src": "975:18:1"
                                                                 }
                                                             ]
@@ -516,11 +591,13 @@
                                                                         {
                                                                             "name": "newFreePtr",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "916:10:1",
                                                                             "src": "916:10:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "928:18:1",
                                                                             "src": "928:18:1",
                                                                             "type": "",
                                                                             "value": "0xffffffffffffffff"
@@ -530,9 +607,11 @@
                                                                     {
                                                                         "name": "gt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "913:2:1",
                                                                         "src": "913:2:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "913:34:1",
                                                                     "src": "913:34:1"
                                                                 },
                                                                 {
@@ -541,11 +620,13 @@
                                                                         {
                                                                             "name": "newFreePtr",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "952:10:1",
                                                                             "src": "952:10:1"
                                                                         },
                                                                         {
                                                                             "name": "memPtr",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "964:6:1",
                                                                             "src": "964:6:1"
                                                                         }
                                                                     ],
@@ -553,9 +634,11 @@
                                                                     {
                                                                         "name": "lt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "949:2:1",
                                                                         "src": "949:2:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "949:22:1",
                                                                     "src": "949:22:1"
                                                                 }
                                                             ],
@@ -563,12 +646,15 @@
                                                             {
                                                                 "name": "or",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "910:2:1",
                                                                 "src": "910:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "910:62:1",
                                                             "src": "910:62:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "907:88:1",
                                                         "src": "907:88:1"
                                                     },
                                                     {
@@ -579,6 +665,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1011:2:1",
                                                                     "src": "1011:2:1",
                                                                     "type": "",
                                                                     "value": "64"
@@ -586,6 +673,7 @@
                                                                 {
                                                                     "name": "newFreePtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1015:10:1",
                                                                     "src": "1015:10:1"
                                                                 }
                                                             ],
@@ -593,29 +681,35 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1004:6:1",
                                                                 "src": "1004:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1004:22:1",
                                                             "src": "1004:22:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "1004:22:1",
                                                         "src": "1004:22:1"
                                                     }
                                                 ]
                                             },
                                             "name": "finalize_allocation",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "751:281:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "memPtr",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "780:6:1",
                                                     "src": "780:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "size",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "788:4:1",
                                                     "src": "788:4:1",
                                                     "type": ""
                                                 }
@@ -626,11 +720,13 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1079:88:1",
                                                 "src": "1079:88:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1089:30:1",
                                                         "src": "1089:30:1",
                                                         "value":
                                                         {
@@ -639,9 +735,11 @@
                                                             {
                                                                 "name": "allocate_unbounded",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1099:18:1",
                                                                 "src": "1099:18:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1099:20:1",
                                                             "src": "1099:20:1"
                                                         },
                                                         "variableNames":
@@ -649,6 +747,7 @@
                                                             {
                                                                 "name": "memPtr",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1089:6:1",
                                                                 "src": "1089:6:1"
                                                             }
                                                         ]
@@ -661,11 +760,13 @@
                                                                 {
                                                                     "name": "memPtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1148:6:1",
                                                                     "src": "1148:6:1"
                                                                 },
                                                                 {
                                                                     "name": "size",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1156:4:1",
                                                                     "src": "1156:4:1"
                                                                 }
                                                             ],
@@ -673,23 +774,28 @@
                                                             {
                                                                 "name": "finalize_allocation",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1128:19:1",
                                                                 "src": "1128:19:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1128:33:1",
                                                             "src": "1128:33:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "1128:33:1",
                                                         "src": "1128:33:1"
                                                     }
                                                 ]
                                             },
                                             "name": "allocate_memory",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1038:129:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "size",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1063:4:1",
                                                     "src": "1063:4:1",
                                                     "type": ""
                                                 }
@@ -699,6 +805,7 @@
                                                 {
                                                     "name": "memPtr",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1072:6:1",
                                                     "src": "1072:6:1",
                                                     "type": ""
                                                 }
@@ -709,6 +816,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1255:229:1",
                                                 "src": "1255:229:1",
                                                 "statements":
                                                 [
@@ -716,6 +824,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "1360:22:1",
                                                             "src": "1360:22:1",
                                                             "statements":
                                                             [
@@ -727,12 +836,15 @@
                                                                         {
                                                                             "name": "panic_error_0x41",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1362:16:1",
                                                                             "src": "1362:16:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "1362:18:1",
                                                                         "src": "1362:18:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "1362:18:1",
                                                                     "src": "1362:18:1"
                                                                 }
                                                             ]
@@ -744,11 +856,13 @@
                                                                 {
                                                                     "name": "length",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1332:6:1",
                                                                     "src": "1332:6:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1340:18:1",
                                                                     "src": "1340:18:1",
                                                                     "type": "",
                                                                     "value": "0xffffffffffffffff"
@@ -758,16 +872,20 @@
                                                             {
                                                                 "name": "gt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1329:2:1",
                                                                 "src": "1329:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1329:30:1",
                                                             "src": "1329:30:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "1326:56:1",
                                                         "src": "1326:56:1"
                                                     },
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1392:25:1",
                                                         "src": "1392:25:1",
                                                         "value":
                                                         {
@@ -776,11 +894,13 @@
                                                                 {
                                                                     "name": "length",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1404:6:1",
                                                                     "src": "1404:6:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1412:4:1",
                                                                     "src": "1412:4:1",
                                                                     "type": "",
                                                                     "value": "0x20"
@@ -790,9 +910,11 @@
                                                             {
                                                                 "name": "mul",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1400:3:1",
                                                                 "src": "1400:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1400:17:1",
                                                             "src": "1400:17:1"
                                                         },
                                                         "variableNames":
@@ -800,12 +922,14 @@
                                                             {
                                                                 "name": "size",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1392:4:1",
                                                                 "src": "1392:4:1"
                                                             }
                                                         ]
                                                     },
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1454:23:1",
                                                         "src": "1454:23:1",
                                                         "value":
                                                         {
@@ -814,11 +938,13 @@
                                                                 {
                                                                     "name": "size",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1466:4:1",
                                                                     "src": "1466:4:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1472:4:1",
                                                                     "src": "1472:4:1",
                                                                     "type": "",
                                                                     "value": "0x20"
@@ -828,9 +954,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1462:3:1",
                                                                 "src": "1462:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1462:15:1",
                                                             "src": "1462:15:1"
                                                         },
                                                         "variableNames":
@@ -838,6 +966,7 @@
                                                             {
                                                                 "name": "size",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1454:4:1",
                                                                 "src": "1454:4:1"
                                                             }
                                                         ]
@@ -846,11 +975,13 @@
                                             },
                                             "name": "array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1173:311:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "length",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1239:6:1",
                                                     "src": "1239:6:1",
                                                     "type": ""
                                                 }
@@ -860,6 +991,7 @@
                                                 {
                                                     "name": "size",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1250:4:1",
                                                     "src": "1250:4:1",
                                                     "type": ""
                                                 }
@@ -870,6 +1002,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1579:28:1",
                                                 "src": "1579:28:1",
                                                 "statements":
                                                 [
@@ -881,6 +1014,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1596:1:1",
                                                                     "src": "1596:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -888,6 +1022,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1599:1:1",
                                                                     "src": "1599:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -897,34 +1032,41 @@
                                                             {
                                                                 "name": "revert",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1589:6:1",
                                                                 "src": "1589:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1589:12:1",
                                                             "src": "1589:12:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "1589:12:1",
                                                         "src": "1589:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1490:117:1",
                                             "src": "1490:117:1"
                                         },
                                         {
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1658:32:1",
                                                 "src": "1658:32:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1668:16:1",
                                                         "src": "1668:16:1",
                                                         "value":
                                                         {
                                                             "name": "value",
                                                             "nodeType": "YulIdentifier",
+                                                            "origin": "1679:5:1",
                                                             "src": "1679:5:1"
                                                         },
                                                         "variableNames":
@@ -932,6 +1074,7 @@
                                                             {
                                                                 "name": "cleaned",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1668:7:1",
                                                                 "src": "1668:7:1"
                                                             }
                                                         ]
@@ -940,11 +1083,13 @@
                                             },
                                             "name": "cleanup_t_uint256",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1613:77:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1640:5:1",
                                                     "src": "1640:5:1",
                                                     "type": ""
                                                 }
@@ -954,6 +1099,7 @@
                                                 {
                                                     "name": "cleaned",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1650:7:1",
                                                     "src": "1650:7:1",
                                                     "type": ""
                                                 }
@@ -964,6 +1110,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1739:79:1",
                                                 "src": "1739:79:1",
                                                 "statements":
                                                 [
@@ -971,6 +1118,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "1796:16:1",
                                                             "src": "1796:16:1",
                                                             "statements":
                                                             [
@@ -982,6 +1130,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "1805:1:1",
                                                                                 "src": "1805:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -989,6 +1138,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "1808:1:1",
                                                                                 "src": "1808:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -998,12 +1148,15 @@
                                                                         {
                                                                             "name": "revert",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1798:6:1",
                                                                             "src": "1798:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "1798:12:1",
                                                                         "src": "1798:12:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "1798:12:1",
                                                                     "src": "1798:12:1"
                                                                 }
                                                             ]
@@ -1018,6 +1171,7 @@
                                                                         {
                                                                             "name": "value",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1762:5:1",
                                                                             "src": "1762:5:1"
                                                                         },
                                                                         {
@@ -1026,6 +1180,7 @@
                                                                                 {
                                                                                     "name": "value",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "1787:5:1",
                                                                                     "src": "1787:5:1"
                                                                                 }
                                                                             ],
@@ -1033,9 +1188,11 @@
                                                                             {
                                                                                 "name": "cleanup_t_uint256",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "1769:17:1",
                                                                                 "src": "1769:17:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "1769:24:1",
                                                                             "src": "1769:24:1"
                                                                         }
                                                                     ],
@@ -1043,9 +1200,11 @@
                                                                     {
                                                                         "name": "eq",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "1759:2:1",
                                                                         "src": "1759:2:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "1759:35:1",
                                                                     "src": "1759:35:1"
                                                                 }
                                                             ],
@@ -1053,23 +1212,28 @@
                                                             {
                                                                 "name": "iszero",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1752:6:1",
                                                                 "src": "1752:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1752:43:1",
                                                             "src": "1752:43:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "1749:63:1",
                                                         "src": "1749:63:1"
                                                     }
                                                 ]
                                             },
                                             "name": "validator_revert_t_uint256",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1696:122:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1732:5:1",
                                                     "src": "1732:5:1",
                                                     "type": ""
                                                 }
@@ -1080,11 +1244,13 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1876:87:1",
                                                 "src": "1876:87:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1886:29:1",
                                                         "src": "1886:29:1",
                                                         "value":
                                                         {
@@ -1093,6 +1259,7 @@
                                                                 {
                                                                     "name": "offset",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1908:6:1",
                                                                     "src": "1908:6:1"
                                                                 }
                                                             ],
@@ -1100,9 +1267,11 @@
                                                             {
                                                                 "name": "calldataload",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1895:12:1",
                                                                 "src": "1895:12:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1895:20:1",
                                                             "src": "1895:20:1"
                                                         },
                                                         "variableNames":
@@ -1110,6 +1279,7 @@
                                                             {
                                                                 "name": "value",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1886:5:1",
                                                                 "src": "1886:5:1"
                                                             }
                                                         ]
@@ -1122,6 +1292,7 @@
                                                                 {
                                                                     "name": "value",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1951:5:1",
                                                                     "src": "1951:5:1"
                                                                 }
                                                             ],
@@ -1129,29 +1300,35 @@
                                                             {
                                                                 "name": "validator_revert_t_uint256",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1924:26:1",
                                                                 "src": "1924:26:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1924:33:1",
                                                             "src": "1924:33:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "1924:33:1",
                                                         "src": "1924:33:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_decode_t_uint256",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1824:139:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "offset",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1854:6:1",
                                                     "src": "1854:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "end",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1862:3:1",
                                                     "src": "1862:3:1",
                                                     "type": ""
                                                 }
@@ -1161,6 +1338,7 @@
                                                 {
                                                     "name": "value",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1870:5:1",
                                                     "src": "1870:5:1",
                                                     "type": ""
                                                 }
@@ -1171,11 +1349,13 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "2088:608:1",
                                                 "src": "2088:608:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "2098:90:1",
                                                         "src": "2098:90:1",
                                                         "value":
                                                         {
@@ -1187,6 +1367,7 @@
                                                                         {
                                                                             "name": "length",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2180:6:1",
                                                                             "src": "2180:6:1"
                                                                         }
                                                                     ],
@@ -1194,9 +1375,11 @@
                                                                     {
                                                                         "name": "array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "2123:56:1",
                                                                         "src": "2123:56:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "2123:64:1",
                                                                     "src": "2123:64:1"
                                                                 }
                                                             ],
@@ -1204,9 +1387,11 @@
                                                             {
                                                                 "name": "allocate_memory",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2107:15:1",
                                                                 "src": "2107:15:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2107:81:1",
                                                             "src": "2107:81:1"
                                                         },
                                                         "variableNames":
@@ -1214,17 +1399,20 @@
                                                             {
                                                                 "name": "array",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2098:5:1",
                                                                 "src": "2098:5:1"
                                                             }
                                                         ]
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "2197:16:1",
                                                         "src": "2197:16:1",
                                                         "value":
                                                         {
                                                             "name": "array",
                                                             "nodeType": "YulIdentifier",
+                                                            "origin": "2208:5:1",
                                                             "src": "2208:5:1"
                                                         },
                                                         "variables":
@@ -1232,6 +1420,7 @@
                                                             {
                                                                 "name": "dst",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "2201:3:1",
                                                                 "src": "2201:3:1",
                                                                 "type": ""
                                                             }
@@ -1245,11 +1434,13 @@
                                                                 {
                                                                     "name": "array",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2230:5:1",
                                                                     "src": "2230:5:1"
                                                                 },
                                                                 {
                                                                     "name": "length",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2237:6:1",
                                                                     "src": "2237:6:1"
                                                                 }
                                                             ],
@@ -1257,16 +1448,20 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2223:6:1",
                                                                 "src": "2223:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2223:21:1",
                                                             "src": "2223:21:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "2223:21:1",
                                                         "src": "2223:21:1"
                                                     },
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "2253:23:1",
                                                         "src": "2253:23:1",
                                                         "value":
                                                         {
@@ -1275,11 +1470,13 @@
                                                                 {
                                                                     "name": "array",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2264:5:1",
                                                                     "src": "2264:5:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "2271:4:1",
                                                                     "src": "2271:4:1",
                                                                     "type": "",
                                                                     "value": "0x20"
@@ -1289,9 +1486,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2260:3:1",
                                                                 "src": "2260:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2260:16:1",
                                                             "src": "2260:16:1"
                                                         },
                                                         "variableNames":
@@ -1299,12 +1498,14 @@
                                                             {
                                                                 "name": "dst",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2253:3:1",
                                                                 "src": "2253:3:1"
                                                             }
                                                         ]
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "2286:44:1",
                                                         "src": "2286:44:1",
                                                         "value":
                                                         {
@@ -1313,6 +1514,7 @@
                                                                 {
                                                                     "name": "offset",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2304:6:1",
                                                                     "src": "2304:6:1"
                                                                 },
                                                                 {
@@ -1321,11 +1523,13 @@
                                                                         {
                                                                             "name": "length",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2316:6:1",
                                                                             "src": "2316:6:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "2324:4:1",
                                                                             "src": "2324:4:1",
                                                                             "type": "",
                                                                             "value": "0x20"
@@ -1335,9 +1539,11 @@
                                                                     {
                                                                         "name": "mul",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "2312:3:1",
                                                                         "src": "2312:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "2312:17:1",
                                                                     "src": "2312:17:1"
                                                                 }
                                                             ],
@@ -1345,9 +1551,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2300:3:1",
                                                                 "src": "2300:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2300:30:1",
                                                             "src": "2300:30:1"
                                                         },
                                                         "variables":
@@ -1355,6 +1563,7 @@
                                                             {
                                                                 "name": "srcEnd",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "2290:6:1",
                                                                 "src": "2290:6:1",
                                                                 "type": ""
                                                             }
@@ -1364,6 +1573,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "2358:103:1",
                                                             "src": "2358:103:1",
                                                             "statements":
                                                             [
@@ -1375,12 +1585,15 @@
                                                                         {
                                                                             "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2372:77:1",
                                                                             "src": "2372:77:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "2372:79:1",
                                                                         "src": "2372:79:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "2372:79:1",
                                                                     "src": "2372:79:1"
                                                                 }
                                                             ]
@@ -1392,11 +1605,13 @@
                                                                 {
                                                                     "name": "srcEnd",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2345:6:1",
                                                                     "src": "2345:6:1"
                                                                 },
                                                                 {
                                                                     "name": "end",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2353:3:1",
                                                                     "src": "2353:3:1"
                                                                 }
                                                             ],
@@ -1404,28 +1619,34 @@
                                                             {
                                                                 "name": "gt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2342:2:1",
                                                                 "src": "2342:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2342:15:1",
                                                             "src": "2342:15:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "2339:122:1",
                                                         "src": "2339:122:1"
                                                     },
                                                     {
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "2546:144:1",
                                                             "src": "2546:144:1",
                                                             "statements":
                                                             [
                                                                 {
                                                                     "nodeType": "YulVariableDeclaration",
+                                                                    "origin": "2561:21:1",
                                                                     "src": "2561:21:1",
                                                                     "value":
                                                                     {
                                                                         "name": "src",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "2579:3:1",
                                                                         "src": "2579:3:1"
                                                                     },
                                                                     "variables":
@@ -1433,6 +1654,7 @@
                                                                         {
                                                                             "name": "elementPos",
                                                                             "nodeType": "YulTypedName",
+                                                                            "origin": "2565:10:1",
                                                                             "src": "2565:10:1",
                                                                             "type": ""
                                                                         }
@@ -1446,6 +1668,7 @@
                                                                             {
                                                                                 "name": "dst",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "2603:3:1",
                                                                                 "src": "2603:3:1"
                                                                             },
                                                                             {
@@ -1454,11 +1677,13 @@
                                                                                     {
                                                                                         "name": "elementPos",
                                                                                         "nodeType": "YulIdentifier",
+                                                                                        "origin": "2629:10:1",
                                                                                         "src": "2629:10:1"
                                                                                     },
                                                                                     {
                                                                                         "name": "end",
                                                                                         "nodeType": "YulIdentifier",
+                                                                                        "origin": "2641:3:1",
                                                                                         "src": "2641:3:1"
                                                                                     }
                                                                                 ],
@@ -1466,9 +1691,11 @@
                                                                                 {
                                                                                     "name": "abi_decode_t_uint256",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "2608:20:1",
                                                                                     "src": "2608:20:1"
                                                                                 },
                                                                                 "nodeType": "YulFunctionCall",
+                                                                                "origin": "2608:37:1",
                                                                                 "src": "2608:37:1"
                                                                             }
                                                                         ],
@@ -1476,16 +1703,20 @@
                                                                         {
                                                                             "name": "mstore",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2596:6:1",
                                                                             "src": "2596:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "2596:50:1",
                                                                         "src": "2596:50:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "2596:50:1",
                                                                     "src": "2596:50:1"
                                                                 },
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "2659:21:1",
                                                                     "src": "2659:21:1",
                                                                     "value":
                                                                     {
@@ -1494,11 +1725,13 @@
                                                                             {
                                                                                 "name": "dst",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "2670:3:1",
                                                                                 "src": "2670:3:1"
                                                                             },
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "2675:4:1",
                                                                                 "src": "2675:4:1",
                                                                                 "type": "",
                                                                                 "value": "0x20"
@@ -1508,9 +1741,11 @@
                                                                         {
                                                                             "name": "add",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2666:3:1",
                                                                             "src": "2666:3:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "2666:14:1",
                                                                         "src": "2666:14:1"
                                                                     },
                                                                     "variableNames":
@@ -1518,6 +1753,7 @@
                                                                         {
                                                                             "name": "dst",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2659:3:1",
                                                                             "src": "2659:3:1"
                                                                         }
                                                                     ]
@@ -1531,11 +1767,13 @@
                                                                 {
                                                                     "name": "src",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2499:3:1",
                                                                     "src": "2499:3:1"
                                                                 },
                                                                 {
                                                                     "name": "srcEnd",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2504:6:1",
                                                                     "src": "2504:6:1"
                                                                 }
                                                             ],
@@ -1543,20 +1781,25 @@
                                                             {
                                                                 "name": "lt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2496:2:1",
                                                                 "src": "2496:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2496:15:1",
                                                             "src": "2496:15:1"
                                                         },
                                                         "nodeType": "YulForLoop",
+                                                        "origin": "2470:220:1",
                                                         "post":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "2512:25:1",
                                                             "src": "2512:25:1",
                                                             "statements":
                                                             [
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "2514:21:1",
                                                                     "src": "2514:21:1",
                                                                     "value":
                                                                     {
@@ -1565,11 +1808,13 @@
                                                                             {
                                                                                 "name": "src",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "2525:3:1",
                                                                                 "src": "2525:3:1"
                                                                             },
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "2530:4:1",
                                                                                 "src": "2530:4:1",
                                                                                 "type": "",
                                                                                 "value": "0x20"
@@ -1579,9 +1824,11 @@
                                                                         {
                                                                             "name": "add",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2521:3:1",
                                                                             "src": "2521:3:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "2521:14:1",
                                                                         "src": "2521:14:1"
                                                                     },
                                                                     "variableNames":
@@ -1589,6 +1836,7 @@
                                                                         {
                                                                             "name": "src",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2514:3:1",
                                                                             "src": "2514:3:1"
                                                                         }
                                                                     ]
@@ -1598,16 +1846,19 @@
                                                         "pre":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "2474:21:1",
                                                             "src": "2474:21:1",
                                                             "statements":
                                                             [
                                                                 {
                                                                     "nodeType": "YulVariableDeclaration",
+                                                                    "origin": "2476:17:1",
                                                                     "src": "2476:17:1",
                                                                     "value":
                                                                     {
                                                                         "name": "offset",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "2487:6:1",
                                                                         "src": "2487:6:1"
                                                                     },
                                                                     "variables":
@@ -1615,6 +1866,7 @@
                                                                         {
                                                                             "name": "src",
                                                                             "nodeType": "YulTypedName",
+                                                                            "origin": "2480:3:1",
                                                                             "src": "2480:3:1",
                                                                             "type": ""
                                                                         }
@@ -1628,23 +1880,27 @@
                                             },
                                             "name": "abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1986:710:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "offset",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2058:6:1",
                                                     "src": "2058:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "length",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2066:6:1",
                                                     "src": "2066:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "end",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2074:3:1",
                                                     "src": "2074:3:1",
                                                     "type": ""
                                                 }
@@ -1654,6 +1910,7 @@
                                                 {
                                                     "name": "array",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2082:5:1",
                                                     "src": "2082:5:1",
                                                     "type": ""
                                                 }
@@ -1664,6 +1921,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "2796:293:1",
                                                 "src": "2796:293:1",
                                                 "statements":
                                                 [
@@ -1671,6 +1929,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "2845:83:1",
                                                             "src": "2845:83:1",
                                                             "statements":
                                                             [
@@ -1682,12 +1941,15 @@
                                                                         {
                                                                             "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2847:77:1",
                                                                             "src": "2847:77:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "2847:79:1",
                                                                         "src": "2847:79:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "2847:79:1",
                                                                     "src": "2847:79:1"
                                                                 }
                                                             ]
@@ -1705,11 +1967,13 @@
                                                                                 {
                                                                                     "name": "offset",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "2824:6:1",
                                                                                     "src": "2824:6:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
                                                                                     "nodeType": "YulLiteral",
+                                                                                    "origin": "2832:4:1",
                                                                                     "src": "2832:4:1",
                                                                                     "type": "",
                                                                                     "value": "0x1f"
@@ -1719,14 +1983,17 @@
                                                                             {
                                                                                 "name": "add",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "2820:3:1",
                                                                                 "src": "2820:3:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "2820:17:1",
                                                                             "src": "2820:17:1"
                                                                         },
                                                                         {
                                                                             "name": "end",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "2839:3:1",
                                                                             "src": "2839:3:1"
                                                                         }
                                                                     ],
@@ -1734,9 +2001,11 @@
                                                                     {
                                                                         "name": "slt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "2816:3:1",
                                                                         "src": "2816:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "2816:27:1",
                                                                     "src": "2816:27:1"
                                                                 }
                                                             ],
@@ -1744,16 +2013,20 @@
                                                             {
                                                                 "name": "iszero",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2809:6:1",
                                                                 "src": "2809:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2809:35:1",
                                                             "src": "2809:35:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "2806:122:1",
                                                         "src": "2806:122:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "2937:34:1",
                                                         "src": "2937:34:1",
                                                         "value":
                                                         {
@@ -1762,6 +2035,7 @@
                                                                 {
                                                                     "name": "offset",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "2964:6:1",
                                                                     "src": "2964:6:1"
                                                                 }
                                                             ],
@@ -1769,9 +2043,11 @@
                                                             {
                                                                 "name": "calldataload",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2951:12:1",
                                                                 "src": "2951:12:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2951:20:1",
                                                             "src": "2951:20:1"
                                                         },
                                                         "variables":
@@ -1779,6 +2055,7 @@
                                                             {
                                                                 "name": "length",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "2941:6:1",
                                                                 "src": "2941:6:1",
                                                                 "type": ""
                                                             }
@@ -1786,6 +2063,7 @@
                                                     },
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "2980:103:1",
                                                         "src": "2980:103:1",
                                                         "value":
                                                         {
@@ -1797,11 +2075,13 @@
                                                                         {
                                                                             "name": "offset",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3056:6:1",
                                                                             "src": "3056:6:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "3064:4:1",
                                                                             "src": "3064:4:1",
                                                                             "type": "",
                                                                             "value": "0x20"
@@ -1811,19 +2091,23 @@
                                                                     {
                                                                         "name": "add",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3052:3:1",
                                                                         "src": "3052:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3052:17:1",
                                                                     "src": "3052:17:1"
                                                                 },
                                                                 {
                                                                     "name": "length",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "3071:6:1",
                                                                     "src": "3071:6:1"
                                                                 },
                                                                 {
                                                                     "name": "end",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "3079:3:1",
                                                                     "src": "3079:3:1"
                                                                 }
                                                             ],
@@ -1831,9 +2115,11 @@
                                                             {
                                                                 "name": "abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2989:62:1",
                                                                 "src": "2989:62:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "2989:94:1",
                                                             "src": "2989:94:1"
                                                         },
                                                         "variableNames":
@@ -1841,6 +2127,7 @@
                                                             {
                                                                 "name": "array",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "2980:5:1",
                                                                 "src": "2980:5:1"
                                                             }
                                                         ]
@@ -1849,17 +2136,20 @@
                                             },
                                             "name": "abi_decode_t_array$_t_uint256_$dyn_memory_ptr",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "2719:370:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "offset",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2774:6:1",
                                                     "src": "2774:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "end",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2782:3:1",
                                                     "src": "2782:3:1",
                                                     "type": ""
                                                 }
@@ -1869,6 +2159,7 @@
                                                 {
                                                     "name": "array",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "2790:5:1",
                                                     "src": "2790:5:1",
                                                     "type": ""
                                                 }
@@ -1879,6 +2170,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "3186:448:1",
                                                 "src": "3186:448:1",
                                                 "statements":
                                                 [
@@ -1886,6 +2178,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "3232:83:1",
                                                             "src": "3232:83:1",
                                                             "statements":
                                                             [
@@ -1897,12 +2190,15 @@
                                                                         {
                                                                             "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3234:77:1",
                                                                             "src": "3234:77:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "3234:79:1",
                                                                         "src": "3234:79:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "3234:79:1",
                                                                     "src": "3234:79:1"
                                                                 }
                                                             ]
@@ -1917,11 +2213,13 @@
                                                                         {
                                                                             "name": "dataEnd",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3207:7:1",
                                                                             "src": "3207:7:1"
                                                                         },
                                                                         {
                                                                             "name": "headStart",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3216:9:1",
                                                                             "src": "3216:9:1"
                                                                         }
                                                                     ],
@@ -1929,14 +2227,17 @@
                                                                     {
                                                                         "name": "sub",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3203:3:1",
                                                                         "src": "3203:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3203:23:1",
                                                                     "src": "3203:23:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "3228:2:1",
                                                                     "src": "3228:2:1",
                                                                     "type": "",
                                                                     "value": "32"
@@ -1946,21 +2247,26 @@
                                                             {
                                                                 "name": "slt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "3199:3:1",
                                                                 "src": "3199:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "3199:32:1",
                                                             "src": "3199:32:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "3196:119:1",
                                                         "src": "3196:119:1"
                                                     },
                                                     {
                                                         "nodeType": "YulBlock",
+                                                        "origin": "3325:302:1",
                                                         "src": "3325:302:1",
                                                         "statements":
                                                         [
                                                             {
                                                                 "nodeType": "YulVariableDeclaration",
+                                                                "origin": "3340:45:1",
                                                                 "src": "3340:45:1",
                                                                 "value":
                                                                 {
@@ -1972,11 +2278,13 @@
                                                                                 {
                                                                                     "name": "headStart",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "3371:9:1",
                                                                                     "src": "3371:9:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
                                                                                     "nodeType": "YulLiteral",
+                                                                                    "origin": "3382:1:1",
                                                                                     "src": "3382:1:1",
                                                                                     "type": "",
                                                                                     "value": "0"
@@ -1986,9 +2294,11 @@
                                                                             {
                                                                                 "name": "add",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "3367:3:1",
                                                                                 "src": "3367:3:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "3367:17:1",
                                                                             "src": "3367:17:1"
                                                                         }
                                                                     ],
@@ -1996,9 +2306,11 @@
                                                                     {
                                                                         "name": "calldataload",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3354:12:1",
                                                                         "src": "3354:12:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3354:31:1",
                                                                     "src": "3354:31:1"
                                                                 },
                                                                 "variables":
@@ -2006,6 +2318,7 @@
                                                                     {
                                                                         "name": "offset",
                                                                         "nodeType": "YulTypedName",
+                                                                        "origin": "3344:6:1",
                                                                         "src": "3344:6:1",
                                                                         "type": ""
                                                                     }
@@ -2015,6 +2328,7 @@
                                                                 "body":
                                                                 {
                                                                     "nodeType": "YulBlock",
+                                                                    "origin": "3432:83:1",
                                                                     "src": "3432:83:1",
                                                                     "statements":
                                                                     [
@@ -2026,12 +2340,15 @@
                                                                                 {
                                                                                     "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "3434:77:1",
                                                                                     "src": "3434:77:1"
                                                                                 },
                                                                                 "nodeType": "YulFunctionCall",
+                                                                                "origin": "3434:79:1",
                                                                                 "src": "3434:79:1"
                                                                             },
                                                                             "nodeType": "YulExpressionStatement",
+                                                                            "origin": "3434:79:1",
                                                                             "src": "3434:79:1"
                                                                         }
                                                                     ]
@@ -2043,11 +2360,13 @@
                                                                         {
                                                                             "name": "offset",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3404:6:1",
                                                                             "src": "3404:6:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "3412:18:1",
                                                                             "src": "3412:18:1",
                                                                             "type": "",
                                                                             "value": "0xffffffffffffffff"
@@ -2057,16 +2376,20 @@
                                                                     {
                                                                         "name": "gt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3401:2:1",
                                                                         "src": "3401:2:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3401:30:1",
                                                                     "src": "3401:30:1"
                                                                 },
                                                                 "nodeType": "YulIf",
+                                                                "origin": "3398:117:1",
                                                                 "src": "3398:117:1"
                                                             },
                                                             {
                                                                 "nodeType": "YulAssignment",
+                                                                "origin": "3529:88:1",
                                                                 "src": "3529:88:1",
                                                                 "value":
                                                                 {
@@ -2078,11 +2401,13 @@
                                                                                 {
                                                                                     "name": "headStart",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "3589:9:1",
                                                                                     "src": "3589:9:1"
                                                                                 },
                                                                                 {
                                                                                     "name": "offset",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "3600:6:1",
                                                                                     "src": "3600:6:1"
                                                                                 }
                                                                             ],
@@ -2090,14 +2415,17 @@
                                                                             {
                                                                                 "name": "add",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "3585:3:1",
                                                                                 "src": "3585:3:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "3585:22:1",
                                                                             "src": "3585:22:1"
                                                                         },
                                                                         {
                                                                             "name": "dataEnd",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3609:7:1",
                                                                             "src": "3609:7:1"
                                                                         }
                                                                     ],
@@ -2105,9 +2433,11 @@
                                                                     {
                                                                         "name": "abi_decode_t_array$_t_uint256_$dyn_memory_ptr",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3539:45:1",
                                                                         "src": "3539:45:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3539:78:1",
                                                                     "src": "3539:78:1"
                                                                 },
                                                                 "variableNames":
@@ -2115,6 +2445,7 @@
                                                                     {
                                                                         "name": "value0",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3529:6:1",
                                                                         "src": "3529:6:1"
                                                                     }
                                                                 ]
@@ -2125,17 +2456,20 @@
                                             },
                                             "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "3095:539:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3156:9:1",
                                                     "src": "3156:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "dataEnd",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3167:7:1",
                                                     "src": "3167:7:1",
                                                     "type": ""
                                                 }
@@ -2145,6 +2479,7 @@
                                                 {
                                                     "name": "value0",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3179:6:1",
                                                     "src": "3179:6:1",
                                                     "type": ""
                                                 }
@@ -2155,6 +2490,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "3705:53:1",
                                                 "src": "3705:53:1",
                                                 "statements":
                                                 [
@@ -2166,6 +2502,7 @@
                                                                 {
                                                                     "name": "pos",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "3722:3:1",
                                                                     "src": "3722:3:1"
                                                                 },
                                                                 {
@@ -2174,6 +2511,7 @@
                                                                         {
                                                                             "name": "value",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3745:5:1",
                                                                             "src": "3745:5:1"
                                                                         }
                                                                     ],
@@ -2181,9 +2519,11 @@
                                                                     {
                                                                         "name": "cleanup_t_uint256",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3727:17:1",
                                                                         "src": "3727:17:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3727:24:1",
                                                                     "src": "3727:24:1"
                                                                 }
                                                             ],
@@ -2191,29 +2531,35 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "3715:6:1",
                                                                 "src": "3715:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "3715:37:1",
                                                             "src": "3715:37:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "3715:37:1",
                                                         "src": "3715:37:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_encode_t_uint256_to_t_uint256_fromStack",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "3640:118:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3693:5:1",
                                                     "src": "3693:5:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "pos",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3700:3:1",
                                                     "src": "3700:3:1",
                                                     "type": ""
                                                 }
@@ -2224,11 +2570,13 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "3862:124:1",
                                                 "src": "3862:124:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "3872:26:1",
                                                         "src": "3872:26:1",
                                                         "value":
                                                         {
@@ -2237,11 +2585,13 @@
                                                                 {
                                                                     "name": "headStart",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "3884:9:1",
                                                                     "src": "3884:9:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "3895:2:1",
                                                                     "src": "3895:2:1",
                                                                     "type": "",
                                                                     "value": "32"
@@ -2251,9 +2601,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "3880:3:1",
                                                                 "src": "3880:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "3880:18:1",
                                                             "src": "3880:18:1"
                                                         },
                                                         "variableNames":
@@ -2261,6 +2613,7 @@
                                                             {
                                                                 "name": "tail",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "3872:4:1",
                                                                 "src": "3872:4:1"
                                                             }
                                                         ]
@@ -2273,6 +2626,7 @@
                                                                 {
                                                                     "name": "value0",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "3952:6:1",
                                                                     "src": "3952:6:1"
                                                                 },
                                                                 {
@@ -2281,11 +2635,13 @@
                                                                         {
                                                                             "name": "headStart",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "3965:9:1",
                                                                             "src": "3965:9:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "3976:1:1",
                                                                             "src": "3976:1:1",
                                                                             "type": "",
                                                                             "value": "0"
@@ -2295,9 +2651,11 @@
                                                                     {
                                                                         "name": "add",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "3961:3:1",
                                                                         "src": "3961:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "3961:17:1",
                                                                     "src": "3961:17:1"
                                                                 }
                                                             ],
@@ -2305,29 +2663,35 @@
                                                             {
                                                                 "name": "abi_encode_t_uint256_to_t_uint256_fromStack",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "3908:43:1",
                                                                 "src": "3908:43:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "3908:71:1",
                                                             "src": "3908:71:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "3908:71:1",
                                                         "src": "3908:71:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "3764:222:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3834:9:1",
                                                     "src": "3834:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "value0",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3846:6:1",
                                                     "src": "3846:6:1",
                                                     "type": ""
                                                 }
@@ -2337,6 +2701,7 @@
                                                 {
                                                     "name": "tail",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "3857:4:1",
                                                     "src": "3857:4:1",
                                                     "type": ""
                                                 }

--- a/test/cmdlineTests/standard_optimizer_generatedSources/args
+++ b/test/cmdlineTests/standard_optimizer_generatedSources/args
@@ -1,0 +1,1 @@
+--pretty-json --json-indent 4 --allow-paths .

--- a/test/cmdlineTests/standard_optimizer_generatedSources/in.sol
+++ b/test/cmdlineTests/standard_optimizer_generatedSources/in.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+pragma abicoder v2;
+
+contract A {
+    function f(uint[] memory) public view returns (uint256) {}
+}

--- a/test/cmdlineTests/standard_optimizer_generatedSources/input.json
+++ b/test/cmdlineTests/standard_optimizer_generatedSources/input.json
@@ -1,21 +1,19 @@
 {
- "language": "Solidity",
- "sources": {
-  "a.sol": {
-   "content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\npragma abicoder v2; contract A { function f(uint[] memory) public view returns (uint256) { } }"
-  }
- },
- "settings": {
-  "evmVersion": "petersburg",
-  "optimizer": { "enabled": true },
-  "outputSelection": {
-   "*": {
-    "A": [
-     "evm.bytecode.object",
-     "evm.deployedBytecode.generatedSources",
-     "evm.bytecode.generatedSources"
-    ]
-   }
-  }
- }
+	"language": "Solidity",
+	"sources": {
+		"a.sol": {"urls": ["standard_optimizer_generatedSources/in.sol"]}
+	},
+	"settings": {
+		"evmVersion": "petersburg",
+		"optimizer": {"enabled": true},
+		"outputSelection": {
+			"*": {
+				"A": [
+					"evm.bytecode.object",
+					"evm.deployedBytecode.generatedSources",
+					"evm.bytecode.generatedSources"
+				]
+			}
+		}
+	}
 }

--- a/test/cmdlineTests/standard_optimizer_generatedSources/output.json
+++ b/test/cmdlineTests/standard_optimizer_generatedSources/output.json
@@ -1,4 +1,1460 @@
-{"contracts":{"a.sol":{"A":{"evm":{"bytecode":{"generatedSources":[],"object":"<BYTECODE REMOVED>"},"deployedBytecode":{"generatedSources":[{"ast":{"nodeType":"YulBlock","src":"0:1445:1","statements":[{"nodeType":"YulBlock","src":"6:3:1","statements":[]},{"body":{"nodeType":"YulBlock","src":"46:95:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"63:1:1","type":"","value":"0"},{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"70:3:1","type":"","value":"224"},{"kind":"number","nodeType":"YulLiteral","src":"75:10:1","type":"","value":"0x4e487b71"}],"functionName":{"name":"shl","nodeType":"YulIdentifier","src":"66:3:1"},"nodeType":"YulFunctionCall","src":"66:20:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"56:6:1"},"nodeType":"YulFunctionCall","src":"56:31:1"},"nodeType":"YulExpressionStatement","src":"56:31:1"},{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"103:1:1","type":"","value":"4"},{"kind":"number","nodeType":"YulLiteral","src":"106:4:1","type":"","value":"0x41"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"96:6:1"},"nodeType":"YulFunctionCall","src":"96:15:1"},"nodeType":"YulExpressionStatement","src":"96:15:1"},{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"127:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"130:4:1","type":"","value":"0x24"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"120:6:1"},"nodeType":"YulFunctionCall","src":"120:15:1"},"nodeType":"YulExpressionStatement","src":"120:15:1"}]},"name":"panic_error_0x41","nodeType":"YulFunctionDefinition","src":"14:127:1"},{"body":{"nodeType":"YulBlock","src":"241:1020:1","statements":[{"nodeType":"YulVariableDeclaration","src":"251:12:1","value":{"kind":"number","nodeType":"YulLiteral","src":"261:2:1","type":"","value":"32"},"variables":[{"name":"_1","nodeType":"YulTypedName","src":"255:2:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"308:16:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"317:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"320:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"310:6:1"},"nodeType":"YulFunctionCall","src":"310:12:1"},"nodeType":"YulExpressionStatement","src":"310:12:1"}]},"condition":{"arguments":[{"arguments":[{"name":"dataEnd","nodeType":"YulIdentifier","src":"283:7:1"},{"name":"headStart","nodeType":"YulIdentifier","src":"292:9:1"}],"functionName":{"name":"sub","nodeType":"YulIdentifier","src":"279:3:1"},"nodeType":"YulFunctionCall","src":"279:23:1"},{"name":"_1","nodeType":"YulIdentifier","src":"304:2:1"}],"functionName":{"name":"slt","nodeType":"YulIdentifier","src":"275:3:1"},"nodeType":"YulFunctionCall","src":"275:32:1"},"nodeType":"YulIf","src":"272:52:1"},{"nodeType":"YulVariableDeclaration","src":"333:37:1","value":{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"360:9:1"}],"functionName":{"name":"calldataload","nodeType":"YulIdentifier","src":"347:12:1"},"nodeType":"YulFunctionCall","src":"347:23:1"},"variables":[{"name":"offset","nodeType":"YulTypedName","src":"337:6:1","type":""}]},{"nodeType":"YulVariableDeclaration","src":"379:28:1","value":{"kind":"number","nodeType":"YulLiteral","src":"389:18:1","type":"","value":"0xffffffffffffffff"},"variables":[{"name":"_2","nodeType":"YulTypedName","src":"383:2:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"434:16:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"443:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"446:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"436:6:1"},"nodeType":"YulFunctionCall","src":"436:12:1"},"nodeType":"YulExpressionStatement","src":"436:12:1"}]},"condition":{"arguments":[{"name":"offset","nodeType":"YulIdentifier","src":"422:6:1"},{"name":"_2","nodeType":"YulIdentifier","src":"430:2:1"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"419:2:1"},"nodeType":"YulFunctionCall","src":"419:14:1"},"nodeType":"YulIf","src":"416:34:1"},{"nodeType":"YulVariableDeclaration","src":"459:32:1","value":{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"473:9:1"},{"name":"offset","nodeType":"YulIdentifier","src":"484:6:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"469:3:1"},"nodeType":"YulFunctionCall","src":"469:22:1"},"variables":[{"name":"_3","nodeType":"YulTypedName","src":"463:2:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"539:16:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"548:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"551:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"541:6:1"},"nodeType":"YulFunctionCall","src":"541:12:1"},"nodeType":"YulExpressionStatement","src":"541:12:1"}]},"condition":{"arguments":[{"arguments":[{"arguments":[{"name":"_3","nodeType":"YulIdentifier","src":"518:2:1"},{"kind":"number","nodeType":"YulLiteral","src":"522:4:1","type":"","value":"0x1f"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"514:3:1"},"nodeType":"YulFunctionCall","src":"514:13:1"},{"name":"dataEnd","nodeType":"YulIdentifier","src":"529:7:1"}],"functionName":{"name":"slt","nodeType":"YulIdentifier","src":"510:3:1"},"nodeType":"YulFunctionCall","src":"510:27:1"}],"functionName":{"name":"iszero","nodeType":"YulIdentifier","src":"503:6:1"},"nodeType":"YulFunctionCall","src":"503:35:1"},"nodeType":"YulIf","src":"500:55:1"},{"nodeType":"YulVariableDeclaration","src":"564:26:1","value":{"arguments":[{"name":"_3","nodeType":"YulIdentifier","src":"587:2:1"}],"functionName":{"name":"calldataload","nodeType":"YulIdentifier","src":"574:12:1"},"nodeType":"YulFunctionCall","src":"574:16:1"},"variables":[{"name":"_4","nodeType":"YulTypedName","src":"568:2:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"613:22:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"panic_error_0x41","nodeType":"YulIdentifier","src":"615:16:1"},"nodeType":"YulFunctionCall","src":"615:18:1"},"nodeType":"YulExpressionStatement","src":"615:18:1"}]},"condition":{"arguments":[{"name":"_4","nodeType":"YulIdentifier","src":"605:2:1"},{"name":"_2","nodeType":"YulIdentifier","src":"609:2:1"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"602:2:1"},"nodeType":"YulFunctionCall","src":"602:10:1"},"nodeType":"YulIf","src":"599:36:1"},{"nodeType":"YulVariableDeclaration","src":"644:20:1","value":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"658:1:1","type":"","value":"5"},{"name":"_4","nodeType":"YulIdentifier","src":"661:2:1"}],"functionName":{"name":"shl","nodeType":"YulIdentifier","src":"654:3:1"},"nodeType":"YulFunctionCall","src":"654:10:1"},"variables":[{"name":"_5","nodeType":"YulTypedName","src":"648:2:1","type":""}]},{"nodeType":"YulVariableDeclaration","src":"673:23:1","value":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"693:2:1","type":"","value":"64"}],"functionName":{"name":"mload","nodeType":"YulIdentifier","src":"687:5:1"},"nodeType":"YulFunctionCall","src":"687:9:1"},"variables":[{"name":"memPtr","nodeType":"YulTypedName","src":"677:6:1","type":""}]},{"nodeType":"YulVariableDeclaration","src":"705:56:1","value":{"arguments":[{"name":"memPtr","nodeType":"YulIdentifier","src":"727:6:1"},{"arguments":[{"arguments":[{"name":"_5","nodeType":"YulIdentifier","src":"743:2:1"},{"kind":"number","nodeType":"YulLiteral","src":"747:2:1","type":"","value":"63"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"739:3:1"},"nodeType":"YulFunctionCall","src":"739:11:1"},{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"756:2:1","type":"","value":"31"}],"functionName":{"name":"not","nodeType":"YulIdentifier","src":"752:3:1"},"nodeType":"YulFunctionCall","src":"752:7:1"}],"functionName":{"name":"and","nodeType":"YulIdentifier","src":"735:3:1"},"nodeType":"YulFunctionCall","src":"735:25:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"723:3:1"},"nodeType":"YulFunctionCall","src":"723:38:1"},"variables":[{"name":"newFreePtr","nodeType":"YulTypedName","src":"709:10:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"820:22:1","statements":[{"expression":{"arguments":[],"functionName":{"name":"panic_error_0x41","nodeType":"YulIdentifier","src":"822:16:1"},"nodeType":"YulFunctionCall","src":"822:18:1"},"nodeType":"YulExpressionStatement","src":"822:18:1"}]},"condition":{"arguments":[{"arguments":[{"name":"newFreePtr","nodeType":"YulIdentifier","src":"779:10:1"},{"name":"_2","nodeType":"YulIdentifier","src":"791:2:1"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"776:2:1"},"nodeType":"YulFunctionCall","src":"776:18:1"},{"arguments":[{"name":"newFreePtr","nodeType":"YulIdentifier","src":"799:10:1"},{"name":"memPtr","nodeType":"YulIdentifier","src":"811:6:1"}],"functionName":{"name":"lt","nodeType":"YulIdentifier","src":"796:2:1"},"nodeType":"YulFunctionCall","src":"796:22:1"}],"functionName":{"name":"or","nodeType":"YulIdentifier","src":"773:2:1"},"nodeType":"YulFunctionCall","src":"773:46:1"},"nodeType":"YulIf","src":"770:72:1"},{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"858:2:1","type":"","value":"64"},{"name":"newFreePtr","nodeType":"YulIdentifier","src":"862:10:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"851:6:1"},"nodeType":"YulFunctionCall","src":"851:22:1"},"nodeType":"YulExpressionStatement","src":"851:22:1"},{"nodeType":"YulVariableDeclaration","src":"882:17:1","value":{"name":"memPtr","nodeType":"YulIdentifier","src":"893:6:1"},"variables":[{"name":"dst","nodeType":"YulTypedName","src":"886:3:1","type":""}]},{"expression":{"arguments":[{"name":"memPtr","nodeType":"YulIdentifier","src":"915:6:1"},{"name":"_4","nodeType":"YulIdentifier","src":"923:2:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"908:6:1"},"nodeType":"YulFunctionCall","src":"908:18:1"},"nodeType":"YulExpressionStatement","src":"908:18:1"},{"nodeType":"YulAssignment","src":"935:22:1","value":{"arguments":[{"name":"memPtr","nodeType":"YulIdentifier","src":"946:6:1"},{"name":"_1","nodeType":"YulIdentifier","src":"954:2:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"942:3:1"},"nodeType":"YulFunctionCall","src":"942:15:1"},"variableNames":[{"name":"dst","nodeType":"YulIdentifier","src":"935:3:1"}]},{"nodeType":"YulVariableDeclaration","src":"966:34:1","value":{"arguments":[{"arguments":[{"name":"_3","nodeType":"YulIdentifier","src":"988:2:1"},{"name":"_5","nodeType":"YulIdentifier","src":"992:2:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"984:3:1"},"nodeType":"YulFunctionCall","src":"984:11:1"},{"name":"_1","nodeType":"YulIdentifier","src":"997:2:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"980:3:1"},"nodeType":"YulFunctionCall","src":"980:20:1"},"variables":[{"name":"srcEnd","nodeType":"YulTypedName","src":"970:6:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"1032:16:1","statements":[{"expression":{"arguments":[{"kind":"number","nodeType":"YulLiteral","src":"1041:1:1","type":"","value":"0"},{"kind":"number","nodeType":"YulLiteral","src":"1044:1:1","type":"","value":"0"}],"functionName":{"name":"revert","nodeType":"YulIdentifier","src":"1034:6:1"},"nodeType":"YulFunctionCall","src":"1034:12:1"},"nodeType":"YulExpressionStatement","src":"1034:12:1"}]},"condition":{"arguments":[{"name":"srcEnd","nodeType":"YulIdentifier","src":"1015:6:1"},{"name":"dataEnd","nodeType":"YulIdentifier","src":"1023:7:1"}],"functionName":{"name":"gt","nodeType":"YulIdentifier","src":"1012:2:1"},"nodeType":"YulFunctionCall","src":"1012:19:1"},"nodeType":"YulIf","src":"1009:39:1"},{"nodeType":"YulVariableDeclaration","src":"1057:22:1","value":{"arguments":[{"name":"_3","nodeType":"YulIdentifier","src":"1072:2:1"},{"name":"_1","nodeType":"YulIdentifier","src":"1076:2:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"1068:3:1"},"nodeType":"YulFunctionCall","src":"1068:11:1"},"variables":[{"name":"src","nodeType":"YulTypedName","src":"1061:3:1","type":""}]},{"body":{"nodeType":"YulBlock","src":"1144:86:1","statements":[{"expression":{"arguments":[{"name":"dst","nodeType":"YulIdentifier","src":"1165:3:1"},{"arguments":[{"name":"src","nodeType":"YulIdentifier","src":"1183:3:1"}],"functionName":{"name":"calldataload","nodeType":"YulIdentifier","src":"1170:12:1"},"nodeType":"YulFunctionCall","src":"1170:17:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"1158:6:1"},"nodeType":"YulFunctionCall","src":"1158:30:1"},"nodeType":"YulExpressionStatement","src":"1158:30:1"},{"nodeType":"YulAssignment","src":"1201:19:1","value":{"arguments":[{"name":"dst","nodeType":"YulIdentifier","src":"1212:3:1"},{"name":"_1","nodeType":"YulIdentifier","src":"1217:2:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"1208:3:1"},"nodeType":"YulFunctionCall","src":"1208:12:1"},"variableNames":[{"name":"dst","nodeType":"YulIdentifier","src":"1201:3:1"}]}]},"condition":{"arguments":[{"name":"src","nodeType":"YulIdentifier","src":"1099:3:1"},{"name":"srcEnd","nodeType":"YulIdentifier","src":"1104:6:1"}],"functionName":{"name":"lt","nodeType":"YulIdentifier","src":"1096:2:1"},"nodeType":"YulFunctionCall","src":"1096:15:1"},"nodeType":"YulForLoop","post":{"nodeType":"YulBlock","src":"1112:23:1","statements":[{"nodeType":"YulAssignment","src":"1114:19:1","value":{"arguments":[{"name":"src","nodeType":"YulIdentifier","src":"1125:3:1"},{"name":"_1","nodeType":"YulIdentifier","src":"1130:2:1"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"1121:3:1"},"nodeType":"YulFunctionCall","src":"1121:12:1"},"variableNames":[{"name":"src","nodeType":"YulIdentifier","src":"1114:3:1"}]}]},"pre":{"nodeType":"YulBlock","src":"1092:3:1","statements":[]},"src":"1088:142:1"},{"nodeType":"YulAssignment","src":"1239:16:1","value":{"name":"memPtr","nodeType":"YulIdentifier","src":"1249:6:1"},"variableNames":[{"name":"value0","nodeType":"YulIdentifier","src":"1239:6:1"}]}]},"name":"abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr","nodeType":"YulFunctionDefinition","parameters":[{"name":"headStart","nodeType":"YulTypedName","src":"207:9:1","type":""},{"name":"dataEnd","nodeType":"YulTypedName","src":"218:7:1","type":""}],"returnVariables":[{"name":"value0","nodeType":"YulTypedName","src":"230:6:1","type":""}],"src":"146:1115:1"},{"body":{"nodeType":"YulBlock","src":"1367:76:1","statements":[{"nodeType":"YulAssignment","src":"1377:26:1","value":{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"1389:9:1"},{"kind":"number","nodeType":"YulLiteral","src":"1400:2:1","type":"","value":"32"}],"functionName":{"name":"add","nodeType":"YulIdentifier","src":"1385:3:1"},"nodeType":"YulFunctionCall","src":"1385:18:1"},"variableNames":[{"name":"tail","nodeType":"YulIdentifier","src":"1377:4:1"}]},{"expression":{"arguments":[{"name":"headStart","nodeType":"YulIdentifier","src":"1419:9:1"},{"name":"value0","nodeType":"YulIdentifier","src":"1430:6:1"}],"functionName":{"name":"mstore","nodeType":"YulIdentifier","src":"1412:6:1"},"nodeType":"YulFunctionCall","src":"1412:25:1"},"nodeType":"YulExpressionStatement","src":"1412:25:1"}]},"name":"abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed","nodeType":"YulFunctionDefinition","parameters":[{"name":"headStart","nodeType":"YulTypedName","src":"1336:9:1","type":""},{"name":"value0","nodeType":"YulTypedName","src":"1347:6:1","type":""}],"returnVariables":[{"name":"tail","nodeType":"YulTypedName","src":"1358:4:1","type":""}],"src":"1266:177:1"}]},"contents":"{
+{
+    "contracts":
+    {
+        "a.sol":
+        {
+            "A":
+            {
+                "evm":
+                {
+                    "bytecode":
+                    {
+                        "generatedSources": [],
+                        "object": "<BYTECODE REMOVED>"
+                    },
+                    "deployedBytecode":
+                    {
+                        "generatedSources":
+                        [
+                            {
+                                "ast":
+                                {
+                                    "nodeType": "YulBlock",
+                                    "src": "0:1445:1",
+                                    "statements":
+                                    [
+                                        {
+                                            "nodeType": "YulBlock",
+                                            "src": "6:3:1",
+                                            "statements": []
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "46:95:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "63:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "70:3:1",
+                                                                            "type": "",
+                                                                            "value": "224"
+                                                                        },
+                                                                        {
+                                                                            "kind": "number",
+                                                                            "nodeType": "YulLiteral",
+                                                                            "src": "75:10:1",
+                                                                            "type": "",
+                                                                            "value": "0x4e487b71"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "shl",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "66:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "66:20:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:31:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "56:31:1"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "103:1:1",
+                                                                    "type": "",
+                                                                    "value": "4"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "106:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x41"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "96:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "96:15:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "96:15:1"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "127:1:1",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "130:4:1",
+                                                                    "type": "",
+                                                                    "value": "0x24"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "120:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "120:15:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "120:15:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "panic_error_0x41",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "14:127:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "241:1020:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "251:12:1",
+                                                        "value":
+                                                        {
+                                                            "kind": "number",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "261:2:1",
+                                                            "type": "",
+                                                            "value": "32"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "_1",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "255:2:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "308:16:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "317:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "320:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "310:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "310:12:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "310:12:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "dataEnd",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "283:7:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "headStart",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "292:9:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "sub",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "279:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "279:23:1"
+                                                                },
+                                                                {
+                                                                    "name": "_1",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "304:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "slt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "275:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "275:32:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "272:52:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "333:37:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "headStart",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "360:9:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "calldataload",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "347:12:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "347:23:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "offset",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "337:6:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "379:28:1",
+                                                        "value":
+                                                        {
+                                                            "kind": "number",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "389:18:1",
+                                                            "type": "",
+                                                            "value": "0xffffffffffffffff"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "_2",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "383:2:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "434:16:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "443:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "446:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "436:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "436:12:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "436:12:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "offset",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "422:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "_2",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "430:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "gt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "419:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "419:14:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "416:34:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "459:32:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "headStart",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "473:9:1"
+                                                                },
+                                                                {
+                                                                    "name": "offset",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "484:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "469:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "469:22:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "_3",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "463:2:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "539:16:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "548:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "551:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "541:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "541:12:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "541:12:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "name": "_3",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "518:2:1"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "number",
+                                                                                    "nodeType": "YulLiteral",
+                                                                                    "src": "522:4:1",
+                                                                                    "type": "",
+                                                                                    "value": "0x1f"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "add",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "514:3:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "514:13:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "dataEnd",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "529:7:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "slt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "510:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "510:27:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "iszero",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "503:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "503:35:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "500:55:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "564:26:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "_3",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "587:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "calldataload",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "574:12:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "574:16:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "_4",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "568:2:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "613:22:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "panic_error_0x41",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "615:16:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "615:18:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "615:18:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "_4",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "605:2:1"
+                                                                },
+                                                                {
+                                                                    "name": "_2",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "609:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "gt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "602:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "602:10:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "599:36:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "644:20:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "658:1:1",
+                                                                    "type": "",
+                                                                    "value": "5"
+                                                                },
+                                                                {
+                                                                    "name": "_4",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "661:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "shl",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "654:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "654:10:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "_5",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "648:2:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "673:23:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "693:2:1",
+                                                                    "type": "",
+                                                                    "value": "64"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mload",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "687:5:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "687:9:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "memPtr",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "677:6:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "705:56:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "memPtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "727:6:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "name": "_5",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "743:2:1"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "number",
+                                                                                    "nodeType": "YulLiteral",
+                                                                                    "src": "747:2:1",
+                                                                                    "type": "",
+                                                                                    "value": "63"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "add",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "739:3:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "739:11:1"
+                                                                        },
+                                                                        {
+                                                                            "arguments":
+                                                                            [
+                                                                                {
+                                                                                    "kind": "number",
+                                                                                    "nodeType": "YulLiteral",
+                                                                                    "src": "756:2:1",
+                                                                                    "type": "",
+                                                                                    "value": "31"
+                                                                                }
+                                                                            ],
+                                                                            "functionName":
+                                                                            {
+                                                                                "name": "not",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "752:3:1"
+                                                                            },
+                                                                            "nodeType": "YulFunctionCall",
+                                                                            "src": "752:7:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "and",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "735:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "735:25:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "723:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "723:38:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "newFreePtr",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "709:10:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "820:22:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments": [],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "panic_error_0x41",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "822:16:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "822:18:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "822:18:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "newFreePtr",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "779:10:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "_2",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "791:2:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "gt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "776:2:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "776:18:1"
+                                                                },
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "newFreePtr",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "799:10:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "memPtr",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "811:6:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "lt",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "796:2:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "796:22:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "or",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "773:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "773:46:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "770:72:1"
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "858:2:1",
+                                                                    "type": "",
+                                                                    "value": "64"
+                                                                },
+                                                                {
+                                                                    "name": "newFreePtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "862:10:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "851:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "851:22:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "851:22:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "882:17:1",
+                                                        "value":
+                                                        {
+                                                            "name": "memPtr",
+                                                            "nodeType": "YulIdentifier",
+                                                            "src": "893:6:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "dst",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "886:3:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "memPtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "915:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "_4",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "923:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "908:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "908:18:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "908:18:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "935:22:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "memPtr",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "946:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "_1",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "954:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "942:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "942:15:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "dst",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "935:3:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "966:34:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "arguments":
+                                                                    [
+                                                                        {
+                                                                            "name": "_3",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "988:2:1"
+                                                                        },
+                                                                        {
+                                                                            "name": "_5",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "992:2:1"
+                                                                        }
+                                                                    ],
+                                                                    "functionName":
+                                                                    {
+                                                                        "name": "add",
+                                                                        "nodeType": "YulIdentifier",
+                                                                        "src": "984:3:1"
+                                                                    },
+                                                                    "nodeType": "YulFunctionCall",
+                                                                    "src": "984:11:1"
+                                                                },
+                                                                {
+                                                                    "name": "_1",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "997:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "980:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "980:20:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "srcEnd",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "970:6:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "1032:16:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "1041:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            },
+                                                                            {
+                                                                                "kind": "number",
+                                                                                "nodeType": "YulLiteral",
+                                                                                "src": "1044:1:1",
+                                                                                "type": "",
+                                                                                "value": "0"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "revert",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1034:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "1034:12:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "1034:12:1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "srcEnd",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1015:6:1"
+                                                                },
+                                                                {
+                                                                    "name": "dataEnd",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1023:7:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "gt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1012:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1012:19:1"
+                                                        },
+                                                        "nodeType": "YulIf",
+                                                        "src": "1009:39:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulVariableDeclaration",
+                                                        "src": "1057:22:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "_3",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1072:2:1"
+                                                                },
+                                                                {
+                                                                    "name": "_1",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1076:2:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1068:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1068:11:1"
+                                                        },
+                                                        "variables":
+                                                        [
+                                                            {
+                                                                "name": "src",
+                                                                "nodeType": "YulTypedName",
+                                                                "src": "1061:3:1",
+                                                                "type": ""
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "body":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "1144:86:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "expression":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "name": "dst",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "1165:3:1"
+                                                                            },
+                                                                            {
+                                                                                "arguments":
+                                                                                [
+                                                                                    {
+                                                                                        "name": "src",
+                                                                                        "nodeType": "YulIdentifier",
+                                                                                        "src": "1183:3:1"
+                                                                                    }
+                                                                                ],
+                                                                                "functionName":
+                                                                                {
+                                                                                    "name": "calldataload",
+                                                                                    "nodeType": "YulIdentifier",
+                                                                                    "src": "1170:12:1"
+                                                                                },
+                                                                                "nodeType": "YulFunctionCall",
+                                                                                "src": "1170:17:1"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "mstore",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1158:6:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "1158:30:1"
+                                                                    },
+                                                                    "nodeType": "YulExpressionStatement",
+                                                                    "src": "1158:30:1"
+                                                                },
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "1201:19:1",
+                                                                    "value":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "name": "dst",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "1212:3:1"
+                                                                            },
+                                                                            {
+                                                                                "name": "_1",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "1217:2:1"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "add",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1208:3:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "1208:12:1"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "dst",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1201:3:1"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "condition":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "src",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1099:3:1"
+                                                                },
+                                                                {
+                                                                    "name": "srcEnd",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1104:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "lt",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1096:2:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1096:15:1"
+                                                        },
+                                                        "nodeType": "YulForLoop",
+                                                        "post":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "1112:23:1",
+                                                            "statements":
+                                                            [
+                                                                {
+                                                                    "nodeType": "YulAssignment",
+                                                                    "src": "1114:19:1",
+                                                                    "value":
+                                                                    {
+                                                                        "arguments":
+                                                                        [
+                                                                            {
+                                                                                "name": "src",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "1125:3:1"
+                                                                            },
+                                                                            {
+                                                                                "name": "_1",
+                                                                                "nodeType": "YulIdentifier",
+                                                                                "src": "1130:2:1"
+                                                                            }
+                                                                        ],
+                                                                        "functionName":
+                                                                        {
+                                                                            "name": "add",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1121:3:1"
+                                                                        },
+                                                                        "nodeType": "YulFunctionCall",
+                                                                        "src": "1121:12:1"
+                                                                    },
+                                                                    "variableNames":
+                                                                    [
+                                                                        {
+                                                                            "name": "src",
+                                                                            "nodeType": "YulIdentifier",
+                                                                            "src": "1114:3:1"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        "pre":
+                                                        {
+                                                            "nodeType": "YulBlock",
+                                                            "src": "1092:3:1",
+                                                            "statements": []
+                                                        },
+                                                        "src": "1088:142:1"
+                                                    },
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1239:16:1",
+                                                        "value":
+                                                        {
+                                                            "name": "memPtr",
+                                                            "nodeType": "YulIdentifier",
+                                                            "src": "1249:6:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "value0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1239:6:1"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "headStart",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "207:9:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "dataEnd",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "218:7:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "value0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "230:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "146:1115:1"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nodeType": "YulBlock",
+                                                "src": "1367:76:1",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "1377:26:1",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "headStart",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1389:9:1"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "1400:2:1",
+                                                                    "type": "",
+                                                                    "value": "32"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "add",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1385:3:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1385:18:1"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "tail",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1377:4:1"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "name": "headStart",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1419:9:1"
+                                                                },
+                                                                {
+                                                                    "name": "value0",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "1430:6:1"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mstore",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "1412:6:1"
+                                                            },
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "1412:25:1"
+                                                        },
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "1412:25:1"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "headStart",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1336:9:1",
+                                                    "type": ""
+                                                },
+                                                {
+                                                    "name": "value0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1347:6:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "tail",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "1358:4:1",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "1266:177:1"
+                                        }
+                                    ]
+                                },
+                                "contents": "{
     { }
     function panic_error_0x41()
     {
@@ -40,4 +1496,22 @@
         tail := add(headStart, 32)
         mstore(headStart, value0)
     }
-}","id":1,"language":"Yul","name":"#utility.yul"}]}}}}},"sources":{"a.sol":{"id":0}}}
+}",
+                                "id": 1,
+                                "language": "Yul",
+                                "name": "#utility.yul"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "sources":
+    {
+        "a.sol":
+        {
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_optimizer_generatedSources/output.json
+++ b/test/cmdlineTests/standard_optimizer_generatedSources/output.json
@@ -20,11 +20,13 @@
                                 "ast":
                                 {
                                     "nodeType": "YulBlock",
+                                    "origin": "0:1445:1",
                                     "src": "0:1445:1",
                                     "statements":
                                     [
                                         {
                                             "nodeType": "YulBlock",
+                                            "origin": "6:3:1",
                                             "src": "6:3:1",
                                             "statements": []
                                         },
@@ -32,6 +34,7 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "46:95:1",
                                                 "src": "46:95:1",
                                                 "statements":
                                                 [
@@ -43,6 +46,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "63:1:1",
                                                                     "src": "63:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -53,6 +57,7 @@
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "70:3:1",
                                                                             "src": "70:3:1",
                                                                             "type": "",
                                                                             "value": "224"
@@ -60,6 +65,7 @@
                                                                         {
                                                                             "kind": "number",
                                                                             "nodeType": "YulLiteral",
+                                                                            "origin": "75:10:1",
                                                                             "src": "75:10:1",
                                                                             "type": "",
                                                                             "value": "0x4e487b71"
@@ -69,9 +75,11 @@
                                                                     {
                                                                         "name": "shl",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "66:3:1",
                                                                         "src": "66:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "66:20:1",
                                                                     "src": "66:20:1"
                                                                 }
                                                             ],
@@ -79,12 +87,15 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "56:6:1",
                                                                 "src": "56:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "56:31:1",
                                                             "src": "56:31:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "56:31:1",
                                                         "src": "56:31:1"
                                                     },
                                                     {
@@ -95,6 +106,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "103:1:1",
                                                                     "src": "103:1:1",
                                                                     "type": "",
                                                                     "value": "4"
@@ -102,6 +114,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "106:4:1",
                                                                     "src": "106:4:1",
                                                                     "type": "",
                                                                     "value": "0x41"
@@ -111,12 +124,15 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "96:6:1",
                                                                 "src": "96:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "96:15:1",
                                                             "src": "96:15:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "96:15:1",
                                                         "src": "96:15:1"
                                                     },
                                                     {
@@ -127,6 +143,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "127:1:1",
                                                                     "src": "127:1:1",
                                                                     "type": "",
                                                                     "value": "0"
@@ -134,6 +151,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "130:4:1",
                                                                     "src": "130:4:1",
                                                                     "type": "",
                                                                     "value": "0x24"
@@ -143,34 +161,41 @@
                                                             {
                                                                 "name": "revert",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "120:6:1",
                                                                 "src": "120:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "120:15:1",
                                                             "src": "120:15:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "120:15:1",
                                                         "src": "120:15:1"
                                                     }
                                                 ]
                                             },
                                             "name": "panic_error_0x41",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "14:127:1",
                                             "src": "14:127:1"
                                         },
                                         {
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "241:1020:1",
                                                 "src": "241:1020:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "251:12:1",
                                                         "src": "251:12:1",
                                                         "value":
                                                         {
                                                             "kind": "number",
                                                             "nodeType": "YulLiteral",
+                                                            "origin": "261:2:1",
                                                             "src": "261:2:1",
                                                             "type": "",
                                                             "value": "32"
@@ -180,6 +205,7 @@
                                                             {
                                                                 "name": "_1",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "255:2:1",
                                                                 "src": "255:2:1",
                                                                 "type": ""
                                                             }
@@ -189,6 +215,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "308:16:1",
                                                             "src": "308:16:1",
                                                             "statements":
                                                             [
@@ -200,6 +227,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "317:1:1",
                                                                                 "src": "317:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -207,6 +235,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "320:1:1",
                                                                                 "src": "320:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -216,12 +245,15 @@
                                                                         {
                                                                             "name": "revert",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "310:6:1",
                                                                             "src": "310:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "310:12:1",
                                                                         "src": "310:12:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "310:12:1",
                                                                     "src": "310:12:1"
                                                                 }
                                                             ]
@@ -236,11 +268,13 @@
                                                                         {
                                                                             "name": "dataEnd",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "283:7:1",
                                                                             "src": "283:7:1"
                                                                         },
                                                                         {
                                                                             "name": "headStart",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "292:9:1",
                                                                             "src": "292:9:1"
                                                                         }
                                                                     ],
@@ -248,14 +282,17 @@
                                                                     {
                                                                         "name": "sub",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "279:3:1",
                                                                         "src": "279:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "279:23:1",
                                                                     "src": "279:23:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "304:2:1",
                                                                     "src": "304:2:1"
                                                                 }
                                                             ],
@@ -263,16 +300,20 @@
                                                             {
                                                                 "name": "slt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "275:3:1",
                                                                 "src": "275:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "275:32:1",
                                                             "src": "275:32:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "272:52:1",
                                                         "src": "272:52:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "333:37:1",
                                                         "src": "333:37:1",
                                                         "value":
                                                         {
@@ -281,6 +322,7 @@
                                                                 {
                                                                     "name": "headStart",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "360:9:1",
                                                                     "src": "360:9:1"
                                                                 }
                                                             ],
@@ -288,9 +330,11 @@
                                                             {
                                                                 "name": "calldataload",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "347:12:1",
                                                                 "src": "347:12:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "347:23:1",
                                                             "src": "347:23:1"
                                                         },
                                                         "variables":
@@ -298,6 +342,7 @@
                                                             {
                                                                 "name": "offset",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "337:6:1",
                                                                 "src": "337:6:1",
                                                                 "type": ""
                                                             }
@@ -305,11 +350,13 @@
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "379:28:1",
                                                         "src": "379:28:1",
                                                         "value":
                                                         {
                                                             "kind": "number",
                                                             "nodeType": "YulLiteral",
+                                                            "origin": "389:18:1",
                                                             "src": "389:18:1",
                                                             "type": "",
                                                             "value": "0xffffffffffffffff"
@@ -319,6 +366,7 @@
                                                             {
                                                                 "name": "_2",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "383:2:1",
                                                                 "src": "383:2:1",
                                                                 "type": ""
                                                             }
@@ -328,6 +376,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "434:16:1",
                                                             "src": "434:16:1",
                                                             "statements":
                                                             [
@@ -339,6 +388,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "443:1:1",
                                                                                 "src": "443:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -346,6 +396,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "446:1:1",
                                                                                 "src": "446:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -355,12 +406,15 @@
                                                                         {
                                                                             "name": "revert",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "436:6:1",
                                                                             "src": "436:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "436:12:1",
                                                                         "src": "436:12:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "436:12:1",
                                                                     "src": "436:12:1"
                                                                 }
                                                             ]
@@ -372,11 +426,13 @@
                                                                 {
                                                                     "name": "offset",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "422:6:1",
                                                                     "src": "422:6:1"
                                                                 },
                                                                 {
                                                                     "name": "_2",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "430:2:1",
                                                                     "src": "430:2:1"
                                                                 }
                                                             ],
@@ -384,16 +440,20 @@
                                                             {
                                                                 "name": "gt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "419:2:1",
                                                                 "src": "419:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "419:14:1",
                                                             "src": "419:14:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "416:34:1",
                                                         "src": "416:34:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "459:32:1",
                                                         "src": "459:32:1",
                                                         "value":
                                                         {
@@ -402,11 +462,13 @@
                                                                 {
                                                                     "name": "headStart",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "473:9:1",
                                                                     "src": "473:9:1"
                                                                 },
                                                                 {
                                                                     "name": "offset",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "484:6:1",
                                                                     "src": "484:6:1"
                                                                 }
                                                             ],
@@ -414,9 +476,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "469:3:1",
                                                                 "src": "469:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "469:22:1",
                                                             "src": "469:22:1"
                                                         },
                                                         "variables":
@@ -424,6 +488,7 @@
                                                             {
                                                                 "name": "_3",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "463:2:1",
                                                                 "src": "463:2:1",
                                                                 "type": ""
                                                             }
@@ -433,6 +498,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "539:16:1",
                                                             "src": "539:16:1",
                                                             "statements":
                                                             [
@@ -444,6 +510,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "548:1:1",
                                                                                 "src": "548:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -451,6 +518,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "551:1:1",
                                                                                 "src": "551:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -460,12 +528,15 @@
                                                                         {
                                                                             "name": "revert",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "541:6:1",
                                                                             "src": "541:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "541:12:1",
                                                                         "src": "541:12:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "541:12:1",
                                                                     "src": "541:12:1"
                                                                 }
                                                             ]
@@ -483,11 +554,13 @@
                                                                                 {
                                                                                     "name": "_3",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "518:2:1",
                                                                                     "src": "518:2:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
                                                                                     "nodeType": "YulLiteral",
+                                                                                    "origin": "522:4:1",
                                                                                     "src": "522:4:1",
                                                                                     "type": "",
                                                                                     "value": "0x1f"
@@ -497,14 +570,17 @@
                                                                             {
                                                                                 "name": "add",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "514:3:1",
                                                                                 "src": "514:3:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "514:13:1",
                                                                             "src": "514:13:1"
                                                                         },
                                                                         {
                                                                             "name": "dataEnd",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "529:7:1",
                                                                             "src": "529:7:1"
                                                                         }
                                                                     ],
@@ -512,9 +588,11 @@
                                                                     {
                                                                         "name": "slt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "510:3:1",
                                                                         "src": "510:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "510:27:1",
                                                                     "src": "510:27:1"
                                                                 }
                                                             ],
@@ -522,16 +600,20 @@
                                                             {
                                                                 "name": "iszero",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "503:6:1",
                                                                 "src": "503:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "503:35:1",
                                                             "src": "503:35:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "500:55:1",
                                                         "src": "500:55:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "564:26:1",
                                                         "src": "564:26:1",
                                                         "value":
                                                         {
@@ -540,6 +622,7 @@
                                                                 {
                                                                     "name": "_3",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "587:2:1",
                                                                     "src": "587:2:1"
                                                                 }
                                                             ],
@@ -547,9 +630,11 @@
                                                             {
                                                                 "name": "calldataload",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "574:12:1",
                                                                 "src": "574:12:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "574:16:1",
                                                             "src": "574:16:1"
                                                         },
                                                         "variables":
@@ -557,6 +642,7 @@
                                                             {
                                                                 "name": "_4",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "568:2:1",
                                                                 "src": "568:2:1",
                                                                 "type": ""
                                                             }
@@ -566,6 +652,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "613:22:1",
                                                             "src": "613:22:1",
                                                             "statements":
                                                             [
@@ -577,12 +664,15 @@
                                                                         {
                                                                             "name": "panic_error_0x41",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "615:16:1",
                                                                             "src": "615:16:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "615:18:1",
                                                                         "src": "615:18:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "615:18:1",
                                                                     "src": "615:18:1"
                                                                 }
                                                             ]
@@ -594,11 +684,13 @@
                                                                 {
                                                                     "name": "_4",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "605:2:1",
                                                                     "src": "605:2:1"
                                                                 },
                                                                 {
                                                                     "name": "_2",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "609:2:1",
                                                                     "src": "609:2:1"
                                                                 }
                                                             ],
@@ -606,16 +698,20 @@
                                                             {
                                                                 "name": "gt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "602:2:1",
                                                                 "src": "602:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "602:10:1",
                                                             "src": "602:10:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "599:36:1",
                                                         "src": "599:36:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "644:20:1",
                                                         "src": "644:20:1",
                                                         "value":
                                                         {
@@ -624,6 +720,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "658:1:1",
                                                                     "src": "658:1:1",
                                                                     "type": "",
                                                                     "value": "5"
@@ -631,6 +728,7 @@
                                                                 {
                                                                     "name": "_4",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "661:2:1",
                                                                     "src": "661:2:1"
                                                                 }
                                                             ],
@@ -638,9 +736,11 @@
                                                             {
                                                                 "name": "shl",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "654:3:1",
                                                                 "src": "654:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "654:10:1",
                                                             "src": "654:10:1"
                                                         },
                                                         "variables":
@@ -648,6 +748,7 @@
                                                             {
                                                                 "name": "_5",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "648:2:1",
                                                                 "src": "648:2:1",
                                                                 "type": ""
                                                             }
@@ -655,6 +756,7 @@
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "673:23:1",
                                                         "src": "673:23:1",
                                                         "value":
                                                         {
@@ -663,6 +765,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "693:2:1",
                                                                     "src": "693:2:1",
                                                                     "type": "",
                                                                     "value": "64"
@@ -672,9 +775,11 @@
                                                             {
                                                                 "name": "mload",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "687:5:1",
                                                                 "src": "687:5:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "687:9:1",
                                                             "src": "687:9:1"
                                                         },
                                                         "variables":
@@ -682,6 +787,7 @@
                                                             {
                                                                 "name": "memPtr",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "677:6:1",
                                                                 "src": "677:6:1",
                                                                 "type": ""
                                                             }
@@ -689,6 +795,7 @@
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "705:56:1",
                                                         "src": "705:56:1",
                                                         "value":
                                                         {
@@ -697,6 +804,7 @@
                                                                 {
                                                                     "name": "memPtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "727:6:1",
                                                                     "src": "727:6:1"
                                                                 },
                                                                 {
@@ -708,11 +816,13 @@
                                                                                 {
                                                                                     "name": "_5",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "743:2:1",
                                                                                     "src": "743:2:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
                                                                                     "nodeType": "YulLiteral",
+                                                                                    "origin": "747:2:1",
                                                                                     "src": "747:2:1",
                                                                                     "type": "",
                                                                                     "value": "63"
@@ -722,9 +832,11 @@
                                                                             {
                                                                                 "name": "add",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "739:3:1",
                                                                                 "src": "739:3:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "739:11:1",
                                                                             "src": "739:11:1"
                                                                         },
                                                                         {
@@ -733,6 +845,7 @@
                                                                                 {
                                                                                     "kind": "number",
                                                                                     "nodeType": "YulLiteral",
+                                                                                    "origin": "756:2:1",
                                                                                     "src": "756:2:1",
                                                                                     "type": "",
                                                                                     "value": "31"
@@ -742,9 +855,11 @@
                                                                             {
                                                                                 "name": "not",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "752:3:1",
                                                                                 "src": "752:3:1"
                                                                             },
                                                                             "nodeType": "YulFunctionCall",
+                                                                            "origin": "752:7:1",
                                                                             "src": "752:7:1"
                                                                         }
                                                                     ],
@@ -752,9 +867,11 @@
                                                                     {
                                                                         "name": "and",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "735:3:1",
                                                                         "src": "735:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "735:25:1",
                                                                     "src": "735:25:1"
                                                                 }
                                                             ],
@@ -762,9 +879,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "723:3:1",
                                                                 "src": "723:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "723:38:1",
                                                             "src": "723:38:1"
                                                         },
                                                         "variables":
@@ -772,6 +891,7 @@
                                                             {
                                                                 "name": "newFreePtr",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "709:10:1",
                                                                 "src": "709:10:1",
                                                                 "type": ""
                                                             }
@@ -781,6 +901,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "820:22:1",
                                                             "src": "820:22:1",
                                                             "statements":
                                                             [
@@ -792,12 +913,15 @@
                                                                         {
                                                                             "name": "panic_error_0x41",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "822:16:1",
                                                                             "src": "822:16:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "822:18:1",
                                                                         "src": "822:18:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "822:18:1",
                                                                     "src": "822:18:1"
                                                                 }
                                                             ]
@@ -812,11 +936,13 @@
                                                                         {
                                                                             "name": "newFreePtr",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "779:10:1",
                                                                             "src": "779:10:1"
                                                                         },
                                                                         {
                                                                             "name": "_2",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "791:2:1",
                                                                             "src": "791:2:1"
                                                                         }
                                                                     ],
@@ -824,9 +950,11 @@
                                                                     {
                                                                         "name": "gt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "776:2:1",
                                                                         "src": "776:2:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "776:18:1",
                                                                     "src": "776:18:1"
                                                                 },
                                                                 {
@@ -835,11 +963,13 @@
                                                                         {
                                                                             "name": "newFreePtr",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "799:10:1",
                                                                             "src": "799:10:1"
                                                                         },
                                                                         {
                                                                             "name": "memPtr",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "811:6:1",
                                                                             "src": "811:6:1"
                                                                         }
                                                                     ],
@@ -847,9 +977,11 @@
                                                                     {
                                                                         "name": "lt",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "796:2:1",
                                                                         "src": "796:2:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "796:22:1",
                                                                     "src": "796:22:1"
                                                                 }
                                                             ],
@@ -857,12 +989,15 @@
                                                             {
                                                                 "name": "or",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "773:2:1",
                                                                 "src": "773:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "773:46:1",
                                                             "src": "773:46:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "770:72:1",
                                                         "src": "770:72:1"
                                                     },
                                                     {
@@ -873,6 +1008,7 @@
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "858:2:1",
                                                                     "src": "858:2:1",
                                                                     "type": "",
                                                                     "value": "64"
@@ -880,6 +1016,7 @@
                                                                 {
                                                                     "name": "newFreePtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "862:10:1",
                                                                     "src": "862:10:1"
                                                                 }
                                                             ],
@@ -887,21 +1024,26 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "851:6:1",
                                                                 "src": "851:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "851:22:1",
                                                             "src": "851:22:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "851:22:1",
                                                         "src": "851:22:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "882:17:1",
                                                         "src": "882:17:1",
                                                         "value":
                                                         {
                                                             "name": "memPtr",
                                                             "nodeType": "YulIdentifier",
+                                                            "origin": "893:6:1",
                                                             "src": "893:6:1"
                                                         },
                                                         "variables":
@@ -909,6 +1051,7 @@
                                                             {
                                                                 "name": "dst",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "886:3:1",
                                                                 "src": "886:3:1",
                                                                 "type": ""
                                                             }
@@ -922,11 +1065,13 @@
                                                                 {
                                                                     "name": "memPtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "915:6:1",
                                                                     "src": "915:6:1"
                                                                 },
                                                                 {
                                                                     "name": "_4",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "923:2:1",
                                                                     "src": "923:2:1"
                                                                 }
                                                             ],
@@ -934,16 +1079,20 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "908:6:1",
                                                                 "src": "908:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "908:18:1",
                                                             "src": "908:18:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "908:18:1",
                                                         "src": "908:18:1"
                                                     },
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "935:22:1",
                                                         "src": "935:22:1",
                                                         "value":
                                                         {
@@ -952,11 +1101,13 @@
                                                                 {
                                                                     "name": "memPtr",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "946:6:1",
                                                                     "src": "946:6:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "954:2:1",
                                                                     "src": "954:2:1"
                                                                 }
                                                             ],
@@ -964,9 +1115,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "942:3:1",
                                                                 "src": "942:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "942:15:1",
                                                             "src": "942:15:1"
                                                         },
                                                         "variableNames":
@@ -974,12 +1127,14 @@
                                                             {
                                                                 "name": "dst",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "935:3:1",
                                                                 "src": "935:3:1"
                                                             }
                                                         ]
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "966:34:1",
                                                         "src": "966:34:1",
                                                         "value":
                                                         {
@@ -991,11 +1146,13 @@
                                                                         {
                                                                             "name": "_3",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "988:2:1",
                                                                             "src": "988:2:1"
                                                                         },
                                                                         {
                                                                             "name": "_5",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "992:2:1",
                                                                             "src": "992:2:1"
                                                                         }
                                                                     ],
@@ -1003,14 +1160,17 @@
                                                                     {
                                                                         "name": "add",
                                                                         "nodeType": "YulIdentifier",
+                                                                        "origin": "984:3:1",
                                                                         "src": "984:3:1"
                                                                     },
                                                                     "nodeType": "YulFunctionCall",
+                                                                    "origin": "984:11:1",
                                                                     "src": "984:11:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "997:2:1",
                                                                     "src": "997:2:1"
                                                                 }
                                                             ],
@@ -1018,9 +1178,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "980:3:1",
                                                                 "src": "980:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "980:20:1",
                                                             "src": "980:20:1"
                                                         },
                                                         "variables":
@@ -1028,6 +1190,7 @@
                                                             {
                                                                 "name": "srcEnd",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "970:6:1",
                                                                 "src": "970:6:1",
                                                                 "type": ""
                                                             }
@@ -1037,6 +1200,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "1032:16:1",
                                                             "src": "1032:16:1",
                                                             "statements":
                                                             [
@@ -1048,6 +1212,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "1041:1:1",
                                                                                 "src": "1041:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -1055,6 +1220,7 @@
                                                                             {
                                                                                 "kind": "number",
                                                                                 "nodeType": "YulLiteral",
+                                                                                "origin": "1044:1:1",
                                                                                 "src": "1044:1:1",
                                                                                 "type": "",
                                                                                 "value": "0"
@@ -1064,12 +1230,15 @@
                                                                         {
                                                                             "name": "revert",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1034:6:1",
                                                                             "src": "1034:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "1034:12:1",
                                                                         "src": "1034:12:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "1034:12:1",
                                                                     "src": "1034:12:1"
                                                                 }
                                                             ]
@@ -1081,11 +1250,13 @@
                                                                 {
                                                                     "name": "srcEnd",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1015:6:1",
                                                                     "src": "1015:6:1"
                                                                 },
                                                                 {
                                                                     "name": "dataEnd",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1023:7:1",
                                                                     "src": "1023:7:1"
                                                                 }
                                                             ],
@@ -1093,16 +1264,20 @@
                                                             {
                                                                 "name": "gt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1012:2:1",
                                                                 "src": "1012:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1012:19:1",
                                                             "src": "1012:19:1"
                                                         },
                                                         "nodeType": "YulIf",
+                                                        "origin": "1009:39:1",
                                                         "src": "1009:39:1"
                                                     },
                                                     {
                                                         "nodeType": "YulVariableDeclaration",
+                                                        "origin": "1057:22:1",
                                                         "src": "1057:22:1",
                                                         "value":
                                                         {
@@ -1111,11 +1286,13 @@
                                                                 {
                                                                     "name": "_3",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1072:2:1",
                                                                     "src": "1072:2:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1076:2:1",
                                                                     "src": "1076:2:1"
                                                                 }
                                                             ],
@@ -1123,9 +1300,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1068:3:1",
                                                                 "src": "1068:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1068:11:1",
                                                             "src": "1068:11:1"
                                                         },
                                                         "variables":
@@ -1133,6 +1312,7 @@
                                                             {
                                                                 "name": "src",
                                                                 "nodeType": "YulTypedName",
+                                                                "origin": "1061:3:1",
                                                                 "src": "1061:3:1",
                                                                 "type": ""
                                                             }
@@ -1142,6 +1322,7 @@
                                                         "body":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "1144:86:1",
                                                             "src": "1144:86:1",
                                                             "statements":
                                                             [
@@ -1153,6 +1334,7 @@
                                                                             {
                                                                                 "name": "dst",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "1165:3:1",
                                                                                 "src": "1165:3:1"
                                                                             },
                                                                             {
@@ -1161,6 +1343,7 @@
                                                                                     {
                                                                                         "name": "src",
                                                                                         "nodeType": "YulIdentifier",
+                                                                                        "origin": "1183:3:1",
                                                                                         "src": "1183:3:1"
                                                                                     }
                                                                                 ],
@@ -1168,9 +1351,11 @@
                                                                                 {
                                                                                     "name": "calldataload",
                                                                                     "nodeType": "YulIdentifier",
+                                                                                    "origin": "1170:12:1",
                                                                                     "src": "1170:12:1"
                                                                                 },
                                                                                 "nodeType": "YulFunctionCall",
+                                                                                "origin": "1170:17:1",
                                                                                 "src": "1170:17:1"
                                                                             }
                                                                         ],
@@ -1178,16 +1363,20 @@
                                                                         {
                                                                             "name": "mstore",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1158:6:1",
                                                                             "src": "1158:6:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "1158:30:1",
                                                                         "src": "1158:30:1"
                                                                     },
                                                                     "nodeType": "YulExpressionStatement",
+                                                                    "origin": "1158:30:1",
                                                                     "src": "1158:30:1"
                                                                 },
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "1201:19:1",
                                                                     "src": "1201:19:1",
                                                                     "value":
                                                                     {
@@ -1196,11 +1385,13 @@
                                                                             {
                                                                                 "name": "dst",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "1212:3:1",
                                                                                 "src": "1212:3:1"
                                                                             },
                                                                             {
                                                                                 "name": "_1",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "1217:2:1",
                                                                                 "src": "1217:2:1"
                                                                             }
                                                                         ],
@@ -1208,9 +1399,11 @@
                                                                         {
                                                                             "name": "add",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1208:3:1",
                                                                             "src": "1208:3:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "1208:12:1",
                                                                         "src": "1208:12:1"
                                                                     },
                                                                     "variableNames":
@@ -1218,6 +1411,7 @@
                                                                         {
                                                                             "name": "dst",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1201:3:1",
                                                                             "src": "1201:3:1"
                                                                         }
                                                                     ]
@@ -1231,11 +1425,13 @@
                                                                 {
                                                                     "name": "src",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1099:3:1",
                                                                     "src": "1099:3:1"
                                                                 },
                                                                 {
                                                                     "name": "srcEnd",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1104:6:1",
                                                                     "src": "1104:6:1"
                                                                 }
                                                             ],
@@ -1243,20 +1439,25 @@
                                                             {
                                                                 "name": "lt",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1096:2:1",
                                                                 "src": "1096:2:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1096:15:1",
                                                             "src": "1096:15:1"
                                                         },
                                                         "nodeType": "YulForLoop",
+                                                        "origin": "1088:142:1",
                                                         "post":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "1112:23:1",
                                                             "src": "1112:23:1",
                                                             "statements":
                                                             [
                                                                 {
                                                                     "nodeType": "YulAssignment",
+                                                                    "origin": "1114:19:1",
                                                                     "src": "1114:19:1",
                                                                     "value":
                                                                     {
@@ -1265,11 +1466,13 @@
                                                                             {
                                                                                 "name": "src",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "1125:3:1",
                                                                                 "src": "1125:3:1"
                                                                             },
                                                                             {
                                                                                 "name": "_1",
                                                                                 "nodeType": "YulIdentifier",
+                                                                                "origin": "1130:2:1",
                                                                                 "src": "1130:2:1"
                                                                             }
                                                                         ],
@@ -1277,9 +1480,11 @@
                                                                         {
                                                                             "name": "add",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1121:3:1",
                                                                             "src": "1121:3:1"
                                                                         },
                                                                         "nodeType": "YulFunctionCall",
+                                                                        "origin": "1121:12:1",
                                                                         "src": "1121:12:1"
                                                                     },
                                                                     "variableNames":
@@ -1287,6 +1492,7 @@
                                                                         {
                                                                             "name": "src",
                                                                             "nodeType": "YulIdentifier",
+                                                                            "origin": "1114:3:1",
                                                                             "src": "1114:3:1"
                                                                         }
                                                                     ]
@@ -1296,6 +1502,7 @@
                                                         "pre":
                                                         {
                                                             "nodeType": "YulBlock",
+                                                            "origin": "1092:3:1",
                                                             "src": "1092:3:1",
                                                             "statements": []
                                                         },
@@ -1303,11 +1510,13 @@
                                                     },
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1239:16:1",
                                                         "src": "1239:16:1",
                                                         "value":
                                                         {
                                                             "name": "memPtr",
                                                             "nodeType": "YulIdentifier",
+                                                            "origin": "1249:6:1",
                                                             "src": "1249:6:1"
                                                         },
                                                         "variableNames":
@@ -1315,6 +1524,7 @@
                                                             {
                                                                 "name": "value0",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1239:6:1",
                                                                 "src": "1239:6:1"
                                                             }
                                                         ]
@@ -1323,17 +1533,20 @@
                                             },
                                             "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "146:1115:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "207:9:1",
                                                     "src": "207:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "dataEnd",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "218:7:1",
                                                     "src": "218:7:1",
                                                     "type": ""
                                                 }
@@ -1343,6 +1556,7 @@
                                                 {
                                                     "name": "value0",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "230:6:1",
                                                     "src": "230:6:1",
                                                     "type": ""
                                                 }
@@ -1353,11 +1567,13 @@
                                             "body":
                                             {
                                                 "nodeType": "YulBlock",
+                                                "origin": "1367:76:1",
                                                 "src": "1367:76:1",
                                                 "statements":
                                                 [
                                                     {
                                                         "nodeType": "YulAssignment",
+                                                        "origin": "1377:26:1",
                                                         "src": "1377:26:1",
                                                         "value":
                                                         {
@@ -1366,11 +1582,13 @@
                                                                 {
                                                                     "name": "headStart",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1389:9:1",
                                                                     "src": "1389:9:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
                                                                     "nodeType": "YulLiteral",
+                                                                    "origin": "1400:2:1",
                                                                     "src": "1400:2:1",
                                                                     "type": "",
                                                                     "value": "32"
@@ -1380,9 +1598,11 @@
                                                             {
                                                                 "name": "add",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1385:3:1",
                                                                 "src": "1385:3:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1385:18:1",
                                                             "src": "1385:18:1"
                                                         },
                                                         "variableNames":
@@ -1390,6 +1610,7 @@
                                                             {
                                                                 "name": "tail",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1377:4:1",
                                                                 "src": "1377:4:1"
                                                             }
                                                         ]
@@ -1402,11 +1623,13 @@
                                                                 {
                                                                     "name": "headStart",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1419:9:1",
                                                                     "src": "1419:9:1"
                                                                 },
                                                                 {
                                                                     "name": "value0",
                                                                     "nodeType": "YulIdentifier",
+                                                                    "origin": "1430:6:1",
                                                                     "src": "1430:6:1"
                                                                 }
                                                             ],
@@ -1414,29 +1637,35 @@
                                                             {
                                                                 "name": "mstore",
                                                                 "nodeType": "YulIdentifier",
+                                                                "origin": "1412:6:1",
                                                                 "src": "1412:6:1"
                                                             },
                                                             "nodeType": "YulFunctionCall",
+                                                            "origin": "1412:25:1",
                                                             "src": "1412:25:1"
                                                         },
                                                         "nodeType": "YulExpressionStatement",
+                                                        "origin": "1412:25:1",
                                                         "src": "1412:25:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed",
                                             "nodeType": "YulFunctionDefinition",
+                                            "origin": "1266:177:1",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1336:9:1",
                                                     "src": "1336:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "value0",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1347:6:1",
                                                     "src": "1347:6:1",
                                                     "type": ""
                                                 }
@@ -1446,6 +1675,7 @@
                                                 {
                                                     "name": "tail",
                                                     "nodeType": "YulTypedName",
+                                                    "origin": "1358:4:1",
                                                     "src": "1358:4:1",
                                                     "type": ""
                                                 }

--- a/test/libsolidity/ASTJSON/assembly/call.json
+++ b/test/libsolidity/ASTJSON/assembly/call.json
@@ -39,6 +39,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "56:34:1",
                   "src": "56:34:1",
                   "statements":
                   [
@@ -53,6 +54,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "67:1:1",
                                 "src": "67:1:1",
                                 "type": "",
                                 "value": "0"
@@ -60,6 +62,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "70:1:1",
                                 "src": "70:1:1",
                                 "type": "",
                                 "value": "1"
@@ -67,6 +70,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "73:1:1",
                                 "src": "73:1:1",
                                 "type": "",
                                 "value": "2"
@@ -74,6 +78,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "76:1:1",
                                 "src": "76:1:1",
                                 "type": "",
                                 "value": "3"
@@ -81,6 +86,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "79:1:1",
                                 "src": "79:1:1",
                                 "type": "",
                                 "value": "4"
@@ -88,6 +94,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "82:1:1",
                                 "src": "82:1:1",
                                 "type": "",
                                 "value": "5"
@@ -95,6 +102,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "85:1:1",
                                 "src": "85:1:1",
                                 "type": "",
                                 "value": "6"
@@ -104,9 +112,11 @@
                             {
                               "name": "call",
                               "nodeType": "YulIdentifier",
+                              "origin": "62:4:1",
                               "src": "62:4:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "62:25:1",
                             "src": "62:25:1"
                           }
                         ],
@@ -114,12 +124,15 @@
                         {
                           "name": "pop",
                           "nodeType": "YulIdentifier",
+                          "origin": "58:3:1",
                           "src": "58:3:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "58:30:1",
                         "src": "58:30:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "58:30:1",
                       "src": "58:30:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/call_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/call_parseOnly.json
@@ -27,6 +27,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "56:34:1",
                   "src": "56:34:1",
                   "statements":
                   [
@@ -41,6 +42,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "67:1:1",
                                 "src": "67:1:1",
                                 "type": "",
                                 "value": "0"
@@ -48,6 +50,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "70:1:1",
                                 "src": "70:1:1",
                                 "type": "",
                                 "value": "1"
@@ -55,6 +58,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "73:1:1",
                                 "src": "73:1:1",
                                 "type": "",
                                 "value": "2"
@@ -62,6 +66,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "76:1:1",
                                 "src": "76:1:1",
                                 "type": "",
                                 "value": "3"
@@ -69,6 +74,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "79:1:1",
                                 "src": "79:1:1",
                                 "type": "",
                                 "value": "4"
@@ -76,6 +82,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "82:1:1",
                                 "src": "82:1:1",
                                 "type": "",
                                 "value": "5"
@@ -83,6 +90,7 @@
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
+                                "origin": "85:1:1",
                                 "src": "85:1:1",
                                 "type": "",
                                 "value": "6"
@@ -92,9 +100,11 @@
                             {
                               "name": "call",
                               "nodeType": "YulIdentifier",
+                              "origin": "62:4:1",
                               "src": "62:4:1"
                             },
                             "nodeType": "YulFunctionCall",
+                            "origin": "62:25:1",
                             "src": "62:25:1"
                           }
                         ],
@@ -102,12 +112,15 @@
                         {
                           "name": "pop",
                           "nodeType": "YulIdentifier",
+                          "origin": "58:3:1",
                           "src": "58:3:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "58:30:1",
                         "src": "58:30:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "58:30:1",
                       "src": "58:30:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/empty_block.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block.json
@@ -39,11 +39,13 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:6:1",
                   "src": "61:6:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulBlock",
+                      "origin": "63:2:1",
                       "src": "63:2:1",
                       "statements": []
                     }

--- a/test/libsolidity/ASTJSON/assembly/empty_block_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block_parseOnly.json
@@ -27,11 +27,13 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:6:1",
                   "src": "61:6:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulBlock",
+                      "origin": "63:2:1",
                       "src": "63:2:1",
                       "statements": []
                     }

--- a/test/libsolidity/ASTJSON/assembly/function.json
+++ b/test/libsolidity/ASTJSON/assembly/function.json
@@ -39,6 +39,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:43:1",
                   "src": "61:43:1",
                   "statements":
                   [
@@ -46,6 +47,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "76:22:1",
                         "src": "76:22:1",
                         "statements":
                         [
@@ -60,6 +62,7 @@
                                     {
                                       "kind": "number",
                                       "nodeType": "YulLiteral",
+                                      "origin": "92:2:1",
                                       "src": "92:2:1",
                                       "type": "",
                                       "value": "20"
@@ -69,9 +72,11 @@
                                   {
                                     "name": "blockhash",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "82:9:1",
                                     "src": "82:9:1"
                                   },
                                   "nodeType": "YulFunctionCall",
+                                  "origin": "82:13:1",
                                   "src": "82:13:1"
                                 }
                               ],
@@ -79,18 +84,22 @@
                               {
                                 "name": "pop",
                                 "nodeType": "YulIdentifier",
+                                "origin": "78:3:1",
                                 "src": "78:3:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "78:18:1",
                               "src": "78:18:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "78:18:1",
                             "src": "78:18:1"
                           }
                         ]
                       },
                       "name": "g",
                       "nodeType": "YulFunctionDefinition",
+                      "origin": "63:35:1",
                       "src": "63:35:1"
                     },
                     {
@@ -101,12 +110,15 @@
                         {
                           "name": "g",
                           "nodeType": "YulIdentifier",
+                          "origin": "99:1:1",
                           "src": "99:1:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "99:3:1",
                         "src": "99:3:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "99:3:1",
                       "src": "99:3:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/function_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/function_parseOnly.json
@@ -27,6 +27,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:43:1",
                   "src": "61:43:1",
                   "statements":
                   [
@@ -34,6 +35,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "76:22:1",
                         "src": "76:22:1",
                         "statements":
                         [
@@ -48,6 +50,7 @@
                                     {
                                       "kind": "number",
                                       "nodeType": "YulLiteral",
+                                      "origin": "92:2:1",
                                       "src": "92:2:1",
                                       "type": "",
                                       "value": "20"
@@ -57,9 +60,11 @@
                                   {
                                     "name": "blockhash",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "82:9:1",
                                     "src": "82:9:1"
                                   },
                                   "nodeType": "YulFunctionCall",
+                                  "origin": "82:13:1",
                                   "src": "82:13:1"
                                 }
                               ],
@@ -67,18 +72,22 @@
                               {
                                 "name": "pop",
                                 "nodeType": "YulIdentifier",
+                                "origin": "78:3:1",
                                 "src": "78:3:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "78:18:1",
                               "src": "78:18:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "78:18:1",
                             "src": "78:18:1"
                           }
                         ]
                       },
                       "name": "g",
                       "nodeType": "YulFunctionDefinition",
+                      "origin": "63:35:1",
                       "src": "63:35:1"
                     },
                     {
@@ -89,12 +98,15 @@
                         {
                           "name": "g",
                           "nodeType": "YulIdentifier",
+                          "origin": "99:1:1",
                           "src": "99:1:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "99:3:1",
                         "src": "99:3:1"
                       },
                       "nodeType": "YulExpressionStatement",
+                      "origin": "99:3:1",
                       "src": "99:3:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/leave.json
+++ b/test/libsolidity/ASTJSON/assembly/leave.json
@@ -39,6 +39,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "56:26:1",
                   "src": "56:26:1",
                   "statements":
                   [
@@ -46,17 +47,20 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "71:9:1",
                         "src": "71:9:1",
                         "statements":
                         [
                           {
                             "nodeType": "YulLeave",
+                            "origin": "73:5:1",
                             "src": "73:5:1"
                           }
                         ]
                       },
                       "name": "f",
                       "nodeType": "YulFunctionDefinition",
+                      "origin": "58:22:1",
                       "src": "58:22:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/leave_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/leave_parseOnly.json
@@ -27,6 +27,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "56:26:1",
                   "src": "56:26:1",
                   "statements":
                   [
@@ -34,17 +35,20 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "71:9:1",
                         "src": "71:9:1",
                         "statements":
                         [
                           {
                             "nodeType": "YulLeave",
+                            "origin": "73:5:1",
                             "src": "73:5:1"
                           }
                         ]
                       },
                       "name": "f",
                       "nodeType": "YulFunctionDefinition",
+                      "origin": "58:22:1",
                       "src": "58:22:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/loop.json
+++ b/test/libsolidity/ASTJSON/assembly/loop.json
@@ -39,6 +39,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:49:1",
                   "src": "61:49:1",
                   "statements":
                   [
@@ -46,15 +47,18 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "90:18:1",
                         "src": "90:18:1",
                         "statements":
                         [
                           {
                             "nodeType": "YulBreak",
+                            "origin": "92:5:1",
                             "src": "92:5:1"
                           },
                           {
                             "nodeType": "YulContinue",
+                            "origin": "98:8:1",
                             "src": "98:8:1"
                           }
                         ]
@@ -63,14 +67,17 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "70:1:1",
                         "src": "70:1:1",
                         "type": "",
                         "value": "1"
                       },
                       "nodeType": "YulForLoop",
+                      "origin": "63:45:1",
                       "post":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "72:17:1",
                         "src": "72:17:1",
                         "statements":
                         [
@@ -85,6 +92,7 @@
                                     {
                                       "kind": "number",
                                       "nodeType": "YulLiteral",
+                                      "origin": "84:1:1",
                                       "src": "84:1:1",
                                       "type": "",
                                       "value": "0"
@@ -94,9 +102,11 @@
                                   {
                                     "name": "sload",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "78:5:1",
                                     "src": "78:5:1"
                                   },
                                   "nodeType": "YulFunctionCall",
+                                  "origin": "78:8:1",
                                   "src": "78:8:1"
                                 }
                               ],
@@ -104,12 +114,15 @@
                               {
                                 "name": "pop",
                                 "nodeType": "YulIdentifier",
+                                "origin": "74:3:1",
                                 "src": "74:3:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "74:13:1",
                               "src": "74:13:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "74:13:1",
                             "src": "74:13:1"
                           }
                         ]
@@ -117,6 +130,7 @@
                       "pre":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "67:2:1",
                         "src": "67:2:1",
                         "statements": []
                       },

--- a/test/libsolidity/ASTJSON/assembly/loop_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/loop_parseOnly.json
@@ -27,6 +27,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:49:1",
                   "src": "61:49:1",
                   "statements":
                   [
@@ -34,15 +35,18 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "90:18:1",
                         "src": "90:18:1",
                         "statements":
                         [
                           {
                             "nodeType": "YulBreak",
+                            "origin": "92:5:1",
                             "src": "92:5:1"
                           },
                           {
                             "nodeType": "YulContinue",
+                            "origin": "98:8:1",
                             "src": "98:8:1"
                           }
                         ]
@@ -51,14 +55,17 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "70:1:1",
                         "src": "70:1:1",
                         "type": "",
                         "value": "1"
                       },
                       "nodeType": "YulForLoop",
+                      "origin": "63:45:1",
                       "post":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "72:17:1",
                         "src": "72:17:1",
                         "statements":
                         [
@@ -73,6 +80,7 @@
                                     {
                                       "kind": "number",
                                       "nodeType": "YulLiteral",
+                                      "origin": "84:1:1",
                                       "src": "84:1:1",
                                       "type": "",
                                       "value": "0"
@@ -82,9 +90,11 @@
                                   {
                                     "name": "sload",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "78:5:1",
                                     "src": "78:5:1"
                                   },
                                   "nodeType": "YulFunctionCall",
+                                  "origin": "78:8:1",
                                   "src": "78:8:1"
                                 }
                               ],
@@ -92,12 +102,15 @@
                               {
                                 "name": "pop",
                                 "nodeType": "YulIdentifier",
+                                "origin": "74:3:1",
                                 "src": "74:3:1"
                               },
                               "nodeType": "YulFunctionCall",
+                              "origin": "74:13:1",
                               "src": "74:13:1"
                             },
                             "nodeType": "YulExpressionStatement",
+                            "origin": "74:13:1",
                             "src": "74:13:1"
                           }
                         ]
@@ -105,6 +118,7 @@
                       "pre":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "67:2:1",
                         "src": "67:2:1",
                         "statements": []
                       },

--- a/test/libsolidity/ASTJSON/assembly/nested_functions.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions.json
@@ -38,6 +38,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "72:78:1",
                   "src": "72:78:1",
                   "statements":
                   [
@@ -45,6 +46,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "94:50:1",
                         "src": "94:50:1",
                         "statements":
                         [
@@ -52,20 +54,24 @@
                             "body":
                             {
                               "nodeType": "YulBlock",
+                              "origin": "118:3:1",
                               "src": "118:3:1",
                               "statements": []
                             },
                             "name": "f2",
                             "nodeType": "YulFunctionDefinition",
+                            "origin": "104:17:1",
                             "src": "104:17:1"
                           },
                           {
                             "nodeType": "YulAssignment",
+                            "origin": "130:6:1",
                             "src": "130:6:1",
                             "value":
                             {
                               "kind": "number",
                               "nodeType": "YulLiteral",
+                              "origin": "135:1:1",
                               "src": "135:1:1",
                               "type": "",
                               "value": "2"
@@ -75,6 +81,7 @@
                               {
                                 "name": "x",
                                 "nodeType": "YulIdentifier",
+                                "origin": "130:1:1",
                                 "src": "130:1:1"
                               }
                             ]
@@ -83,6 +90,7 @@
                       },
                       "name": "f1",
                       "nodeType": "YulFunctionDefinition",
+                      "origin": "80:64:1",
                       "src": "80:64:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/nested_functions_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions_parseOnly.json
@@ -27,6 +27,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "72:78:1",
                   "src": "72:78:1",
                   "statements":
                   [
@@ -34,6 +35,7 @@
                       "body":
                       {
                         "nodeType": "YulBlock",
+                        "origin": "94:50:1",
                         "src": "94:50:1",
                         "statements":
                         [
@@ -41,20 +43,24 @@
                             "body":
                             {
                               "nodeType": "YulBlock",
+                              "origin": "118:3:1",
                               "src": "118:3:1",
                               "statements": []
                             },
                             "name": "f2",
                             "nodeType": "YulFunctionDefinition",
+                            "origin": "104:17:1",
                             "src": "104:17:1"
                           },
                           {
                             "nodeType": "YulAssignment",
+                            "origin": "130:6:1",
                             "src": "130:6:1",
                             "value":
                             {
                               "kind": "number",
                               "nodeType": "YulLiteral",
+                              "origin": "135:1:1",
                               "src": "135:1:1",
                               "type": "",
                               "value": "2"
@@ -64,6 +70,7 @@
                               {
                                 "name": "x",
                                 "nodeType": "YulIdentifier",
+                                "origin": "130:1:1",
                                 "src": "130:1:1"
                               }
                             ]
@@ -72,6 +79,7 @@
                       },
                       "name": "f1",
                       "nodeType": "YulFunctionDefinition",
+                      "origin": "80:64:1",
                       "src": "80:64:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/slot_offset.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset.json
@@ -120,16 +120,19 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "95:45:1",
                   "src": "95:45:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "97:17:1",
                       "src": "97:17:1",
                       "value":
                       {
                         "name": "s.offset",
                         "nodeType": "YulIdentifier",
+                        "origin": "106:8:1",
                         "src": "106:8:1"
                       },
                       "variables":
@@ -137,6 +140,7 @@
                         {
                           "name": "x",
                           "nodeType": "YulTypedName",
+                          "origin": "101:1:1",
                           "src": "101:1:1",
                           "type": ""
                         }
@@ -144,6 +148,7 @@
                     },
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "115:23:1",
                       "src": "115:23:1",
                       "value":
                       {
@@ -152,11 +157,13 @@
                           {
                             "name": "s.slot",
                             "nodeType": "YulIdentifier",
+                            "origin": "128:6:1",
                             "src": "128:6:1"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "136:1:1",
                             "src": "136:1:1",
                             "type": "",
                             "value": "2"
@@ -166,9 +173,11 @@
                         {
                           "name": "mul",
                           "nodeType": "YulIdentifier",
+                          "origin": "124:3:1",
                           "src": "124:3:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "124:14:1",
                         "src": "124:14:1"
                       },
                       "variables":
@@ -176,6 +185,7 @@
                         {
                           "name": "y",
                           "nodeType": "YulTypedName",
+                          "origin": "119:1:1",
                           "src": "119:1:1",
                           "type": ""
                         }

--- a/test/libsolidity/ASTJSON/assembly/slot_offset_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset_parseOnly.json
@@ -86,16 +86,19 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "95:45:1",
                   "src": "95:45:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "97:17:1",
                       "src": "97:17:1",
                       "value":
                       {
                         "name": "s.offset",
                         "nodeType": "YulIdentifier",
+                        "origin": "106:8:1",
                         "src": "106:8:1"
                       },
                       "variables":
@@ -103,6 +106,7 @@
                         {
                           "name": "x",
                           "nodeType": "YulTypedName",
+                          "origin": "101:1:1",
                           "src": "101:1:1",
                           "type": ""
                         }
@@ -110,6 +114,7 @@
                     },
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "115:23:1",
                       "src": "115:23:1",
                       "value":
                       {
@@ -118,11 +123,13 @@
                           {
                             "name": "s.slot",
                             "nodeType": "YulIdentifier",
+                            "origin": "128:6:1",
                             "src": "128:6:1"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "136:1:1",
                             "src": "136:1:1",
                             "type": "",
                             "value": "2"
@@ -132,9 +139,11 @@
                         {
                           "name": "mul",
                           "nodeType": "YulIdentifier",
+                          "origin": "124:3:1",
                           "src": "124:3:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "124:14:1",
                         "src": "124:14:1"
                       },
                       "variables":
@@ -142,6 +151,7 @@
                         {
                           "name": "y",
                           "nodeType": "YulTypedName",
+                          "origin": "119:1:1",
                           "src": "119:1:1",
                           "type": ""
                         }

--- a/test/libsolidity/ASTJSON/assembly/stringlit.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit.json
@@ -39,17 +39,20 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "56:18:1",
                   "src": "56:18:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "58:14:1",
                       "src": "58:14:1",
                       "value":
                       {
                         "hexValue": "616263",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "67:5:1",
                         "src": "67:5:1",
                         "type": "",
                         "value": "abc"
@@ -59,6 +62,7 @@
                         {
                           "name": "x",
                           "nodeType": "YulTypedName",
+                          "origin": "62:1:1",
                           "src": "62:1:1",
                           "type": ""
                         }

--- a/test/libsolidity/ASTJSON/assembly/stringlit_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit_parseOnly.json
@@ -27,17 +27,20 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "56:18:1",
                   "src": "56:18:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "58:14:1",
                       "src": "58:14:1",
                       "value":
                       {
                         "hexValue": "616263",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "67:5:1",
                         "src": "67:5:1",
                         "type": "",
                         "value": "abc"
@@ -47,6 +50,7 @@
                         {
                           "name": "x",
                           "nodeType": "YulTypedName",
+                          "origin": "62:1:1",
                           "src": "62:1:1",
                           "type": ""
                         }

--- a/test/libsolidity/ASTJSON/assembly/switch.json
+++ b/test/libsolidity/ASTJSON/assembly/switch.json
@@ -38,16 +38,19 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:129:1",
                   "src": "61:129:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "75:10:1",
                       "src": "75:10:1",
                       "value":
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "84:1:1",
                         "src": "84:1:1",
                         "type": "",
                         "value": "0"
@@ -57,6 +60,7 @@
                         {
                           "name": "f",
                           "nodeType": "YulTypedName",
+                          "origin": "79:1:1",
                           "src": "79:1:1",
                           "type": ""
                         }
@@ -69,16 +73,19 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "139:10:1",
                             "src": "139:10:1",
                             "statements":
                             [
                               {
                                 "nodeType": "YulAssignment",
+                                "origin": "141:6:1",
                                 "src": "141:6:1",
                                 "value":
                                 {
                                   "kind": "number",
                                   "nodeType": "YulLiteral",
+                                  "origin": "146:1:1",
                                   "src": "146:1:1",
                                   "type": "",
                                   "value": "1"
@@ -88,6 +95,7 @@
                                   {
                                     "name": "f",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "141:1:1",
                                     "src": "141:1:1"
                                   }
                                 ]
@@ -95,11 +103,13 @@
                             ]
                           },
                           "nodeType": "YulCase",
+                          "origin": "132:17:1",
                           "src": "132:17:1",
                           "value":
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "137:1:1",
                             "src": "137:1:1",
                             "type": "",
                             "value": "0"
@@ -109,16 +119,19 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "170:10:1",
                             "src": "170:10:1",
                             "statements":
                             [
                               {
                                 "nodeType": "YulAssignment",
+                                "origin": "172:6:1",
                                 "src": "172:6:1",
                                 "value":
                                 {
                                   "kind": "number",
                                   "nodeType": "YulLiteral",
+                                  "origin": "177:1:1",
                                   "src": "177:1:1",
                                   "type": "",
                                   "value": "2"
@@ -128,6 +141,7 @@
                                   {
                                     "name": "f",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "172:1:1",
                                     "src": "172:1:1"
                                   }
                                 ]
@@ -135,6 +149,7 @@
                             ]
                           },
                           "nodeType": "YulCase",
+                          "origin": "162:18:1",
                           "src": "162:18:1",
                           "value": "default"
                         }
@@ -146,12 +161,15 @@
                         {
                           "name": "calldatasize",
                           "nodeType": "YulIdentifier",
+                          "origin": "105:12:1",
                           "src": "105:12:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "105:14:1",
                         "src": "105:14:1"
                       },
                       "nodeType": "YulSwitch",
+                      "origin": "98:82:1",
                       "src": "98:82:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/switch_default.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default.json
@@ -39,6 +39,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:33:1",
                   "src": "61:33:1",
                   "statements":
                   [
@@ -49,15 +50,18 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "79:2:1",
                             "src": "79:2:1",
                             "statements": []
                           },
                           "nodeType": "YulCase",
+                          "origin": "72:9:1",
                           "src": "72:9:1",
                           "value":
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "77:1:1",
                             "src": "77:1:1",
                             "type": "",
                             "value": "0"
@@ -67,10 +71,12 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "90:2:1",
                             "src": "90:2:1",
                             "statements": []
                           },
                           "nodeType": "YulCase",
+                          "origin": "82:10:1",
                           "src": "82:10:1",
                           "value": "default"
                         }
@@ -79,11 +85,13 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "70:1:1",
                         "src": "70:1:1",
                         "type": "",
                         "value": "0"
                       },
                       "nodeType": "YulSwitch",
+                      "origin": "63:29:1",
                       "src": "63:29:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/switch_default_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default_parseOnly.json
@@ -27,6 +27,7 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:33:1",
                   "src": "61:33:1",
                   "statements":
                   [
@@ -37,15 +38,18 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "79:2:1",
                             "src": "79:2:1",
                             "statements": []
                           },
                           "nodeType": "YulCase",
+                          "origin": "72:9:1",
                           "src": "72:9:1",
                           "value":
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "77:1:1",
                             "src": "77:1:1",
                             "type": "",
                             "value": "0"
@@ -55,10 +59,12 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "90:2:1",
                             "src": "90:2:1",
                             "statements": []
                           },
                           "nodeType": "YulCase",
+                          "origin": "82:10:1",
                           "src": "82:10:1",
                           "value": "default"
                         }
@@ -67,11 +73,13 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "70:1:1",
                         "src": "70:1:1",
                         "type": "",
                         "value": "0"
                       },
                       "nodeType": "YulSwitch",
+                      "origin": "63:29:1",
                       "src": "63:29:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/switch_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_parseOnly.json
@@ -27,16 +27,19 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "61:129:1",
                   "src": "61:129:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "75:10:1",
                       "src": "75:10:1",
                       "value":
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "84:1:1",
                         "src": "84:1:1",
                         "type": "",
                         "value": "0"
@@ -46,6 +49,7 @@
                         {
                           "name": "f",
                           "nodeType": "YulTypedName",
+                          "origin": "79:1:1",
                           "src": "79:1:1",
                           "type": ""
                         }
@@ -58,16 +62,19 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "139:10:1",
                             "src": "139:10:1",
                             "statements":
                             [
                               {
                                 "nodeType": "YulAssignment",
+                                "origin": "141:6:1",
                                 "src": "141:6:1",
                                 "value":
                                 {
                                   "kind": "number",
                                   "nodeType": "YulLiteral",
+                                  "origin": "146:1:1",
                                   "src": "146:1:1",
                                   "type": "",
                                   "value": "1"
@@ -77,6 +84,7 @@
                                   {
                                     "name": "f",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "141:1:1",
                                     "src": "141:1:1"
                                   }
                                 ]
@@ -84,11 +92,13 @@
                             ]
                           },
                           "nodeType": "YulCase",
+                          "origin": "132:17:1",
                           "src": "132:17:1",
                           "value":
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
+                            "origin": "137:1:1",
                             "src": "137:1:1",
                             "type": "",
                             "value": "0"
@@ -98,16 +108,19 @@
                           "body":
                           {
                             "nodeType": "YulBlock",
+                            "origin": "170:10:1",
                             "src": "170:10:1",
                             "statements":
                             [
                               {
                                 "nodeType": "YulAssignment",
+                                "origin": "172:6:1",
                                 "src": "172:6:1",
                                 "value":
                                 {
                                   "kind": "number",
                                   "nodeType": "YulLiteral",
+                                  "origin": "177:1:1",
                                   "src": "177:1:1",
                                   "type": "",
                                   "value": "2"
@@ -117,6 +130,7 @@
                                   {
                                     "name": "f",
                                     "nodeType": "YulIdentifier",
+                                    "origin": "172:1:1",
                                     "src": "172:1:1"
                                   }
                                 ]
@@ -124,6 +138,7 @@
                             ]
                           },
                           "nodeType": "YulCase",
+                          "origin": "162:18:1",
                           "src": "162:18:1",
                           "value": "default"
                         }
@@ -135,12 +150,15 @@
                         {
                           "name": "calldatasize",
                           "nodeType": "YulIdentifier",
+                          "origin": "105:12:1",
                           "src": "105:12:1"
                         },
                         "nodeType": "YulFunctionCall",
+                        "origin": "105:14:1",
                         "src": "105:14:1"
                       },
                       "nodeType": "YulSwitch",
+                      "origin": "98:82:1",
                       "src": "98:82:1"
                     }
                   ]

--- a/test/libsolidity/ASTJSON/assembly/var_access.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access.json
@@ -81,16 +81,19 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "77:10:1",
                   "src": "77:10:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulAssignment",
+                      "origin": "79:6:1",
                       "src": "79:6:1",
                       "value":
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "84:1:1",
                         "src": "84:1:1",
                         "type": "",
                         "value": "7"
@@ -100,6 +103,7 @@
                         {
                           "name": "x",
                           "nodeType": "YulIdentifier",
+                          "origin": "79:1:1",
                           "src": "79:1:1"
                         }
                       ]

--- a/test/libsolidity/ASTJSON/assembly/var_access_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access_parseOnly.json
@@ -60,16 +60,19 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "77:10:1",
                   "src": "77:10:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulAssignment",
+                      "origin": "79:6:1",
                       "src": "79:6:1",
                       "value":
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
+                        "origin": "84:1:1",
                         "src": "84:1:1",
                         "type": "",
                         "value": "7"
@@ -79,6 +82,7 @@
                         {
                           "name": "x",
                           "nodeType": "YulIdentifier",
+                          "origin": "79:1:1",
                           "src": "79:1:1"
                         }
                       ]

--- a/test/libsolidity/ASTJSON/yul_hex_literal.json
+++ b/test/libsolidity/ASTJSON/yul_hex_literal.json
@@ -39,17 +39,20 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "66:142:1",
                   "src": "66:142:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "80:15:1",
                       "src": "80:15:1",
                       "value":
                       {
                         "hexValue": "74657374",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "89:6:1",
                         "src": "89:6:1",
                         "type": "",
                         "value": "test"
@@ -59,6 +62,7 @@
                         {
                           "name": "a",
                           "nodeType": "YulTypedName",
+                          "origin": "84:1:1",
                           "src": "84:1:1",
                           "type": ""
                         }
@@ -66,12 +70,14 @@
                     },
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "108:54:1",
                       "src": "108:54:1",
                       "value":
                       {
                         "hexValue": "112233445566778899aabbccddeeff6677889900",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "117:45:1",
                         "src": "117:45:1",
                         "type": ""
                       },
@@ -80,6 +86,7 @@
                         {
                           "name": "b",
                           "nodeType": "YulTypedName",
+                          "origin": "112:1:1",
                           "src": "112:1:1",
                           "type": ""
                         }
@@ -87,12 +94,14 @@
                     },
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "175:23:1",
                       "src": "175:23:1",
                       "value":
                       {
                         "hexValue": "1234abcd",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "184:14:1",
                         "src": "184:14:1",
                         "type": ""
                       },
@@ -101,6 +110,7 @@
                         {
                           "name": "c",
                           "nodeType": "YulTypedName",
+                          "origin": "179:1:1",
                           "src": "179:1:1",
                           "type": ""
                         }

--- a/test/libsolidity/ASTJSON/yul_hex_literal_parseOnly.json
+++ b/test/libsolidity/ASTJSON/yul_hex_literal_parseOnly.json
@@ -27,17 +27,20 @@
                 "AST":
                 {
                   "nodeType": "YulBlock",
+                  "origin": "66:142:1",
                   "src": "66:142:1",
                   "statements":
                   [
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "80:15:1",
                       "src": "80:15:1",
                       "value":
                       {
                         "hexValue": "74657374",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "89:6:1",
                         "src": "89:6:1",
                         "type": "",
                         "value": "test"
@@ -47,6 +50,7 @@
                         {
                           "name": "a",
                           "nodeType": "YulTypedName",
+                          "origin": "84:1:1",
                           "src": "84:1:1",
                           "type": ""
                         }
@@ -54,12 +58,14 @@
                     },
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "108:54:1",
                       "src": "108:54:1",
                       "value":
                       {
                         "hexValue": "112233445566778899aabbccddeeff6677889900",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "117:45:1",
                         "src": "117:45:1",
                         "type": ""
                       },
@@ -68,6 +74,7 @@
                         {
                           "name": "b",
                           "nodeType": "YulTypedName",
+                          "origin": "112:1:1",
                           "src": "112:1:1",
                           "type": ""
                         }
@@ -75,12 +82,14 @@
                     },
                     {
                       "nodeType": "YulVariableDeclaration",
+                      "origin": "175:23:1",
                       "src": "175:23:1",
                       "value":
                       {
                         "hexValue": "1234abcd",
                         "kind": "string",
                         "nodeType": "YulLiteral",
+                        "origin": "184:14:1",
                         "src": "184:14:1",
                         "type": ""
                       },
@@ -89,6 +98,7 @@
                         {
                           "name": "c",
                           "nodeType": "YulTypedName",
+                          "origin": "179:1:1",
                           "src": "179:1:1",
                           "type": ""
                         }


### PR DESCRIPTION
Originally requested in https://github.com/ethereum/solidity/pull/11998#discussion_r713163128.
Depends on #11998.
Related to #11043.

- [ ] Problem: the location does not always follow the format described by our docs on [Source Mappings](https://docs.soliditylang.org/en/latest/internals/source_mappings.html).