### PR TITLE
Refactor ASTJSON tests to allow easier addition of variations.

### DIFF
--- a/test/libsolidity/ASTJSONTest.h
+++ b/test/libsolidity/ASTJSONTest.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <libsolutil/AnsiColorized.h>
+#include <libsolidity/interface/CompilerStack.h>
 #include <test/TestCase.h>
 
 #include <iosfwd>
@@ -37,6 +38,32 @@ namespace solidity::frontend::test
 class ASTJSONTest: public TestCase
 {
 public:
+	struct TestVariant
+	{
+		TestVariant(std::string_view _baseName, CompilerStack::State _stopAfter):
+			baseName(_baseName),
+			stopAfter(_stopAfter)
+		{}
+
+		std::string name() const
+		{
+			return stopAfter == CompilerStack::State::Parsed ? "parseOnly" : "";
+		}
+
+		std::string astFilename() const
+		{
+			return std::string(baseName) +
+				(name().empty() ? "" : "_") +
+				name() +
+				".json";
+		}
+
+		std::string baseName;
+		CompilerStack::State stopAfter;
+		std::string result;
+		std::string expectation;
+	};
+
 	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
 		return std::make_unique<ASTJSONTest>(_config.filename);
@@ -49,11 +76,9 @@ public:
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
 private:
 	bool runTest(
-		std::string& _expectation,
-		std::string& _result,
+		TestVariant& _testVariant,
 		std::map<std::string, unsigned> const& _sourceIndices,
 		CompilerStack& _compiler,
-		std::string const& _variation,
 		std::ostream& _stream,
 		std::string const& _linePrefix = "",
 		bool const _formatted = false
@@ -61,15 +86,12 @@ private:
 	void updateExpectation(
 		std::string const& _filename,
 		std::string const& _expectation,
-		std::string const& _variation
+		std::string const& _variant
 	) const;
 
+	std::vector<TestVariant> m_variants;
+
 	std::vector<std::pair<std::string, std::string>> m_sources;
-	std::string m_expectationParseOnly;
-	std::string m_astFilename;
-	std::string m_astParseOnlyFilename;
-	std::string m_result;
-	std::string m_resultParseOnly;
 };
 
 }


### PR DESCRIPTION
I did all the work, wanting to add a variation (parsingAndImporting) and when I was almost done I noticed that there are no imports in the ASTJSON tests because they are individual .sol files, not .json inputs.
But the work was almost done and the result is a nicer class, so I am submiting this now :)