### PR TITLE
[BREAKING] Disallow codecopy and codesize in pure functions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Breaking changes:
  * Disallow ``.pop()`` on arrays containing nested mappings.
  * Disallow ``delete`` on types that contain nested mappings.
+ * Disallow ``codecopy`` and ``codesize`` in ``pure`` functions.
  * Inline Assembly: Consider functions, function parameters and return variables for shadowing checks.
  * Commandline Interface: Remapping targets are not automatically added to allowed paths.
  * Commandline Interface: Assembler mode no longer enables all outputs by default.

--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -225,6 +225,7 @@ Functions can be declared ``pure`` in which case they promise not to read from o
 In particular, it should be possible to evaluate a ``pure`` function at compile-time given
 only its inputs and ``msg.data``, but without any knowledge of the current blockchain state.
 This means that reading from ``immutable`` variables can be a non-pure operation.
+Similarly, the inline assembly builtins ``codecopy`` and ``codesize`` are not pure.
 
 .. note::
   If the compiler's EVM target is Byzantium or newer (default) the opcode ``STATICCALL`` is used,

--- a/libevmasm/SemanticInformation.cpp
+++ b/libevmasm/SemanticInformation.cpp
@@ -351,6 +351,8 @@ bool SemanticInformation::invalidInPureFunctions(Instruction _instruction)
 	case Instruction::ORIGIN:
 	case Instruction::CALLER:
 	case Instruction::CALLVALUE:
+	case Instruction::CODESIZE:
+	case Instruction::CODECOPY:
 	case Instruction::CHAINID:
 	case Instruction::BASEFEE:
 	case Instruction::GAS:

--- a/test/libsolidity/syntaxTests/inlineAssembly/hex_switch_case.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/hex_switch_case.sol
@@ -1,7 +1,7 @@
 contract C {
   function f() public pure {
     assembly {
-      switch codesize()
+      switch calldatasize()
       case hex"00" {}
       case hex"1122" {}
     }

--- a/test/libsolidity/syntaxTests/inlineAssembly/string_literal_switch_case.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/string_literal_switch_case.sol
@@ -1,7 +1,7 @@
 contract C {
   function f() public pure {
     assembly {
-      switch codesize()
+      switch calldatasize()
       case "1" {}
       case "2" {}
     }

--- a/test/libsolidity/syntaxTests/viewPureChecker/assembly.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/assembly.sol
@@ -26,5 +26,11 @@ contract C {
     function l() public view {
         assembly { pop(extcodesize(0)) }
     }
+    function m() public view {
+        assembly { codecopy(0,0,0) }
+    }
+    function n() public view {
+        assembly { pop(codesize()) }
+    }
 }
 // ----


### PR DESCRIPTION
Obvious part of https://github.com/ethereum/solidity/issues/12260.

Not entirely sure about ``msg.data`` and ``calldataload``/``calldatasize``, so I'll keep them as is for now and the issue open.