### PR TITLE
Fix warning from Xcode 12.4 about a reference in `ranges::zip_view`

### DIFF
--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -247,7 +247,7 @@ Stack createIdealLayout(Stack const& _operationOutput, Stack const& _post, Calla
 	// before the operation, i.e. if PreviousSlot{2} is at a position at which _post contains VariableSlot{"tmp"},
 	// then we want the variable tmp in the slot at offset 2 in the layout before the operation.
 	vector<optional<StackSlot>> idealLayout(_post.size(), nullopt);
-	for (auto const& [slot, idealPosition]: ranges::zip_view(_post, layout))
+	for (auto&& [slot, idealPosition]: ranges::zip_view(_post, layout))
 		if (PreviousSlot* previousSlot = std::get_if<PreviousSlot>(&idealPosition))
 			idealLayout.at(previousSlot->slot) = slot;
 


### PR DESCRIPTION
The error message from clang seems to suggest that in this case, `zip_view` returns a pair of references already.
```
/Users/distiller/project/libyul/backends/evm/StackLayoutGenerator.cpp:250:19: error: loop variable '[slot, idealPosition]' is always a copy because the range of type 'ranges::zip_view<vector<variant<FunctionCallReturnLabelSlot, FunctionReturnLabelSlot, VariableSlot, LiteralSlot, TemporarySlot, JunkSlot>, allocator<variant<FunctionCallReturnLabelSlot, FunctionReturnLabelSlot, VariableSlot, LiteralSlot, TemporarySlot, JunkSlot> > >, vector<variant<PreviousSlot, variant<FunctionCallReturnLabelSlot, FunctionReturnLabelSlot, VariableSlot, LiteralSlot, TemporarySlot, JunkSlot> >, allocator<variant<PreviousSlot, variant<FunctionCallReturnLabelSlot, FunctionReturnLabelSlot, VariableSlot, LiteralSlot, TemporarySlot, JunkSlot> > > > >' (aka 'ranges::zip_view<std::__1::vector<std::__1::variant<solidity::yul::FunctionCallReturnLabelSlot, solidity::yul::FunctionReturnLabelSlot, solidity::yul::VariableSlot, solidity::yul::LiteralSlot, solidity::yul::TemporarySlot, solidity::yul::JunkSlot>, std::__1::allocator<std::__1::variant<solidity::yul::FunctionCallReturnLabelSlot, solidity::yul::FunctionReturnLabelSlot, solidity::yul::VariableSlot, solidity::yul::LiteralSlot, solidity::yul::TemporarySlot, solidity::yul::JunkSlot> > >, std::__1::vector<std::__1::variant<PreviousSlot, std::__1::variant<solidity::yul::FunctionCallReturnLabelSlot, solidity::yul::FunctionReturnLabelSlot, solidity::yul::VariableSlot, solidity::yul::LiteralSlot, solidity::yul::TemporarySlot, solidity::yul::JunkSlot> >, std::__1::allocator<std::__1::variant<PreviousSlot, std::__1::variant<solidity::yul::FunctionCallReturnLabelSlot, solidity::yul::FunctionReturnLabelSlot, solidity::yul::VariableSlot, solidity::yul::LiteralSlot, solidity::yul::TemporarySlot, solidity::yul::JunkSlot> > > > >') does not return a reference [-Werror,-Wrange-loop-analysis]
        for (auto const& [slot, idealPosition]: ranges::zip_view(_post, layout))
                         ^
/Users/distiller/project/libyul/backends/evm/StackLayoutGenerator.cpp:281:16: note: in instantiation of function template specialization '(anonymous namespace)::createIdealLayout<(lambda at /Users/distiller/project/libyul/backends/evm/StackLayoutGenerator.cpp:275:30)>' requested here
        Stack stack = createIdealLayout(_operation.output, _exitStack, generateSlotOnTheFly);
                      ^
/Users/distiller/project/libyul/backends/evm/StackLayoutGenerator.cpp:250:7: note: use non-reference type 'ranges::common_pair<std::__1::variant<solidity::yul::FunctionCallReturnLabelSlot, solidity::yul::FunctionReturnLabelSlot, solidity::yul::VariableSlot, solidity::yul::LiteralSlot, solidity::yul::TemporarySlot, solidity::yul::JunkSlot> &, std::__1::variant<PreviousSlot, std::__1::variant<solidity::yul::FunctionCallReturnLabelSlot, solidity::yul::FunctionReturnLabelSlot, solidity::yul::VariableSlot, solidity::yul::LiteralSlot, solidity::yul::TemporarySlot, solidity::yul::JunkSlot> > &>'
        for (auto const& [slot, idealPosition]: ranges::zip_view(_post, layout))

```

("use non-reference type 'ranges::common_Pair<std::variant<...> &, std::variant<...>&>'")

References https://github.com/ethereum/solidity/pull/12408
