### PR TITLE
Remove leftovers of `compact-format` and `interface` from `--combined-json`

### DIFF
--- a/scripts/ASTImportTest.sh
+++ b/scripts/ASTImportTest.sh
@@ -45,9 +45,9 @@ function testImportExportEquivalence {
         ! [[ -e stderr.txt ]] || { echo "stderr.txt already exists. Refusing to overwrite."; exit 1; }
 
         # save exported json as expected result (silently)
-        $SOLC --combined-json ast,compact-format --pretty-json "$nth_input_file" "${all_input_files[@]}" > expected.json 2> /dev/null
+        $SOLC --combined-json ast --pretty-json "$nth_input_file" "${all_input_files[@]}" > expected.json 2> /dev/null
         # import it, and export it again as obtained result (silently)
-        if ! $SOLC --import-ast --combined-json ast,compact-format --pretty-json expected.json > obtained.json 2> stderr.txt
+        if ! $SOLC --import-ast --combined-json ast --pretty-json expected.json > obtained.json 2> stderr.txt
         then
             # For investigating, use exit 1 here so the script stops at the
             # first failing test

--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -20,7 +20,7 @@
 # ------------------------------------------------------------------------------
 
 YULARGS=(--strict-assembly)
-FULLARGS=(--optimize --ignore-missing --combined-json "abi,asm,ast,bin,bin-runtime,compact-format,devdoc,hashes,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
+FULLARGS=(--optimize --ignore-missing --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,hashes,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
 OLDARGS=(--optimize --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
 function compileFull()
 {

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -95,7 +95,7 @@ private:
 
 	/// Tries to read @ m_sourceCodes as a JSONs holding ASTs
 	/// such that they can be imported into the compiler  (importASTs())
-	/// (produced by --combined-json ast,compact-format <file.sol>
+	/// (produced by --combined-json ast <file.sol>
 	/// or standard-json output
 	std::map<std::string, Json::Value> parseAstFromInput();
 

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -63,7 +63,6 @@ static string const g_strAstCompactJson = "ast-compact-json";
 static string const g_strBinary = "bin";
 static string const g_strBinaryRuntime = "bin-runtime";
 static string const g_strCombinedJson = "combined-json";
-static string const g_strCompactJSON = "compact-format";
 static string const g_strErrorRecovery = "error-recovery";
 static string const g_strEVM = "evm";
 static string const g_strEVMVersion = "evm-version";
@@ -75,7 +74,6 @@ static string const g_strGas = "gas";
 static string const g_strHelp = "help";
 static string const g_strImportAst = "import-ast";
 static string const g_strInputFile = "input-file";
-static string const g_strInterface = "interface";
 static string const g_strYul = "yul";
 static string const g_strYulDialect = "yul-dialect";
 static string const g_strIR = "ir";
@@ -146,12 +144,10 @@ static set<string> const g_combinedJsonArgs
 	g_strAst,
 	g_strBinary,
 	g_strBinaryRuntime,
-	g_strCompactJSON,
 	g_strFunDebug,
 	g_strFunDebugRuntime,
 	g_strGeneratedSources,
 	g_strGeneratedSourcesRuntime,
-	g_strInterface,
 	g_strMetadata,
 	g_strNatspecUser,
 	g_strNatspecDev,
@@ -627,7 +623,7 @@ General Information)").c_str(),
 			g_strImportAst.c_str(),
 			("Import ASTs to be compiled, assumes input holds the AST in compact JSON format. "
 			"Supported Inputs is the output of the --" + g_strStandardJSON + " or the one produced by "
-			"--" + g_strCombinedJson + " " + g_strAst + "," + g_strCompactJSON).c_str()
+			"--" + g_strCombinedJson + " " + g_strAst).c_str()
 		)
 	;
 	desc.add(alternativeInputModes);

--- a/test/cmdlineTests/ast_json_import_wrong_evmVersion/args
+++ b/test/cmdlineTests/ast_json_import_wrong_evmVersion/args
@@ -1,1 +1,1 @@
---evm-version=homestead --import-ast --combined-json ast,compact-format --pretty-json
+--evm-version=homestead --import-ast --combined-json ast --pretty-json

--- a/test/stopAfterParseTests.sh
+++ b/test/stopAfterParseTests.sh
@@ -18,7 +18,7 @@ cd "$FILETMP" || exit 1
 function testFile()
 {
 	set +e
-	ALLOUTPUT=$($SOLC --combined-json ast,compact-format --pretty-json "$@" --stop-after parsing 2>&1)
+	ALLOUTPUT=$($SOLC --combined-json ast --pretty-json "$@" --stop-after parsing 2>&1)
 	local RESULT=$?
 	set -e
 	if test ${RESULT} -ne 0; then


### PR DESCRIPTION
These two values are completely ignored by the compiler but they're still valid as `--combined-json` arguments. This PR removes them.

Technically it's a breaking change, but this option has already stopped doing what it was originally supposed to do so at this point it's just cleanup of stuff that's already broken.