### PR TITLE
Fix ExpressionSplitter example

### DIFF
--- a/docs/internals/optimizer.rst
+++ b/docs/internals/optimizer.rst
@@ -521,7 +521,7 @@ ExpressionSplitter
 
 The expression splitter turns expressions like ``add(mload(0x123), mul(mload(0x456), 0x20))``
 into a sequence of declarations of unique variables that are assigned sub-expressions
-of that expression so that each function call has only variables or literals
+of that expression so that each function call has only variables
 as arguments.
 
 The above would be transformed into
@@ -529,10 +529,13 @@ The above would be transformed into
 .. code-block:: yul
 
     {
-        let _1 := mload(0x123)
-        let _2 := mul(_1, 0x20)
-        let _3 := mload(0x456)
-        let z := add(_3, _2)
+        let _1 = 0x20
+        let _2 = 0x456
+        let _3 = mload(_2)
+        let _4 = mul(_3, _1)
+        let _5 = 0x123
+        let _6 = mload(_5)
+        let z = add(_6, _4)
     }
 
 Note that this transformation does not change the order of opcodes or function calls.
@@ -543,7 +546,7 @@ this "outlining" of the inner expressions in all cases. We can sidestep this lim
 
 The final program should be in a form such that (with the exception of loop conditions)
 function calls cannot appear nested inside expressions
-and all function call arguments have to be literals or variables.
+and all function call arguments have to be variables.
 
 The benefits of this form are that it is much easier to re-order the sequence of opcodes
 and it is also easier to perform function call inlining. Furthermore, it is simpler


### PR DESCRIPTION
Fix error (0x123 and 0x456 were swapped) and split constants into expressions