### PR TITLE
Refactor CLI output selection flags

### DIFF
--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -578,7 +578,7 @@ General Information)").c_str(),
 		)
 		(
 			g_strRevertStrings.c_str(),
-			po::value<string>()->value_name(boost::join(g_revertStringsArgs, ",")),
+			po::value<string>()->value_name(joinHumanReadable(g_revertStringsArgs, ",")),
 			"Strip revert (and require) reason strings or add additional debugging information."
 		)
 		(
@@ -632,12 +632,12 @@ General Information)").c_str(),
 	assemblyModeOptions.add_options()
 		(
 			g_strMachine.c_str(),
-			po::value<string>()->value_name(boost::join(g_machineArgs, ",")),
+			po::value<string>()->value_name(joinHumanReadable(g_machineArgs, ",")),
 			"Target machine in assembly or Yul mode."
 		)
 		(
 			g_strYulDialect.c_str(),
-			po::value<string>()->value_name(boost::join(g_yulDialectArgs, ",")),
+			po::value<string>()->value_name(joinHumanReadable(g_yulDialectArgs, ",")),
 			"Input dialect to use in assembly or yul mode."
 		)
 	;
@@ -709,7 +709,7 @@ General Information)").c_str(),
 		)
 		(
 			g_strCombinedJson.c_str(),
-			po::value<string>()->value_name(boost::join(g_combinedJsonArgs, ",")),
+			po::value<string>()->value_name(joinHumanReadable(g_combinedJsonArgs, ",")),
 			"Output a single json document containing the specified information."
 		)
 	;
@@ -719,7 +719,7 @@ General Information)").c_str(),
 	metadataOptions.add_options()
 		(
 			g_strMetadataHash.c_str(),
-			po::value<string>()->value_name(boost::join(g_metadataHashArgs, ",")),
+			po::value<string>()->value_name(joinHumanReadable(g_metadataHashArgs, ",")),
 			"Choose hash method for the bytecode metadata or disable it."
 		)
 		(

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -176,6 +176,16 @@ bool CompilerOutputs::operator==(CompilerOutputs const& _other) const noexcept
 	return true;
 }
 
+ostream& operator<<(ostream& _out, CompilerOutputs const& _selection)
+{
+	vector<string> serializedSelection;
+	for (auto&& [componentName, component]: CompilerOutputs::componentMap())
+		if (_selection.*component)
+			serializedSelection.push_back(CompilerOutputs::componentName(component));
+
+	return _out << joinHumanReadable(serializedSelection, ",");
+}
+
 string const& CompilerOutputs::componentName(bool CompilerOutputs::* _component)
 {
 	solAssert(_component, "");
@@ -194,6 +204,17 @@ bool CombinedJsonRequests::operator==(CombinedJsonRequests const& _other) const 
 		if (this->*member != _other.*member)
 			return false;
 	return true;
+}
+
+
+ostream& operator<<(ostream& _out, CombinedJsonRequests const& _requests)
+{
+	vector<string> serializedRequests;
+	for (auto&& [componentName, component]: CombinedJsonRequests::componentMap())
+		if (_requests.*component)
+			serializedRequests.push_back(CombinedJsonRequests::componentName(component));
+
+	return _out << joinHumanReadable(serializedRequests, ",");
 }
 
 string const& CombinedJsonRequests::componentName(bool CombinedJsonRequests::* _component)

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -55,6 +55,7 @@ struct CompilerOutputs
 {
 	bool operator!=(CompilerOutputs const& _other) const noexcept { return !(*this == _other); }
 	bool operator==(CompilerOutputs const& _other) const noexcept;
+	friend std::ostream& operator<<(std::ostream& _out, CompilerOutputs const& _requests);
 
 	static std::string const& componentName(bool CompilerOutputs::* _component);
 	static auto const& componentMap()
@@ -100,6 +101,7 @@ struct CombinedJsonRequests
 {
 	bool operator!=(CombinedJsonRequests const& _other) const noexcept { return !(*this == _other); }
 	bool operator==(CombinedJsonRequests const& _other) const noexcept;
+	friend std::ostream& operator<<(std::ostream& _out, CombinedJsonRequests const& _requests);
 
 	static std::string const& componentName(bool CombinedJsonRequests::* _component);
 	static auto const& componentMap()

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -101,6 +101,31 @@ struct CombinedJsonRequests
 	bool operator!=(CombinedJsonRequests const& _other) const noexcept { return !(*this == _other); }
 	bool operator==(CombinedJsonRequests const& _other) const noexcept;
 
+	static std::string const& componentName(bool CombinedJsonRequests::* _component);
+	static auto const& componentMap()
+	{
+		static std::map<std::string, bool CombinedJsonRequests::*> const components = {
+			{"abi", &CombinedJsonRequests::abi},
+			{"metadata", &CombinedJsonRequests::metadata},
+			{"bin", &CombinedJsonRequests::binary},
+			{"bin-runtime", &CombinedJsonRequests::binaryRuntime},
+			{"opcodes", &CombinedJsonRequests::opcodes},
+			{"asm", &CombinedJsonRequests::asm_},
+			{"storage-layout", &CombinedJsonRequests::storageLayout},
+			{"generated-sources", &CombinedJsonRequests::generatedSources},
+			{"generated-sources-runtime", &CombinedJsonRequests::generatedSourcesRuntime},
+			{"srcmap", &CombinedJsonRequests::srcMap},
+			{"srcmap-runtime", &CombinedJsonRequests::srcMapRuntime},
+			{"function-debug", &CombinedJsonRequests::funDebug},
+			{"function-debug-runtime", &CombinedJsonRequests::funDebugRuntime},
+			{"hashes", &CombinedJsonRequests::signatureHashes},
+			{"devdoc", &CombinedJsonRequests::natspecDev},
+			{"userdoc", &CombinedJsonRequests::natspecUser},
+			{"ast", &CombinedJsonRequests::ast},
+		};
+		return components;
+	}
+
 	bool abi = false;
 	bool metadata = false;
 	bool binary = false;

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -56,6 +56,29 @@ struct CompilerOutputs
 	bool operator!=(CompilerOutputs const& _other) const noexcept { return !(*this == _other); }
 	bool operator==(CompilerOutputs const& _other) const noexcept;
 
+	static std::string const& componentName(bool CompilerOutputs::* _component);
+	static auto const& componentMap()
+	{
+		static std::map<std::string, bool CompilerOutputs::*> const components = {
+			{"ast-compact-json", &CompilerOutputs::astCompactJson},
+			{"asm", &CompilerOutputs::asm_},
+			{"asm-json", &CompilerOutputs::asmJson},
+			{"opcodes", &CompilerOutputs::opcodes},
+			{"bin", &CompilerOutputs::binary},
+			{"bin-runtime", &CompilerOutputs::binaryRuntime},
+			{"abi", &CompilerOutputs::abi},
+			{"ir", &CompilerOutputs::ir},
+			{"ir-optimized", &CompilerOutputs::irOptimized},
+			{"ewasm", &CompilerOutputs::ewasm},
+			{"hashes", &CompilerOutputs::signatureHashes},
+			{"userdoc", &CompilerOutputs::natspecUser},
+			{"devdoc", &CompilerOutputs::natspecDev},
+			{"metadata", &CompilerOutputs::metadata},
+			{"storage-layout", &CompilerOutputs::storageLayout},
+		};
+		return components;
+	}
+
 	bool astCompactJson = false;
 	bool asm_ = false;
 	bool asmJson = false;


### PR DESCRIPTION
~Depends on #12069. In draft mode until that PR is merged.~ Merged.

A small refactor to bring the structs that represent sets of boolean flags for selecting compiler outputs more in line with what I did with `DebugInfoSelection` in #11944. Now they use maps of pointer-to-members to avoid enumerating fields by hand - this gets really repetitive and error prone with structs that have 15+ fields.

This is needed for the next PR which actually changes the validation logic.