### PR TITLE
Remove incorrect outer block from for loop init rewriter documentation.

### DIFF
--- a/docs/internals/optimizer.rst
+++ b/docs/internals/optimizer.rst
@@ -429,11 +429,9 @@ is transformed to
 
 .. code-block:: text
 
-    {
-        Init...
-        for {} C { Post... } {
-            Body...
-        }
+    Init...
+    for {} C { Post... } {
+        Body...
     }
 
 This eases the rest of the optimization process because we can ignore


### PR DESCRIPTION
As we realized in private correspondence with @acoglio, the documentation incorrectly suggests that ``ForLoopInitRewriter`` introduces an additional scope.

There is no need to restate that without such a scope this relies on the ``Disambiguator``, since we already document that all steps depend on it.