### PR TITLE
[CI] Store yul-phaser as an artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,13 @@ defaults:
       path: upload/
 
   # compiled tool executable target
-  - artifacts_tools: &artifacts_tools
+  - artifact_solidity_upgrade: &artifact_solidity_upgrade
       path: build/tools/solidity-upgrade
       destination: solidity-upgrade
+
+  - artifact_yul_phaser: &artifact_yul_phaser
+      path: build/tools/yul-phaser
+      destination: yul-phaser
 
   # compiled executable targets
   - artifacts_executables: &artifacts_executables
@@ -447,7 +451,8 @@ jobs:
       - checkout
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - store_artifacts: *artifacts_tools
+      - store_artifacts: *artifact_solidity_upgrade
+      - store_artifacts: *artifact_yul_phaser
       - persist_to_workspace: *artifacts_executables
 
   # x64 ASAN build, for testing for memory related bugs
@@ -644,7 +649,8 @@ jobs:
             - /usr/local/Homebrew
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - store_artifacts: *artifacts_tools
+      - store_artifacts: *artifact_solidity_upgrade
+      - store_artifacts: *artifact_yul_phaser
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
I noticed that `artifacts_tools` does not include yul-phaser. Not sure we need it as an artifact but the same can probably be said for `solidity-upgrade` so if we have one, we should have both.

Looks like `store_artifacts` supports only single files and whole directories so I had to create separate templates.