### PR TITLE
ICE in StructType::isDynamicallyEncoded() when a function has a calldata struct argument with an internal type inside :: Issue 11610

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ Bugfixes:
  * TypeChecker: Improved error message for constant variables with (nested) mapping types.
  * Yul Assembler: Fix internal error when function names are not unique.
  * Yul IR Generator: Do not output empty switches/if-bodies for empty contracts.
+ * ICE in StructType::isDynamicallyEncoded() when a function has a calldata struct argument with an internal type inside
 
 
 Build System:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -387,7 +387,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 			_var.referenceLocation() == VariableDeclaration::Location::Storage &&
 			!m_currentContract->abstract()
 		)
-			m_errorReporter.typeError(
+			m_errorReporter.fatalTypeError(
 				3644_error,
 				_var.location(),
 				"This parameter has a type that can only be used internally. "
@@ -403,7 +403,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 				solAssert(!message.empty(), "Expected detailed error message!");
 				if (_function.isConstructor())
 					message += " You can make the contract abstract to avoid this problem.";
-				m_errorReporter.typeError(4103_error, _var.location(), message);
+				m_errorReporter.fatalTypeError(4103_error, _var.location(), message);
 			}
 			else if (
 				!useABICoderV2() &&

--- a/test/libsolidity/syntaxTests/calldata_struct_argument_with_internal_type_inside.sol
+++ b/test/libsolidity/syntaxTests/calldata_struct_argument_with_internal_type_inside.sol
@@ -1,0 +1,9 @@
+contract C {
+  struct S {
+    function() a;
+  }
+  function f(S[2] calldata) {}
+}
+// ----
+// SyntaxError 4937: (50-78): No visibility specified. Did you intend to add "public"?
+// TypeError 4103: (61-74): Internal type is not allowed for public or external functions.


### PR DESCRIPTION
TypeChecker.cpp :: Replced typeError with fataTypeError in lines 390 and 406. 
Test file added in test/libsolidity/syntaxTests/calldata_struct_argument_with_internal_type_inside.sol
Relevant line added to Changelog.md

Closes #11610 