### PR TITLE
Less verbose errors from `compileFull()`

### DIFF
--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -20,7 +20,7 @@
 # ------------------------------------------------------------------------------
 
 YULARGS=(--strict-assembly)
-FULLARGS=(--optimize --ignore-missing --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,hashes,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
+FULLARGS=(--optimize --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,hashes,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
 OLDARGS=(--optimize --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
 function compileFull()
 {

--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -99,7 +99,7 @@ function compileFull()
         printError "Inside directory:"
         echo "    $(pwd)"
         printError "Input was:"
-        cat -- "${files[@]}"
+        echo "${files[@]}"
         false
     fi
 }

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -424,7 +424,8 @@ printTask "Compiling various other contracts and libraries..."
     do
         echo " - $dir"
         cd "$dir"
-        compileFull --expect-warnings ./*.sol ./*/*.sol
+        # shellcheck disable=SC2046 # These file names are not supposed to contain spaces.
+        compileFull --expect-warnings $(find . -name '*.sol')
         cd ..
     done
 )


### PR DESCRIPTION
Recently I've been getting oddly verbose output from command-line tests in case of some failures. Turns out that it's because #11645 made `compileFull()` print content of input files on failure - and in case of tests like `corion` the content is very long. This PR makes it print only file names.

I also noticed that shell globs used to find input files sometimes results in literal `./*/*` being passed to the compiler, which is apparently the reason why `--ignore-missing` flag is used. I fixed that by replacing the glob with `find`.