### PR TITLE
[pylint] Use multiple processes when possible

### DIFF
--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -1,4 +1,10 @@
 # vim:et:ts=4
+[MASTER]
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s). You


### PR DESCRIPTION
I noticed that the default is for pylint to use only one core. This PR enables auto-detection.

It does not change that much about running time since it's pretty fast already (IMO it's not even worth changing the resource class in CI) but if we can enable it, why not. One unexpected advantage is that when running locally, output appears faster, while it's still working.