### PR TITLE
Make external test scripts more flexible

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -41,8 +41,7 @@ function colony_test
     setup_solcjs "$DIR" "$SOLJSON"
     download_project "$repo" "$branch" "$DIR"
 
-    replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    neutralize_package_json_hooks
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
     yarn
     git submodule update --init

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -52,7 +52,7 @@ function colony_test
     cd ..
 
     replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    force_solc_modules "${DIR}/solc"
 
     for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
         truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -27,24 +27,37 @@ source test/externalTests/common.sh
 verify_input "$1"
 SOLJSON="$1"
 
-function install_fn { yarn; git submodule update --init; }
 function compile_fn { yarn run provision:token:contracts; }
 function test_fn { yarn run test:contracts; }
 
 function colony_test
 {
-    OPTIMIZER_LEVEL=3
-    CONFIG="truffle.js"
+    local repo="https://github.com/solidity-external-tests/colonyNetwork.git"
+    local branch=develop_080
+    local config_file="truffle.js"
+    local min_optimizer_level=3
+    local max_optimizer_level=3
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/colonyNetwork.git develop_080
-    run_install "$SOLJSON" install_fn
+    setup_solcjs "$DIR" "$SOLJSON"
+    download_project "$repo" "$branch" "$DIR"
+
+    replace_version_pragmas
+    force_truffle_solc_modules "$SOLJSON"
+    force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
+    yarn
+    git submodule update --init
 
     cd lib
     rm -Rf dappsys
     git clone https://github.com/solidity-external-tests/dappsys-monolithic.git -b master_080 dappsys
     cd ..
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn
+    replace_version_pragmas
+    force_truffle_solc_modules "$SOLJSON"
+
+    for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
+        truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn
+    done
 }
 
 external_test ColonyNetworks colony_test

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -96,6 +96,14 @@ function replace_version_pragmas
     find . test -name '*.sol' -type f -print0 | xargs -0 sed -i -E -e 's/pragma solidity [^;]+;/pragma solidity >=0.0;/'
 }
 
+function neutralize_package_lock
+{
+    # Remove lock files (if they exist) to prevent them from overriding our changes in package.json
+    printLog "Removing package lock files..."
+    rm --force --verbose yarn.lock
+    rm --force --verbose package-lock.json
+}
+
 function force_truffle_solc_modules
 {
     local soljson="$1"

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -104,6 +104,14 @@ function neutralize_package_lock
     rm --force --verbose package-lock.json
 }
 
+function neutralize_package_json_hooks
+{
+    printLog "Disabling package.json hooks..."
+    [[ -f package.json ]] || fail "package.json not found"
+    sed -i 's|"prepublish": *".*"|"prepublish": ""|g' package.json
+    sed -i 's|"prepare": *".*"|"prepare": ""|g' package.json
+}
+
 function force_truffle_solc_modules
 {
     local soljson="$1"

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -112,25 +112,22 @@ function neutralize_package_json_hooks
     sed -i 's|"prepare": *".*"|"prepare": ""|g' package.json
 }
 
-function force_truffle_solc_modules
+function force_solc_modules
 {
-    local soljson="$1"
+    local custom_solcjs_path="${1:-solc/}"
 
-    # Replace solc package by v0.5.0 and then overwrite with current version.
-    printLog "Forcing solc version for all Truffle modules..."
-    for d in node_modules node_modules/truffle/node_modules
+    [[ -d node_modules/ ]] || assertFail
+
+    printLog "Replacing all installed solc-js with a link to the latest version..."
+    soljson_binaries=$(find node_modules -type f -path "*/solc/soljson.js")
+    for soljson_binary in $soljson_binaries
     do
-    (
-        if [ -d "$d" ]; then
-            cd $d
-            rm -rf solc
-            git clone --depth 1 -b master https://github.com/ethereum/solc-js.git solc
-            cp "$soljson" solc/soljson.js
+        local solc_module_path
+        solc_module_path=$(dirname "$soljson_binary")
 
-            cd solc
-            npm install
-        fi
-    )
+        printLog "Found and replaced solc-js in $solc_module_path"
+        rm -r "$solc_module_path"
+        ln -s "$custom_solcjs_path" "$solc_module_path"
     done
 }
 

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -44,9 +44,7 @@ function ens_test
     # Use latest Truffle. Older versions crash on the output from 0.8.0.
     force_truffle_version ^5.1.55
 
-    # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
-    rm -f package-lock.json
-
+    neutralize_package_lock
     replace_version_pragmas
     force_truffle_solc_modules "$SOLJSON"
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -50,7 +50,7 @@ function ens_test
     npm install
 
     replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    force_solc_modules "${DIR}/solc"
 
     for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
         truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -45,8 +45,7 @@ function ens_test
     force_truffle_version ^5.1.55
 
     neutralize_package_lock
-    replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    neutralize_package_json_hooks
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
     npm install
 

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -46,8 +46,7 @@ function gnosis_safe_test
     sed -i -E 's|"@gnosis.pm/util-contracts": "[^"]+"|"@gnosis.pm/util-contracts": "github:solidity-external-tests/util-contracts#solc-7_080"|g' package.json
 
     neutralize_package_lock
-    replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    neutralize_package_json_hooks
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
     npm install --package-lock
 

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -51,7 +51,7 @@ function gnosis_safe_test
     npm install --package-lock
 
     replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    force_solc_modules "${DIR}/solc"
 
     for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
         truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -45,9 +45,7 @@ function gnosis_safe_test
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080|g' package.json
     sed -i -E 's|"@gnosis.pm/util-contracts": "[^"]+"|"@gnosis.pm/util-contracts": "github:solidity-external-tests/util-contracts#solc-7_080"|g' package.json
 
-    # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
-    rm -f package-lock.json
-
+    neutralize_package_lock
     replace_version_pragmas
     force_truffle_solc_modules "$SOLJSON"
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -49,7 +49,7 @@ function gnosis_safe_test
     npm install --package-lock
 
     replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    force_solc_modules "${DIR}/solc"
 
     for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
         truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -27,25 +27,36 @@ source test/externalTests/common.sh
 verify_input "$1"
 SOLJSON="$1"
 
-function install_fn { npm install --package-lock; }
 function compile_fn { npx truffle compile; }
 function test_fn { npm test; }
 
 function gnosis_safe_test
 {
-    OPTIMIZER_LEVEL=2
-    CONFIG="truffle-config.js"
+    local repo="https://github.com/solidity-external-tests/safe-contracts.git"
+    local branch=development_080
+    local config_file="truffle-config.js"
+    local min_optimizer_level=2
+    local max_optimizer_level=3
 
-    truffle_setup "$SOLJSON" https://github.com/solidity-external-tests/safe-contracts.git development_080
+    setup_solcjs "$DIR" "$SOLJSON"
+    download_project "$repo" "$branch" "$DIR"
 
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080|g' package.json
 
     # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
     rm -f package-lock.json
 
-    run_install "$SOLJSON" install_fn
+    replace_version_pragmas
+    force_truffle_solc_modules "$SOLJSON"
+    force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
+    npm install --package-lock
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn
+    replace_version_pragmas
+    force_truffle_solc_modules "$SOLJSON"
+
+    for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
+        truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn
+    done
 }
 
 external_test Gnosis-Safe gnosis_safe_test

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -43,9 +43,7 @@ function gnosis_safe_test
 
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080|g' package.json
 
-    # Remove the lock file (if it exists) to prevent it from overriding our changes in package.json
-    rm -f package-lock.json
-
+    neutralize_package_lock
     replace_version_pragmas
     force_truffle_solc_modules "$SOLJSON"
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -44,8 +44,7 @@ function gnosis_safe_test
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080|g' package.json
 
     neutralize_package_lock
-    replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    neutralize_package_json_hooks
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
     npm install --package-lock
 

--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -28,7 +28,6 @@ verify_version_input "$1" "$2"
 SOLJSON="$1"
 VERSION="$2"
 
-function install_fn { echo "Nothing to install."; }
 function compile_fn { echo "Nothing to compile."; }
 function test_fn { npm test; }
 

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -27,19 +27,31 @@ source test/externalTests/common.sh
 verify_input "$1"
 SOLJSON="$1"
 
-function install_fn { npm install; }
 function compile_fn { npx truffle compile; }
 function test_fn { npm run test; }
 
 function zeppelin_test
 {
-    OPTIMIZER_LEVEL=1
-    CONFIG="truffle-config.js"
+    local repo="https://github.com/OpenZeppelin/openzeppelin-contracts.git"
+    local branch=master
+    local config_file="truffle-config.js"
+    local min_optimizer_level=1
+    local max_optimizer_level=3
 
-    truffle_setup "$SOLJSON" https://github.com/OpenZeppelin/openzeppelin-contracts.git master
-    run_install "$SOLJSON" install_fn
+    setup_solcjs "$DIR" "$SOLJSON"
+    download_project "$repo" "$branch" "$DIR"
 
-    truffle_run_test "$SOLJSON" compile_fn test_fn
+    replace_version_pragmas
+    force_truffle_solc_modules "$SOLJSON"
+    force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
+    npm install
+
+    replace_version_pragmas
+    force_truffle_solc_modules "$SOLJSON"
+
+    for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
+        truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn
+    done
 }
 
 external_test Zeppelin zeppelin_test

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -46,7 +46,7 @@ function zeppelin_test
     npm install
 
     replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    force_solc_modules "${DIR}/solc"
 
     for level in $(seq "$min_optimizer_level" "$max_optimizer_level"); do
         truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -41,8 +41,7 @@ function zeppelin_test
     setup_solcjs "$DIR" "$SOLJSON"
     download_project "$repo" "$branch" "$DIR"
 
-    replace_version_pragmas
-    force_truffle_solc_modules "$SOLJSON"
+    neutralize_package_json_hooks
     force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
     npm install
 


### PR DESCRIPTION
Another refactor in preparation for fixing #10745.
~Depends on #12173 (draft until that PR is merged).~ Merged.
Depends on #12259.

Currently the external test scripts are all made with Truffle in mind and are a bit hard to customize both if they need some special steps and when they use a different framework. This PR "unrolls" the top-level functions and puts their content directly in each test script so that it can be adjusted more easily. It also does small general refactors:
- Adds `set -e` to the scripts so that failures interrupt them.
- Changes arguments of some functions or adds defaults so that the calls are a bit less verbose.
- Removes some global variables in favor of locals+parameters.