### PR TITLE
0.y.z makes more sense than 0.x for the current version.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ version of Solidity. Apart from exceptional cases, only the latest version recei
 `security fixes <https://github.com/ethereum/solidity/security/policy#supported-versions>`_.
 Furthermore, breaking changes as well as
 new features are introduced regularly. We currently use
-a 0.x version number `to indicate this fast pace of change <https://semver.org/#spec-item-4>`_.
+a 0.y.z version number `to indicate this fast pace of change <https://semver.org/#spec-item-4>`_.
 
 .. warning::
 


### PR DESCRIPTION
https://docs.soliditylang.org/en/v0.8.9/#:~:text=We%20currently%20use%20a%200.x%20version%20number%20to%20indicate%20this%20fast%20pace%20of%20change.