### PR TITLE
Switch ENS external test to ens-contracts repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1363,8 +1363,8 @@ workflows:
           name: t_native_test_ext_ens
           project: ens
           binary_type: native
-          # NOTE: One of the dependencies (fsevents) fails to build its native extension on node.js 12+.
-          nodejs_version: '10'
+          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+          nodejs_version: '16'
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags


### PR DESCRIPTION
Fixes #8557.
~Depends on #12192 (draft until that PR is merged).~ Merged.

[ens-contracts](https://github.com/ensdomains/ens-contracts) seems to be the new consolidated repo for all ENS contracts. The project uses Hardhat now and is compatible with Solidity >= 0.8.4.

The test also now uses the upstream directly rather than our fork in solidity-external-tests.