### PR TITLE
Relocating download Section in docs

### DIFF
--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -13,13 +13,13 @@
     </span>
     <div class="rst-other-versions">
         <dl>
-            <dt>{{ _('Versions') }}</dt> {% for slug, url in versions %}
-            <dd><a href="{{ url }}">{{ slug }}</a></dd>
+            <dt>{{ _('Downloads') }}</dt> {% for type, url in downloads %}
+            <dd><a href="{{ url }}">{{ type }}</a></dd>
             {% endfor %}
         </dl>
         <dl>
-            <dt>{{ _('Downloads') }}</dt> {% for type, url in downloads %}
-            <dd><a href="{{ url }}">{{ type }}</a></dd>
+            <dt>{{ _('Versions') }}</dt> {% for slug, url in versions %}
+            <dd><a href="{{ url }}">{{ slug }}</a></dd>
             {% endfor %}
         </dl>
         <dl>

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,7 +1,11 @@
 {# Add rst-badge after rst-versions for small badge style. #}
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-    <span class="fa fa-book fa-element"> RTD </span>
+    {% for type, url in downloads %}
+        {% if type == 'PDF' %}
+            <a href="{{ url }}">{{ type }}</a>
+        {% endif %}
+    {% endfor %}
 
     <span class="fa fa-element">
     <input class="container_toggle" type="checkbox" id="switch" name="mode">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,12 @@ a 0.y.z version number `to indicate this fast pace of change <https://semver.org
 Ideas for improving Solidity or this documentation are always welcome,
 read our :doc:`contributors guide <contributing>` for more details.
 
+.. Hint::
+
+   You can download this documentation as PDF, HTML or Epub by clicking on the versions 
+   flyout menu in the left bottom corner and selecting the preferred download format.
+
+
 Getting Started
 ---------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ read our :doc:`contributors guide <contributing>` for more details.
 
 .. Hint::
 
-   You can download this documentation as PDF, HTML or Epub by clicking on the versions 
-   flyout menu in the left bottom corner and selecting the preferred download format.
+  You can download this documentation as PDF, HTML or Epub by clicking on the versions
+  flyout menu in the bottom-left corner and selecting the preferred download format.
 
 
 Getting Started


### PR DESCRIPTION
1. Modified index.rst to include a Hint section for Downloads
2. Modified _templates/versions.html to place downloads section ahead of Versions section

Closes #12238 