### PR TITLE
Error helpers + small refactors in `cmdlineTests.sh`

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -39,6 +39,74 @@ function fail()
     return 1
 }
 
+function msg_on_error()
+{
+    local error_message
+    local no_stdout=false
+    local no_stderr=false
+
+    while [[ $1 =~ ^-- ]]
+    do
+        case "$1" in
+            --msg)
+                error_message="$2"
+                shift
+                shift
+                ;;
+            --no-stdout)
+                no_stdout=true
+                shift
+                ;;
+            --no-stderr)
+                no_stderr=true
+                shift
+                ;;
+            --silent)
+                no_stdout=true
+                no_stderr=true
+                shift
+                ;;
+            *)
+                fail "Invalid option for msg_on_error: $1"
+                ;;
+        esac
+    done
+
+    local command=("$@")
+
+    local stdout_file stderr_file
+    stdout_file="$(mktemp -t cmdline_test_command_stdout_XXXXXX.txt)"
+    stderr_file="$(mktemp -t cmdline_test_command_stderr_XXXXXX.txt)"
+
+    if "${command[@]}" > "$stdout_file" 2> "$stderr_file"
+    then
+        [[ $no_stdout == "true" ]] || cat "$stdout_file"
+        [[ $no_stderr == "true" ]] || >&2 cat "$stderr_file"
+        rm "$stdout_file" "$stderr_file"
+        return 0
+    else
+        printError "Command failed: $SOLC ${command[*]}"
+        if [[ -s "$stdout_file" ]]
+        then
+            printError "stdout:"
+            >&2 cat "$stdout_file"
+        else
+            printError "stdout: <EMPTY>"
+        fi
+        if [[ -s "$stderr_file" ]]
+        then
+            printError "stderr:"
+            >&2 cat "$stderr_file"
+        else
+            printError "stderr: <EMPTY>"
+        fi
+
+        printError "$error_message"
+        rm "$stdout_file" "$stderr_file"
+        return 1
+    fi
+}
+
 safe_kill()
 {
     local PID=${1}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,6 +33,12 @@ else
     function printLog() { echo "$(tput setaf 3)$1$(tput sgr0)"; }
 fi
 
+function fail()
+{
+    printError "$@"
+    return 1
+}
+
 safe_kill()
 {
     local PID=${1}

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -323,8 +323,7 @@ printTask "Testing unknown options..."
     then
         echo "Passed"
     else
-        printError "Incorrect response to unknown options: $output"
-        exit 1
+        fail "Incorrect response to unknown options: $output"
     fi
 )
 
@@ -346,8 +345,7 @@ printTask "Running general commandline tests..."
     do
         if ! [[ -d $tdir ]]
         then
-            printError "Test directory not found: $tdir"
-            exit 1
+            fail "Test directory not found: $tdir"
         fi
 
         printTask " - ${tdir}"
@@ -383,7 +381,7 @@ printTask "Running general commandline tests..."
 
         if [ "${inputFile}" = "${tdir}/input.json" ]
         then
-            ! [ -e "${tdir}/stdin" ] || { printError "Found a file called 'stdin' but redirecting standard input in JSON mode is not allowed."; exit 1; }
+            ! [ -e "${tdir}/stdin" ] || fail "Found a file called 'stdin' but redirecting standard input in JSON mode is not allowed."
 
             stdin="${inputFile}"
             inputFile=""
@@ -394,7 +392,7 @@ printTask "Running general commandline tests..."
             if [ -e "${tdir}/stdin" ]
             then
                 stdin="${tdir}/stdin"
-                [ -f "${tdir}/stdin" ] || { printError "'stdin' is not a regular file."; exit 1; }
+                [ -f "${tdir}/stdin" ] || fail "'stdin' is not a regular file."
             else
                 stdin=""
             fi
@@ -543,22 +541,19 @@ SOLTMPDIR=$(mktemp -d)
     # This should fail
     if [[ ! ("$output" =~ "No input files given") || ($result == 0) ]]
     then
-        printError "Incorrect response to empty input arg list: $output"
-        exit 1
+        fail "Incorrect response to empty input arg list: $output"
     fi
 
     # The contract should be compiled
     if ! output=$(echo 'contract C {} ' | "$SOLC" - --bin 2>/dev/null | grep -q "<stdin>:C")
     then
-        printError "Failed to compile a simple contract from standard input"
-        exit 1
+        fail "Failed to compile a simple contract from standard input"
     fi
 
     # This should not fail
     if ! output=$(echo '' | "$SOLC" --ast-compact-json - 2>/dev/null)
     then
-        printError "Incorrect response to --ast-compact-json option with empty stdin"
-        exit 1
+        fail "Incorrect response to --ast-compact-json option with empty stdin"
     fi
 )
 rm -r "$SOLTMPDIR"

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -283,7 +283,7 @@ EOF
         [[ $stderr_expectation_file == "" ]] && exit 1
     fi
 
-    rm -f "$stdout_path" "$stderr_path"
+    rm "$stdout_path" "$stderr_path"
 }
 
 
@@ -471,7 +471,7 @@ SOLTMPDIR=$(mktemp -d)
         compileFull "${opts[@]}" "$SOLTMPDIR/$f"
     done
 )
-rm -rf "$SOLTMPDIR"
+rm -r "$SOLTMPDIR"
 echo "Done."
 
 printTask "Testing library checksum..."
@@ -497,7 +497,7 @@ SOLTMPDIR=$(mktemp -d)
     # Now the placeholder and explanation should be gone.
     grep -q -v '[/_]' C.bin
 )
-rm -rf "$SOLTMPDIR"
+rm -r "$SOLTMPDIR"
 
 printTask "Testing overwriting files..."
 SOLTMPDIR=$(mktemp -d)
@@ -510,7 +510,7 @@ SOLTMPDIR=$(mktemp -d)
     # Unless we force
     echo 'contract C {} ' | "$SOLC" - --overwrite --bin -o "$SOLTMPDIR/non-existing-stuff-to-create" 2>/dev/null
 )
-rm -rf "$SOLTMPDIR"
+rm -r "$SOLTMPDIR"
 
 printTask "Testing assemble, yul, strict-assembly and optimize..."
 (
@@ -574,7 +574,7 @@ SOLTMPDIR=$(mktemp -d)
         exit 1
     fi
 )
-rm -rf "$SOLTMPDIR"
+rm -r "$SOLTMPDIR"
 
 printTask "Testing AST export with stop-after=parsing..."
 "$REPO_ROOT/test/stopAfterParseTests.sh"
@@ -590,6 +590,6 @@ SOLTMPDIR=$(mktemp -d)
     echo ./*.sol | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
     echo ./*.sol | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
 )
-rm -rf "$SOLTMPDIR"
+rm -r "$SOLTMPDIR"
 
 echo "Commandline tests successful."

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -26,7 +26,7 @@
 # (c) 2016 solidity contributors.
 #------------------------------------------------------------------------------
 
-set -e
+set -eo pipefail
 
 ## GLOBAL VARIABLES
 

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -485,7 +485,6 @@ printTask "Testing linking itself..."
 SOLTMPDIR=$(mktemp -d)
 (
     cd "$SOLTMPDIR"
-    set -e
     echo 'library L { function f() public pure {} } contract C { function f() public pure { L.f(); } }' > x.sol
     "$SOLC" --bin -o . x.sol 2>/dev/null
     # Explanation and placeholder should be there
@@ -502,7 +501,6 @@ rm -r "$SOLTMPDIR"
 printTask "Testing overwriting files..."
 SOLTMPDIR=$(mktemp -d)
 (
-    set -e
     # First time it works
     echo 'contract C {} ' | "$SOLC" - --bin -o "$SOLTMPDIR/non-existing-stuff-to-create" 2>/dev/null
     # Second time it fails
@@ -538,7 +536,7 @@ printTask "Testing standard input..."
 SOLTMPDIR=$(mktemp -d)
 (
     set +e
-    output=$("$SOLC" --bin  2>&1)
+    output=$("$SOLC" --bin 2>&1)
     result=$?
     set -e
 
@@ -563,6 +561,7 @@ SOLTMPDIR=$(mktemp -d)
         exit 1
     fi
 )
+rm -r "$SOLTMPDIR"
 
 printTask "Testing AST import..."
 SOLTMPDIR=$(mktemp -d)


### PR DESCRIPTION
A bunch of small tweaks to improve error reporting extracted out of my upcoming PR for #11877.

The biggest part is a helper Bash function that takes a command, and, if that command fails, prints stdout, stderr and exits. Doing this manually after every command adds a lot of boilerplate. I'll have 5 commands to handle so at this point it's more efficient to just write one reusable helper. It's also already useful in `cmdlineTests.sh` because there are a lot of places where we expect success and stderr gets sent to `/dev/null`. The helper will make debugging test failures there easier.

Other than that there are a few small refactors: `fail` helper, removal of `--force` from `rm`, unnecessary `set -e` in a few places and one missing `rm -r "$SOLTMPDIR"` (finally my `/tmp` won't be filled with garbage after running these tests). I have also enabled `set -o pipefail` - looks like it does not cause any spurious failures in this script.