### PR TITLE
CI: Don't require `jq` to extract workflow name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
             # Workflow name is not exposed as an env variable. Has to be queried from the API.
             # The name is not critical so if anything fails, use the raw workflow ID as a fallback.
             workflow_info=$(curl --silent "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}") || true
-            workflow_name=$(echo "$workflow_info" | jq --raw-output .name || echo "$CIRCLE_WORKFLOW_ID")
+            workflow_name=$(echo "$workflow_info" | grep -E '"\s*name"\s*:\s*".*"' | cut -d \" -f 4 || echo "$CIRCLE_WORKFLOW_ID")
 
             [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
             [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."


### PR DESCRIPTION
A small tweak to #12315. Looks like `jq` is less widespread than I thought. I don't want to go over all jobs and install it so instead this PR replaces it with a combination of `grep` and `cut` that should be more portable, even it not as flexible.