### PR TITLE
Update circleci mac xcode version to 13.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ defaults:
 
   - base_osx: &base_osx
       macos:
-        xcode: "11.0.0"
+        xcode: "13.2.0"
       environment:
         TERM: xterm
         MAKEFLAGS: -j 5


### PR DESCRIPTION
The fe github ci is failing to build solidity v0.8.10 (via solc-rust) on macos, using a newer version of xcode than is specified in the circleci config in this repo (xcode 12.x vs xcode 11.0).

https://github.com/ethereum/fe/runs/4529012071?check_suite_focus=true

The problem seems to be that clang 12.x (apple's fork at least) emits a warning here:
```
solidity/libyul/backends/evm/StackLayoutGenerator.cpp:250:19: error: loop variable '[slot, idealPosition]' is always a copy because the range of type 'ranges::zip_view<
[...snip...]
does not return a reference [-Werror,-Wrange-loop-analysis]

          for (auto const& [slot, idealPosition]: ranges::zip_view(_post, layout))
```

which makes the build fail due to the `-Werror` flag.

I'm starting this pr by just updating the version of xcode specified in the circleci config in order to reproduce the issue. If the build fails on circleci, I'm happy make the tiny code change to fix the warning. I'm also inclined to add an option to the cmake config to allow `-Werror` to be disabled (by downstream users like solc-rust) to avoid this sort of issue in the future.