### PR TITLE
More strongly recommend to use the latest version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,10 @@ With Solidity you can create contracts for uses such as voting, crowdfunding, bl
 and multi-signature wallets.
 
 When deploying contracts, you should use the latest released
-version of Solidity. This is because breaking changes as well as
-new features and bug fixes are introduced regularly. We currently use
+version of Solidity. Apart from exceptional cases, only the latest version receives
+`security fixes<https://github.com/ethereum/solidity/security/policy#supported-versions>`.
+Furthermore, breaking changes as well as
+new features are introduced regularly. We currently use
 a 0.x version number `to indicate this fast pace of change <https://semver.org/#spec-item-4>`_.
 
 .. warning::


### PR DESCRIPTION
The publish Solidity security policy should be helpful to people when deciding which version of Solidity to use. So a reference is added.