### PR TITLE
Extracted test cases from SolidityEndToEnd.cpp

### DIFF
--- a/test/libsolidity/semanticTests/enums/invalid_enum_logged.sol
+++ b/test/libsolidity/semanticTests/enums/invalid_enum_logged.sol
@@ -1,0 +1,24 @@
+contract C {
+    enum X { A, B }
+    event Log(X);
+
+    function test_log() public returns (uint) {
+        X garbled = X.A;
+        assembly {
+            garbled := 5
+        }
+        emit Log(garbled);
+        return 1;
+    }
+    function test_log_ok() public returns (uint) {
+        X x = X.A;
+        emit Log(x);
+        return 1;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// test_log_ok() -> 1
+// ~ emit Log(uint8): 0x00
+// test_log() -> FAILURE, hex"4e487b71", 0x21

--- a/test/libsolidity/semanticTests/libraries/library_staticcall_delegatecall.sol
+++ b/test/libsolidity/semanticTests/libraries/library_staticcall_delegatecall.sol
@@ -1,0 +1,20 @@
+library Lib {
+    function x() public view returns (uint) {
+        return 1;
+    }
+}
+contract Test {
+    uint t;
+    function f() public returns (uint) {
+        t = 2;
+        return this.g();
+    }
+    function g() public view returns (uint) {
+        return Lib.x();
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// library: Lib
+// f() -> 1

--- a/test/libsolidity/semanticTests/memoryManagement/memory_types_initialisation.sol
+++ b/test/libsolidity/semanticTests/memoryManagement/memory_types_initialisation.sol
@@ -1,0 +1,17 @@
+contract Test {
+    mapping(uint=>uint) data;
+    function stat() public returns (uint[5] memory)
+    {
+        data[2] = 3; // make sure to use some memory
+    }
+    function dyn() public returns (uint[] memory) { stat(); }
+    function nested() public returns (uint[3][] memory) { stat(); }
+    function nestedStat() public returns (uint[3][7] memory) { stat(); }
+}
+// ====
+// compileViaYul: also
+// ----
+// stat() -> 0, 0, 0, 0, 0
+// dyn() -> 0x20, 0
+// nested() -> 0x20, 0
+// nestedStat() -> 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/test/libsolidity/semanticTests/strings/constant_string_literal.sol
+++ b/test/libsolidity/semanticTests/strings/constant_string_literal.sol
@@ -1,0 +1,25 @@
+contract Test {
+    bytes32 constant public b = "abcdefghijklmnopq";
+    string constant public x = "abefghijklmnopqabcdefghijklmnopqabcdefghijklmnopqabca";
+
+    constructor() {
+        string memory xx = x;
+        bytes32 bb = b;
+    }
+    function getB() public returns (bytes32) { return b; }
+    function getX() public returns (string memory) { return x; }
+    function getX2() public returns (string memory r) { r = x; }
+    function unused() public returns (uint) {
+        "unusedunusedunusedunusedunusedunusedunusedunusedunusedunusedunusedunused";
+        return 2;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// b() -> 0x6162636465666768696a6b6c6d6e6f7071000000000000000000000000000000
+// x() -> 0x20, 0x35, 0x616265666768696a6b6c6d6e6f70716162636465666768696a6b6c6d6e6f7071, 44048183304486788312148433451363384677562177293131179093971701692629931524096
+// getB() -> 0x6162636465666768696a6b6c6d6e6f7071000000000000000000000000000000
+// getX() -> 0x20, 0x35, 0x616265666768696a6b6c6d6e6f70716162636465666768696a6b6c6d6e6f7071, 44048183304486788312148433451363384677562177293131179093971701692629931524096
+// getX2() -> 0x20, 0x35, 0x616265666768696a6b6c6d6e6f70716162636465666768696a6b6c6d6e6f7071, 44048183304486788312148433451363384677562177293131179093971701692629931524096
+// unused() -> 2

--- a/test/libsolidity/semanticTests/strings/return_string.sol
+++ b/test/libsolidity/semanticTests/strings/return_string.sol
@@ -1,0 +1,20 @@
+contract Main {
+    string public s;
+    function set(string calldata _s) external {
+        s = _s;
+    }
+    function get1() public returns (string memory r) {
+        return s;
+    }
+    function get2() public returns (string memory r) {
+        r = s;
+    }
+}
+// ====
+// compileToEwasm: also
+// compileViaYul: also
+// ----
+// set(string): 0x20, 5, "Julia" ->
+// get1() -> 0x20, 5, "Julia"
+// get2() -> 0x20, 5, "Julia"
+// s() -> 0x20, 5, "Julia"

--- a/test/libsolidity/semanticTests/structs/packed_storage_structs_delete.sol
+++ b/test/libsolidity/semanticTests/structs/packed_storage_structs_delete.sol
@@ -1,0 +1,27 @@
+contract C {
+    struct str { uint8 a; uint16 b; uint8 c; }
+    uint8 x;
+    uint16 y;
+    str data;
+    function test() public returns (uint) {
+        x = 1;
+        y = 2;
+        data.a = 2;
+        data.b = 0xabcd;
+        data.c = 0xfa;
+        if (x != 1 || y != 2 || data.a != 2 || data.b != 0xabcd || data.c != 0xfa)
+            return 2;
+        delete y;
+        delete data.b;
+        if (x != 1 || y != 0 || data.a != 2 || data.b != 0 || data.c != 0xfa)
+            return 3;
+        delete x;
+        delete data;
+        return 1;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// test() -> 1
+// storageEmpty -> 1

--- a/test/libsolidity/semanticTests/variables/storing_invalid_boolean.sol
+++ b/test/libsolidity/semanticTests/variables/storing_invalid_boolean.sol
@@ -1,0 +1,35 @@
+contract C {
+    event Ev(bool);
+    bool public perm;
+    function set() public returns(uint) {
+        bool tmp;
+        assembly {
+            tmp := 5
+        }
+        perm = tmp;
+        return 1;
+    }
+    function ret() public returns(bool) {
+        bool tmp;
+        assembly {
+            tmp := 5
+        }
+        return tmp;
+    }
+    function ev() public returns(uint) {
+        bool tmp;
+        assembly {
+            tmp := 5
+        }
+        emit Ev(tmp);
+        return 1;
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// set() -> 1
+// perm() -> true
+// ret() -> true
+// ev() -> 1
+// ~ emit Ev(bool): true


### PR DESCRIPTION
Extracted Test Cases from SolidityEndToEnd.cpp are := 
1. enum_referencing ( removed in latest commit )
2. invalid_enum_logged
3. library_staticcall_delegatecall
4. memory_types_initialisation
5. constant_string_literal
6. return_string
7. packed_storage_structs_delete
8. storing_invalid_boolean

Helps #12253 . Extended from previous Draft PR at #12289 