### PR TITLE
Assert and stack traces for Bash scripts

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -138,24 +138,30 @@ function msg_on_error()
         rm "$stdout_file" "$stderr_file"
         return 0
     else
-        printError "Command failed: $SOLC ${command[*]}"
+        printError ""
+        printError "Command failed: ${error_message}"
+        printError "    command: $SOLC ${command[*]}"
         if [[ -s "$stdout_file" ]]
         then
-            printError "stdout:"
+            printError "--- stdout ---"
+            printError "-----------"
             >&2 cat "$stdout_file"
+            printError "--------------"
         else
-            printError "stdout: <EMPTY>"
+            printError "    stdout: <EMPTY>"
         fi
         if [[ -s "$stderr_file" ]]
         then
-            printError "stderr:"
+            printError "--- stderr ---"
             >&2 cat "$stderr_file"
+            printError "--------------"
         else
-            printError "stderr: <EMPTY>"
+            printError "    stderr: <EMPTY>"
         fi
 
-        printError "$error_message"
         rm "$stdout_file" "$stderr_file"
+
+        printStackTrace
         return 1
     fi
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -19,6 +19,9 @@
 # (c) 2016-2019 solidity contributors.
 # ------------------------------------------------------------------------------
 
+# The fail() function defined below requires set -e to be enabled.
+set -e
+
 # Save the initial working directory so that printStackTrace() can access it even if the sourcing
 # changes directory. The paths returned by `caller` are relative to it.
 _initial_work_dir=$(pwd)
@@ -78,6 +81,8 @@ function printStackTrace
 function fail()
 {
     printError "$@"
+
+    # Using return rather than exit lets the invoking code handle the failure by suppressing the exit code.
     return 1
 }
 
@@ -120,7 +125,7 @@ function msg_on_error()
                 shift
                 ;;
             *)
-                fail "Invalid option for msg_on_error: $1"
+                assertFail "Invalid option for msg_on_error: $1"
                 ;;
         esac
     done


### PR DESCRIPTION
While working on #12141 I was really missing a quick way to assert stuff and the lack of a proper stack traces when a script fails makes debugging really annoying. This PR adds a rudimentary helper that can print a stack trace and a function that we can get an assert-like failure.