### PR TITLE
Calldata struct array arugment with internal type inside

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Compiler Features:
 Bugfixes:
  * Code Generator: Fix a crash when using ``@use-src`` and compiling from Yul to ewasm.
  * SMTChecker: Fix internal error when an unsafe target is solved more than once and the counterexample messages are different.
+ * Fix internal error when a function has a calldata struct argument with an internal type inside.
+
 
 
 ### 0.8.10 (2021-11-09)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -387,7 +387,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 			_var.referenceLocation() == VariableDeclaration::Location::Storage &&
 			!m_currentContract->abstract()
 		)
-			m_errorReporter.typeError(
+			m_errorReporter.fatalTypeError(
 				3644_error,
 				_var.location(),
 				"This parameter has a type that can only be used internally. "
@@ -403,7 +403,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 				solAssert(!message.empty(), "Expected detailed error message!");
 				if (_function.isConstructor())
 					message += " You can make the contract abstract to avoid this problem.";
-				m_errorReporter.typeError(4103_error, _var.location(), message);
+				m_errorReporter.fatalTypeError(4103_error, _var.location(), message);
 			}
 			else if (
 				!useABICoderV2() &&

--- a/test/libsolidity/syntaxTests/abiEncoder/external_functions_taking_internal_types_nested_struct_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/external_functions_taking_internal_types_nested_struct_with_mapping.sol
@@ -7,4 +7,3 @@ contract C {
 }
 // ----
 // TypeError 4103: (132-140): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (132-140): Type struct C.S is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/abiEncoder/external_functions_taking_internal_types_struct_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/external_functions_taking_internal_types_struct_with_mapping.sol
@@ -6,4 +6,3 @@ contract C {
 }
 // ----
 // TypeError 4103: (105-113): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (105-113): Type struct C.S is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/array/function_mapping.sol
+++ b/test/libsolidity/syntaxTests/array/function_mapping.sol
@@ -5,4 +5,3 @@ contract Test {
 }
 // ----
 // TypeError 4103: (66-98): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (66-98): Type mapping(uint256 => uint256)[] is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/constructor/constructor_mapping_memory.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_mapping_memory.sol
@@ -3,4 +3,3 @@ contract A {
 }
 // ----
 // TypeError 4103: (29-59): Types containing (nested) mappings can only be parameters or return variables of internal or library functions. You can make the contract abstract to avoid this problem.
-// TypeError 4061: (29-59): Type mapping(uint256 => uint256) is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/functionCalls/calldata_struct_argument_with_internal_data_type_inside.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/calldata_struct_argument_with_internal_data_type_inside.sol
@@ -1,0 +1,8 @@
+contract C {
+	struct S {
+		function() a;
+	}
+	function f(S calldata) public {}
+}
+// ----
+// TypeError 4103: (56-66): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionCalls/calldata_struct_array_argument_with_internal_data_type_inside.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/calldata_struct_array_argument_with_internal_data_type_inside.sol
@@ -1,0 +1,8 @@
+contract C {
+	struct S {
+		function() a;
+	}
+	function f(S[2] calldata) public {}
+}
+// ----
+// TypeError 4103: (56-69): Internal type is not allowed for public or external functions.

--- a/test/libsolidity/syntaxTests/functionCalls/calldata_struct_array_argument_with_internal_data_type_inside_as_constructor_parameter.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/calldata_struct_array_argument_with_internal_data_type_inside_as_constructor_parameter.sol
@@ -1,0 +1,8 @@
+contract C {
+	struct S {
+		function() a;
+	}
+	constructor (S[2] storage) public {}
+}
+// ----
+// TypeError 3644: (58-70): This parameter has a type that can only be used internally. You can make the contract abstract to avoid this problem.

--- a/test/libsolidity/syntaxTests/structs/calldata_struct_mapping_function.sol
+++ b/test/libsolidity/syntaxTests/structs/calldata_struct_mapping_function.sol
@@ -12,4 +12,3 @@ contract test {
 }
 // ----
 // TypeError 4103: (155-167): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (155-167): Type struct test.S is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_nested_mapping_memory.sol
+++ b/test/libsolidity/syntaxTests/structs/recursion/recursive_struct_nested_mapping_memory.sol
@@ -7,4 +7,3 @@ library a {
 }
 // ----
 // TypeError 4103: (149-157): Recursive structs can only be passed as storage pointers to libraries, not as memory objects to contract functions.
-// TypeError 4061: (149-157): Type struct a.b is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_array_data_location_function_param_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_array_data_location_function_param_external.sol
@@ -3,4 +3,3 @@ contract c {
 }
 // ----
 // TypeError 4103: (29-61): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (29-61): Type mapping(uint256 => uint256)[] is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_external.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_external.sol
@@ -3,4 +3,3 @@ contract c {
 }
 // ----
 // TypeError 4103: (29-59): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (29-59): Type mapping(uint256 => uint256) is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_public.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_data_location_function_param_public.sol
@@ -3,4 +3,3 @@ contract c {
 }
 // ----
 // TypeError 4103: (29-57): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (29-57): Type mapping(uint256 => uint256) is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_function_calldata.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_function_calldata.sol
@@ -9,4 +9,3 @@ contract test {
 }
 // ----
 // TypeError 4103: (121-133): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (121-133): Type struct test.S is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_return_public_memory.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_return_public_memory.sol
@@ -4,4 +4,3 @@ contract C {
 }
 // ----
 // TypeError 4103: (51-79): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (51-79): Type mapping(uint256 => uint256) is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_struct_data_location_memory.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_struct_data_location_memory.sol
@@ -5,4 +5,3 @@ contract C {
 }
 // ----
 // TypeError 4103: (104-112): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (104-112): Type struct C.S is only valid in storage because it contains a (nested) mapping.

--- a/test/libsolidity/syntaxTests/types/mapping/mapping_struct_recusrive_data_location_memory.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/mapping_struct_recusrive_data_location_memory.sol
@@ -7,4 +7,3 @@ contract C {
 }
 // ----
 // TypeError 4103: (148-156): Types containing (nested) mappings can only be parameters or return variables of internal or library functions.
-// TypeError 4061: (148-156): Type struct C.U is only valid in storage because it contains a (nested) mapping.


### PR DESCRIPTION
ICE in StructType : isDynamicallyEncoded() : Function has a calldata struct array argument with an internal type inside :: Issue 11610

TypeChecker.cpp :: Replced typeError with fataTypeError in lines 390 and 406.
Test files added in test/libsolidity/syntaxTests/functionCalls/

Changes made to 13 other test cases to match new outputs
Relevant line added to Changelog.md

Closes #11610 
#12028  is mentioned as a duplicate of #11610  , so that could be looked at as well.
Builds on reviews and comments from #12266 