### PR TITLE
Graceful error handling in soltest/isoltest + improved soltestAssert()

### DIFF
--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -58,13 +58,13 @@ struct InvalidAstError: virtual util::Exception {};
 #endif
 
 #define solAssert_1(CONDITION) \
-	solAssert_2(CONDITION, "")
+	solAssert_2((CONDITION), "")
 
 #define solAssert_2(CONDITION, DESCRIPTION) \
 	assertThrowWithDefaultDescription( \
-		CONDITION, \
+		(CONDITION), \
 		::solidity::langutil::InternalCompilerError, \
-		DESCRIPTION, \
+		(DESCRIPTION), \
 		"Solidity assertion failed" \
 	)
 
@@ -77,13 +77,13 @@ struct InvalidAstError: virtual util::Exception {};
 #endif
 
 #define solUnimplementedAssert_1(CONDITION) \
-	solUnimplementedAssert_2(CONDITION, "")
+	solUnimplementedAssert_2((CONDITION), "")
 
 #define solUnimplementedAssert_2(CONDITION, DESCRIPTION) \
 	assertThrowWithDefaultDescription( \
-		CONDITION, \
+		(CONDITION), \
 		::solidity::langutil::UnimplementedFeatureError, \
-		DESCRIPTION, \
+		(DESCRIPTION), \
 		"Unimplemented feature" \
 	)
 
@@ -105,9 +105,9 @@ struct InvalidAstError: virtual util::Exception {};
 
 #define astAssert_2(CONDITION, DESCRIPTION) \
 	assertThrowWithDefaultDescription( \
-		CONDITION, \
+		(CONDITION), \
 		::solidity::langutil::InvalidAstError, \
-		DESCRIPTION, \
+		(DESCRIPTION), \
 		"AST assertion failed" \
 	)
 

--- a/libsmtutil/Exceptions.h
+++ b/libsmtutil/Exceptions.h
@@ -38,13 +38,13 @@ struct SMTLogicError: virtual util::Exception {};
 #endif
 
 #define smtAssert_1(CONDITION) \
-	smtAssert_2(CONDITION, "")
+	smtAssert_2((CONDITION), "")
 
 #define smtAssert_2(CONDITION, DESCRIPTION) \
 	assertThrowWithDefaultDescription( \
-		CONDITION, \
+		(CONDITION), \
 		::solidity::smtutil::SMTLogicError, \
-		DESCRIPTION, \
+		(DESCRIPTION), \
 		"SMT assertion failed" \
 	)
 

--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -63,7 +63,7 @@ inline std::string stringOrDefault(std::string _string, std::string _defaultStri
 		if (!(_condition)) \
 			solThrow( \
 				_exceptionType, \
-				::solidity::util::assertions::stringOrDefault(_description, _defaultDescription) \
+				::solidity::util::assertions::stringOrDefault((_description), (_defaultDescription)) \
 			); \
 	} \
 	while (false)
@@ -72,6 +72,6 @@ inline std::string stringOrDefault(std::string _string, std::string _defaultStri
 /// Use it as assertThrow(1 == 1, ExceptionType, "Mathematics is wrong.");
 /// The second parameter must be an exception class (rather than an instance).
 #define assertThrow(_condition, _exceptionType, _description) \
-	assertThrowWithDefaultDescription(_condition, _exceptionType, _description, "Assertion failed")
+	assertThrowWithDefaultDescription((_condition), _exceptionType, (_description), "Assertion failed")
 
 }

--- a/libsolutil/Exceptions.h
+++ b/libsolutil/Exceptions.h
@@ -48,7 +48,7 @@ struct Exception: virtual std::exception, virtual boost::exception
 #define solThrow(_exceptionType, _description) \
 	::boost::throw_exception( \
 		_exceptionType() << \
-		::solidity::util::errinfo_comment(_description) << \
+		::solidity::util::errinfo_comment((_description)) << \
 		::boost::throw_function(ETH_FUNC) << \
 		::boost::throw_file(__FILE__) << \
 		::boost::throw_line(__LINE__) \

--- a/libyul/Exceptions.h
+++ b/libyul/Exceptions.h
@@ -63,13 +63,13 @@ struct StackTooDeepError: virtual YulException
 #endif
 
 #define yulAssert_1(CONDITION) \
-	yulAssert_2(CONDITION, "")
+	yulAssert_2((CONDITION), "")
 
 #define yulAssert_2(CONDITION, DESCRIPTION) \
 	assertThrowWithDefaultDescription( \
-		CONDITION, \
+		(CONDITION), \
 		::solidity::yul::YulAssertion, \
-		DESCRIPTION, \
+		(DESCRIPTION), \
 		"Yul assertion failed" \
 	)
 

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -159,26 +159,33 @@ bool CommonOptions::parse(int argc, char const* const* argv)
 	po::variables_map arguments;
 	addOptions();
 
-	po::command_line_parser cmdLineParser(argc, argv);
-	cmdLineParser.options(options);
-	auto parsedOptions = cmdLineParser.run();
-	po::store(parsedOptions, arguments);
-	po::notify(arguments);
+	try
+	{
+		po::command_line_parser cmdLineParser(argc, argv);
+		cmdLineParser.options(options);
+		auto parsedOptions = cmdLineParser.run();
+		po::store(parsedOptions, arguments);
+		po::notify(arguments);
 
-	for (auto const& parsedOption: parsedOptions.options)
-		if (parsedOption.position_key >= 0)
-		{
-			if (
-				parsedOption.original_tokens.empty() ||
-				(parsedOption.original_tokens.size() == 1 && parsedOption.original_tokens.front().empty())
-			)
-				continue; // ignore empty options
-			std::stringstream errorMessage;
-			errorMessage << "Unrecognized option: ";
-			for (auto const& token: parsedOption.original_tokens)
-				errorMessage << token;
-			BOOST_THROW_EXCEPTION(std::runtime_error(errorMessage.str()));
-		}
+		for (auto const& parsedOption: parsedOptions.options)
+			if (parsedOption.position_key >= 0)
+			{
+				if (
+					parsedOption.original_tokens.empty() ||
+					(parsedOption.original_tokens.size() == 1 && parsedOption.original_tokens.front().empty())
+				)
+					continue; // ignore empty options
+				std::stringstream errorMessage;
+				errorMessage << "Unrecognized option: ";
+				for (auto const& token: parsedOption.original_tokens)
+					errorMessage << token;
+				BOOST_THROW_EXCEPTION(std::runtime_error(errorMessage.str()));
+			}
+	}
+	catch (po::error const& exception)
+	{
+		solThrow(ConfigException, exception.what());
+	}
 
 	if (vmPaths.empty())
 	{

--- a/test/Common.h
+++ b/test/Common.h
@@ -75,6 +75,9 @@ struct CommonOptions
 	langutil::EVMVersion evmVersion() const;
 
 	virtual void addOptions();
+	// @returns true if the program should continue, false if it should exit immediately without
+	// reporting an error.
+	// Throws ConfigException or std::runtime_error if parsing fails.
 	virtual bool parse(int argc, char const* const* argv);
 	// Throws a ConfigException on error
 	virtual void validate() const;

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -204,15 +204,18 @@ int registerTests(
 	return numTestsAdded;
 }
 
-void initializeOptions()
+bool initializeOptions()
 {
 	auto const& suite = boost::unit_test::framework::master_test_suite();
 
 	auto options = std::make_unique<solidity::test::CommonOptions>();
-	solAssert(options->parse(suite.argc, suite.argv), "Failed to parse options!");
+	bool shouldContinue = options->parse(suite.argc, suite.argv);
+	if (!shouldContinue)
+		return false;
 	options->validate();
 
 	solidity::test::CommonOptions::setSingleton(std::move(options));
+	return true;
 }
 
 }
@@ -228,7 +231,9 @@ test_suite* init_unit_test_suite( int /*argc*/, char* /*argv*/[] )
 	master_test_suite_t& master = framework::master_test_suite();
 	master.p_name.value = "SolidityTests";
 
-	initializeOptions();
+	bool shouldContinue = initializeOptions();
+	if (!shouldContinue)
+		exit(0);
 
 	if (!solidity::test::loadVMs(solidity::test::CommonOptions::get()))
 		exit(1);

--- a/test/boostTest.cpp
+++ b/test/boostTest.cpp
@@ -235,10 +235,10 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[])
 	{
 		bool shouldContinue = initializeOptions();
 		if (!shouldContinue)
-			exit(0);
+			exit(EXIT_SUCCESS);
 
 		if (!solidity::test::loadVMs(solidity::test::CommonOptions::get()))
-			exit(1);
+			exit(EXIT_FAILURE);
 
 		if (solidity::test::CommonOptions::get().disableSemanticTests)
 			cout << endl << "--- SKIPPING ALL SEMANTICS TESTS ---" << endl << endl;
@@ -298,12 +298,12 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[])
 	catch (solidity::test::ConfigException const& exception)
 	{
 		cerr << exception.what() << endl;
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	catch (std::runtime_error const& exception)
 	{
 		cerr << exception.what() << endl;
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	return nullptr;

--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -75,9 +75,9 @@ void IsolTestOptions::addOptions()
 
 bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 {
-	bool const res = CommonOptions::parse(_argc, _argv);
+	bool const shouldContinue = CommonOptions::parse(_argc, _argv);
 
-	if (showHelp || !res)
+	if (showHelp || !shouldContinue)
 	{
 		std::cout << options << std::endl;
 		return false;
@@ -85,7 +85,7 @@ bool IsolTestOptions::parse(int _argc, char const* const* _argv)
 
 	enforceGasTest = enforceGasTest || (evmVersion() == langutil::EVMVersion{} && !useABIEncoderV1);
 
-	return res;
+	return shouldContinue;
 }
 
 void IsolTestOptions::validate() const

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -433,8 +433,9 @@ int main(int argc, char const *argv[])
 		{
 			auto options = std::make_unique<IsolTestOptions>();
 
-			if (!options->parse(argc, argv))
-				return -1;
+			bool shouldContinue = options->parse(argc, argv);
+			if (!shouldContinue)
+				return 0;
 
 			options->validate();
 			CommonOptions::setSingleton(std::move(options));

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -499,9 +499,20 @@ int main(int argc, char const *argv[])
 
 		return global_stats ? 0 : 1;
 	}
-	catch (std::exception const& _exception)
+	catch (boost::program_options::error const& exception)
 	{
-		cerr << _exception.what() << endl;
+		cerr << exception.what() << endl;
+		return 1;
+	}
+	catch (std::runtime_error const& exception)
+	{
+		cerr << exception.what() << endl;
+		return 1;
+	}
+	catch (...)
+	{
+		cerr << "Unhandled exception caught." << endl;
+		cerr << boost::current_exception_diagnostic_information() << endl;
 		return 1;
 	}
 }

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -435,7 +435,7 @@ int main(int argc, char const *argv[])
 
 			bool shouldContinue = options->parse(argc, argv);
 			if (!shouldContinue)
-				return 0;
+				return EXIT_SUCCESS;
 
 			options->validate();
 			CommonOptions::setSingleton(std::move(options));
@@ -444,7 +444,7 @@ int main(int argc, char const *argv[])
 		auto& options = dynamic_cast<IsolTestOptions const&>(CommonOptions::get());
 
 		if (!solidity::test::loadVMs(options))
-			return 1;
+			return EXIT_FAILURE;
 
 		if (options.disableSemanticTests)
 			cout << endl << "--- SKIPPING ALL SEMANTICS TESTS ---" << endl << endl;
@@ -480,7 +480,7 @@ int main(int argc, char const *argv[])
 			if (stats)
 				global_stats += *stats;
 			else
-				return 1;
+				return EXIT_FAILURE;
 		}
 
 		cout << endl << "Summary: ";
@@ -498,22 +498,22 @@ int main(int argc, char const *argv[])
 		if (options.disableSemanticTests)
 			cout << "\nNOTE: Skipped semantics tests.\n" << endl;
 
-		return global_stats ? 0 : 1;
+		return global_stats ? EXIT_SUCCESS : EXIT_FAILURE;
 	}
 	catch (boost::program_options::error const& exception)
 	{
 		cerr << exception.what() << endl;
-		return 1;
+		return EXIT_FAILURE;
 	}
 	catch (std::runtime_error const& exception)
 	{
 		cerr << exception.what() << endl;
-		return 1;
+		return EXIT_FAILURE;
 	}
 	catch (...)
 	{
 		cerr << "Unhandled exception caught." << endl;
 		cerr << boost::current_exception_diagnostic_information() << endl;
-		return 1;
+		return EXIT_FAILURE;
 	}
 }


### PR DESCRIPTION
Fixes #11917.

While working on #12282 I hit an assertion in `ByteUtils` but it looked like something completely different. That's because `soltestAssert()` throws `std::runtime_error` rather than some special exception type reserved for assertions. I also noticed that in #12019 I did not cover `soltestAssert()`. This PR refactors the macro to be in line with `solAssert()`, i.e. allow skipping the message, provide a default message and use a dedicated exception type.

I have also added exception handlers that intercept normal errors (like command-line validation errors) and print them in a way that does not make you think you hit a bug.

Also, `--help` no longer returns an error code. It's normal and expected behavior. A similar change was made for `solc` in #12118.

I recommend reviewing with the option to ignore whitespace changes enabled - changes are actually small but some blocks had to be reindented due to the added `try`/`catch`.