### PR TITLE
`--include-path` option (revived)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,8 +7,9 @@ Language Features:
 
 
 Compiler Features:
+ * Commandline Interface: Add ``--include-path`` option for specifying extra directories that may contain importable code (e.g. packaged third-party libraries).
  * Commandline Interface: Do not implicitly run evm bytecode generation unless needed for the requested output.
- * Commandline Interface: Normalize paths specified on the command line and make them relative for files located inside base path.
+ * Commandline Interface: Normalize paths specified on the command line and make them relative for files located inside base path and/or include paths.
  * Immutable variables can be read at construction time once they are initialized.
  * SMTChecker: Support low level ``call`` as external calls to unknown code.
  * SMTChecker: Add constraints to better correlate ``address(this).balance`` and ``msg.value``.

--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -339,6 +339,15 @@ of the compiler.
 
     Include paths cannot have empty values and must be used together with a non-empty base path.
 
+.. note::
+
+    Include paths and base path can overlap as long as it does not make import resolution ambiguous.
+    For example, you can specify a directory inside base path as an include directory or have an
+    include directory that is a subdirectory of another include directory.
+    The compiler will only issue an error if the source unit name passed to the Host Filesystem
+    Loader represents an existing path when combined with multiple include paths or an include path
+    and base path.
+
 .. _cli-path-normalization-and-stripping:
 
 CLI Path Normalization and Stripping

--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -72,8 +72,9 @@ The initial content of the VFS depends on how you invoke the compiler:
        solc contract.sol /usr/local/dapp-bin/token.sol
 
    The source unit name of a file loaded this way is constructed by converting its path to a
-   canonical form and making it relative to the base path if it is located inside.
-   See :ref:`Base Path Normalization and Stripping <base-path-normalization-and-stripping>` for
+   canonical form and, if possible, making it relative to either the base path or one of the
+   include paths.
+   See :ref:`CLI Path Normalization and Stripping <cli-path-normalization-and-stripping>` for
    a detailed description of this process.
 
    .. index:: standard JSON
@@ -295,16 +296,36 @@ Here are some examples of what you can expect if they are not:
 
     The use of relative imports containing leading ``..`` segments is not recommended.
     The same effect can be achieved in a more reliable way by using direct imports with
-    :ref:`base path <base-path>` and :ref:`import remapping <import-remapping>`.
+    :ref:`base path and include paths <base-and-include-paths>`.
 
-.. index:: ! base path, ! --base-path
-.. _base-path:
+.. index:: ! base path, ! --base-path, ! include paths, ! --include-path
+.. _base-and-include-paths:
 
-Base Path
-=========
+Base Path and Include Paths
+===========================
 
-The base path specifies the directory that the Host Filesystem Loader will load files from.
-It is simply prepended to a source unit name before the filesystem lookup is performed.
+The base path and include paths represent directories that the Host Filesystem Loader will load files from.
+When a source unit name is passed to the loader, it prepends the base path to it and performs a
+filesystem lookup.
+If the lookup does not succeed, the same is done with all directories on the include path list.
+
+It is recommended to set the base path to the root directory of your project and use include paths to
+specify additional locations that may contain libraries your project depends on.
+This lets you import from these libraries in a uniform way, no matter where they are located in the
+filesystem relative to your project.
+For example, if you use npm to install packages and your contract imports
+``@openzeppelin/contracts/utils/Strings.sol``, you can use these options to tell the compiler that
+the library can be found in one of the npm package directories:
+
+.. code-block:: bash
+
+    solc contract.sol \
+        --base-path . \
+        --include-path node_modules/ \
+        --include-path /usr/local/lib/node_modules/
+
+Your contract will compile (with the same exact metadata) no matter whether you install the library
+in the local or global package directory or even directly under your project root.
 
 By default the base path is empty, which leaves the source unit name unchanged.
 When the source unit name is a relative path, this results in the file being looked up in the
@@ -314,10 +335,14 @@ interpreted as absolute paths on disk.
 If the base path itself is relative, it is interpreted as relative to the current working directory
 of the compiler.
 
-.. _base-path-normalization-and-stripping:
+.. note::
 
-Base Path Normalization and Stripping
--------------------------------------
+    Include paths cannot have empty values and must be used together with a non-empty base path.
+
+.. _cli-path-normalization-and-stripping:
+
+CLI Path Normalization and Stripping
+------------------------------------
 
 On the command line the compiler behaves just as you would expect from any other program:
 it accepts paths in a format native to the platform and relative paths are relative to the current
@@ -326,7 +351,7 @@ The source unit names assigned to files whose paths are specified on the command
 should not change just because the project is being compiled on a different platform or because the
 compiler happens to have been invoked from a different directory.
 To achieve this, paths to source files coming from the command line must be converted to a canonical
-form, and, if possible, made relative to the base path.
+form, and, if possible, made relative to the base path or one of the include paths.
 
 The normalization rules are as follows:
 
@@ -357,7 +382,8 @@ The normalization rules are as follows:
     You can avoid such situations by ensuring that all the files are available within a single
     directory tree on the same drive.
 
-Once canonicalized, the base path is stripped from all source file paths that start with it.
+After normalization the compiler attempts to make the source file path relative.
+It tries the base path first and then the include paths in the order they were given.
 If the base path is empty or not specified, it is treated as if it was equal to the path to the
 current working directory (with all symbolic links resolved).
 The result is accepted only if the normalized directory path is the exact prefix of the normalized
@@ -388,11 +414,11 @@ locations that are considered safe by default:
   - The directories used as :ref:`remapping <import-remapping>` targets.
     If the target is not a directory (i.e does not end with ``/``, ``/.`` or ``/..``) the directory
     containing the target is used instead.
-  - Base path.
+  - Base path and include paths.
 
 - In Standard JSON mode:
 
-  - Base path.
+  - Base path and include paths.
 
 Additional directories can be whitelisted using the ``--allow-paths`` option.
 The option accepts a comma-separated list of paths:
@@ -403,6 +429,7 @@ The option accepts a comma-separated list of paths:
     solc token/contract.sol \
         lib/util.sol=libs/util.sol \
         --base-path=token/ \
+        --include-path=/lib/ \
         --allow-paths=../utils/,/tmp/libraries
 
 When the compiler is invoked with the command shown above, the Host Filesystem Loader will allow
@@ -410,6 +437,7 @@ importing files from the following directories:
 
 - ``/home/user/project/token/`` (because ``token/`` contains the input file and also because it is
   the base path),
+- ``/lib/`` (because ``/lib/`` is one of the include paths),
 - ``/home/user/project/libs/`` (because ``libs/`` is a directory containing a remapping target),
 - ``/home/user/utils/`` (because of ``../utils/`` passed to ``--allow-paths``),
 - ``/tmp/libraries/`` (because of ``/tmp/libraries`` passed to ``--allow-paths``),
@@ -491,6 +519,13 @@ Loader, which will then look in ``/project/dapp-bin/library/iterable_mapping.sol
     To be able to reproduce the same bytecode with such a remapping on a different machine, you
     would need to recreate parts of your local directory structure in the VFS and (if you rely on
     Host Filesystem Loader) also in the host filesystem.
+
+    To avoid having your local directory structure embedded in the metadata, it is recommended to
+    designate the directories containing libraries as *include paths* instead.
+    For example, in the example above ``--include-path /home/user/packages/`` would let you use
+    imports starting with ``mymath/``.
+    Unlike remapping, the option on its own will not make ``mymath`` appear as ``@math`` but this
+    can be achieved by creating a symbolic link or renaming the package subdirectory.
 
 As a more complex example, suppose you rely on a module that uses an old version of dapp-bin that
 you checked out to ``/project/dapp-bin_old``, then you can run:

--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -394,6 +394,16 @@ The resulting file path becomes the source unit name.
 
 .. note::
 
+    The relative path produced by stripping must remain unique within the base path and include paths.
+    For example the compiler will issue an error for the following command if both
+    ``/project/contract.sol`` and ``/lib/contract.sol`` exist:
+
+    .. code-block:: bash
+
+        solc /project/contract.sol --base-path /project --include-path /lib
+
+.. note::
+
     Prior to version 0.8.8, CLI path stripping was not performed and the only normalization applied
     was the conversion of path separators.
     When working with older versions of the compiler it is recommended to invoke the compiler from

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -33,7 +33,7 @@ This parameter has effects on the following (this might change in the future):
 - the size of the binary search in the function dispatch routine
 - the way constants like large numbers or strings are stored
 
-.. index:: allowed paths, --allow-paths, base path, --base-path
+.. index:: allowed paths, --allow-paths, base path, --base-path, include paths, --include-path
 
 Base Path and Import Remapping
 ------------------------------
@@ -49,9 +49,9 @@ This essentially instructs the compiler to search for anything starting with
 ``github.com/ethereum/dapp-bin/`` under ``/usr/local/lib/dapp-bin``.
 
 When accessing the filesystem to search for imports, :ref:`paths that do not start with ./
-or ../ <direct-imports>` are treated as relative to the directory specified using
-``--base-path`` option (or the current working directory if base path is not specified).
-Furthermore, the part added via ``--base-path`` will not appear in the contract metadata.
+or ../ <direct-imports>` are treated as relative to the directories specified using
+``--base-path`` and ``--include-path`` options (or the current working directory if base path is not specified).
+Furthermore, the part of the path added via these options will not appear in the contract metadata.
 
 For security reasons the compiler has :ref:`restrictions on what directories it can access <allowed-paths>`.
 Directories of source files specified on the command line and target paths of

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -44,12 +44,19 @@ public:
 		Enabled,  ///< Follow symbolic links. The path should contain no symlinks.
 	};
 
-	/// Constructs a FileReader with a base path and a set of allowed directories that
-	/// will be used when requesting files from this file reader instance.
-	explicit FileReader(boost::filesystem::path _basePath = {}, FileSystemPathSet _allowedDirectories = {});
+	/// Constructs a FileReader with a base path and sets of include paths and allowed directories
+	/// that will be used when requesting files from this file reader instance.
+	explicit FileReader(
+		boost::filesystem::path _basePath = {},
+		std::vector<boost::filesystem::path> const& _includePaths = {},
+		FileSystemPathSet _allowedDirectories = {}
+	);
 
 	void setBasePath(boost::filesystem::path const& _path);
 	boost::filesystem::path const& basePath() const noexcept { return m_basePath; }
+
+	void addIncludePath(boost::filesystem::path const& _path);
+	std::vector<boost::filesystem::path> const& includePaths() const noexcept { return m_includePaths; }
 
 	void allowDirectory(boost::filesystem::path _path);
 	FileSystemPathSet const& allowedDirectories() const noexcept { return m_allowedDirectories; }
@@ -84,6 +91,10 @@ public:
 	{
 		return [this](std::string const& _kind, std::string const& _path) { return readFile(_kind, _path); };
 	}
+
+	/// Creates a source unit name by normalizing a path given on the command line and, if possible,
+	/// making it relative to base path or one of the include directories.
+	std::string cliPathToSourceUnitName(boost::filesystem::path const& _cliPath);
 
 	/// Normalizes a filesystem path to make it include all components up to the filesystem root,
 	/// remove small, inconsequential differences that do not affect the meaning and make it look
@@ -129,6 +140,9 @@ private:
 
 	/// Base path, used for resolving relative paths in imports.
 	boost::filesystem::path m_basePath;
+
+	/// Additional directories used for resolving relative paths in imports.
+	std::vector<boost::filesystem::path> m_includePaths;
 
 	/// list of allowed directories to read files from
 	FileSystemPathSet m_allowedDirectories;

--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -96,6 +96,13 @@ public:
 	/// making it relative to base path or one of the include directories.
 	std::string cliPathToSourceUnitName(boost::filesystem::path const& _cliPath);
 
+	/// Checks if a set contains any paths that lead to different files but would receive identical
+	/// source unit names. Files are considered the same if their paths are exactly the same after
+	/// normalization (without following symlinks).
+	/// @returns a map containing all the conflicting source unit names and the paths that would
+	/// receive them. The returned paths are normalized.
+	std::map<std::string, FileSystemPathSet> detectSourceUnitNameCollisions(FileSystemPathSet const& _cliPaths);
+
 	/// Normalizes a filesystem path to make it include all components up to the filesystem root,
 	/// remove small, inconsequential differences that do not affect the meaning and make it look
 	/// the same on all platforms (if possible).

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -422,6 +422,9 @@ bool CommandLineInterface::readInputFiles()
 		}
 	}
 
+	for (boost::filesystem::path const& includePath: m_options.input.includePaths)
+		m_fileReader.addIncludePath(includePath);
+
 	for (boost::filesystem::path const& allowedDirectory: m_options.input.allowedDirectories)
 		m_fileReader.allowDirectory(allowedDirectory);
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -428,6 +428,24 @@ bool CommandLineInterface::readInputFiles()
 	for (boost::filesystem::path const& allowedDirectory: m_options.input.allowedDirectories)
 		m_fileReader.allowDirectory(allowedDirectory);
 
+	map<std::string, set<boost::filesystem::path>> collisions =
+		m_fileReader.detectSourceUnitNameCollisions(m_options.input.paths);
+	if (!collisions.empty())
+	{
+		auto pathToQuotedString = [](boost::filesystem::path const& _path){ return "\"" + _path.string() + "\""; };
+
+		serr() << "Source unit name collision detected. ";
+		serr() << "The specified values of base path and/or include paths would result in multiple ";
+		serr() << "input files being assigned the same source unit name:" << endl;
+		for (auto const& [sourceUnitName, normalizedInputPaths]: collisions)
+		{
+			serr() << sourceUnitName << " matches: ";
+			serr() << joinHumanReadable(normalizedInputPaths | ranges::views::transform(pathToQuotedString)) << endl;
+		}
+
+		return false;
+	}
+
 	for (boost::filesystem::path const& infile: m_options.input.paths)
 	{
 		if (!boost::filesystem::exists(infile))

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -111,6 +111,7 @@ struct CommandLineOptions
 		std::vector<ImportRemapper::Remapping> remappings;
 		bool addStdin = false;
 		boost::filesystem::path basePath = "";
+		std::vector<boost::filesystem::path> includePaths;
 		FileReader::FileSystemPathSet allowedDirectories;
 		bool ignoreMissingFiles = false;
 		bool errorRecovery = false;

--- a/test/FilesystemUtils.cpp
+++ b/test/FilesystemUtils.cpp
@@ -31,7 +31,8 @@ void solidity::test::createFilesWithParentDirs(set<boost::filesystem::path> cons
 		if (!path.parent_path().empty())
 			boost::filesystem::create_directories(path.parent_path());
 
-		ofstream newFile(path.string());
+		// Use binary mode to avoid line ending conversion on Windows.
+		ofstream newFile(path.string(), std::ofstream::binary);
 		newFile << _content;
 
 		if (newFile.fail() || !boost::filesystem::exists(path))

--- a/test/solc/CommandLineInterfaceAllowPaths.cpp
+++ b/test/solc/CommandLineInterfaceAllowPaths.cpp
@@ -344,10 +344,14 @@ BOOST_FIXTURE_TEST_CASE(allow_path_should_work_with_various_import_forms, AllowP
 	BOOST_TEST(checkImport("import 'a/../../code/a/../a/b/c.sol'", {"--allow-paths", "../code/a/b/c.sol"}));
 	BOOST_TEST(checkImport("import 'a/../../code/a///b/c.sol'", {"--allow-paths", "../code/a/b/c.sol"}));
 
-	// UNC paths in imports
+#if !defined(_WIN32)
+	// UNC paths in imports.
+	// Unfortunately can't test it on Windows without having an existing UNC path. On Linux we can
+	// at least rely on the fact that `//` works like `/`.
 	string uncImportPath = "/" + m_portablePrefix + "/a/b/c.sol";
 	soltestAssert(FileReader::isUNCPath(uncImportPath), "");
 	BOOST_TEST(checkImport("import '" + uncImportPath + "'", {"--allow-paths", "../code/a/b/c.sol"}) == ImportCheck::PathDisallowed());
+#endif
 }
 
 BOOST_FIXTURE_TEST_CASE(allow_path_automatic_whitelisting_input_files, AllowPathsFixture)

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -117,6 +117,8 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 			"a:b=c/d",
 			":contract.sol=",
 			"--base-path=/home/user/",
+			"--include-path=/usr/lib/include/",
+			"--include-path=/home/user/include",
 			"--allow-paths=/tmp,/home,project,../contracts",
 			"--ignore-missing",
 			"--error-recovery",
@@ -168,6 +170,8 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 
 		expectedOptions.input.addStdin = true;
 		expectedOptions.input.basePath = "/home/user/";
+		expectedOptions.input.includePaths = {"/usr/lib/include/", "/home/user/include"};
+
 		expectedOptions.input.allowedDirectories = {"/tmp", "/home", "project", "../contracts", "c", "/usr/lib"};
 		expectedOptions.input.ignoreMissingFiles = true;
 		expectedOptions.input.errorRecovery = (inputMode == InputMode::Compiler);
@@ -257,6 +261,8 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 			"a:b=c/d",
 			":contract.yul=",
 			"--base-path=/home/user/",
+			"--include-path=/usr/lib/include/",
+			"--include-path=/home/user/include",
 			"--allow-paths=/tmp,/home,project,../contracts",
 			"--ignore-missing",
 			"--error-recovery",            // Ignored in assembly mode
@@ -307,6 +313,7 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 		};
 		expectedOptions.input.addStdin = true;
 		expectedOptions.input.basePath = "/home/user/";
+		expectedOptions.input.includePaths = {"/usr/lib/include/", "/home/user/include"};
 		expectedOptions.input.allowedDirectories = {"/tmp", "/home", "project", "../contracts", "c", "/usr/lib"};
 		expectedOptions.input.ignoreMissingFiles = true;
 		expectedOptions.output.overwriteFiles = true;
@@ -350,6 +357,8 @@ BOOST_AUTO_TEST_CASE(standard_json_mode_options)
 		"input.json",
 		"--standard-json",
 		"--base-path=/home/user/",
+		"--include-path=/usr/lib/include/",
+		"--include-path=/home/user/include",
 		"--allow-paths=/tmp,/home,project,../contracts",
 		"--ignore-missing",
 		"--error-recovery",                // Ignored in Standard JSON mode
@@ -390,6 +399,7 @@ BOOST_AUTO_TEST_CASE(standard_json_mode_options)
 	expectedOptions.input.mode = InputMode::StandardJson;
 	expectedOptions.input.paths = {"input.json"};
 	expectedOptions.input.basePath = "/home/user/";
+	expectedOptions.input.includePaths = {"/usr/lib/include/", "/home/user/include"};
 	expectedOptions.input.allowedDirectories = {"/tmp", "/home", "project", "../contracts"};
 	expectedOptions.input.ignoreMissingFiles = true;
 	expectedOptions.output.dir = "/tmp/out";


### PR DESCRIPTION
This is the same as #11848 but that PR got accidentally merged into its base branch.

> Implements the `solc` part of #11409.
> `solc-js` part is in https://github.com/ethereum/solc-js/pull/544.
> Depends on #11688.