### PR TITLE
[CI] Base image templates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,7 +491,7 @@ jobs:
       - checkout
       - run: *run_docs_pragma_min_version
 
-  t_pyscripts_ubu:
+  t_ubu_pyscripts:
     <<: *base_ubuntu2004
     steps:
       - checkout
@@ -499,7 +499,7 @@ jobs:
           name: Python unit tests
           command: python3 test/pyscriptTests.py
 
-  t_pyscripts_win:
+  t_win_pyscripts:
     <<: *base_win_powershell
     steps:
       - run: git config --global core.autocrlf false
@@ -767,7 +767,7 @@ jobs:
           path: docs/_build/html/
           destination: docs-html
 
-  t_ubu_soltest: &t_ubu_soltest
+  t_ubu_soltest_all: &t_ubu_soltest_all
     <<: *base_ubuntu2004
     parallelism: 6
     <<: *steps_soltest_all
@@ -806,10 +806,10 @@ jobs:
       OPTIMIZE: 0
     <<: *steps_soltest
 
-  t_ubu_release_soltest: &t_ubu_release_soltest
+  t_ubu_release_soltest_all: &t_ubu_release_soltest_all
     # NOTE: This definition is identical to t_ubu_soltest_all but in the workflow we make it depend on
     # a different job (b_ubu_release) so the workspace it attaches contains a different executable.
-    <<: *t_ubu_soltest
+    <<: *t_ubu_soltest_all
 
   t_ubu_cli: &t_ubu_cli
     <<: *base_ubuntu2004
@@ -825,7 +825,7 @@ jobs:
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
     <<: *steps_cmdline_tests
 
-  t_ubu_asan:
+  t_ubu_asan_soltest:
     <<: *base_ubuntu2004
     parallelism: 6
     environment:
@@ -835,7 +835,7 @@ jobs:
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
     <<: *steps_soltest
 
-  t_ubu_asan_clang:
+  t_ubu_asan_clang_soltest:
     <<: *base_ubuntu2004_clang
     environment:
       EVM: << pipeline.parameters.evm-version >>
@@ -844,7 +844,7 @@ jobs:
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
     <<: *steps_soltest
 
-  t_ubu_ubsan_clang:
+  t_ubu_ubsan_clang_soltest:
     <<: *base_ubuntu2004_clang
     environment:
       EVM: << pipeline.parameters.evm-version >>
@@ -978,7 +978,7 @@ jobs:
     environment:
       FORCE_RELEASE: ON
 
-  t_win: &t_win
+  t_win_soltest: &t_win_soltest
     <<: *base_win_powershell
     steps:
       # NOTE: Git's default core.autocrlf is fine for running soltest. We get additional coverage
@@ -995,8 +995,8 @@ jobs:
       - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
 
-  t_win_release:
-    <<: *t_win
+  t_win_release_soltest:
+    <<: *t_win_soltest
 
   b_bytecode_ubu:
     <<: *base_ubuntu2004
@@ -1128,8 +1128,8 @@ workflows:
       - chk_errorcodes: *workflow_trigger_on_tags
       - chk_antlr_grammar: *workflow_trigger_on_tags
       - chk_docs_pragma_min_version: *workflow_trigger_on_tags
-      - t_pyscripts_ubu: *workflow_trigger_on_tags
-      - t_pyscripts_win: *workflow_trigger_on_tags
+      - t_ubu_pyscripts: *workflow_trigger_on_tags
+      - t_win_pyscripts: *workflow_trigger_on_tags
 
       # build-only
       - b_docs: *workflow_trigger_on_tags
@@ -1151,7 +1151,7 @@ workflows:
       # Ubuntu build and tests
       - b_ubu: *workflow_trigger_on_tags
       - t_ubu_cli: *workflow_ubuntu2004
-      - t_ubu_soltest: *workflow_ubuntu2004
+      - t_ubu_soltest_all: *workflow_ubuntu2004
       - t_ubu_soltest_enforce_yul: *workflow_ubuntu2004
       - b_ubu_clang: *workflow_trigger_on_tags
       - t_ubu_clang_soltest: *workflow_ubuntu2004_clang
@@ -1159,7 +1159,7 @@ workflows:
       # Ubuntu fake release build and tests
       - b_ubu_release: *workflow_trigger_on_tags
       - t_ubu_release_cli: *workflow_ubuntu2004_release
-      - t_ubu_release_soltest: *workflow_ubuntu2004_release
+      - t_ubu_release_soltest_all: *workflow_ubuntu2004_release
 
       # Emscripten build and tests that take 15 minutes or less
       - b_ems: *workflow_trigger_on_tags
@@ -1222,8 +1222,8 @@ workflows:
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags
       - b_win_release: *workflow_trigger_on_tags
-      - t_win: *workflow_win
-      - t_win_release: *workflow_win_release
+      - t_win_soltest: *workflow_win
+      - t_win_release_soltest: *workflow_win_release
 
       # Bytecode comparison:
       - b_bytecode_ubu:
@@ -1267,13 +1267,13 @@ workflows:
       # ASan build and tests
       - b_ubu_asan: *workflow_trigger_on_tags
       - b_ubu_asan_clang: *workflow_trigger_on_tags
-      - t_ubu_asan: *workflow_ubuntu2004_asan
-      - t_ubu_asan_clang: *workflow_ubuntu2004_asan_clang
+      - t_ubu_asan_soltest: *workflow_ubuntu2004_asan
+      - t_ubu_asan_clang_soltest: *workflow_ubuntu2004_asan_clang
       - t_ubu_asan_cli: *workflow_ubuntu2004_asan
 
       # UBSan build and tests
       - b_ubu_ubsan_clang: *workflow_trigger_on_tags
-      - t_ubu_ubsan_clang: *workflow_ubuntu2004_ubsan_clang
+      - t_ubu_ubsan_clang_soltest: *workflow_ubuntu2004_ubsan_clang
       - t_ubu_ubsan_clang_cli: *workflow_ubuntu2004_ubsan_clang
 
       # Emscripten build and tests that take more than 15 minutes to execute

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,14 +212,93 @@ defaults:
   - base_ubuntu1604_clang: &base_ubuntu1604_clang
       docker:
         - image: << pipeline.parameters.ubuntu-1604-clang-ossfuzz-docker-image >>
+      environment:
+        TERM: xterm
 
   - base_ubuntu2004_clang: &base_ubuntu2004_clang
       docker:
         - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
+      environment:
+        TERM: xterm
+        CC: clang
+        CXX: clang++
+        MAKEFLAGS: -j 3
+
+  - base_ubuntu2004_clang_xlarge: &base_ubuntu2004_clang_xlarge
+      <<: *base_ubuntu2004_clang
+      resource_class: xlarge
+      environment:
+        TERM: xterm
+        CC: clang
+        CXX: clang++
+        MAKEFLAGS: -j 10
 
   - base_ubuntu2004: &base_ubuntu2004
       docker:
         - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+      environment:
+        TERM: xterm
+
+  - base_ubuntu2004_xlarge: &base_ubuntu2004_xlarge
+      <<: *base_ubuntu2004
+      resource_class: xlarge
+      environment:
+        TERM: xterm
+        MAKEFLAGS: -j 10
+
+  - base_buildpack_focal: &base_buildpack_focal
+      docker:
+        - image: buildpack-deps:focal
+      environment:
+        TERM: xterm
+
+  - base_buildpack_latest: &base_buildpack_latest
+      docker:
+        - image: buildpack-deps:latest
+      environment:
+        TERM: xterm
+
+  - base_archlinux: &base_archlinux
+      docker:
+        - image: archlinux:base
+      environment:
+        TERM: xterm
+
+  - base_win_powershell: &base_win_powershell
+      executor:
+        name: win/default
+        shell: powershell.exe
+
+  - base_win_cmd: &base_win_cmd
+      executor:
+        name: win/default
+        shell: cmd.exe
+
+  - base_osx: &base_osx
+      macos:
+        xcode: "11.0.0"
+      environment:
+        TERM: xterm
+
+  - base_ems_xlarge: &base_ems_xlarge
+      docker:
+        - image: << pipeline.parameters.emscripten-docker-image >>
+      resource_class: xlarge
+      environment:
+        TERM: xterm
+        MAKEFLAGS: -j 10
+
+  - base_python: &base_python
+      docker:
+        - image: circleci/python:3.6
+      environment:
+        TERM: xterm
+
+  - base_node_latest: &base_node_latest
+      docker:
+        - image: circleci/node
+      environment:
+        TERM: xterm
 
   # --------------------------------------------------------------------------
   # Workflow Templates
@@ -303,10 +382,7 @@ defaults:
 jobs:
 
   chk_spelling:
-    docker:
-      - image: circleci/python:3.6
-    environment:
-      TERM: xterm
+    <<: *base_python
     steps:
       - checkout
       - attach_workspace:
@@ -320,10 +396,7 @@ jobs:
           command: ~/.local/bin/codespell -S "*.enc,.git,Dockerfile*" -I ./scripts/codespell_whitelist.txt
 
   chk_docs_examples:
-    docker:
-      - image: circleci/node
-    environment:
-      TERM: xterm
+    <<: *base_node_latest
     steps:
       - checkout
       - attach_workspace:
@@ -336,8 +409,7 @@ jobs:
           command: ./test/docsCodeStyle.sh
 
   chk_coding_style:
-    docker:
-      - image: buildpack-deps:focal
+    <<: *base_buildpack_focal
     steps:
       - checkout
       - run:
@@ -354,8 +426,7 @@ jobs:
           command: ./scripts/check_symlinks.sh
 
   chk_errorcodes:
-    docker:
-      - image: circleci/python:3.6
+    <<: *base_python
     steps:
       - checkout
       - run:
@@ -363,8 +434,7 @@ jobs:
           command: ./scripts/error_codes.py --check
 
   chk_pylint:
-    docker:
-      - image: buildpack-deps:focal
+    <<: *base_buildpack_focal
     steps:
       - checkout
       - run:
@@ -379,8 +449,7 @@ jobs:
           command: ./scripts/pylint_all.py
 
   chk_antlr_grammar:
-    docker:
-      - image: buildpack-deps:focal
+    <<: *base_buildpack_focal
     steps:
       - checkout
       - run:
@@ -391,10 +460,7 @@ jobs:
           command: ./scripts/test_antlr_grammar.sh
 
   chk_buglist:
-    docker:
-      - image: circleci/node
-    environment:
-      TERM: xterm
+    <<: *base_node_latest
     steps:
       - checkout
       - run:
@@ -408,10 +474,7 @@ jobs:
           command: ./test/buglistTests.js
 
   chk_proofs:
-    docker:
-      - image: buildpack-deps:latest
-    environment:
-      TERM: xterm
+    <<: *base_buildpack_latest
     steps:
       - checkout
       - run:
@@ -423,17 +486,13 @@ jobs:
       - run: *run_proofs
 
   chk_docs_pragma_min_version:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
-    environment:
-      TERM: xterm
+    <<: *base_ubuntu2004
     steps:
       - checkout
       - run: *run_docs_pragma_min_version
 
   t_pyscripts_ubu:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+    <<: *base_ubuntu2004
     steps:
       - checkout
       - run:
@@ -441,9 +500,7 @@ jobs:
           command: python3 test/pyscriptTests.py
 
   t_pyscripts_win:
-    executor:
-      name: win/default
-      shell: powershell.exe
+    <<: *base_win_powershell
     steps:
       - run: git config --global core.autocrlf false
       - checkout
@@ -452,11 +509,7 @@ jobs:
           command: python.exe test/pyscriptTests.py
 
   b_ubu: &b_ubu
-    resource_class: xlarge
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
-    environment:
-      MAKEFLAGS: -j 10
+    <<: *base_ubuntu2004_xlarge
     steps:
       - checkout
       - run: *run_build
@@ -467,7 +520,7 @@ jobs:
 
   # x64 ASAN build, for testing for memory related bugs
   b_ubu_asan: &b_ubu_asan
-    <<: *b_ubu
+    <<: *base_ubuntu2004_xlarge
     environment:
       CMAKE_OPTIONS: -DSANITIZE=address
       MAKEFLAGS: -j 10
@@ -479,13 +532,7 @@ jobs:
       - persist_to_workspace: *artifacts_executables
 
   b_ubu_clang: &b_ubu_clang
-    resource_class: xlarge
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
-    environment:
-      CC: clang
-      CXX: clang++
-      MAKEFLAGS: -j 10
+    <<: *base_ubuntu2004_clang_xlarge
     steps:
       - checkout
       - run: *run_build
@@ -493,8 +540,7 @@ jobs:
       - persist_to_workspace: *artifacts_executables
 
   b_ubu_asan_clang: &b_ubu_asan_clang
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
+    <<: *base_ubuntu2004_clang
     environment:
       CC: clang
       CXX: clang++
@@ -507,8 +553,7 @@ jobs:
       - persist_to_workspace: *artifacts_executables
 
   b_ubu_ubsan_clang: &b_ubu_ubsan_clang
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
+    <<: *base_ubuntu2004_clang
     environment:
       CC: clang
       CXX: clang++
@@ -528,7 +573,7 @@ jobs:
       MAKEFLAGS: -j 10
 
   b_ubu_static:
-    <<: *b_ubu
+    <<: *base_ubuntu2004_xlarge
     environment:
       MAKEFLAGS: -j 10
       CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DUSE_Z3_DLOPEN=ON -DUSE_CVC4=OFF -DSOLC_STATIC_STDLIBS=ON
@@ -541,7 +586,7 @@ jobs:
       - store_artifacts: *artifacts_solc
 
   b_ubu_codecov:
-    <<: *b_ubu
+    <<: *base_ubuntu2004_xlarge
     environment:
       COVERAGE: ON
       CMAKE_BUILD_TYPE: Debug
@@ -576,7 +621,7 @@ jobs:
   # Builds in C++20 mode and uses debug build in order to speed up.
   # Do *NOT* store any artifacts or workspace as we don't run tests on this build.
   b_ubu_cxx20:
-    <<: *b_ubu
+    <<: *base_ubuntu2004_xlarge
     environment:
       CMAKE_BUILD_TYPE: Debug
       CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=20 -DUSE_CVC4=OFF
@@ -586,13 +631,7 @@ jobs:
       - run: *run_build
 
   b_ubu_ossfuzz: &b_ubu_ossfuzz
-    docker:
-      - image: << pipeline.parameters.ubuntu-1604-clang-ossfuzz-docker-image >>
-    environment:
-      CC: clang
-      CXX: clang++
-      TERM: xterm
-      MAKEFLAGS: -j 3
+    <<: *base_ubuntu1604_clang
     steps:
       - checkout
       - run: *setup_prerelease_commit_hash
@@ -617,8 +656,7 @@ jobs:
       - store_artifacts: *artifacts_test_results
 
   b_archlinux:
-    docker:
-      - image: archlinux:base
+    <<: *base_archlinux
     environment:
       TERM: xterm
       MAKEFLAGS: -j 3
@@ -633,8 +671,7 @@ jobs:
       - persist_to_workspace: *artifacts_executables
 
   b_osx:
-    macos:
-      xcode: "11.0.0"
+    <<: *base_osx
     environment:
       TERM: xterm
       CMAKE_BUILD_TYPE: Release
@@ -670,8 +707,7 @@ jobs:
             - build/test/tools/solfuzzer
 
   t_osx_soltest:
-    macos:
-      xcode: "11.0.0"
+    <<: *base_osx
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
@@ -688,10 +724,7 @@ jobs:
       - store_artifacts: *artifacts_test_results
 
   t_osx_cli:
-    macos:
-      xcode: "11.0.0"
-    environment:
-      TERM: xterm
+    <<: *base_osx
     steps:
       - checkout
       - restore_cache:
@@ -703,12 +736,7 @@ jobs:
       - store_artifacts: *artifacts_test_results
 
   b_ems:
-    resource_class: xlarge
-    docker:
-      - image: << pipeline.parameters.emscripten-docker-image >>
-    environment:
-      MAKEFLAGS: -j 10
-      TERM: xterm
+    <<: *base_ems_xlarge
     steps:
       - checkout
       - run:
@@ -728,8 +756,7 @@ jobs:
             - version.txt
 
   b_docs:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+    <<: *base_ubuntu2004
     steps:
       - checkout
       - run: *setup_prerelease_commit_hash
@@ -746,34 +773,31 @@ jobs:
     <<: *steps_soltest_all
 
   t_archlinux_soltest: &t_archlinux_soltest
-      docker:
-        - image: archlinux:base
-      environment:
-        EVM: << pipeline.parameters.evm-version >>
-        OPTIMIZE: 0
-        TERM: xterm
-        # For Archlinux we do not have prebuilt docker images and we would need to build evmone from source,
-        # thus we forgo semantics tests to speed things up.
-        SOLTEST_FLAGS: --no-semantic-tests
-      steps:
-        - run:
-            name: Install runtime dependencies
-            command: |
-              pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake z3 cvc4 git openssh tar
-        - when:
-            condition: true
-            <<: *steps_soltest
+    <<: *base_archlinux
+    environment:
+      EVM: << pipeline.parameters.evm-version >>
+      OPTIMIZE: 0
+      TERM: xterm
+      # For Archlinux we do not have prebuilt docker images and we would need to build evmone from source,
+      # thus we forgo semantics tests to speed things up.
+      SOLTEST_FLAGS: --no-semantic-tests
+    steps:
+      - run:
+          name: Install runtime dependencies
+          command: |
+            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake z3 cvc4 git openssh tar
+      - when:
+          condition: true
+          <<: *steps_soltest
 
   t_ubu_soltest_enforce_yul: &t_ubu_soltest_enforce_yul
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+    <<: *base_ubuntu2004
     environment:
       EVM: << pipeline.parameters.evm-version >>
       SOLTEST_FLAGS: --enforce-via-yul
       OPTIMIZE: 0
       TERM: xterm
     <<: *steps_soltest
-
 
   t_ubu_clang_soltest: &t_ubu_clang_soltest
     <<: *base_ubuntu2004_clang
@@ -788,17 +812,14 @@ jobs:
     <<: *t_ubu_soltest
 
   t_ubu_cli: &t_ubu_cli
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
-    environment:
-      TERM: xterm
+    <<: *base_ubuntu2004
     <<: *steps_cmdline_tests
 
   t_ubu_release_cli: &t_ubu_release_cli
     <<: *t_ubu_cli
 
   t_ubu_asan_cli:
-    <<: *t_ubu_cli
+    <<: *base_ubuntu2004
     environment:
       TERM: xterm
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
@@ -824,10 +845,9 @@ jobs:
     <<: *steps_soltest
 
   t_ubu_ubsan_clang:
+    <<: *base_ubuntu2004_clang
     environment:
       EVM: << pipeline.parameters.evm-version >>
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
     steps:
       - when:
           condition: true
@@ -835,8 +855,7 @@ jobs:
       - gitter_notify_failure
 
   t_ubu_ubsan_clang_cli:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
+    <<: *base_ubuntu2004_clang
     steps:
       - when:
           condition: true
@@ -844,10 +863,7 @@ jobs:
       - gitter_notify_failure
 
   t_ems_solcjs:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
-    environment:
-      TERM: xterm
+    <<: *base_ubuntu2004
     steps:
       - checkout
       - attach_workspace:
@@ -866,8 +882,7 @@ jobs:
             test/externalTests/solc-js/solc-js.sh /tmp/workspace/soljson.js $(cat /tmp/workspace/version.txt)
 
   t_ems_ext_hardhat:
-    docker:
-      - image: circleci/node
+    <<: *base_node_latest
     environment:
       TERM: xterm
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js
@@ -929,9 +944,7 @@ jobs:
             - gitter_notify_success
 
   b_win: &b_win
-    executor:
-      name: win/default
-      shell: powershell.exe
+    <<: *base_win_powershell
     steps:
       # NOTE: Not disabling git's core.autocrlf here because we want to build using the typical Windows config.
       - checkout
@@ -966,9 +979,7 @@ jobs:
       FORCE_RELEASE: ON
 
   t_win: &t_win
-    executor:
-      name: win/default
-      shell: powershell.exe
+    <<: *base_win_powershell
     steps:
       # NOTE: Git's default core.autocrlf is fine for running soltest. We get additional coverage
       # for files using CRLF that way.
@@ -988,8 +999,7 @@ jobs:
     <<: *t_win
 
   b_bytecode_ubu:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+    <<: *base_ubuntu2004
     steps:
       - checkout
       - attach_workspace:
@@ -1009,10 +1019,7 @@ jobs:
             - bytecode-report-ubuntu-cli.txt
 
   b_bytecode_osx:
-    macos:
-      xcode: "11.0.0"
-    environment:
-      TERM: xterm
+    <<: *base_osx
     steps:
       - checkout
       - attach_workspace:
@@ -1032,9 +1039,7 @@ jobs:
             - bytecode-report-osx-cli.txt
 
   b_bytecode_win:
-    executor:
-      name: win/default
-      shell: cmd.exe
+    <<: *base_win_cmd
     steps:
       # NOTE: For bytecode generation we need the input files to be byte-for-byte identical on all
       # platforms so line ending conversions must absolutely be disabled.
@@ -1057,8 +1062,7 @@ jobs:
             - bytecode-report-windows-cli.txt
 
   b_bytecode_ems:
-    docker:
-      - image: circleci/node:16
+    <<: *base_node_latest
     environment:
       SOLC_EMSCRIPTEN: "On"
     steps:
@@ -1074,8 +1078,7 @@ jobs:
             - bytecode-report-emscripten.txt
 
   t_bytecode_compare:
-    docker:
-      - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+    <<: *base_ubuntu2004
     environment:
       REPORT_FILES: |
         bytecode-report-emscripten.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ defaults:
       destination: test_results/
 
   # --------------------------------------------------------------------------
-  # Tests Templates
+  # Step Templates
 
   # store_test_results helper
   - store_test_results: &store_test_results
@@ -181,6 +181,9 @@ defaults:
         - checkout
         - attach_workspace:
             at: build
+        # NOTE: Different build jobs produce different soltest executables (release/debug,
+        # clang/gcc, windows/linux/macos, etc.). The executable used by these steps comes from the
+        # attached workspace and we only see the items added to the workspace by jobs we depend on.
         - run: *run_soltest
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
@@ -203,22 +206,20 @@ defaults:
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
 
-  - test_ubuntu1604_clang: &test_ubuntu1604_clang
+  # --------------------------------------------------------------------------
+  # Base Image Templates
+
+  - base_ubuntu1604_clang: &base_ubuntu1604_clang
       docker:
         - image: << pipeline.parameters.ubuntu-1604-clang-ossfuzz-docker-image >>
-      <<: *steps_soltest
 
-  - test_ubuntu2004_clang: &test_ubuntu2004_clang
+  - base_ubuntu2004_clang: &base_ubuntu2004_clang
       docker:
         - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
-      <<: *steps_soltest
 
-  - test_ubuntu2004: &test_ubuntu2004
+  - base_ubuntu2004: &base_ubuntu2004
       docker:
         - image: << pipeline.parameters.ubuntu-2004-docker-image >>
-      parallelism: 6
-      <<: *steps_soltest_all
-
 
   # --------------------------------------------------------------------------
   # Workflow Templates
@@ -551,7 +552,8 @@ jobs:
       - persist_to_workspace: *artifacts_executables
 
   t_ubu_codecov:
-    <<: *test_ubuntu2004
+    <<: *base_ubuntu2004
+    parallelism: 6
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 1
@@ -598,7 +600,7 @@ jobs:
       - persist_to_workspace: *artifacts_executables_ossfuzz
 
   t_ubu_ossfuzz: &t_ubu_ossfuzz
-    <<: *test_ubuntu1604_clang
+    <<: *base_ubuntu1604_clang
     steps:
       - checkout
       - attach_workspace:
@@ -739,7 +741,9 @@ jobs:
           destination: docs-html
 
   t_ubu_soltest: &t_ubu_soltest
-    <<: *test_ubuntu2004
+    <<: *base_ubuntu2004
+    parallelism: 6
+    <<: *steps_soltest_all
 
   t_archlinux_soltest: &t_archlinux_soltest
       docker:
@@ -772,12 +776,15 @@ jobs:
 
 
   t_ubu_clang_soltest: &t_ubu_clang_soltest
-    <<: *test_ubuntu2004_clang
+    <<: *base_ubuntu2004_clang
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
+    <<: *steps_soltest
 
   t_ubu_release_soltest: &t_ubu_release_soltest
+    # NOTE: This definition is identical to t_ubu_soltest_all but in the workflow we make it depend on
+    # a different job (b_ubu_release) so the workspace it attaches contains a different executable.
     <<: *t_ubu_soltest
 
   t_ubu_cli: &t_ubu_cli
@@ -798,20 +805,23 @@ jobs:
     <<: *steps_cmdline_tests
 
   t_ubu_asan:
-    <<: *test_ubuntu2004
+    <<: *base_ubuntu2004
+    parallelism: 6
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
+    <<: *steps_soltest
 
   t_ubu_asan_clang:
-    <<: *test_ubuntu2004_clang
+    <<: *base_ubuntu2004_clang
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
+    <<: *steps_soltest
 
   t_ubu_ubsan_clang:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,14 +219,6 @@ defaults:
       parallelism: 6
       <<: *steps_soltest_all
 
-  - test_asan: &test_asan
-      <<: *test_ubuntu2004
-      <<: *steps_soltest
-
-  - test_ubuntu2004_clang_cli: &test_ubuntu2004_clang_cli
-      docker:
-        - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
-      <<: *steps_cmdline_tests
 
   # --------------------------------------------------------------------------
   # Workflow Templates
@@ -806,7 +798,7 @@ jobs:
     <<: *steps_cmdline_tests
 
   t_ubu_asan:
-    <<: *test_asan
+    <<: *test_ubuntu2004
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0


### PR DESCRIPTION
Implements part of #11846.
~Depends on #12182 (draft until it's merged).~ Merged.

This is a refactor I did while trying to enable gitter notifications for all nightly jobs. The fact that steps are often shared by being included in the `test_` templates made adding notifications only for jobs that do not run on PRs a bit complicated.

This PR replaces them with a consistent set of `base_` templates that define the base docker image, resource class and some default environment variables and steps are now always provided explicitly in the job. It also renames jobs so that it's easier to see what they run - `soltest` or `soltest_all` is now always included in the name and the python job names now follow the same naming convention as other jobs.