### PR TITLE
Make optimizer level 2 in external tests actually different from level 3

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -35,6 +35,7 @@ function colony_test
     local repo="https://github.com/solidity-external-tests/colonyNetwork.git"
     local branch=develop_080
     local config_file="truffle.js"
+    # On levels 1 and 2 it compiles but tests run out of gas
     local min_optimizer_level=3
     local max_optimizer_level=3
 

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -245,7 +245,7 @@ function optimizer_settings_for_level
 
     case "$level" in
         1) echo "{enabled: false}" ;;
-        2) echo "{enabled: true}" ;;
+        2) echo "{enabled: true, details: {yul: false}}" ;;
         3) echo "{enabled: true, details: {yul: true}}" ;;
         *)
             printError "Optimizer level not found. Please define OPTIMIZER_LEVEL=[1, 2, 3]"

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -34,7 +34,7 @@ function ens_test
 {
     local repo="https://github.com/ensdomains/ens.git"
     local branch=master
-    local config_file="truffle-config.js"
+    local config_file="truffle.js"
     local min_optimizer_level=1
     local max_optimizer_level=3
 

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -36,6 +36,7 @@ function gnosis_safe_test
     local repo="https://github.com/solidity-external-tests/safe-contracts.git"
     local branch=v2_080
     local config_file="truffle-config.js"
+    # level 1: "Error: while migrating GnosisSafe: Returned error: base fee exceeds gas limit"
     local min_optimizer_level=2
     local max_optimizer_level=3
 

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -63,4 +63,4 @@ function gnosis_safe_test
     done
 }
 
-external_test Gnosis-Safe gnosis_safe_test
+external_test Gnosis-Safe-V2 gnosis_safe_test

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -35,7 +35,8 @@ function gnosis_safe_test
     local repo="https://github.com/solidity-external-tests/safe-contracts.git"
     local branch=development_080
     local config_file="truffle-config.js"
-    local min_optimizer_level=2
+    # levels 1 and 2: "Stack too deep" error
+    local min_optimizer_level=3
     local max_optimizer_level=3
 
     local selected_optimizer_levels


### PR DESCRIPTION
`{enabled: true}` is equivalent to `{enabled: true, details: {yul: true}}` in optimizer settings so currently level 2 is the same as 3. It just makes the test ineffective but does not break it, which is why it must have gone unnoticed when we made Yul optimizer setting dependent on the general optimizer setting.

This PR makes level 2 effective again. It also corrects minimum level for the gnosis test because fails on the real level 2. I also added comments explaining in each case why certain levels are skipped.

There are also two tiny unrelated corrections:
- Both gnosis tests used the same name. This does not make anything fail but affects the name of the temporary dir where the output is stored. With the same name it's hard to distinguish them.
- ENS test was writing config to `truffle-config.js` rather than the `truffle.js` present in the repo. It did not break the test because `truffle-config.js` takes precedence and `truffle.sj` does not contain anything critical but it was triggering a warning from Truffle.