### PR TITLE
Fix defaults for `--enforce-gas-cost` in isoltest

### DIFF
--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -60,7 +60,6 @@ IsolTestOptions::IsolTestOptions():
 	CommonOptions(description)
 {
 	enforceViaYul = true;
-	enforceGasTest = (evmVersion() == langutil::EVMVersion{});
 }
 
 void IsolTestOptions::addOptions()
@@ -83,6 +82,8 @@ bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 		std::cout << options << std::endl;
 		return false;
 	}
+
+	enforceGasTest = enforceGasTest || (evmVersion() == langutil::EVMVersion{});
 
 	return res;
 }

--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -83,7 +83,7 @@ bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 		return false;
 	}
 
-	enforceGasTest = enforceGasTest || (evmVersion() == langutil::EVMVersion{});
+	enforceGasTest = enforceGasTest || (evmVersion() == langutil::EVMVersion{} && !useABIEncoderV1);
 
 	return res;
 }


### PR DESCRIPTION
While working on #12177 I noticed that `isoltest` is broken with EVM versions other than the latest. This is because it has a bug which always enables gas cost enforcement in tests and we support that only on the latest EVM. If you try older EVM, you get a validation error. This does not affect `soltest` (it does not enable gas enforcement automatically) so it went unnoticed until now.

Also, `--abiencoderv1` conflicts with gas enforcement too. The PR fixes that by enabling gas enforcement automatically only if this option is not used.