### PR TITLE
fixed example address payable

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -241,7 +241,7 @@ and to send Ether (in units of wei) to a payable address using the ``transfer`` 
 .. code-block:: solidity
     :force:
 
-    address payable x = address(0x123);
+    address payable x = payable(0x123);
     address myAddress = address(this);
     if (x.balance < 10 && myAddress.balance >= 10) x.transfer(10);
 


### PR DESCRIPTION
This PR fix an error in documentation example about address type [here](https://docs.soliditylang.org/en/v0.8.9/types.html#members-of-addresses).

When testing this example on remix i get the error:

```
TypeError: Type address is not implicitly convertible to expected type address payable.
 --> contracts/address.sol:7:9:
  |
7 |         address payable x = address(0x123);
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
So the change is:

```diff
- address payable x = address(0x123);
+ address payable x = payable(0x123);
address myAddress = address(this);
if (x.balance < 10 && myAddress.balance >= 10) x.transfer(10);
```

