### PR TITLE
Fix formatting for strings with control characters in isoltest expectations

### DIFF
--- a/test/libsolidity/semanticTests/isoltestTesting/format_raw_string_with_control_chars.sol
+++ b/test/libsolidity/semanticTests/isoltestTesting/format_raw_string_with_control_chars.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f(string memory s) external pure returns (string memory) {
+        return s;
+    }
+}
+// NOTE: The test is here to illustrate the problem with formatting control chars in strings in
+// test expectations but unfortunately it can only be triggered manually. It does not test anything
+// unless you introduce a difference in expectations to force isoltest to reformat them.
+// ====
+// compileViaYul: also
+// ----
+// f(string): 0x20, 16, "\xf0\x9f\x98\x83\xf0\x9f\x98\x83\xf0\x9f\x98\x83\xf0\x9f\x98\x83" -> 0x20, 16, "\xf0\x9f\x98\x83\xf0\x9f\x98\x83\xf0\x9f\x98\x83\xf0\x9f\x98\x83" # Input/Output: "😃😃😃😃" #

--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -219,7 +219,7 @@ string BytesUtils::formatString(bytes const& _bytes, size_t _cutOff)
 				if (isprint(v))
 					os << v;
 				else
-					os << "\\x" << toHex(v);
+					os << "\\x" << toHex(v, HexCase::Lower);
 		}
 	}
 	os << "\"";

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -322,7 +322,9 @@ string TestFunctionCall::formatRawParameters(
 			if (param.format.newline)
 				os << endl << _linePrefix << "// ";
 			for (auto const c: param.rawString)
-				os << (c >= ' ' ? string(1, c) : "\\x" + toHex(static_cast<uint8_t>(c)));
+				// NOTE: Even though we have a toHex() overload specifically for uint8_t, the compiler
+				// chooses the one for bytes if the second argument is omitted.
+				os << (c >= ' ' ? string(1, c) : "\\x" + toHex(static_cast<uint8_t>(c), HexCase::Lower));
 			if (&param != &_params.back())
 				os << ", ";
 		}


### PR DESCRIPTION
Found while working on #12282.

An autoupdate of gas expectations in `semanticTests/externalContracts/strings.sol` resulted in an assertion failure in `BytesUtils::alignLeft()` because the string was longer than 32 bytes. I think this is the problem from #7197.
```
Exception during test: /solidity/test/libsolidity/util/BytesUtils.cpp(41): Throw in function static solidity::bytes solidity::frontend::test::BytesUtils::alignLeft(solidity::bytes)
Dynamic exception type: boost::wrapexcept<std::runtime_error>
std::exception::what: 
```

The root cause though was that isoltest reformatted the expectations in a weird way. It read this:
```
// utf8len(string): 0x20, 16, "\xf0\x9f\x98\x83\xf0\x9f\x98\x83\xf0\x9f\x98\x83\xf0\x9f\x98\x83" -> 4 # Input: "😃😃😃😃" #
```
but spewed out this:
```
// utf8len(string): 0x20, 16, "\x00000000000000000000000000000000000000000000000000000000000000f0\x000000000000000000000000000000000000000000000000000000000000009f\x0000000000000000000000000000000000000000000000000000000000000098\x0000000000000000000000000000000000000000000000000000000000000083\x00000000000000000000000000000000000000000000000000000000000000f0\x000000000000000000000000000000000000000000000000000000000000009f\x0000000000000000000000000000000000000000000000000000000000000098\x0000000000000000000000000000000000000000000000000000000000000083\x00000000000000000000000000000000000000000000000000000000000000f0\x000000000000000000000000000000000000000000000000000000000000009f\x0000000000000000000000000000000000000000000000000000000000000098\x0000000000000000000000000000000000000000000000000000000000000083\x00000000000000000000000000000000000000000000000000000000000000f0\x000000000000000000000000000000000000000000000000000000000000009f\x0000000000000000000000000000000000000000000000000000000000000098\x0000000000000000000000000000000000000000000000000000000000000083" -> 4 # Input: "😃😃😃😃" #
```

Apparently calling `toHex(static_cast<uint8_t>(c))` results in a call to the overload for `bytes` rather than `uint8_t`. Which is bizarre because while `toHex()` has optional arguments, the type is an exact match so there's no ambiguity. I wonder if it's some obscure quirk of the language or a compiler bug.