### PR TITLE
Preset selection in external tests

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -24,7 +24,16 @@ set -e
 
 CURRENT_EVM_VERSION=london
 
-function print_optimizer_presets_or_exit
+AVAILABLE_PRESETS=(
+    legacy-no-optimize
+    ir-no-optimize
+    legacy-optimize-evm-only
+    ir-optimize-evm-only
+    legacy-optimize-evm+yul
+    ir-optimize-evm+yul
+)
+
+function print_presets_or_exit
 {
     local selected_presets="$1"
 
@@ -37,10 +46,22 @@ function verify_input
 {
     local binary_type="$1"
     local binary_path="$2"
+    local selected_presets="$3"
 
-    (( $# == 2 )) || fail "Usage: $0 native|solcjs <path to solc or soljson.js>"
+    (( $# >= 2 && $# <= 3 )) || fail "Usage: $0 native|solcjs <path to solc or soljson.js> [preset]"
     [[ $binary_type == native || $binary_type == solcjs ]] || fail "Invalid binary type: '${binary_type}'. Must be either 'native' or 'solcjs'."
     [[ -f "$binary_path" ]] || fail "The compiler binary does not exist at '${binary_path}'"
+
+    if [[ $selected_presets != "" ]]
+    then
+        for preset in $selected_presets
+        do
+            if [[ " ${AVAILABLE_PRESETS[*]} " != *" $preset "* ]]
+            then
+                fail "Preset '${preset}' does not exist. Available presets: ${AVAILABLE_PRESETS[*]}."
+            fi
+        done
+    fi
 }
 
 function setup_solc
@@ -265,6 +286,8 @@ function settings_from_preset
 {
     local preset="$1"
     local evm_version="$2"
+
+    [[ " ${AVAILABLE_PRESETS[*]} " == *" $preset "* ]] || assertFail
 
     case "$preset" in
         # NOTE: Remember to update `parallelism` of `t_ems_ext` job in CI config if you add/remove presets

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { yarn build; }
 function test_fn { yarn test; }
@@ -49,9 +50,8 @@ function ens_test
         legacy-optimize-evm+yul
     )
 
-    local selected_optimizer_presets
-    selected_optimizer_presets=$(circleci_select_steps_multiarg "${settings_presets[@]}")
-    print_optimizer_presets_or_exit "$selected_optimizer_presets"
+    [[ $SELECTED_PRESETS != "" ]] || SELECTED_PRESETS=$(circleci_select_steps_multiarg "${settings_presets[@]}")
+    print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
     download_project "$repo" "$branch" "$DIR"
@@ -60,13 +60,13 @@ function ens_test
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
-    force_hardhat_compiler_settings "$config_file" "$(first_word "$selected_optimizer_presets")"
+    force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     yarn install
 
     replace_version_pragmas
     neutralize_packaged_contracts
 
-    for preset in $selected_optimizer_presets; do
+    for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
     done
 }

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { npx truffle compile; }
 function test_fn { npm test; }
@@ -49,9 +50,8 @@ function gnosis_safe_test
         legacy-optimize-evm+yul
     )
 
-    local selected_optimizer_presets
-    selected_optimizer_presets=$(circleci_select_steps_multiarg "${settings_presets[@]}")
-    print_optimizer_presets_or_exit "$selected_optimizer_presets"
+    [[ $SELECTED_PRESETS != "" ]] || SELECTED_PRESETS=$(circleci_select_steps_multiarg "${settings_presets[@]}")
+    print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
     download_project "$repo" "$branch" "$DIR"
@@ -62,13 +62,13 @@ function gnosis_safe_test
 
     neutralize_package_lock
     neutralize_package_json_hooks
-    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$(first_word "$selected_optimizer_presets")"
+    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$(first_word "$SELECTED_PRESETS")"
     npm install --package-lock
 
     replace_version_pragmas
     [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc"
 
-    for preset in $selected_optimizer_presets; do
+    for preset in $SELECTED_PRESETS; do
         truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
     done
 }


### PR DESCRIPTION
This PR make it possible to run just a single preset of an external test. This will be especially useful in combination with benchmarking - it will allow you to get a report for the optimization level you're interested in without having to run through all 6 presets - but might also be handy in CI.