### PR TITLE
Fix index link appearance in docs menu

### DIFF
--- a/docs/_static/css/toggle.css
+++ b/docs/_static/css/toggle.css
@@ -75,3 +75,9 @@ html.transition *:after {
     transition: ease-in-out 200ms !important;
     transition-delay: 0 !important;
 }
+
+nav.wy-nav-side {
+    /* The default padding of 2em is too small and the "Keyword Index" link gets obscured
+     * by the version toggle. */
+    padding-bottom: 3em;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -2,5 +2,9 @@
 
 {% block menu %}
     {{ super() }}
-    <a href="{{ pathto('genindex') }}">Keyword Index</a>
+    <ul>
+        <li>
+            <a href="{{ pathto('genindex') }}">Keyword Index</a>
+        </li>
+    </ul>
 {% endblock %}


### PR DESCRIPTION
Fixes some small breakage in docs layout:
- The plain `<a>` element used for "Keyword index" for some reason gets styled the same way as if it was the currently selected menu option. RTD theme adds a `[+]` buttons to such options when they're selected but the button does not get styled correctly.
    - I changed the HTML generated for the link to more closely resemble the HTML for other menu items (it's a list now). This fixes the issue.
    - One remaining issue is that "Keyword index" does not get highlighted when it's the selected option. But this is a separate problem and was there even before my fix.
- The version toggle was obscuring the index link. I slightly increased the padding at the buttom to fix this.

### Before
![index-link-before](https://user-images.githubusercontent.com/137030/137314391-ff87f1cc-d8ce-49ec-a967-89ca17305aff.png)

### After
![index-link-after](https://user-images.githubusercontent.com/137030/137314387-900f96f8-8da8-42ff-9490-dc8a46ae0937.png)