### PR TITLE
Links to issue templates that automatically apply the `Solidity` project

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Report
+    url: https://github.com/ethereum/solidity/issues/new?template=bug_report.md&projects=ethereum/solidity/43
+  - name: Documentation Issue
+    url: https://github.com/ethereum/solidity/issues/new?template=documentation_issue.md&projects=ethereum/solidity/43
+  - name: Feature Request
+    url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43


### PR DESCRIPTION
Partially addresses #8969.

Apparently it's not possible to have github select the project automatically in issue templates but it is possible to do so through the `project` query parameter in new issue URLs. And the `URL`s can be customized via [`config.yml`](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser). This PR creates this config and assigns new issues by default to the `Solidity` project.

It also removes the `general.md` template, which seems unused.

Unfortunately I have no way to test this so if we want to try this, we'll have to just merge it and see what happens. If things go bad we can revert. **A few things to check after it's merged**:
1. Currently issues in the [template chooser](https://github.com/ethereum/solidity/issues/new/choose) have descriptions taken from the `about` property in the templates. You can specify `about` in `config.yml` too. I did not do it to avoid duplication and I hope github will just take it from the templates.
2. You can specify labels in the URLs via `labels` parameter. I did not specify it and I'm hoping that github will also take these from the issue templates (once we have them there: #12412).
3. The `Report a security vulnerability` entry on the list seems special. I did not specify it because docs don't mention it. We need to make sure it does not disappear.
4. I'm setting `blank_issues_enabled` to `false` so that users always have to use one of these templates. I'm not sure if this will just remove the blank issue link from template chooser or completely forbid creating blank ones. In case it forbids them we might want to actually start using the `general.md` template for this.