### PR TITLE
`solThrow()`

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -201,7 +201,7 @@ void CompilerStack::findAndReportCyclicContractDependencies()
 void CompilerStack::setRemappings(vector<ImportRemapper::Remapping> _remappings)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set remappings before parsing."));
+		solThrow(CompilerError, "Must set remappings before parsing.");
 	for (auto const& remapping: _remappings)
 		solAssert(!remapping.prefix.empty(), "");
 	m_importRemapper.setRemappings(move(_remappings));
@@ -210,28 +210,28 @@ void CompilerStack::setRemappings(vector<ImportRemapper::Remapping> _remappings)
 void CompilerStack::setViaIR(bool _viaIR)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set viaIR before parsing."));
+		solThrow(CompilerError, "Must set viaIR before parsing.");
 	m_viaIR = _viaIR;
 }
 
 void CompilerStack::setEVMVersion(langutil::EVMVersion _version)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set EVM version before parsing."));
+		solThrow(CompilerError, "Must set EVM version before parsing.");
 	m_evmVersion = _version;
 }
 
 void CompilerStack::setModelCheckerSettings(ModelCheckerSettings _settings)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set model checking settings before parsing."));
+		solThrow(CompilerError, "Must set model checking settings before parsing.");
 	m_modelCheckerSettings = _settings;
 }
 
 void CompilerStack::setLibraries(std::map<std::string, util::h160> const& _libraries)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set libraries before parsing."));
+		solThrow(CompilerError, "Must set libraries before parsing.");
 	m_libraries = _libraries;
 }
 
@@ -245,14 +245,14 @@ void CompilerStack::setOptimiserSettings(bool _optimize, size_t _runs)
 void CompilerStack::setOptimiserSettings(OptimiserSettings _settings)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set optimiser settings before parsing."));
+		solThrow(CompilerError, "Must set optimiser settings before parsing.");
 	m_optimiserSettings = std::move(_settings);
 }
 
 void CompilerStack::setRevertStringBehaviour(RevertStrings _revertStrings)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set revert string settings before parsing."));
+		solThrow(CompilerError, "Must set revert string settings before parsing.");
 	solUnimplementedAssert(_revertStrings != RevertStrings::VerboseDebug);
 	m_revertStrings = _revertStrings;
 }
@@ -260,21 +260,21 @@ void CompilerStack::setRevertStringBehaviour(RevertStrings _revertStrings)
 void CompilerStack::useMetadataLiteralSources(bool _metadataLiteralSources)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set use literal sources before parsing."));
+		solThrow(CompilerError, "Must set use literal sources before parsing.");
 	m_metadataLiteralSources = _metadataLiteralSources;
 }
 
 void CompilerStack::setMetadataHash(MetadataHash _metadataHash)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set metadata hash before parsing."));
+		solThrow(CompilerError, "Must set metadata hash before parsing.");
 	m_metadataHash = _metadataHash;
 }
 
 void CompilerStack::addSMTLib2Response(h256 const& _hash, string const& _response)
 {
 	if (m_stackState >= ParsedAndImported)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must add SMTLib2 responses before parsing."));
+		solThrow(CompilerError, "Must add SMTLib2 responses before parsing.");
 	m_smtlib2Responses[_hash] = _response;
 }
 
@@ -310,9 +310,9 @@ void CompilerStack::reset(bool _keepSettings)
 void CompilerStack::setSources(StringMap _sources)
 {
 	if (m_stackState == SourcesSet)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Cannot change sources once set."));
+		solThrow(CompilerError, "Cannot change sources once set.");
 	if (m_stackState != Empty)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must set sources before parsing."));
+		solThrow(CompilerError, "Must set sources before parsing.");
 	for (auto source: _sources)
 		m_sources[source.first].charStream = make_unique<CharStream>(/*content*/std::move(source.second), /*name*/source.first);
 	m_stackState = SourcesSet;
@@ -321,7 +321,7 @@ void CompilerStack::setSources(StringMap _sources)
 bool CompilerStack::parse()
 {
 	if (m_stackState != SourcesSet)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must call parse only after the SourcesSet state."));
+		solThrow(CompilerError, "Must call parse only after the SourcesSet state.");
 	m_errorReporter.clear();
 
 	if (SemVerVersion{string(VersionString)}.isPrerelease())
@@ -369,7 +369,7 @@ bool CompilerStack::parse()
 void CompilerStack::importASTs(map<string, Json::Value> const& _sources)
 {
 	if (m_stackState != Empty)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must call importASTs only before the SourcesSet state."));
+		solThrow(CompilerError, "Must call importASTs only before the SourcesSet state.");
 	m_sourceJsons = _sources;
 	map<string, ASTPointer<SourceUnit>> reconstructedSources = ASTJsonImporter(m_evmVersion).jsonToSourceUnit(m_sourceJsons);
 	for (auto& src: reconstructedSources)
@@ -392,7 +392,7 @@ void CompilerStack::importASTs(map<string, Json::Value> const& _sources)
 bool CompilerStack::analyze()
 {
 	if (m_stackState != ParsedAndImported || m_stackState >= AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Must call analyze only after parsing was performed."));
+		solThrow(CompilerError, "Must call analyze only after parsing was performed.");
 	resolveImports();
 
 	for (Source const* source: m_sourceOrder)
@@ -619,7 +619,7 @@ bool CompilerStack::compile(State _stopAfter)
 		return true;
 
 	if (m_hasError)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Called compile with errors."));
+		solThrow(CompilerError, "Called compile with errors.");
 
 	// Only compile contracts individually which have been requested.
 	map<ContractDefinition const*, shared_ptr<Compiler const>> otherCompilers;
@@ -691,7 +691,7 @@ void CompilerStack::link()
 vector<string> CompilerStack::contractNames() const
 {
 	if (m_stackState < Parsed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
+		solThrow(CompilerError, "Parsing was not successful.");
 	vector<string> contractNames;
 	for (auto const& contract: m_contracts)
 		contractNames.push_back(contract.first);
@@ -701,7 +701,7 @@ vector<string> CompilerStack::contractNames() const
 string const CompilerStack::lastContractName(optional<string> const& _sourceName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
+		solThrow(CompilerError, "Parsing was not successful.");
 	// try to find some user-supplied contract
 	string contractName;
 	for (auto const& it: m_sources)
@@ -714,7 +714,7 @@ string const CompilerStack::lastContractName(optional<string> const& _sourceName
 evmasm::AssemblyItems const* CompilerStack::assemblyItems(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& currentContract = contract(_contractName);
 	return currentContract.evmAssembly ? &currentContract.evmAssembly->items() : nullptr;
@@ -723,7 +723,7 @@ evmasm::AssemblyItems const* CompilerStack::assemblyItems(string const& _contrac
 evmasm::AssemblyItems const* CompilerStack::runtimeAssemblyItems(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& currentContract = contract(_contractName);
 	return currentContract.evmRuntimeAssembly ? &currentContract.evmRuntimeAssembly->items() : nullptr;
@@ -732,7 +732,7 @@ evmasm::AssemblyItems const* CompilerStack::runtimeAssemblyItems(string const& _
 Json::Value CompilerStack::generatedSources(string const& _contractName, bool _runtime) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& c = contract(_contractName);
 	util::LazyInit<Json::Value const> const& sources =
@@ -775,7 +775,7 @@ Json::Value CompilerStack::generatedSources(string const& _contractName, bool _r
 string const* CompilerStack::sourceMapping(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& c = contract(_contractName);
 	if (!c.sourceMapping)
@@ -789,7 +789,7 @@ string const* CompilerStack::sourceMapping(string const& _contractName) const
 string const* CompilerStack::runtimeSourceMapping(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& c = contract(_contractName);
 	if (!c.runtimeSourceMapping)
@@ -805,7 +805,7 @@ string const* CompilerStack::runtimeSourceMapping(string const& _contractName) c
 std::string const CompilerStack::filesystemFriendlyName(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("No compiled contracts found."));
+		solThrow(CompilerError, "No compiled contracts found.");
 
 	// Look up the contract (by its fully-qualified name)
 	Contract const& matchContract = m_contracts.at(_contractName);
@@ -829,7 +829,7 @@ std::string const CompilerStack::filesystemFriendlyName(string const& _contractN
 string const& CompilerStack::yulIR(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).yulIR;
 }
@@ -837,7 +837,7 @@ string const& CompilerStack::yulIR(string const& _contractName) const
 string const& CompilerStack::yulIROptimized(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).yulIROptimized;
 }
@@ -845,7 +845,7 @@ string const& CompilerStack::yulIROptimized(string const& _contractName) const
 string const& CompilerStack::ewasm(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).ewasm;
 }
@@ -853,7 +853,7 @@ string const& CompilerStack::ewasm(string const& _contractName) const
 evmasm::LinkerObject const& CompilerStack::ewasmObject(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).ewasmObject;
 }
@@ -861,7 +861,7 @@ evmasm::LinkerObject const& CompilerStack::ewasmObject(string const& _contractNa
 evmasm::LinkerObject const& CompilerStack::object(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).object;
 }
@@ -869,7 +869,7 @@ evmasm::LinkerObject const& CompilerStack::object(string const& _contractName) c
 evmasm::LinkerObject const& CompilerStack::runtimeObject(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).runtimeObject;
 }
@@ -878,7 +878,7 @@ evmasm::LinkerObject const& CompilerStack::runtimeObject(string const& _contract
 string CompilerStack::assemblyString(string const& _contractName, StringMap const& _sourceCodes) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& currentContract = contract(_contractName);
 	if (currentContract.evmAssembly)
@@ -891,7 +891,7 @@ string CompilerStack::assemblyString(string const& _contractName, StringMap cons
 Json::Value CompilerStack::assemblyJSON(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	Contract const& currentContract = contract(_contractName);
 	if (currentContract.evmAssembly)
@@ -922,7 +922,7 @@ map<string, unsigned> CompilerStack::sourceIndices() const
 Json::Value const& CompilerStack::contractABI(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	return contractABI(contract(_contractName));
 }
@@ -930,7 +930,7 @@ Json::Value const& CompilerStack::contractABI(string const& _contractName) const
 Json::Value const& CompilerStack::contractABI(Contract const& _contract) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	solAssert(_contract.contract, "");
 
@@ -940,7 +940,7 @@ Json::Value const& CompilerStack::contractABI(Contract const& _contract) const
 Json::Value const& CompilerStack::storageLayout(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	return storageLayout(contract(_contractName));
 }
@@ -948,7 +948,7 @@ Json::Value const& CompilerStack::storageLayout(string const& _contractName) con
 Json::Value const& CompilerStack::storageLayout(Contract const& _contract) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	solAssert(_contract.contract, "");
 
@@ -958,7 +958,7 @@ Json::Value const& CompilerStack::storageLayout(Contract const& _contract) const
 Json::Value const& CompilerStack::natspecUser(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	return natspecUser(contract(_contractName));
 }
@@ -966,7 +966,7 @@ Json::Value const& CompilerStack::natspecUser(string const& _contractName) const
 Json::Value const& CompilerStack::natspecUser(Contract const& _contract) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	solAssert(_contract.contract, "");
 
@@ -976,7 +976,7 @@ Json::Value const& CompilerStack::natspecUser(Contract const& _contract) const
 Json::Value const& CompilerStack::natspecDev(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	return natspecDev(contract(_contractName));
 }
@@ -984,7 +984,7 @@ Json::Value const& CompilerStack::natspecDev(string const& _contractName) const
 Json::Value const& CompilerStack::natspecDev(Contract const& _contract) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	solAssert(_contract.contract, "");
 
@@ -994,7 +994,7 @@ Json::Value const& CompilerStack::natspecDev(Contract const& _contract) const
 Json::Value CompilerStack::methodIdentifiers(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	Json::Value methodIdentifiers(Json::objectValue);
 	for (auto const& it: contractDefinition(_contractName).interfaceFunctions())
@@ -1005,7 +1005,7 @@ Json::Value CompilerStack::methodIdentifiers(string const& _contractName) const
 bytes CompilerStack::cborMetadata(string const& _contractName, bool _forIR) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	return createCBORMetadata(contract(_contractName), _forIR);
 }
@@ -1013,7 +1013,7 @@ bytes CompilerStack::cborMetadata(string const& _contractName, bool _forIR) cons
 string const& CompilerStack::metadata(Contract const& _contract) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	solAssert(_contract.contract, "");
 
@@ -1023,7 +1023,7 @@ string const& CompilerStack::metadata(Contract const& _contract) const
 CharStream const& CompilerStack::charStream(string const& _sourceName) const
 {
 	if (m_stackState < SourcesSet)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("No sources set."));
+		solThrow(CompilerError, "No sources set.");
 
 	solAssert(source(_sourceName).charStream, "");
 
@@ -1033,9 +1033,9 @@ CharStream const& CompilerStack::charStream(string const& _sourceName) const
 SourceUnit const& CompilerStack::ast(string const& _sourceName) const
 {
 	if (m_stackState < Parsed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing not yet performed."));
+		solThrow(CompilerError, "Parsing not yet performed.");
 	if (!source(_sourceName).ast && !m_parserErrorRecovery)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Parsing was not successful."));
+		solThrow(CompilerError, "Parsing was not successful.");
 
 	return *source(_sourceName).ast;
 }
@@ -1043,7 +1043,7 @@ SourceUnit const& CompilerStack::ast(string const& _sourceName) const
 ContractDefinition const& CompilerStack::contractDefinition(string const& _contractName) const
 {
 	if (m_stackState < AnalysisPerformed)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+		solThrow(CompilerError, "Analysis was not successful.");
 
 	return *contract(_contractName).contract;
 }
@@ -1054,7 +1054,7 @@ size_t CompilerStack::functionEntryPoint(
 ) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	for (auto&& [name, data]: contract(_contractName).runtimeObject.functionDebugData)
 		if (data.sourceID == _function.id())
@@ -1256,7 +1256,7 @@ void CompilerStack::compileContract(
 	solAssert(!m_viaIR, "");
 	solAssert(m_stackState >= AnalysisPerformed, "");
 	if (m_hasError)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Called compile with errors."));
+		solThrow(CompilerError, "Called compile with errors.");
 
 	if (_otherCompilers.count(&_contract))
 		return;
@@ -1294,7 +1294,7 @@ void CompilerStack::generateIR(ContractDefinition const& _contract)
 {
 	solAssert(m_stackState >= AnalysisPerformed, "");
 	if (m_hasError)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Called generateIR with errors."));
+		solThrow(CompilerError, "Called generateIR with errors.");
 
 	Contract& compiledContract = m_contracts.at(_contract.fullyQualifiedName());
 	if (!compiledContract.yulIR.empty())
@@ -1331,7 +1331,7 @@ void CompilerStack::generateEVMFromIR(ContractDefinition const& _contract)
 {
 	solAssert(m_stackState >= AnalysisPerformed, "");
 	if (m_hasError)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Called generateEVMFromIR with errors."));
+		solThrow(CompilerError, "Called generateEVMFromIR with errors.");
 
 	if (!_contract.canBeDeployed())
 		return;
@@ -1358,7 +1358,7 @@ void CompilerStack::generateEwasm(ContractDefinition const& _contract)
 {
 	solAssert(m_stackState >= AnalysisPerformed, "");
 	if (m_hasError)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Called generateEwasm with errors."));
+		solThrow(CompilerError, "Called generateEwasm with errors.");
 
 	if (!_contract.canBeDeployed())
 		return;
@@ -1412,14 +1412,14 @@ CompilerStack::Contract const& CompilerStack::contract(string const& _contractNa
 	}
 
 	// If we get here, both lookup methods failed.
-	BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Contract \"" + _contractName + "\" not found."));
+	solThrow(CompilerError, "Contract \"" + _contractName + "\" not found.");
 }
 
 CompilerStack::Source const& CompilerStack::source(string const& _sourceName) const
 {
 	auto it = m_sources.find(_sourceName);
 	if (it == m_sources.end())
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Given source file not found."));
+		solThrow(CompilerError, "Given source file not found.");
 
 	return it->second;
 }
@@ -1658,7 +1658,7 @@ Json::Value gasToJson(GasEstimator::GasConsumption const& _gas)
 Json::Value CompilerStack::gasEstimates(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
-		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Compilation was not successful."));
+		solThrow(CompilerError, "Compilation was not successful.");
 
 	if (!assemblyItems(_contractName) && !runtimeAssemblyItems(_contractName))
 		return Json::Value();

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -104,10 +104,7 @@ ReadCallback::Result FileReader::readFile(string const& _kind, string const& _so
 	try
 	{
 		if (_kind != ReadCallback::kindString(ReadCallback::Kind::ReadFile))
-			BOOST_THROW_EXCEPTION(InternalCompilerError() << errinfo_comment(
-				"ReadFile callback used as callback kind " +
-				_kind
-			));
+			solAssert(false, "ReadFile callback used as callback kind " + _kind);
 		string strippedSourceUnitName = _sourceUnitName;
 		if (strippedSourceUnitName.find("file://") == 0)
 			strippedSourceUnitName.erase(0, 7);

--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -61,14 +61,9 @@ inline std::string stringOrDefault(std::string _string, std::string _defaultStri
 	do \
 	{ \
 		if (!(_condition)) \
-			::boost::throw_exception( \
-				_exceptionType() << \
-				::solidity::util::errinfo_comment( \
-					::solidity::util::assertions::stringOrDefault(_description, _defaultDescription) \
-				) << \
-				::boost::throw_function(ETH_FUNC) << \
-				::boost::throw_file(__FILE__) << \
-				::boost::throw_line(__LINE__) \
+			solThrow( \
+				_exceptionType, \
+				::solidity::util::assertions::stringOrDefault(_description, _defaultDescription) \
 			); \
 	} \
 	while (false)

--- a/libsolutil/Exceptions.h
+++ b/libsolutil/Exceptions.h
@@ -43,6 +43,19 @@ struct Exception: virtual std::exception, virtual boost::exception
 private:
 };
 
+/// Throws an exception with a given description and extra information about the location the
+/// exception was thrown from.
+/// @param _exceptionType The type of the exception to throw (not an instance).
+/// @param _description The message that describes the error.
+#define solThrow(_exceptionType, _description) \
+	::boost::throw_exception( \
+		_exceptionType() << \
+		::solidity::util::errinfo_comment(_description) << \
+		::boost::throw_function(ETH_FUNC) << \
+		::boost::throw_file(__FILE__) << \
+		::boost::throw_line(__LINE__) \
+	)
+
 #define DEV_SIMPLE_EXCEPTION(X) struct X: virtual ::solidity::util::Exception { const char* what() const noexcept override { return #X; } }
 
 DEV_SIMPLE_EXCEPTION(InvalidAddress);


### PR DESCRIPTION
Another smaller PR extracted from #11800.

This one adds a macro similar to `assertThrow()` but meant for actual error handling rather than for checking assertions. It can replace the more verbose `BOOST_THROW_EXCEPTION` in cases where the exception inherits from `util::Exception` and the only information we add to it is a message.

There's intentionally no variant without a message because I think that exceptions that interrupt the program should always have a message attached.