### PR TITLE
Semantic test for high level call to precompiles.

### DIFF
--- a/test/libsolidity/semanticTests/functionCall/precompile_extcodesize_check.sol
+++ b/test/libsolidity/semanticTests/functionCall/precompile_extcodesize_check.sol
@@ -1,0 +1,25 @@
+interface Identity {
+    function selectorAndAppendValue(uint value) external pure returns (uint);
+}
+contract C {
+    Identity constant i = Identity(address(0x0004));
+    function testHighLevel() external pure returns (bool) {
+        // Should fail because `extcodesize(4) = 0`
+        i.selectorAndAppendValue(5);
+        return true;
+    }
+    function testLowLevel() external view returns (uint value) {
+        (bool success, bytes memory ret) =
+            address(4).staticcall(
+                abi.encodeWithSelector(Identity.selectorAndAppendValue.selector, uint(5))
+            );
+        value = abi.decode(ret, (uint));
+    }
+
+}
+// ====
+// compileViaYul: also
+// EVMVersion: >=constantinople
+// ----
+// testHighLevel() -> FAILURE
+// testLowLevel() -> 0xc76596d400000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
Because of the extcodesize check, the high level call will fail. Even though the low level call can
succeed and return data.

Related to https://github.com/ethereum/solidity/pull/12205