### PR TITLE
[CI] Correct workflow name in gitter notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ commands:
             workflow_info=$(curl --silent "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}") || true
             workflow_name=$(echo "$workflow_info" | jq --raw-output .name || echo "$CIRCLE_WORKFLOW_ID")
 
-            [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
-            [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
 
             curl "https://api.gitter.im/v1/rooms/${GITTER_NOTIFY_ROOM_ID}/chatMessages" \
               --request POST \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,13 @@ commands:
             # but it's broken. CircleCI associates runs on develop/breaking with random old PRs.
             [[ $CIRCLE_BRANCH == develop || $CIRCLE_BRANCH == breaking ]] || { echo "Running on a PR or a feature branch - notification skipped."; exit 0; }
 
-            [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ Nightly job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
-            [[ "<< parameters.event >>" == "success" ]] && message=" ✅ Nightly job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            # Workflow name is not exposed as an env variable. Has to be queried from the API.
+            # The name is not critical so if anything fails, use the raw workflow ID as a fallback.
+            workflow_info=$(curl --silent "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}") || true
+            workflow_name=$(echo "$workflow_info" | jq --raw-output .name || echo "$CIRCLE_WORKFLOW_ID")
+
+            [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build #${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
 
             curl "https://api.gitter.im/v1/rooms/${GITTER_NOTIFY_ROOM_ID}/chatMessages" \
               --request POST \


### PR DESCRIPTION
Currently gitter notifications from CI look like this, even if they're not a part of a nightly run:

> ❌ Nightly job **b_archlinux** failed on **develop**. Please see [build #909430](https://circleci.com/gh/ethereum/solidity/909430) for details.

This PR changes it to something like this:
> ❌ [main] Job **b_archlinux** failed on **develop**. Please see [build 909430](https://circleci.com/gh/ethereum/solidity/909430) for details.

- Workflow name is used instead of hard-coded `Nightly`. Unfortunately this requires an API request and `jq` installed on the host because there's no env variable that has the workflow name.
- I removed the `#` character from build name because with it the number is interpreted as a channel name and the link is harder to click.