### PR TITLE
Fix broken Remix link style

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -45,6 +45,7 @@ pre {
 /* menu section headers */
 .wy-menu .caption {
     color: #65afff !important;
+}
 
 /* Link to Remix IDE shown next to code snippets */
 p.remix-link-container {
@@ -82,3 +83,4 @@ a.remix-link:hover {
 
 a.remix-link:hover .link-text {
     display: block;
+}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,6 +1,7 @@
 {% extends "!footer.html" %}
 
 {% block extrafooter %}
-    <br>
-    <a href="{{ pathto('credits-and-attribution') }}">Credits and attribution</a>.
+    <p>
+        <a href="{{ pathto('credits-and-attribution') }}">Credits and attribution</a>.
+    </p>
 {% endblock %}


### PR DESCRIPTION
Looks like I accidentally broke the CSS when I was rebasing #11697 on top of #11927. The missing braces make the browser completely ignore the style for Remix links.

The PR also slightly adjust spacing of the `Credits and attribution` link in the footer.