### PR TITLE
Default messages in assertion macros

### DIFF
--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -47,16 +47,16 @@ struct InvalidAstError: virtual util::Exception {};
 
 /// Assertion that throws an InternalCompilerError containing the given description if it is not met.
 #define solAssert(CONDITION, DESCRIPTION) \
-	assertThrow(CONDITION, ::solidity::langutil::InternalCompilerError, DESCRIPTION)
+	assertThrowWithDefaultDescription(CONDITION, ::solidity::langutil::InternalCompilerError, DESCRIPTION, "Solidity assertion failed")
 
 #define solUnimplementedAssert(CONDITION, DESCRIPTION) \
-	assertThrow(CONDITION, ::solidity::langutil::UnimplementedFeatureError, DESCRIPTION)
+	assertThrowWithDefaultDescription(CONDITION, ::solidity::langutil::UnimplementedFeatureError, DESCRIPTION, "Unimplemented feature")
 
 #define solUnimplemented(DESCRIPTION) \
 	solUnimplementedAssert(false, DESCRIPTION)
 
 #define astAssert(CONDITION, DESCRIPTION) \
-	assertThrow(CONDITION, ::solidity::langutil::InvalidAstError, DESCRIPTION)
+	assertThrowWithDefaultDescription(CONDITION, ::solidity::langutil::InvalidAstError, DESCRIPTION, "AST assertion failed")
 
 using errorSourceLocationInfo = std::pair<std::string, SourceLocation>;
 

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -28,6 +28,10 @@
 #include <libsolutil/CommonData.h>
 #include <liblangutil/SourceLocation.h>
 
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/facilities/empty.hpp>
+#include <boost/preprocessor/facilities/overload.hpp>
+
 #include <string>
 #include <utility>
 #include <vector>
@@ -45,18 +49,68 @@ struct FatalError: virtual util::Exception {};
 struct UnimplementedFeatureError: virtual util::Exception {};
 struct InvalidAstError: virtual util::Exception {};
 
+
 /// Assertion that throws an InternalCompilerError containing the given description if it is not met.
-#define solAssert(CONDITION, DESCRIPTION) \
-	assertThrowWithDefaultDescription(CONDITION, ::solidity::langutil::InternalCompilerError, DESCRIPTION, "Solidity assertion failed")
+#if !BOOST_PP_VARIADICS_MSVC
+#define solAssert(...) BOOST_PP_OVERLOAD(solAssert_,__VA_ARGS__)(__VA_ARGS__)
+#else
+#define solAssert(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(solAssert_,__VA_ARGS__)(__VA_ARGS__),BOOST_PP_EMPTY())
+#endif
 
-#define solUnimplementedAssert(CONDITION, DESCRIPTION) \
-	assertThrowWithDefaultDescription(CONDITION, ::solidity::langutil::UnimplementedFeatureError, DESCRIPTION, "Unimplemented feature")
+#define solAssert_1(CONDITION) \
+	solAssert_2(CONDITION, "")
 
+#define solAssert_2(CONDITION, DESCRIPTION) \
+	assertThrowWithDefaultDescription( \
+		CONDITION, \
+		::solidity::langutil::InternalCompilerError, \
+		DESCRIPTION, \
+		"Solidity assertion failed" \
+	)
+
+
+/// Assertion that throws an UnimplementedFeatureError containing the given description if it is not met.
+#if !BOOST_PP_VARIADICS_MSVC
+#define solUnimplementedAssert(...) BOOST_PP_OVERLOAD(solUnimplementedAssert_,__VA_ARGS__)(__VA_ARGS__)
+#else
+#define solUnimplementedAssert(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(solUnimplementedAssert_,__VA_ARGS__)(__VA_ARGS__),BOOST_PP_EMPTY())
+#endif
+
+#define solUnimplementedAssert_1(CONDITION) \
+	solUnimplementedAssert_2(CONDITION, "")
+
+#define solUnimplementedAssert_2(CONDITION, DESCRIPTION) \
+	assertThrowWithDefaultDescription( \
+		CONDITION, \
+		::solidity::langutil::UnimplementedFeatureError, \
+		DESCRIPTION, \
+		"Unimplemented feature" \
+	)
+
+
+/// Helper that unconditionally reports an unimplemented feature.
 #define solUnimplemented(DESCRIPTION) \
 	solUnimplementedAssert(false, DESCRIPTION)
 
-#define astAssert(CONDITION, DESCRIPTION) \
-	assertThrowWithDefaultDescription(CONDITION, ::solidity::langutil::InvalidAstError, DESCRIPTION, "AST assertion failed")
+
+/// Assertion that throws an InvalidAstError containing the given description if it is not met.
+#if !BOOST_PP_VARIADICS_MSVC
+#define astAssert(...) BOOST_PP_OVERLOAD(astAssert_,__VA_ARGS__)(__VA_ARGS__)
+#else
+#define astAssert(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(astAssert_,__VA_ARGS__)(__VA_ARGS__),BOOST_PP_EMPTY())
+#endif
+
+#define astAssert_1(CONDITION) \
+	astAssert_2(CONDITION, "")
+
+#define astAssert_2(CONDITION, DESCRIPTION) \
+	assertThrowWithDefaultDescription( \
+		CONDITION, \
+		::solidity::langutil::InvalidAstError, \
+		DESCRIPTION, \
+		"AST assertion failed" \
+	)
+
 
 using errorSourceLocationInfo = std::pair<std::string, SourceLocation>;
 

--- a/libsmtutil/CHCSmtLib2Interface.cpp
+++ b/libsmtutil/CHCSmtLib2Interface.cpp
@@ -60,8 +60,8 @@ void CHCSmtLib2Interface::reset()
 
 void CHCSmtLib2Interface::registerRelation(Expression const& _expr)
 {
-	smtAssert(_expr.sort, "");
-	smtAssert(_expr.sort->kind == Kind::Function, "");
+	smtAssert(_expr.sort);
+	smtAssert(_expr.sort->kind == Kind::Function);
 	if (!m_variables.count(_expr.name))
 	{
 		auto fSort = dynamic_pointer_cast<FunctionSort>(_expr.sort);
@@ -124,7 +124,7 @@ pair<CheckResult, CHCSolverInterface::CexGraph> CHCSmtLib2Interface::query(Expre
 
 void CHCSmtLib2Interface::declareVariable(string const& _name, SortPointer const& _sort)
 {
-	smtAssert(_sort, "");
+	smtAssert(_sort);
 	if (_sort->kind == Kind::Function)
 		declareFunction(_name, _sort);
 	else if (!m_variables.count(_name))
@@ -172,13 +172,13 @@ string CHCSmtLib2Interface::forall()
 
 void CHCSmtLib2Interface::declareFunction(string const& _name, SortPointer const& _sort)
 {
-	smtAssert(_sort, "");
-	smtAssert(_sort->kind == Kind::Function, "");
+	smtAssert(_sort);
+	smtAssert(_sort->kind == Kind::Function);
 	// TODO Use domain and codomain as key as well
 	if (!m_variables.count(_name))
 	{
 		auto fSort = dynamic_pointer_cast<FunctionSort>(_sort);
-		smtAssert(fSort->codomain, "");
+		smtAssert(fSort->codomain);
 		string domain = toSmtLibSort(fSort->domain);
 		string codomain = toSmtLibSort(*fSort->codomain);
 		m_variables.insert(_name);

--- a/libsmtutil/Exceptions.h
+++ b/libsmtutil/Exceptions.h
@@ -27,6 +27,6 @@ namespace solidity::smtutil
 struct SMTLogicError: virtual util::Exception {};
 
 #define smtAssert(CONDITION, DESCRIPTION) \
-	assertThrow(CONDITION, SMTLogicError, DESCRIPTION)
+	assertThrowWithDefaultDescription(CONDITION, SMTLogicError, DESCRIPTION, "SMT assertion failed")
 
 }

--- a/libsmtutil/Exceptions.h
+++ b/libsmtutil/Exceptions.h
@@ -21,12 +21,31 @@
 #include <libsolutil/Assertions.h>
 #include <libsolutil/Exceptions.h>
 
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/facilities/empty.hpp>
+#include <boost/preprocessor/facilities/overload.hpp>
+
 namespace solidity::smtutil
 {
 
 struct SMTLogicError: virtual util::Exception {};
 
-#define smtAssert(CONDITION, DESCRIPTION) \
-	assertThrowWithDefaultDescription(CONDITION, SMTLogicError, DESCRIPTION, "SMT assertion failed")
+/// Assertion that throws an SMTLogicError containing the given description if it is not met.
+#if !BOOST_PP_VARIADICS_MSVC
+#define smtAssert(...) BOOST_PP_OVERLOAD(smtAssert_,__VA_ARGS__)(__VA_ARGS__)
+#else
+#define smtAssert(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(smtAssert_,__VA_ARGS__)(__VA_ARGS__),BOOST_PP_EMPTY())
+#endif
+
+#define smtAssert_1(CONDITION) \
+	smtAssert_2(CONDITION, "")
+
+#define smtAssert_2(CONDITION, DESCRIPTION) \
+	assertThrowWithDefaultDescription( \
+		CONDITION, \
+		::solidity::smtutil::SMTLogicError, \
+		DESCRIPTION, \
+		"SMT assertion failed" \
+	)
 
 }

--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -553,7 +553,7 @@ void ControlFlowBuilder::operator()(yul::FunctionDefinition const&)
 void ControlFlowBuilder::operator()(yul::Leave const&)
 {
 	// This has to be implemented, if we ever decide to visit functions.
-	solUnimplementedAssert(false, "");
+	solUnimplemented("");
 }
 
 bool ControlFlowBuilder::visit(VariableDeclaration const& _variableDeclaration)

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -61,7 +61,7 @@ map<string, ASTPointer<SourceUnit>> ASTJsonImporter::jsonToSourceUnit(map<string
 		m_sourceNames.emplace_back(make_shared<string const>(src.first));
 	for (auto const& srcPair: _sourceList)
 	{
-		astAssert(!srcPair.second.isNull(), "");
+		astAssert(!srcPair.second.isNull());
 		astAssert(member(srcPair.second,"nodeType") == "SourceUnit", "The 'nodeType' of the highest node must be 'SourceUnit'.");
 		m_sourceUnits[srcPair.first] = createSourceUnit(srcPair.second, srcPair.first);
 	}
@@ -485,17 +485,17 @@ ASTPointer<VariableDeclaration> ASTJsonImporter::createVariableDeclaration(Json:
 	if (mutabilityStr == "constant")
 	{
 		mutability = VariableDeclaration::Mutability::Constant;
-		astAssert(memberAsBool(_node, "constant"), "");
+		astAssert(memberAsBool(_node, "constant"));
 	}
 	else
 	{
-		astAssert(!memberAsBool(_node, "constant"), "");
+		astAssert(!memberAsBool(_node, "constant"));
 		if (mutabilityStr == "mutable")
 			mutability = VariableDeclaration::Mutability::Mutable;
 		else if (mutabilityStr == "immutable")
 			mutability = VariableDeclaration::Mutability::Immutable;
 		else
-			astAssert(false, "");
+			astAssert(false);
 	}
 
 	return createASTNode<VariableDeclaration>(

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2112,8 +2112,7 @@ bool ExpressionCompiler::visit(IndexRangeAccess const& _indexAccess)
 	solUnimplementedAssert(
 		arrayType->location() == DataLocation::CallData &&
 		arrayType->isDynamicallySized() &&
-		!arrayType->baseType()->isDynamicallyEncoded(),
-		""
+		!arrayType->baseType()->isDynamicallyEncoded()
 	);
 
 	if (_indexAccess.startExpression())

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -155,7 +155,7 @@ ImmutableItem::ImmutableItem(CompilerContext& _compilerContext, VariableDeclarat
 
 void ImmutableItem::retrieveValue(SourceLocation const&, bool) const
 {
-	solUnimplementedAssert(m_dataType->isValueType(), "");
+	solUnimplementedAssert(m_dataType->isValueType());
 
 	if (m_context.runtimeContext())
 		CompilerUtils(m_context).loadFromMemory(
@@ -172,7 +172,7 @@ void ImmutableItem::retrieveValue(SourceLocation const&, bool) const
 void ImmutableItem::storeValue(Type const& _sourceType, SourceLocation const&, bool _move) const
 {
 	CompilerUtils utils(m_context);
-	solUnimplementedAssert(m_dataType->isValueType(), "");
+	solUnimplementedAssert(m_dataType->isValueType());
 	solAssert(_sourceType.isValueType(), "");
 
 	utils.convertType(_sourceType, *m_dataType, true);

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -1217,7 +1217,7 @@ string YulUtilFunctions::extractByteArrayLengthFunction()
 std::string YulUtilFunctions::resizeArrayFunction(ArrayType const& _type)
 {
 	solAssert(_type.location() == DataLocation::Storage, "");
-	solUnimplementedAssert(_type.baseType()->storageBytes() <= 32, "...");
+	solUnimplementedAssert(_type.baseType()->storageBytes() <= 32);
 
 	if (_type.isByteArray())
 		return resizeDynamicByteArrayFunction(_type);
@@ -1259,7 +1259,7 @@ string YulUtilFunctions::cleanUpStorageArrayEndFunction(ArrayType const& _type)
 	solAssert(_type.location() == DataLocation::Storage, "");
 	solAssert(_type.baseType()->category() != Type::Category::Mapping, "");
 	solAssert(!_type.isByteArray(), "");
-	solUnimplementedAssert(_type.baseType()->storageBytes() <= 32, "");
+	solUnimplementedAssert(_type.baseType()->storageBytes() <= 32);
 
 	string functionName = "cleanup_storage_array_end_" + _type.identifier();
 	return m_functionCollector.createFunction(functionName, [&](vector<string>& _args, vector<string>&) {
@@ -1555,7 +1555,7 @@ string YulUtilFunctions::storageArrayPushFunction(ArrayType const& _type, Type c
 	if (!_fromType)
 		_fromType = _type.baseType();
 	else if (_fromType->isValueType())
-		solUnimplementedAssert(*_fromType == *_type.baseType(), "");
+		solUnimplementedAssert(*_fromType == *_type.baseType());
 
 	string functionName =
 		string{"array_push_from_"} +
@@ -3304,10 +3304,10 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 				if (auto const* toFixedBytes = dynamic_cast<FixedBytesType const*>(&_to))
 					convert = shiftLeftFunction(256 - toFixedBytes->numBytes() * 8);
 				else if (dynamic_cast<FixedPointType const*>(&_to))
-					solUnimplementedAssert(false, "");
+					solUnimplemented("");
 				else if (dynamic_cast<IntegerType const*>(&_to))
 				{
-					solUnimplementedAssert(fromCategory != Type::Category::FixedPoint, "");
+					solUnimplementedAssert(fromCategory != Type::Category::FixedPoint);
 					convert = identityFunction();
 				}
 				else if (toCategory == Type::Category::Enum)
@@ -3346,8 +3346,8 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 				body = "converted := value";
 			else
 			{
-				solUnimplementedAssert(toStructType.location() == DataLocation::Memory, "");
-				solUnimplementedAssert(fromStructType.location() != DataLocation::Memory, "");
+				solUnimplementedAssert(toStructType.location() == DataLocation::Memory);
+				solUnimplementedAssert(fromStructType.location() != DataLocation::Memory);
 
 				if (fromStructType.location() == DataLocation::CallData)
 					body = Whiskers(R"(
@@ -3416,7 +3416,7 @@ string YulUtilFunctions::conversionFunction(Type const& _from, Type const& _to)
 		}
 		case Type::Category::Tuple:
 		{
-			solUnimplementedAssert(false, "Tuple conversion not implemented.");
+			solUnimplemented("Tuple conversion not implemented.");
 			break;
 		}
 		case Type::Category::TypeType:
@@ -4107,7 +4107,7 @@ string YulUtilFunctions::zeroValueFunction(Type const& _type, bool _splitFunctio
 			else if (auto const* structType = dynamic_cast<StructType const*>(&_type))
 				templ("zeroValue", allocateAndInitializeMemoryStructFunction(*structType) + "()");
 			else
-				solUnimplementedAssert(false, "");
+				solUnimplemented("");
 		}
 
 		return templ.render();

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -544,7 +544,7 @@ string IRGenerator::generateGetter(VariableDeclaration const& _varDecl)
 		if (_varDecl.immutable())
 		{
 			solAssert(paramTypes.empty(), "");
-			solUnimplementedAssert(type->sizeOnStack() == 1, "");
+			solUnimplementedAssert(type->sizeOnStack() == 1);
 			return Whiskers(R"(
 				/// @ast-id <astID>
 				<sourceLocationComment>
@@ -925,8 +925,8 @@ string IRGenerator::deployCode(ContractDefinition const& _contract)
 	else
 		for (VariableDeclaration const* immutable: ContractType(_contract).immutableVariables())
 		{
-			solUnimplementedAssert(immutable->type()->isValueType(), "");
-			solUnimplementedAssert(immutable->type()->sizeOnStack() == 1, "");
+			solUnimplementedAssert(immutable->type()->isValueType());
+			solUnimplementedAssert(immutable->type()->sizeOnStack() == 1);
 			immutables.emplace_back(map<string, string>{
 				{"immutableName"s, to_string(immutable->id())},
 				{"value"s, "mload(" + to_string(m_context.immutableMemoryOffset(*immutable)) + ")"}

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -108,7 +108,7 @@ private:
 	{
 		auto const& reference = m_references.at(&_identifier);
 		auto const varDecl = dynamic_cast<VariableDeclaration const*>(reference.declaration);
-		solUnimplementedAssert(varDecl, "");
+		solUnimplementedAssert(varDecl);
 		string const& suffix = reference.suffix;
 
 		string value;
@@ -737,7 +737,7 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 			) << "(" << IRVariable(_unaryOperation.subExpression()).name() << ")\n";
 		}
 		else
-			solUnimplementedAssert(false, "Unary operator not yet implemented");
+			solUnimplemented("Unary operator not yet implemented");
 	}
 	else if (resultType.category() == Type::Category::FixedBytes)
 	{
@@ -755,7 +755,7 @@ bool IRGeneratorForStatements::visit(UnaryOperation const& _unaryOperation)
 		appendSimpleUnaryOperation(_unaryOperation, _unaryOperation.subExpression());
 	}
 	else
-		solUnimplementedAssert(false, "Unary operator not yet implemented");
+		solUnimplemented("Unary operator not yet implemented");
 
 	return false;
 }
@@ -1546,7 +1546,7 @@ void IRGeneratorForStatements::endVisit(FunctionCallOptions const& _options)
 	setLocation(_options);
 	FunctionType const& previousType = dynamic_cast<FunctionType const&>(*_options.expression().annotation().type);
 
-	solUnimplementedAssert(!previousType.bound(), "");
+	solUnimplementedAssert(!previousType.bound());
 
 	// Copy over existing values.
 	for (auto const& item: previousType.stackItems())
@@ -1716,7 +1716,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 		{
 			solUnimplementedAssert(
 				dynamic_cast<FunctionType const&>(*_memberAccess.expression().annotation().type).kind() ==
-				FunctionType::Kind::External, ""
+				FunctionType::Kind::External
 			);
 			define(IRVariable{_memberAccess}, IRVariable(_memberAccess.expression()).part("address"));
 		}
@@ -2264,7 +2264,7 @@ void IRGeneratorForStatements::endVisit(IndexRangeAccess const& _indexRangeAcces
 			break;
 		}
 		default:
-			solUnimplementedAssert(false, "Index range accesses is implemented only on calldata arrays.");
+			solUnimplemented("Index range accesses is implemented only on calldata arrays.");
 	}
 }
 
@@ -2910,8 +2910,8 @@ void IRGeneratorForStatements::writeToLValue(IRLValue const& _lvalue, IRVariable
 			[&](IRLValue::Stack const& _stack) { assign(_stack.variable, _value); },
 			[&](IRLValue::Immutable const& _immutable)
 			{
-				solUnimplementedAssert(_lvalue.type.isValueType(), "");
-				solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1, "");
+				solUnimplementedAssert(_lvalue.type.isValueType());
+				solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1);
 				solAssert(_lvalue.type == *_immutable.variable->type(), "");
 				size_t memOffset = m_context.immutableMemoryOffset(*_immutable.variable);
 
@@ -2970,8 +2970,8 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 			define(result, _stack.variable);
 		},
 		[&](IRLValue::Immutable const& _immutable) {
-			solUnimplementedAssert(_lvalue.type.isValueType(), "");
-			solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1, "");
+			solUnimplementedAssert(_lvalue.type.isValueType());
+			solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1);
 			solAssert(_lvalue.type == *_immutable.variable->type(), "");
 			if (m_context.executionContext() == IRGenerationContext::ExecutionContext::Creation)
 			{

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -253,7 +253,7 @@ void CompilerStack::setRevertStringBehaviour(RevertStrings _revertStrings)
 {
 	if (m_stackState >= ParsedAndImported)
 		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set revert string settings before parsing."));
-	solUnimplementedAssert(_revertStrings != RevertStrings::VerboseDebug, "");
+	solUnimplementedAssert(_revertStrings != RevertStrings::VerboseDebug);
 	m_revertStrings = _revertStrings;
 }
 

--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -77,6 +77,6 @@ inline std::string stringOrDefault(std::string _string, std::string _defaultStri
 /// Use it as assertThrow(1 == 1, ExceptionType, "Mathematics is wrong.");
 /// The second parameter must be an exception class (rather than an instance).
 #define assertThrow(_condition, _exceptionType, _description) \
-	assertThrowWithDefaultDescription(_condition, _exceptionType, _description, "")
+	assertThrowWithDefaultDescription(_condition, _exceptionType, _description, "Assertion failed")
 
 }

--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -27,6 +27,8 @@
 
 #include <libsolutil/Exceptions.h>
 
+#include <string>
+
 namespace solidity::util
 {
 
@@ -38,21 +40,43 @@ namespace solidity::util
 #define ETH_FUNC __func__
 #endif
 
-/// Assertion that throws an exception containing the given description if it is not met.
-/// Use it as assertThrow(1 == 1, ExceptionType, "Mathematics is wrong.");
-/// Do NOT supply an exception object as the second parameter.
-#define assertThrow(_condition, _exceptionType, _description) \
+namespace assertions
+{
+
+inline std::string stringOrDefault(std::string _string, std::string _defaultString)
+{
+	// NOTE: Putting this in a function rather than directly in a macro prevents the string from
+	// being evaluated multiple times if it's not just a literal.
+	return (!_string.empty() ? _string : _defaultString);
+}
+
+}
+
+/// Base macro that can be used to implement assertion macros.
+/// Throws an exception containing the given description if the condition is not met.
+/// Allows you to provide the default description for the case where the user of your macro does
+/// not provide any.
+/// The second parameter must be an exception class (rather than an instance).
+#define assertThrowWithDefaultDescription(_condition, _exceptionType, _description, _defaultDescription) \
 	do \
 	{ \
 		if (!(_condition)) \
 			::boost::throw_exception( \
 				_exceptionType() << \
-				::solidity::util::errinfo_comment(_description) << \
+				::solidity::util::errinfo_comment( \
+					::solidity::util::assertions::stringOrDefault(_description, _defaultDescription) \
+				) << \
 				::boost::throw_function(ETH_FUNC) << \
 				::boost::throw_file(__FILE__) << \
 				::boost::throw_line(__LINE__) \
 			); \
 	} \
 	while (false)
+
+/// Assertion that throws an exception containing the given description if it is not met.
+/// Use it as assertThrow(1 == 1, ExceptionType, "Mathematics is wrong.");
+/// The second parameter must be an exception class (rather than an instance).
+#define assertThrow(_condition, _exceptionType, _description) \
+	assertThrowWithDefaultDescription(_condition, _exceptionType, _description, "")
 
 }

--- a/libyul/Exceptions.h
+++ b/libyul/Exceptions.h
@@ -53,6 +53,6 @@ struct StackTooDeepError: virtual YulException
 
 /// Assertion that throws an YulAssertion containing the given description if it is not met.
 #define yulAssert(CONDITION, DESCRIPTION) \
-	assertThrow(CONDITION, ::solidity::yul::YulAssertion, DESCRIPTION)
+	assertThrowWithDefaultDescription(CONDITION, ::solidity::yul::YulAssertion, DESCRIPTION, "Yul assertion failed")
 
 }

--- a/libyul/Exceptions.h
+++ b/libyul/Exceptions.h
@@ -26,6 +26,10 @@
 
 #include <libyul/YulString.h>
 
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/facilities/empty.hpp>
+#include <boost/preprocessor/facilities/overload.hpp>
+
 namespace solidity::yul
 {
 
@@ -52,7 +56,21 @@ struct StackTooDeepError: virtual YulException
 };
 
 /// Assertion that throws an YulAssertion containing the given description if it is not met.
-#define yulAssert(CONDITION, DESCRIPTION) \
-	assertThrowWithDefaultDescription(CONDITION, ::solidity::yul::YulAssertion, DESCRIPTION, "Yul assertion failed")
+#if !BOOST_PP_VARIADICS_MSVC
+#define yulAssert(...) BOOST_PP_OVERLOAD(yulAssert_,__VA_ARGS__)(__VA_ARGS__)
+#else
+#define yulAssert(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(yulAssert_,__VA_ARGS__)(__VA_ARGS__),BOOST_PP_EMPTY())
+#endif
+
+#define yulAssert_1(CONDITION) \
+	yulAssert_2(CONDITION, "")
+
+#define yulAssert_2(CONDITION, DESCRIPTION) \
+	assertThrowWithDefaultDescription( \
+		CONDITION, \
+		::solidity::yul::YulAssertion, \
+		DESCRIPTION, \
+		"Yul assertion failed" \
+	)
 
 }

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -1259,7 +1259,7 @@ bool CommandLineParser::processArgs()
 	if (m_options.input.mode == InputMode::Compiler)
 		m_options.input.errorRecovery = (m_args.count(g_strErrorRecovery) > 0);
 
-	solAssert(m_options.input.mode == InputMode::Compiler || m_options.input.mode == InputMode::CompilerWithASTImport, "");
+	solAssert(m_options.input.mode == InputMode::Compiler || m_options.input.mode == InputMode::CompilerWithASTImport);
 	return true;
 }
 

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -118,7 +118,7 @@ public:
 		size_t _columns
 	)
 	{
-		yulAssert(_columns > 0, "");
+		yulAssert(_columns > 0);
 
 		auto hasShorterString = [](auto const& a, auto const& b) { return a.second.size() < b.second.size(); };
 		size_t longestDescriptionLength = std::max(
@@ -151,7 +151,7 @@ public:
 				);
 			});
 
-		yulAssert(sortedOptions.size() > 0, "");
+		yulAssert(sortedOptions.size() > 0);
 		size_t rows = (sortedOptions.size() - 1) / _columns + 1;
 		for (size_t row = 0; row < rows; ++row)
 		{


### PR DESCRIPTION
This is an attempt to improve the situation in #12017 a little. It should also be an improvement for external tools because for these our ICEs are often puzzling when they have no message at all (see e.g. https://github.com/trufflesuite/truffle/issues/2849).

- Now if you use `""` in an assertion, it gets replaced with a generic message, like `"Solidity assertion failed"` or `"Unimplemented feature"`, depending on the assertion type.
- You can now skip the empty string in `solAssert()` and other assertions, making them more convenient.