### PR TITLE
Fix version check for docs

### DIFF
--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -124,7 +124,7 @@ function findMinimalVersion()
         fi
     done
 
-    if [[ "$version" == "" ]]
+    if [[ "$version" == "" && "$greater" == false ]]
     then
         printError "No release ${sign}${pragmaVersion} was listed in available releases!"
         exit 1


### PR DESCRIPTION
Versions using the syntax `>0.8.8` would cause an error in the CI if you are on
that version due to the removal of the `greater` check in c63fd0a1af

This adds that check back.