### PR TITLE
Prefer `make_unique` over `new`

### DIFF
--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -991,7 +991,7 @@ void CHC::resetSourceAnalysis()
 	if (usesZ3)
 	{
 		/// z3::fixedpoint does not have a reset mechanism, so we need to create another.
-		m_interface.reset(new Z3CHCInterface(m_settings.timeout));
+		m_interface = std::make_unique<Z3CHCInterface>(m_settings.timeout);
 		auto z3Interface = dynamic_cast<Z3CHCInterface const*>(m_interface.get());
 		solAssert(z3Interface, "");
 		m_context.setSolver(z3Interface->z3Interface());

--- a/tools/solidityUpgrade/SourceUpgrade.cpp
+++ b/tools/solidityUpgrade/SourceUpgrade.cpp
@@ -533,7 +533,7 @@ void SourceUpgrade::resetCompiler()
 
 void SourceUpgrade::resetCompiler(ReadCallback::Callback const& _callback)
 {
-	m_compiler.reset(new CompilerStack(_callback));
+	m_compiler = std::make_unique<CompilerStack>(_callback);
 	m_compiler->setSources(m_sourceCodes);
 	m_compiler->setParserErrorRecovery(true);
 }


### PR DESCRIPTION
Recommended preference for C++17 development practices of modern C++ projects.