### PR TITLE
Avoid double compilation in Colony external test

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -49,7 +49,7 @@ function colony_test
 
     neutralize_package_json_hooks
     force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$min_optimizer_level"
-    yarn
+    yarn install
     git submodule update --init
 
     cd lib


### PR DESCRIPTION
Bare `yarn` command does more than just `yarn install` (I think it runs `yarn build` as well). As a result contracts are being compiled twice because we also run `yarn build` explicitly, which can be seen in the output of the colony job.