### PR TITLE
[pylint] Disable the opinionated too-many-xyz warnings

### DIFF
--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -187,7 +187,7 @@ def parse_cli_output(source_file_name: Path, cli_output: str) -> FileReport:
     return file_report
 
 
-def prepare_compiler_input(  # pylint: disable=too-many-arguments
+def prepare_compiler_input(
     compiler_path: Path,
     source_file_name: Path,
     optimize: bool,
@@ -256,7 +256,7 @@ def detect_metadata_cli_option_support(compiler_path: Path):
     return process.returncode == 0
 
 
-def run_compiler(  # pylint: disable=too-many-arguments
+def run_compiler(
     compiler_path: Path,
     source_file_name: Path,
     optimize: bool,
@@ -320,7 +320,7 @@ def run_compiler(  # pylint: disable=too-many-arguments
         return parse_cli_output(Path(source_file_name), process.stdout)
 
 
-def generate_report(  # pylint: disable=too-many-arguments,too-many-locals
+def generate_report(
     source_file_names: List[str],
     compiler_path: Path,
     interface: CompilerInterface,

--- a/scripts/endToEndExtraction/verify-testcases.py
+++ b/scripts/endToEndExtraction/verify-testcases.py
@@ -9,8 +9,6 @@
 #
 # verify-testcases.py will compare both traces. If these traces are identical, the extracted tests were
 # identical with the tests specified in SolidityEndToEndTest.cpp.
-#
-# pylint: disable=too-many-instance-attributes
 
 import re
 import os

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -254,8 +254,6 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
 
 
 def main(argv):
-    # pylint: disable=too-many-branches, too-many-locals, too-many-statements
-
     check = False
     fix = False
     no_confirm = False

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -25,7 +25,13 @@ disable=
     pointless-string-statement,
     redefined-outer-name,
     too-few-public-methods,
-    too-many-public-methods
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-locals,
+    too-many-public-methods,
+    too-many-statements,
+    ungrouped-imports
 
 [BASIC]
 


### PR DESCRIPTION
Followup for https://github.com/ethereum/solidity/pull/11350#discussion_r760497667.

We decided we'd prefer these warnings disabled globally since they're not helpful - we're always disabling them locally anyway.