### PR TITLE
Extra debug info about unknown exceptions

### DIFF
--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -171,7 +171,7 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 	}
 	catch (...)
 	{
-		return ReadCallback::Result{false, "Unknown exception in read callback."};
+		return ReadCallback::Result{false, "Unknown exception in read callback: " + boost::current_exception_diagnostic_information()};
 	}
 }
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1151,13 +1151,13 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 			"Exception during compilation: " + boost::diagnostic_information(_exception)
 		));
 	}
-	catch (std::exception const& _e)
+	catch (std::exception const& _exception)
 	{
 		errors.append(formatError(
 			Error::Severity::Error,
 			"Exception",
 			"general",
-			"Unknown exception during compilation" + (_e.what() ? ": " + string(_e.what()) : ".")
+			"Unknown exception during compilation: " + boost::diagnostic_information(_exception)
 		));
 	}
 	catch (...)
@@ -1166,7 +1166,7 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 			Error::Severity::Error,
 			"Exception",
 			"general",
-			"Unknown exception during compilation."
+			"Unknown exception during compilation: " + boost::current_exception_diagnostic_information()
 		));
 	}
 
@@ -1481,7 +1481,7 @@ Json::Value StandardCompiler::compile(Json::Value const& _input) noexcept
 	}
 	catch (...)
 	{
-		return formatFatalError("InternalCompilerError", "Internal exception in StandardCompiler::compile");
+		return formatFatalError("InternalCompilerError", "Internal exception in StandardCompiler::compile: " +  boost::current_exception_diagnostic_information());
 	}
 }
 

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -87,6 +87,10 @@ void runTestCase(TestCase::Config const& _config, TestCase::TestCaseCreator cons
 	{
 		BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
 	}
+	catch (...)
+	{
+		BOOST_ERROR("Unknown exception during extracted test: " << boost::current_exception_diagnostic_information());
+	}
 }
 
 int registerTests(

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -112,9 +112,14 @@ bytes compileFirstExpression(
 		if (!sourceUnit)
 			return bytes();
 	}
-	catch(boost::exception const& _e)
+	catch (boost::exception const& _e)
 	{
-		auto msg = std::string("Parsing source code failed with: \n") + boost::diagnostic_information(_e);
+		string msg = "Parsing source code failed with:\n" + boost::diagnostic_information(_e);
+		BOOST_FAIL(msg);
+	}
+	catch (...)
+	{
+		string msg = "Parsing source code failed with:\n" + boost::current_exception_diagnostic_information();
 		BOOST_FAIL(msg);
 	}
 

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -201,15 +201,13 @@ TestTool::Result TestTool::process()
 	catch (std::exception const& _e)
 	{
 		AnsiColorized(cout, formatted, {BOLD, RED}) <<
-			"Exception during test" <<
-			(_e.what() ? ": " + string(_e.what()) : ".") <<
-			endl;
+			"Exception during test: " << boost::diagnostic_information(_e) << endl;
 		return Result::Exception;
 	}
 	catch (...)
 	{
 		AnsiColorized(cout, formatted, {BOLD, RED}) <<
-			"Unknown exception during test." << endl;
+			"Unknown exception during test: " << boost::current_exception_diagnostic_information() << endl;
 		return Result::Exception;
 	}
 }

--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -306,13 +306,13 @@ void SourceUpgrade::tryCompile() const
 	{
 		error() << "Exception during compilation: " << boost::diagnostic_information(_exception) << endl;
 	}
-	catch (std::exception const& _e)
+	catch (std::exception const& _exception)
 	{
-		error() << (_e.what() ? ": " + string(_e.what()) : ".") << endl;
+		error() << "Exception during compilation: " << boost::diagnostic_information(_exception) << endl;
 	}
 	catch (...)
 	{
-		error() << "Unknown exception during compilation." << endl;
+		error() << "Unknown exception during compilation: " << boost::current_exception_diagnostic_information() << endl;
 	}
 }
 
@@ -517,7 +517,7 @@ ReadCallback::Callback SourceUpgrade::fileReader()
 		}
 		catch (...)
 		{
-			return ReadCallback::Result{false, "Unknown exception in read callback."};
+			return ReadCallback::Result{false, "Unknown exception in read callback: " + boost::current_exception_diagnostic_information()};
 		}
 	};
 

--- a/tools/solidityUpgrade/main.cpp
+++ b/tools/solidityUpgrade/main.cpp
@@ -86,6 +86,10 @@ int main(int argc, char** argv)
 	{
 		cerr << "Exception while processing input: " << boost::diagnostic_information(_exception) << endl;
 	}
+	catch (...)
+	{
+		cerr << "Unknown exception while processing input: " << boost::current_exception_diagnostic_information() << endl;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
We can use `boost::current_exception_diagnostic_information()` to get some info about the exception (in particular its type) even in the `(...)` handler. Also, `boost::diagnostic_information()` works with `std::exception` too.

Related to #11762. Does not depend on it but also does not touch the handlers refactored in that PR.