### PR TITLE
Fix `t_ems_test_ext_colony` nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1413,4 +1413,5 @@ workflows:
           name: t_ems_test_ext_colony
           project: colony
           binary_type: solcjs
+          nodejs_version: '14'
           resource_class: medium


### PR DESCRIPTION
This fixes the [`t_ems_test_ext_colony`](https://app.circleci.com/pipelines/github/ethereum/solidity/20939/workflows/94cccdc5-cad7-496a-8368-76ebb9691870/jobs/921133) job, which has been failing in the nightly run for a few days.

I think it's because it runs on nodejs 17. Apparently I introduced the bug in #12192 - I changed the default nodejs version for external tests to `latest` (currently nodejs 17) there but only for the compile-only test and missed the nightly one.

The job fails because `python` is needed to build the native extension for the `sleep` npm package. We could easily install Python but I think it might still not run on 17 due to other problems and for now I just want to restore the job to what it was.