### PR TITLE
LSP goto definition

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 * JSON-AST: Added selector field for errors and events.
  * Peephole Optimizer: Optimize comparisons in front of conditional jumps and conditional jumps across a single unconditional jump.
  * Yul Optimizer: Remove ``sstore`` and ``mstore`` operations that are never read from.
+ * LSP: Implements goto-definition.
 
 Bugfixes:
  * Yul IR Code Generation: Optimize embedded creation code with correct settings. This fixes potential mismatches between the constructor code of a contract compiled in isolation and the bytecode in ``type(C).creationCode``, resp. the bytecode used for ``new C(...)``.

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -155,10 +155,10 @@ set(sources
 	interface/StorageLayout.h
 	interface/Version.cpp
 	interface/Version.h
-	lsp/LanguageServer.cpp
-	lsp/LanguageServer.h
 	lsp/FileRepository.cpp
 	lsp/FileRepository.h
+	lsp/GotoDefinition.cpp
+	lsp/GotoDefinition.h
 	lsp/HandlerBase.cpp
 	lsp/HandlerBase.h
 	lsp/LanguageServer.cpp

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -159,8 +159,14 @@ set(sources
 	lsp/LanguageServer.h
 	lsp/FileRepository.cpp
 	lsp/FileRepository.h
+	lsp/HandlerBase.cpp
+	lsp/HandlerBase.h
+	lsp/LanguageServer.cpp
+	lsp/LanguageServer.h
 	lsp/Transport.cpp
 	lsp/Transport.h
+	lsp/Utils.cpp
+	lsp/Utils.h
 	parsing/DocStringParser.cpp
 	parsing/DocStringParser.h
 	parsing/Parser.cpp

--- a/libsolidity/ast/ASTUtils.h
+++ b/libsolidity/ast/ASTUtils.h
@@ -21,9 +21,11 @@
 namespace solidity::frontend
 {
 
-class VariableDeclaration;
+class ASTNode;
 class Declaration;
 class Expression;
+class SourceUnit;
+class VariableDeclaration;
 
 /// Find the topmost referenced constant variable declaration when the given variable
 /// declaration value is an identifier. Works only for constant variable declarations.
@@ -32,5 +34,8 @@ VariableDeclaration const* rootConstVariableDeclaration(VariableDeclaration cons
 
 /// Returns true if the constant variable declaration is recursive.
 bool isConstantVariableRecursive(VariableDeclaration const& _varDecl);
+
+/// Returns the innermost AST node that covers the given location or nullptr if not found.
+ASTNode const* locateInnermostASTNode(int _offsetInFile, SourceUnit const& _sourceUnit);
 
 }

--- a/libsolidity/lsp/GotoDefinition.cpp
+++ b/libsolidity/lsp/GotoDefinition.cpp
@@ -1,0 +1,66 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/lsp/GotoDefinition.h>
+#include <libsolidity/lsp/Transport.h> // for RequestError
+#include <libsolidity/lsp/Utils.h>
+#include <libsolidity/ast/AST.h>
+#include <libsolidity/ast/ASTUtils.h>
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace solidity::frontend;
+using namespace solidity::langutil;
+using namespace solidity::lsp;
+using namespace std;
+
+void GotoDefinition::operator()(MessageID _id, Json::Value const& _args)
+{
+	auto const [sourceUnitName, lineColumn] = extractSourceUnitNameAndLineColumn(_args);
+
+	ASTNode const* sourceNode = m_server.astNodeAtSourceLocation(sourceUnitName, lineColumn);
+
+	vector<SourceLocation> locations;
+	if (auto const* expression = dynamic_cast<Expression const*>(sourceNode))
+	{
+		// Handles all expressions that can have one or more declaration annotation.
+		if (auto const* declaration = referencedDeclaration(expression))
+			if (auto location = declarationLocation(declaration))
+				locations.emplace_back(move(location.value()));
+	}
+	else if (auto const* identifierPath = dynamic_cast<IdentifierPath const*>(sourceNode))
+	{
+		if (auto const* declaration = identifierPath->annotation().referencedDeclaration)
+			if (auto location = declarationLocation(declaration))
+				locations.emplace_back(move(location.value()));
+	}
+	else if (auto const* importDirective = dynamic_cast<ImportDirective const*>(sourceNode))
+	{
+		auto const& path = *importDirective->annotation().absolutePath;
+		if (fileRepository().sourceUnits().count(path))
+			locations.emplace_back(SourceLocation{0, 0, make_shared<string const>(path)});
+	}
+
+	Json::Value reply = Json::arrayValue;
+	for (SourceLocation const& location: locations)
+		reply.append(toJson(location));
+	client().reply(_id, reply);
+}

--- a/libsolidity/lsp/GotoDefinition.h
+++ b/libsolidity/lsp/GotoDefinition.h
@@ -1,0 +1,31 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolidity/lsp/HandlerBase.h>
+
+namespace solidity::lsp
+{
+
+class GotoDefinition: public HandlerBase
+{
+public:
+	explicit GotoDefinition(LanguageServer& _server): HandlerBase(_server) {}
+
+	void operator()(MessageID, Json::Value const&);
+};
+
+}

--- a/libsolidity/lsp/HandlerBase.cpp
+++ b/libsolidity/lsp/HandlerBase.cpp
@@ -1,0 +1,63 @@
+#include <libsolidity/lsp/HandlerBase.h>
+#include <libsolidity/lsp/LanguageServer.h>
+#include <libsolidity/lsp/Utils.h>
+#include <libsolidity/ast/AST.h>
+
+#include <liblangutil/Exceptions.h>
+
+using namespace std;
+
+namespace solidity::lsp
+{
+
+using namespace langutil;
+
+Json::Value HandlerBase::toRange(SourceLocation const& _location) const
+{
+	if (!_location.hasText())
+		return toJsonRange({}, {});
+
+	solAssert(_location.sourceName, "");
+	langutil::CharStream const& stream = charStreamProvider().charStream(*_location.sourceName);
+	LineColumn start = stream.translatePositionToLineColumn(_location.start);
+	LineColumn end = stream.translatePositionToLineColumn(_location.end);
+	return toJsonRange(start, end);
+}
+
+Json::Value HandlerBase::toJson(SourceLocation const& _location) const
+{
+	solAssert(_location.sourceName);
+	Json::Value item = Json::objectValue;
+	item["uri"] = fileRepository().sourceUnitNameToClientPath(*_location.sourceName);
+	item["range"] = toRange(_location);
+	return item;
+}
+
+optional<SourceLocation> HandlerBase::parsePosition(string const& _sourceUnitName, Json::Value const& _position) const
+{
+	if (!fileRepository().sourceUnits().count(_sourceUnitName))
+		return nullopt;
+
+	if (optional<LineColumn> lineColumn = parseLineColumn(_position))
+		if (optional<int> const offset = CharStream::translateLineColumnToPosition(
+			fileRepository().sourceUnits().at(_sourceUnitName),
+			*lineColumn
+		))
+			return SourceLocation{*offset, *offset, make_shared<string>(_sourceUnitName)};
+	return nullopt;
+}
+
+optional<SourceLocation> HandlerBase::parseRange(string const& _sourceUnitName, Json::Value const& _range) const
+{
+	if (!_range.isObject())
+		return nullopt;
+	optional<SourceLocation> start = parsePosition(_sourceUnitName, _range["start"]);
+	optional<SourceLocation> end = parsePosition(_sourceUnitName, _range["end"]);
+	if (!start || !end)
+		return nullopt;
+	solAssert(*start->sourceName == *end->sourceName);
+	start->end = end->end;
+	return start;
+}
+
+}

--- a/libsolidity/lsp/HandlerBase.cpp
+++ b/libsolidity/lsp/HandlerBase.cpp
@@ -1,3 +1,22 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#include <libsolutil/Exceptions.h>
+
 #include <libsolidity/lsp/HandlerBase.h>
 #include <libsolidity/lsp/LanguageServer.h>
 #include <libsolidity/lsp/Utils.h>
@@ -5,12 +24,12 @@
 
 #include <liblangutil/Exceptions.h>
 
+#include <fmt/format.h>
+
+using namespace solidity::langutil;
+using namespace solidity::lsp;
+using namespace solidity::util;
 using namespace std;
-
-namespace solidity::lsp
-{
-
-using namespace langutil;
 
 Json::Value HandlerBase::toRange(SourceLocation const& _location) const
 {
@@ -33,31 +52,27 @@ Json::Value HandlerBase::toJson(SourceLocation const& _location) const
 	return item;
 }
 
-optional<SourceLocation> HandlerBase::parsePosition(string const& _sourceUnitName, Json::Value const& _position) const
+pair<string, LineColumn> HandlerBase::extractSourceUnitNameAndLineColumn(Json::Value const& _args) const
 {
-	if (!fileRepository().sourceUnits().count(_sourceUnitName))
-		return nullopt;
+	string const uri = _args["textDocument"]["uri"].asString();
+	string const sourceUnitName = fileRepository().clientPathToSourceUnitName(uri);
+	if (!fileRepository().sourceUnits().count(sourceUnitName))
+		BOOST_THROW_EXCEPTION(
+			RequestError(ErrorCode::RequestFailed) <<
+			errinfo_comment("Unknown file: " + uri)
+		);
 
-	if (optional<LineColumn> lineColumn = parseLineColumn(_position))
-		if (optional<int> const offset = CharStream::translateLineColumnToPosition(
-			fileRepository().sourceUnits().at(_sourceUnitName),
-			*lineColumn
-		))
-			return SourceLocation{*offset, *offset, make_shared<string>(_sourceUnitName)};
-	return nullopt;
-}
+	auto const lineColumn = parseLineColumn(_args["position"]);
+	if (!lineColumn)
+		BOOST_THROW_EXCEPTION(
+			RequestError(ErrorCode::RequestFailed) <<
+			errinfo_comment(fmt::format(
+				"Unknown position {line}:{column} in file: {file}",
+				fmt::arg("line", lineColumn.value().line),
+				fmt::arg("column", lineColumn.value().column),
+				fmt::arg("file", sourceUnitName)
+			))
+		);
 
-optional<SourceLocation> HandlerBase::parseRange(string const& _sourceUnitName, Json::Value const& _range) const
-{
-	if (!_range.isObject())
-		return nullopt;
-	optional<SourceLocation> start = parsePosition(_sourceUnitName, _range["start"]);
-	optional<SourceLocation> end = parsePosition(_sourceUnitName, _range["end"]);
-	if (!start || !end)
-		return nullopt;
-	solAssert(*start->sourceName == *end->sourceName);
-	start->end = end->end;
-	return start;
-}
-
+	return {sourceUnitName, *lineColumn};
 }

--- a/libsolidity/lsp/HandlerBase.h
+++ b/libsolidity/lsp/HandlerBase.h
@@ -1,3 +1,20 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
 #pragma once
 
 #include <libsolidity/lsp/FileRepository.h>
@@ -24,22 +41,15 @@ public:
 	Json::Value toRange(langutil::SourceLocation const& _location) const;
 	Json::Value toJson(langutil::SourceLocation const& _location) const;
 
-	std::optional<langutil::SourceLocation> parsePosition(
-		std::string const& _sourceUnitName,
-		Json::Value const& _position
-	) const;
+	/// @returns source unit name and the line column position as extracted
+	/// from the JSON-RPC parameters.
+	std::pair<std::string, langutil::LineColumn> extractSourceUnitNameAndLineColumn(Json::Value const& _params) const;
 
-	/// @returns the source location given a source unit name and an LSP Range object,
-	/// or nullopt on failure.
-	std::optional<langutil::SourceLocation> parseRange(
-		std::string const& _sourceUnitName,
-		Json::Value const& _range
-	) const;
+	langutil::CharStreamProvider const& charStreamProvider() const noexcept { return m_server.charStreamProvider(); }
+	FileRepository const& fileRepository() const noexcept { return m_server.fileRepository(); }
+	Transport& client() const noexcept { return m_server.client(); }
 
-	langutil::CharStreamProvider const& charStreamProvider() const noexcept { return m_server.charStreamProvider(); };
-	FileRepository const& fileRepository() const noexcept { return m_server.fileRepository(); };
-	Transport& client() const noexcept { return m_server.client(); };
-
+protected:
 	LanguageServer& m_server;
 };
 

--- a/libsolidity/lsp/HandlerBase.h
+++ b/libsolidity/lsp/HandlerBase.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <libsolidity/lsp/FileRepository.h>
+#include <libsolidity/lsp/LanguageServer.h>
+
+#include <liblangutil/SourceLocation.h>
+#include <liblangutil/CharStreamProvider.h>
+
+#include <optional>
+
+namespace solidity::lsp
+{
+
+class Transport;
+
+/**
+ * Helper base class for implementing handlers.
+ */
+class HandlerBase
+{
+public:
+	explicit HandlerBase(LanguageServer& _server): m_server{_server} {}
+
+	Json::Value toRange(langutil::SourceLocation const& _location) const;
+	Json::Value toJson(langutil::SourceLocation const& _location) const;
+
+	std::optional<langutil::SourceLocation> parsePosition(
+		std::string const& _sourceUnitName,
+		Json::Value const& _position
+	) const;
+
+	/// @returns the source location given a source unit name and an LSP Range object,
+	/// or nullopt on failure.
+	std::optional<langutil::SourceLocation> parseRange(
+		std::string const& _sourceUnitName,
+		Json::Value const& _range
+	) const;
+
+	langutil::CharStreamProvider const& charStreamProvider() const noexcept { return m_server.charStreamProvider(); };
+	FileRepository const& fileRepository() const noexcept { return m_server.fileRepository(); };
+	Transport& client() const noexcept { return m_server.client(); };
+
+	LanguageServer& m_server;
+};
+
+}

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -57,6 +57,11 @@ public:
 	/// @return boolean indicating normal or abnormal termination.
 	bool run();
 
+	FileRepository& fileRepository() noexcept { return m_fileRepository; }
+	Transport& client() noexcept { return m_client; }
+	frontend::ASTNode const* requestASTNode(std::string const& _sourceUnitName, langutil::LineColumn const& _filePos);
+	langutil::CharStreamProvider const& charStreamProvider() const noexcept { return m_compilerStack; }
+
 private:
 	/// Checks if the server is initialized (to be used by messages that need it to be initialized).
 	/// Reports an error and returns false if not.
@@ -72,22 +77,18 @@ private:
 
 	/// Compile everything until after analysis phase.
 	void compile();
+	using MessageHandler = std::function<void(MessageID, Json::Value const&)>;
 
-	std::optional<langutil::SourceLocation> parsePosition(
-		std::string const& _sourceUnitName,
-		Json::Value const& _position
-	) const;
 	/// @returns the source location given a source unit name and an LSP Range object,
 	/// or nullopt on failure.
 	std::optional<langutil::SourceLocation> parseRange(
 		std::string const& _sourceUnitName,
 		Json::Value const& _range
-	) const;
-	Json::Value toRange(langutil::SourceLocation const& _location) const;
-	Json::Value toJson(langutil::SourceLocation const& _location) const;
+	);
+	Json::Value toRange(langutil::SourceLocation const& _location);
+	Json::Value toJson(langutil::SourceLocation const& _location);
 
 	// LSP related member fields
-	using MessageHandler = std::function<void(MessageID, Json::Value const&)>;
 
 	enum class State { Started, Initialized, ShutdownRequested, ExitRequested, ExitWithoutShutdown };
 	State m_state = State::Started;

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -59,7 +59,7 @@ public:
 
 	FileRepository& fileRepository() noexcept { return m_fileRepository; }
 	Transport& client() noexcept { return m_client; }
-	frontend::ASTNode const* requestASTNode(std::string const& _sourceUnitName, langutil::LineColumn const& _filePos);
+	frontend::ASTNode const* astNodeAtSourceLocation(std::string const& _sourceUnitName, langutil::LineColumn const& _filePos);
 	langutil::CharStreamProvider const& charStreamProvider() const noexcept { return m_compilerStack; }
 
 private:
@@ -71,6 +71,7 @@ private:
 	void handleTextDocumentDidOpen(Json::Value const& _args);
 	void handleTextDocumentDidChange(Json::Value const& _args);
 	void handleTextDocumentDidClose(Json::Value const& _args);
+	void handleGotoDefinition(MessageID _id, Json::Value const& _args);
 
 	/// Invoked when the server user-supplied configuration changes (initiated by the client).
 	void changeConfiguration(Json::Value const&);
@@ -79,12 +80,6 @@ private:
 	void compile();
 	using MessageHandler = std::function<void(MessageID, Json::Value const&)>;
 
-	/// @returns the source location given a source unit name and an LSP Range object,
-	/// or nullopt on failure.
-	std::optional<langutil::SourceLocation> parseRange(
-		std::string const& _sourceUnitName,
-		Json::Value const& _range
-	);
 	Json::Value toRange(langutil::SourceLocation const& _location);
 	Json::Value toJson(langutil::SourceLocation const& _location);
 

--- a/libsolidity/lsp/Utils.cpp
+++ b/libsolidity/lsp/Utils.cpp
@@ -1,0 +1,70 @@
+#include <liblangutil/CharStreamProvider.h>
+#include <liblangutil/Exceptions.h>
+#include <libsolidity/ast/AST.h>
+#include <libsolidity/lsp/FileRepository.h>
+#include <libsolidity/lsp/Utils.h>
+
+namespace solidity::lsp
+{
+
+using namespace frontend;
+using namespace langutil;
+using namespace std;
+
+optional<LineColumn> parseLineColumn(Json::Value const& _lineColumn)
+{
+	if (_lineColumn.isObject() && _lineColumn["line"].isInt() && _lineColumn["character"].isInt())
+		return LineColumn{_lineColumn["line"].asInt(), _lineColumn["character"].asInt()};
+	else
+		return nullopt;
+}
+
+Json::Value toJson(LineColumn _pos)
+{
+	Json::Value json = Json::objectValue;
+	json["line"] = max(_pos.line, 0);
+	json["character"] = max(_pos.column, 0);
+
+	return json;
+}
+
+Json::Value toJsonRange(LineColumn const& _start, LineColumn const& _end)
+{
+	Json::Value json;
+	json["start"] = toJson(_start);
+	json["end"] = toJson(_end);
+	return json;
+}
+
+vector<Declaration const*> allAnnotatedDeclarations(Expression const* _expression)
+{
+	vector<Declaration const*> output;
+
+	if (auto const* identifier = dynamic_cast<Identifier const*>(_expression))
+	{
+		output.push_back(identifier->annotation().referencedDeclaration);
+		output += identifier->annotation().candidateDeclarations;
+	}
+	else if (auto const* memberAccess = dynamic_cast<MemberAccess const*>(_expression))
+	{
+		output.push_back(memberAccess->annotation().referencedDeclaration);
+	}
+
+	return output;
+}
+
+optional<SourceLocation> declarationPosition(Declaration const* _declaration)
+{
+	if (!_declaration)
+		return nullopt;
+
+	if (_declaration->nameLocation().isValid())
+		return _declaration->nameLocation();
+
+	if (_declaration->location().isValid())
+		return _declaration->location();
+
+	return nullopt;
+}
+
+}

--- a/libsolidity/lsp/Utils.h
+++ b/libsolidity/lsp/Utils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <liblangutil/SourceLocation.h>
+
+#include <libsolidity/ast/ASTForward.h>
+
+#include <libsolutil/JSON.h>
+
+#include <optional>
+#include <vector>
+
+namespace solidity::langutil
+{
+class CharStreamProvider;
+}
+
+namespace solidity::lsp
+{
+
+class FileRepository;
+
+std::optional<langutil::LineColumn> parseLineColumn(Json::Value const& _lineColumn);
+Json::Value toJson(langutil::LineColumn _pos);
+Json::Value toJsonRange(langutil::LineColumn const& _start, langutil::LineColumn const& _end);
+
+std::vector<frontend::Declaration const*> allAnnotatedDeclarations(frontend::Expression const* _expression);
+std::optional<langutil::SourceLocation> declarationPosition(frontend::Declaration const* _declaration);
+
+}

--- a/libsolidity/lsp/Utils.h
+++ b/libsolidity/lsp/Utils.h
@@ -1,3 +1,21 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
 #pragma once
 
 #include <liblangutil/SourceLocation.h>
@@ -8,6 +26,13 @@
 
 #include <optional>
 #include <vector>
+
+#if !defined(NDEBUG)
+#include <fstream>
+#define lspDebug(message) (std::ofstream("/tmp/solc.log", std::ios::app) << (message) << std::endl)
+#else
+#define lspDebug(message) do {} while (0)
+#endif
 
 namespace solidity::langutil
 {
@@ -20,10 +45,35 @@ namespace solidity::lsp
 class FileRepository;
 
 std::optional<langutil::LineColumn> parseLineColumn(Json::Value const& _lineColumn);
-Json::Value toJson(langutil::LineColumn _pos);
+Json::Value toJson(langutil::LineColumn const& _pos);
 Json::Value toJsonRange(langutil::LineColumn const& _start, langutil::LineColumn const& _end);
 
-std::vector<frontend::Declaration const*> allAnnotatedDeclarations(frontend::Expression const* _expression);
-std::optional<langutil::SourceLocation> declarationPosition(frontend::Declaration const* _declaration);
+/// @returns the source location given a source unit name and an LSP Range object,
+/// or nullopt on failure.
+std::optional<langutil::SourceLocation> parsePosition(
+	FileRepository const& _fileRepository,
+	std::string const& _sourceUnitName,
+	Json::Value const& _position
+);
+
+/// @returns the source location given a source unit name and an LSP Range object,
+/// or nullopt on failure.
+std::optional<langutil::SourceLocation> parseRange(
+	FileRepository const& _fileRepository,
+	std::string const& _sourceUnitName,
+	Json::Value const& _range
+);
+
+/// Extracts the resolved declaration of the given expression AST node.
+///
+/// This may for example be the type declaration of an identifier,
+/// or the type declaration of a structured member identifier.
+///
+/// @returns the resolved type declaration if found, or nullptr otherwise.
+frontend::Declaration const* referencedDeclaration(frontend::Expression const* _expression);
+
+/// @returns the location of the declaration's name, if present, or the location of the complete
+/// declaration otherwise. If the input declaration is nullptr, std::nullopt is returned instead.
+std::optional<langutil::SourceLocation> declarationLocation(frontend::Declaration const* _declaration);
 
 }

--- a/test/libsolidity/lsp/goto_definition.sol
+++ b/test/libsolidity/lsp/goto_definition.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import "./lib.sol";
+
+interface I
+{
+    function f(uint x) external returns (uint);
+}
+
+contract IA is I
+{
+    function f(uint x) public pure override returns (uint) { return x + 1; }
+}
+
+contract IB is I
+{
+    function f(uint x) public pure override returns (uint) { return x + 2; }
+}
+
+library IntLib
+{
+    function add(int self, int b) public pure returns (int) { return self + b; }
+}
+
+contract C
+{
+    I obj;
+    function virtual_inheritance() public payable
+    {
+        obj = new IA();
+        obj.f(1); // goto-definition should jump to definition of interface.
+    }
+
+    using IntLib for *;
+    function using_for(int i) pure public
+    {
+        i.add(5);
+        14.add(4);
+    }
+
+    function useLib(uint n) public payable returns (uint)
+    {
+        return Lib.add(n, 1);
+    }
+
+    function enums(Color c) public pure returns (Color d)
+    {
+        Color e = Color.Red;
+        if (c == e)
+            d = Color.Green;
+        else
+            d = c;
+    }
+
+    type Price is uint128;
+    function udlTest() public pure returns (uint128)
+    {
+        Price p = Price.wrap(128);
+        return Price.unwrap(p);
+    }
+
+    function structCtorTest(uint8 v) public pure returns (uint8 result)
+    {
+        RGBColor memory c = RGBColor(v, 2 * v, 3 * v);
+        result = c.red;
+    }
+}

--- a/test/libsolidity/lsp/goto_definition_imports.sol
+++ b/test/libsolidity/lsp/goto_definition_imports.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import {Weather as Wetter} from "./lib.sol";
+import "./lib.sol" as That;
+
+contract C
+{
+    function test_symbol_alias() public pure returns (Wetter result)
+    {
+        result = Wetter.Sunny;
+    }
+
+    function test_library_alias() public pure returns (That.Color result)
+    {
+        That.Color color = That.Color.Red;
+        result = color;
+    }
+}

--- a/test/libsolidity/lsp/lib.sol
+++ b/test/libsolidity/lsp/lib.sol
@@ -1,6 +1,25 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0;
 
+/// Some Error type E.
+error E(uint, uint);
+
+enum Weather {
+    Sunny,
+    Cloudy,
+    Rainy
+}
+
+/// Some custom Color enum type holding 3 colors.
+enum Color {
+    /// Red color.
+    Red,
+    /// Green color.
+    Green,
+    /// Blue color.
+    Blue
+}
+
 library Lib
 {
     function add(uint a, uint b) public pure returns (uint result)
@@ -12,4 +31,11 @@ library Lib
     {
         uint unused;
     }
+}
+
+struct RGBColor
+{
+    uint8 red;
+    uint8 green;
+    uint8 blue;
 }


### PR DESCRIPTION
Implements `textDocument/definition` and adds test for it.

- [x] type symbol -> type definition (contract, enum type, enum value type, ...)
- [x] variable name -> var decl
- [x] return variable name `x` -> jump to `x` in `returns (uint x)`
- [x] `import "file.sol"` -> jump to top of imported file "file.sol"
- [x] `import {x} from "file.sol"`, hover `x` -> jump to `x` in "file.sol"
- [x] `import {x as y} from "file.sol"`, having `y` hovered in file -> jump `x` in "file.sol"
- [x] function call name -> jump to function definition
- [x] function parameter name `x` to jump to function parameter def `x`
- [x] "Can you check how virtual lookup works in this case? Is it at least relative to the location of the expression or will it always go to the base?"
- ...?