### PR TITLE
Tiny refactors in external tests and scripts

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -35,7 +35,7 @@ then
     exit 1
 fi
 
-function preparedGrep()
+function preparedGrep
 {
     git grep -nIE "$1" -- '*.h' '*.cpp' | grep -v "${EXCLUDE_FILES_JOINED}"
     return $?

--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -5,7 +5,7 @@ ROOTDIR="/root/project"
 BUILDDIR="${ROOTDIR}/build"
 mkdir -p "${BUILDDIR}" && mkdir -p "$BUILDDIR/deps"
 
-generate_protobuf_bindings()
+function generate_protobuf_bindings
 {
   cd "${ROOTDIR}"/test/tools/ossfuzz
   # Generate protobuf C++ bindings
@@ -15,7 +15,7 @@ generate_protobuf_bindings()
   done
 }
 
-build_fuzzers()
+function build_fuzzers
 {
   cd "${BUILDDIR}"
   cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-function error() {
+function error
+{
   echo >&2 "ERROR: ${1} Aborting." && false
 }
 
-function warning() {
+function warning
+{
   echo >&2 "WARNING: ${1}"
 }
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -29,15 +29,15 @@ _initial_work_dir=$(pwd)
 if [ "$CIRCLECI" ]
 then
     export TERM="${TERM:-xterm}"
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
-    function printError() { >&2 echo "$(tput setaf 1)$1$(tput setaf 7)"; }
-    function printWarning() { >&2 echo "$(tput setaf 11)$1$(tput setaf 7)"; }
-    function printLog() { echo "$(tput setaf 3)$1$(tput setaf 7)"; }
+    function printTask { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
+    function printError { >&2 echo "$(tput setaf 1)$1$(tput setaf 7)"; }
+    function printWarning { >&2 echo "$(tput setaf 11)$1$(tput setaf 7)"; }
+    function printLog { echo "$(tput setaf 3)$1$(tput setaf 7)"; }
 else
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
-    function printError() { >&2 echo "$(tput setaf 1)$1$(tput sgr0)"; }
-    function printWarning() { >&2 echo "$(tput setaf 11)$1$(tput sgr0)"; }
-    function printLog() { echo "$(tput setaf 3)$1$(tput sgr0)"; }
+    function printTask { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
+    function printError { >&2 echo "$(tput setaf 1)$1$(tput sgr0)"; }
+    function printWarning { >&2 echo "$(tput setaf 11)$1$(tput sgr0)"; }
+    function printLog { echo "$(tput setaf 3)$1$(tput sgr0)"; }
 fi
 
 function printStackTrace
@@ -78,7 +78,7 @@ function printStackTrace
     done
 }
 
-function fail()
+function fail
 {
     printError "$@"
 
@@ -86,7 +86,7 @@ function fail()
     return 1
 }
 
-function assertFail()
+function assertFail
 {
     printError ""
     (( $# == 0 )) && printError "Assertion failed."
@@ -97,7 +97,7 @@ function assertFail()
     exit 2
 }
 
-function msg_on_error()
+function msg_on_error
 {
     local error_message
     local no_stdout=false
@@ -171,7 +171,7 @@ function msg_on_error()
     fi
 }
 
-safe_kill()
+function safe_kill
 {
     local PID=${1}
     local NAME=${2:-${1}}

--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -22,7 +22,8 @@
 YULARGS=(--strict-assembly)
 FULLARGS=(--optimize --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,hashes,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
 OLDARGS=(--optimize --combined-json "abi,asm,ast,bin,bin-runtime,devdoc,interface,metadata,opcodes,srcmap,srcmap-runtime,userdoc")
-function compileFull()
+
+function compileFull
 {
     local expected_exit_code=0
     local expect_output='none'

--- a/scripts/docker_deploy_manual.sh
+++ b/scripts/docker_deploy_manual.sh
@@ -28,7 +28,7 @@ else
     date -u +"nightly.%Y.%-m.%-d" > prerelease.txt
 fi
 
-tag_and_push()
+function tag_and_push
 {
     docker tag "$image:$1" "$image:$2"
     docker push "$image:$2"

--- a/scripts/docs_version_pragma_check.sh
+++ b/scripts/docs_version_pragma_check.sh
@@ -36,7 +36,7 @@ source "${REPO_ROOT}/scripts/common_cmdline.sh"
 
 developmentVersion=$("$REPO_ROOT/scripts/get_version.sh")
 
-function versionGreater()
+function versionGreater
 {
     v1=$1
     v2=$2
@@ -58,7 +58,7 @@ function versionGreater()
     return 1
 }
 
-function versionEqual()
+function versionEqual
 {
     if [[ "$1" == "$2" ]]
     then
@@ -67,7 +67,7 @@ function versionEqual()
     return 1
 }
 
-function getAllAvailableVersions()
+function getAllAvailableVersions
 {
     allVersions=()
     local allListedVersions
@@ -85,7 +85,7 @@ function getAllAvailableVersions()
     done
 }
 
-function findMinimalVersion()
+function findMinimalVersion
 {
     local f=$1
     local greater=false

--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -50,14 +50,14 @@
 # FIXME: Can't use set -u because the old Bash on macOS treats empty arrays as unbound variables
 set -eo pipefail
 
-die()
+function die
 {
     # shellcheck disable=SC2059
     >&2 printf "ERROR: $1\n" "${@:2}"
     exit 1
 }
 
-get_reported_solc_version()
+function get_reported_solc_version
 {
     local solc_binary="$1"
 
@@ -70,7 +70,7 @@ get_reported_solc_version()
     echo "$version_banner" | tail -n 1 | sed -n -E 's/^Version: (.*)$/\1/p'
 }
 
-validate_reported_version()
+function validate_reported_version
 {
     local reported_version="$1"
     local expected_version_and_commit="$2"

--- a/scripts/soltest.sh
+++ b/scripts/soltest.sh
@@ -8,7 +8,8 @@ BOOST_OPTIONS=()
 SOLTEST_OPTIONS=()
 SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 
-usage() {
+function usage
+{
 	echo 2>&1 "
 Usage: $0 [options] [soltest-options]
 Runs BOOST C++ unit test program, soltest.

--- a/scripts/test_antlr_grammar.sh
+++ b/scripts/test_antlr_grammar.sh
@@ -20,7 +20,7 @@ SGR_BLUE="\033[34m"
 vt_cursor_up() { echo -ne "\033[A"; }
 vt_cursor_begin_of_line() { echo -ne "\r"; }
 
-download_antlr4()
+function download_antlr4
 {
   if [[ ! -e "$ANTLR_JAR" ]]
   then
@@ -28,7 +28,7 @@ download_antlr4()
   fi
 }
 
-prepare_workdir()
+function prepare_workdir
 {
   mkdir -p "${ROOT_DIR}/build/deps"
   mkdir -p "${WORKDIR}"
@@ -51,7 +51,7 @@ javac -classpath "${ANTLR_JAR}" "${WORKDIR}/src/"*.java -d "${WORKDIR}/target/"
 
 # Run tests
 failed_count=0
-test_file()
+function test_file
 {
   local SOL_FILE
   SOL_FILE="$(${READLINK}  -m "${1}")"

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -38,7 +38,8 @@ source "${REPO_ROOT}/scripts/common.sh"
 WORKDIR=$(mktemp -d)
 CMDLINE_PID=
 
-cleanup() {
+function cleanup
+{
     # ensure failing commands don't cause termination during cleanup (especially within safe_kill)
     set +e
 

--- a/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
+++ b/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
@@ -38,7 +38,8 @@ ORANGE='\033[0;33m'
 CYAN='\033[0;36m'
 RESET='\033[0m'
 
-function generate_bytecode_report() {
+function generate_bytecode_report
+{
   rm -rf /tmp/report.txt
 
   local EXIT_STATUS
@@ -74,7 +75,8 @@ function generate_bytecode_report() {
     echo -e "${RED}FAILURE${RESET}"
   fi
 }
-function clean_git_checkout() {
+function clean_git_checkout
+{
   git submodule deinit --all -q
   git reset --hard HEAD --quiet
   git clean -f -d -x --quiet
@@ -82,7 +84,8 @@ function clean_git_checkout() {
   git submodule init -q
   git submodule update -q
 }
-function process_tag() {
+function process_tag
+{
   local TAG=$1
   cd /src
   # Checkout the historic commit instead of the tag directly.

--- a/scripts/yul_coverage.sh
+++ b/scripts/yul_coverage.sh
@@ -83,7 +83,8 @@ for arg in "$@"; do
   esac
 done
 
-show_output_if() {
+function show_output_if
+{
   local VAR=${1}
   if [ -n "${VAR}" ]; then
     echo "${SOL_FILE}"
@@ -102,7 +103,8 @@ if [ ! -f "${SOLC}" ]; then
   exit 1
 fi
 
-test_file() {
+function test_file
+{
   local SOL_FILE
   local OUTPUT
   SOL_FILE=${1}

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -154,7 +154,7 @@ function ask_expectation_update
 
 # General helper function for testing SOLC behaviour, based on file name, compile opts, exit code, stdout and stderr.
 # An failure is expected.
-function test_solc_behaviour()
+function test_solc_behaviour
 {
     local filename="${1}"
     local solc_args
@@ -288,7 +288,7 @@ EOF
 }
 
 
-function test_solc_assembly_output()
+function test_solc_assembly_output
 {
     local input="${1}"
     local expected="${2}"

--- a/test/docsCodeStyle.sh
+++ b/test/docsCodeStyle.sh
@@ -10,11 +10,11 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
 if [ "$CIRCLECI" ]
 then
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput setaf 7)"; }
+    function printTask { echo "$(tput bold)$(tput setaf 2)$1$(tput setaf 7)"; }
+    function printError { echo "$(tput setaf 1)$1$(tput setaf 7)"; }
 else
-    function printTask() { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
-    function printError() { echo "$(tput setaf 1)$1$(tput sgr0)"; }
+    function printTask { echo "$(tput bold)$(tput setaf 2)$1$(tput sgr0)"; }
+    function printError { echo "$(tput setaf 1)$1$(tput sgr0)"; }
 fi
 
 printTask "Checking docs examples style"

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -18,6 +18,9 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+
+set -e
+
 source scripts/common.sh
 source test/externalTests/common.sh
 

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -251,7 +251,7 @@ function external_test
 
     printTask "Testing $name..."
     echo "==========================="
-    DIR=$(mktemp -d)
+    DIR=$(mktemp -d -t "ext-test-${name}-XXXXXX")
     (
         if [ -z "$main_fn" ]; then
             printError "Test main function not defined."

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -187,7 +187,8 @@ function run_test
     $test_fn
 }
 
-function optimizer_settings_for_level {
+function optimizer_settings_for_level
+{
     local level="$1"
 
     case "$level" in
@@ -201,7 +202,8 @@ function optimizer_settings_for_level {
     esac
 }
 
-function truffle_compiler_settings {
+function truffle_compiler_settings
+{
     local solc_path="$1"
     local level="$2"
     local evm_version="$3"

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -18,6 +18,9 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+
+set -e
+
 source scripts/common.sh
 source test/externalTests/common.sh
 

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -18,6 +18,9 @@
 #
 # (c) 2020 solidity contributors.
 #------------------------------------------------------------------------------
+
+set -e
+
 source scripts/common.sh
 source test/externalTests/common.sh
 

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -18,6 +18,9 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+
+set -e
+
 source scripts/common.sh
 source test/externalTests/common.sh
 

--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -18,6 +18,9 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+
+set -e
+
 source scripts/common.sh
 source test/externalTests/common.sh
 

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -18,6 +18,9 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
+
+set -e
+
 source scripts/common.sh
 source test/externalTests/common.sh
 

--- a/test/stopAfterParseTests.sh
+++ b/test/stopAfterParseTests.sh
@@ -15,7 +15,7 @@ FILETMP=$(mktemp -d)
 cd "$FILETMP" || exit 1
 
 
-function testFile()
+function testFile
 {
 	set +e
 	ALLOUTPUT=$($SOLC --combined-json ast --pretty-json "$@" --stop-after parsing 2>&1)


### PR DESCRIPTION
This was originally a part of #12191, extracted into a separate PR as suggested by @axic.
- Consistent style for Bash function declarations.
- `set -e` in external tests.
- Named temporary dirs in external tests so that it's easier to locate the results in `/tmp/`.