### PR TITLE
Labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug Report
 about: Bug reports about the Solidity Compiler.
+labels: ["bug :bug:"]
 ---
 
 <!--## Prerequisites

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,13 +9,12 @@ labels: ["bug :bug:"]
 - First, many thanks for taking part in the community. We really appreciate that.
 - We realize there is a lot of information requested here. We ask only that you do your best to provide as much information as possible so we can better help you.
 - Support questions are better asked in one of the following locations:
-	- [Solidity chat](https://gitter.im/ethereum/solidity)
-	- [Stack Overflow](https://ethereum.stackexchange.com/)
+    - [Solidity chat](https://gitter.im/ethereum/solidity)
+    - [Stack Overflow](https://ethereum.stackexchange.com/)
 - Ensure the issue isn't already reported.
 - The issue should be reproducible with the latest solidity version; however, this isn't a hard requirement and being reproducible with an older version is sufficient.
 
 *Delete the above section and the instructions in the sections below before submitting*
-
 -->
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -6,18 +6,12 @@ labels: ["documentation :book:"]
 
 ## Page
 
-<!--
-Please link directly to the page which you think has a problem
--->
+<!--Please link directly to the page which you think has a problem.-->
 
 ## Abstract
 
-<!--
-Please describe in detail what is wrong.
--->
+<!--Please describe in detail what is wrong.-->
 
 ## Pull request
 
-<!--
-Please link to your pull request which resolves this issue
--->
+<!--Please link to your pull request which resolves this issue.-->

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,6 +1,7 @@
 ---
 name: Documentation Issue
 about: Solidity documentation.
+labels: ["documentation :book:"]
 ---
 
 ## Page

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,40 +9,29 @@ labels: ["feature"]
 - First, many thanks for taking part in the community. We really appreciate that.
 - We realize there is a lot of data requested here. We ask only that you do your best to provide as much information as possible so we can better help you.
 - Support questions are better asked in one of the following locations:
-	- [Solidity chat](https://gitter.im/ethereum/solidity)
-	- [Stack Overflow](https://ethereum.stackexchange.com/)
+    - [Solidity chat](https://gitter.im/ethereum/solidity)
+    - [Stack Overflow](https://ethereum.stackexchange.com/)
 - Ensure the issue isn't already reported (check `feature` and `language design` labels).
 
 *Delete the above section and the instructions in the sections below before submitting*
-
 -->
 
 ## Abstract
 
-<!--
-Please describe by example what problem you see in the current Solidity language
-and reason about it.
--->
+<!--Please describe by example what problem you see in the current Solidity language and reason about it.-->
 
 ## Motivation
 
-<!--
-In this section you describe how you propose to address the problem you described earlier,
-including by giving one or more exemplary source code snippets for demonstration.
--->
+<!--In this section you describe how you propose to address the problem you described earlier, including by giving one or more exemplary source code snippets for demonstration.-->
 
 ## Specification
 
-<!--
-The technical specification should describe the syntax and semantics of any new feature. The
-specification should be detailed enough to allow any developer to implement the functionality.
--->
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow any developer to implement the functionality.-->
 
 ## Backwards Compatibility
 
 <!--
-All language changes that introduce backwards incompatibilities must include a section describing
-these incompatibilities and their severity.
+All language changes that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity.
 
 Please describe how you propose to deal with these incompatibilities.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature Request
 about: Solidity language or infrastructure feature requests.
+labels: ["feature"]
 ---
 
 <!--## Prerequisites


### PR DESCRIPTION
https://github.com/ethereum/solidity-blog/pull/159#discussion_r769602005 by @christianparpart gave me and idea that we could automatically apply labels in our issue templates.

The PR also does some minor cleanup in templates:
- Replaces tabs with spaces
- Removes hard wrapping to make the instructions look more concise. Text in Github's issue editor is always soft wrapped. It also will never show up in the preview and even if it did, Github does not remove hard wrapping when rendering issue comments as would normally happen in markdown.