### PR TITLE
Move `about` field from issue templates to `config.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,5 @@
 ---
 name: Bug Report
-about: Bug reports about the Solidity Compiler.
 labels: ["bug :bug:"]
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: Bug Report
     url: https://github.com/ethereum/solidity/issues/new?template=bug_report.md&projects=ethereum/solidity/43
+    about: Bug reports about the Solidity Compiler.
   - name: Documentation Issue
     url: https://github.com/ethereum/solidity/issues/new?template=documentation_issue.md&projects=ethereum/solidity/43
+    about: Solidity documentation.
   - name: Feature Request
     url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43
+    about: Solidity language or infrastructure feature requests.

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,6 +1,5 @@
 ---
 name: Documentation Issue
-about: Solidity documentation.
 labels: ["documentation :book:"]
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,5 @@
 ---
 name: Feature Request
-about: Solidity language or infrastructure feature requests.
 labels: ["feature"]
 ---
 


### PR DESCRIPTION
Follow-up to #12413.

The config gets picked up but the URLs don't show up in the template chooser. Let's see if adding `about` fields in the config fixes that.