### PR TITLE
Update error message for error 6651 (`Data location must be ...`)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,9 @@ Bugfixes:
  * Yul IR Generator: Do not output empty switches/if-bodies for empty contracts.
 
 
+Important Bugfixes in Experimental Features:
+ * Yul IR Generator: Changes to function return variables referenced in modifier invocation arguments were not properly forwarded if there was more than one return variable.
+
 
 ### 0.8.9 (2021-09-29)
 

--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -376,12 +376,17 @@ void DeclarationTypeChecker::endVisit(VariableDeclaration const& _variable)
 			if (_variable.isConstructorParameter())
 				errorString += " for constructor parameter";
 			else if (_variable.isCallableOrCatchParameter())
+			{
+				string visibility;
+				if (auto const* callable = dynamic_cast<CallableDeclaration const*>(_variable.scope()))
+					visibility = Declaration::visibilityToString(callable->visibility());
 				errorString +=
-					" for " +
-					string(_variable.isReturnParameter() ? "return " : "") +
-					"parameter in" +
-					string(_variable.isExternalCallableParameter() ? " external" : "") +
-					" function";
+				" for " +
+				(_variable.isReturnParameter() ? "return "s : ""s) +
+				"parameter in" +
+				(visibility.empty() ? visibility : " "s + visibility) +
+				" function";
+			}
 			else
 				errorString += " for variable";
 		}

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -438,7 +438,7 @@ string IRGenerator::generateModifier(
 		for (size_t i = 0; i < retParamsIn.size(); ++i)
 		{
 			retParams.emplace_back(m_context.newYulVariable());
-			assignRetParams += retParams.back() + " := " + retParamsIn[i] + "\n";
+			assignRetParams += retParams.at(i) + " := " + retParamsIn.at(i) + "\n";
 		}
 		t("retParams", joinHumanReadable(retParams));
 		t("assignRetParams", assignRetParams);
@@ -529,7 +529,7 @@ string IRGenerator::generateFunctionWithModifierInner(FunctionDefinition const& 
 		for (size_t i = 0; i < retParams.size(); ++i)
 		{
 			retParamsIn.emplace_back(m_context.newYulVariable());
-			assignRetParams += retParams.back() + " := " + retParamsIn[i] + "\n";
+			assignRetParams += retParams.at(i) + " := " + retParamsIn.at(i) + "\n";
 		}
 		vector<string> params = retParamsIn;
 		for (auto const& varDecl: _function.parameters())

--- a/test/libsolidity/semanticTests/functionCall/precompile_extcodesize_check.sol
+++ b/test/libsolidity/semanticTests/functionCall/precompile_extcodesize_check.sol
@@ -1,0 +1,25 @@
+interface Identity {
+    function selectorAndAppendValue(uint value) external pure returns (uint);
+}
+contract C {
+    Identity constant i = Identity(address(0x0004));
+    function testHighLevel() external pure returns (bool) {
+        // Should fail because `extcodesize(4) = 0`
+        i.selectorAndAppendValue(5);
+        return true;
+    }
+    function testLowLevel() external view returns (uint value) {
+        (bool success, bytes memory ret) =
+            address(4).staticcall(
+                abi.encodeWithSelector(Identity.selectorAndAppendValue.selector, uint(5))
+            );
+        value = abi.decode(ret, (uint));
+    }
+
+}
+// ====
+// compileViaYul: also
+// EVMVersion: >=constantinople
+// ----
+// testHighLevel() -> FAILURE
+// testLowLevel() -> 0xc76596d400000000000000000000000000000000000000000000000000000000

--- a/test/libsolidity/semanticTests/modifiers/function_modifier_return_reference.sol
+++ b/test/libsolidity/semanticTests/modifiers/function_modifier_return_reference.sol
@@ -1,0 +1,15 @@
+contract C {
+    modifier m1(uint value) {
+        _;
+    }
+    modifier m2(uint value) {
+        _;
+    }
+
+    function f() public m1(x = 2) m2(y = 3) returns (uint x, uint y) {
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 2, 3

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/external_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/external_function_return_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function i() external pure returns(uint[]) {}
 }
 // ----
-// TypeError 6651: (52-58): Data location must be "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (52-58): Data location must be "memory" or "calldata" for return parameter in external function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function g(uint[]) internal pure {}
 }
 // ----
-// TypeError 6651: (28-34): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (28-34): Data location must be "storage", "memory" or "calldata" for parameter in internal function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/internal_function_return_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function g() internal pure returns(uint[]) {}
 }
 // ----
-// TypeError 6651: (52-58): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (52-58): Data location must be "storage", "memory" or "calldata" for return parameter in internal function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_external_function_return_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_external_function_return_no_data_location.sol
@@ -6,7 +6,7 @@ library L {
     function j() external pure returns (mapping(uint => uint)) {}
 }
 // ----
-// TypeError 6651: (77-84): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (129-135): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (180-181): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (226-247): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (77-84): Data location must be "storage", "memory" or "calldata" for return parameter in external function, but none was given.
+// TypeError 6651: (129-135): Data location must be "storage", "memory" or "calldata" for return parameter in external function, but none was given.
+// TypeError 6651: (180-181): Data location must be "storage", "memory" or "calldata" for return parameter in external function, but none was given.
+// TypeError 6651: (226-247): Data location must be "storage", "memory" or "calldata" for return parameter in external function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_internal_function_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_internal_function_no_data_location.sol
@@ -10,11 +10,11 @@ library L {
     function jp(mapping(uint => uint)) internal pure {}
 }
 // ----
-// TypeError 6651: (77-84): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (129-135): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (180-181): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (226-247): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (268-275): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (310-316): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (351-352): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (387-408): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (77-84): Data location must be "storage", "memory" or "calldata" for return parameter in internal function, but none was given.
+// TypeError 6651: (129-135): Data location must be "storage", "memory" or "calldata" for return parameter in internal function, but none was given.
+// TypeError 6651: (180-181): Data location must be "storage", "memory" or "calldata" for return parameter in internal function, but none was given.
+// TypeError 6651: (226-247): Data location must be "storage", "memory" or "calldata" for return parameter in internal function, but none was given.
+// TypeError 6651: (268-275): Data location must be "storage", "memory" or "calldata" for parameter in internal function, but none was given.
+// TypeError 6651: (310-316): Data location must be "storage", "memory" or "calldata" for parameter in internal function, but none was given.
+// TypeError 6651: (351-352): Data location must be "storage", "memory" or "calldata" for parameter in internal function, but none was given.
+// TypeError 6651: (387-408): Data location must be "storage", "memory" or "calldata" for parameter in internal function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_private_function_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_private_function_no_data_location.sol
@@ -10,11 +10,11 @@ library L {
     function jp(mapping(uint => uint)) private pure {}
 }
 // ----
-// TypeError 6651: (76-83): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (127-133): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (177-178): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (222-243): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (264-271): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (305-311): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (345-346): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (380-401): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (76-83): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (127-133): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (177-178): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (222-243): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (264-271): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.
+// TypeError 6651: (305-311): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.
+// TypeError 6651: (345-346): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.
+// TypeError 6651: (380-401): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_public_function_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_public_function_no_data_location.sol
@@ -9,11 +9,11 @@ library L {
     function ip(S) private pure {}
     function jp(mapping(uint => uint)) private pure {}}
 // ----
-// TypeError 6651: (76-83): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (127-133): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (177-178): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (222-243): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
-// TypeError 6651: (264-271): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (305-311): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (345-346): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
-// TypeError 6651: (380-401): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (76-83): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (127-133): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (177-178): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (222-243): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.
+// TypeError 6651: (264-271): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.
+// TypeError 6651: (305-311): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.
+// TypeError 6651: (345-346): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.
+// TypeError 6651: (380-401): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function f(uint[]) private pure {}
 }
 // ----
-// TypeError 6651: (28-34): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (28-34): Data location must be "storage", "memory" or "calldata" for parameter in private function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_return_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function f() private pure returns(uint[]) {}
 }
 // ----
-// TypeError 6651: (51-57): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (51-57): Data location must be "storage", "memory" or "calldata" for return parameter in private function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_storage.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_storage.sol
@@ -2,4 +2,4 @@ contract test {
     function f(bytes storage) public;
 }
 // ----
-// TypeError 6651: (31-44): Data location must be "memory" or "calldata" for parameter in function, but "storage" was given.
+// TypeError 6651: (31-44): Data location must be "memory" or "calldata" for parameter in public function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function h(uint[]) public pure {}
 }
 // ----
-// TypeError 6651: (28-34): Data location must be "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (28-34): Data location must be "memory" or "calldata" for parameter in public function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_return_parameters_no_data_location.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_return_parameters_no_data_location.sol
@@ -2,4 +2,4 @@ contract C {
     function h() public pure returns(uint[]) {}
 }
 // ----
-// TypeError 6651: (50-56): Data location must be "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (50-56): Data location must be "memory" or "calldata" for return parameter in public function, but none was given.

--- a/test/libsolidity/syntaxTests/types/mapping/argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/argument_public.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6651: (28-57): Data location must be "memory" or "calldata" for parameter in function, but "storage" was given.
+// TypeError 6651: (28-57): Data location must be "memory" or "calldata" for parameter in public function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/array_argument_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/array_argument_public.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6651: (28-59): Data location must be "memory" or "calldata" for parameter in function, but "storage" was given.
+// TypeError 6651: (28-59): Data location must be "memory" or "calldata" for parameter in public function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/contract_storage_parameter_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/contract_storage_parameter_with_mapping.sol
@@ -3,4 +3,4 @@ contract C {
     function f(S storage s) public {}
 }
 // ----
-// TypeError 6651: (69-80): Data location must be "memory" or "calldata" for parameter in function, but "storage" was given.
+// TypeError 6651: (69-80): Data location must be "memory" or "calldata" for parameter in public function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_array_return_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_array_return_external.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6651: (53-84): Data location must be "memory" or "calldata" for return parameter in function, but "storage" was given.
+// TypeError 6651: (53-84): Data location must be "memory" or "calldata" for return parameter in external function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_array_return_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_array_return_public.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6651: (51-82): Data location must be "memory" or "calldata" for return parameter in function, but "storage" was given.
+// TypeError 6651: (51-82): Data location must be "memory" or "calldata" for return parameter in public function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_return_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_return_external.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6651: (53-82): Data location must be "memory" or "calldata" for return parameter in function, but "storage" was given.
+// TypeError 6651: (53-82): Data location must be "memory" or "calldata" for return parameter in external function, but "storage" was given.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_return_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_return_public.sol
@@ -3,4 +3,4 @@ contract C {
     }
 }
 // ----
-// TypeError 6651: (51-80): Data location must be "memory" or "calldata" for return parameter in function, but "storage" was given.
+// TypeError 6651: (51-80): Data location must be "memory" or "calldata" for return parameter in public function, but "storage" was given.


### PR DESCRIPTION
External and public functions are not allowed to have parameters whose data location is storage. The error message has been updated to reflect this fact. 

This was originally requested in  #[11987](https://github.com/ethereum/solidity/issues/11987)