### PR TITLE
Use range-v3 loops: delete boost includes

### DIFF
--- a/libsolidity/analysis/PostTypeChecker.cpp
+++ b/libsolidity/analysis/PostTypeChecker.cpp
@@ -25,7 +25,6 @@
 #include <libsolutil/Algorithms.h>
 #include <libsolutil/FunctionSelector.h>
 
-#include <boost/range/adaptor/map.hpp>
 #include <memory>
 
 using namespace std;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -41,7 +41,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/range/algorithm/copy.hpp>
 
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/reverse.hpp>


### PR DESCRIPTION
An addition to issue #10738
couldn't change boost::for_each to
std::for_each, doesn't compile.


- Build successful
- ./scripts/test.sh successful  
