### PR TITLE
Add missing condition to `gitter_notify` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ commands:
     steps:
       - run:
           name: "Gitter notification"
+          when: << parameters.condition >>
           command: |
             [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ Nightly job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
             [[ "<< parameters.event >>" == "success" ]] && message=" ✅ Nightly job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."


### PR DESCRIPTION
This fixes a small bug introduced in #12182. I did test it but only really to check that notifications appear. Turns out I did not notice that the condition that ensures that notification only shows up on success/failure was missing from the command. This PR adds it.

Without the fix, [notifications from nightly jobs are sent unconditionally](https://gitter.im/ethereum/solidity-dev?at=61774bbc29ddcd029343d9fe). I tested the fix in 3 scenarios:
- [Successful `b_docs` job with `on_fail` condition](https://app.circleci.com/pipelines/github/ethereum/solidity/20000/workflows/467d1abc-5de5-4f35-a9ba-24509f422c29/jobs/883571). No notification.
- [Successful `b_docs` job with `on_success` condition](https://app.circleci.com/pipelines/github/ethereum/solidity/20002/workflows/0297c180-e81a-4ee7-9d5f-46ebb31ab087/jobs/883618). A [success notification](https://gitter.im/ethereum/solidity-dev?at=6177c100d78911028afefa6f) was sent.
- [Failed `b_docs` job with `on_fail` condition](https://app.circleci.com/pipelines/github/ethereum/solidity/20003/workflows/e57ea098-692c-4986-9341-265ff3989fb8/jobs/883638). A [failure notification](https://gitter.im/ethereum/solidity-dev?at=6177c100d78911028afefa6f) was sent.