### PR TITLE
Don't return zero exit code when writing linked files to disk fails

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Compiler Features:
 Bugfixes:
  * Commandline Interface: Fix extra newline character being appended to sources passed through standard input, affecting their hashes.
  * Commandline Interface: Report output selection options unsupported by the selected input mode instead of ignoring them.
+ * Commandline Interface: Don't return zero exit code when writing linked files to disk fails.
  * SMTChecker: Fix internal error in magic type access (``block``, ``msg``, ``tx``).
  * TypeChecker: Fix internal error when using user defined value types in public library functions.
  * Yul IR Generator: Do not output empty switches/if-bodies for empty contracts.

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -553,7 +553,7 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 	if (fs::exists(pathName) && !m_options.output.overwriteFiles)
 	{
 		serr() << "Refusing to overwrite existing file \"" << pathName << "\" (use --overwrite to force)." << endl;
-		m_error = true;
+		m_outputFailed = true;
 		return;
 	}
 	ofstream outFile(pathName);
@@ -561,7 +561,7 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 	if (!outFile)
 	{
 		serr() << "Could not write to file \"" << pathName << "\"." << endl;
-		m_error = true;
+		m_outputFailed = true;
 		return;
 	}
 }
@@ -855,7 +855,7 @@ bool CommandLineInterface::actOnInput()
 		solAssert(m_options.input.mode == InputMode::Compiler || m_options.input.mode == InputMode::CompilerWithASTImport, "");
 		outputCompilationResults();
 	}
-	return !m_error;
+	return !m_outputFailed;
 }
 
 bool CommandLineInterface::link()

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -937,6 +937,7 @@ void CommandLineInterface::writeLinkedFiles()
 			if (!outFile)
 			{
 				serr() << "Could not write to file " << src.first << ". Aborting." << endl;
+				m_outputFailed = true;
 				return;
 			}
 		}

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -121,7 +121,7 @@ private:
 	std::ostream& m_sout;
 	std::ostream& m_serr;
 	bool m_hasOutput = false;
-	bool m_error = false; ///< If true, some error occurred.
+	bool m_outputFailed = false; ///< If true, creation or write to some of the output files failed.
 	FileReader m_fileReader;
 	std::optional<std::string> m_standardJsonInput;
 	std::unique_ptr<frontend::CompilerStack> m_compiler;


### PR DESCRIPTION
- Depends on #12124

A tiny bug I noticed while working on #11800. We're returning 0 even though the operation failed.