### PR TITLE
[CI] Adjust job parallelism to actually match available resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,6 @@ jobs:
 
   t_ubu_codecov:
     <<: *base_ubuntu2004
-    parallelism: 6
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 1
@@ -878,7 +877,7 @@ jobs:
 
   t_ubu_soltest_all: &t_ubu_soltest_all
     <<: *base_ubuntu2004
-    parallelism: 6
+    parallelism: 15 # 7 EVM versions, each with/without optimization + 1 ABIv1/@nooptions run
     <<: *steps_soltest_all
 
   t_archlinux_soltest: &t_archlinux_soltest
@@ -937,7 +936,6 @@ jobs:
 
   t_ubu_asan_soltest:
     <<: *base_ubuntu2004
-    parallelism: 6
     environment:
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -31,6 +31,7 @@ REPODIR="$(realpath "$(dirname "$0")"/..)"
 # shellcheck source=scripts/common.sh
 source "${REPODIR}/scripts/common.sh"
 
+# NOTE: If you add/remove values, remember to update `parallelism` setting in CircleCI config.
 EVM_VALUES=(homestead byzantium constantinople petersburg istanbul berlin london)
 DEFAULT_EVM=london
 [[ " ${EVM_VALUES[*]} " =~ $DEFAULT_EVM ]]


### PR DESCRIPTION
I have noticed that `parallelism` setting for our jobs does not actually match how parallel they actually are:
- `t_ubu_codecov` and `t_ubu_asan_soltest` run `soltest.sh` (not `soltest_all.sh`) so I think they do not take advantage of `parallelism: 6` at all.
- `t_ubu_soltest_all` and `t_ubu_release_soltest_all` actually do 15 separate soltest runs so `parallelism: 6` seems low. I think that increasing `parallelism` would decrease their runtime from 30 min to something more reasonable.

Still a draft because I need to see how much this actually speeds things up and potentially adjust the numbers. I set `soltest_all` parallelism to `15` (2.5 times more) but some runs are longer than others so I suspect it won't give us a 2.5x speed up. On the other hand maybe there's no harm in having it at 29 because I think that we only pay for the time each parallel job actually takes. I would have to look at our credit use to be able to verify that though.