### PR TITLE
Fix ESLint warnings/errors in external test JS

### DIFF
--- a/test/externalTests/solc-js/determinism.js
+++ b/test/externalTests/solc-js/determinism.js
@@ -4,17 +4,17 @@ const solc = require('../index.js');
 
 tape('Deterministic Compilation', function (t) {
   t.test('DAO', function (st) {
-    var input = {};
-    var prevBytecode = null;
-    var testdir = 'test/DAO/';
-    var files = ['DAO.sol', 'Token.sol', 'TokenCreation.sol', 'ManagedAccount.sol'];
-    var i;
+    const input = {};
+    let prevBytecode = null;
+    const testdir = 'test/DAO/';
+    const files = ['DAO.sol', 'Token.sol', 'TokenCreation.sol', 'ManagedAccount.sol'];
+    let i;
     for (i in files) {
-      var file = files[i];
+      const file = files[i];
       input[file] = { content: fs.readFileSync(testdir + file, 'utf8') };
     }
     for (i = 0; i < 10; i++) {
-      var output = JSON.parse(solc.compile(JSON.stringify({
+      const output = JSON.parse(solc.compile(JSON.stringify({
         language: 'Solidity',
         settings: {
           optimizer: {
@@ -22,7 +22,7 @@ tape('Deterministic Compilation', function (t) {
           },
           outputSelection: {
             '*': {
-              '*': [ 'evm.bytecode' ]
+              '*': ['evm.bytecode']
             }
           }
         },
@@ -31,9 +31,9 @@ tape('Deterministic Compilation', function (t) {
       st.ok(output);
       st.ok(output.contracts);
       st.ok(output.contracts['DAO.sol']);
-      st.ok(output.contracts['DAO.sol']['DAO']);
-      st.ok(output.contracts['DAO.sol']['DAO'].evm.bytecode.object);
-      var bytecode = output.contracts['DAO.sol']['DAO'].evm.bytecode.object;
+      st.ok(output.contracts['DAO.sol'].DAO);
+      st.ok(output.contracts['DAO.sol'].DAO.evm.bytecode.object);
+      const bytecode = output.contracts['DAO.sol'].DAO.evm.bytecode.object;
       st.ok(bytecode.length > 0);
       if (prevBytecode !== null) {
         st.equal(prevBytecode, bytecode);


### PR DESCRIPTION
Any linter problems were already fixed in solc-js in https://github.com/ethereum/solc-js/pull/567 but we have some JS files in the main repo here that need to be cleaned up too.