### PR TITLE
Verify checksums of packages downloaded by scripts

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -48,23 +48,28 @@ then
   ./scripts/install_obsolete_jsoncpp_1_7_4.sh
 
   # z3
-  z3_version="z3-4.8.12"
-  osx_version="osx-10.15.7"
-  wget "https://github.com/Z3Prover/z3/releases/download/$z3_version/$z3_version-x64-$osx_version.zip"
-  unzip "$z3_version-x64-$osx_version.zip"
-  rm -f "$z3_version-x64-$osx_version.zip"
-  cp "$z3_version-x64-$osx_version/bin/libz3.a" /usr/local/lib
-  cp "$z3_version-x64-$osx_version/bin/z3" /usr/local/bin
-  cp "$z3_version-x64-$osx_version"/include/* /usr/local/include
-  rm -rf "$z3_version-x64-$osx_version"
+  z3_version="4.8.12"
+  z3_dir="z3-${z3_version}-x64-osx-10.15.7"
+  z3_package="${z3_dir}.zip"
+  wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_package}"
+  unzip "$z3_package"
+  rm -f "$z3_package"
+  cp "${z3_dir}/bin/libz3.a" /usr/local/lib
+  cp "${z3_dir}/bin/z3" /usr/local/bin
+  cp "${z3_dir}/include/"* /usr/local/include
+  rm -rf "$z3_dir"
 
   # evmone
-  wget https://github.com/ethereum/evmone/releases/download/v0.8.0/evmone-0.8.0-darwin-x86_64.tar.gz
-  tar xzpf evmone-0.8.0-darwin-x86_64.tar.gz -C /usr/local
-  rm -f evmone-0.8.0-darwin-x86_64.tar.gz
+  evmone_version="0.8.0"
+  evmone_package="evmone-${evmone_version}-darwin-x86_64.tar.gz"
+  wget "https://github.com/ethereum/evmone/releases/download/v${evmone_version}/${evmone_package}"
+  tar xzpf "$evmone_package" -C /usr/local
+  rm -f "$evmone_package"
 
   # hera
-  wget https://github.com/ewasm/hera/releases/download/v0.5.0/hera-0.5.0-darwin-x86_64.tar.gz
-  tar xzpf hera-0.5.0-darwin-x86_64.tar.gz -C /usr/local
-  rm -f hera-0.5.0-darwin-x86_64.tar.gz
+  hera_version="0.5.0"
+  hera_package="hera-${hera_version}-darwin-x86_64.tar.gz"
+  wget "https://github.com/ewasm/hera/releases/download/v${hera_version}/${hera_package}"
+  tar xzpf "$hera_package" -C /usr/local
+  rm -f "$hera_package"
 fi

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -53,23 +53,23 @@ then
   z3_package="${z3_dir}.zip"
   wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_package}"
   unzip "$z3_package"
-  rm -f "$z3_package"
+  rm "$z3_package"
   cp "${z3_dir}/bin/libz3.a" /usr/local/lib
   cp "${z3_dir}/bin/z3" /usr/local/bin
   cp "${z3_dir}/include/"* /usr/local/include
-  rm -rf "$z3_dir"
+  rm -r "$z3_dir"
 
   # evmone
   evmone_version="0.8.0"
   evmone_package="evmone-${evmone_version}-darwin-x86_64.tar.gz"
   wget "https://github.com/ethereum/evmone/releases/download/v${evmone_version}/${evmone_package}"
   tar xzpf "$evmone_package" -C /usr/local
-  rm -f "$evmone_package"
+  rm "$evmone_package"
 
   # hera
   hera_version="0.5.0"
   hera_package="hera-${hera_version}-darwin-x86_64.tar.gz"
   wget "https://github.com/ewasm/hera/releases/download/v${hera_version}/${hera_package}"
   tar xzpf "$hera_package" -C /usr/local
-  rm -f "$hera_package"
+  rm "$hera_package"
 fi

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -35,6 +35,21 @@
 
 set -eu
 
+function validate_checksum {
+  local package="$1"
+  local expected_checksum="$2"
+
+  local actual_checksum
+  actual_checksum=$(sha256sum "$package")
+  if [[ $actual_checksum != "${expected_checksum}  ${package}" ]]
+  then
+    >&2 echo "ERROR: Wrong checksum for package $package."
+    >&2 echo "Actual:   $actual_checksum"
+    >&2 echo "Expected: $expected_checksum"
+    exit 1
+  fi
+}
+
 if [ ! -f /usr/local/lib/libz3.a ] # if this file does not exists (cache was not restored), rebuild dependencies
 then
   git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
@@ -52,6 +67,7 @@ then
   z3_dir="z3-${z3_version}-x64-osx-10.15.7"
   z3_package="${z3_dir}.zip"
   wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_package}"
+  validate_checksum "$z3_package" a1f6ef3c99456147c4d3f2652dc6bc90951c4ab3fe7741a255eb794f0ab8938c
   unzip "$z3_package"
   rm "$z3_package"
   cp "${z3_dir}/bin/libz3.a" /usr/local/lib
@@ -63,6 +79,7 @@ then
   evmone_version="0.8.0"
   evmone_package="evmone-${evmone_version}-darwin-x86_64.tar.gz"
   wget "https://github.com/ethereum/evmone/releases/download/v${evmone_version}/${evmone_package}"
+  validate_checksum "$evmone_package" e8efef478822f0ed6d0493e89004181e895893f93963152a2a81589acc3a0828
   tar xzpf "$evmone_package" -C /usr/local
   rm "$evmone_package"
 
@@ -70,6 +87,7 @@ then
   hera_version="0.5.0"
   hera_package="hera-${hera_version}-darwin-x86_64.tar.gz"
   wget "https://github.com/ewasm/hera/releases/download/v${hera_version}/${hera_package}"
+  validate_checksum "$hera_package" 190050d7ace384ecd79ec1b1f607a9ff40e196b4eec75932958d4814d221d059
   tar xzpf "$hera_package" -C /usr/local
   rm "$hera_package"
 fi

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -33,7 +33,13 @@ REPO_ROOT="$(dirname "$0")"/..
     mkdir -p "$SOLDIR/deps/downloads/" 2>/dev/null || true
     jsoncpp_version="1.9.3"
     jsoncpp_package_path="$SOLDIR/deps/downloads/jsoncpp-${jsoncpp_version}.tar.gz"
+    jsoncpp_sha256=8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d
     wget -O "$jsoncpp_package_path" "https://github.com/open-source-parsers/jsoncpp/archive/${jsoncpp_version}.tar.gz"
+    if ! [ "$(sha256sum "$jsoncpp_package_path")" = "${jsoncpp_sha256}  ${jsoncpp_package_path}" ]
+    then
+        >&2 echo "ERROR: Downloaded jsoncpp source package has wrong checksum."
+        exit 1
+    fi
     mkdir -p "$REPO_ROOT/upload"
     tar --owner 0 --group 0 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
     rm -r "$TEMPDIR"

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -31,7 +31,9 @@ REPO_ROOT="$(dirname "$0")"/..
     fi
     # Add dependencies
     mkdir -p "$SOLDIR/deps/downloads/" 2>/dev/null || true
-    wget -O "$SOLDIR/deps/downloads/jsoncpp-1.9.3.tar.gz" https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
+    jsoncpp_version="1.9.3"
+    jsoncpp_package_path="$SOLDIR/deps/downloads/jsoncpp-${jsoncpp_version}.tar.gz"
+    wget -O "$jsoncpp_package_path" "https://github.com/open-source-parsers/jsoncpp/archive/${jsoncpp_version}.tar.gz"
     mkdir -p "$REPO_ROOT/upload"
     tar --owner 0 --group 0 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
     rm -r "$TEMPDIR"

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -7,12 +7,18 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
   New-Item -ItemType Directory -Force -Path "$PSScriptRoot\..\deps"
 
   Invoke-WebRequest -URI "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-win64-x64.zip" -OutFile cmake.zip
+  if ((Get-FileHash cmake.zip).Hash -ne "5f4ec834fbd9b62fbf73bc48ed459fa2ea6a86c403106c90fedc2ac76d51612d") {
+    throw 'Downloaded CMake source package has wrong checksum.'
+  }
   tar -xf cmake.zip
   mv cmake-3.18.2-win64-x64 "$PSScriptRoot\..\deps\cmake"
 
   # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
   # and serving it a page that requires JavaScript.
   Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.zip" -OutFile boost.zip -UserAgent ""
+  if ((Get-FileHash boost.zip).Hash -ne "a0e7ce67c52d816708fdeccdd8c9725626ba61254c13c18770498cacd514710a") {
+    throw 'Downloaded Boost source package has wrong checksum.'
+  }
   tar -xf boost.zip
   cd boost_1_74_0
   .\bootstrap.bat

--- a/scripts/install_obsolete_jsoncpp_1_7_4.sh
+++ b/scripts/install_obsolete_jsoncpp_1_7_4.sh
@@ -4,9 +4,11 @@ set -eu
 TEMPDIR=$(mktemp -d)
 (
     cd "$TEMPDIR"
-    wget https://github.com/open-source-parsers/jsoncpp/archive/1.7.4.tar.gz
-    tar xvzf "1.7.4.tar.gz"
-    cd "jsoncpp-1.7.4"
+    jsoncpp_version="1.7.4"
+    jsoncpp_package="jsoncpp-${jsoncpp_version}.tar.gz"
+    wget -O "$jsoncpp_package" https://github.com/open-source-parsers/jsoncpp/archive/${jsoncpp_version}.tar.gz
+    tar xvzf "$jsoncpp_package"
+    cd "jsoncpp-${jsoncpp_version}"
     mkdir -p build
     cd build
     cmake -DARCHIVE_INSTALL_DIR=. -G "Unix Makefiles" ..

--- a/scripts/install_obsolete_jsoncpp_1_7_4.sh
+++ b/scripts/install_obsolete_jsoncpp_1_7_4.sh
@@ -15,4 +15,4 @@ TEMPDIR=$(mktemp -d)
     make
     make install
 )
-rm -rf "$TEMPDIR"
+rm -r "$TEMPDIR"

--- a/scripts/install_obsolete_jsoncpp_1_7_4.sh
+++ b/scripts/install_obsolete_jsoncpp_1_7_4.sh
@@ -6,7 +6,13 @@ TEMPDIR=$(mktemp -d)
     cd "$TEMPDIR"
     jsoncpp_version="1.7.4"
     jsoncpp_package="jsoncpp-${jsoncpp_version}.tar.gz"
+    jsoncpp_sha256=10dcd0677e80727e572a1e462193e51a5fde3e023b99e144b2ee1a469835f769
     wget -O "$jsoncpp_package" https://github.com/open-source-parsers/jsoncpp/archive/${jsoncpp_version}.tar.gz
+    if ! [ "$(sha256sum "$jsoncpp_package")" = "${jsoncpp_sha256}  ${jsoncpp_package}" ]
+    then
+        >&2 echo "ERROR: Downloaded jsoncpp source package has wrong checksum."
+        exit 1
+    fi
     tar xvzf "$jsoncpp_package"
     cd "jsoncpp-${jsoncpp_version}"
     mkdir -p build


### PR DESCRIPTION
We verify checksums in CMake and in docker images. This PR adds verification also to random scripts that download packages. Mostly for CI but not only.

~Note: this has wrong checksums right now because I want to make sure that this will actually fail in CI, especially on Windows.~ It has correct checksums now.