### PR TITLE
Restore security policy link and labels in issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,5 @@
 ---
 name: Bug Report
-labels: ["bug :bug:"]
 ---
 
 <!--## Prerequisites

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,13 @@
 blank_issues_enabled: false
 contact_links:
   - name: Bug Report
-    url: https://github.com/ethereum/solidity/issues/new?template=bug_report.md&projects=ethereum/solidity/43
+    url: https://github.com/ethereum/solidity/issues/new?template=bug_report.md&projects=ethereum/solidity/43&labels=bug+%3Abug%3A
     about: Bug reports about the Solidity Compiler.
   - name: Documentation Issue
-    url: https://github.com/ethereum/solidity/issues/new?template=documentation_issue.md&projects=ethereum/solidity/43
+    url: https://github.com/ethereum/solidity/issues/new?template=documentation_issue.md&projects=ethereum/solidity/43&labels=documentation+%3Abook%3A
     about: Solidity documentation.
   - name: Feature Request
-    url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43
+    url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43&labels=feature
     about: Solidity language or infrastructure feature requests.
   - name: Report a security vulnerability
     url: https://github.com/ethereum/solidity/security/policy

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,6 @@ contact_links:
   - name: Feature Request
     url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43
     about: Solidity language or infrastructure feature requests.
+  - name: Report a security vulnerability
+    url: https://github.com/ethereum/solidity/security/policy
+    about: Please review our security policy for more details.

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,6 +1,5 @@
 ---
 name: Documentation Issue
-labels: ["documentation :book:"]
 ---
 
 ## Page

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,5 @@
 ---
 name: Feature Request
-labels: ["feature"]
 ---
 
 <!--## Prerequisites


### PR DESCRIPTION
Follow-up to #12419 and #12413.

After #12413 URLs work but the "security policy" link has disappeared from the template chooser and also `labels` fields in the templates are now ignored.

This PR:
- Manually adds the security policy link
- Puts labels in the URLs directly