### PR TITLE
[Docs] Fix formatting of the "security fixes" link on the main page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ and multi-signature wallets.
 
 When deploying contracts, you should use the latest released
 version of Solidity. Apart from exceptional cases, only the latest version receives
-`security fixes<https://github.com/ethereum/solidity/security/policy#supported-versions>`.
+`security fixes <https://github.com/ethereum/solidity/security/policy#supported-versions>`_.
 Furthermore, breaking changes as well as
 new features are introduced regularly. We currently use
 a 0.x version number `to indicate this fast pace of change <https://semver.org/#spec-item-4>`_.


### PR DESCRIPTION
Quick fix
<img width="1443" alt="Screen Shot 2021-10-19 at 10 52 48" src="https://user-images.githubusercontent.com/382183/137936173-3b0f2ffe-5be5-4a36-8bf8-d68ca52a8d61.png">


