### PR TITLE
Use Hardhat and the right binary for OpenZeppelin external tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1223,7 +1223,6 @@ workflows:
           name: t_ems_compile_ext_zeppelin
           project: zeppelin
           compile_only: 1
-          nodejs_version: '14'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_compile_ext_ens
@@ -1250,7 +1249,8 @@ workflows:
           <<: *workflow_emscripten
           name: t_ems_test_ext_zeppelin
           project: zeppelin
-          nodejs_version: '14'
+          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+          nodejs_version: '16'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_test_ext_ens

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,8 +946,8 @@ jobs:
         type: integer
         default: 0
       nodejs_version:
-        type: integer
-        default: 14
+        type: string
+        default: latest
     docker:
       - image: circleci/node:<<parameters.nodejs_version>>
     # NOTE: Each external test does 3 separate compile&test runs
@@ -1205,28 +1205,32 @@ workflows:
           name: t_ems_compile_ext_colony
           project: colony
           compile_only: 1
+          nodejs_version: '14'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_compile_ext_gnosis
           project: gnosis
           compile_only: 1
+          nodejs_version: '14'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_compile_ext_gnosis_v2
           project: gnosis-v2
           compile_only: 1
+          nodejs_version: '14'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_compile_ext_zeppelin
           project: zeppelin
           compile_only: 1
+          nodejs_version: '14'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_compile_ext_ens
           project: ens
           compile_only: 1
           # NOTE: One of the dependencies (fsevents) fails to build its native extension on node.js 12+.
-          nodejs_version: 10
+          nodejs_version: '10'
 
       # FIXME: Gnosis tests are pretty flaky right now. They often fail on CircleCI due to random ProviderError
       # and there are also other less frequent problems. See https://github.com/gnosis/safe-contracts/issues/216.
@@ -1235,23 +1239,24 @@ workflows:
       #    name: t_ems_test_ext_gnosis
       #    project: gnosis
       #    # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
-      #    nodejs_version: 12
+      #    nodejs_version: '12'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_test_ext_gnosis_v2
           project: gnosis-v2
           # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
-          nodejs_version: 12
+          nodejs_version: '12'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_test_ext_zeppelin
           project: zeppelin
+          nodejs_version: '14'
       - t_ems_ext:
           <<: *workflow_emscripten
           name: t_ems_test_ext_ens
           project: ens
           # NOTE: One of the dependencies (fsevents) fails to build its native extension on node.js 12+.
-          nodejs_version: 10
+          nodejs_version: '10'
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -27,14 +27,14 @@ source test/externalTests/common.sh
 verify_input "$1"
 SOLJSON="$1"
 
-function compile_fn { npx truffle compile; }
-function test_fn { npm run test; }
+function compile_fn { npm run compile; }
+function test_fn { npm test; }
 
 function zeppelin_test
 {
     local repo="https://github.com/OpenZeppelin/openzeppelin-contracts.git"
     local branch=master
-    local config_file="truffle-config.js"
+    local config_file="hardhat.config.js"
     local min_optimizer_level=1
     local max_optimizer_level=3
 
@@ -46,14 +46,14 @@ function zeppelin_test
     download_project "$repo" "$branch" "$DIR"
 
     neutralize_package_json_hooks
-    force_truffle_compiler_settings "$config_file" "${DIR}/solc" "$min_optimizer_level"
+    force_hardhat_compiler_binary "$config_file" "$SOLJSON"
+    force_hardhat_compiler_settings "$config_file" "$min_optimizer_level"
     npm install
 
     replace_version_pragmas
-    force_solc_modules "${DIR}/solc"
 
     for level in $selected_optimizer_levels; do
-        truffle_run_test "$config_file" "${DIR}/solc" "$level" compile_fn test_fn
+        hardhat_run_test "$config_file" "$level" compile_fn test_fn
     done
 }
 


### PR DESCRIPTION
Fixes #10745.
~Depends on #12191 (draft until that PR is merged).~ Merged.