### PR TITLE
New Wikipedia feature implemented in Solidity docs!

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,3 +4,12 @@
     {{ super() }}
 	<a href="{{ pathto('genindex') }}">Keyword Index</a>
   {% endblock %}
+
+  {%- block extrahead %}
+	<script src="https://unpkg.com/wikipedia-preview@1.4.0/dist/wikipedia-preview.production.js"></script>
+	  <script>
+            wikipediaPreview.init({
+              detectLinks: true
+            })
+	  </script>
+  {% endblock %}


### PR DESCRIPTION
  
Hello everyone! Not many people knew about this (including me) but recently the Inuka team at the Wikimedia Foundation released Wikipedia previews for external websites, meaning that any website can implement this and have the Wikipedia page previews work on their website too! (Wikipedia page previews are the page previews that pop up when you hover over certain terms while browsing the Wikipedia on a computer, they also work on mobile but in a different manner).
Anyway, the point is: I think it would be a great addition to the Solidity docs, it would mean that the reader wouldn't have to open a 
  Wikipedia page every time they want to get a quick grasp of a concept or just to get a refresher, basically it has the same purpose as it does inside Wikipedia.
A few things to note are: 
1. I've never used reStructuredText before so the change in code I'm proposing may be totally or partially broken, so feel free to make changes if necessary.
2. I did test the script elements part of the code with developer tools override and it worked wonderfully.
3. My implementation doesn't make design changes to the Hyperlink, it is not the same as in the "Wikimedia's Demo" link below, the Hyperlinks stay the same, the only thing that changes is when you hover over (or click, on mobile) a Wikipedia Hyperlink a Wikipedia page preview is shown. 

I will now be leaving some relevant links to this PR below.

Wikimedia's blog post on the feature: https://diff.wikimedia.org/2021/07/29/new-wikipedia-preview-feature-provides-context-from-wikipedia-across-the-web/

Official GitHub repo for the feature being discussed: https://github.com/wikimedia/wikipedia-preview

Wikimedia's Demo: https://wikimedia.github.io/wikipedia-preview/demo/articles/english.html