### PR TITLE
Update the workaround for restore_cache on macOS not to delete files completely

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,16 +160,34 @@ defaults:
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
 
-  - steps_restore_cache_homebrew_workaround: &steps_restore_cache_homebrew_workaround
+  - steps_homebrew_workaround_before_restore_cache: &steps_homebrew_workaround_before_restore_cache
       steps:
         - run:
-            # FIXME: For some reason restore_cache fails saying that it cannot remove the scm/ dir.
-            # The directory contains only two files: `git` (wrapper script over git) and `svn` (symlink
-            # to `git`). This looks like a bug in restore_cache. Removing scm/ is a workaround.
+            # Homebrew has recently replaced one of its dirs with a symlink to another.
+            # This makes tar used by restore_cache fail - the image contains an older version of
+            # Homebrew installed where it's a directory and tar refuses to overwrite a dir with a link.
+            # Removing the directory manually is a workaround that works only in case we do have
+            # cached files to restore. If we don't, we still need this dir because it contains
+            # a git wrapper that Homebrew uses to update itself. The solution is to just rename the
+            # dir before restore_cache and renamed it back afterwards.
             # See https://github.com/ethereum/solidity/pull/12106 for more details.
             name: Workaround for restore_cache + /usr/local/Homebrew/Library/Homebrew/shims/scm/
             command: |
-              rm -r /usr/local/Homebrew/Library/Homebrew/shims/scm/
+              cd /usr/local/Homebrew/Library/Homebrew/shims/
+              mv scm/ scm-backup/
+
+  - steps_homebrew_workaround_after_restore_cache: &steps_homebrew_workaround_after_restore_cache
+      steps:
+        - run:
+            name: Workaround for restore_cache + /usr/local/Homebrew/Library/Homebrew/shims/scm/
+            command: |
+              cd /usr/local/Homebrew/Library/Homebrew/shims/
+              if ! [[ -e scm/ ]]
+              then
+                mv scm-backup/ scm/
+              else
+                rm -r scm-backup/
+              fi
 
   - test_ubuntu1604_clang: &test_ubuntu1604_clang
       docker:
@@ -638,12 +656,17 @@ jobs:
       - checkout
       - when:
           condition: true
-          <<: *steps_restore_cache_homebrew_workaround
+          # FIXME: Remove this workaround when CircleCI fixes restore_cache.
+          <<: *steps_homebrew_workaround_before_restore_cache
       - restore_cache:
           keys:
             - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
       # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
       # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
+      - when:
+          condition: true
+          # FIXME: Remove this workaround when CircleCI fixes restore_cache.
+          <<: *steps_homebrew_workaround_after_restore_cache
       - run:
           name: Install build dependencies
           command: ./.circleci/osx_install_dependencies.sh
@@ -677,10 +700,15 @@ jobs:
       - checkout
       - when:
           condition: true
-          <<: *steps_restore_cache_homebrew_workaround
+          # FIXME: Remove this workaround when CircleCI fixes restore_cache.
+          <<: *steps_homebrew_workaround_before_restore_cache
       - restore_cache:
           keys:
             - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+      - when:
+          condition: true
+          # FIXME: Remove this workaround when CircleCI fixes restore_cache.
+          <<: *steps_homebrew_workaround_after_restore_cache
       - attach_workspace:
           at: .
       - run: *run_soltest
@@ -696,10 +724,15 @@ jobs:
       - checkout
       - when:
           condition: true
-          <<: *steps_restore_cache_homebrew_workaround
+          # FIXME: Remove this workaround when CircleCI fixes restore_cache.
+          <<: *steps_homebrew_workaround_before_restore_cache
       - restore_cache:
           keys:
             - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+      - when:
+          condition: true
+          # FIXME: Remove this workaround when CircleCI fixes restore_cache.
+          <<: *steps_homebrew_workaround_after_restore_cache
       - attach_workspace:
           at: .
       - run: *run_cmdline_tests


### PR DESCRIPTION
#12106 fixed `b_osx` job in cases where there's something cached to restore but now it fails when we don't have the cache. That's because Homebrew needs the files we delete to be able to update itself.

I don't think there's a way to check if there's something to restore so this PR tries to fix it in a different way - it replaces the directory with a symlink manually so that it's still there but does not make tar refuse to overwrite it.

Closes #12134.