### PR TITLE
Include OS and CPU architecture in CircleCI cache keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,14 +627,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
       # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
       - run:
           name: Install build dependencies
           command: ./.circleci/osx_install_dependencies.sh
       - save_cache:
-          key: dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+          key: dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
           paths:
             - /usr/local/bin
             - /usr/local/sbin
@@ -663,7 +663,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - attach_workspace:
           at: .
       - run: *run_soltest
@@ -679,7 +679,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       - attach_workspace:
           at: .
       - run: *run_cmdline_tests
@@ -886,14 +886,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-win-{{ checksum "scripts/install_deps.ps1" }}
+            - dependencies-win-{{ arch }}-{{ checksum "scripts/install_deps.ps1" }}
       # DO NOT EDIT between here and save_cache, but rather edit .\scripts\install_deps.ps1
       # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
       - run:
           name: "Installing dependencies"
           command: .\scripts\install_deps.ps1
       - save_cache:
-          key: dependencies-win-{{ checksum "scripts/install_deps.ps1" }}
+          key: dependencies-win-{{ arch }}-{{ checksum "scripts/install_deps.ps1" }}
           paths:
             - .\deps
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,17 @@ defaults:
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
 
+  - steps_restore_cache_homebrew_workaround: &steps_restore_cache_homebrew_workaround
+      steps:
+        - run:
+            # FIXME: For some reason restore_cache fails saying that it cannot remove the scm/ dir.
+            # The directory contains only two files: `git` (wrapper script over git) and `svn` (symlink
+            # to `git`). This looks like a bug in restore_cache. Removing scm/ is a workaround.
+            # See https://github.com/ethereum/solidity/pull/12106 for more details.
+            name: Workaround for restore_cache + /usr/local/Homebrew/Library/Homebrew/shims/scm/
+            command: |
+              rm -r /usr/local/Homebrew/Library/Homebrew/shims/scm/
+
   - test_ubuntu1604_clang: &test_ubuntu1604_clang
       docker:
         - image: << pipeline.parameters.ubuntu-1604-clang-ossfuzz-docker-image >>
@@ -625,6 +636,9 @@ jobs:
       MAKEFLAGS: -j 5
     steps:
       - checkout
+      - when:
+          condition: true
+          <<: *steps_restore_cache_homebrew_workaround
       - restore_cache:
           keys:
             - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
@@ -661,6 +675,9 @@ jobs:
       TERM: xterm
     steps:
       - checkout
+      - when:
+          condition: true
+          <<: *steps_restore_cache_homebrew_workaround
       - restore_cache:
           keys:
             - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
@@ -677,6 +694,9 @@ jobs:
       TERM: xterm
     steps:
       - checkout
+      - when:
+          condition: true
+          <<: *steps_restore_cache_homebrew_workaround
       - restore_cache:
           keys:
             - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}


### PR DESCRIPTION
Recently [`b_osx`](https://app.circleci.com/pipelines/github/ethereum/solidity/19527/workflows/1cda61f8-788b-4fad-aa1a-a71e71696c04/jobs/865363) job has been failing in some of our PRs. Specifically external PRs that have been inactive for some time.

```
Failed to unarchive cache

Error untarring cache: Error extracting tarball /var/folders/1b/gl7yt7ds26vcyr1pkgld6l040000gn/T/cache3415993642 : usr/local/Homebrew/Library/Homebrew/shims/scm: Can't remove already-existing dir tar: Error exit delayed from previous errors. : exit status 1
```

["Error untarring cache" when running a macOS job](https://support.circleci.com/hc/en-us/articles/360056920051--Error-untarring-cache-when-running-a-macOS-job) suggests to include `{{ arch }}` in cache key. The reason for failures is probably that there has been an OS update after these PRs were last updated and the cache is simply no longer valid.

This PR adds `{{ arch }}` to cache keys on macOS and also on Windows just in case.