### PR TITLE
Minor fix to forEach on Yul AST nodes.

### DIFF
--- a/libyul/optimiser/ASTWalker.h
+++ b/libyul/optimiser/ASTWalker.h
@@ -111,8 +111,7 @@ template <
 >
 struct ForEach: Base
 {
-	template<typename Callable>
-	ForEach(Callable&& _visitor): visitor(std::forward<Callable>(_visitor)) {}
+	ForEach(Visitor& _visitor): visitor(_visitor) {}
 
 	using Base::operator();
 	void operator()(Node& _node) override
@@ -121,7 +120,7 @@ struct ForEach: Base
 		Base::operator()(_node);
 	}
 
-	Visitor visitor;
+	Visitor& visitor;
 };
 }
 
@@ -130,7 +129,7 @@ struct ForEach: Base
 template<typename Node, typename Entry, typename Visitor>
 void forEach(Entry&& _entry, Visitor&& _visitor)
 {
-	detail::ForEach<Node, std::decay_t<Visitor>>{std::forward<Visitor>(_visitor)}(std::forward<Entry>(_entry));
+	detail::ForEach<Node, Visitor&>{_visitor}(_entry);
 }
 
 }


### PR DESCRIPTION
I commented that we might need ``decay_t`` to make this work for lvalue references to callable objects as ``_visitor``, thinking that the member of ``detail::ForEach`` couldn't be a reference - but actually, thinking through lifetimes, it *should* be a reference in this case and the current version with ``decay_t`` would needlessly copy.

Not that it matters too much - in all likelyhood it will always be a lambda passed by value anyways, but still :-).

Or well, one might e.g. try to pass a reference to the same mutable generic lambda to ``forEach<Assignment const>`` and ``forEach<VariableDeclaration const>`` and would get into trouble, since the lambda closure would be copied and not passed by reference... so better to fix.

And actually, we can *always* use a reference and don't need to forward: no matter what you pass into ``forEach``, it will live through the entire lifetime of the body of ``forEach``, so no need to ever copy or move it anywhere, but we can just keep it there and reference it.

I tested it and this way it works with zero-copy and zero-move no matter what you pass to it.