### PR TITLE
Restoring the RTD icon. Downloads section to still be above Versions section

### DIFF
--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,11 +1,7 @@
 {# Add rst-badge after rst-versions for small badge style. #}
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-    {% for type, url in downloads %}
-        {% if type == 'PDF' %}
-            <a href="{{ url }}">{{ type }}</a>
-        {% endif %}
-    {% endfor %}
+    <span class="fa fa-book fa-element"> RTD </span>
 
     <span class="fa fa-element">
     <input class="container_toggle" type="checkbox" id="switch" name="mode">


### PR DESCRIPTION
Helps #12238

PR #12277 attempted the following:
1. To replace the RTD icon in the footer with a link to the PDF of the relevant version of the documentation :  For unclear reasons related to RTD deployment, the requisite fields were not populated in the PDF link that replaced the RTD icon.

2. To Swap the order of the Downloads and Versions sections in the footer pull-up menu : The order was not swapped in the final rendering of the documentation. 

The current PR tries to solve the second problem. That of the order of Downloads and the Versions section in the pull-up menu.
