### PR TITLE
Disallowed --metadata-literal, --model-checker-show-unproved, --model-checker-div-mod-no-slacks outside of compiler mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Commandline Interface: Disallow the following options outside of the compiler mode: ``--via-ir``,``--metadata-literal``, ``--metadata-hash``, ``--model-checker-show-unproved``, ``--model-checker-div-mod-no-slacks``, ``--model-checker-engine``, ``--model-checker-invariants``, ``--model-checker-solvers``, ``--model-checker-timeout``, ``--model-checker-contracts``, ``--model-checker-targets``.
 
 
 ### 0.8.15 (2022-06-15)

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -911,12 +911,26 @@ void CommandLineParser::processArgs()
 		// TODO: This should eventually contain all options.
 		{g_strErrorRecovery, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
 		{g_strExperimentalViaIR, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
-		{g_strViaIR, {InputMode::Compiler, InputMode::CompilerWithASTImport}}
+		{g_strViaIR, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strMetadataLiteral, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strMetadataHash, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerShowUnproved, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerDivModNoSlacks, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerEngine, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerInvariants, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerSolvers, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerTimeout, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerContracts, {InputMode::Compiler, InputMode::CompilerWithASTImport}},
+		{g_strModelCheckerTargets, {InputMode::Compiler, InputMode::CompilerWithASTImport}}
 	};
 	vector<string> invalidOptionsForCurrentInputMode;
 	for (auto const& [optionName, inputModes]: validOptionInputModeCombinations)
 	{
-		if (m_args.count(optionName) > 0 && inputModes.count(m_options.input.mode) == 0)
+		if (
+			m_args.count(optionName) > 0 &&
+			inputModes.count(m_options.input.mode) == 0 &&
+			!m_args[optionName].defaulted()
+		)
 			invalidOptionsForCurrentInputMode.push_back(optionName);
 	}
 

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -281,20 +281,6 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 			"--libraries="
 				"dir1/file1.sol:L=0x1234567890123456789012345678901234567890,"
 				"dir2/file2.sol:L=0x1111122222333334444455555666667777788888",
-			"--metadata-hash=swarm",       // Ignored in assembly mode
-			"--metadata-literal",          // Ignored in assembly mode
-			"--model-checker-contracts="   // Ignored in assembly mode
-				"contract1.yul:A,"
-				"contract2.yul:B",
-			"--model-checker-div-mod-no-slacks", // Ignored in assembly mode
-			"--model-checker-engine=bmc",  // Ignored in assembly mode
-			"--model-checker-invariants=contract,reentrancy",  // Ignored in assembly mode
-			"--model-checker-show-unproved", // Ignored in assembly mode
-			"--model-checker-solvers=z3,smtlib2", // Ignored in assembly mode
-			"--model-checker-targets="     // Ignored in assembly mode
-				"underflow,"
-				"divByZero",
-			"--model-checker-timeout=5",   // Ignored in assembly mode
 			"--asm",
 			"--bin",
 			"--ir-optimized",
@@ -378,20 +364,6 @@ BOOST_AUTO_TEST_CASE(standard_json_mode_options)
 			"dir2/file2.sol:L=0x1111122222333334444455555666667777788888",
 		"--gas",                           // Accepted but has no effect in Standard JSON mode
 		"--combined-json=abi,bin",         // Accepted but has no effect in Standard JSON mode
-		"--metadata-hash=swarm",           // Ignored in Standard JSON mode
-		"--metadata-literal",              // Ignored in Standard JSON mode
-		"--model-checker-contracts="       // Ignored in Standard JSON mode
-			"contract1.yul:A,"
-			"contract2.yul:B",
-		"--model-checker-div-mod-no-slacks", // Ignored in Standard JSON mode
-		"--model-checker-engine=bmc",      // Ignored in Standard JSON mode
-		"--model-checker-invariants=contract,reentrancy",      // Ignored in Standard JSON mode
-		"--model-checker-show-unproved",      // Ignored in Standard JSON mode
-		"--model-checker-solvers=z3,smtlib2", // Ignored in Standard JSON mode
-		"--model-checker-targets="         // Ignored in Standard JSON mode
-			"underflow,"
-			"divByZero",
-		"--model-checker-timeout=5",       // Ignored in Standard JSON mode
 	};
 
 	CommandLineOptions expectedOptions;
@@ -424,16 +396,30 @@ BOOST_AUTO_TEST_CASE(invalid_options_input_modes_combinations)
 		// TODO: This should eventually contain all options.
 		{"--error-recovery", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
 		{"--experimental-via-ir", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
-		{"--via-ir", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}}
+		{"--via-ir", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--metadata-literal", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--metadata-hash=swarm", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-show-unproved", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-div-mod-no-slacks", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-engine=bmc", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-invariants=contract,reentrancy", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-solvers=z3,smtlib2", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-timeout=5", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-contracts=contract1.yul:A,contract2.yul:B", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}},
+		{"--model-checker-targets=underflow,divByZero", {"--assemble", "--yul", "--strict-assembly", "--standard-json", "--link"}}
 	};
 
 	for (auto const& [optionName, inputModes]: invalidOptionInputModeCombinations)
 		for (string const& inputMode: inputModes)
 		{
 			stringstream serr;
+			size_t separatorPosition = optionName.find("=");
+			string optionNameWithoutValue = optionName.substr(0, separatorPosition);
+			soltestAssert(!optionNameWithoutValue.empty());
+
 			vector<string> commandLine = {"solc", optionName, "file", inputMode};
 
-			string expectedMessage = "The following options are not supported in the current input mode: " + optionName;
+			string expectedMessage = "The following options are not supported in the current input mode: " + optionNameWithoutValue;
 			auto hasCorrectMessage = [&](CommandLineValidationError const& _exception) { return _exception.what() == expectedMessage; };
 
 			BOOST_CHECK_EXCEPTION(parseCommandLine(commandLine), CommandLineValidationError, hasCorrectMessage);


### PR DESCRIPTION
Partially solves #11629.

Disallowed following options outside of compiler mode:  
1. --metadata-literal
2. --model-checker-show-unproved
3. --model-checker-div-mod-no-slacks 
4. . --via-ir
5. --metadata-hash=swarm