### PR TITLE
LSP for solcjs

### DIFF
--- a/libsolc/CMakeLists.txt
+++ b/libsolc/CMakeLists.txt
@@ -7,6 +7,9 @@ if (EMSCRIPTEN)
 		solidity_alloc
 		solidity_free
 		solidity_reset
+		solidity_lsp_start
+		solidity_lsp_send
+		solidity_lsp_send_receive
 	)
 	# Specify which functions to export in soljson.js.
 	# Note that additional Emscripten-generated methods needed by solc-js are

--- a/libsolc/libsolc.cpp
+++ b/libsolc/libsolc.cpp
@@ -137,13 +137,22 @@ extern char* solidity_compile(char const* _input, CStyleReadFileCallback _readCa
 	return solidityAllocations.emplace_back(compile(_input, _readCallback, _readContext)).data();
 }
 
-extern int solidity_lsp_start(CStyleReadFileCallback /*TODO(pr) _readCallback*/, void* /*_readContext*/) noexcept
+extern int solidity_lsp_start(CStyleReadFileCallback _readCallback) noexcept
 {
 	if (languageServer || languageServerTransport)
 		return -1;
 
-	languageServerTransport = make_unique<lsp::MockTransport>();
-	languageServer = make_unique<lsp::LanguageServer>(*languageServerTransport);
+	try
+	{
+		languageServerTransport = make_unique<lsp::MockTransport>();
+		languageServer = make_unique<lsp::LanguageServer>(*languageServerTransport);
+		(void) _readCallback; // TODO(pr) pass to LanguageServer()
+	}
+	catch (...)
+	{
+		return -2;
+	}
+
 	return 0;
 }
 

--- a/libsolc/libsolc.h
+++ b/libsolc/libsolc.h
@@ -90,6 +90,40 @@ void solidity_free(char* _data) SOLC_NOEXCEPT;
 /// @returns A pointer to the result. The pointer returned must be freed by the caller using solidity_free() or solidity_reset().
 char* solidity_compile(char const* _input, CStyleReadFileCallback _readCallback, void* _readContext) SOLC_NOEXCEPT;
 
+/// @TODO the biggest problem here is that the callback has to be synchronous.
+/// With "compile" we would just record requested files and trigger a recompile later,
+/// so we might need a way to trigger a recompile.
+
+/// Switch into LSP mode. Can be undone using solidity_reset().
+///
+/// @returns 0 on success and -1 on failure. A failure can only happen due to mis-use of the API,
+/// such as, the LSP mode has been already initiated.
+int solidity_lsp_start(CStyleReadFileCallback _readCallback, void* _readContext) SOLC_NOEXCEPT;
+
+/// Sends a single JSON-RPC message to the LSP server.
+/// This message must not include any HTTP headers but only hold the payload.
+///
+/// @retval 0 Success.
+/// @retval -1 Server not initialized.
+/// @retval -2 Server not running (e.g. termination initiated).
+/// @retval -3 Could not parse JSON RPC message.
+int solidity_lsp_send(char const* _input) SOLC_NOEXCEPT;
+
+/// Tries to pop a pending message from the LSP server.
+/// @returns either an empty string if not possible
+/// (e.g. no message available or server shut down) or a stringified JSON response message.
+char const* solidity_try_receive() SOLC_NOEXCEPT;
+
+/// Send one or more JSON-RPC messages to the LSP (including the HTTP headers),
+/// expecting a response.
+/// If the input is empty, just checks for a pending response.
+/// @returns JSON-RPC message (inculding HTTP headers), can be empty (or nullptr).
+/// If the result is not null, it has to be freed by the caller using solidity_free.
+///
+/// This can cause the callback provided in solidity_lsp to be invoked.
+/// Should only be called after having called solidity_lsp.
+char const *solidity_lsp_send_receive(char const* _input) SOLC_NOEXCEPT;
+
 /// Frees up any allocated memory.
 ///
 /// NOTE: the pointer returned by solidity_compile as well as any other pointer retrieved via solidity_alloc()

--- a/libsolc/libsolc.h
+++ b/libsolc/libsolc.h
@@ -98,7 +98,7 @@ char* solidity_compile(char const* _input, CStyleReadFileCallback _readCallback,
 ///
 /// @returns 0 on success and -1 on failure. A failure can only happen due to mis-use of the API,
 /// such as, the LSP mode has been already initiated.
-int solidity_lsp_start(CStyleReadFileCallback _readCallback, void* _readContext) SOLC_NOEXCEPT;
+int solidity_lsp_start(CStyleReadFileCallback _readCallback) SOLC_NOEXCEPT;
 
 /// Sends a single JSON-RPC message to the LSP server.
 /// This message must not include any HTTP headers but only hold the payload.
@@ -120,8 +120,8 @@ char const* solidity_try_receive() SOLC_NOEXCEPT;
 /// @returns JSON-RPC message (inculding HTTP headers), can be empty (or nullptr).
 /// If the result is not null, it has to be freed by the caller using solidity_free.
 ///
-/// This can cause the callback provided in solidity_lsp to be invoked.
-/// Should only be called after having called solidity_lsp.
+/// This can cause the callback provided in solidity_lsp_start to be invoked.
+/// Should only be called after having called solidity_lsp_start.
 char const *solidity_lsp_send_receive(char const* _input) SOLC_NOEXCEPT;
 
 /// Frees up any allocated memory.

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -176,3 +176,7 @@ set(sources
 
 add_library(solidity ${sources})
 target_link_libraries(solidity PUBLIC yul evmasm langutil smtutil solutil Boost::boost fmt::fmt-header-only)
+
+if(EMSCRIPTEN)
+	target_compile_definitions(solidity PRIVATE EMSCRIPTEN=1)
+endif()

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -244,7 +244,13 @@ boost::filesystem::path FileReader::normalizeCLIPathForVFS(
 	// - Preserves case. Even if the filesystem is case-insensitive but case-preserving and the
 	//   case differs, the actual case from disk is NOT detected.
 
-	boost::filesystem::path canonicalWorkDir = boost::filesystem::weakly_canonical(boost::filesystem::current_path());
+	boost::filesystem::path canonicalWorkDir =
+#if defined(EMSCRIPTEN)
+		boost::filesystem::path("/")
+#else
+		boost::filesystem::weakly_canonical(boost::filesystem::current_path())
+#endif
+		;
 
 	// NOTE: On UNIX systems the path returned from current_path() has symlinks resolved while on
 	// Windows it does not. To get consistent results we resolve them on all platforms.

--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -68,6 +68,7 @@ int toDiagnosticSeverity(Error::Type _errorType)
 
 }
 
+// TODO provide constructor with custom read callback
 LanguageServer::LanguageServer(Transport& _transport):
 	m_client{_transport},
 	m_handlers{
@@ -180,37 +181,9 @@ void LanguageServer::compileAndUpdateDiagnostics()
 
 bool LanguageServer::run()
 {
-	while (m_state != State::ExitRequested && m_state != State::ExitWithoutShutdown && !m_client.closed())
-	{
-		MessageID id;
-		try
-		{
-			optional<Json::Value> const jsonMessage = m_client.receive();
-			if (!jsonMessage)
-				continue;
+	while (isRunning())
+		runIteration();
 
-			if ((*jsonMessage)["method"].isString())
-			{
-				string const methodName = (*jsonMessage)["method"].asString();
-				id = (*jsonMessage)["id"];
-
-				if (auto handler = util::valueOrDefault(m_handlers, methodName))
-					handler(id, (*jsonMessage)["params"]);
-				else
-					m_client.error(id, ErrorCode::MethodNotFound, "Unknown method " + methodName);
-			}
-			else
-				m_client.error({}, ErrorCode::ParseError, "\"method\" has to be a string.");
-		}
-		catch (RequestError const& error)
-		{
-			m_client.error(id, error.code(), error.comment() ? *error.comment() : ""s);
-		}
-		catch (...)
-		{
-			m_client.error(id, ErrorCode::InternalError, "Unhandled exception: "s + boost::current_exception_diagnostic_information());
-		}
-	}
 	return m_state == State::ExitRequested;
 }
 
@@ -221,6 +194,38 @@ void LanguageServer::requireServerInitialized()
 		ErrorCode::ServerNotInitialized,
 		"Server is not properly initialized."
 	);
+}
+
+bool LanguageServer::runIteration()
+{
+	MessageID id;
+	try
+	{
+		optional<Json::Value> const jsonMessage = m_client.receive();
+		if (!jsonMessage)
+			return true;
+
+		if ((*jsonMessage)["method"].isString())
+		{
+			string const methodName = (*jsonMessage)["method"].asString();
+			id = (*jsonMessage)["id"];
+
+			if (auto handler = util::valueOrDefault(m_handlers, methodName))
+				handler(id, (*jsonMessage)["params"]);
+			else
+				m_client.error(id, ErrorCode::MethodNotFound, "Unknown method " + methodName);
+		}
+	}
+	catch (RequestError const& error)
+	{
+		m_client.error(id, error.code(), error.comment() ? *error.comment() : ""s);
+	}
+	catch (...)
+	{
+		m_client.error(id, ErrorCode::InternalError, "Unhandled exception: "s + boost::current_exception_diagnostic_information());
+	}
+
+	return isRunning();
 }
 
 void LanguageServer::handleInitialize(MessageID _id, Json::Value const& _args)

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -62,6 +62,17 @@ public:
 	frontend::ASTNode const* astNodeAtSourceLocation(std::string const& _sourceUnitName, langutil::LineColumn const& _filePos);
 	langutil::CharStreamProvider const& charStreamProvider() const noexcept { return m_compilerStack; }
 
+	/// Run a single iteration of processing inputs and generating outputs.
+	/// To be used when we are not in control of the event loop.
+	/// @returns false if the process is supposed to terminate.
+	bool runIteration();
+
+	/// @returns true if the server has not terminated yet, false otherwise.
+	bool isRunning() const noexcept
+	{
+		return m_state != State::ExitRequested && m_state != State::ExitWithoutShutdown && !m_client.closed();
+	}
+
 private:
 	/// Checks if the server is initialized (to be used by messages that need it to be initialized).
 	/// Reports an error and returns false if not.


### PR DESCRIPTION
Open questions:

**Interface**
- [ ] do we want to have a generic, input/output function that has a context (probably yes)?
- [ ] do we want to have a generic "set read callback" function?
- [ ] do we actually need to "start the lsp"?
- [ ] how to handle the fact that the file read callback has to be synchronous?

**Implementation**
- [ ] we need to redesign the FileRepository so that it can get a file read callback from outside. How should it handle things like base path and include paths? Not at all?

---

Some ideas / solutions from a call with @axic:
- we stay with `lsp_start` and `lsp_send_receive` for now.
- we should add two new kinds to the read callback:
  - `LookupPath`: gets a compiler-internal path and returns an absolute file url (or other url)
  - `ReadFileAt`: gets a url returned by `LookupPath` and returns its contents
 this mechanism allows the LSP server to store the internal / url mapping and thus report source locations correctly in all circumstances.
- the solcjs wrapper should have `lsp: { start(readCallback), abort() }`, where `start(readCallback)` returns a function that wraps `send_receive`.
- the include path mechanism has to be implemented by the lsp client plugin (this also has the benefit that the plugin can e.g. detect the framework the project uses and handle special paths properly)

What is still unsolved how to make this work nicely in a context where we cannot do synchronous file reads. The `LookupPath` callback would have to store the path and return an error. When the `send_receive` calls returns, we can read the file and once we have it, we somehow need to re-trigger the compiler analysis so that it asks for the file again. How to trigger the compiler is the main question.