### PR TITLE
Include actual contract size in the code size warning

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -83,6 +83,7 @@
 #include <utility>
 #include <map>
 #include <limits>
+#include <string>
 
 using namespace std;
 using namespace solidity;
@@ -1248,7 +1249,9 @@ void CompilerStack::assemble(
 		m_errorReporter.warning(
 			5574_error,
 			_contract.location(),
-			"Contract code size exceeds 24576 bytes (a limit introduced in Spurious Dragon). "
+			"Contract code size is "s +
+			to_string(compiledContract.runtimeObject.bytecode.size()) +
+			" bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). "
 			"This contract may not be deployable on mainnet. "
 			"Consider enabling the optimizer (with a low \"runs\" value!), "
 			"turning off revert strings, or using libraries."

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -77,6 +77,8 @@ void SyntaxTest::setupCompiler()
 		OptimiserSettings::full() :
 		OptimiserSettings::minimal()
 	);
+	compiler().setMetadataFormat(CompilerStack::MetadataFormat::NoMetadata);
+	compiler().setMetadataHash(CompilerStack::MetadataHash::None);
 }
 
 void SyntaxTest::parseAndAnalyze()

--- a/test/libsolidity/syntaxTests/bytecode_too_large_abiencoder_v1.sol
+++ b/test/libsolidity/syntaxTests/bytecode_too_large_abiencoder_v1.sol
@@ -1,4 +1,4 @@
-pragma abicoder v2;
+pragma abicoder v1;
 
 contract test {
     function f() public pure returns (string memory ret) {
@@ -9,4 +9,4 @@ contract test {
 // ====
 // EVMVersion: >byzantium
 // ----
-// Warning 5574: (21-27154): Contract code size is 27199 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
+// Warning 5574: (21-27154): Contract code size is 27209 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.

--- a/test/libsolidity/syntaxTests/bytecode_too_large_byzantium.sol
+++ b/test/libsolidity/syntaxTests/bytecode_too_large_byzantium.sol
@@ -1,5 +1,3 @@
-pragma abicoder v2;
-
 contract test {
     function f() public pure returns (string memory ret) {
         // 27000 bytes long data
@@ -7,6 +5,6 @@ contract test {
     }
 }
 // ====
-// EVMVersion: >byzantium
+// EVMVersion: =byzantium
 // ----
-// Warning 5574: (21-27154): Contract code size is 27199 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
+// Warning 5574: (0-27133): Contract code size is 27227 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.

--- a/test/libsolidity/syntaxTests/bytecode_too_large_homestead.sol
+++ b/test/libsolidity/syntaxTests/bytecode_too_large_homestead.sol
@@ -1,5 +1,3 @@
-pragma abicoder v2;
-
 contract test {
     function f() public pure returns (string memory ret) {
         // 27000 bytes long data
@@ -7,6 +5,5 @@ contract test {
     }
 }
 // ====
-// EVMVersion: >byzantium
+// EVMVersion: =homestead
 // ----
-// Warning 5574: (21-27154): Contract code size is 27199 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.


### PR DESCRIPTION
Contract size warning missing a crucial bit of information required in order to fix it
Fixes #12171